### PR TITLE
renderOnDemand failed on plugin startup when plugin wants to display several html elements

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -435,10 +435,15 @@ function renderOnDemand(e,callback,noBehaviour) {
     proxy.render(function (t) {
         var contextTagName = e.parentNode.tagName;
         var c;
-        if (contextTagName=="TBODY") {
-            c = document.createElement("DIV");
-            c.innerHTML = "<TABLE><TBODY>"+t.responseText+"</TBODY></TABLE>";
-            c = c.firstChild.firstChild;
+
+        if ( contextTagName=="TBODY" ) {
+          c = document.createElement("DIV");
+          var tableHead = document.createElement("TABLE");
+          c.appendChild( tableHead );
+          var tableBody = document.createElement("TBODY");
+          tableHead.appendChild(tableBody);
+          tableBody.innerHTML = t.responseText;
+          c = c.firstChild.firstChild;
         } else {
             c = document.createElement(contextTagName);
             c.innerHTML = t.responseText;


### PR DESCRIPTION
All resulted from string concatenation not working when trying to concatenate the plugin ui content with html table elements.
Fixed this by creating table elements properly instead of concatenating stuff to innerHTML.
