### PR TITLE
Fix TaskThread.ListenerAndText chicken and egg issue

### DIFF
--- a/core/src/main/java/hudson/model/TaskThread.java
+++ b/core/src/main/java/hudson/model/TaskThread.java
@@ -56,7 +56,7 @@ public abstract class TaskThread extends Thread {
     /**
      * Represents the output from this task thread.
      */
-    private final AnnotatedLargeText<TaskThread> log;
+    private final AnnotatedLargeText<TaskAction> log;
 
     /**
      * Represents the interface to produce output.
@@ -151,9 +151,9 @@ public abstract class TaskThread extends Thread {
      */
     public static final class ListenerAndText {
         final TaskListener listener;
-        final AnnotatedLargeText<TaskThread> text;
+        final AnnotatedLargeText<TaskAction> text;
 
-        public ListenerAndText(TaskListener listener, AnnotatedLargeText<TaskThread> text) {
+        public ListenerAndText(TaskListener listener, AnnotatedLargeText<TaskAction> text) {
             this.listener = listener;
             this.text = text;
         }
@@ -177,23 +177,23 @@ public abstract class TaskThread extends Thread {
         /**
          * Creates one that's backed by memory.
          */
-        public static ListenerAndText forMemory(TaskThread context) {
+        public static ListenerAndText forMemory(TaskAction context) {
             // StringWriter is synchronized
             ByteBuffer log = new ByteBuffer();
 
             return new ListenerAndText(
                 new StreamTaskListener(log),
-                new AnnotatedLargeText<TaskThread>(log,Charset.defaultCharset(),false,context)
+                new AnnotatedLargeText<TaskAction>(log,Charset.defaultCharset(),false,context)
             );
         }
 
         /**
          * Creates one that's backed by a file. 
          */
-        public static ListenerAndText forFile(File f, TaskThread context) throws IOException {
+        public static ListenerAndText forFile(File f, TaskAction context) throws IOException {
             return new ListenerAndText(
                 new StreamTaskListener(f),
-                new AnnotatedLargeText<TaskThread>(f,Charset.defaultCharset(),false,context)
+                new AnnotatedLargeText<TaskAction>(f,Charset.defaultCharset(),false,context)
             );
         }
     }

--- a/core/src/test/java/hudson/model/TaskActionTest.java
+++ b/core/src/test/java/hudson/model/TaskActionTest.java
@@ -1,0 +1,67 @@
+package hudson.model;
+
+import junit.framework.TestCase;
+
+import java.io.ByteArrayOutputStream;
+
+import hudson.console.AnnotatedLargeText;
+import hudson.security.ACL;
+import hudson.security.Permission;
+import hudson.security.PermissionGroup;
+import org.acegisecurity.Authentication;
+
+/**
+ * @author Jerome Lacoste
+ */
+public class TaskActionTest extends TestCase {
+
+    private static class MyTaskThread extends TaskThread {
+        MyTaskThread(TaskAction taskAction) {
+            super(taskAction, ListenerAndText.forMemory(taskAction));
+        }
+        protected void perform(TaskListener listener) throws Exception {
+            listener.hyperlink("/localpath", "a link");
+        }            
+    }
+  
+    private static class MyTaskAction extends TaskAction {
+        void start() {
+            workerThread = new MyTaskThread(this);
+            workerThread.start();
+        }  
+    
+        public String getIconFileName() {
+            return "Iconfilename";
+        }
+        public String getDisplayName() {
+            return "My Task Thread";
+        }
+        
+        public String getUrlName() {
+            return "xyz";
+        }
+        protected Permission getPermission() {
+            return Permission.READ;
+        }
+
+        protected ACL getACL() {
+            return new ACL() {
+                public boolean hasPermission(Authentication a, Permission permission) {
+                     return true;
+                }
+            };
+        }
+    }
+
+    public void testAnnotatedText() throws Exception {
+        MyTaskAction action = new MyTaskAction();
+        action.start();
+        AnnotatedLargeText annotatedText = action.obtainLog();
+        while (!annotatedText.isComplete()) {
+            Thread.sleep(10);
+        }
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        annotatedText.writeLogTo(0, os);
+        assertTrue(os.toString("UTF-8").startsWith("a linkCompleted"));
+    }
+}


### PR DESCRIPTION
Fix for https://groups.google.com/d/topic/jenkinsci-dev/Drm0Gbpelac/discussion

The only users of the old API shouldn't have been able to use the ListenerAndText created with the former API anyway.

The unit test added unfortunately doesn't test proper annotation (it would need to write HTML instead). If someone knows how to work around the few singletons in the system (stapler current request, Jenkins.theInstance), etc, be my guest.
