### PR TITLE
Restart button does not restart jenkins after plugin upload

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -104,16 +104,6 @@ THE SOFTWARE.
         </j:choose>
       </table>
 
-      <j:if test="${it.isPluginUploaded()}">
-        <div style="margin: 1em; height: 1em">
-          <div class="error">
-            ${%New plugins will take effect once you restart Jenkins}
-            <j:if test="${app.lifecycle.canRestart()}">
-              <s:submit value="${%Restart Once No Jobs Are Running}" />
-            </j:if>
-          </div>
-        </div>
-      </j:if>
       <div class="warning" id="needRestart" style="display:none; margin: 1em; height: 1em">
         <form method="post" action="${rootURL}/safeRestart">
           ${%Changes will take effect when you restart Jenkins}
@@ -145,6 +135,9 @@ THE SOFTWARE.
             return String(e.checked)!=e.getAttribute('original');
           });
 
+          <j:if test="${it.isPluginUploaded()}">
+            e = true;
+          </j:if>
           $('needRestart').style.display = (e!=null?"block":"none");
         }
 


### PR DESCRIPTION
Restart button that appears under list of installed plugins after plugin
upload does not restart jenkins when clicked.

More than that, after turning on/off some of installed plugins,
two restart buttons appear (only one of them work) on the page in
question.

Such behaviour should definitely be fixed.

As far as I can judge JENKINS-10044 is related issue.
