### PR TITLE
Jenkins-9787

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -13,6 +13,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <goals>
@@ -33,7 +34,7 @@
       <plugin>
         <groupId>org.jvnet.localizer</groupId>
         <artifactId>maven-localizer-plugin</artifactId>
-        <version>1.10</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <goals>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -841,7 +841,7 @@ THE SOFTWARE.
       </plugin>
       <plugin><!-- skip slow dependency analysis -->
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.1</version>
+        <version>2.4</version>
         <configuration>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
         </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,7 +48,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jvnet.hudson.tools</groupId>
         <artifactId>maven-encoding-plugin</artifactId>
-        <version>1.1</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <goals>
@@ -61,7 +61,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>com.infradna.tool</groupId>
         <artifactId>bridge-method-injector</artifactId>
-        <version>1.4</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <goals>
@@ -73,6 +73,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>maven-stapler-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <extensions>true</extensions>
         <dependencies>
           <dependency>
@@ -89,7 +90,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jvnet.localizer</groupId>
         <artifactId>maven-localizer-plugin</artifactId>
-        <version>1.10</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <goals>
@@ -105,7 +106,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.kohsuke</groupId>
         <artifactId>access-modifier-checker</artifactId>
-        <version>1.0</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <goals>
@@ -117,7 +118,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>antlr-maven-plugin</artifactId>
-        <version>2.1</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <id>cron</id>
@@ -144,6 +145,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
         <artifactId>maven-antrun-extended-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <phase>generate-resources</phase>
@@ -181,6 +183,7 @@ THE SOFTWARE.
       </plugin>
       <plugin><!-- set main class -->
         <artifactId>maven-jar-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <archive>
             <manifest>
@@ -198,7 +201,7 @@ THE SOFTWARE.
         -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>apt-maven-plugin</artifactId>
-        <version>1.0-alpha-4</version>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <force>true</force><!-- disable staleness check -->
           <factory>org.jvnet.hudson.tools.ExtensionPointListerFactory</factory>
@@ -246,7 +249,7 @@ THE SOFTWARE.
           <plugin><!-- execute apt:process for "Extension points" Wiki page generation -->
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>apt-maven-plugin</artifactId>
-            <version>1.0-alpha-2</version>
+            <!-- version specified in grandparent pom -->
             <executions>
               <execution>
                 <goals>
@@ -263,6 +266,7 @@ THE SOFTWARE.
             -->
             <groupId>org.kohsuke.stapler</groupId>
             <artifactId>maven-stapler-plugin</artifactId>
+            <!-- version specified in grandparent pom -->
             <executions>
               <execution>
                 <goals>
@@ -308,6 +312,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.kohsuke.gmaven</groupId>
             <artifactId>gmaven-plugin</artifactId>
+            <!-- version specified in grandparent pom -->
             <executions>
               <!-- run unit test -->
               <execution>
@@ -327,6 +332,7 @@ THE SOFTWARE.
           <plugin>
             <!-- unit tests are run by GMaven through Ant. -->
             <artifactId>maven-surefire-plugin</artifactId>
+            <!-- version specified in grandparent pom -->
             <configuration>
               <skipTests>true</skipTests>
             </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -291,7 +291,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>findbugs-maven-plugin</artifactId>
-            <version>1.2</version>
+            <version>2.3.2</version>
             <configuration>
               <effort>Max</effort>
               <threshold>Normal</threshold>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -339,12 +339,13 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>maven-stapler-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <extensions>true</extensions>
       </plugin>
       <plugin>
         <groupId>org.jvnet.localizer</groupId>
         <artifactId>maven-localizer-plugin</artifactId>
-        <version>1.8</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <goals>
@@ -360,6 +361,7 @@ THE SOFTWARE.
       <plugin><!-- generate licenses.xml -->
         <groupId>com.cloudbees</groupId>
         <artifactId>maven-license-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <generateLicenseXml>target/${project.artifactId}/WEB-INF/licenses.xml</generateLicenseXml>
         </configuration>
@@ -367,6 +369,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
         <artifactId>maven-antrun-extended-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <id>resgen</id>
@@ -397,7 +400,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.4-apb-SNAPSHOT</version>
+          <!-- version specified in grandparent pom -->
           <inherited>true</inherited>
           <configuration>
             <formats>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -157,7 +157,7 @@
       <plugin>
         <groupId>org.codehaus.groovy.maven</groupId>
         <artifactId>gmaven-plugin</artifactId>
-        <version>1.0-rc-5</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <id>test-in-groovy</id>
@@ -178,6 +178,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <systemProperties>
             <property>
@@ -190,7 +191,7 @@
       <plugin>
         <groupId>com.cloudbees</groupId>
         <artifactId>maven-license-plugin</artifactId>
