### PR TITLE
Partial fix for HUDSON-7745

### DIFF
--- a/remoting/src/main/java/hudson/remoting/PipeWindow.java
+++ b/remoting/src/main/java/hudson/remoting/PipeWindow.java
@@ -99,8 +99,6 @@ abstract class PipeWindow {
 
     static class Real extends PipeWindow {
         private int available;
-        private long written;
-        private long acked;
         private final int oid;
         /**
          * The only strong reference to the key, which in turn
@@ -118,7 +116,6 @@ abstract class PipeWindow {
             if (LOGGER.isLoggable(FINER))
                 LOGGER.finer(String.format("increase(%d,%d)->%d",oid,delta,delta+available));
             available += delta;
-            acked += delta;
             notifyAll();
         }
 
@@ -139,7 +136,7 @@ abstract class PipeWindow {
                 if (available>0)
                     return available;
 
-                while (available==0) {
+                while (available<=0) {
                     wait();
                 }
             }
@@ -155,7 +152,6 @@ abstract class PipeWindow {
             if (LOGGER.isLoggable(FINER))
                 LOGGER.finer(String.format("decrease(%d,%d)->%d",oid,delta,available-delta));
             available -= delta;
-            written+= delta;
             /*
             HUDSON-7745 says the following assertion fails, which AFAICT is only possible if multiple
             threads write to OutputStream concurrently, but that doesn't happen in most of the situations, so

--- a/remoting/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/remoting/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -81,7 +81,7 @@ final class ProxyOutputStream extends OutputStream {
         this.channel = channel;
         this.oid = oid;
 
-        window =  channel.getPipeWindow(oid);
+        window = channel.getPipeWindow(oid);
 
         // if we already have bytes to write, do so now.
         if(tmp!=null) {
@@ -115,6 +115,11 @@ final class ProxyOutputStream extends OutputStream {
             while (len>0) {
                 int sendable;
                 try {
+                    // @TODO This is just a hack for now. Figure out why the window is unexpectedly destroyed.
+                    if (window == null)
+                    {
+                        window = channel.getPipeWindow(oid);
+                    }
                     sendable = Math.min(window.get(),len);
                 } catch (InterruptedException e) {
                     throw (IOException)new InterruptedIOException().initCause(e);

--- a/remoting/src/main/java/hudson/remoting/ProxyOutputStream.java
+++ b/remoting/src/main/java/hudson/remoting/ProxyOutputStream.java
@@ -116,8 +116,7 @@ final class ProxyOutputStream extends OutputStream {
                 int sendable;
                 try {
                     // @TODO This is just a hack for now. Figure out why the window is unexpectedly destroyed.
-                    if (window == null)
-                    {
+                    if (window == null) {
                         window = channel.getPipeWindow(oid);
                     }
                     sendable = Math.min(window.get(),len);


### PR DESCRIPTION
There was an issue in PipeWindow.java where the available size could drop below 0.  A wait was enforced while the value was exactly zero, but not less than zero.  This was causing a NegativeArrayIndexException because that value is ultimately used to index into an array.

In addition to that, there is apparently a call to ProxyOutputStream.connect and subsequently channel.getpipewindow which causes ProxyOutputStream.window to get set to null. A quick check for window == null prior to using it appears to resolve that issue.

The other two failures identified in HUDSON-7745, particularly the "Not in GZIP format" error will take some more time to track down.
