### PR TITLE
Fix JENKINS-10903 Canceling a parent multi-configuration build produce a build.xml that can't be deserialized

### DIFF
--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -23,6 +23,7 @@
  */
 package hudson.util;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.mapper.AnnotationMapper;
@@ -45,6 +46,7 @@ import jenkins.model.Jenkins;
 import hudson.model.Label;
 import hudson.model.Result;
 import hudson.model.Saveable;
+import hudson.util.xstream.ImmutableListConverter;
 import hudson.util.xstream.ImmutableMapConverter;
 import hudson.util.xstream.MapperDelegate;
 
@@ -107,6 +109,7 @@ public class XStream2 extends XStream {
 
         registerConverter(new RobustCollectionConverter(getMapper(),getReflectionProvider()),10);
         registerConverter(new ImmutableMapConverter(getMapper(),getReflectionProvider()),10);
+        registerConverter(new ImmutableListConverter(getMapper(),getReflectionProvider()),10);
         registerConverter(new ConcurrentHashMapConverter(getMapper(),getReflectionProvider()),10);
         registerConverter(new CopyOnWriteMap.Tree.ConverterImpl(getMapper()),10); // needs to override MapConverter
         registerConverter(new DescribableList.ConverterImpl(getMapper()),10); // explicitly added to handle subtypes
@@ -124,6 +127,8 @@ public class XStream2 extends XStream {
             public String serializedClass(Class type) {
                 if (type != null && ImmutableMap.class.isAssignableFrom(type))
                     return super.serializedClass(ImmutableMap.class);
+                else if (type != null && ImmutableList.class.isAssignableFrom(type))
+                    return super.serializedClass(ImmutableList.class);
                 else
                     return super.serializedClass(type);
             }

--- a/core/src/main/java/hudson/util/xstream/ImmutableListConverter.java
+++ b/core/src/main/java/hudson/util/xstream/ImmutableListConverter.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010, InfraDNA, Inc.
+ * Copyright (c) 2011, Richard Mortimer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.util.xstream;
+
+import com.google.common.collect.ImmutableList;
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.collections.CollectionConverter;
+import com.thoughtworks.xstream.converters.reflection.ReflectionProvider;
+import com.thoughtworks.xstream.converters.reflection.SerializableConverter;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.mapper.Mapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link ImmutableList} should convert like a list, instead of via serialization.
+ *
+ * @author Kohsuke Kawaguchi
+ * @author Richard Mortimer
+ */
+public class ImmutableListConverter extends CollectionConverter {
+    private final SerializableConverter sc;
+
+    public ImmutableListConverter(XStream xs) {
+        this(xs.getMapper(),xs.getReflectionProvider());
+    }
+
+    public ImmutableListConverter(Mapper mapper, ReflectionProvider reflectionProvider) {
+        super(mapper);
+        sc = new SerializableConverter(mapper,reflectionProvider);
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return ImmutableList.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        return ImmutableList.copyOf((List)super.unmarshal(reader, context));
+    }
+
+    @Override
+    protected Object createCollection(Class type) {
+        return new ArrayList();
+    }
+}

--- a/core/src/test/java/hudson/util/XStream2Test.java
+++ b/core/src/test/java/hudson/util/XStream2Test.java
@@ -23,12 +23,16 @@
  */
 package hudson.util;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import junit.framework.TestCase;
 import hudson.model.Result;
 import hudson.model.Run;
+
 import org.jvnet.hudson.test.Bug;
 
+import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -125,7 +129,6 @@ public class XStream2Test extends TestCase {
         Map<?,?> m;
     }
 
-
     public void testImmutableMap() {
         XStream2 xs = new XStream2();
 
@@ -164,6 +167,54 @@ public class XStream2Test extends TestCase {
 
         assertSame(m.getClass(),a.m.getClass());    // should get back the exact same type, not just a random map
         assertEquals(m,a.m);
+    }
+
+    private static class ImmutableListHolder {
+        ImmutableList<?> l;
+    }
+
+    private static class ListHolder {
+        List<?> l;
+    }
+
+    public void testImmutableList() {
+        XStream2 xs = new XStream2();
+
+        roundtripImmutableList(xs, ImmutableList.of());
+        roundtripImmutableList(xs, ImmutableList.of("abc"));
+        roundtripImmutableList(xs, ImmutableList.of("abc", "def"));
+
+        roundtripImmutableListAsPlainList(xs, ImmutableList.of());
+        roundtripImmutableListAsPlainList(xs, ImmutableList.of("abc"));
+        roundtripImmutableListAsPlainList(xs, ImmutableList.of("abc", "def"));
+    }
+
+    /**
+     * Since the field type is {@link ImmutableList}, XML shouldn't contain a reference to the type name.
+     */
+    private void roundtripImmutableList(XStream2 xs, ImmutableList<?> l) {
+        ImmutableListHolder a = new ImmutableListHolder();
+        a.l = l;
+        String xml = xs.toXML(a);
+        //System.out.println(xml);
+        assertFalse("shouldn't contain the class name",xml.contains("google"));
+        assertFalse("shouldn't contain the class name",xml.contains("class"));
+        a = (ImmutableListHolder)xs.fromXML(xml);
+
+        assertSame(l.getClass(),a.l.getClass());    // should get back the exact same type, not just a random list
+        assertEquals(l,a.l);
+    }
+
+    private void roundtripImmutableListAsPlainList(XStream2 xs, ImmutableList<?> l) {
+        ListHolder a = new ListHolder();
+        a.l = l;
+        String xml = xs.toXML(a);
+        //System.out.println(xml);
+        assertTrue("XML should mention the class name",xml.contains('\"'+ImmutableList.class.getName()+'\"'));
+        a = (ListHolder)xs.fromXML(xml);
+
+        assertSame(l.getClass(),a.l.getClass());    // should get back the exact same type, not just a random list
+        assertEquals(l,a.l);
     }
 
     @Bug(8006) // Previously a null entry in an array caused NPE

--- a/core/src/test/java/hudson/util/XStream2Test.java
+++ b/core/src/test/java/hudson/util/XStream2Test.java
@@ -26,6 +26,7 @@ package hudson.util;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import junit.framework.TestCase;
+import hudson.matrix.MatrixRun;
 import hudson.model.Result;
 import hudson.model.Run;
 
@@ -35,9 +36,12 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
+import jenkins.model.CauseOfInterruption;
+import jenkins.model.InterruptedBuildAction;
+
 /**
  * Tests for XML serialization of java objects.
- * @author Kohsuke Kawaguchi, Mike Dillon, Alan Harder
+ * @author Kohsuke Kawaguchi, Mike Dillon, Alan Harder, Richard Mortimer
  */
 public class XStream2Test extends TestCase {
 
@@ -237,5 +241,23 @@ public class XStream2Test extends TestCase {
 
     public static class Point {
         public int x,y;
+    }
+
+    /**
+     * Unmarshall a matrix build.xml result.
+     * (JENKINS-10903)
+     */
+    public void testUnMarshalRunMatrix() {
+        InputStream is = XStream2Test.class.getResourceAsStream("runMatrix.xml");
+        MatrixRun result = (MatrixRun) Run.XSTREAM.fromXML(is);
+        assertNotNull(result);
+        assertNotNull(result.getActions());
+        assertEquals(2, result.getActions().size());
+        InterruptedBuildAction action = (InterruptedBuildAction) result.getActions().get(1);
+        assertNotNull(action.getCauses());
+        assertEquals(1, action.getCauses().size());
+        CauseOfInterruption.UserInterruption cause =
+            (CauseOfInterruption.UserInterruption) action.getCauses().get(0);
+        assertNotNull(cause);
     }
 }

--- a/core/src/test/resources/hudson/util/runMatrix.xml
+++ b/core/src/test/resources/hudson/util/runMatrix.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<matrix-run>
+  <actions>
+    <hudson.model.CauseAction>
+      <causes>
+        <hudson.model.Cause_-UpstreamCause>
+          <upstreamProject>MatrixProject</upstreamProject>
+          <upstreamUrl>job/MatrixProject/</upstreamUrl>
+          <upstreamBuild>8</upstreamBuild>
+          <upstreamCauses>
+            <hudson.model.Cause_-UserCause>
+              <authenticationName>auser</authenticationName>
+            </hudson.model.Cause_-UserCause>
+          </upstreamCauses>
+        </hudson.model.Cause_-UpstreamCause>
+      </causes>
+    </hudson.model.CauseAction>
+    <jenkins.model.InterruptedBuildAction>
+      <causes class="com.google.common.collect.SingletonImmutableList" resolves-to="com.google.common.collect.ImmutableList$SerializedForm">
+        <elements>
+          <jenkins.model.CauseOfInterruption_-UserInterruption>
+            <user>auser</user>
+          </jenkins.model.CauseOfInterruption_-UserInterruption>
+        </elements>
+      </causes>
+    </jenkins.model.InterruptedBuildAction>
+  </actions>
+  <number>8</number>
+  <result>ABORTED</result>
+  <duration>3253844</duration>
+  <charset>windows-1252</charset>
+  <keepLog>false</keepLog>
+  <builtOn>amachine</builtOn>
+  <workspace>C:\jenkins\slave\workspace\MatrixProject\blah\blah\blah</workspace>
+  <hudsonVersion>1.427</hudsonVersion>
+  <culprits>
+    <string>auser</string>
+  </culprits>
+</matrix-run>


### PR DESCRIPTION
Fix applied in 2 steps. The first makes serialization round-trip correctly. Then the second adds a special case to allow it to read in existing "broken" build.xml files.

Unit tests included in the commits.

I'll happily sign a CLA if you think this commit is big enough to warrant it.
