### PR TITLE
Do not keep changing permissions on install directory.

### DIFF
--- a/debian/debian/jenkins.postinst
+++ b/debian/debian/jenkins.postinst
@@ -42,8 +42,8 @@ case "$1" in
         fi
       
         # directories needed for jenkins
-        chown jenkins:adm /var/lib/jenkins /var/log/jenkins
-        chmod 750         /var/lib/jenkins /var/log/jenkins
+        chown -R jenkins:adm /var/lib/jenkins /var/log/jenkins
+        #chmod 750         /var/lib/jenkins /var/log/jenkins
 
         # make sure jenkins can delete everything in /var/run/jenkins to re-explode war
         chown -R jenkins:adm /var/run/jenkins


### PR DESCRIPTION
We keep having to re-enable world read/execute on /var/lib/jenkins. 
This permissions change should not be reapplied for every update, 
maybe fine for initial install.
