### PR TITLE
Do not include trailing periods in console links.

### DIFF
--- a/core/src/main/java/hudson/console/UrlAnnotator.java
+++ b/core/src/main/java/hudson/console/UrlAnnotator.java
@@ -40,7 +40,7 @@ public class UrlAnnotator extends ConsoleAnnotatorFactory<Object> {
          * In addition, the last character shouldn't be ',' ':', '"', etc, as often those things show up right next
          * to URL in plain text (e.g., test="http://www.example.com/")
          */
-        private static final Pattern URL = Pattern.compile("\\b(http|https|ftp)://[^\\s<>]+[^\\s<>,:\"'()\\[\\]=]");
+        private static final Pattern URL = Pattern.compile("\\b(http|https|ftp)://[^\\s<>]+[^\\s<>,\\.:\"'()\\[\\]=]");
 
         private static final String OPEN = "'\"()[]<>";
         private static final String CLOSE= "'\")(][><";

--- a/core/src/test/java/hudson/console/UrlAnnotatorTest.java
+++ b/core/src/test/java/hudson/console/UrlAnnotatorTest.java
@@ -53,5 +53,8 @@ public class UrlAnnotatorTest extends TestCase {
                 + "ftp://bar</a> or &lt;<a href='https://baz/'>https://baz/</a> or (<a "
                 + "href='http://a.b.c/x.y'>http://a.b.c/x.y</a> Bye",
                 text.toString(true));
+        text = new MarkupText("Punctuation: http://foo/.");
+        ca.annotate(null, text);
+        assertEquals("Punctuation: <a href='http://foo/'>http://foo/</a>.", text.toString(true));
     }
 }


### PR DESCRIPTION
Trailing periods create incorrect links in output from the svn-tag plugin, but may affect other plugins as well.

For example, tagging http://my-tag.com/ results in:
"There was no old tag at <a href="http://my-tag.com/.">http://my-tag.com/.</a>"

Since commas, colons, and quotes are ignored already, periods probably should be handled in the same fashion.
