### PR TITLE
Minor improvements to Mac installer

### DIFF
--- a/osx/scripts/postinstall-launchd
+++ b/osx/scripts/postinstall-launchd
@@ -3,7 +3,7 @@
 JENKINS_PLIST="/Library/LaunchDaemons/org.jenkins-ci.plist"
 
 # Because PackageMaker just copies the components, we need to fix the permissions
-chown root:admin ${JENKINS_PLIST}
+chown root:wheel ${JENKINS_PLIST}
 chmod 644 ${JENKINS_PLIST}
 mkdir -p /Users/Shared/Jenkins
 chown -R daemon:daemon /Users/Shared/Jenkins

--- a/osx/scripts/postinstall-launchd
+++ b/osx/scripts/postinstall-launchd
@@ -10,4 +10,3 @@ chown -R daemon:daemon /Users/Shared/Jenkins
 
 # Load and start the launch daemon
 /bin/launchctl load ${JENKINS_PLIST}
-/bin/launchctl start org.jenkins-ci

--- a/osx/scripts/postinstall-war
+++ b/osx/scripts/postinstall-war
@@ -3,5 +3,5 @@
 JENKINS_APP="/Applications/Jenkins"
 
 # Fix Jenkins Permissions
-chown -R root:admin ${JENKINS_APP}
+chown -R root:wheel ${JENKINS_APP}
 chmod -R 755 ${JENKINS_APP}

--- a/osx/scripts/preinstall-launchd
+++ b/osx/scripts/preinstall-launchd
@@ -5,3 +5,6 @@ JENKINS_PLIST="/Library/LaunchAgents/org.jenkins-ci.plist"
 if [ -f ${JENKINS_PLIST} ]; then
 	rm ${JENKINS_PLIST}
 fi
+
+JENKINS_DAEMON_PLIST="/Library/LaunchDaemons/org.jenkins-ci.plist"
+launchctl unload ${JENKINS_DAEMON_PLIST} || echo 'Failed to unload old Jenkins launch daemon. Maybe it is was not loaded?'


### PR DESCRIPTION
I'd like to submit these patches to be considered for merging into Jenkins. These patches change file owners and permissions to be more in line with Mac conventions. Also, the launch daemon config file should be reloaded on upgrades.
