### PR TITLE
JENKINS-9691: Boldify names of executed mojos for Freestyle and Maven2/3 jobs using Maven3 in console output

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -79,6 +79,8 @@ Upcoming changes</a>
   <li class=rfe>
     Replaced all gif images with png images (transparency support).
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3969">issue 3969</a>)
+  <li class=rfe>
+    Make mojo plugins bold in console output of Maven3.
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/tasks/_maven/Maven3MojoNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/Maven3MojoNote.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010, InfraDNA, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.tasks._maven;
+
+import hudson.Extension;
+import hudson.MarkupText;
+import hudson.console.ConsoleAnnotationDescriptor;
+import hudson.console.ConsoleAnnotator;
+import hudson.console.ConsoleNote;
+
+import java.util.regex.Pattern;
+
+/**
+ * Marks the log line that reports that Maven3 is executing a mojo.
+ * It'll look something like this:
+ *
+ * <pre>[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---</pre>
+ *
+ * or
+ *
+ * <pre>[INFO] --- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---</pre>
+ *
+ * or
+ *
+ * <pre>[INFO] --- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---</pre>
+ *
+ * @author Mirko Friedenhagen
+ */
+public class Maven3MojoNote extends ConsoleNote {
+    public Maven3MojoNote() {
+    }
+
+    @Override
+    public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
+        text.addMarkup(7,text.length(),"<b class=maven-mojo>","</b>");
+        return null;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        public String getDisplayName() {
+            return "Maven3 Mojos";
+        }
+    }
+
+    public static Pattern PATTERN = Pattern.compile("\\[INFO\\] --- (.*-plugin):([^:]*):([^ ]*) \\((.*)\\) (.*) ---");
+}

--- a/core/src/main/java/hudson/tasks/_maven/Maven3MojoNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/Maven3MojoNote.java
@@ -60,9 +60,9 @@ public class Maven3MojoNote extends ConsoleNote {
     @Extension
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
         public String getDisplayName() {
-            return "Maven3 Mojos";
+            return "Maven 3 Mojos";
         }
     }
 
-    public static Pattern PATTERN = Pattern.compile("\\[INFO\\] --- (.*-plugin):([^:]*):([^ ]*) \\((.*)\\) (.*) ---");
+    public static Pattern PATTERN = Pattern.compile("\\[INFO\\] --- .+-plugin:[^:]+:[^ ]+ \\(.+\\) @ .+ ---");
 }

