### PR TITLE
HUDSON-8505 : Allow users to re-enable Monitors from Hudson config

### DIFF
--- a/core/src/main/java/hudson/model/Hudson.java
+++ b/core/src/main/java/hudson/model/Hudson.java
@@ -2515,6 +2515,13 @@ public final class Hudson extends Node implements ItemGroup<TopLevelItem>, Stapl
                 globalNodeProperties.rebuild(req, np, NodeProperty.for_(this));
             }
 
+            // Monitors
+            for (AdministrativeMonitor monitor : administrativeMonitors) {
+                if (json.has(monitor.id)) {
+                    monitor.disable(false);
+                }
+            }
+
             version = VERSION;
 
             save();

--- a/core/src/main/resources/hudson/model/Hudson/configure.jelly
+++ b/core/src/main/resources/hudson/model/Hudson/configure.jelly
@@ -44,6 +44,7 @@ THE SOFTWARE.
       <f:entry title="${%# of executors}" field="numExecutors">
         <f:textbox />
       </f:entry>
+
       <j:if test="${!empty(it.slaves)}">
         <f:entry title="${%Labels}" field="labelString">
           <f:textbox />
@@ -188,6 +189,24 @@ THE SOFTWARE.
           </f:block>
         </f:section>
       </j:if>
+
+      <f:section title="${%monitors.disabled}">
+        <f:block>
+          <!-- list of monitors -->
+          <j:set var="disabledMonitorsNb" value="0" />
+          <j:forEach var="monitor" items="${it.administrativeMonitors}">
+            <j:if test="${!monitor.enabled}">
+              <f:optionalBlock name="${monitor.id}" checked="${monitor.enabled}"
+                               title="${monitor.displayName}" help="/help/system-config/enableMonitor.html" />
+              <j:set var="disabledMonitorsNb" value="${disabledMonitorsNb+1}" />
+            </j:if>
+          </j:forEach>
+          <j:if test="${disabledMonitorsNb eq 0}">
+            ${%monitors.disabled.empty}
+          </j:if>
+        </f:block>
+      </f:section>
+
 
       <f:block>
         <f:submit value="${%Save}" />

--- a/core/src/main/resources/hudson/model/Hudson/configure.properties
+++ b/core/src/main/resources/hudson/model/Hudson/configure.properties
@@ -28,3 +28,9 @@ statsBlurb=\
   Help make Hudson better by sending anonymous usage statistics and crash reports to the Hudson project.
 
 no.such.JDK=<span class=error>No such JDK exists</span>
+
+monitors.disabled=\
+  Disabled monitors
+
+monitors.disabled.empty=\
+  No disabled monitors

--- a/war/src/main/webapp/help/system-config/enableMonitor.html
+++ b/war/src/main/webapp/help/system-config/enableMonitor.html
@@ -1,0 +1,3 @@
+<div>
+  Unless it is disabled, a monitor would show a warning on the "Manage Hudson" page it has detected something wrong. Check it to re-enable the monitor.
+</div>


### PR DESCRIPTION
A simple patch to allow to reactivate dismissed monitors
