### PR TITLE
[JENKINS-7725] mailto: links should be absolute URIs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -425,6 +425,11 @@ THE SOFTWARE.
       <artifactId>junit-dep</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency><!-- needed by Jelly -->
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -430,6 +430,23 @@ THE SOFTWARE.
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.4.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.4.10</version>
+      <scope>test</scope>
+    </dependency>
     <dependency><!-- needed by Jelly -->
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1169,7 +1169,7 @@ public class Functions {
     public static String getActionUrl(String itUrl,Action action) {
         String urlName = action.getUrlName();
         if(urlName==null)   return null;    // to avoid NPE and fail to render the whole page
-        if(SCHEME.matcher(urlName).matches())
+        if(SCHEME.matcher(urlName).find())
             return urlName; // absolute URL
         if(urlName.startsWith("/"))
             return Stapler.getCurrentRequest().getContextPath()+urlName;
@@ -1363,7 +1363,7 @@ public class Functions {
         return DescriptorVisibilityFilter.apply(context,descriptors);
     }
     
-    private static final Pattern SCHEME = Pattern.compile("[a-z]+://.+");
+    private static final Pattern SCHEME = Pattern.compile("^([a-zA-Z][a-zA-Z0-9+.-]*):");
 
     /**
      * Returns true if we are running unit tests.

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -28,29 +28,20 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
+import static org.mockito.Mockito.*;
 
 public class FunctionsTest {
     @Test
     @Bug(7725)
     public void testGetActionUrl_mailto(){
         String mailto = "mailto:nobody@example.com";
-        String result = Functions.getActionUrl(null, new MockAction(mailto));
+        String result = Functions.getActionUrl(null, createMockAction(mailto));
         assertEquals(mailto, result);
     }
 
-    private static final class MockAction implements Action {
-        private String url;
-        public MockAction(String url) {
-            this.url = url;
-        }
-        public String getIconFileName() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-        public String getDisplayName() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-        public String getUrlName() {
-            return url;
-        }
+    private static Action createMockAction(String uri) {
+        Action action = mock(Action.class);
+        when(action.getUrlName()).thenReturn(uri);
+        return action;
     }
 }

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2011, OHTAKE Tomohiro.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson;
+
+import hudson.model.Action;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.jvnet.hudson.test.Bug;
+
+public class FunctionsTest {
+    @Test
+    @Bug(7725)
+    public void testGetActionUrl_mailto(){
+        String mailto = "mailto:nobody@example.com";
+        String result = Functions.getActionUrl(null, new MockAction(mailto));
+        assertEquals(mailto, result);
+    }
+
+    private static final class MockAction implements Action {
+        private String url;
+        public MockAction(String url) {
+            this.url = url;
+        }
+        public String getIconFileName() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+        public String getDisplayName() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+        public String getUrlName() {
+            return url;
+        }
+    }
+}

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -32,11 +32,31 @@ import static org.mockito.Mockito.*;
 
 public class FunctionsTest {
     @Test
+    public void testGetActionUrl_absoluteUriWithAuthority(){
+        String[] uris = {
+            "http://example.com/foo/bar",
+            "https://example.com/foo/bar",
+            "ftp://example.com/foo/bar",
+            "svn+ssh://nobody@example.com/foo/bar",
+        };
+        for(String uri : uris) {
+            String result = Functions.getActionUrl(null, createMockAction(uri));
+            assertEquals(uri, result);
+        }
+    }
+
+    @Test
     @Bug(7725)
-    public void testGetActionUrl_mailto(){
-        String mailto = "mailto:nobody@example.com";
-        String result = Functions.getActionUrl(null, createMockAction(mailto));
-        assertEquals(mailto, result);
+    public void testGetActionUrl_absoluteUriWithoutAuthority(){
+        String[] uris = {
+            "mailto:nobody@example.com",
+            "mailto:nobody@example.com?subject=hello",
+            "javascript:alert('hello')",
+        };
+        for(String uri : uris) {
+            String result = Functions.getActionUrl(null, createMockAction(uri));
+            assertEquals(uri, result);
+        }
     }
 
     private static Action createMockAction(String uri) {


### PR DESCRIPTION
Jenkins is assuming that absolute URIs are "[a-z]+://.+".
On the other hand, RFC-3986 states that
scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ).
I have changed the scheme regex to comply with RFC-3986.

This pull request may introduce an issue.
Suppose an action's urlName is "i:am:assuming:this:is:relative:uri",
the urlName will be regarded as an absolute URI.
Absolutely it is an absolute URI according to RFC-3986. 
The plugin has to change urlName to "./i:am:assuming:this:is:relative:uri".
