### PR TITLE
FIXES JENKINS-10913 Add support for maven-android-plugin integration test

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
@@ -230,6 +230,7 @@ public class SurefireArchiver extends MavenReporter {
             && (!mojo.is("org.eclipse.tycho", "tycho-surefire-plugin", "test"))
             && (!mojo.is("org.sonatype.tycho", "maven-osgi-test-plugin", "test"))
             && (!mojo.is("org.codehaus.mojo", "gwt-maven-plugin", "test"))
+            && (!mojo.is("com.jayway.maven.plugins.android.generation2", "maven-android-plugin", "internal-integration-test"))
             && (!mojo.is("org.apache.maven.plugins", "maven-surefire-plugin", "test"))
             && (!mojo.is("org.apache.maven.plugins", "maven-failsafe-plugin", "integration-test")))
             return false;
@@ -276,6 +277,11 @@ public class SurefireArchiver extends MavenReporter {
                 }
 	        } else if (mojo.is("org.eclipse.tycho", "tycho-surefire-plugin", "test")) {
                 Boolean skipTests = mojo.getConfigurationValue("skipTest", Boolean.class);
+                if (((skipTests != null) && (skipTests))) {
+                    return false;
+                }
+            } else if (mojo.is("com.jayway.maven.plugins.android.generation2", "maven-android-plugin", "internal-integration-test")) {
+                Boolean skipTests = mojo.getConfigurationValue("skipTests", Boolean.class);
                 if (((skipTests != null) && (skipTests))) {
                     return false;
                 }


### PR DESCRIPTION
FIXES JENKINS-10913 Add support for maven-android-plugin integration test reports.

This makes Jenkins parse the junit compatible test result output produced by maven-android-plugin version 3.0.0-alpha-6 and later
See
http://code.google.com/p/maven-android-plugin/wiki/Changelog
http://www.simpligility.com/2011/09/easier-android-test-reporting-with-maven-and-hudson/