-        <version>1.3</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@ THE SOFTWARE.
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.1-beta-1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.8</version>
           <configuration>
@@ -178,6 +183,68 @@ THE SOFTWARE.
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <!-- see http://maven-junit-plugin.kenai.com/ for more info -->
+          <groupId>org.kohsuke</groupId>
+          <artifactId>maven-junit-plugin</artifactId>
+          <version>1.9</version>
+         </plugin>
+        <plugin>
+          <groupId>org.jvnet.localizer</groupId>
+          <artifactId>maven-localizer-plugin</artifactId>
+          <version>1.10</version>
+         </plugin>
+        <plugin>
+          <groupId>org.jvnet.hudson.tools</groupId>
+          <artifactId>maven-encoding-plugin</artifactId>
+          <version>1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>com.infradna.tool</groupId>
+          <artifactId>bridge-method-injector</artifactId>
+          <version>1.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>antlr-maven-plugin</artifactId>
+          <version>2.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>apt-maven-plugin</artifactId>
+          <version>1.0-alpha-4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cobertura-maven-plugin</artifactId>
+          <version>2.4-apb-SNAPSHOT</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <version>2.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-pmd-plugin</artifactId>
+          <version>2.5</version>
+         </plugin>
+        <plugin>
+          <!-- this is really just a patched version of maven-jetty-plugin to workaround issue #932 -->
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-jenkins-dev-plugin</artifactId>
+          <version>6.1.26-jenkins-1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.jvnet.updatecenter2</groupId>
+          <artifactId>maven-makepkgs-plugin</artifactId>
+          <version>0.3</version>
+         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.5</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@ THE SOFTWARE.
         -->
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-jenkins-dev-plugin</artifactId>
-        <version>6.1.26-jenkins-1</version>
+        <version>6.1.26-jenkins-2</version>
       </plugin>
 
       <!--<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -418,9 +418,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.5</version>
-            <configuration>
-            </configuration>
+            <version>2.6</version>
           </plugin>
         </plugins>
       </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@ THE SOFTWARE.
           <!-- this is really just a patched version of maven-jetty-plugin to workaround issue #932 -->
           <groupId>org.jenkins-ci.tools</groupId>
           <artifactId>maven-jenkins-dev-plugin</artifactId>
-          <version>6.1.26-jenkins-1</version>
+          <version>6.1.26-jenkins-2</version>
         </plugin>
         <plugin>
           <groupId>org.jvnet.updatecenter2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <version>1.0</version>
+        <version>1.2</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.1</version>
+          <version>2.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.4-apb-SNAPSHOT</version>
+          <version>2.5</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -239,8 +239,8 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.jvnet.updatecenter2</groupId>
           <artifactId>maven-makepkgs-plugin</artifactId>
-          <version>0.3</version>
-         </plugin>
+          <version>0.5.1</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,11 @@ THE SOFTWARE.
           <artifactId>maven-antrun-plugin</artifactId>
           <version>1.6</version>
         </plugin>
+        <plugin>
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+          <version>1.69</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,10 @@ THE SOFTWARE.
           <version>2.6</version>
         </plugin>
         <plugin>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.2</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>2.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.jvnet.localizer</groupId>
           <artifactId>maven-localizer-plugin</artifactId>
-          <version>1.10</version>
+          <version>1.12</version>
          </plugin>
         <plugin>
           <groupId>org.jvnet.hudson.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.6.1</version>
+          <version>2.8</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -344,13 +344,6 @@ THE SOFTWARE.
       </plugin>-->
     </plugins>
 
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-http</artifactId>
-        <version>1.0-beta-5</version>
-      </extension>
-    </extensions>
   </build>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.8</version>
+          <version>2.8.1</version>
           <configuration>
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>2.1-beta-1</version>
+          <version>2.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.2-beta-5</version>
+          <version>2.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
           <artifactId>maven-antrun-extended-plugin</artifactId>
-          <version>1.39</version>
+          <version>1.42</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.5</version>
-        </plugin>        
+          <version>2.6</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>2.4.3</version>
+          <version>2.5</version>
         </plugin>
         <plugin>
           <!--

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>2.1</version>
+          <version>2.3.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -403,7 +403,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>findbugs-maven-plugin</artifactId>
-            <version>2.4</version>
+            <version>2.3.2</version>
             <configuration>
               <threshold>High</threshold>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.5</version>
+          <version>1.6</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -44,7 +44,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.1</version>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <threshold>High</threshold>
         </configuration>
@@ -52,7 +52,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>2.5</version>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <!--rulesets>
             <ruleset>ruleset.xml</ruleset>
