### PR TITLE
Added example to make jenkins listen to IPv4 only.

### DIFF
--- a/debian/debian/jenkins.default
+++ b/debian/debian/jenkins.default
@@ -8,6 +8,7 @@ JAVA=/usr/bin/java
 
 # arguments to pass to java
 #JAVA_ARGS="-Xmx256m"
+#JAVA_ARGS="-Djava.net.preferIPv4Stack=true" # make jenkins listen on IPv4 address
 
 PIDFILE=/var/run/jenkins/jenkins.pid
 


### PR DESCRIPTION
I stumbled accross this problem when installing jenkins on my server. Adding this to /etc/defaults/jenkins might safe others some time.
