### PR TITLE
[JENKINS-9687] log build step which has changed the build result to console

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -79,6 +79,9 @@ Upcoming changes</a>
   <li class=rfe>
     Replaced all gif images with png images (transparency support).
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3969">issue 3969</a>)
+  <li class=rfe>
+    Log which build step has changed the build result to build console
+    (<a href="http://issues.jenkins-ci.org/browse/JENKINS-9687">issue 9687</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 


### PR DESCRIPTION
Logs whenever a build step changes the build result to the console.

Note: I've also added a getName() method the the BuildStep interface to be able to log a more descriptive name than just the BuildStep's class name. If that change is to heavy weight in your opinion we can also just use e.g. the simple class name.
