### PR TITLE
Reopened [JENKINS-1613] Improved functionality for rebuilding subset of matrix

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/core/src/main/java/hudson/matrix/MatrixBuild.java
@@ -152,8 +152,7 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
         return r;
     }
     
-    private MatrixRun getRunForConfiguration( MatrixConfiguration c, int number )
-    {
+    private MatrixRun getRunForConfiguration( MatrixConfiguration c, int number ) {
         MatrixRun b = c.getNearestOldBuild(getNumber());
         if(b.getNumber()!=getNumber() && linkedNumber > 0) {
         	b = c.getNearestOldBuild(linkedNumber);

--- a/core/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/core/src/main/java/hudson/matrix/MatrixBuild.java
@@ -116,15 +116,33 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
     }
 
     /**
+     * If greater than zero, the {@link MatrixBuild} originates from the given build number.
+     */
+    public int linkedNumber = 0;
+    
+    /**
+     * Sets the linked number
+     * @param linkedNumber A given number indicating the origin
+     */
+    public void setLinkedNumber( int linkedNumber ) {
+    	this.linkedNumber = linkedNumber;
+    }
+
+
+    /**
      * Gets the {@link MatrixRun} in this build that corresponds
      * to the given combination.
      */
     public MatrixRun getRun(Combination c) {
         MatrixConfiguration config = getParent().getItem(c);
         if(config==null)    return null;
-        return config.getNearestOldBuild(getNumber());
+        MatrixRun b = config.getNearestOldBuild(getNumber());
+        if(b.getNumber()!=getNumber() && linkedNumber > 0) {
+        	b = config.getNearestOldBuild(linkedNumber);
+        }
+        return b;
     }
-
+    
     /**
      * Returns all {@link MatrixRun}s for this {@link MatrixBuild}.
      */
@@ -133,6 +151,9 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
         List<MatrixRun> r = new ArrayList<MatrixRun>();
         for(MatrixConfiguration c : getParent().getItems()) {
             MatrixRun b = c.getNearestOldBuild(getNumber());
+            if(b.getNumber()!=getNumber() && linkedNumber > 0) {
+            	b = c.getNearestOldBuild(linkedNumber);
+            }
             if (b != null) r.add(b);
         }
         return r;

--- a/core/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/core/src/main/java/hudson/matrix/MatrixBuild.java
@@ -136,11 +136,7 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
     public MatrixRun getRun(Combination c) {
         MatrixConfiguration config = getParent().getItem(c);
         if(config==null)    return null;
-        MatrixRun b = config.getNearestOldBuild(getNumber());
-        if(b.getNumber()!=getNumber() && linkedNumber > 0) {
-        	b = config.getNearestOldBuild(linkedNumber);
-        }
-        return b;
+        return getRunForConfiguration( config, getNumber() );
     }
     
     /**
@@ -150,13 +146,20 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
     public List<MatrixRun> getRuns() {
         List<MatrixRun> r = new ArrayList<MatrixRun>();
         for(MatrixConfiguration c : getParent().getItems()) {
-            MatrixRun b = c.getNearestOldBuild(getNumber());
-            if(b.getNumber()!=getNumber() && linkedNumber > 0) {
-            	b = c.getNearestOldBuild(linkedNumber);
-            }
+            MatrixRun b = getRunForConfiguration( c, getNumber() );
             if (b != null) r.add(b);
         }
         return r;
+    }
+    
+    private MatrixRun getRunForConfiguration( MatrixConfiguration c, int number )
+    {
+        MatrixRun b = c.getNearestOldBuild(getNumber());
+        if(b.getNumber()!=getNumber() && linkedNumber > 0) {
+        	b = c.getNearestOldBuild(linkedNumber);
+        }
+        
+        return b;
     }
 
     /**


### PR DESCRIPTION
This change ensures that a rebuild matrix has the possibility to originate from exactly one matrix build.
Given the current strategy, a rebuild matrix can be composed of several different matrix builds.
