### PR TITLE
[JENKINS-9634] ignore wrong nargs on osx

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -1059,13 +1059,16 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                             m.skip0();
                             arguments.add(m.readString());
                         }
-                    } catch (IndexOutOfBoundsException e) {
-                        throw new IllegalStateException("Failed to parse arguments: arg0="+args0+", arguments="+arguments+", nargs="+nargs,e);
-                    }
 
-                    // this is how you can read environment variables
-                    while(m.peek()!=0)
-                    envVars.addLine(m.readString());
+                        // this is how you can read environment variables
+                        while(m.peek()!=0)
+                          envVars.addLine(m.readString());
+                    } catch (IndexOutOfBoundsException e) {
+                        for( int i=arguments.size(); i<nargs; i++) {
+                            arguments.add("");
+                        }
+                        LOGGER.log(Level.INFO, "Failed to parse arguments: arg0="+args0+", arguments="+arguments+", nargs="+nargs+". Continuing anyway.");
+                    }
                 } catch (IOException e) {
                     // this happens with insufficient permissions, so just ignore the problem.
                 }


### PR DESCRIPTION
Apparently some processes can make argn be larger than the
number of args, and pad out the end with nulls, which makes
us go out of bounds. Just ignore it when this happens.
