### PR TITLE
Don't include /etc/apt/sources.list.d/jenkins.list in dpkg

### DIFF
--- a/debian/debian/jenkins.install
+++ b/debian/debian/jenkins.install
@@ -1,2 +1,1 @@
 jenkins.war usr/share/jenkins
-debian/jenkins.list etc/apt/sources.list.d

--- a/debian/debian/jenkins.list
+++ b/debian/debian/jenkins.list
@@ -1,1 +1,0 @@
-deb http://pkg.jenkins-ci.org/debian binary/


### PR DESCRIPTION
The attached patch removes `/etc/apt/sources.lists.d/jenkins.list` from the Debian package.

The presence of `jenkins.list` prevents the sysadmin from controlling the updating of the Jenkins package. For example, it:
- bypasses any local apt mirror
- causes problems for `apt-get update` on machines without external internet access (e.g. intranet build clusters)

`jenkins.list` should be distributed separately from the package.

Regards,
Tom
