### PR TITLE
Log with a specific user when controlling Windows slave

### DIFF
--- a/core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/config.jelly
+++ b/core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/config.jelly
@@ -33,4 +33,12 @@ THE SOFTWARE.
   <f:entry title="${%Host}" field="host">
     <f:textbox/>
   </f:entry>
+  <f:optionalBlock field="logOn" title="${%Log on using a different account}" checked="${instance.logOn != null}">
+    <f:entry title="${%User name}" field="userName">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Password}" field="password">
+      <f:password />
+    </f:entry>
+  </f:optionalBlock>
 </j:jelly>

--- a/core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/config_fr.properties
+++ b/core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/config_fr.properties
@@ -22,3 +22,6 @@
 
 Administrator\ user\ name=Nom de l''utilisateur administrateur
 Password=Mot de passe
+Log\ on\ using\ a\ different\ account=Se connecter en utilisant un utilisateur différent
+User\ name=Nom d''utilisateur
+Host=Hôte

--- a/core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/help-host_fr.html
+++ b/core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/help-host_fr.html
@@ -1,0 +1,3 @@
+<div>
+    Fournissez le nom de la machine Windows s'il est diff&eacute;rent du nom de l'esclave.
+</div>


### PR DESCRIPTION
Add an additional option in "Let Jenkins control this Windows slave as a
Windows service" to specify a user under which the service will be run.

This allows to use a different user than "Local System" to register a
windows service.

Added as well a few fr translations for strings in this config page.
