### PR TITLE
fix for JENKINS-8658 (jenkins still picks ~/.hudson as default when ran using java -jar) 

### DIFF
--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -262,7 +262,7 @@ public final class WebAppMain implements ServletContextListener {
     }
 
     /** Add some metadata to a File, allowing to trace setup issues */
-    private class FileAndDescription {
+    private static class FileAndDescription {
         File file;
         String description;
         public FileAndDescription(File file,String description) {

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -109,7 +109,7 @@ THE SOFTWARE.
                 <mkdir dir="target/generated-resources" />
 
                 <!-- put executable war header -->
-                <resolveArtifact groupId="org.jvnet.hudson" artifactId="executable-war" version="1.17" type="jar" property="executable-war.jar" />
+                <resolveArtifact groupId="org.jvnet.hudson" artifactId="executable-war" version="1.18-SNAPSHOT" type="jar" property="executable-war.jar" />
                 <unjar src="${executable-war.jar}" dest="target/generated-resources">
                   <patternset>
                     <include name="**/*.class" />


### PR DESCRIPTION
extra/executable-war Main class causes jenkings to extract the war under ~/.hudson by default thus making the webapp pick that directory as homeDir.

As extras/executable-war, the full fix depends on the patch attached to JENKINS-8658

The attached commits just try to make it easier to further troubleshoot potential user issues when picking the homeDir

Related to https://github.com/jenkinsci/extras-executable-war/pull/1
