### PR TITLE
HUDSON-8317

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixProject.java
+++ b/core/src/main/java/hudson/matrix/MatrixProject.java
@@ -65,6 +65,7 @@ import javax.servlet.ServletException;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.lang.Boolean;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -132,6 +133,11 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
     private boolean runSequentially;
     
     /**
+    * Disable the creation of axis-specific workspace directories
+    */
+    private boolean shareWorkspaceAmongAxes; 
+
+    /**
      * Filter to select a number of combinations to build first
      */
     private String touchStoneCombinationFilter;
@@ -175,6 +181,18 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
 
     public void setRunSequentially(boolean runSequentially) throws IOException {
         this.runSequentially = runSequentially;
+        save();
+    }
+
+    /**
+    * If true, {@link MatrixRun}s share workspaces rather than creating unique directories for themselves.
+    */
+    public boolean isShareWorkspaceAmongAxes() {
+        return shareWorkspaceAmongAxes; 
+    }
+
+    public void setShareWorkspaceAmongAxes(boolean shareWorkspaceAmongAxes) throws IOException {
+        this.shareWorkspaceAmongAxes = shareWorkspaceAmongAxes;
         save();
     }
 
@@ -592,6 +610,7 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
 
         if(req.hasParameter("customWorkspace")) {
             customWorkspace = req.getParameter("customWorkspace.directory");
+            shareWorkspaceAmongAxes = json.getJSONObject("customWorkspace").getBoolean("shareWorkspaceAmongAxes");
         } else {
             customWorkspace = null;        
         }

--- a/core/src/main/java/hudson/matrix/MatrixRun.java
+++ b/core/src/main/java/hudson/matrix/MatrixRun.java
@@ -153,7 +153,11 @@ public class MatrixRun extends Build<MatrixConfiguration,MatrixRun> {
                 // Use custom workspace as defined in the matrix project settings.
                 FilePath ws = n.getRootPath().child(getEnvironment(listener).expand(customWorkspace));
                 // We allow custom workspaces to be used concurrently between jobs.
-                return Lease.createDummyLease(ws.child(subtree));
+                if (getParent().getParent().isShareWorkspaceAmongAxes()) {
+                  return Lease.createDummyLease(ws);
+                } else {
+                  return Lease.createDummyLease(ws.child(subtree));
+                }
             } else {
                 // Use default workspace as assigned by Hudson.
                 Node node = getBuiltOn();

--- a/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace.jelly
@@ -1,0 +1,35 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, id:cactusman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!-- custom workspace -->
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<f:optionalBlock name="customWorkspace" title="${%Use custom workspace}" checked="${it.customWorkspace!=null}" help="/help/project-config/custom-workspace.html">
+    <f:entry title="${%Directory}">
+      <f:textbox name="customWorkspace.directory" value="${it.customWorkspace}" />
+    </f:entry>
+    <f:entry help="/help/matrix/shareworkspace.html">
+      <f:checkbox title="${%Share workspace among all axes}" name="shareWorkspaceAmongAxes" field="shareWorkspaceAmongAxes" checked="${it.shareWorkspaceAmongAxes}"/>
+    </f:entry>
+  </f:optionalBlock>
+</j:jelly>

--- a/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_da.properties
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_da.properties
@@ -1,0 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc. Kohsuke Kawaguchi. Knud Poulsen.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Use\ custom\ workspace=Benyt s\u00e6rligt arbejdsomr\u00e5de
+Directory=Direktorie

--- a/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_de.properties
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_de.properties
@@ -1,0 +1,24 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Simon Wiest
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Use\ custom\ workspace=Verzeichnis des Arbeitsbereichs anpassen
+Directory=Verzeichnis

--- a/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_es.properties
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_es.properties
@@ -1,0 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Use\ custom\ workspace=Utilizar un directorio de trabajo personalizado
+Directory=Directorio

--- a/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_fr.properties
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_fr.properties
@@ -1,0 +1,24 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Eric Lefevre-Ardant
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Use\ custom\ workspace=Utiliser un répertoire de travail spécifique
+Directory=Répertoire

--- a/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_ja.properties
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_ja.properties
@@ -1,0 +1,24 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Use\ custom\ workspace=\u30ab\u30b9\u30bf\u30e0\u30ef\u30fc\u30af\u30b9\u30da\u30fc\u30b9\u306e\u4f7f\u7528
+Directory=\u30c7\u30a3\u30ec\u30af\u30c8\u30ea

--- a/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_pt_BR.properties
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_pt_BR.properties
@@ -1,0 +1,24 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Reginaldo L. Russinholi, Cleiber Silva
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Use\ custom\ workspace=Usar workspace customizado
+Directory=Diret\u00f3rio

--- a/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_ru.properties
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_ru.properties
@@ -1,0 +1,24 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Mike Salnikov
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Use\ custom\ workspace=\u0418\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u044c \u0434\u0440\u0443\u0433\u0443\u044e \u0434\u0438\u0440\u0435\u043a\u0442\u043e\u0440\u0438\u044e
+Directory=\u0414\u0438\u0440\u0435\u043a\u0442\u043e\u0440\u0438\u044f

--- a/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_tr.properties
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_tr.properties
@@ -1,0 +1,24 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Oguz Dag
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Use\ custom\ workspace=\u00d6zel \u00e7al\u0131\u015fma alan\u0131n\u0131 kullan
+Directory=Dizin

--- a/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_zh_TW.properties
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/config-customWorkspace_zh_TW.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Directory=\u76EE\u9304

--- a/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
       <p:config-quietPeriod />
       <p:config-retryCount />
       <p:config-blockWhenUpstreamBuilding />
-      <p:config-customWorkspace />
+      <st:include page="config-customWorkspace.jelly"/>
     </f:advanced>
   </f:section>
 

--- a/war/src/main/webapp/help/matrix/shareworkspace.html
+++ b/war/src/main/webapp/help/matrix/shareworkspace.html
@@ -1,0 +1,3 @@
+<div>
+    Normally Hudson will execute the job for each axis combination in a workspace directory unique to the axis combination (e.g. ${WORKSPACE}/axis1/a/axis2/b).  This option will instead cause all axis combinations to share the root workspace.
+</div>


### PR DESCRIPTION
Fix for HUDSON-8317 - Matrix jobs with custom workspaces should be able to share the root with no axis-specific subtree
