### PR TITLE
JENKINS-6439: Fixed Timeline widget's default view off by one day.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -61,6 +61,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=bug>
+    Default viewport of the Timeline widgets were off by one day.
+    (<a href="http://issues.jenkins-ci.org/browse/JENKINS-6439">issue 6439</a>)
+  <li class=bug>
     Label expression logic wasn't supporting a binary operator sequence like "a || b || c"
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-8537">issue 8537</a>)
   <li class=bug>

--- a/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
+++ b/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
@@ -70,7 +70,7 @@ THE SOFTWARE.
         theme1.timeline_start = new Date(${it.firstBuild.timeInMillis-24*60*60*1000});
         theme1.timeline_stop  = new Date(${it.lastBuild.timeInMillis+24*60*60*1000});
 
-        var d = theme1.timeline_stop;
+        var d = new Date(${it.lastBuild.timeInMillis});
         var bandInfos = [
             // the bar that shows outline
             Timeline.createBandInfo({


### PR DESCRIPTION
Second part of the JENKINS-6439 fix.

Signed-off-by: Matthias Kraft Matthias.Kraft@softwareag.com