--- a/core/src/main/java/hudson/tasks/_maven/MavenConsoleAnnotator.java
+++ b/core/src/main/java/hudson/tasks/_maven/MavenConsoleAnnotator.java
@@ -60,6 +60,10 @@ public class MavenConsoleAnnotator extends LineTransformationOutputStream {
         if (m.matches())
             new MavenMojoNote().encodeTo(out);
 
+        m = Maven3MojoNote.PATTERN.matcher(line);
+        if (m.matches())
+            new Maven3MojoNote().encodeTo(out);
+
         m = MavenWarningNote.PATTERN.matcher(line);
         if (m.find())
             new MavenWarningNote().encodeTo(out);

--- a/core/src/test/java/hudson/tasks/_maven/Maven3MojoNoteTest.java
+++ b/core/src/test/java/hudson/tasks/_maven/Maven3MojoNoteTest.java
@@ -1,0 +1,31 @@
+package hudson.tasks._maven;
+
+import static org.junit.Assert.assertEquals;
+import hudson.MarkupText;
+
+import org.junit.Test;
+
+public class Maven3MojoNoteTest {
+
+	@Test
+	public void testAnnotateMavenPlugin() {
+		assertEquals("[INFO] <b class=maven-mojo>--- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---</b>", annotate("[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---"));
+	}
+
+	@Test
+	public void testAnnotateCodehausPlugin() {
+		assertEquals("[INFO] <b class=maven-mojo>--- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---</b>", annotate("[INFO] --- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---"));
+	}
+
+	@Test
+	public void testAnnotateOtherPlugin() {
+		assertEquals("[INFO] <b class=maven-mojo>--- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---</b>", annotate("[INFO] --- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---"));
+	}
+
+    private String annotate(String text) {
+        MarkupText markupText = new MarkupText(text);
+        new Maven3MojoNote().annotate(new Object(), markupText, 0);
+        return markupText.toString(true);
+    }
+
+}

--- a/core/src/test/java/hudson/tasks/_maven/Maven3MojoNoteTest.java
+++ b/core/src/test/java/hudson/tasks/_maven/Maven3MojoNoteTest.java
@@ -1,6 +1,7 @@
 package hudson.tasks._maven;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import hudson.MarkupText;
 
 import org.junit.Test;
@@ -9,21 +10,27 @@ public class Maven3MojoNoteTest {
 
 	@Test
 	public void testAnnotateMavenPlugin() {
-		assertEquals("[INFO] <b class=maven-mojo>--- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---</b>", annotate("[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---"));
+		check("[INFO] <b class=maven-mojo>--- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---</b>", "[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---");
 	}
 
 	@Test
 	public void testAnnotateCodehausPlugin() {
-		assertEquals("[INFO] <b class=maven-mojo>--- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---</b>", annotate("[INFO] --- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---"));
+		check("[INFO] <b class=maven-mojo>--- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---</b>", "[INFO] --- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---");
+
 	}
 
 	@Test
 	public void testAnnotateOtherPlugin() {
-		assertEquals("[INFO] <b class=maven-mojo>--- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---</b>", annotate("[INFO] --- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---"));
+		check("[INFO] <b class=maven-mojo>--- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---</b>", "[INFO] --- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---");
+	}
+
+	private void check(final String decorated, final String input) {
+		assertTrue(input + " does not match" + Maven3MojoNote.PATTERN, Maven3MojoNote.PATTERN.matcher(input).matches());
+		assertEquals(decorated, annotate(input));
 	}
 
     private String annotate(String text) {
-        MarkupText markupText = new MarkupText(text);
+        final MarkupText markupText = new MarkupText(text);
         new Maven3MojoNote().annotate(new Object(), markupText, 0);
         return markupText.toString(true);
     }

--- a/maven-plugin/src/main/java/hudson/maven/util/ExecutionEventLogger.java
+++ b/maven-plugin/src/main/java/hudson/maven/util/ExecutionEventLogger.java
@@ -19,6 +19,7 @@ package hudson.maven.util;
  * under the License.
  */
 
+import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -261,13 +262,18 @@ public class ExecutionEventLogger
     {
         if ( logger.isInfoEnabled() )
         {
-            StringBuilder buffer = new StringBuilder( 128 );
-
+			final Maven3PluginMojoNote note = new Maven3PluginMojoNote();
+			final StringBuilder buffer = new StringBuilder( 128 );
+			try {
+				buffer.append( note.encode() );
+			} catch ( IOException e ) {
+				// As we use only memory buffers this should not happen, ever.
+				throw new RuntimeException( "Could not encode note?", e );
+			}
             buffer.append( "--- " );
             append( buffer, event.getMojoExecution() );
             append( buffer, event.getProject() );
             buffer.append( " ---" );
-
             logger.info( "" );
             logger.info( buffer.toString() );
         }

--- a/maven-plugin/src/main/java/hudson/maven/util/Maven3PluginMojoNote.java
+++ b/maven-plugin/src/main/java/hudson/maven/util/Maven3PluginMojoNote.java
@@ -1,0 +1,42 @@
+package hudson.maven.util;
+
+import hudson.Extension;
+import hudson.MarkupText;
+import hudson.console.ConsoleAnnotationDescriptor;
+import hudson.console.ConsoleAnnotator;
+import hudson.console.ConsoleNote;
+
+/**
+ * Marks the log line that reports that Maven3 is executing a mojo.
+ * It'll look something like this:
+ *
+ * <pre>[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---</pre>
+ *
+ * or
+ *
+ * <pre>[INFO] --- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---</pre>
+ *
+ * or
+ *
+ * <pre>[INFO] --- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---</pre>
+ *
+ * @author Mirko Friedenhagen
+ */
+public class Maven3PluginMojoNote extends ConsoleNote {
+
+	@Override
+	public ConsoleAnnotator annotate(Object context, MarkupText text,
+			int charPos) {
+		text.addMarkup(7, text.length(), "<b class=maven-mojo>", "</b>");
+		return null;
+	}
+
+	@Extension
+	public static final class DescriptorImpl extends
+			ConsoleAnnotationDescriptor {
+		public String getDisplayName() {
+			return "Maven-Plugin Maven 3 Mojos";
+		}
+	}
+
+}


### PR DESCRIPTION
With Maven2 the name and goal of an executed mojo will be printed in bold letters to the console. However Maven 3 changed the console output during start of executed mojos, so the old regex does not work anymore for freestyle jobs. Moreover Maven2/3 jobs use the ExecutionEventLogger to print names to the console.
