### PR TITLE
Patch for JENKINS-4959 Block up-/downstream Projects of matrix projects

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -58,6 +58,9 @@ Upcoming changes</a>
   <li class=bug>
     "Ant Version" field in "Invoke Ant" Build step missing in 1.416
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-10036">issue 10036</a>)
+  <li class=bug>
+    Block up-/downstream Projects of matrix projects
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-4959">issue 4959</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
@@ -35,6 +35,7 @@ THE SOFTWARE.
       <p:config-quietPeriod />
       <p:config-retryCount />
       <p:config-blockWhenUpstreamBuilding />
+      <p:config-blockWhenDownstreamBuilding />
       <p:config-customWorkspace />
     </f:advanced>
   </f:section>


### PR DESCRIPTION
Enabled the config block when Downstream building to matrix config page.
uses default core handling for blocking. 
