### PR TITLE
[JENKINS-11121] Scheduler now checks for requested JDK prior to launching the job on an executor

### DIFF
--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -312,6 +312,14 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         if(l==null && getMode()== Mode.EXCLUSIVE)
             return CauseOfBlockage.fromMessage(Messages._Node_BecauseNodeIsReserved(getNodeName()));   // this node is reserved for tasks that are tied to it
 
+        /**
+         * check if requested JDK is available on this node.
+         */
+        if(item.task instanceof Project) {
+            CauseOfBlockage c = ((Project)item.task).canRunOnNode(this);
+            if(c!=null) return c;
+        }
+
         // Check each NodeProperty to see whether they object to this node
         // taking the task
         for (NodeProperty prop: getNodeProperties()) {

--- a/core/src/main/java/hudson/model/Project.java
+++ b/core/src/main/java/hudson/model/Project.java
@@ -27,6 +27,7 @@ package hudson.model;
 import hudson.Util;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.Descriptor.FormException;
+import hudson.model.queue.CauseOfBlockage;
 import hudson.tasks.BuildStep;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildWrapper;
@@ -179,6 +180,17 @@ public abstract class Project<P extends Project<P,B>,B extends Build<P,B>>
     public MavenInstallation inferMavenInstallation() {
         Maven m = getBuildersList().get(Maven.class);
         if (m!=null)    return m.getMaven();
+        return null;
+    }
+
+    /**
+     * checks if this very project can run on the given node
+     * 
+     * @param node
+     * @return null if the project can run. A {@link CauseOfBlockage}
+     * object is returned if not.
+     */
+    public CauseOfBlockage canRunOnNode(Node node) {
         return null;
     }
 


### PR DESCRIPTION
I ask you to merge these changes into jenkins master. Please see a complete problem and feature description here https://issues.jenkins-ci.org/browse/JENKINS-11121.

Again, the feature was tested exhaustively. Since the enhancement needs a rather complex jenkins setup, unit testing is a huge challenge and is therefore not done (yet). I will try to add some tests as soon as I have some loose time here at work.

Thanks!
Florian
