### PR TITLE
Post build deploy task : Deploy with unique versions (timestamp) should be configured by default

### DIFF
--- a/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/config.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/config.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
       <f:textbox />
     </f:entry>
     <f:entry field="uniqueVersion">
-      <f:checkbox title="${%Assign unique versions to snapshots}"/>
+      <f:checkbox title="${%Assign unique versions to snapshots}" default="true"/>
     </f:entry>
     <j:if test="${descriptor.showEvenIfUnstableOption()}">
       <f:entry field="evenIfUnstable">


### PR DESCRIPTION
JENKINS-9807 : [Maven Jobs] Post build deploy task : Deploy with unique versions (timestamp) should be configured by default

I didn't find to do it by updating the RedeployPublisher constructor like we discussed with KK. I put a default value in the config.jelly. I think it should be compatible for users already being using it but I would like a review. 
