### PR TITLE
Connect and Disconnect permissions for slaves

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -305,7 +305,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     @CLIMethod(name="connect-node")
     public void cliConnect(@Option(name="-f",usage="Cancel any currently pending connect operation and retry from scratch") boolean force) throws ExecutionException, InterruptedException {
-        checkPermission(Jenkins.ADMINISTER);
+        checkPermission(CONNECT);
         connect(force).get();
     }
 
@@ -361,7 +361,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     @CLIMethod(name="disconnect-node")
     public void cliDisconnect(@Option(name="-m",usage="Record the note about why you are disconnecting this node") String cause) throws ExecutionException, InterruptedException {
-        checkPermission(Jenkins.ADMINISTER);
+        checkPermission(DISCONNECT);
         disconnect(new ByCLI(cause)).get();
     }
 
@@ -370,13 +370,13 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     @CLIMethod(name="offline-node")
     public void cliOffline(@Option(name="-m",usage="Record the note about why you are disconnecting this node") String cause) throws ExecutionException, InterruptedException {
-        checkPermission(Jenkins.ADMINISTER);
+        checkPermission(DISCONNECT);
         setTemporarilyOffline(true,new ByCLI(cause));
     }
 
     @CLIMethod(name="online-node")
     public void cliOnline() throws ExecutionException, InterruptedException {
-        checkPermission(Jenkins.ADMINISTER);
+        checkPermission(CONNECT);
         setTemporarilyOffline(false,null);
     }
 
