### PR TITLE
Fix for JENKINS-10443: Added way to mark all plugins to be updated at onc

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=bug>
+    Added way to mark all plugins to be updated at once
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-10443">issue 10443</a>)
+  <li class=bug>
     Fixed a bug in the UI JavaScript behavior with IE
   <li class=bug>
     Matrix project pages don't show latest test results.

--- a/core/src/main/resources/hudson/PluginManager/index.jelly
+++ b/core/src/main/resources/hudson/PluginManager/index.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <local:table page="updates" list="${app.updateCenter.updates}" xmlns:local="/hudson/PluginManager">
     <div style="margin-top:1em">
+      Select: <a href="javascript:toggleCheckboxes(true);">All</a>, <a href="javascript:toggleCheckboxes(false);">None</a><br/>
       ${%UpdatePageDescription}
       <j:if test="${!empty(app.updateCenter.jobs)}">
         <br/> ${%UpdatePageLegend(rootURL+'/updateCenter/')}

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1944,6 +1944,19 @@ function buildFormTree(form) {
     }
 }
 
+/**
+ * @param {boolean} toggle
+ *      When true, will check all checkboxes in the page. When false, unchecks them all.
+ */
+var toggleCheckboxes = function(toggle) {
+    var inputs = document.getElementsByTagName("input");
+    for(var i=0; i<inputs.length; i++) {
+        if(inputs[i].type === "checkbox") {
+            inputs[i].checked = toggle;
+        }
+    }
+};
+
 // this used to be in prototype.js but it must have been removed somewhere between 1.4.0 to 1.5.1
 String.prototype.trim = function() {
     var temp = this;


### PR DESCRIPTION
Fix for JENKINS-10443: Added way to mark all plugins to be updated at once
