### PR TITLE
[FIXED JENKINS-9691] Boldify names of executed mojos for Freestyle and Maven2/3 jobs using Maven3 in console output.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -82,6 +82,9 @@ Upcoming changes</a>
   <li class=rfe>
     Replaced all gif images with png images (transparency support).
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-3969">issue 3969</a>)
+  <li class=rfe>
+    Boldify names of executed mojos for Freestyle and Maven2/3 jobs using Maven3 in console output.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-9691">issue 9691</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/tasks/_maven/Maven3MojoNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/Maven3MojoNote.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010, InfraDNA, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.tasks._maven;
+
+import hudson.Extension;
+import hudson.MarkupText;
+import hudson.console.ConsoleAnnotationDescriptor;
+import hudson.console.ConsoleAnnotator;
+import hudson.console.ConsoleNote;
+
+import java.util.regex.Pattern;
+
+/**
+ * Marks the log line that reports that Maven3 is executing a mojo.
+ * It'll look something like this:
+ *
+ * <pre>[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---</pre>
+ *
+ * or
+ *
+ * <pre>[INFO] --- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---</pre>
+ *
+ * or
+ *
+ * <pre>[INFO] --- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---</pre>
+ *
+ * @author Mirko Friedenhagen
+ */
+public class Maven3MojoNote extends ConsoleNote {
+    public Maven3MojoNote() {
+    }
+
+    @Override
+    public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
+        text.addMarkup(7,text.length(),"<b class=maven-mojo>","</b>");
+        return null;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        public String getDisplayName() {
+            return "Maven 3 Mojos";
+        }
+    }
+
+    public static Pattern PATTERN = Pattern.compile("\\[INFO\\] --- .+-plugin:[^:]+:[^ ]+ \\(.+\\) @ .+ ---");
+}

--- a/core/src/main/java/hudson/tasks/_maven/MavenConsoleAnnotator.java
+++ b/core/src/main/java/hudson/tasks/_maven/MavenConsoleAnnotator.java
@@ -60,6 +60,10 @@ public class MavenConsoleAnnotator extends LineTransformationOutputStream {
         if (m.matches())
             new MavenMojoNote().encodeTo(out);
 
+        m = Maven3MojoNote.PATTERN.matcher(line);
+        if (m.matches())
+            new Maven3MojoNote().encodeTo(out);
+
         m = MavenWarningNote.PATTERN.matcher(line);
         if (m.find())
             new MavenWarningNote().encodeTo(out);

--- a/core/src/test/java/hudson/tasks/_maven/Maven3MojoNoteTest.java
+++ b/core/src/test/java/hudson/tasks/_maven/Maven3MojoNoteTest.java
@@ -1,0 +1,38 @@
+package hudson.tasks._maven;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import hudson.MarkupText;
+
+import org.junit.Test;
+
+public class Maven3MojoNoteTest {
+
+	@Test
+	public void testAnnotateMavenPlugin() {
+		check("[INFO] <b class=maven-mojo>--- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---</b>", "[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ jobConfigHistory ---");
+	}
+
+	@Test
+	public void testAnnotateCodehausPlugin() {
+		check("[INFO] <b class=maven-mojo>--- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---</b>", "[INFO] --- cobertura-maven-plugin:2.4:instrument (report:cobertura) @ sardine ---");
+
+	}
+
+	@Test
+	public void testAnnotateOtherPlugin() {
+		check("[INFO] <b class=maven-mojo>--- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---</b>", "[INFO] --- gmaven-plugin:1.0-rc-5:generateTestStubs (test-in-groovy) @ jobConfigHistory ---");
+	}
+
+	private void check(final String decorated, final String input) {
+		assertTrue(input + " does not match" + Maven3MojoNote.PATTERN, Maven3MojoNote.PATTERN.matcher(input).matches());
+		assertEquals(decorated, annotate(input));
+	}
+
+    private String annotate(String text) {
+        final MarkupText markupText = new MarkupText(text);
+        new Maven3MojoNote().annotate(new Object(), markupText, 0);
+        return markupText.toString(true);
+    }
+
+}

--- a/maven-plugin/src/main/java/hudson/maven/util/ExecutionEventLogger.java
+++ b/maven-plugin/src/main/java/hudson/maven/util/ExecutionEventLogger.java
@@ -19,6 +19,9 @@ package hudson.maven.util;
  * under the License.
  */
 
+import hudson.tasks._maven.Maven3MojoNote;
+
+import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -261,13 +264,18 @@ public class ExecutionEventLogger
     {
         if ( logger.isInfoEnabled() )
         {
-            StringBuilder buffer = new StringBuilder( 128 );
-
+            final Maven3MojoNote note = new Maven3MojoNote();
+            final StringBuilder buffer = new StringBuilder( 128 );
+            try {
+                buffer.append( note.encode() );
+            } catch ( IOException e ) {
+                // As we use only memory buffers this should not happen, ever.
+                throw new RuntimeException( "Could not encode note?", e );
+            }
             buffer.append( "--- " );
             append( buffer, event.getMojoExecution() );
             append( buffer, event.getProject() );
             buffer.append( " ---" );
-
             logger.info( "" );
             logger.info( buffer.toString() );
         }


### PR DESCRIPTION
With Maven3 the output format for mojos has changed:
- Add a new Maven3MojoNote and use it in MavenConsoleAnnotator.
- This is sufficient for Freestyle jobs running Maven2 or 3 and Maven2/3
  jobs running Maven 2.
- Maven2/3 jobs running Maven 3 are using ExecutionEventLogger for
  printing start of mojo execution to console.

Working samples: http://huschteguzzel.de/hudson/job/test-multimodule/24/console and http://huschteguzzel.de/hudson/job/test-multimodule-freestyle/4/console
