### PR TITLE
Test email has "Hudson" in it

### DIFF
--- a/core/src/main/java/hudson/tasks/Mailer.java
+++ b/core/src/main/java/hudson/tasks/Mailer.java
@@ -455,7 +455,7 @@ public class Mailer extends Notifier {
                 
                 MimeMessage msg = new MimeMessage(createSession(smtpServer,smtpPort,useSsl,smtpAuthUserName,Secret.fromString(smtpAuthPassword)));
                 msg.setSubject("Test email #" + ++testEmailCount);
-                msg.setContent("This is test email #" + testEmailCount + " sent from Hudson Continuous Integration server.", "text/plain");
+                msg.setContent("This is test email #" + testEmailCount + " sent from " + Hudson.getInstance().getDisplayName(), "text/plain");
                 msg.setFrom(new InternetAddress(adminAddress));
                 msg.setSentDate(new Date());
                 msg.setRecipient(Message.RecipientType.TO, new InternetAddress(adminAddress));


### PR DESCRIPTION
I noticed the Test email has "Hudson" in it, so I changed it to Jenkins.

lacostej suggested using Hudson.getInstance().getDescription() instead.  Made sense, so I did.

I couldn't figure out how to change the commits from my previous pull request, so here's a new one.
