### PR TITLE
Stop a matrix-project build

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -1203,6 +1203,8 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
      */
     public synchronized void doStop(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         Executor e = getExecutor();
+        if (e==null)
+            e = getOneOffExecutor();
         if (e!=null)
             e.doStop(req,rsp);
         else

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -407,6 +407,20 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     }
 
     /**
+     * Gets the one off {@link Executor} building this job, if it's being built.
+     * Otherwise null.
+     */
+    public Executor getOneOffExecutor() {
+        for( Computer c : Jenkins.getInstance().getComputers() ) {
+            for (Executor e : c.getOneOffExecutors()) {
+                if(e.getCurrentExecutable()==this)
+                    return e;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Gets the charset in which the log file is written.
      * @return never null.
      * @since 1.257


### PR DESCRIPTION
When stopping a build from the project page the doStop method does not take into account one off executors.