@@ -62,6 +62,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <archive>
             <manifest>
@@ -91,6 +92,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
         <artifactId>maven-antrun-extended-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <id>generate-resources</id>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -46,48 +46,17 @@ THE SOFTWARE.
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <skip>true</skip><!-- tests now run by maven-junit-plugin -->
-        </configuration>
+        <groupId>org.kohsuke.stapler</groupId>
+        <artifactId>maven-stapler-plugin</artifactId>
+        <version>1.15</version>
+        <extensions>true</extensions>
       </plugin>
       <plugin>
-        <!-- see http://maven-junit-plugin.kenai.com/ for more info -->
-        <groupId>org.kohsuke</groupId>
-        <artifactId>maven-junit-plugin</artifactId>
-        <version>1.9</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <fork>true</fork>
-              <concurrency>${concurrency}</concurrency>
-              <argLine>-Dfile.encoding=UTF-8</argLine>
-              <timeout>300</timeout>
-              <systemProperties>
-                <property>
-                  <!-- use AntClassLoader that supports predictable file handle release -->
-                  <name>hudson.ClassicPluginStrategy.useAntClassLoader</name>
-                  <value>true</value>
-                </property>
-                <property>
-                  <name>hudson.maven.debug</name>
-                  <value>${mavenDebug}</value>
-                </property>
-                <property>
-                  <name>java.io.tmpdir</name>
-                  <value>${project.build.directory}</value>
-                </property> 
-                <property>
-                  <name>buildDirectory</name>
-                  <value>${project.build.directory}</value>
-                </property>                               
-              </systemProperties>
-            </configuration>
-          </execution>
-        </executions>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+          <!-- tests now run by maven-junit-plugin -->
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.kohsuke.gmaven</groupId>
@@ -120,15 +89,9 @@ THE SOFTWARE.
           </dependency>
         </dependencies>
       </plugin>
-      <plugin>
-        <groupId>org.kohsuke.stapler</groupId>
-        <artifactId>maven-stapler-plugin</artifactId>
-        <version>1.15</version>
-        <extensions>true</extensions>
-      </plugin>
     </plugins>
   </build>
-  
+
   <dependencies>
     <dependency>
       <!--
@@ -159,7 +122,8 @@ THE SOFTWARE.
       <groupId>org.jvnet.hudson</groupId>
       <artifactId>test-annotations</artifactId>
       <version>1.0</version>
-      <scope>compile</scope><!-- in this module we need this as a compile scope, whereas in the parent it's test -->
+      <scope>compile</scope>
+      <!-- in this module we need this as a compile scope, whereas in the parent it's test -->
     </dependency>
     <dependency>
       <groupId>org.jvnet.mock-javamail</groupId>
@@ -181,11 +145,11 @@ THE SOFTWARE.
       <artifactId>htmlunit</artifactId>
       <version>2.6-jenkins-4</version>
       <exclusions>
-      	<exclusion>
-	      	<!--  hides JDK DOM classes in Eclipse -->
-      		<groupId>xml-apis</groupId>
-      		<artifactId>xml-apis</artifactId>
-      	</exclusion>
+        <exclusion>
+          <!--  hides JDK DOM classes in Eclipse -->
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -214,6 +178,54 @@ THE SOFTWARE.
   </dependencies>
 
   <profiles>
+
+    <profile>
+      <id>run-test-harness</id>
+      <build>
+        <plugins>
+          <plugin>
+            <!-- see http://maven-junit-plugin.kenai.com/ for more info -->
+            <groupId>org.kohsuke</groupId>
+            <artifactId>maven-junit-plugin</artifactId>
+            <version>1.9</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <fork>true</fork>
+                  <concurrency>${concurrency}</concurrency>
+                  <argLine>-Dfile.encoding=UTF-8</argLine>
+                  <timeout>300</timeout>
+                  <systemProperties>
+                    <property>
+                      <!-- use AntClassLoader that supports predictable file handle release -->
+                      <name>hudson.ClassicPluginStrategy.useAntClassLoader</name>
+                      <value>true</value>
+                    </property>
+                    <property>
+                      <name>hudson.maven.debug</name>
+                      <value>${mavenDebug}</value>
+                    </property>
+                    <property>
+                      <name>java.io.tmpdir</name>
+                      <value>${project.build.directory}</value>
+                    </property>
+                    <property>
+                      <name>buildDirectory</name>
+                      <value>${project.build.directory}</value>
+                    </property>
+                  </systemProperties>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+    </profile>
+
     <profile>
       <id>light-test</id>
       <properties>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -47,6 +47,7 @@ THE SOFTWARE.
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <skip>true</skip><!-- tests now run by maven-junit-plugin -->
         </configuration>
