### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1819,7 +1819,7 @@ public final class FilePath implements Serializable {
         value = fixEmpty(value);
 
         // none entered yet, or something is seriously wrong
-        if(value==null || (AbstractProject<?,?>)subject ==null) return FormValidation.ok();
+        if(value==null) return FormValidation.ok();
 
         // a common mistake is to use wildcard
         if(value.contains("*")) return FormValidation.error(Messages.FilePath_validateRelativePath_wildcardNotAllowed());

--- a/core/src/main/java/hudson/MarkupText.java
+++ b/core/src/main/java/hudson/MarkupText.java
@@ -193,7 +193,7 @@ public class MarkupText extends AbstractMarkupText {
          * Replaces the group tokens like "$0", "$1", and etc with their actual matches.
          */
         public String replace(String s) {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder(s.length() + 10);
 
             for( int i=0; i<s.length(); i++) {
                 char ch = s.charAt(i);

--- a/core/src/main/java/hudson/Plugin.java
+++ b/core/src/main/java/hudson/Plugin.java
@@ -227,8 +227,9 @@ public abstract class Plugin implements Saveable {
      */
     public void save() throws IOException {
         if(BulkChange.contains(this))   return;
-        getConfigXml().write(this);
-        SaveableListener.fireOnChange(this, getConfigXml());
+        XmlFile config = getConfigXml();
+        config.write(this);
+        SaveableListener.fireOnChange(this, config);
     }
 
     /**

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -485,9 +485,10 @@ public class PluginWrapper implements Comparable<PluginWrapper> {
      * or null if there's no back up.
      */
     public String getBackupVersion() {
-        if (getBackupFile().exists()) {
+        File backup = getBackupFile();
+        if (backup.exists()) {
             try {
-                JarFile backupPlugin = new JarFile(getBackupFile());
+                JarFile backupPlugin = new JarFile(backup);
                 return backupPlugin.getManifest().getMainAttributes().getValue("Plugin-Version");
             } catch (IOException e) {
                 LOGGER.log(WARNING, "Failed to get backup version ", e);

--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -89,8 +89,9 @@ public final class ProxyConfiguration implements Saveable {
 
     public void save() throws IOException {
         if(BulkChange.contains(this))   return;
-        getXmlFile().write(this);
-        SaveableListener.fireOnChange(this, getXmlFile());
+        XmlFile config = getXmlFile();
+        config.write(this);
+        SaveableListener.fireOnChange(this, config);
     }
 
     public static XmlFile getXmlFile() {

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1033,7 +1033,7 @@ public class Util {
                 listener.getLogger().println(String.format("ln -s %s %s failed: %d %s",targetPath, symlinkFile, r, errmsg));
         } catch (IOException e) {
             PrintStream log = listener.getLogger();
-            log.printf("ln %s %s failed\n",targetPath, new File(baseDir, symlinkPath));
+            log.printf("ln %s %s failed%n",targetPath, new File(baseDir, symlinkPath));
             Util.displayIOException(e,listener);
             e.printStackTrace( log );
         }

--- a/core/src/main/java/hudson/cli/InstallPluginCommand.java
+++ b/core/src/main/java/hudson/cli/InstallPluginCommand.java
@@ -116,7 +116,8 @@ public class InstallPluginCommand extends CLICommand {
                         Data dt = s.getData();
                         if (dt==null)
                             stdout.println(Messages.InstallPluginCommand_NoUpdateDataRetrieved(s.getUrl()));
-                        candidates.addAll(dt.plugins.keySet());
+                        else
+                            candidates.addAll(dt.plugins.keySet());
                     }
                     stdout.println(Messages.InstallPluginCommand_DidYouMean(source,EditDistance.findNearest(source,candidates)));
                 }

--- a/core/src/main/java/hudson/cli/ListChangesCommand.java
+++ b/core/src/main/java/hudson/cli/ListChangesCommand.java
@@ -60,7 +60,7 @@ public class ListChangesCommand extends AbstractBuildRangeCommand {
             for (AbstractBuild build : builds) {
                 ChangeLogSet<?> cs = build.getChangeSet();
                 for (Entry e : cs) {
-                    stdout.printf("%s,%s\n",
+                    stdout.printf("%s,%s%n",
                             QuotedStringTokenizer.quote(e.getAuthor().getId()),
                             QuotedStringTokenizer.quote(e.getMsg()));
                 }
@@ -70,7 +70,7 @@ public class ListChangesCommand extends AbstractBuildRangeCommand {
             for (AbstractBuild build : builds) {
                 ChangeLogSet<?> cs = build.getChangeSet();
                 for (Entry e : cs) {
-                    stdout.printf("%s\t%s\n",e.getAuthor(),e.getMsg());
+                    stdout.printf("%s\t%s%n",e.getAuthor(),e.getMsg());
                     for (String p : e.getAffectedPaths())
                         stdout.println("  "+p);
                 }

--- a/core/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/core/src/main/java/hudson/matrix/MatrixBuild.java
@@ -220,7 +220,7 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
                 }
                 
                 if (p.getTouchStoneResultCondition() != null && r.isWorseThan(p.getTouchStoneResultCondition())) {
-                    logger.printf("Touchstone configurations resulted in %s, so aborting...\n", r);
+                    logger.printf("Touchstone configurations resulted in %s, so aborting...%n", r);
                     return r;
                 }
                 

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -425,14 +425,16 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                     // error message doesn't point users to the slave. So let's do it here.
                     listener.hyperlink("/computer/"+builtOn+"/log","Looks like the node went offline during the build. Check the slave log for the details.");
 
-                    // grab the end of the log file. This might not work very well if the slave already
-                    // starts reconnecting. Fixing this requires a ring buffer in slave logs.
-                    AnnotatedLargeText<Computer> log = c.getLogText();
-                    StringWriter w = new StringWriter();
-                    log.writeHtmlTo(Math.max(0,c.getLogFile().length()-10240),w);
+                    if (c != null) {
+                        // grab the end of the log file. This might not work very well if the slave already
+                        // starts reconnecting. Fixing this requires a ring buffer in slave logs.
+                        AnnotatedLargeText<Computer> log = c.getLogText();
+                        StringWriter w = new StringWriter();
+                        log.writeHtmlTo(Math.max(0,c.getLogFile().length()-10240),w);
 
-                    listener.getLogger().print(ExpandableDetailsNote.encodeTo("details",w.toString()));
-                    listener.getLogger().println();
+                        listener.getLogger().print(ExpandableDetailsNote.encodeTo("details",w.toString()));
+                        listener.getLogger().println();
+                    }
                 }
 
                 // kill run-away processes that are left

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -798,8 +798,6 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
     List<T> newInstancesFromHeteroList(StaplerRequest req, JSONObject formData, String key,
                 Collection<? extends Descriptor<T>> descriptors) throws FormException {
 
-        List<T> items = new ArrayList<T>();
-
         return newInstancesFromHeteroList(req,formData.get(key),descriptors);
     }
 

--- a/core/src/main/java/hudson/security/FederatedLoginService.java
+++ b/core/src/main/java/hudson/security/FederatedLoginService.java
@@ -37,6 +37,7 @@ import org.kohsuke.stapler.StaplerResponse;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.io.Serializable;
 
 /**
  * Abstraction for a login mechanism through external authenticator/identity provider
@@ -109,7 +110,7 @@ public abstract class FederatedLoginService implements ExtensionPoint {
     /**
      * Identity information as obtained from {@link FederatedLoginService}.
      */
-    public abstract class FederatedIdentity {
+    public abstract class FederatedIdentity implements Serializable {
         /**
          * Gets the string representation of the identity in the form that makes sense to the enclosing
          * {@link FederatedLoginService}, such as full OpenID URL.

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -580,7 +580,7 @@ public class SlaveComputer extends Computer {
 
         // if this method is called from within the slave computation thread, this should work
         Channel c = Channel.current();
-        if (c!=null && c.getProperty("slave")==Boolean.TRUE)
+        if (c!=null && Boolean.TRUE.equals(c.getProperty("slave")))
             return c;
 
         return null;

--- a/core/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/core/src/main/java/hudson/tasks/junit/TestResult.java
@@ -170,8 +170,8 @@ public final class TestResult extends MetaTabulatedResult {
             File f = new File(baseDir,includedFiles[0]);
             throw new AbortException(
                 String.format(
-                "Test reports were found but none of them are new. Did tests run? \n"+
-                "For example, %s is %s old\n", f,
+                "Test reports were found but none of them are new. Did tests run? %n"+
+                "For example, %s is %s old%n", f,
                 Util.getTimeSpanString(buildTime-f.lastModified())));
         }
     }

--- a/core/src/main/java/hudson/tasks/test/DefaultTestResultParserImpl.java
+++ b/core/src/main/java/hudson/tasks/test/DefaultTestResultParserImpl.java
@@ -103,8 +103,8 @@ public abstract class DefaultTestResultParserImpl extends TestResultParser imple
                     // none of the files were new
                     throw new AbortException(
                         String.format(
-                        "Test reports were found but none of them are new. Did tests run? \n"+
-                        "For example, %s is %s old\n", paths[0].getRemote(),
+                        "Test reports were found but none of them are new. Did tests run? %n"+
+                        "For example, %s is %s old%n", paths[0].getRemote(),
                         Util.getTimeSpanString(localBuildTime-paths[0].lastModified())));
                 }
 

--- a/core/src/main/java/hudson/util/Graph.java
+++ b/core/src/main/java/hudson/util/Graph.java
@@ -148,11 +148,6 @@ public abstract class Graph {
     public void doMap(StaplerRequest req, StaplerResponse rsp) throws IOException {
         if (req.checkIfModified(timestamp, rsp)) return;
 
-        String w = req.getParameter("width");
-        if(w==null)     w=String.valueOf(defaultW);
-        String h = req.getParameter("height");
-        if(h==null)     h=String.valueOf(defaultH);
-
         ChartRenderingInfo info = new ChartRenderingInfo();
         render(req,info);
 

--- a/core/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/core/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -441,58 +441,55 @@ public class QuotedStringTokenizer
         if (first!=last || (first!='"' && first!='\''))
             return s;
 
-        StringBuffer b=new StringBuffer(s.length()-2);
-        synchronized(b)
+        StringBuilder b=new StringBuilder(s.length()-2);
+        boolean escape=false;
+        for (int i=1;i<s.length()-1;i++)
         {
-            boolean escape=false;
-            for (int i=1;i<s.length()-1;i++)
+            char c = s.charAt(i);
+
+            if (escape)
             {
-                char c = s.charAt(i);
-
-                if (escape)
+                escape=false;
+                switch (c)
                 {
-                    escape=false;
-                    switch (c)
-                    {
-                        case 'n':
-                            b.append('\n');
-                            break;
-                        case 'r':
-                            b.append('\r');
-                            break;
-                        case 't':
-                            b.append('\t');
-                            break;
-                        case 'f':
-                            b.append('\f');
-                            break;
-                        case 'b':
-                            b.append('\b');
-                            break;
-                        case 'u':
-                            b.append((char)(
-                                    (convertHexDigit((byte)s.charAt(i++))<<24)+
-                                    (convertHexDigit((byte)s.charAt(i++))<<16)+
-                                    (convertHexDigit((byte)s.charAt(i++))<<8)+
-                                    (convertHexDigit((byte)s.charAt(i++)))
-                                    )
-                            );
-                            break;
-                        default:
-                            b.append(c);
-                    }
+                    case 'n':
+                        b.append('\n');
+                        break;
+                    case 'r':
+                        b.append('\r');
+                        break;
+                    case 't':
+                        b.append('\t');
+                        break;
+                    case 'f':
+                        b.append('\f');
+                        break;
+                    case 'b':
+                        b.append('\b');
+                        break;
+                    case 'u':
+                        b.append((char)(
+                                (convertHexDigit((byte)s.charAt(i++))<<24)+
+                                (convertHexDigit((byte)s.charAt(i++))<<16)+
+                                (convertHexDigit((byte)s.charAt(i++))<<8)+
+                                (convertHexDigit((byte)s.charAt(i++)))
+                                )
+                        );
+                        break;
+                    default:
+                        b.append(c);
                 }
-                else if (c=='\\')
-                {
-                    escape=true;
-                    continue;
-                }
-                else
-                    b.append(c);
             }
-
-            return b.toString();
+            else if (c=='\\')
+            {
+                escape=true;
+                continue;
+            }
+            else
+                b.append(c);
         }
+
+        return b.toString();
     }
 
     /* ------------------------------------------------------------ */

--- a/core/src/main/java/hudson/util/VersionNumber.java
+++ b/core/src/main/java/hudson/util/VersionNumber.java
@@ -105,7 +105,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
 
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         for( int i=0; i<digits.length; i++ ) {
             if(i!=0)    buf.append('.');
             buf.append( Integer.toString(digits[i]) );

--- a/core/src/main/java/hudson/util/spring/BeanBuilder.java
+++ b/core/src/main/java/hudson/util/spring/BeanBuilder.java
@@ -391,9 +391,9 @@ public class BeanBuilder extends GroovyObjectSupport {
     private void finalizeDeferredProperties() {
         for (DeferredProperty dp : deferredProperties.values()) {
             if (dp.value instanceof List) {
-                dp.value = manageListIfNecessary(dp.value);
+                dp.value = manageListIfNecessary((List)dp.value);
             } else if (dp.value instanceof Map) {
-                dp.value = manageMapIfNecessary(dp.value);
+                dp.value = manageMapIfNecessary((Map)dp.value);
             }
             dp.setInBeanConfig();
         }
@@ -558,10 +558,9 @@ public class BeanBuilder extends GroovyObjectSupport {
 	 * @param value The current map
 	 * @return A ManagedMap or a normal map
 	 */
-	private Object manageMapIfNecessary(Object value) {
-		Map<Object,Object> map = (Map)value;
+	private Object manageMapIfNecessary(Map<Object, Object> value) {
 		boolean containsRuntimeRefs = false;
-        for (Entry<Object,Object> e : map.entrySet()) {
+        for (Entry<Object, Object> e : value.entrySet()) {
             Object v = e.getValue();
             if (v instanceof RuntimeBeanReference) {
                 containsRuntimeRefs = true;
@@ -575,7 +574,7 @@ public class BeanBuilder extends GroovyObjectSupport {
 		if(containsRuntimeRefs) {
 //			return new ManagedMap(map);
             ManagedMap m = new ManagedMap();
-            m.putAll(map);
+            m.putAll(value);
             return m;
         }
 		return value;
@@ -588,10 +587,9 @@ public class BeanBuilder extends GroovyObjectSupport {
 	 * @param value The object that represents the list
 	 * @return Either a new list or a managed one
 	 */
-	private Object manageListIfNecessary(Object value) {
-		List list = (List)value;
+	private Object manageListIfNecessary(List<Object> value) {
 		boolean containsRuntimeRefs = false;
-		for (ListIterator i = list.listIterator(); i.hasNext();) {
+		for (ListIterator<Object> i = value.listIterator(); i.hasNext();) {
 			Object e = i.next();
 			if(e instanceof RuntimeBeanReference) {
 				containsRuntimeRefs = true;
@@ -604,7 +602,7 @@ public class BeanBuilder extends GroovyObjectSupport {
         }
 		if(containsRuntimeRefs) {
 			List tmp = new ManagedList();
-			tmp.addAll((List)value);
+			tmp.addAll(value);
 			value = tmp;
 		}
 		return value;


### PR DESCRIPTION
remove unused code
use %n for new lines in format strings
don't use synchronized collections in a local-only context
guard against npes
method parms should document the types of values they expect
remove wasteful duplicate method calls
don't use reference comparisons with Booleans
remove needless null check, subject isn't null (from above)
Classes that derive from FederatedIdentity are put into the session and should therefore be serializable
