### PR TITLE
Include file and directory permissions in tars and zip files we generate.

### DIFF
--- a/core/src/main/java/hudson/util/io/Archiver.java
+++ b/core/src/main/java/hudson/util/io/Archiver.java
@@ -24,9 +24,12 @@
 
 package hudson.util.io;
 
+import hudson.Functions;
+import hudson.os.PosixAPI;
 import hudson.util.FileVisitor;
 
 import java.io.Closeable;
+import java.io.File;
 
 /**
  * {@link FileVisitor} that creates archive files.
@@ -43,4 +46,19 @@ public abstract class Archiver extends FileVisitor implements Closeable {
     public int countEntries() {
         return entriesWritten;
     }
+
+    /**
+     * Gets the mode of a file/directory, if appropriate. Returns -1 if not on Unix.
+     */
+     public int getPathMode(String p) {
+        // If we're on Windows...
+        if (Functions.isWindows()) {
+            return -1;
+        }
+        // If we're on Unix...
+        else {
+            return PosixAPI.get().stat(p).mode();
+        }
+    }
+    
 }

--- a/core/src/main/java/hudson/util/io/TarArchiver.java
+++ b/core/src/main/java/hudson/util/io/TarArchiver.java
@@ -64,6 +64,7 @@ final class TarArchiver extends Archiver {
     @Override
     public void visitSymlink(File link, String target, String relativePath) throws IOException {
         TarEntry e = new TarEntry(relativePath, LF_SYMLINK);
+        e.setMode(getPathMode(link.getPath()));
 
         try {
             StringBuffer linkName = (StringBuffer) LINKNAME_FIELD.get(e);
@@ -89,6 +90,7 @@ final class TarArchiver extends Archiver {
         if(file.isDirectory())
             relativePath+='/';
         TarEntry te = new TarEntry(relativePath);
+        te.setMode(getPathMode(file.getPath()));
         te.setModTime(file.lastModified());
         if(!file.isDirectory())
             te.setSize(file.length());

--- a/core/src/main/java/hudson/util/io/ZipArchiver.java
+++ b/core/src/main/java/hudson/util/io/ZipArchiver.java
@@ -50,12 +50,15 @@ final class ZipArchiver extends Archiver {
     public void visit(File f, String relativePath) throws IOException {
         if(f.isDirectory()) {
             ZipEntry dirZipEntry = new ZipEntry(relativePath+'/');
+            dirZipEntry.setUnixMode(getPathMode(f.getPath()));
             // Setting this bit explicitly is needed by some unzipping applications (see HUDSON-3294).
             dirZipEntry.setExternalAttributes(BITMASK_IS_DIRECTORY);
             zip.putNextEntry(dirZipEntry);
             zip.closeEntry();
         } else {
-            zip.putNextEntry(new ZipEntry(relativePath));
+            ZipEntry fileZipEntry = new ZipEntry(relativePath);
+            fileZipEntry.setUnixMode(getPathMode(f.getPath()));
+            zip.putNextEntry(fileZipEntry);
             FileInputStream in = new FileInputStream(f);
             int len;
             while((len=in.read(buf))>0)


### PR DESCRIPTION
[FIXED JENKINS-9397] Added convenience method to hudson.util.io.Archiver to get the Unix mode (if appropriate) for a file, and modified TarArchiver and ZipArchiver to utilise this to get and set the Unix mode for files whent they're being archived.