@@ -55,7 +56,7 @@ THE SOFTWARE.
         <!-- see http://maven-junit-plugin.kenai.com/ for more info -->
         <groupId>org.kohsuke</groupId>
         <artifactId>maven-junit-plugin</artifactId>
-        <version>1.9</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <goals>
@@ -92,7 +93,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.kohsuke.gmaven</groupId>
         <artifactId>gmaven-plugin</artifactId>
-        <version>1.0-rc-5-patch-2</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <id>preset-packager</id>
@@ -123,7 +124,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>maven-stapler-plugin</artifactId>
-        <version>1.15</version>
+        <!-- version specified in grandparent pom -->
         <extensions>true</extensions>
       </plugin>
     </plugins>
@@ -230,6 +231,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.kohsuke.gmaven</groupId>
             <artifactId>gmaven-plugin</artifactId>
+            <!-- version specified in grandparent pom -->
             <executions>
               <!-- run unit test -->
               <execution>
@@ -246,14 +248,6 @@ THE SOFTWARE.
                 </configuration>
               </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <!-- unit tests are run by GMaven through Ant. -->
-            <groupId>com.sun.maven</groupId>
-            <artifactId>maven-junit-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -48,11 +48,12 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>maven-stapler-plugin</artifactId>
-        <version>1.15</version>
+        <!-- version specified in grandparent pom -->
         <extensions>true</extensions>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <skip>true</skip>
           <!-- tests now run by maven-junit-plugin -->
@@ -61,7 +62,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.kohsuke.gmaven</groupId>
         <artifactId>gmaven-plugin</artifactId>
-        <version>1.0-rc-5-patch-2</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <id>preset-packager</id>
@@ -187,7 +188,7 @@ THE SOFTWARE.
             <!-- see http://maven-junit-plugin.kenai.com/ for more info -->
             <groupId>org.kohsuke</groupId>
             <artifactId>maven-junit-plugin</artifactId>
-            <version>1.9</version>
+            <!-- version specified in grandparent pom -->
             <executions>
               <execution>
                 <goals>
@@ -242,6 +243,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.kohsuke.gmaven</groupId>
             <artifactId>gmaven-plugin</artifactId>
+            <!-- version specified in grandparent pom -->
             <executions>
               <!-- run unit test -->
               <execution>
@@ -258,14 +260,6 @@ THE SOFTWARE.
                 </configuration>
               </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <!-- unit tests are run by GMaven through Ant. -->
-            <groupId>com.sun.maven</groupId>
-            <artifactId>maven-junit-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/ui-samples-plugin/pom.xml
+++ b/ui-samples-plugin/pom.xml
@@ -92,13 +92,13 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>maven-stapler-plugin</artifactId>
-        <version>1.15</version>
+        <!-- version specified in grandparent pom -->
         <extensions>true</extensions>
       </plugin>
       <plugin>
         <groupId>org.jvnet.localizer</groupId>
         <artifactId>maven-localizer-plugin</artifactId>
-        <version>1.8</version>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <goals>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -44,7 +44,7 @@ THE SOFTWARE.
     <plugins>
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1-beta-1</version>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
           <webResources>
@@ -68,6 +68,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <phase>generate-resources</phase>
@@ -83,6 +84,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
         <artifactId>maven-antrun-extended-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <executions>
           <execution>
             <id>package</id>
@@ -135,6 +137,7 @@ THE SOFTWARE.
       <plugin><!-- generate licenses.xml -->
         <groupId>com.cloudbees</groupId>
         <artifactId>maven-license-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <generateLicenseXml>target/classes/META-INF/licenses.xml</generateLicenseXml>
           <inlineScript>
@@ -152,7 +155,7 @@ THE SOFTWARE.
         <!-- this is really just a patched version of maven-jetty-plugin to workaround issue #932 -->
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-jenkins-dev-plugin</artifactId>
-        <version>6.1.26-jenkins-1</version>
+        <!-- version specified in grandparent pom -->
         <configuration>
           <contextPath>${contextPath}</contextPath>
           <!--
@@ -316,7 +319,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.jvnet.updatecenter2</groupId>
             <artifactId>maven-makepkgs-plugin</artifactId>
-            <version>0.3</version>
+            <!-- version specified in grandparent pom -->
             <executions>
               <execution>
                 <goals>
@@ -341,6 +344,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
+            <!-- version specified in grandparent pom -->
             <executions>
               <!-- sign the war -->
               <execution>


### PR DESCRIPTION
Follow more Maven best practices

Share all versions of plugins in the main PluginManagement
Remove hardcoded http wagon (incompatible with M3
Keep up-to-date plugins when possible

To be applied after Jenkins-9788
