### PR TITLE
Enabled shortcut key on script console

### DIFF
--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
       <!-- this is where the example goes -->
       <d:invokeBody />
 
-      <form action="script" method="post">
+      <form action="script" method="post" name="form1">
         <textarea id="script" name="script" style="width:100%; height:10em">${request.getParameter('script')}</textarea>
         <div align="right">
           <f:submit  value="${%Run}"/>
@@ -53,7 +53,14 @@ THE SOFTWARE.
       <script>
         var w = CodeMirror.fromTextArea(document.getElementById("script"),{
           mode:"text/x-groovy",
-          lineNumbers: true
+          lineNumbers: true,
+          onKeyEvent: function(editor, event){
+            if (event.ctrlKey &amp;&amp; event.keyCode == Event.KEY_RETURN) {
+              editor.save();
+              document.form1.submit();
+              Event.stop(event);
+            }
+          }
         }).getWrapperElement();
         w.setAttribute("style","border:1px solid black; margin-top: 1em; margin-bottom: 1em")
       </script>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -17,7 +17,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+LIABILITY
+, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
@@ -51,18 +52,45 @@ THE SOFTWARE.
       <st:adjunct includes="org.kohsuke.stapler.codemirror.mode.clike.clike"/>
       <st:adjunct includes="org.kohsuke.stapler.codemirror.theme.default"/>
       <script>
-        var w = CodeMirror.fromTextArea(document.getElementById("script"),{
-          mode:"text/x-groovy",
-          lineNumbers: true,
-          onKeyEvent: function(editor, event){
-            if (event.ctrlKey &amp;&amp; event.keyCode == Event.KEY_RETURN) {
-              editor.save();
-              document.form1.submit();
-              Event.stop(event);
+        (function() {
+          var cmdKeyDown = false;
+          
+          var w = CodeMirror.fromTextArea(document.getElementById("script"),{
+            mode:"text/x-groovy",
+            lineNumbers: true,
+            onKeyEvent: function(editor, event){
+              function saveAndSubmit() {
+                editor.save();
+                document.form1.submit();
+                event.stop();
+              }
+              
+              // Mac (Command + Enter)
+              if (navigator.userAgent.indexOf('Mac') > -1) {
+                if (event.type == 'keydown') {
+                  if (event.keyCode == 91 || event.keyCode == 93) {
+                    cmdKeyDown = true;
+                  }
+                }
+                if (event.type == 'keyup') {
+                  if (event.keyCode == 91 || event.keyCode == 93) {
+                    cmdKeyDown = false;
+                  }
+                }
+                if (cmdKeyDown &amp;&amp; event.keyCode == Event.KEY_RETURN) {
+                  saveAndSubmit();
+                }
+                
+              // Windows, Linux (Ctrl + Enter)
+              } else {
+                if (event.ctrlKey &amp;&amp; event.keyCode == Event.KEY_RETURN) {
+                  saveAndSubmit();
+                }
+              }
             }
-          }
-        }).getWrapperElement();
-        w.setAttribute("style","border:1px solid black; margin-top: 1em; margin-bottom: 1em")
+          }).getWrapperElement();
+          w.setAttribute("style","border:1px solid black; margin-top: 1em; margin-bottom: 1em")
+        })();
       </script>
       <j:if test="${output!=null}">
         <h2>${%Result}</h2>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -17,8 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY
-, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
@@ -87,12 +86,14 @@ THE SOFTWARE.
                 }
                 if (cmdKeyDown &amp;&amp; event.keyCode == Event.KEY_RETURN) {
                   saveAndSubmit();
+                  return true;
                 }
                 
               // Windows, Linux (Ctrl + Enter)
               } else {
                 if (event.ctrlKey &amp;&amp; event.keyCode == Event.KEY_RETURN) {
                   saveAndSubmit();
+                  return true;
                 }
               }
             }

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -59,6 +59,18 @@ THE SOFTWARE.
             mode:"text/x-groovy",
             lineNumbers: true,
             onKeyEvent: function(editor, event){
+              function isGeckoCommandKey() {
+                return Prototype.Browser.Gecko &amp;&amp; event.keyCode == 224
+              }
+              function isOperaCommandKey() {
+                return Prototype.Browser.Opera &amp;&amp; event.keyCode == 17
+              }
+              function isWebKitCommandKey() {
+                return Prototype.Browser.WebKit &amp;&amp; (event.keyCode == 91 || event.keyCode == 93)
+              }
+              function isCommandKey() {
+                return isGeckoCommandKey() || isOperaCommandKey() || isWebKitCommandKey();
+              }
               function saveAndSubmit() {
                 editor.save();
                 document.form1.submit();
@@ -67,15 +79,11 @@ THE SOFTWARE.
               
               // Mac (Command + Enter)
               if (navigator.userAgent.indexOf('Mac') > -1) {
-                if (event.type == 'keydown') {
-                  if (event.keyCode == 91 || event.keyCode == 93) {
-                    cmdKeyDown = true;
-                  }
+                if (event.type == 'keydown' &amp;&amp; isCommandKey()) {
+                  cmdKeyDown = true;
                 }
-                if (event.type == 'keyup') {
-                  if (event.keyCode == 91 || event.keyCode == 93) {
-                    cmdKeyDown = false;
-                  }
+                if (event.type == 'keyup' &amp;&amp; isCommandKey()) {
+                  cmdKeyDown = false;
                 }
                 if (cmdKeyDown &amp;&amp; event.keyCode == Event.KEY_RETURN) {
                   saveAndSubmit();


### PR DESCRIPTION
I add shortcut key on script console to submit.
- Mac : Command + Enter
- Windows, Linux : Ctrl + Enter

In the past, on script console I inputted a tab key to focus submit button and submit, but now cannot do that way on CodeMirror syntax highlighting editor. So, I think adding the shortcut key.

tested:
- Windows XP : IE7, Firefox, Chrome, Opera
- Mac : Firefox, Chrome, Opera, Safari
