### PR TITLE
Fix for JENKINS-9281

### DIFF
--- a/debian/debian/jenkins.init
+++ b/debian/debian/jenkins.init
@@ -68,7 +68,7 @@ check_tcp_port() {
         port=$default
     fi
     
-    count=`netstat --listen --numeric-ports | grep \:$port | grep -c . `
+    count=`netstat --listen --numeric-ports | grep \:$port[[:space:]] | grep -c . `
     
     if [ $count -ne 0 ]; then
         echo "The selected $service port ($port) seems to be in use by another program "


### PR DESCRIPTION
The debian init script checks if the selected port number is in use, but can give false positives when the selected port is a prefix of other in-use ports. This commit matches the entire port number instead using POSIX character class.
