### PR TITLE
Add the  "Disable Project" button to matrix parent and maven2 projects

### DIFF
--- a/core/src/main/resources/hudson/matrix/MatrixProject/index.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/index.jelly
@@ -29,8 +29,8 @@ THE SOFTWARE.
     <l:main-panel>
       <h1>${%Project} ${it.name}</h1>
       <t:editableDescription permission="${it.CONFIGURE}"/>
-
-      <j:if test="${it.disabled}">
+	  <j:choose>
+      <j:when test="${it.disabled}">
         <div class="warning">
           <form method="post" action="enable">
             ${%This project is currently disabled}
@@ -39,7 +39,17 @@ THE SOFTWARE.
             </l:hasPermission>
           </form>
         </div>
-      </j:if>
+        </j:when>
+        <j:otherwise>
+         <div align="right">
+          <form method="post" action="disable">
+            <l:hasPermission permission="${it.CONFIGURE}">
+              <f:submit value="${%Disable Project}" />
+            </l:hasPermission>
+          </form>
+          </div>
+        </j:otherwise>
+      </j:choose>
 
       <st:include page="ajaxMatrix.jelly" />
 

--- a/core/src/main/resources/hudson/matrix/MatrixProject/index.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/index.jelly
@@ -29,8 +29,8 @@ THE SOFTWARE.
     <l:main-panel>
       <h1>${%Project} ${it.name}</h1>
       <t:editableDescription permission="${it.CONFIGURE}"/>
-	  <j:choose>
-      <j:when test="${it.disabled}">
+      <j:choose>
+        <j:when test="${it.disabled}">
         <div class="warning">
           <form method="post" action="enable">
             ${%This project is currently disabled}

--- a/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/index.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/index.jelly
@@ -29,8 +29,8 @@ THE SOFTWARE.
     <l:main-panel>
       <h1>${it.pronoun} ${it.displayName}</h1>
       <t:editableDescription permission="${it.CONFIGURE}"/>
-
-      <j:if test="${it.disabled}">
+	  <j:choose>
+      <j:when test="${it.disabled}">
         <div class="warning">
           <form method="post" action="enable">
             ${%This project is currently disabled}
@@ -39,7 +39,17 @@ THE SOFTWARE.
             </l:hasPermission>
           </form>
         </div>
-      </j:if>
+        </j:when>
+        <j:otherwise>
+         <div align="right">
+          <form method="post" action="disable">
+            <l:hasPermission permission="${it.CONFIGURE}">
+              <f:submit value="${%Disable Project}" />
+            </l:hasPermission>
+          </form>
+          </div>
+        </j:otherwise>
+      </j:choose>
 
       <p:projectActionFloatingBox />
 
@@ -84,3 +94,4 @@ THE SOFTWARE.
     </l:main-panel>
   </l:layout>
 </j:jelly>
+

--- a/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/index.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/index.jelly
@@ -29,8 +29,8 @@ THE SOFTWARE.
     <l:main-panel>
       <h1>${it.pronoun} ${it.displayName}</h1>
       <t:editableDescription permission="${it.CONFIGURE}"/>
-	  <j:choose>
-      <j:when test="${it.disabled}">
+      <j:choose>
+        <j:when test="${it.disabled}">
         <div class="warning">
           <form method="post" action="enable">
             ${%This project is currently disabled}
@@ -94,4 +94,3 @@ THE SOFTWARE.
     </l:main-panel>
   </l:layout>
 </j:jelly>
-


### PR DESCRIPTION
I've added the Disable Project button to the jelly templates for both the Matrix (parent) and maven2 projects.

I tested this out with a maven build.

This is my first time hacking on hudson and first real-world use of git and github, so hopefully I got everything right :-)
