### PR TITLE
Updated Jenkins CLI Version Command Output

### DIFF
--- a/core/src/main/java/hudson/cli/VersionCommand.java
+++ b/core/src/main/java/hudson/cli/VersionCommand.java
@@ -27,7 +27,7 @@ import hudson.Extension;
 import jenkins.model.Jenkins;
 
 /**
- * Shows the version.
+ * Retrieves the current version.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/cli/VersionCommand.java
+++ b/core/src/main/java/hudson/cli/VersionCommand.java
@@ -35,7 +35,7 @@ import jenkins.model.Jenkins;
 public class VersionCommand extends CLICommand {
     @Override
     public String getShortDescription() {
-        return "Shows the Hudson version";
+        return "Outputs the current version";
     }
 
     protected int run() {


### PR DESCRIPTION
Changed from: "Shows the Hudson version"
Changed to: "Outputs the current version"

Also slightly modified the javadoc short description line.
