### PR TITLE
[FIXED JENKINS-7395] Allow sites to override the default update center URL.

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -96,6 +96,9 @@ import org.acegisecurity.context.SecurityContextHolder;
  * @since 1.220
  */
 public class UpdateCenter extends AbstractModelObject implements Saveable {
+	
+    private static final String UPDATE_CENTER_URL = System.getProperty(UpdateCenter.class.getName()+".updateCenterUrl","http://updates.jenkins-ci.org/");
+	
     /**
      * {@link ExecutorService} that performs installation.
      */
@@ -689,7 +692,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable {
          *      Absolute URL that ends with '/'.
          */
         public String getUpdateCenterUrl() {
-            return "http://updates.jenkins-ci.org/";
+            return UPDATE_CENTER_URL;
         }
 
         /**


### PR DESCRIPTION
[FIXED JENKINS-7395] Allow sites to override the default update center URL.
For example, jenkins sites behind HTTPS will want to pass -Dhudson.model.UpdateCenter.updateCenterUrl=https://updates.jenkins-ci.org/
