### PR TITLE
Replace crappy VersionNumber with better implementation.

### DIFF
--- a/core/src/main/java/hudson/util/VersionNumber.java
+++ b/core/src/main/java/hudson/util/VersionNumber.java
@@ -1,45 +1,36 @@
-/*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- *
- * Copyright 1997-2007 Sun Microsystems, Inc. All rights reserved.
- *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License. You can obtain
- * a copy of the License at https://glassfish.dev.java.net/public/CDDL+GPL.html
- * or glassfish/bootstrap/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at glassfish/bootstrap/legal/LICENSE.txt.
- * Sun designates this particular file as subject to the "Classpath" exception
- * as provided by Sun in the GPL Version 2 section of the License file that
- * accompanied this code.  If applicable, add the following below the License
- * Header, with the fields enclosed by brackets [] replaced by your own
- * identifying information: "Portions Copyrighted [year]
- * [name of copyright owner]"
- *
- * Contributor(s):
- *
- * If you wish your version of this file to be governed by only the CDDL or
- * only the GPL Version 2, indicate your decision by adding "[Contributor]
- * elects to include this software in this distribution under the [CDDL or GPL
- * Version 2] license."  If you don't indicate a single choice of license, a
- * recipient has the option to distribute your version of this file under
- * either the CDDL, the GPL Version 2 or to extend the choice of license to
- * its licensees as provided above.  However, if you add GPL Version 2 code
- * and therefore, elected the GPL Version 2 license, then the option applies
- * only if the new code is made subject to such option by the copyright
- * holder.
- */
 package hudson.util;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
-import java.util.StringTokenizer;
+import java.util.Properties;
+import java.util.Stack;
 
 /**
- * Immutable representation of a dot or '-'-separated digits (such as "1.0.1" or "1.0-52").
+ * Immutable representation of a version number based on the Mercury version numbering scheme.
  *
  * {@link VersionNumber}s are {@link Comparable}.
  *
@@ -59,94 +50,436 @@ import java.util.StringTokenizer;
  * </pre>
  *
  * @author
- *     Kohsuke Kawaguchi (kohsuke.kawaguchi@sun.com)
+ *     Stephen Connolly (kohsuke.kawaguchi@sun.com)
  * @since 1.139
  */
