### PR TITLE
Introduce a Jenkins.RUN_SCRIPTS permission

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -57,6 +57,8 @@ Upcoming changes</a>
 <ul class=image>
   <li class=rfe>
   Bundling <a href="https://wiki.jenkins-ci.org/display/JENKINS/Translation+Assistance+Plugin">the translation assistance plugin</a> in the hope of increasing the contribution.
+  <li class=rfe>
+  Introduce a fine-grained permission to control who is allowed to run the Groovy Console.
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/cli/GroovyCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyCommand.java
@@ -69,8 +69,8 @@ public class GroovyCommand extends CLICommand implements Serializable {
     public List<String> remaining = new ArrayList<String>();
 
     protected int run() throws Exception {
-        // this allows the caller to manipulate the JVM state, so require the admin privilege.
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        // this allows the caller to manipulate the JVM state, so require the execute script privilege.
+        Jenkins.getInstance().checkPermission(Jenkins.EXECUTE_SCRIPT);
 
         Binding binding = new Binding();
         binding.setProperty("out",new PrintWriter(stdout,true));

--- a/core/src/main/java/hudson/cli/GroovyCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyCommand.java
@@ -70,7 +70,7 @@ public class GroovyCommand extends CLICommand implements Serializable {
 
     protected int run() throws Exception {
         // this allows the caller to manipulate the JVM state, so require the execute script privilege.
-        Jenkins.getInstance().checkPermission(Jenkins.EXECUTE_SCRIPT);
+        Jenkins.getInstance().checkPermission(Jenkins.RUN_SCRIPTS);
 
         Binding binding = new Binding();
         binding.setProperty("out",new PrintWriter(stdout,true));

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3126,7 +3126,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
 
     private void doScript(StaplerRequest req, StaplerResponse rsp, RequestDispatcher view) throws IOException, ServletException {
         // ability to run arbitrary script is dangerous
-        checkPermission(EXECUTE_SCRIPT);
+        checkPermission(RUN_SCRIPTS);
 
         String text = req.getParameter("script");
         if (text != null) {
@@ -3622,7 +3622,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
     public static final PermissionGroup PERMISSIONS = Permission.HUDSON_PERMISSIONS;
     public static final Permission ADMINISTER = Permission.HUDSON_ADMINISTER;
     public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
-    public static final Permission EXECUTE_SCRIPT = new Permission(PERMISSIONS, "ExecuteScript", Messages._Hudson_ExecuteScriptPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
+    public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
 
     /**
      * {@link Authentication} object that represents the anonymous user.

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -25,6 +25,7 @@
  */
 package jenkins.model;
 
+import hudson.model.Messages;
 import hudson.model.Node;
 import hudson.model.AbstractCIBase;
 import hudson.model.AbstractProject;
@@ -3125,7 +3126,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
 
     private void doScript(StaplerRequest req, StaplerResponse rsp, RequestDispatcher view) throws IOException, ServletException {
         // ability to run arbitrary script is dangerous
-        checkPermission(ADMINISTER);
+        checkPermission(EXECUTE_SCRIPT);
 
         String text = req.getParameter("script");
         if (text != null) {
@@ -3621,6 +3622,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
     public static final PermissionGroup PERMISSIONS = Permission.HUDSON_PERMISSIONS;
     public static final Permission ADMINISTER = Permission.HUDSON_ADMINISTER;
     public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
+    public static final Permission EXECUTE_SCRIPT = new Permission(PERMISSIONS, "ExecuteScript", Messages._Hudson_ExecuteScriptPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
 
     /**
      * {@link Authentication} object that represents the anonymous user.

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -143,8 +143,8 @@ Hudson.ReadPermission.Description=\
   This permission is useful when you don''t want unauthenticated users to see \
   Jenkins pages &mdash; revoke this permission from the anonymous user, then \
   add "authenticated" pseudo-user and grant the read access. 
-Hudson.ExecuteScriptPermission.Description=\
-  The "execute script" permission is necessary for running groovy scripts \
+Hudson.RunScriptsPermission.Description=\
+  The "run scripts" permission is necessary for running groovy scripts \
   via the groovy console or groovy cli command.
 Hudson.NodeDescription=the master Jenkins node
 

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -143,6 +143,9 @@ Hudson.ReadPermission.Description=\
   This permission is useful when you don''t want unauthenticated users to see \
   Jenkins pages &mdash; revoke this permission from the anonymous user, then \
   add "authenticated" pseudo-user and grant the read access. 
+Hudson.ExecuteScriptPermission.Description=\
+  The "execute script" permission is necessary for running groovy scripts \
+  via the groovy console or groovy cli command.
 Hudson.NodeDescription=the master Jenkins node
 
 Item.Permissions.Title=Job

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -92,7 +92,7 @@ THE SOFTWARE.
       <local:feature icon="terminal.png"    href="cli"         title="${%Jenkins CLI}">
         ${%JenkinsCliText}
       </local:feature>
-      <l:hasPermission permission="${it.EXECUTE_SCRIPT}">
+      <l:hasPermission permission="${it.RUN_SCRIPTS}">
         <local:feature icon="notepad.png"      href="script"      title="${%Script Console}">
           ${%Executes arbitrary script for administration/trouble-shooting/diagnostics.}
         </local:feature>

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -92,9 +92,11 @@ THE SOFTWARE.
       <local:feature icon="terminal.png"    href="cli"         title="${%Jenkins CLI}">
         ${%JenkinsCliText}
       </local:feature>
-      <local:feature icon="notepad.png"      href="script"      title="${%Script Console}">
-        ${%Executes arbitrary script for administration/trouble-shooting/diagnostics.}
-      </local:feature>
+      <l:hasPermission permission="${it.EXECUTE_SCRIPT}">
+        <local:feature icon="notepad.png"      href="script"      title="${%Script Console}">
+          ${%Executes arbitrary script for administration/trouble-shooting/diagnostics.}
+        </local:feature>
+      </l:hasPermission>
       <local:feature icon="network.png"      href="computer/"   title="${%Manage Nodes}">
         ${%Add, remove, control and monitor the various nodes that Jenkins runs jobs on.}
       </local:feature>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout norefresh="true" permission="${h.EXECUTE_SCRIPT}">
+  <l:layout norefresh="true" permission="${h.RUN_SCRIPTS}">
     <st:include page="sidepanel.jelly" />
 
     <l:main-panel>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout norefresh="true">
+  <l:layout norefresh="true" permission="${h.EXECUTE_SCRIPT}">
     <st:include page="sidepanel.jelly" />
 
     <l:main-panel>


### PR DESCRIPTION
Introduce a fine-grained permission to control who is allowed to run the Groovy Console.

This is Jenkins.RUN_SCRIPTS and is meant to be enforced wherever users can execute arbitrary scripts which access Jenkins internal API's.
