### PR TITLE
JENKINS-11013 NOT_BUILT status is reported inconsistently

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=>
+  <li class=bug>
+    NOT_BUILT &amp; other build status are reported inconsistently
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11013">issue 11013</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/core/src/main/java/hudson/matrix/MatrixBuild.java
@@ -287,6 +287,7 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
                     if(p.isRunSequentially())
                         scheduleConfigurationBuild(logger, c);
                     Result buildResult = waitForCompletion(listener, c);
+                    logger.println(Messages.MatrixBuild_Completed(c.getDisplayName(), buildResult));
                     r = r.combine(buildResult);
                 }
 

--- a/core/src/main/java/hudson/model/BallColor.java
+++ b/core/src/main/java/hudson/model/BallColor.java
@@ -67,6 +67,8 @@ public enum BallColor implements StatusIcon {
     DISABLED_ANIME("grey_anime",Messages._BallColor_InProgress(), ColorPalette.GREY),
     ABORTED("grey",Messages._BallColor_Aborted(), ColorPalette.GREY),
     ABORTED_ANIME("grey_anime",Messages._BallColor_InProgress(), ColorPalette.GREY),
+    NOTBUILT("grey",Messages._BallColor_NotBuilt(), ColorPalette.GREY),
+    NOTBUILT_ANIME("grey_anime",Messages._BallColor_InProgress(), ColorPalette.GREY),
     ;
 
     private final Localizable description;

--- a/core/src/main/java/hudson/model/Result.java
+++ b/core/src/main/java/hudson/model/Result.java
@@ -62,7 +62,7 @@ public final class Result implements Serializable, CustomExportedBean {
      * This status code is used in a multi-stage build (like maven2)
      * where a problem in earlier stage prevented later stages from building.
      */
-    public static final Result NOT_BUILT = new Result("NOT_BUILT",BallColor.GREY,3);
+    public static final Result NOT_BUILT = new Result("NOT_BUILT",BallColor.NOTBUILT,3);
     /**
      * The build was manually aborted.
      *

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1622,6 +1622,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         if(getResult()==Result.ABORTED)
             return new Summary(false, Messages.Run_Summary_Aborted());
 
+        if(getResult()==Result.NOT_BUILT)
+            return new Summary(false, Messages.Run_Summary_NotBuilt());
+
         if(getResult()==Result.UNSTABLE) {
             if(((Run)this) instanceof AbstractBuild) {
                 AbstractTestResultAction trN = ((AbstractBuild)(Run)this).getTestResultAction();

--- a/core/src/main/java/hudson/tasks/MailSender.java
+++ b/core/src/main/java/hudson/tasks/MailSender.java
@@ -138,7 +138,7 @@ public class MailSender {
         do {
             b=b.getPreviousBuild();
             if(b==null) return null;
-        } while(b.getResult()==Result.ABORTED);
+        } while((b.getResult()==Result.ABORTED) || (b.getResult()==Result.NOT_BUILT));
         return b.getResult();
     }
 

--- a/core/src/main/resources/hudson/matrix/MatrixBuild/ajaxMatrix.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixBuild/ajaxMatrix.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
         </j:when>
         <j:otherwise>
           <a href="${p.shortUrl}/">
-            <img src="${imagesURL}/24x24/${b.buildStatusUrl}" tooltip="${p.tooltip} ${it.number!=b.number?'- skipped':''}" alt="${p.tooltip}" style="${it.number!=b.number?'opacity:0.5':''}" height="24" width="24"/>
+            <img src="${imagesURL}/24x24/${b.buildStatusUrl}" tooltip="${p.tooltip} ${it.number!=b.number?(it.isBuilding()?'- pending' : '- skipped'):''}" alt="${p.tooltip}" style="${it.number!=b.number?'opacity:0.5':''}" height="24" width="24"/>
             <j:if test="${empty(o.x) and empty(o.y)}">
               ${p.combination.toString(o.z)}
             </j:if>

--- a/core/src/main/resources/hudson/matrix/Messages.properties
+++ b/core/src/main/resources/hudson/matrix/Messages.properties
@@ -27,6 +27,7 @@ MatrixBuild.Triggering=Triggering {0}
 MatrixBuild.AppearsCancelled={0} appears to be cancelled
 MatrixBuild.Cancelled=Cancelled {0}
 MatrixBuild.Interrupting=Interrupting {0}
+MatrixBuild.Completed={0} completed with result {1}
 
 MatrixConfiguration.Pronoun=Configuration
 

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -70,6 +70,7 @@ BallColor.Aborted=Aborted
 BallColor.Disabled=Disabled
 BallColor.Failed=Failed
 BallColor.InProgress=In progress
+BallColor.NotBuilt=Not built
 BallColor.Pending=Pending
 BallColor.Success=Success
 BallColor.Unstable=Unstable

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -203,6 +203,7 @@ Run.InProgressDuration={0} and counting
 Run.Summary.Stable=stable
 Run.Summary.Unstable=unstable
 Run.Summary.Aborted=aborted
+Run.Summary.NotBuilt=not built
 Run.Summary.BackToNormal=back to normal
 Run.Summary.BrokenForALongTime=broken for a long time
 Run.Summary.BrokenSinceThisBuild=broken since this build


### PR DESCRIPTION
A number of small fixes to ensure that the NOT_BUILT status is reported properly.

Most were noticed whilst trying to debug a few matrix build issues. I also did a sweep search of core for usages of Result and noticed that NOT_BUILT was being treated the same as SUCCESS or FAILURE when determining transitions from successful to unsuccessful builds.

The changes have been tested on my jenkins instance running locally. I have not had time to look into adding unit tests for each of the issues.
