### PR TITLE
JENKINS-10913 Add support for maven-android-plugin integration test

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,6 +55,9 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
+  <li class=bug>
+    Add support for android-maven-plugin integration test reports and fix an error with 2.x maven-android-plugin
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-10913">issue 10913</a>)    
   <li class=rfe>
     Added a way to show avatar images on user pages.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-7494">issue 7494</a>)

--- a/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
@@ -231,6 +231,7 @@ public class SurefireArchiver extends MavenReporter {
             && (!mojo.is("org.sonatype.tycho", "maven-osgi-test-plugin", "test"))
             && (!mojo.is("org.codehaus.mojo", "gwt-maven-plugin", "test"))
             && (!mojo.is("com.jayway.maven.plugins.android.generation2", "maven-android-plugin", "internal-integration-test"))
+            && (!mojo.is("com.jayway.maven.plugins.android.generation2", "android-maven-plugin", "internal-integration-test"))
             && (!mojo.is("org.apache.maven.plugins", "maven-surefire-plugin", "test"))
             && (!mojo.is("org.apache.maven.plugins", "maven-failsafe-plugin", "integration-test")))
             return false;
@@ -280,10 +281,20 @@ public class SurefireArchiver extends MavenReporter {
                 if (((skipTests != null) && (skipTests))) {
                     return false;
                 }
-            } else if (mojo.is("com.jayway.maven.plugins.android.generation2", "maven-android-plugin", "internal-integration-test")) {
+            } else if (mojo.is("com.jayway.maven.plugins.android.generation2", "android-maven-plugin", "internal-integration-test")) {
                 Boolean skipTests = mojo.getConfigurationValue("skipTests", Boolean.class);
                 if (((skipTests != null) && (skipTests))) {
                     return false;
+                }
+            } else if (mojo.is("com.jayway.maven.plugins.android.generation2", "maven-android-plugin", "internal-integration-test")) {
+                if (mojo.pluginName.version.compareTo("3.0.0-alpha-6") < 0) {
+                    // Earlier versions do not support tests
+                    return false;
+                } else {
+                    Boolean skipTests = mojo.getConfigurationValue("skipTests", Boolean.class);
+                    if (((skipTests != null) && (skipTests))) {
+                        return false;
+                    }
                 }
             } else if (mojo.is("org.codehaus.mojo", "gwt-maven-plugin", "test") && mojo.pluginName.version.compareTo("1.2") < 0) {
                     // gwt-maven-plugin < 1.2 does not implement required Surefire option


### PR DESCRIPTION
This fixes a regression with older versions of the maven-android-plugin - Reported by Wiebe Elsinga. 

[FIXED JENKINS-10913] Add support for maven-android-plugin integration test

Earlier versions of the plugin (2.x and prior to 3.0.0-alpha6) do not produce
test reports and also do not accept the same configuration properties. Ignore
those earlier versions.
Also accept the new plugin name android-maven-plugin (changed to fit with
Maven plugin naming guidelines).
