### PR TITLE
Allow blank rootDN in LDAPSecurityRealm

### DIFF
--- a/core/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/core/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -223,6 +223,12 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
     public final String rootDN;
 
     /**
+     * Allow the rootDN to be inferred? Default is false.
+     * If true, allow rootDN to be blank.
+     */
+    public final boolean inhibitInferRootDN;
+
+    /**
      * Specifies the relative DN from {@link #rootDN the root DN}.
      * This is used to narrow down the search space when doing user search.
      *
@@ -281,11 +287,12 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
     private transient LdapTemplate ldapTemplate;
 
     @DataBoundConstructor
-    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String managerDN, String managerPassword) {
+    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String managerDN, String managerPassword, boolean inhibitInferRootDN) {
         this.server = server.trim();
         this.managerDN = fixEmpty(managerDN);
         this.managerPassword = Scrambler.scramble(fixEmpty(managerPassword));
-        if(fixEmptyAndTrim(rootDN)==null)    rootDN= fixNull(inferRootDN(server));
+        this.inhibitInferRootDN = inhibitInferRootDN;
+        if(!inhibitInferRootDN && fixEmptyAndTrim(rootDN)==null) rootDN= fixNull(inferRootDN(server));
         this.rootDN = rootDN.trim();
         this.userSearchBase = fixNull(userSearchBase).trim();
         userSearch = fixEmptyAndTrim(userSearch);

--- a/core/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
+++ b/core/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
@@ -31,6 +31,8 @@ THE SOFTWARE.
   <f:advanced>
     <f:entry title="${%root DN}" help="/help/security/ldap/rootDN.html">
       <f:textbox name="ldap.rootDN" value="${instance.rootDN}" />
+      <f:checkbox name="ldap.inhibitInferRootDN" checked="${instance.inhibitInferRootDN}"
+        title="${%Allow blank rootDN}"/>
     </f:entry>
     <f:entry title="${%User search base}" help="/help/security/ldap/userSearchBase.html">
       <f:textbox name="ldap.userSearchBase" value="${instance.userSearchBase}" />

--- a/test/src/test/groovy/hudson/security/LDAPSecurityRealmTest.groovy
+++ b/test/src/test/groovy/hudson/security/LDAPSecurityRealmTest.groovy
@@ -42,7 +42,7 @@ public class LDAPSecurityRealmTest extends HudsonTestCase {
      * basic syntax errors and such.
      */
     void testGroovyBeanDef() {
-        hudson.securityRealm = new LDAPSecurityRealm("ldap.itd.umich.edu",null,null,null,null,null,null);
+        hudson.securityRealm = new LDAPSecurityRealm("ldap.itd.umich.edu",null,null,null,null,null,null,null);
         println hudson.securityRealm.securityComponents // force the component creation
     }
 


### PR DESCRIPTION
Add inhibitInferRootDN to LDAPSecurityRealm. This allows rootDN to be blank (via a checkbox), important for some broken AD servers accessed via LDAP.

Needs translations.

Addresses:
http://jenkins.361315.n4.nabble.com/LDAP-and-empty-root-DN-values-td2216124.html
http://jenkins.361315.n4.nabble.com/Active-Directory-problem-td1290316.html
et al
