### PR TITLE
[JENKINS-10851] Re-excluding Xalan as it makes Jenkins KO with IBM JVM

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -158,6 +158,10 @@ THE SOFTWARE.
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xalan</groupId>
+          <artifactId>xalan</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
[JENKINS-10851] Reverting part of 1fd7fb2c11dd3cb46843d274fcd4aaf44 : excluding xalan because its presence makes Jenkins KO on IBM JVM.
