### PR TITLE
Submitting this as it causes me pain with every rpm update.

### DIFF
--- a/rpm/SPECS/jenkins.spec
+++ b/rpm/SPECS/jenkins.spec
@@ -134,8 +134,8 @@ exit 0
 %attr(0755,jenkins,jenkins) %dir %{workdir}
 %attr(0750,jenkins,jenkins) /var/log/jenkins
 %config /etc/logrotate.d/%{name}
-%config /etc/init.d/%{name}
-%config /etc/sysconfig/%{name}
+%config(noreplace) /etc/init.d/%{name}
+%config(noreplace) /etc/sysconfig/%{name}
 /etc/yum.repos.d/jenkins.repo
 /usr/sbin/rc%{name}
 


### PR DESCRIPTION
The rpm should create a new config with .rpmnew instead of rotating out existing configs.
This is a fix for JENKINS-10037.
