### PR TITLE
[JENKINS-11151] HTTPS on port 80 makes Jenkins infer his URI incorrectly

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -58,6 +58,9 @@ Upcoming changes</a>
   <li class=rfe>
     Added a way to show avatar images on user pages.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-7494">issue 7494</a>)
+  <li class=bug>
+    HTTPS on port 80 makes Jenkins infer his URI incorrectly
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11151">issue 11151</a>)
 
 </ul>
 </div><!--=TRUNK-END=-->

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -647,7 +647,7 @@ public class Functions {
         StringBuilder buf = new StringBuilder();
         buf.append(req.getScheme()).append("://");
         buf.append(req.getServerName());
-        if(req.getLocalPort()!=80)
+        if(! (req.getScheme().equals("http") && req.getLocalPort()==80 || req.getScheme().equals("https") && req.getLocalPort()==443))
             buf.append(':').append(req.getLocalPort());
         buf.append(req.getContextPath()).append('/');
         return buf.toString();


### PR DESCRIPTION
If Jenkins' HTTP__S__ port is 80, Jenkins cannot infer his URI correctly.
Suppose that the correct URI of Jenkins is https://jenkins.local:80/,
he infers that his URI is https://jenkins.local/.
It lacks the port number 80.

This pull request fixes the issue above.
