### PR TITLE
JENKINS-9786 : Jenkins can read repositories definitions from Maven POMs 

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -65,6 +65,9 @@ Upcoming changes</a>
   <li class=rfe>
     Improve the post deployment job to make a clear error if you disabled artifacts archives
     (<a href="http://issues.jenkins-ci.org/browse/JENKINS-9791">issue 9791</a>)
+  <li class=rfe>
+    Post-build deploy task for Maven jobs : Repositories definitions can now be read from the POMs.
+    (<a href="http://issues.jenkins-ci.org/browse/JENKINS-9786">issue 9786</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/maven-plugin/src/main/java/hudson/maven/RedeployPublisher.java
+++ b/maven-plugin/src/main/java/hudson/maven/RedeployPublisher.java
@@ -28,31 +28,15 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.maven.reporters.MavenAbstractArtifactRecord;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.Hudson;
-import hudson.model.Node;
-import hudson.model.Result;
-import hudson.model.TaskListener;
+import hudson.maven.reporters.MavenArtifactRecord;
+import hudson.model.*;
 import hudson.remoting.Callable;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Maven.MavenInstallation;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
-import hudson.util.FormValidation;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Properties;
-
 import net.sf.json.JSONObject;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.deployer.ArtifactDeploymentException;
@@ -65,8 +49,12 @@ import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.repository.Proxy;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * {@link Publisher} for {@link MavenModuleSetBuild} to deploy artifacts
@@ -90,6 +78,7 @@ public class RedeployPublisher extends Recorder {
     /**
      * For backward compatibility
      */
+    @Deprecated
     public RedeployPublisher(String id, String url, boolean uniqueVersion) {
     	this(id, url, uniqueVersion, false);
     }
@@ -105,47 +94,52 @@ public class RedeployPublisher extends Recorder {
         this.evenIfUnstable = evenIfUnstable;
     }
 
-    public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        if(build.getResult().isWorseThan(getTreshold()))
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        if (build.getResult().isWorseThan(getTreshold()))
             return true;    // build failed. Don't publish
 
-        if (url==null) {
-            listener.getLogger().println("No Repository URL is specified.");
+        List<MavenAbstractArtifactRecord> mavenAbstractArtifactRecords = getActions(build, listener);
+        if (mavenAbstractArtifactRecords == null || mavenAbstractArtifactRecords.isEmpty()) {
+            listener.getLogger().println("[ERROR] No artifacts are recorded. Is this a Maven project?");
             build.setResult(Result.FAILURE);
             return true;
         }
 
-        List<MavenAbstractArtifactRecord> mars = getActions( build, listener );
-        if(mars==null || mars.isEmpty()) {
-            listener.getLogger().println("No artifacts are recorded. Is this a Maven project?");
-            build.setResult(Result.FAILURE);
-            return true;
-        }
 
         if(build instanceof MavenModuleSetBuild && ((MavenModuleSetBuild)build).getParent().isArchivingDisabled()){
           listener.getLogger().println("[ERROR] You cannot use the \"Deploy artifacts to Maven repository\" feature if you " +
-                                           "disabled " +
-                                           "automatic artifact archiving");
+                                           "disabled automatic artifact archiving");
           build.setResult(Result.FAILURE);
           return true;
         }
 
-        listener.getLogger().println("Deploying artifacts to "+url);
+        long startupTime = Calendar.getInstance().getTimeInMillis();
+
         try {
-            
-            //MavenEmbedder embedder = MavenUtil.createEmbedder(listener,build);
-            MavenEmbedder embedder = createEmbedder(listener,build);
+            MavenEmbedder embedder = createEmbedder(listener, build);
             ArtifactRepositoryLayout layout =
-                (ArtifactRepositoryLayout) embedder.lookup( ArtifactRepositoryLayout.ROLE,"default");
+                    (ArtifactRepositoryLayout) embedder.lookup(ArtifactRepositoryLayout.ROLE, "default");
             ArtifactRepositoryFactory factory =
-                (ArtifactRepositoryFactory) embedder.lookup(ArtifactRepositoryFactory.ROLE);
-
-            final ArtifactRepository repository = factory.createDeploymentArtifactRepository(
-                    id, url, layout, uniqueVersion);
-            WrappedArtifactRepository repo = new WrappedArtifactRepository(repository,uniqueVersion);
-            for (MavenAbstractArtifactRecord mar : mars)
-                mar.deploy(embedder,repo,listener);
-
+                    (ArtifactRepositoryFactory) embedder.lookup(ArtifactRepositoryFactory.ROLE);
+            ArtifactRepository artifactRepository = null;
+            if (url != null) {
+                // By default we try to get the repository definition from the job configuration
+                artifactRepository = getDeploymentRepository(factory, layout, id, url);
+            }
+            for (MavenAbstractArtifactRecord mavenAbstractArtifactRecord : mavenAbstractArtifactRecords) {
+                if (artifactRepository == null && mavenAbstractArtifactRecord instanceof MavenArtifactRecord) {
+                    // If no repository definition is set on the job level we try to take it from the POM
+                    MavenArtifactRecord mavenArtifactRecord = (MavenArtifactRecord) mavenAbstractArtifactRecord;
+                    artifactRepository = getDeploymentRepository(factory, layout, mavenArtifactRecord.repositoryId, mavenArtifactRecord.repositoryUrl);
+                }
+                if (artifactRepository == null) {
+                    listener.getLogger().println("[ERROR] No Repository settings defined in the job configuration or distributionManagement of the module.");
+                    build.setResult(Result.FAILURE);
+                    return true;
+                }
+                mavenAbstractArtifactRecord.deploy(embedder, artifactRepository, listener);
+            }
+            listener.getLogger().println("[INFO] Deployment done in " + Util.getTimeSpanString(Calendar.getInstance().getTimeInMillis() - startupTime));
             return true;
         } catch (MavenEmbedderException e) {
             e.printStackTrace(listener.error(e.getMessage()));
@@ -156,7 +150,15 @@ public class RedeployPublisher extends Recorder {
         }
         // failed
         build.setResult(Result.FAILURE);
+        listener.getLogger().println("[INFO] Deployment failed after " + Util.getTimeSpanString(Calendar.getInstance().getTimeInMillis() - startupTime));
         return true;
+    }
+
+    private ArtifactRepository getDeploymentRepository(ArtifactRepositoryFactory factory, ArtifactRepositoryLayout layout, String repositoryId, String repositoryUrl) throws ComponentLookupException {
+        if (repositoryUrl == null) return null;
+        final ArtifactRepository repository = factory.createDeploymentArtifactRepository(
+                repositoryId, repositoryUrl, layout, uniqueVersion);
+        return new WrappedArtifactRepository(repository, uniqueVersion);
     }
 
     /**
@@ -312,13 +314,6 @@ public class RedeployPublisher extends Recorder {
             return true;
         }
 
-        public FormValidation doCheckUrl(@QueryParameter String url) {
-            String fixedUrl = hudson.Util.fixEmptyAndTrim(url);
-            if (fixedUrl==null)
-                return FormValidation.error(Messages.RedeployPublisher_RepositoryURL_Mandatory());
-
-            return FormValidation.ok();
-        }
     }
     
     //---------------------------------------------

--- a/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/config.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/config.jelly
@@ -24,10 +24,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="${%Repository URL}" field="url">
-    <f:textbox />
-  </f:entry>
   <f:advanced>
+    <f:entry title="${%Repository URL}" field="url">
+      <f:textbox />
+    </f:entry>
     <f:entry title="${%Repository ID}" field="id">
       <f:textbox />
     </f:entry>

--- a/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/config_fr.properties
+++ b/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/config_fr.properties
@@ -21,5 +21,6 @@
 # THE SOFTWARE.
 
 Repository\ URL=URL du repository
-Repository\ ID=ID du repository
-Assign\ unique\ versions\ to\ snapshots=Affecter des numéros de version uniques aux snapshots
+Repository\ ID=Identifiant du repository
+Assign\ unique\ versions\ to\ snapshots=Affecter des num\u00e9ros de version uniques aux snapshots
+Deploy\ even\ if\ the\ build\ is\ unstable=D\u00e9ploiment\\ m\u00eame si\\ le\\ build est\\ instable.


### PR DESCRIPTION
JENKINS-9786 : Jenkins can read repositories definitions from Maven POMs to use the deploy task after the build. It's no more necessary to set/duplicate this information in the job configuration.
