### PR TITLE
[FIXED JENKINS-9699] Fix unescaped apostrophe in French translation.

### DIFF
--- a/core/src/main/resources/hudson/triggers/Messages_fr.properties
+++ b/core/src/main/resources/hudson/triggers/Messages_fr.properties
@@ -24,4 +24,4 @@ SCMTrigger.DisplayName=Scruter l''outil de gestion de version
 SCMTrigger.getDisplayName=Log du dernier accès à {0}
 SCMTrigger.SCMTriggerCause.ShortDescription=Un changement dans la base de code a provoqué le lancement de ce job
 TimerTrigger.DisplayName=Construire périodiquement
-TimerTrigger.TimerTriggerCause.ShortDescription=L''échéance d'une alarme périodique a provoqué le lancement de ce job
+TimerTrigger.TimerTriggerCause.ShortDescription=L''\u00e9\u00e9ch\u00e9ance d''une alarme p\u00e9riodique a provoqu\u00e9 le lancement de ce job


### PR DESCRIPTION
Simple as can be.
