### PR TITLE
Jenkins 10831 maven submodule build fails doing mkdir on master.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=bug>
+    maven submodule build fails doing mkdir on master.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-10831">issue 10831</
+  <li class=bug>
     CLI clients should be able to see plugin classes
     <a href="http://jenkins.361315.n4.nabble.com/channel-example-and-plugin-classes-gives-ClassNotFoundException-tp3756092p3756092.html">report</a>
   <li class=bug>

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -186,6 +186,16 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     }
 
     /**
+     * Set the name of the slave that the build was performed on.
+     * @param builtOn
+     * @since 1.429
+     */
+    public void setBuiltOnStr( String builtOn )
+    {
+        this.builtOn = builtOn;
+    }
+
+    /**
      * Gets the nearest ancestor {@link AbstractBuild} that belongs to
      * {@linkplain AbstractProject#getRootProject() the root project of getProject()} that
      * dominates/governs/encompasses this build.

--- a/maven-plugin/src/main/java/hudson/maven/MavenBuild.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenBuild.java
@@ -95,13 +95,6 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
      * @since 1.98.
      */
     private List<ExecutedMojo> executedMojos;
-
-    /**
-     * Name of the slave this project was built on.
-     * Null or "" if built by the master. (null happens when we read old record that didn't have this information.)
-     * @since 1.394
-     */
-    private String builtOn;    
     
     public MavenBuild(MavenModule job) throws IOException {
         super(job);
@@ -292,26 +285,6 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
     public MavenModule getParent() {// don't know why, but javac wants this
         return super.getParent();
     }
-
-    /**
-     * @see hudson.model.AbstractBuild#getBuiltOn()
-     * @since 1.394
-     */
-    public Node getBuiltOn() {
-        if(builtOn==null || builtOn.equals(""))
-            return Jenkins.getInstance();
-        else
-            return Jenkins.getInstance().getNode(builtOn);
-    }
-
-    /**
-     * @param builtOn
-     * @since 1.394
-     */
-    public void setBuiltOnStr( String builtOn )
-    {
-        this.builtOn = builtOn;
-    }    
 
     /**
      * Runs Maven and builds the project.


### PR DESCRIPTION
Remove the shadow copy of builtOn from MavenBuild.java and move the setter to AbstractBuild.java to allow MavenModuleSetBuild.java to continue to set the build node.

In the case of a sub-module build the builtOn member variable in AbstractBuild.java was left at null and this meant that any callers of getBuiltOnStr() were seeing a different value to callers of getBuiltOn(). This caused the workspace FilePath to be resolved as being on the master rather than being on the appropriate slave.
