### PR TITLE
[JENKINS-9210] Fingerprint's age should be sorted by its elapsed time

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -61,6 +61,9 @@ Upcoming changes</a>
   <li class=bug>
     Avoid overwriting the repository definitions.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11229">issue 11229</a>)
+  <li class=bug>
+    Fingerprint's age should be sorted by its elapsed time
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-9210">issue 9210</a>)
   <li class=rfe>
     Improved the classloading performance
 </ul>

--- a/core/src/main/resources/hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
+++ b/core/src/main/resources/hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
         <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
         ${%Recorded Fingerprints}
       </h1>
-      <table class="fingerprint-in-build sortable">
+      <table class="fingerprint-in-build sortable bigtable">
         <tr>
           <th initialSortDir="down">${%File}</th>
           <th>${%Original owner}</th>

--- a/core/src/main/resources/hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
+++ b/core/src/main/resources/hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
@@ -62,7 +62,7 @@ THE SOFTWARE.
                 </j:otherwise>
               </j:choose>
             </td>
-            <td>
+            <td data="${-f.timestamp.time}">
               ${f.timestampString} old
             </td>
             <td>


### PR DESCRIPTION
Fingerprint's age should be sorted by its elapsed time instead of human-readable form.
