### PR TITLE
Fix whitespace in maven installation

### DIFF
--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -381,7 +381,7 @@ public class Maven extends Builder {
 
         @DataBoundConstructor
         public MavenInstallation(String name, String home, List<? extends ToolProperty<?>> properties) {
-            super(name, home, properties);
+            super(Util.fixEmptyAndTrim(name), Util.fixEmptyAndTrim(home), properties);
         }
 
         /**


### PR DESCRIPTION
I just spent a while chasing down a problem which turned out to be trailing whitespace on the maven installation path.  This should fix it.

Would you prefer if I pushed this down into the ToolInstallation constructor?

Thanks,
-Dom
