### PR TITLE
RemoteClassLoader is not honoring the classloader that's passed to the Channel contructor

### DIFF
--- a/remoting/src/main/java/hudson/remoting/Channel.java
+++ b/remoting/src/main/java/hudson/remoting/Channel.java
@@ -239,6 +239,11 @@ public class Channel implements VirtualChannel, IChannel {
     /*package*/ final ExecutorService pipeWriter;
 
     /**
+     * ClassLaoder that remote classloaders should use as the basis.
+     */
+    /*package*/ final ClassLoader baseClassLoader;
+
+    /**
      * Communication mode.
      * @since 1.161
      */
@@ -356,6 +361,7 @@ public class Channel implements VirtualChannel, IChannel {
 
         if (base==null)
             base = getClass().getClassLoader();
+        this.baseClassLoader = base;
 
         if(export(this,false)!=1)
             throw new AssertionError(); // export number 1 is reserved for the channel itself

--- a/remoting/src/main/java/hudson/remoting/ImportedClassLoaderTable.java
+++ b/remoting/src/main/java/hudson/remoting/ImportedClassLoaderTable.java
@@ -54,7 +54,7 @@ final class ImportedClassLoaderTable {
         if(r==null) {
             // we need to be able to use the same hudson.remoting classes, hence delegate
             // to this class loader.
-            r = RemoteClassLoader.create(getClass().getClassLoader(),classLoaderProxy);
+            r = RemoteClassLoader.create(channel.baseClassLoader,classLoaderProxy);
             classLoaders.put(classLoaderProxy,r);
         }
         return r;


### PR DESCRIPTION
This is one we found a CloudBees that KK has found a fix for
