### PR TITLE
Fix rendering problem in HTTP Proxy Configuration page

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
   <st:include page="sidepanel.jelly"/>
   <l:main-panel>
     <local:tabBar page="advanced" xmlns:local="/hudson/PluginManager" />
-    <table id="pluginsAdv" class="pane bigtable" style="margin-top:0; border-top:none">
+    <table id="pluginsAdv" class="pane" style="margin-top:0; border-top:none">
       <tr style="border-top:none">
         <td>
           <h1>${%HTTP Proxy Configuration}</h1>


### PR DESCRIPTION
If you override IE's document mode settings or you add DOCTYPE / X-UA-Compatible,
IE cannot render HTTP Proxy Configuration page properly.

IE7 standard mode renders whole cell in gray on mouse overed.
IE8 and IE9 standard modes render glitchy borders on each cell.
