### PR TITLE
JENKINS-10036

### DIFF
--- a/core/src/main/resources/hudson/tasks/Ant/config.groovy
+++ b/core/src/main/resources/hudson/tasks/Ant/config.groovy
@@ -24,7 +24,7 @@
 package hudson.tasks.Ant;
 f=namespace(lib.FormTagLib)
 
-if (!descriptor.installations) {
+if (descriptor.installations.length != 0) {
     f.entry(title:_("Ant Version")) {
         select(class:"setting-input",name:"ant.antName") {
             option(value:"(Default)", _("Default"))


### PR DESCRIPTION
Caused by the conversion from jelly to groovy:
https://github.com/mrobinet/jenkins/commit/4434ed77063bcb1b939072011b2c7ec9401ce771#core/src/main/resources/hudson/tasks/Ant/config.groovy

Rather than showing the list of Ant installations when some exist, it currently only shows the list when none exist.
