### PR TITLE
ldap group memberUid to check against name

### DIFF
--- a/war/src/main/webapp/WEB-INF/security/LDAPBindSecurityRealm.groovy
+++ b/war/src/main/webapp/WEB-INF/security/LDAPBindSecurityRealm.groovy
@@ -64,7 +64,7 @@ bindAuthenticator(BindAuthenticator2,initialDirContextFactory) {
 authoritiesPopulator(AuthoritiesPopulatorImpl, initialDirContextFactory, instance.groupSearchBase) {
     // see DefaultLdapAuthoritiesPopulator for other possible configurations
     searchSubtree = true;
-    groupSearchFilter = "(| (member={0}) (uniqueMember={0}) (memberUid={1}))";
+    groupSearchFilter = "(| (member={0}) (uniqueMember={0}) (memberUid={0}))";
 }
 
 authenticationManager(ProviderManager) {


### PR DESCRIPTION
according to rfc2307 which says the memberUid is a name (not a uid
strangely enough)

just going by
http://manpages.ubuntu.com/manpages/natty/man5/sssd-ldap.5.html
ldap_schema description and my broken install on ubuntu...

I can't say what ldif I used except it was standard (I didn't write it)
and ldapscripts and phpLDAPadmin all seem to want the field to be a name.

If anyone is relying on the broken implementation it would be safer to add another clause rather than change the clause as I have done.  If adding a clause, add it before the (memberUid={1}) because that throws an integer conversion exception for me.
