### PR TITLE
Enable MarkupFormatters to control CodeMirror

### DIFF
--- a/core/src/main/java/hudson/markup/MarkupFormatter.java
+++ b/core/src/main/java/hudson/markup/MarkupFormatter.java
@@ -40,6 +40,11 @@ import java.io.Writer;
  * <p>
  * This is an extension point in Hudson, allowing plugins to implement different markup formatters.
  *
+ * <p>
+ * Implement the following methods to enable and control CodeMirror syntax highlighting
+ * public String getCodeMirrorMode() // return null to disable CodeMirror dynamically
+ * public String getCodeMirrorConfig()
+ *   
  * <h2>Views</h2>
  * <p>
  * This extension point must have a valid <tt>config.jelly</tt> that feeds the constructor.

--- a/core/src/main/java/hudson/markup/RawHtmlMarkupFormatter.java
+++ b/core/src/main/java/hudson/markup/RawHtmlMarkupFormatter.java
@@ -22,6 +22,14 @@ public class RawHtmlMarkupFormatter extends MarkupFormatter {
         output.write(markup);
     }
 
+    public String getCodeMirrorMode() {
+        return "htmlmixed";
+    }
+
+    public String getCodeMirrorConfig() {
+        return "mode:'text/html'";
+    }
+
     @Extension
     public static class DescriptorImpl extends MarkupFormatterDescriptor {
         @Override

--- a/core/src/main/resources/hudson/model/AbstractModelObject/descriptionForm.jelly
+++ b/core/src/main/resources/hudson/model/AbstractModelObject/descriptionForm.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
       <table>
         <f:entry help="${app.markupFormatter.helpUrl}">
           <f:textarea name="description" value="${it.description}"
-                      codemirror-mode="htmlmixed" codemirror-config="mode:'text/html'"/>
+                      codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}"/>
         </f:entry>
       </table>
       <div align="right">

--- a/core/src/main/resources/hudson/model/AbstractModelObject/editDescription.jelly
+++ b/core/src/main/resources/hudson/model/AbstractModelObject/editDescription.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
         <table>
           <f:entry help="${app.markupFormatter.helpUrl}">
             <f:textarea name="description" value="${it.description}"
-                        codemirror-mode="htmlmixed" codemirror-config="mode:'text/html'"/>
+                        codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}"/>
           </f:entry>
         </table>
         <f:submit value="${%Submit}" />

--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -41,7 +41,7 @@ THE SOFTWARE.
           </f:entry>
         </j:if>
         <f:entry title="${%Description}" help="${app.markupFormatter.helpUrl}">
-          <f:textarea name="description" value="${it.description}" codemirror-mode="htmlmixed" codemirror-config="mode:'text/html'"/>
+          <f:textarea name="description" value="${it.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}"/>
         </f:entry>
 
         <j:if test="${it.supportsLogRotator()}">

--- a/core/src/main/resources/hudson/model/Run/configure.jelly
+++ b/core/src/main/resources/hudson/model/Run/configure.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
           <f:textbox name="displayName" value="${it.hasCustomDisplayName()?it.displayName:''}"/>
         </f:entry>
         <f:entry title="${%Description}" help="/help/run-config/description.html">
-          <f:textarea name="description" value="${it.description}" codemirror-mode="htmlmixed" codemirror-config="mode:'text/html'"/>
+          <f:textarea name="description" value="${it.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}"/>
         </f:entry>
 
         <j:if test="${h.hasPermission(it,it.UPDATE)}">

--- a/core/src/main/resources/hudson/model/View/configure.jelly
+++ b/core/src/main/resources/hudson/model/View/configure.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
           <f:textbox name="name" value="${it.viewName}" />
         </f:entry>
         <f:entry title="${%Description}" help="/help/view-config/description.html">
-          <f:textarea name="description" field="description" />
+          <f:textarea name="description" field="description" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}"/>
         </f:entry>
         <f:entry title="${%Filter build queue}" help="/help/view-config/filter-queue.html">
         	<f:checkbox name="filterQueue" field="filterQueue"/>

--- a/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
@@ -48,7 +48,7 @@ THE SOFTWARE.
       </f:advanced>
       <f:entry title="${%System Message}" help="/help/system-config/systemMessage.html">
         <f:textarea name="system_message" value="${it.systemMessage}"
-                    codemirror-mode="htmlmixed" codemirror-config="mode:'text/html'" />
+                    codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}"/>
       </f:entry>
       <f:entry title="${%# of executors}" field="numExecutors">
         <f:textbox />


### PR DESCRIPTION
Use duck typing to preserve interface

The default RawHtmlFormatter will enable html syntax highlighting
MarkupFormatters that do not implement getCodeMirrorMode() will use plain textarea (e.g. https://wiki.jenkins-ci.org/display/JENKINS/Escaped+Markup+Plugin)

https://wiki.jenkins-ci.org/display/JENKINS/PegDown+Formatter+Plugin will enable html highlighting unless SUPPRESS_ALL_HTML is selected (in new release if this pull is merged)
