### PR TITLE
JENKINS-4756 the EXECUTOR_NUMBER environment variable is not unique

### DIFF
--- a/test/src/test/java/hudson/model/ExecutorTest.java
+++ b/test/src/test/java/hudson/model/ExecutorTest.java
@@ -12,9 +12,7 @@ public class ExecutorTest extends HudsonTestCase {
         Executor e = c.getExecutors().get(0);
 
         // kill an executor
-        e.killHard();
-        while (e.isAlive())
-            Thread.sleep(10);
+        kill(e);
 
         // make sure it's dead
         assertTrue(c.getExecutors().contains(e));
@@ -27,6 +25,44 @@ public class ExecutorTest extends HudsonTestCase {
         submit(p.getFormByName("yank"));
 
         assertFalse(c.getExecutors().contains(e));
-
+        waitUntilExecutorSizeIs(c, 2);
     }
+
+    public void testWhenAnExecuterIsYankedANewExecuterTakesItsPlace() throws Exception {
+        final Hudson hudson = Hudson.getInstance();
+        Computer c = hudson.toComputer();
+        Executor e = getExecutorByNumber(c, 0);
+
+        kill(e);
+        e.doYank();
+
+        waitUntilExecutorSizeIs(c, 2);
+
+        assertNotNull(getExecutorByNumber(c, 0));
+        assertNotNull(getExecutorByNumber(c, 1));
+    }
+
+    private void waitUntilExecutorSizeIs(Computer c, int executorCollectionSize) throws InterruptedException {
+        int timeOut = 10;
+        while (c.getExecutors().size() != executorCollectionSize) {
+            Thread.sleep(10);
+            if (timeOut-- == 0) fail("executor collection size was not " + executorCollectionSize);
+        }
+    }
+
+    private void kill(Executor e) throws InterruptedException {
+        e.killHard();
+        while (e.isAlive())
+            Thread.sleep(10);
+    }
+
+    private Executor getExecutorByNumber(Computer c, int executorNumber) {
+        for (Executor executor : c.getExecutors()) {
+            if (executor.getNumber() == executorNumber) {
+                return executor;
+            }
+        }
+        return null;
+    }
+
 }


### PR DESCRIPTION
Hi,

I fixed the JENKINS-4756 issue.  I changed how the executer number is created and a check to see if there are enough executers after a remove (in case of a doYank) and added a test for it.

--Janick
