### PR TITLE
Fix: jenkins did not record test results generated by the GWT maven plugin

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
@@ -247,6 +247,7 @@ public class SurefireArchiver extends MavenReporter {
             && (!mojo.is("org.sonatype.flexmojos", "flexmojos-maven-plugin", "test-run"))
             && (!mojo.is("org.eclipse.tycho", "tycho-surefire-plugin", "test"))
             && (!mojo.is("org.sonatype.tycho", "maven-osgi-test-plugin", "test"))
+            && (!mojo.is("org.codehaus.mojo", "gwt-maven-plugin", "test"))
             && (!mojo.is("org.apache.maven.plugins", "maven-surefire-plugin", "test"))
             && (!mojo.is("org.apache.maven.plugins", "maven-failsafe-plugin", "integration-test")))
             return false;


### PR DESCRIPTION
GWT test results are not generated by the regular Surefire plugin, so I had to add gwt-maven-plugin to the list in SurefireArchiver to get it to work.
