### PR TITLE
Jenkins 8592

### DIFF
--- a/remoting/src/main/java/hudson/remoting/Pipe.java
+++ b/remoting/src/main/java/hudson/remoting/Pipe.java
@@ -23,6 +23,7 @@
  */
 package hudson.remoting;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -92,7 +93,19 @@ public final class Pipe implements Serializable {
      * Gets the reading end of the pipe.
      */
     public InputStream getIn() {
-        return in;
+        return new FilterInputStream(in) {
+            @Override
+            public void close() throws IOException {
+                try {
+                    // Since closing the reading side does not stop the writing side. We read till the stream is done.
+                    final byte[] buffer = new byte[4096];
+                    while(read(buffer) != -1) {
+                    }
+                } finally {
+                    super.close();
+                }
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
This is what seems to be the easy fix for [JENKINS-8592](http://issues.jenkins-ci.org/browse/JENKINS-8592). Since the current assumption is that the reader will read to the end, we just make sure they do that prior to closing.

A better way would be to send the close event back through the channel to the sending side, but doing that may be a little risky. This change should be pretty safe and allow us to close this bug sooner rather then later.

Thoughts?
