### PR TITLE
[JENKINS-9301] don't recalculate dependency graph if modules haven't changed

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/MavenModule.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModule.java
@@ -191,6 +191,15 @@ public final class MavenModule extends AbstractMavenProject<MavenModule,MavenBui
             }
         }
     }
+    
+    /**
+     * Returns if the given POM likely describes the same module with the same dependencies.
+     * Implementation needs not be 100% accurate in the true case, but it MUST return false
+     * if is not the same.
+     */
+    public boolean isSameModule(PomInfo pom) {
+        return pom.isSimilar(this.moduleName, this.dependencies);
+    }
 
     @Override
     protected void doSetName(String name) {

--- a/maven-plugin/src/main/java/hudson/maven/PomInfo.java
+++ b/maven-plugin/src/main/java/hudson/maven/PomInfo.java
@@ -155,7 +155,7 @@ final class PomInfo implements Serializable {
         this.groupId = project.getGroupId();
         this.artifactId = project.getArtifactId();
     }
-
+    
     /**
      * Creates {@link ModuleDependency} that represents this {@link PomInfo}.
      */
@@ -227,6 +227,15 @@ final class PomInfo implements Serializable {
         PomInfo pomInfo = (PomInfo) obj;
         return StringUtils.equals( pomInfo.groupId, this.groupId ) 
             && StringUtils.equals( pomInfo.artifactId, this.artifactId ); 
+    }
+    
+    /**
+     * Returns if groupId, artifactId and dependencies are the same.
+     */
+    public boolean isSimilar(ModuleName moduleName, Set<ModuleDependency> dependencies) {
+        return StringUtils.equals(this.groupId, moduleName.groupId)
+            && StringUtils.equals(this.artifactId, moduleName.artifactId)
+            && this.dependencies.equals(dependencies);
     }
     
     /**


### PR DESCRIPTION
This is a partially fix for https://issues.jenkins-ci.org/browse/JENKINS-9301 and was inspired by a similar change in Hudson https://github.com/hudson/hudson/commit/8424f8705e9ceec5f08f1cc17ef617009e0660ee, but fixes some errors/unoptimized code in it.
