### PR TITLE
Vertically align setting-name class to middle

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -244,6 +244,7 @@ pre.console {
 
 .setting-name {
   white-space: nowrap;
+  vertical-align: middle;
 }
 
 .setting-main {


### PR DESCRIPTION
This will align the name to the left of the fields to be centered instead of top aligned.
# Before

![](http://img.skitch.com/20110622-tywmg1a1i7hj959ekry25b9frb.png)
# After

![](http://img.skitch.com/20110622-ea8m61wmhmsri6qkaki1nqrxh9.png)
