### PR TITLE
Jenkins should check also node properties before assinging a flyweight ta

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -966,6 +966,7 @@ public class Queue extends ResourceController implements Saveable {
                 Computer c = n.toComputer();
                 if (c==null || c.isOffline())    continue;
                 if (lbl!=null && !lbl.contains(n))  continue;
+                if (n.canTake(p) != null) continue;
                 c.startFlyWeightTask(new WorkUnitContext(p).createWorkUnit(p.task));
                 pendings.add(p);
                 return;


### PR DESCRIPTION
Jenkins should check also node properties before assinging a flyweight task on a node