@@ -963,14 +963,15 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     public HttpResponse doToggleOffline(@QueryParameter String offlineMessage) throws IOException, ServletException {
-        checkPermission(Jenkins.ADMINISTER);
         if(!temporarilyOffline) {
+            checkPermission(DISCONNECT);
             offlineMessage = Util.fixEmptyAndTrim(offlineMessage);
             setTemporarilyOffline(!temporarilyOffline,
                     OfflineCause.create(hudson.slaves.Messages._SlaveComputer_DisconnectedBy(
                         Jenkins.getAuthentication().getName(),
                         offlineMessage!=null ? " : " + offlineMessage : "")));
         } else {
+            checkPermission(CONNECT);
             setTemporarilyOffline(!temporarilyOffline,null);
         }
         return HttpResponses.redirectToDot();
@@ -1158,6 +1159,8 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     public static final Permission CONFIGURE = new Permission(PERMISSIONS,"Configure", Messages._Computer_ConfigurePermission_Description(), Permission.CONFIGURE, PermissionScope.COMPUTER);
     public static final Permission DELETE = new Permission(PERMISSIONS,"Delete", Messages._Computer_DeletePermission_Description(), Permission.DELETE, PermissionScope.COMPUTER);
     public static final Permission CREATE = new Permission(PERMISSIONS,"Create", Messages._Computer_CreatePermission_Description(), Permission.CREATE);
+    public static final Permission DISCONNECT = new Permission(PERMISSIONS,"Disconnect", Messages._Computer_DisconnectPermission_Description(), Jenkins.ADMINISTER, PermissionScope.COMPUTER);
+    public static final Permission CONNECT = new Permission(PERMISSIONS,"Connect", Messages._Computer_ConnectPermission_Description(), DISCONNECT, PermissionScope.COMPUTER);
 
     private static final Logger LOGGER = Logger.getLogger(Computer.class.getName());
 }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -409,7 +409,7 @@ public class SlaveComputer extends Computer {
     public HttpResponse doDoDisconnect(@QueryParameter String offlineMessage) throws IOException, ServletException {
         if (channel!=null) {
             //does nothing in case computer is already disconnected
-            checkPermission(Jenkins.ADMINISTER);
+            checkPermission(DISCONNECT);
             offlineMessage = Util.fixEmptyAndTrim(offlineMessage);
             disconnect(OfflineCause.create(Messages._SlaveComputer_DisconnectedBy(
                     Jenkins.getAuthentication().getName(),

--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -27,23 +27,26 @@ THE SOFTWARE.
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
+
       <!-- temporarily offline switch -->
-      <l:isAdmin>
       <div style="float:right">
         <j:choose>
           <j:when test="${it.temporarilyOffline}">
-            <form method="post" action="toggleOffline">
-              <f:submit value="${%submit.temporarilyOffline}"  />
-            </form>
+            <l:hasPermission permission="${it.CONNECT}">
+              <form method="post" action="toggleOffline">
+                <f:submit value="${%submit.temporarilyOffline}"  />
+              </form>
+            </l:hasPermission>
           </j:when>
           <j:otherwise>
-            <form method="post" action="markOffline">
-              <f:submit value="${%submit.not.temporarilyOffline}"  />
-            </form>
+            <l:hasPermission permission="${it.DISCONNECT}">
+              <form method="post" action="markOffline">
+                <f:submit value="${%submit.not.temporarilyOffline}"  />
+              </form>
+            </l:hasPermission>
           </j:otherwise>
         </j:choose>
       </div>
-      </l:isAdmin>
 
       <h1>
         <img src="${imagesURL}/48x48/${it.icon}" width="48" height="48" alt=""/>

--- a/core/src/main/resources/hudson/model/Computer/markOffline.jelly
+++ b/core/src/main/resources/hudson/model/Computer/markOffline.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <l:layout title="${%title(it.displayName)}" norefresh="true">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <l:isAdmin>
+      <l:hasPermission permission="${it.DISCONNECT}">
         <h2>${%title(it.displayName)}</h2>
         <p>
           ${%blurb}
@@ -38,7 +38,7 @@ THE SOFTWARE.
             <f:submit value="${%submit}"  />
           </p>
         </form>
-      </l:isAdmin>
+      </l:hasPermission>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -93,6 +93,8 @@ Computer.Permissions.Title=Slave
 Computer.ConfigurePermission.Description=This permission allows users to configure slaves.
 Computer.DeletePermission.Description=This permission allows users to delete existing slaves.
 Computer.CreatePermission.Description=This permission allows users to create slaves.
+Computer.ConnectPermission.Description=This permission allows users to connect slaves or mark slaves as online.
+Computer.DisconnectPermission.Description=This permission allows users to disconnect slaves or mark slaves as temporarily offline.
 Computer.BadChannel=Slave node offline or not a remote channel (such as master node).
 
 ComputerSet.NoSuchSlave=No such slave: {0}

--- a/core/src/main/resources/hudson/slaves/ComputerLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/ComputerLauncher/main.jelly
@@ -31,19 +31,20 @@ THE SOFTWARE.
           ${%launchingDescription}
           <a href="log">${%See log for more details}</a>
         </p>
-        <l:isAdmin>
+
+        <l:hasPermission permission="${it.CONNECT}">
           <form method="get" action="launchSlaveAgent">
             <f:submit value="${%Relaunch slave agent}" />
           </form>
-        </l:isAdmin>
+        </l:hasPermission>
       </j:when>
 
       <j:otherwise>
-        <l:isAdmin>
+        <l:hasPermission permission="${it.CONNECT}">
           <form method="get" action="launchSlaveAgent">
             <f:submit value="${%Launch slave agent}" />
           </form>
-        </l:isAdmin>
+        </l:hasPermission>
       </j:otherwise>
     </j:choose>
   </j:if>

--- a/core/src/main/resources/hudson/slaves/SlaveComputer/log.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/log.jelly
@@ -27,13 +27,13 @@ THE SOFTWARE.
   <l:layout title="${it.displayName} log" secured="true">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <l:isAdmin>
+      <l:hasPermission permission="${it.CONNECT}">
         <pre id="out" />
         <div id="spinner">
           <img src="${imagesURL}/spinner.gif" alt=""/>
         </div>
         <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner" />
-      </l:isAdmin>
+      </l:hasPermission>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/slaves/SlaveComputer/sidepanel2.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/sidepanel2.jelly
@@ -24,11 +24,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:isAdmin>
-    <l:task icon="images/24x24/clipboard.png" href="log" title="${%Log}" />
-    <l:task icon="images/24x24/computer.png" href="systemInfo" title="${%System Information}" />
-    <j:if test="${it.channel!=null}">
-      <l:task icon="images/24x24/edit-delete.png" href="disconnect" title="${%Disconnect}" />
-    </j:if>
-  </l:isAdmin>
+  <l:task icon="images/24x24/clipboard.png" href="log" title="${%Log}" permission="${it.CONNECT}" />
+  <l:task icon="images/24x24/computer.png" href="systemInfo" title="${%System Information}" permission="${it.CONNECT}"/>
+  <j:if test="${it.channel!=null}">
+    <l:task icon="images/24x24/edit-delete.png" href="disconnect" title="${%Disconnect}" permission="${it.DISCONNECT}"/>
+  </j:if>
+
 </j:jelly>

--- a/core/src/main/resources/hudson/slaves/SlaveComputer/systemInfo.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/systemInfo.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
 
     <l:main-panel>
-      <l:isAdmin>
+      <l:hasPermission permission="${it.CONNECT}">
         <h1>${it.oSDescription} slave, version ${it.slaveVersion}</h1>
         <h1>${%System Properties}</h1>
         <t:propertyTable items="${it.systemProperties}" />
@@ -44,7 +44,7 @@ THE SOFTWARE.
           <h2>${t.key}</h2>
           <pre>${t.value}</pre>
         </j:forEach>
-      </l:isAdmin>
+      </l:hasPermission>
     </l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION
This pull request adds two new permissions in the COMPUTER permissions scope.

1) DISCONNECT, which also implies Jenkins.ADMINISTER

2) CONNECT, which also implies DISCONNECT.

When permissions are granted for CONNECT a user may connect or re-connect a slave or mark a slave as online. In addition such a user can view the slave log and system info.

When permissions are granted for DISCONNECT a user may disconnect a slave or mark a slave as temporarily offline.

DISCONNECT also implies CONNECT so that a user does not "lock" themselves out from slave connection management.
