### PR TITLE
[JENKINS-11306] Debian init script: return a proper status code when Jenkins is not running.

### DIFF
--- a/debian/debian/jenkins.init
+++ b/debian/debian/jenkins.init
@@ -205,27 +205,35 @@ case "$1" in
     esac
     ;;
   status)
-      get_daemon_status
-      case "$?" in 
-	 0) echo "$DESC is running with the pid `cat $PIDFILE`";;
-         *) 
-	      get_running
-	      procs=$?
-	      if [ $procs -eq 0 ]; then 
-		  echo -n "$DESC is not running"
-		  if [ -f $PIDFILE ]; then 
-		      echo ", but the pidfile ($PIDFILE) still exists"
-		  else 
-		      echo
-		  fi
-
-	      else 
-		  echo "$procs instances of jenkins are running at the moment"
-		  echo "but the pidfile $PIDFILE is missing"
-	      fi
-	      ;;
-      esac
-    ;;
+	get_daemon_status
+	case "$?" in 
+	 0) 
+		echo "$DESC is running with the pid `cat $PIDFILE`"
+		rc=0
+		;;
+	*) 
+		get_running
+		procs=$?
+		if [ $procs -eq 0 ]; then 
+			echo -n "$DESC is not running"
+			if [ -f $PIDFILE ]; then 
+				echo ", but the pidfile ($PIDFILE) still exists"
+				rc=1
+			else 
+				echo
+				rc=3
+			fi
+		
+		else 
+			echo "$procs instances of jenkins are running at the moment"
+			echo "but the pidfile $PIDFILE is missing"
+			rc=0
+		fi
+		
+		exit $rc
+		;;
+	esac
+	;;
   *)
     echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
     exit 3


### PR DESCRIPTION
Hi,

I enhanced the Debian init script to return a proper exit code when Jenkins is not running. According to LSB standards, the following codes should be returned:
- 0 if program is running or service is OK;
- 1 if program is dead and /var/run pid file exists;
- 3 if program is not running.

Having exit code different than 0 means the init script can be used for monitoring purpose.

Could you consider merging this pull request?

Thanks and best regards,
Reynald
