### PR TITLE
[JENKINS-9577] Fix last modification timestamp after unzip

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -499,7 +499,6 @@ public final class FilePath implements Serializable {
                         p.mkdirs();
                     }
                     IOUtils.copy(zip.getInputStream(e), f);
-                    f.setLastModified(e.getTime());
                     try {
                         FilePath target = new FilePath(f);
                         int mode = e.getUnixMode();
@@ -508,6 +507,7 @@ public final class FilePath implements Serializable {
                     } catch (InterruptedException ex) {
                         LOGGER.log(Level.WARNING, "unable to set permissions", ex);
                     }
+                    f.setLastModified(e.getTime());
                 }
             }
         } finally {


### PR DESCRIPTION
Reordered operations in order to set the file modification time
after applying the permissions.
