### PR TITLE
[JENKINS-5335] Add html doctype on Jenkins to avoid quirks mode.

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:i="jelly:fmt" xmlns:x="jelly:xml">
   <st:documentation>
     Outer-most tag for a normal (non-AJAX) HTML rendering.
     This is used with nested &lt;header>, &lt;side-panel>, and &lt;main-panel>
@@ -82,7 +82,8 @@ THE SOFTWARE.
       <st:include it="${pd}" page="httpHeaders.jelly" optional="true"/>
     </j:forEach>
   </j:if>
-  <html>
+<x:doctype name="html" />
+<html>
   <head>
     ${h.checkPermission(it,permission)}
 


### PR DESCRIPTION
Here is an attempt to fix JENKINS-5335. Warning: this is my first Jenkins pull request.
