### PR TITLE
Add ability to specify hostname for Windows service

### DIFF
--- a/core/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
+++ b/core/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
@@ -87,10 +87,17 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
     
     public final Secret password;
 
-    @DataBoundConstructor
+    public final String host;
+    
     public ManagedWindowsServiceLauncher(String userName, String password) {
+        this (userName, password, null);
+    }
+    
+    @DataBoundConstructor
+    public ManagedWindowsServiceLauncher(String userName, String password, String host) {
         this.userName = userName;
         this.password = Secret.fromString(password);
+        this.host = host;
     }
 
     private JIDefaultAuthInfoImpl createAuth() {
@@ -286,7 +293,12 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
      * Determines the host name (or the IP address) to connect to.
      */
     protected String determineHost(Computer c) throws IOException, InterruptedException {
-        return c.getName();
+        // If host not provided, default to the slave name
+        if (host==null || host.equals("")) {
+            return c.getName();
+        } else {
+            return host;
+        }
     }
 
     private void copySlaveJar(PrintStream logger, SmbFile remoteRoot) throws IOException {

--- a/core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/config.jelly
+++ b/core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/config.jelly
@@ -30,4 +30,7 @@ THE SOFTWARE.
   <f:entry title="${%Password}" field="password">
     <f:password />
   </f:entry>
+  <f:entry title="${%Host}" field="host">
+    <f:textbox/>
+  </f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/help-host.html
+++ b/core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/help-host.html
@@ -1,0 +1,3 @@
+<div>
+    Provide the host name of the Windows host if different to the name of the Slave.
+</div>


### PR DESCRIPTION
Right now, the name of a slave needs to match the computer name when using the Windows service option in Jenkins.

This request adds a Host field to the Node config screen to allow you to specify a hostname that's different from the slave name if required. The computer name defaults to the slave name if host isn't specified.

This is my first pull request for core so let me know if there's anything that needs to be fixed up / added / etc.
