### PR TITLE
Output user ID to User page

### DIFF
--- a/core/src/main/resources/hudson/model/User/index.jelly
+++ b/core/src/main/resources/hudson/model/User/index.jelly
@@ -32,6 +32,7 @@ THE SOFTWARE.
       </h1>
       <t:editableDescription permission="${app.ADMINISTER}" />
       <!-- give properties a chance to contribute summary item -->
+      ${%Jenkins User Id}: ${it.id}
       <j:forEach var="p" items="${it.allProperties}">
         <st:include page="summary.jelly" from="${p}" optional="true" it="${p}" />
       </j:forEach>

--- a/core/src/main/resources/hudson/model/User/index_de.properties
+++ b/core/src/main/resources/hudson/model/User/index_de.properties
@@ -1,0 +1,23 @@
+# The MIT License
+# 
+# Copyright (c) 2011 Olaf Lenz
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Jenkins\ User\ Id=Jenkins Benutzer Id

--- a/core/src/main/resources/hudson/model/View/People/index.jelly
+++ b/core/src/main/resources/hudson/model/View/People/index.jelly
@@ -39,6 +39,7 @@ THE SOFTWARE.
         <tr>
           <th />
           <th>${%Name}</th>
+          <th>${%User Id}</th>
           <th initialSortDir="up">${%Last Active}</th>
           <th>${%On}</th>
         </tr>
@@ -47,6 +48,7 @@ THE SOFTWARE.
             <td><a href="${rootURL}/${p.user.url}/"><img src="${imagesURL}/${iconSize}/user.png"
                  alt="" class="icon${iconSize}"/></a></td>
             <td><a href="${rootURL}/${p.user.url}/">${p.user}</a></td>
+            <td><a href="${rootURL}/${p.user.url}/">${p.user.id}</a></td>
             <td data="${p.timeSortKey}">${p.lastChangeTimeString}</td>
             <td><a href="${rootURL}/${p.project.url}">${p.project.fullDisplayName}</a></td>
           </tr>

--- a/core/src/main/resources/hudson/model/View/People/index.jelly
+++ b/core/src/main/resources/hudson/model/View/People/index.jelly
@@ -38,8 +38,8 @@ THE SOFTWARE.
       <table class="sortable pane bigtable" id="people">
         <tr>
           <th />
-          <th>${%Name}</th>
           <th>${%User Id}</th>
+          <th>${%Name}</th>
           <th initialSortDir="up">${%Last Active}</th>
           <th>${%On}</th>
         </tr>
@@ -47,8 +47,8 @@ THE SOFTWARE.
           <tr>
             <td><a href="${rootURL}/${p.user.url}/"><img src="${imagesURL}/${iconSize}/user.png"
                  alt="" class="icon${iconSize}"/></a></td>
-            <td><a href="${rootURL}/${p.user.url}/">${p.user}</a></td>
             <td><a href="${rootURL}/${p.user.url}/">${p.user.id}</a></td>
+            <td><a href="${rootURL}/${p.user.url}/">${p.user}</a></td>
             <td data="${p.timeSortKey}">${p.lastChangeTimeString}</td>
             <td><a href="${rootURL}/${p.project.url}">${p.project.fullDisplayName}</a></td>
           </tr>

--- a/core/src/main/resources/hudson/model/View/People/index_de.properties
+++ b/core/src/main/resources/hudson/model/View/People/index_de.properties
@@ -25,3 +25,4 @@ Last\ Active=Letzte Aktivität
 On=Job
 All\ People=Alle Benutzer
 People=Benutzer
+User\ Id=Jenkins Benutzer Id

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
@@ -34,12 +34,14 @@ THE SOFTWARE.
         <tr>
           <th style="width:32px"/>
           <th>${%Name}</th>
+          <th>${%User Id}</th>
           <th style="width:32px"/>
         </tr>
         <j:forEach var="user" items="${it.allUsers}">
           <tr>
             <td><a href="${user.url}/"><img src="${imagesURL}/32x32/user.png" alt="" height="32" width="32"/></a></td>
             <td><a href="${user.url}/">${user}</a></td>
+            <td><a href="${user.url}/">${user.id}</a></td>
             <td>
               <a href="${user.url}/configure"><img src="${imagesURL}/32x32/setting.png" alt="Setting" height="32" width="32"/></a>
               <j:if test="${user.canDelete()}">

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
@@ -33,15 +33,15 @@ THE SOFTWARE.
       <table class="sortable pane bigtable" id="people">
         <tr>
           <th style="width:32px"/>
-          <th>${%Name}</th>
           <th>${%User Id}</th>
+          <th>${%Name}</th>
           <th style="width:32px"/>
         </tr>
         <j:forEach var="user" items="${it.allUsers}">
           <tr>
             <td><a href="${user.url}/"><img src="${imagesURL}/32x32/user.png" alt="" height="32" width="32"/></a></td>
-            <td><a href="${user.url}/">${user}</a></td>
             <td><a href="${user.url}/">${user.id}</a></td>
+            <td><a href="${user.url}/">${user}</a></td>
             <td>
               <a href="${user.url}/configure"><img src="${imagesURL}/32x32/setting.png" alt="Setting" height="32" width="32"/></a>
               <j:if test="${user.canDelete()}">

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index_de.properties
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index_de.properties
@@ -26,4 +26,5 @@ Diese Benutzer können sich bei Jenkins anmelden. Dies ist eine Untermenge \
 angelegte Benutzer enthalten kann. Diese Benutzer haben zwar Commits zu Projekten \
 beigetragen, dürfen sich aber nicht direkt bei Jenkins anmelden.
 Name=Name
+User\ Id=Benutzer Id
 Users=Benutzer


### PR DESCRIPTION
This is my first commit to Jenkins, so I hope in case of errors you might be forgiving.

With this patch, Jenkins will output the User Id of a user to the User page. Without this page, the only way to find out about your user id is via the URL.

Olaf