+
+/**
+ * Generic implementation of version comparison. (Replacing previous implementation since 1.139)
+ *
+ * @author Stephen Connolly (stephenc@apache.org)
+ * @author Kenney Westerhof (kenney@apache.org)
+ * @author Hervé Boutemy (hboutemy@apache.org)
+ * @since 1.415
+ */
 public class VersionNumber implements Comparable<VersionNumber> {
-    private final int[] digits;
+    private String value;
+
+    private String canonical;
+
+    private ListItem items;
+
+    private interface Item {
+        public static final int INTEGER_ITEM = 0;
+
+        public static final int STRING_ITEM = 1;
+
+        public static final int LIST_ITEM = 2;
+
+        public static final int WILDCARD_ITEM = 3;
+
+        public int compareTo(Item item);
+
+        public int getType();
+
+        public boolean isNull();
+    }
 
     /**
-     * Parses a string like "1.0.2" into the version number.
-     *
-     * @throws IllegalArgumentException
-     *      if the parsing fails.
+     * Represents a wild-card item in the version item list.
      */
-    public VersionNumber( String num ) {
-        StringTokenizer tokens = new StringTokenizer(num,".-");
-        digits = new int[tokens.countTokens()];
-        if(digits.length<2)
-            throw new IllegalArgumentException("Failed to parse "+num+" as version number");
+    private static class WildCardItem implements Item {
 
-        int i=0;
-        while( tokens.hasMoreTokens() ) {
-            String token = tokens.nextToken().toLowerCase(Locale.ENGLISH);
-            if(token.equals("*")) {
-                digits[i++] = 1000;
-            } else
-            if(token.startsWith("snapshot")) {
-                digits[i-1]--;
-                digits[i++] = 1000;
-                break;
-            } else
-            if(token.startsWith("ea")) {
-                if(token.length()==2)
-                    digits[i++] = -1000;    // just "ea"
-                else
-                    digits[i++] = -1000 + Integer.parseInt(token.substring(2)); // "eaNNN"
-            } else {
-                digits[i++] = Integer.parseInt(token);
+        public int compareTo(Item item) {
+            switch (item.getType()) {
+                case INTEGER_ITEM:
+                case LIST_ITEM:
+                case STRING_ITEM:
+                    return 1;
+                case WILDCARD_ITEM:
+                    return 0;
+                default:
+                    return 1;
             }
         }
+
+        public int getType() {
+            return WILDCARD_ITEM;
+        }
+
+        public boolean isNull() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "*";
+        }
+    }
+
+    /**
+     * Represents a numeric item in the version item list.
+     */
+    private static class IntegerItem
+            implements Item {
+        private static final BigInteger BigInteger_ZERO = new BigInteger("0");
+
+        private final BigInteger value;
+
+        public static final IntegerItem ZERO = new IntegerItem();
+
+        private IntegerItem() {
+            this.value = BigInteger_ZERO;
+        }
+
+        public IntegerItem(String str) {
+            this.value = new BigInteger(str);
+        }
+
+        public int getType() {
+            return INTEGER_ITEM;
+        }
+
+        public boolean isNull() {
+            return BigInteger_ZERO.equals(value);
+        }
+
+        public int compareTo(Item item) {
+            if (item == null) {
+                return BigInteger_ZERO.equals(value) ? 0 : 1; // 1.0 == 1, 1.1 > 1
+            }
+
+            switch (item.getType()) {
+                case INTEGER_ITEM:
+                    return value.compareTo(((IntegerItem) item).value);
+
+                case STRING_ITEM:
+                    return 1; // 1.1 > 1-sp
+
+                case LIST_ITEM:
+                    return 1; // 1.1 > 1-1
+
+                case WILDCARD_ITEM:
+                    return 0;
+
+                default:
+                    throw new RuntimeException("invalid item: " + item.getClass());
+            }
+        }
+
+        public String toString() {
+            return value.toString();
+        }
+    }
+
+    /**
+     * Represents a string in the version item list, usually a qualifier.
+     */
+    private static class StringItem implements Item {
+        private final static String[] QUALIFIERS = {"snapshot", "alpha", "beta", "milestone", "rc", "", "sp"};
+
+        private final static List<String> _QUALIFIERS = Arrays.asList(QUALIFIERS);
+
+        private final static Properties ALIASES = new Properties();
+
+        static {
+            ALIASES.put("ga", "");
+            ALIASES.put("final", "");
+            ALIASES.put("cr", "rc");
+            ALIASES.put("ea", "rc");
+        }
+
+        /**
+         * A comparable for the empty-string qualifier. This one is used to determine if a given qualifier makes the
+         * version older than one without a qualifier, or more recent.
+         */
+        private static String RELEASE_VERSION_INDEX = String.valueOf(_QUALIFIERS.indexOf(""));
+
+        private String value;
+
+        public StringItem(String value, boolean followedByDigit) {
+            if (followedByDigit && value.length() == 1) {
+                // a1 = alpha-1, b1 = beta-1, m1 = milestone-1
+                switch (value.charAt(0)) {
+                    case 'a':
+                        value = "alpha";
+                        break;
+                    case 'b':
+                        value = "beta";
+                        break;
+                    case 'm':
+                        value = "milestone";
+                        break;
+                }
+            }
+            this.value = ALIASES.getProperty(value, value);
+        }
+
+        public int getType() {
+            return STRING_ITEM;
+        }
+
+        public boolean isNull() {
+            return (comparableQualifier(value).compareTo(RELEASE_VERSION_INDEX) == 0);
+        }
+
+        /**
+         * Returns a comparable for a qualifier.
+         * <p/>
+         * This method both takes into account the ordering of known qualifiers as well as lexical ordering for unknown
+         * qualifiers.
+         * <p/>
+         * just returning an Integer with the index here is faster, but requires a lot of if/then/else to check for -1
+         * or QUALIFIERS.size and then resort to lexical ordering. Most comparisons are decided by the first character,
+         * so this is still fast. If more characters are needed then it requires a lexical sort anyway.
+         *
+         * @param qualifier
+         * @return
+         */
+        public static String comparableQualifier(String qualifier) {
+            int i = _QUALIFIERS.indexOf(qualifier);
+
+            return i == -1 ? _QUALIFIERS.size() + "-" + qualifier : String.valueOf(i);
+        }
+
+        public int compareTo(Item item) {
+            if (item == null) {
+                // 1-rc < 1, 1-ga > 1
+                return comparableQualifier(value).compareTo(RELEASE_VERSION_INDEX);
+            }
+            switch (item.getType()) {
+                case INTEGER_ITEM:
+                    return -1; // 1.any < 1.1 ?
+
+                case STRING_ITEM:
+                    return comparableQualifier(value).compareTo(comparableQualifier(((StringItem) item).value));
+
+                case LIST_ITEM:
+                    return -1; // 1.any < 1-1
+
+                case WILDCARD_ITEM:
+                    return -1;
+
+                default:
+                    throw new RuntimeException("invalid item: " + item.getClass());
+            }
+        }
+
+        public String toString() {
+            return value;
+        }
+    }
+
+    /**
+     * Represents a version list item. This class is used both for the global item list and for sub-lists (which start
+     * with '-(number)' in the version specification).
+     */
+    private static class ListItem extends ArrayList<Item> implements Item {
+        public int getType() {
+            return LIST_ITEM;
+        }
+
+        public boolean isNull() {
+            return (size() == 0);
+        }
+
+        void normalize() {
+            for (ListIterator iterator = listIterator(size()); iterator.hasPrevious(); ) {
+                Item item = (Item) iterator.previous();
+                if (item.isNull()) {
+                    iterator.remove(); // remove null trailing items: 0, "", empty list
+                } else {
+                    break;
+                }
+            }
+        }
+
+        public int compareTo(Item item) {
+            if (item == null) {
+                if (size() == 0) {
+                    return 0; // 1-0 = 1- (normalize) = 1
+                }
+                Item first = (Item) get(0);
+                return first.compareTo(null);
+            }
+
+            switch (item.getType()) {
+                case INTEGER_ITEM:
+                    return -1; // 1-1 < 1.0.x
+
+                case STRING_ITEM:
+                    return 1; // 1-1 > 1-sp
+
+                case LIST_ITEM:
+                    Iterator left = iterator();
+                    Iterator right = ((ListItem) item).iterator();
+
+                    while (left.hasNext() || right.hasNext()) {
+                        Item l = left.hasNext() ? (Item) left.next() : null;
+                        Item r = right.hasNext() ? (Item) right.next() : null;
+
+                        // if this is shorter, then invert the compare and mul with -1
+                        int result = l == null ? -1 * r.compareTo(l) : l.compareTo(r);
+
+                        if (result != 0) {
+                            return result;
+                        }
+                    }
+
+                    return 0;
+
+                case WILDCARD_ITEM:
+                    return -1;
+
+                default:
+                    throw new RuntimeException("invalid item: " + item.getClass());
+            }
+        }
+
+        public String toString() {
+            StringBuilder buffer = new StringBuilder("(");
+            for (Iterator<Item> iter = iterator(); iter.hasNext(); ) {
+                buffer.append(iter.next());
+                if (iter.hasNext()) {
+                    buffer.append(',');
+                }
+            }
+            buffer.append(')');
+            return buffer.toString();
+        }
+    }
+
+    public VersionNumber(String version) {
+        parseVersion(version);
+    }
+
+    private void parseVersion(String version) {
+        this.value = version;
+
+        items = new ListItem();
+
+        version = version.toLowerCase(Locale.ENGLISH);
+
+        ListItem list = items;
+
+        Stack<Item> stack = new Stack<Item>();
+        stack.push(list);
+
+        boolean isDigit = false;
+
+        int startIndex = 0;
+
+        for (int i = 0; i < version.length(); i++) {
+            char c = version.charAt(i);
+
+            if (c == '.') {
+                if (i == startIndex) {
+                    list.add(IntegerItem.ZERO);
+                } else {
+                    list.add(parseItem(isDigit, version.substring(startIndex, i)));
+                }
+                startIndex = i + 1;
+            } else if (c == '-') {
+                if (i == startIndex) {
+                    list.add(IntegerItem.ZERO);
+                } else {
+                    list.add(parseItem(isDigit, version.substring(startIndex, i)));
+                }
+                startIndex = i + 1;
+
+                if (isDigit) {
+                    list.normalize(); // 1.0-* = 1-*
+
+                    if ((i + 1 < version.length()) && Character.isDigit(version.charAt(i + 1))) {
+                        // new ListItem only if previous were digits and new char is a digit,
+                        // ie need to differentiate only 1.1 from 1-1
+                        list.add(list = new ListItem());
+
+                        stack.push(list);
+                    }
+                }
+            } else if (c == '*') {
+                list.add(new WildCardItem());
+                startIndex = i + 1;
+            } else if (Character.isDigit(c)) {
+                if (!isDigit && i > startIndex) {
+                    list.add(new StringItem(version.substring(startIndex, i), true));
+                    startIndex = i;
+                }
+
+                isDigit = true;
+            } else if (Character.isWhitespace(c)) {
+                if (i > startIndex) {
+                    if (isDigit) {
+                        list.add(parseItem(true, version.substring(startIndex, i)));
+                    } else {
+                        list.add(new StringItem(version.substring(startIndex, i), true));
+                    }
+                    startIndex = i;
+                }
+
+                isDigit = false;
+            } else {
+                if (isDigit && i > startIndex) {
+                    list.add(parseItem(true, version.substring(startIndex, i)));
+                    startIndex = i;
+                }
+
+                isDigit = false;
+            }
+        }
+
+        if (version.length() > startIndex) {
+            list.add(parseItem(isDigit, version.substring(startIndex)));
+        }
+
+        while (!stack.isEmpty()) {
+            list = (ListItem) stack.pop();
+            list.normalize();
+        }
+
+        canonical = items.toString();
+    }
+
+    private static Item parseItem(boolean isDigit, String buf) {
+        return isDigit ? (Item) new IntegerItem(buf) : (Item) new StringItem(buf, false);
+    }
+
+    public int compareTo(VersionNumber o) {
+        return items.compareTo(o.items);
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    public boolean equals(Object o) {
+        return (o instanceof VersionNumber) && canonical.equals(((VersionNumber) o).canonical);
+    }
+
+    public int hashCode() {
+        return canonical.hashCode();
+    }
+
+    public boolean isOlderThan(VersionNumber rhs) {
+        return compareTo(rhs) < 0;
+    }
+
+    public boolean isNewerThan(VersionNumber rhs) {
+        return compareTo(rhs) > 0;
     }
 
     public int digit(int idx) {
-        return digits[idx];
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder buf = new StringBuilder();
-        for( int i=0; i<digits.length; i++ ) {
-            if(i!=0)    buf.append('.');
-            buf.append( Integer.toString(digits[i]) );
+        Iterator i = items.iterator();
+        Item item = (Item) i.next();
+        while (idx > 0 && i.hasNext()) {
+            if (item instanceof IntegerItem) {
+                idx--;
+            }
+            i.next();
         }
-        return buf.toString();
-    }
-
-    public boolean isOlderThan( VersionNumber rhs ) {
-        return compareTo(rhs)<0;
-    }
-
-    public boolean isNewerThan( VersionNumber rhs ) {
-        return compareTo(rhs)>0;
+        return ((IntegerItem) item).value.intValue();
     }
 
 
-    @Override
-    public boolean equals( Object o ) {
-        if (!(o instanceof VersionNumber))  return false;
-        return compareTo((VersionNumber)o)==0;
-    }
-
-    @Override
-    public int hashCode() {
-        int x=0;
-        for (int i : digits)
-            x = (x << 1) | i;
-        return x;
-    }
-
-    public int compareTo(VersionNumber rhs) {
-        for( int i=0; ; i++ ) {
-            if( i==this.digits.length && i==rhs.digits.length )
-                return 0;   // equals
-            if( i==this.digits.length )
-                return -1;  // rhs is larger
-            if( i==rhs.digits.length )
-                return 1;
-
-            int r = this.digits[i] - rhs.digits[i];
-            if(r!=0)    return r;
-        }
-    }
 }

--- a/core/src/main/java/hudson/util/VersionNumber.java
+++ b/core/src/main/java/hudson/util/VersionNumber.java
@@ -50,7 +50,7 @@ import java.util.Stack;
  * </pre>
  *
  * @author
- *     Stephen Connolly (kohsuke.kawaguchi@sun.com)
+ *     Stephen Connolly
  * @since 1.139
  */
 

--- a/core/src/test/java/hudson/util/VersionNumberTest.java
+++ b/core/src/test/java/hudson/util/VersionNumberTest.java
@@ -36,7 +36,10 @@ public class VersionNumberTest extends TestCase {
        assertTrue(new VersionNumber("2.0.1-SNAPSHOT").isNewerThan(new VersionNumber("2.0.0.99")));
        assertTrue(new VersionNumber("2.0.0.99").isNewerThan(new VersionNumber("2.0.0")));
        assertTrue(new VersionNumber("2.0.0").isNewerThan(new VersionNumber("2.0.ea")));
-       assertTrue(new VersionNumber("2.0.ea").isNewerThan(new VersionNumber("2.0")));
+       assertTrue(new VersionNumber("2.0").isNewerThan(new VersionNumber("2.0.ea")));
+       // the inversion of the previous test case from the old behaviour is explained by
+       // which makes more sense than before
+       assertTrue(new VersionNumber("2.0.0").equals(new VersionNumber("2.0")));
     }
     
     public void testEarlyAccess() {
@@ -48,7 +51,8 @@ public class VersionNumberTest extends TestCase {
     public void testSnapshots() {
         assertTrue(new VersionNumber("1.12").isNewerThan(new VersionNumber("1.12-SNAPSHOT (private-08/24/2008 12:13-hudson)")));
         assertTrue(new VersionNumber("1.12-SNAPSHOT (private-08/24/2008 12:13-hudson)").isNewerThan(new VersionNumber("1.11")));
-        assertTrue(new VersionNumber("1.12-SNAPSHOT").equals(new VersionNumber("1.11.*")));
+        // This is changed from the old impl because snapshots are no longer a "magic" number
+        assertFalse(new VersionNumber("1.12-SNAPSHOT").equals(new VersionNumber("1.11.*")));
         assertTrue(new VersionNumber("1.11.*").isNewerThan(new VersionNumber("1.11.9")));
     }
 }


### PR DESCRIPTION
replace old CDDL+GPLv2 Version Number comparator with one that is both ASL and has a better understanding of Maven version numbers (with some tweaks for wildcard support)
- Had to change the logic of two test cases (2.0 is now newer than 2.0.ea and 1.12-SNAPSHOT is no longer equal to 1.11.*) both of which make more sense than the original test cases
- Should now allow custom builds with text/alpha qualifiers in the version number.

Signature of new version (based on the Mercury Version Number comparison code developed at Apache Maven):

public class hudson.util.VersionNumber extends java.lang.Object implements java.lang.Comparable{
    public hudson.util.VersionNumber(java.lang.String);    public int compareTo(hudson.util.VersionNumber);
    public java.lang.String toString();
    public boolean equals(java.lang.Object);
    public int hashCode();
    public boolean isOlderThan(hudson.util.VersionNumber);
    public boolean isNewerThan(hudson.util.VersionNumber);
    public int digit(int);
    public int compareTo(java.lang.Object);
}

Signature of original version:

public class hudson.util.VersionNumber extends java.lang.Object implements java.lang.Comparable{
    public hudson.util.VersionNumber(java.lang.String);
    public int digit(int);
    public java.lang.String toString();
    public boolean isOlderThan(hudson.util.VersionNumber);
    public boolean isNewerThan(hudson.util.VersionNumber);
    public boolean equals(java.lang.Object);
    public int hashCode();
    public int compareTo(hudson.util.VersionNumber);
    public int compareTo(java.lang.Object);
}
