### PR TITLE
JENKINS-9212

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -292,10 +292,47 @@ public class UpdateCenter extends AbstractModelObject implements Saveable {
      * Schedules a Jenkins restart.
      */
     public void doSafeRestart(StaplerRequest request, StaplerResponse response) throws IOException, ServletException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
-        addJob(new RestartJenkinsJob(getCoreSource()));
-        LOGGER.info("Scheduling Jenkings reboot");
+        synchronized (jobs) {
+            if (!isRestartScheduled()) {
+                Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+                addJob(new RestartJenkinsJob(getCoreSource()));
+                LOGGER.info("Scheduling Jenkins reboot");
+            }
+        }
         response.sendRedirect2(".");
+    }
+    
+    /**
+     * Cancel all scheduled jenkins restarts
+     */
+    public void doCancelRestart(StaplerResponse response) throws IOException, ServletException {
+        synchronized (jobs) {
+            for (UpdateCenterJob job : jobs) {
+                if (job instanceof RestartJenkinsJob) {
+                    if (((RestartJenkinsJob) job).cancel()) {
+                        LOGGER.info("Scheduled Jenkins reboot unscheduled");
+                    }
+                }
+            }
+        }
+        response.sendRedirect2(".");
+    }
+    
+    /**
+     * Checks if restart is scheduled
+     * 
+     */
+    public boolean isRestartScheduled() {
+        for (UpdateCenterJob job : getJobs()) {
+            if (job instanceof RestartJenkinsJob) {
+                RestartJenkinsJob.RestartJenkinsJobStatus status = ((RestartJenkinsJob) job).status;
+                if (status instanceof RestartJenkinsJob.Pending
+                        || status instanceof RestartJenkinsJob.Running) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -712,22 +749,64 @@ public class UpdateCenter extends AbstractModelObject implements Saveable {
             return installerService.submit(this,this);
         }
     }
-
+            
     /**
      * Restarts jenkins.
      */
     public class RestartJenkinsJob extends UpdateCenterJob {
+               
+         /**
+         * Immutable state of this job.
+         */
+        public volatile RestartJenkinsJobStatus status = new Pending();
+        
+        /**
+         * Cancel job
+         */     
+        public synchronized boolean cancel() {
+            if (status instanceof Pending) {
+                status = new Canceled();
+                return true;
+            }
+            return false;
+        }
+        
         public RestartJenkinsJob(UpdateSite site) {
             super(site);
         }
 
-        public void run() {
+        public synchronized void run() {
+            if (!(status instanceof Pending)) {
+                return;
+            }
+            status = new Running();
             try {
                 Jenkins.getInstance().safeRestart();
             }
             catch (RestartNotSupportedException exception) {
                 // ignore if restart is not allowed
+                status = new Failure();
             }
+        }
+        
+        public abstract class RestartJenkinsJobStatus {
+            
+        }
+        
+        public class Pending extends RestartJenkinsJobStatus {
+            
+        }
+        
+        public class Running extends RestartJenkinsJobStatus {
+            
+        }
+        
+        public class Failure extends RestartJenkinsJobStatus {
+            
+        }
+        
+        public class Canceled extends RestartJenkinsJobStatus {
+            
         }
     }
 

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -754,6 +754,10 @@ public class UpdateCenter extends AbstractModelObject implements Saveable {
      * Restarts jenkins.
      */
     public class RestartJenkinsJob extends UpdateCenterJob {
+        /**
+         * Unique ID that identifies this job.
+         */
+        public final int id = iota.incrementAndGet();
                
          /**
          * Immutable state of this job.
@@ -791,6 +795,8 @@ public class UpdateCenter extends AbstractModelObject implements Saveable {
         
         public abstract class RestartJenkinsJobStatus {
             
+            public final int id = iota.incrementAndGet();
+   
         }
         
         public class Pending extends RestartJenkinsJobStatus {

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Canceled/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Canceled/status.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Ulli Hafner
+Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Alan Harder
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,11 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <tr id="restart">
-    <td style="vertical-align: top; padding-right:1em">${%Restarting Jenkins}</td>
-    <j:set var="status" value="${it.status}" />
-    <td id="status${status.id}">
-      <st:include it="${status}" page="status.jelly" />
-    </td>
-  </tr>
+    <img src="${imagesURL}/24x24/red.png" alt="" height="24" width="24"/> ${%Canceled}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Ulli Hafner
+Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Alan Harder
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,11 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <tr id="restart">
-    <td style="vertical-align: top; padding-right:1em">${%Restarting Jenkins}</td>
-    <j:set var="status" value="${it.status}" />
-    <td id="status${status.id}">
-      <st:include it="${status}" page="status.jelly" />
-    </td>
-  </tr>
+    <img src="${imagesURL}/24x24/red.png" alt="" height="24" width="24"/> ${%Failure}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_da.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_da.properties
@@ -1,0 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc. Kohsuke Kawaguchi. Knud Poulsen.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Failure=Fejl
+Details=Detaljer

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_de.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_de.properties
@@ -1,6 +1,6 @@
 # The MIT License
 # 
-# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,4 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-warning=Once the installation is completed, Jenkins needs to be restarted for changes to take effect.
+Failure=Fehlgeschlagen
+Details=Details

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_es.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_es.properties
@@ -1,0 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Failure=Falló
+Details=Detalles

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_fr.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_fr.properties
@@ -1,0 +1,23 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Failure=\u00C9chec

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_ja.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_ja.properties
@@ -1,0 +1,24 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2011, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Failure=\u5931\u6557
+Details=\u8a73\u7d30

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_nl.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_nl.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Failure=Gefaald

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_pt_BR.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status_pt_BR.properties
@@ -1,0 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc., Cleiber Silva
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Failure=Falha
+Details=Detalhes

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Ulli Hafner
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,11 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <tr id="restart">
-    <td style="vertical-align: top; padding-right:1em">${%Restarting Jenkins}</td>
-    <j:set var="status" value="${it.status}" />
-    <td id="status${status.id}">
-      <st:include it="${status}" page="status.jelly" />
-    </td>
-  </tr>
+  <img src="${imagesURL}/24x24/grey.png" alt="" height="24" width="24"/> ${%Pending}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_ca.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_ca.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=Pendent

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_da.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_da.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc. Kohsuke Kawaguchi. Knud Poulsen.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=I k\u00f8

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_de.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_de.properties
@@ -1,0 +1,24 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=In Arbeit
+

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_es.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_es.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=Pendiente

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_fi.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_fi.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=Odottaa

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_fr.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_fr.properties
@@ -1,0 +1,23 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=En cours

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_it.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_it.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=In attesa

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_ja.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_ja.properties
@@ -1,0 +1,23 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=\u4fdd\u7559

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_nb_NO.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_nb_NO.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=Forest\u00E5ende

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_nl.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_nl.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=Bezig

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_pt_BR.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_pt_BR.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc., Cleiber Silva
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=Pendente

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_sv_SE.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status_sv_SE.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Pending=V\u00E4ntande

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Running/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Running/status.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Ulli Hafner
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,11 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <tr id="restart">
-    <td style="vertical-align: top; padding-right:1em">${%Restarting Jenkins}</td>
-    <j:set var="status" value="${it.status}" />
-    <td id="status${status.id}">
-      <st:include it="${status}" page="status.jelly" />
-    </td>
-  </tr>
+    <img src="${imagesURL}/24x24/grey_anime.gif" alt="" height="24" width="24"/> ${%Running}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/row.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/row.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <tr id="restart">
+  <tr id="row${it.id}">
     <td style="vertical-align: top; padding-right:1em">${%Restarting Jenkins}</td>
     <j:set var="status" value="${it.status}" />
     <td id="status${status.id}">

--- a/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
@@ -36,18 +36,22 @@ THE SOFTWARE.
       </j:forEach>
     </table>
     
-    <form method="post" id="scheduleRestart" action="">
-      <p class="info">
-        <j:if test="${app.lifecycle.canRestart()}">
-          <j:if test="${app.isQuietingDown() or it.isRestartScheduled()}">
-            <input onchange="submitScheduleForm(this)" type="checkbox" checked="checked" />
+    <div id="scheduleRestartBlock">
+      <form method="post" id="scheduleRestart" action="">
+        <p class="info">
+          <j:if test="${app.lifecycle.canRestart()}">
+            <j:if test="${app.isQuietingDown() or it.isRestartScheduled()}">
+              <input id="scheduleRestartCheckbox" onchange="submitScheduleForm(this)" type="checkbox" checked="checked" />
+            </j:if>
+            <j:if test="${!app.isQuietingDown() and !it.isRestartScheduled()}">
+              <input id="scheduleRestartCheckbox" onchange="submitScheduleForm(this)" type="checkbox" />
+            </j:if>
           </j:if>
-          <j:if test="${!app.isQuietingDown() and !it.isRestartScheduled()}">
-            <input onchange="submitScheduleForm(this)" type="checkbox" />
-          </j:if>
-        </j:if>
-        ${%warning}
-      </p>
-    </form>
+          <label for="scheduleRestartCheckbox">
+            ${%warning}
+          </label>
+        </p>
+      </form>
+    </div>
   </l:ajax>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
@@ -29,10 +29,25 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:ajax>
+    
     <table id="log">
       <j:forEach var="i" items="${it.jobs}">
         <st:include it="${i}" page="row.jelly" />
       </j:forEach>
     </table>
+    
+    <form method="post" id="scheduleRestart" action="">
+      <p class="info">
+        <j:if test="${app.lifecycle.canRestart()}">
+          <j:if test="${app.isQuietingDown() or it.isRestartScheduled()}">
+            <input onchange="submitScheduleForm(this)" type="checkbox" checked="checked" />
+          </j:if>
+          <j:if test="${!app.isQuietingDown() and !it.isRestartScheduled()}">
+            <input onchange="submitScheduleForm(this)" type="checkbox" />
+          </j:if>
+        </j:if>
+        ${%warning}
+      </p>
+    </form>
   </l:ajax>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/body.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/body.properties
@@ -1,0 +1,23 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+warning=Restart Jenkins when installation is complete and no jobs are running

--- a/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
@@ -56,13 +56,11 @@ THE SOFTWARE.
                         if(target==null) {
                           document.getElementById("log").appendChild(row);
                         } else {
-                          if (row.id != 'restart') {
-                            var tcell = target.cells[1];
-                            var scell = row.cells[1];
-                            if(scell.id!=tcell.id) {
-                              tcell.innerHTML = scell.innerHTML;
-                              tcell.id = scell.id;
-                            }
+                          var tcell = target.cells[1];
+                          var scell = row.cells[1];
+                          if(scell.id!=tcell.id) {
+                            tcell.innerHTML = scell.innerHTML;
+                            tcell.id = scell.id;
                           }
                         }
                       }

--- a/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
@@ -64,6 +64,8 @@ THE SOFTWARE.
                           }
                         }
                       }
+                      var scheduleDiv = document.getElementById('scheduleRestartBlock');
+                      scheduleDiv.innerHTML = div.lastChild.innerHTML;
                       refresh();
                   }
               });

--- a/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
@@ -32,16 +32,13 @@ THE SOFTWARE.
   <st:include page="sidepanel.jelly" />
   <l:main-panel>
     <h1>${%Installing Plugins/Upgrades}</h1>
-
-    <form method="post" action="safeRestart">
-      <p class="warning">
-        ${%warning}
-        <j:if test="${app.lifecycle.canRestart()}">
-          <f:submit value="${%Schedule Restart}" />
-        </j:if>
-      </p>
-    </form>
-
+    <script><![CDATA[
+      function submitScheduleForm(el) {
+          var form = document.getElementById("scheduleRestart");
+          form.action = el.checked ? "safeRestart" : "cancelRestart";
+          form.submit();
+      }
+    ]]></script>
     <st:include page="body.jelly" />
 
     <script><![CDATA[


### PR DESCRIPTION
"Schedule restart" button in update center is replaced with checkbox in
the bottom of the page. "Canceled", "Pending" and "Running" icons are
used for "Restart Jenkins" job.

Issue with restart button restarting jenkins even if the update is still
running was fixed by 40e9dd70 (see JENKINS-7567).
