### PR TITLE
[FIXED JENKINS-7798]

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -878,17 +878,20 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             String childPath = path + child;
             String childHref = pathHref + Util.rawEncode(child);
             File sub = new File(dir, child);
+            String length = sub.isFile() ? String.valueOf(sub.length()) : "0";
             boolean collapsed = (children.length==1 && parent!=null);
             Artifact a;
             if (collapsed) {
                 // Collapse single items into parent node where possible:
                 a = new Artifact(parent.getFileName() + '/' + child, childPath,
-                                 sub.isDirectory() ? null : childHref, parent.getTreeNodeId());
+                                 sub.isDirectory() ? null : childHref, length,
+                                 parent.getTreeNodeId());
                 r.tree.put(a, r.tree.remove(parent));
             } else {
                 // Use null href for a directory:
                 a = new Artifact(child, childPath,
-                                 sub.isDirectory() ? null : childHref, "n" + ++r.idSeq);
+                                 sub.isDirectory() ? null : childHref, length,
+                                 "n" + ++r.idSeq);
                 r.tree.put(a, parent!=null ? parent.getTreeNodeId() : null);
             }
             if (sub.isDirectory()) {
@@ -896,7 +899,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                 if (n>=upTo) break;
             } else {
                 // Don't store collapsed path in ArrayList (for correct data in external API)
-                r.add(collapsed ? new Artifact(child, a.relativePath, a.href, a.treeNodeId) : a);
+                r.add(collapsed ? new Artifact(child, a.relativePath, a.href, length, a.treeNodeId) : a);
                 if (++n>=upTo) break;
             }
         }
@@ -1031,11 +1034,17 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
          */
         private String treeNodeId;
 
-        /*package for test*/ Artifact(String name, String relativePath, String href, String treeNodeId) {
+        /**
+         *length of this artifact for files.
+         */
+        private String length;
+
+        /*package for test*/ Artifact(String name, String relativePath, String href, String len, String treeNodeId) {
             this.name = name;
             this.relativePath = relativePath;
             this.href = href;
             this.treeNodeId = treeNodeId;
+            this.length = len;
         }
 
         /**
@@ -1060,6 +1069,10 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
         public String getHref() {
             return href;
+        }
+
+        public String getLength() {
+            return length;
         }
 
         public String getTreeNodeId() {

--- a/core/src/main/resources/hudson/model/Run/artifacts-index.jelly
+++ b/core/src/main/resources/hudson/model/Run/artifacts-index.jelly
@@ -24,19 +24,29 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <j:if test="${!h.isArtifactsPermissionEnabled() or h.isArtifactsPermissionEnabled() and h.hasPermission(it.ARTIFACTS)}">
-    <l:layout title="${it.fullDisplayName} Artifacts">
-      <st:include page="sidepanel.jelly" />
-      <l:main-panel>
-        <t:buildCaption>
-          ${%Build Artifacts}
-        </t:buildCaption>
-        <ul>
-          <j:forEach var="f" items="${it.artifacts}">
-            <li><a href="artifact/${f.href}">${f.displayPath}</a></li>
-          </j:forEach>
-        </ul>
-      </l:main-panel>
-    </l:layout>
-  </j:if>
+    <j:if test="${!h.isArtifactsPermissionEnabled() or h.isArtifactsPermissionEnabled() and h.hasPermission(it.ARTIFACTS)}">
+        <l:layout title="${it.fullDisplayName} Artifacts">
+            <st:include page="sidepanel.jelly" />
+            <l:main-panel>
+                <t:buildCaption>
+                        ${%Build Artifacts}
+                </t:buildCaption>
+                <table class="fileList">
+                    <j:forEach var="f" items="${it.artifacts}">
+                        <tr>
+                            <td>
+                                <img src="${imagesURL}/16x16/text.png" alt="" height="16" width="16"/>
+                            </td>
+                            <td>
+                                <a href="artifact/${f.href}">${f.displayPath}</a>
+                            </td>
+                            <td class="fileSize">
+                                ${f.length}
+                            </td>
+                        </tr>
+                    </j:forEach>
+                </table>
+            </l:main-panel>
+        </l:layout>
+    </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/core/src/main/resources/lib/hudson/artifactList.jelly
@@ -47,15 +47,24 @@ THE SOFTWARE.
         <j:choose>
           <j:when test="${size(artifacts) le build.LIST_CUTOFF}">
             <!-- if not too many, just list them -->
-            <ul>
-              <j:forEach var="f" items="${artifacts}">
-                <li>
-                  <a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
-                  <st:nbsp/>
-                  <a href="${baseURL}artifact/${f.href}/*fingerprint*/"><img src="${imagesURL}/16x16/fingerprint.png" alt="[fingerprint]" height="16" width="16" /></a>
-                </li>
-              </j:forEach>
-            </ul>
+            <table class="fileList">
+		<j:forEach var="f" items="${artifacts}">
+                        <tr>
+				<td>
+					<img src="${imagesURL}/16x16/text.png" alt="" height="16" width="16"/>
+				</td>
+				<td>
+					<a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
+				</td>
+				<td class="fileSize">
+					${f.length}
+				</td>
+				<td>
+					<a href="${baseURL}artifact/${f.href}/*fingerprint*/"><img src="${imagesURL}/16x16/fingerprint.png" alt="[fingerprint]" height="16" width="16" /></a>
+				</td>
+			</tr>
+		</j:forEach>
+	    </table>
           </j:when>
           <j:when test="${size(artifacts) le build.TREE_CUTOFF}">
               <!-- otherwise (unless way too many) use a tree view -->


### PR DESCRIPTION
File size should be shown on project dashboard for archived artifacts.

Run.java:
    Add member String length to Artifact object.
    Add paramter String len to Artifact constructor.
    Add method String getLength to Artifact object.
    addArtifacts method of Run class gets length of files as string
    for actual files or "0" if a directory and passes this as arg
    to Artifact constructor.

artifacts-index.jelly and artifactList.jelly
    reworked to use same approach as
    core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
    The desire being a consistent look in the interface.

Signed-off-by: Stephen Ware stephen.e.ware@intel.com

Be gentle...it's my first time. And thanks!
