### PR TITLE
Validate view name based on current context

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,7 +55,9 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
-  <li class=>
+  <li class=bug>
+  	Validate new view name relative to current context
+  </li>
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/resources/hudson/model/Hudson/newView.jelly
+++ b/core/src/main/resources/hudson/model/Hudson/newView.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
     <l:main-panel>
       <f:form method="post" action="createView" name="createView">
         <f:entry title="${%View name}">
-          <f:textbox id="name" name="name" checkUrl="'${rootURL}/viewExistsCheck?value='+encodeURIComponent(this.value)"
+          <f:textbox id="name" name="name" checkUrl="'viewExistsCheck?value='+encodeURIComponent(this.value)"
                      onchange="updateOk(this.form)" onkeyup="updateOk(this.form)" />
           <script>
             $('name').focus();


### PR DESCRIPTION
This change will allow correct validation when adding a new view to a ViewGroup (like in NestedView plugin)
