### PR TITLE
Pre checkout

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -412,6 +412,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 workspace = lease.path.getRemote();
                 node.getFileSystemProvisioner().prepareWorkspace(AbstractBuild.this,lease.path,listener);
 
+                preCheckout(launcher,listener);
                 checkout(listener);
 
                 if (!preBuild(listener,project.getProperties()))
@@ -489,6 +490,25 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             return l;
         }
 
+        
+        /**
+         * Run preCheckout on {@link BuildWrapper}s
+         * 
+         * @param launcher
+         * 		The launcher, never null.
+         * @param listener
+         * 		Never null, connected to the main build output.
+         * @throws IOException
+         * @throws InterruptedException
+         */
+        private void preCheckout(Launcher launcher, BuildListener listener) throws IOException, InterruptedException{
+        	if (project instanceof BuildableItemWithBuildWrappers) {
+                BuildableItemWithBuildWrappers biwbw = (BuildableItemWithBuildWrappers) project;
+                for (BuildWrapper bw : biwbw.getBuildWrappersList())
+                    bw.preCheckout(AbstractBuild.this,launcher,listener);
+            }
+        }
+        
         private void checkout(BuildListener listener) throws Exception {
             try {
                 for (int retryCount=project.getScmCheckoutRetryCount(); ; retryCount--) {

--- a/core/src/main/java/hudson/tasks/BuildWrapper.java
+++ b/core/src/main/java/hudson/tasks/BuildWrapper.java
@@ -202,6 +202,28 @@ public abstract class BuildWrapper extends AbstractDescribableImpl<BuildWrapper>
     }
 
     /**
+     * Provides an opportunity for a {@link BuildWrapper} to perform some actions before SCM checkout.
+     *
+     * <p>
+     * This hook is called early on in the build (before {@link #setUp(AbstractBuild, Launcher, BuildListener)}, 
+     * but after {@link #decorateLauncher(AbstractBuild, Launcher, BuildListener)} is invoked.)
+     * The typical use is delete existing workspace before new build starts etc.
+     *
+     * <p>
+     * The default implementation is no-op.
+     * 
+     * @param build
+     *      The build in progress for which this {@link BuildWrapper} is called. Never null.
+     * @param launcher
+     *      The launcher. Never null. 
+     * @param listener
+     *      Connected to the build output. Never null. Can be used for error reporting.
+     *      
+     */
+    public void preCheckout(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException{
+    }
+    
+    /**
      * {@link Action} to be displayed in the job page.
      *
      * @param job


### PR DESCRIPTION
Added pre-checkout method.
This method is called after assinging the workspace to the build, but before SCM checkout. Can be implemented by BuildWrappers. The typical use is delete existing workspace before new build starts etc.
