### PR TITLE
Ignore null reporters field in MavenBuild$RunnerImpl.post2 and avoid a NPE.

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/MavenBuild.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenBuild.java
@@ -750,8 +750,11 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
         }
 
         public void post2(BuildListener listener) throws Exception {
-            for (MavenReporter reporter : reporters)
-                reporter.end(MavenBuild.this,launcher,listener);
+            if (reporters != null) {
+                for (MavenReporter reporter : reporters) {
+                    reporter.end(MavenBuild.this,launcher,listener);
+                }
+            }
         }
 
     }


### PR DESCRIPTION
The NPE can occur if a build fails during checkout and hence the run phase
never gets called. See JENKINS-10831 for an example of this happening.

Checking for null is a simple check and it does suppress the error but I'm wondering if reporters should be set by other means if doRun does not get called. Please pull if the simple check is good enough.
