### PR TITLE
gwt-maven-plugin < 1.2 compliance

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
@@ -285,8 +285,10 @@ public class SurefireArchiver extends MavenReporter {
                 if (((skipTests != null) && (skipTests))) {
                     return false;
                 }
+            } else if (mojo.is("org.codehaus.mojo", "gwt-maven-plugin", "test") && mojo.pluginName.version.compareTo("1.2") < 0) {
+                    // gwt-maven-plugin < 1.2 does not implement required Surefire option
+                    return false;
             }
-
         } catch (ComponentConfigurationException e) {
             return false;
         }


### PR DESCRIPTION
Fix for https://github.com/fred-o/jenkins/commit/bc99134c4587ef62def455e355ffb648462c236f which breaks the build when using gwt-maven-plugin < 1.2
