### PR TITLE
Jenkins 6455

### DIFF
--- a/core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body_fr.properties
+++ b/core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body_fr.properties
@@ -20,11 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-All\ Failed\ Tests=Tous les tests qui ont échoués
+All\ Failed\ Tests=Tous les tests qui ont \u00E9chou\u00E9
 Loading...=Chargement...
 Skip=Pass\u00E9
 Test\ Name=Nom du test
-Duration=Durée
+Duration=Dur\u00E9e
 Age=Age
 All\ Tests=Tous les tests
 Fail=Echec


### PR DESCRIPTION
http://issues.jenkins-ci.org/browse/JENKINS-6455

fixed typo in french translation, and escaped the non ascii characters
