### PR TITLE
Added base class for groovy view modularization

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -651,6 +651,21 @@ THE SOFTWARE.
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.kohsuke.gmaven</groupId>
+        <artifactId>gmaven-plugin</artifactId>
+        <!-- version specified in grandparent pom -->
+        <executions>
+          <execution>
+            <goals>
+              <goal>generateStubs</goal>
+              <goal>compile</goal>
+              <goal>generateTestStubs</goal>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -672,7 +687,7 @@ THE SOFTWARE.
         <configuration>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
         </configuration>
-      </plugin> 
+      </plugin>
     </plugins>
   </reporting>
 

--- a/core/src/main/groovy/jenkins/util/groovy/AbstractGroovyViewModule.groovy
+++ b/core/src/main/groovy/jenkins/util/groovy/AbstractGroovyViewModule.groovy
@@ -1,0 +1,47 @@
+package jenkins.util.groovy
+
+import lib.FormTagLib
+import lib.LayoutTagLib
+import org.kohsuke.stapler.jelly.groovy.JellyBuilder
+import org.kohsuke.stapler.jelly.groovy.Namespace
+import lib.JenkinsTagLib
+
+/**
+ * Base class for utility classes for Groovy view scripts
+ * <p />
+ * Usage from script of a subclass, say ViewHelper:
+ * <p />
+ * <tt>new ViewHelper(delegate).method();</tt>
+ * <p />
+ * see <tt>ModularizeViewScript</tt> in ui-samples for an example how to use this class.
+ *
+ * @author Stefan Wolf (wolfs)
+ */
+abstract class AbstractGroovyViewModule {
+  JellyBuilder builder
+  FormTagLib f
+  LayoutTagLib l
+  JenkinsTagLib t
+  Namespace st
+
+  public AbstractGroovyViewModule(JellyBuilder b) {
+    builder = b
+    f= builder.namespace(FormTagLib)
+    l=builder.namespace(LayoutTagLib)
+    t=builder.namespace(JenkinsTagLib)
+    st=builder.namespace("jelly:stapler")
+
+  }
+
+  def methodMissing(String name, args) {
+    builder.invokeMethod(name,args)
+  }
+
+  def propertyMissing(String name) {
+    builder.getProperty(name)
+  }
+
+  def propertyMissing(String name, value) {
+    builder.setProperty(name, value)
+  }
+}

--- a/ui-samples-plugin/src/main/resources/jenkins/plugins/ui_samples/ModularizeViewScript/index.groovy
+++ b/ui-samples-plugin/src/main/resources/jenkins/plugins/ui_samples/ModularizeViewScript/index.groovy
@@ -1,6 +1,7 @@
 package jenkins.plugins.ui_samples.ModularizeViewScript
+
 import org.kohsuke.stapler.jelly.groovy.JellyBuilder
-import lib.FormTagLib
+import jenkins.util.groovy.AbstractGroovyViewModule
 
 namespace("/lib/samples").sample(title:_("Define View Fragments Elsewhere")) {
 
@@ -19,18 +20,14 @@ namespace("/lib/samples").sample(title:_("Define View Fragments Elsewhere")) {
 
 // I defined this class here just to make the sample concise.
 // this class can be defined anywhere, and typically you'd do this somewhere in your src/main/groovy
-static class SomeGenerator {
-    JellyBuilder b;
-    FormTagLib f;
-
+static class SomeGenerator extends AbstractGroovyViewModule {
     SomeGenerator(JellyBuilder builder) {
-        this.b = builder
-        f = builder.namespace(FormTagLib.class)
+      super(builder)
     }
 
     def generateSomeFragment() {
-        b.h2("Two")
-        b.div(style:"background-color:gray; padding:2em") {
+        h2("Two")
+        div(style:"background-color:gray; padding:2em") {
             p("Hello")  // once inside a closure, no explicit 'b.' reference is needed. this is just like other Groovy builders
 
             // calling other methods
@@ -39,7 +36,7 @@ static class SomeGenerator {
     }
 
     def generateMoreFragment(String msg) {
-        b.h2(msg);
+        h2(msg);
         f.textarea();
     }
 }


### PR DESCRIPTION
Added a base class AbstractGroovyViewModule which allows for easy modularization of groovy views. It uses methodMissing and propertyMissing to delegate to the jellyBuilder. I also updated the example in ui-samples.

I used the forked gmaven plugin to enable compilation of groovy classes in core. It would be nice if we could just use the default gmaven plugin and to enable compilation of groovy classes for all modules (+ plugins?).
