### PR TITLE
JENKINS-10182 - Fixed NPE for Job.doDescription() when description is NULL.

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -27,6 +27,7 @@ import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import hudson.Extension;
 import hudson.ExtensionPoint;
 import hudson.PermalinkList;
+import hudson.Util;
 import hudson.cli.declarative.CLIResolver;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Fingerprint.Range;
@@ -1002,7 +1003,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         if (req.getMethod().equals("GET")) {
             //read
             rsp.setContentType("text/plain;charset=UTF-8");
-            rsp.getWriter().write(this.getDescription());
+            rsp.getWriter().write(Util.fixNull(this.getDescription()));
             return;
         }
         if (req.getMethod().equals("POST")) {

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -26,6 +26,7 @@ package hudson.model;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.WebAssert;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.TextPage;
 
 import hudson.util.TextFile;
 import java.io.IOException;
@@ -226,5 +227,16 @@ public class JobTest extends HudsonTestCase {
         assertEquals(3, r.getArtifactsUpTo(3).size());
         assertEquals(2, r.getArtifactsUpTo(2).size());
         assertEquals(1, r.getArtifactsUpTo(1).size());
+    }
+
+    @Bug(10182)
+    public void testEmptyDescriptionReturnsEmptyPage() throws Exception {
+        // A NPE was thrown if a job had a null (empty) description.
+        WebClient wc = createWebClient();
+        FreeStyleProject project = createFreeStyleProject("project");
+        project.setDescription("description");
+        assertEquals("description", ((TextPage) wc.goTo("job/project/description", "text/plain")).getContent());
+        project.setDescription(null);
+        assertEquals("", ((TextPage) wc.goTo("job/project/description", "text/plain")).getContent());
     }
 }


### PR DESCRIPTION
[FIXED JENKINS-10182] Used Util.fixNull() to handle the case when a jobs description is null, and tries to retrieve the description using the api.
