### PR TITLE
Link to the console output from the status icon of an entry in the HistoryWidget.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -131,6 +131,8 @@ Upcoming changes</a>
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-7537">issue 7537</a>)
   <li class=rfe>
     Added "about Jenkins" screen that shows the 3rd party license acknowledgement.
+  <li class=rfe>
+    Link to the console output from the status icon of an entry in the HistoryWidget.
 </ul>
 <h3><a name=v1.408>What's new in 1.408</a> (2011/04/18)</h3>
 <ul class=image>

--- a/changelog.html
+++ b/changelog.html
@@ -66,6 +66,8 @@ Upcoming changes</a>
   <li class=rfe>
     Add active configurations in remote API for matrix projects.
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-9248">issue 9248</a>)
+  <li class=rfe>
+    Link to the console output from the status icon of an entry in the HistoryWidget.
 </ul>
 </div><!--=TRUNK-END=-->
 
@@ -131,8 +133,6 @@ Upcoming changes</a>
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-7537">issue 7537</a>)
   <li class=rfe>
     Added "about Jenkins" screen that shows the 3rd party license acknowledgement.
-  <li class=rfe>
-    Link to the console output from the status icon of an entry in the HistoryWidget.
 </ul>
 <h3><a name=v1.408>What's new in 1.408</a> (2011/04/18)</h3>
 <ul class=image>

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
   <j:set var="transitive" value="${(it.firstTransientBuildKey!=null and (it.adapter.compare(build,it.firstTransientBuildKey) ge 0)) ? 'transitive' : null}" />
   <tr class="build-row no-wrap ${transitive}">
     <td>
-      <img width="16" height="16" src="${imagesURL}/16x16/${build.buildStatusUrl}" alt="${build.iconColor.description}" tooltip="${build.iconColor.description}" /><st:nbsp/>
+      <a href="${link}console"><img width="16" height="16" src="${imagesURL}/16x16/${build.buildStatusUrl}" alt="${build.iconColor.description} &gt; ${%Console Output}" tooltip="${build.iconColor.description} &gt; ${%Console Output}" /></a><st:nbsp/>
       ${build.displayName}
     </td>
     <td style="padding-right:0">


### PR DESCRIPTION
When analyzing failed or unstable builds, having the console output available from the status icon saves one click, which is very convenient if you have a lot of jobs. For sample output see:
http://huschteguzzel.de/hudson/job/sardine/ 
Note that the status icons of the builds are now links to the console.
When digging through 30 broken builds in the morning (not that bad as we have about 1200 jobs), the console link has helped a lot and was the only feature some developers were missing when we ditched our homegrown version against unpatched jenkins.
