### PR TITLE
Fix JENKINS-9689

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -453,7 +453,7 @@ function renderOnDemand(e,callback,noBehaviour) {
         }
         Element.remove(e);
 
-	t.responseText.evalScripts();
+        t.responseText.evalScripts();
         Behaviour.applySubtree(elements,true);
 
         if (callback)   callback(t);

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -453,6 +453,7 @@ function renderOnDemand(e,callback,noBehaviour) {
         }
         Element.remove(e);
 
+	t.responseText.evalScripts();
         Behaviour.applySubtree(elements,true);
 
         if (callback)   callback(t);


### PR DESCRIPTION
The line that was removed in a previous commit is what causes the scripts to execute in rendered on demand sections of views. Re-adding this line allows the node/label tree to be drawn, and possibly fixes issues with other plugins that are trying to register custom behaviors.
