### PR TITLE
Fix problem causing Eclipse errors

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -593,7 +593,16 @@ THE SOFTWARE.
           <groupId>commons-cli</groupId>
           <artifactId>commons-cli</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jvnet.hudson</groupId>
+          <artifactId>commons-jelly</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jvnet.hudson</groupId>
+      <artifactId>commons-jelly</artifactId>
+      <version>1.1-hudson-20100305</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson</groupId>


### PR DESCRIPTION
The problem is that there is a dependency conflict. This exclusion fixes it. The maven build doesn't seem to care but Eclipse does: the older version of the class doesn't have a method that we use. (asWrite).
