### PR TITLE
Allow maven builds to (opionally) make use of the token-macro-plugin.

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -253,6 +253,14 @@ THE SOFTWARE.
       <artifactId>nekohtml</artifactId>
       <version>1.9.13</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>token-macro</artifactId>
+      <version>1.0</version>
+      <optional>true</optional>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/maven-plugin/src/main/java/hudson/maven/AbstractMavenProcessFactory.java
+++ b/maven-plugin/src/main/java/hudson/maven/AbstractMavenProcessFactory.java
@@ -38,6 +38,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.framework.io.IOException2;
 
 /*
@@ -88,11 +89,14 @@ public abstract class AbstractMavenProcessFactory
      */
     private final FilePath workDir;
 
-    AbstractMavenProcessFactory(MavenModuleSet mms, Launcher launcher, EnvVars envVars, FilePath workDir) {
+    private final String mavenOpts;
+
+    AbstractMavenProcessFactory(MavenModuleSet mms, Launcher launcher, EnvVars envVars, String mavenOpts, FilePath workDir) {
         this.mms = mms;
         this.launcher = launcher;
         this.envVars = envVars;
         this.workDir = workDir;
+        this.mavenOpts = mavenOpts;
     }
 
     /**
@@ -243,8 +247,11 @@ public abstract class AbstractMavenProcessFactory
      */
     protected abstract ArgumentListBuilder buildMavenAgentCmdLine(BuildListener listener,int tcpPort) 
         throws IOException, InterruptedException;
-    
+
     public String getMavenOpts() {
+        if( this.mavenOpts != null )
+            return this.mavenOpts;
+
         String mavenOpts = mms.getMavenOpts();
 
         if ((mavenOpts==null) || (mavenOpts.trim().length()==0)) {
@@ -267,6 +274,7 @@ public abstract class AbstractMavenProcessFactory
         
         return envVars.expand(mavenOpts);
     }
+
 
     public MavenInstallation getMavenInstallation(TaskListener log) throws IOException, InterruptedException {
         MavenInstallation mi = mms.getMaven();

--- a/maven-plugin/src/main/java/hudson/maven/Maven3ProcessFactory.java
+++ b/maven-plugin/src/main/java/hudson/maven/Maven3ProcessFactory.java
@@ -51,8 +51,8 @@ import org.jvnet.hudson.maven3.launcher.Maven3Launcher;
 public class Maven3ProcessFactory extends AbstractMavenProcessFactory implements ProcessCache.Factory
 {
 
-    Maven3ProcessFactory(MavenModuleSet mms, Launcher launcher, EnvVars envVars, FilePath workDir) {
-        super( mms, launcher, envVars, workDir );
+    Maven3ProcessFactory(MavenModuleSet mms, Launcher launcher, EnvVars envVars, String mavenOpts, FilePath workDir) {
+        super( mms, launcher, envVars, mavenOpts, workDir );
     }
     /**
      * Builds the command line argument list to launch the maven process.

--- a/maven-plugin/src/main/java/hudson/maven/MavenProcessFactory.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenProcessFactory.java
@@ -78,8 +78,8 @@ import java.util.logging.Logger;
 final class MavenProcessFactory extends AbstractMavenProcessFactory implements ProcessCache.Factory {
 
 
-    MavenProcessFactory(MavenModuleSet mms, Launcher launcher, EnvVars envVars, FilePath workDir) {
-        super( mms, launcher, envVars, workDir );
+    MavenProcessFactory(MavenModuleSet mms, Launcher launcher, EnvVars envVars, String mavenOpts, FilePath workDir) {
+        super( mms, launcher, envVars, mavenOpts, workDir );
     }
 
     /**


### PR DESCRIPTION
It is useful to be able to pass parameters in the form of
-Doption=${THING}
to the maven builds.

The new token-macro-plugin stuff from KK is ideal for this.

To get the actual parameters through to the launch commandline requires
some adjustments to the Launcher API, because it is not aware of the
build itself, which is neccessary to do the options expansion. So instead
pass these through to the launcher itself.

If the token-macro-plugin is not installed, the behaviour remains as before.
