### PR TITLE
Jenkins 6128

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -683,7 +683,11 @@ public class Fingerprint implements ModelObject, Saveable {
             if(j==null)
                 continue;
 
-            int oldest = j.getFirstBuild().getNumber();
+            Run firstBuild = j.getFirstBuild();
+			if(firstBuild==null)
+                continue;
+
+            int oldest = firstBuild.getNumber();
             if(!e.getValue().isSmallerThan(oldest))
                 return true;
         }

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -684,7 +684,7 @@ public class Fingerprint implements ModelObject, Saveable {
                 continue;
 
             Run firstBuild = j.getFirstBuild();
-			if(firstBuild==null)
+            if(firstBuild==null)
                 continue;
 
             int oldest = firstBuild.getNumber();


### PR DESCRIPTION
Hi.

I've just done a fix for http://issues.jenkins-ci.org/browse/JENKINS-6128
It simply adds an additional null check for Run returned by Job.getFirstBuild().
This is necessary since Job.getFirstBuild() is returning null if the Map returned by _getRuns() is empty.

Unfortunately, I'm not able to provide a test case for this scenario since Fingerprint.isAlive() requires a Hudson instance and I don't have the faintest idea, yet, how to create a HudsonTestCase...

Hope this helps,
Joern.
