### PR TITLE
Fix for JENKINS-8929

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -100,6 +100,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1082,9 +1083,10 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     protected AbstractProject getBuildingDownstream() {
     	DependencyGraph graph = Hudson.getInstance().getDependencyGraph();
         Set<AbstractProject> tups = graph.getTransitiveDownstream(this);
-        tups.add(this);
+        Queue queue = Hudson.getInstance().getQueue();
+
         for (AbstractProject tup : tups) {
-            if(tup!=this && (tup.isBuilding() || tup.isInQueue()))
+			if(tup.isBuilding() || queue.getUnblockedItems().containsKey(tup))
                 return tup;
         }
         return null;

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -639,9 +639,8 @@ public class Queue extends ResourceController implements Saveable {
      */
     synchronized ItemList<Item> getUnblockedItems() {
     	ItemList<Item> queuedNotBlocked = new ItemList<Item>();
-        queuedNotBlocked.addAll(waitingList);
-        queuedNotBlocked.addAll(pendings);
-        queuedNotBlocked.addAll(buildables);
+        queuedNotBlocked.addAll(Arrays.asList(getItems()));
+        queuedNotBlocked.removeAll(blockedProjects);
         return queuedNotBlocked;
     }
 

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -77,6 +77,7 @@ import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -631,6 +632,17 @@ public class Queue extends ResourceController implements Saveable {
      */
     public synchronized List<BuildableItem> getPendingItems() {
         return new ArrayList<BuildableItem>(pendings.values());
+    }
+
+    /**
+     * Gets all items that are in the queue but not blocked
+     */
+    synchronized ItemList<Item> getUnblockedItems() {
+    	ItemList<Item> queuedNotBlocked = new ItemList<Item>();
+        queuedNotBlocked.addAll(waitingList);
+        queuedNotBlocked.addAll(pendings);
+        queuedNotBlocked.addAll(buildables);
+        return queuedNotBlocked;
     }
 
     /**
@@ -1557,7 +1569,7 @@ public class Queue extends ResourceController implements Saveable {
     /**
      * {@link ArrayList} of {@link Item} with more convenience methods.
      */
-    private static class ItemList<T extends Item> extends ArrayList<T> {
+    static class ItemList<T extends Item> extends ArrayList<T> {
     	public T get(Task task) {
     		for (T item: this) {
     			if (item.task == task) {


### PR DESCRIPTION
This is a minor change to core to fix <a href="http://issues.jenkins-ci.org/browse/JENKINS-8929">JENKINS-8929</a>; it changes the logic for blocking on downstream builds so that it does not block on a downstream build that is itself blocked.  This prevents the deadlock.
