### PR TITLE
JDK installer now uses Jenkins proxy settings

### DIFF
--- a/core/src/main/java/hudson/tools/JDKInstaller.java
+++ b/core/src/main/java/hudson/tools/JDKInstaller.java
@@ -23,6 +23,9 @@
  */
 package hudson.tools;
 
+import com.gargoylesoftware.htmlunit.BrowserVersion;
+import com.gargoylesoftware.htmlunit.DefaultCredentialsProvider;
+import com.gargoylesoftware.htmlunit.ProxyConfig;
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebClient;
@@ -31,6 +34,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.ProxyConfiguration;
 import hudson.Launcher;
 import hudson.Launcher.ProcStarter;
 import hudson.Util;
@@ -45,6 +49,7 @@ import hudson.util.HttpResponses;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.apache.commons.httpclient.auth.CredentialsProvider;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpResponse;
@@ -344,6 +349,21 @@ public class JDKInstaller extends ToolInstaller {
         URL src = new URL(primary.filepath);
 
         WebClient wc = new WebClient();
+        // honor jenkins proxy settings in WebClient
+        Jenkins h = Jenkins.getInstance();
+        ProxyConfiguration jpc = h!=null ? h.proxy : null;
+        if(jpc != null) {
+            ProxyConfig pc = new ProxyConfig();
+            pc.setProxyHost(jpc.name);
+            pc.setProxyPort(jpc.port);
+            wc.setProxyConfig(pc);
+            if(jpc.getUserName() != null) {
+                DefaultCredentialsProvider cp = new DefaultCredentialsProvider();
+                cp.addCredentials(jpc.getUserName(), jpc.getPassword(), jpc.name, jpc.port, null);
+                wc.setCredentialsProvider(cp);
+            }
+        }
+        
         wc.setJavaScriptEnabled(false);
         wc.setCssEnabled(false);
         Page page = wc.getPage(src);


### PR DESCRIPTION
When the JDK installer was rewritten to use htmlunit's WebClient, the implementer forgot to tell WebClient to use Jenkins' proxy settings.  This patch fixes that.

Another problem I have is that our corporate proxy blocks requests from bad/unknown User-Agents.  I had to manually set WebClient's User-Agent string to a value I knew our proxy would accept because the default was rejected.  That fix isn't included in this patch because it doesn't seem like a good permanent solution for all possible proxies.
