### PR TITLE
Fix for JENKINS-7785

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/reporters/MavenSiteArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/MavenSiteArchiver.java
@@ -23,30 +23,31 @@
  */
 package hudson.maven.reporters;
 
+import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
-import hudson.Extension;
 import hudson.maven.MavenBuild;
 import hudson.maven.MavenBuildProxy;
+import hudson.maven.MavenBuildProxy.BuildCallable;
 import hudson.maven.MavenModule;
 import hudson.maven.MavenModuleSet;
 import hudson.maven.MavenReporter;
 import hudson.maven.MavenReporterDescriptor;
 import hudson.maven.MojoInfo;
-import hudson.maven.MavenBuildProxy.BuildCallable;
 import hudson.model.AbstractItem;
 import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.DirectoryBrowserSupport;
 import hudson.model.ProminentProjectAction;
 import hudson.model.Result;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 
 /**
  * Watches out for the execution of maven-site-plugin and records its output.
@@ -61,6 +62,11 @@ public class MavenSiteArchiver extends MavenReporter {
     public boolean postExecute(MavenBuildProxy build, MavenProject pom, MojoInfo mojo, BuildListener listener, Throwable error) throws InterruptedException, IOException {
         if(!mojo.is("org.apache.maven.plugins","maven-site-plugin","site"))
             return true;
+
+    	if(build.isArchivingDisabled()) {
+    		listener.getLogger().println("[JENKINS] Archiving disabled - not archiving site for " + pom.getName());
+    		return true;
+    	}
 
         File destDir;
         try {


### PR DESCRIPTION
This is a fix for JENKINS-7785.  When automatic artifact archiving is disabled Jenkins still attempts to archive sites generated.  I believe this is incorrect.  If artifact archiving is disabled then archiving sites should also be disabled.

In addition there are currently some bugs regarding site archiving that are causing my builds to frequently fail JENKINS-7922.  If we can disable site archiving then that gives those afflicted with this bug a workaround until JENKINS-7922 is fixed.  Currently there is no known workaround for JENKINS-7922 other than to not use a maven build.
