### PR TITLE
Use a prettier string representation of jobs

### DIFF
--- a/core/src/main/java/hudson/cli/handlers/AbstractProjectOptionHandler.java
+++ b/core/src/main/java/hudson/cli/handlers/AbstractProjectOptionHandler.java
@@ -51,11 +51,11 @@ public class AbstractProjectOptionHandler extends OptionHandler<AbstractProject>
 
         AbstractProject s = h.getItemByFullName(src,AbstractProject.class);
         if (s==null) {
+            String exceptionMessage = "No such job '"+src+"'";
             AbstractProject nearest = AbstractProject.findNearest(src);
             if (nearest!=null)
-                throw new CmdLineException(owner, "No such job '"+src+"' perhaps you meant "+ nearest +"?");
-            else
-                throw new CmdLineException(owner, "No such job '"+src+"'");
+                exceptionMessage += " perhaps you meant "+nearest.getName()+"?";
+            throw new CmdLineException(owner, exceptionMessage);
         }
         setter.addValue(s);
         return 1;

--- a/core/src/main/java/hudson/cli/handlers/TopLevelItemOptionHandler.java
+++ b/core/src/main/java/hudson/cli/handlers/TopLevelItemOptionHandler.java
@@ -28,8 +28,13 @@ public class TopLevelItemOptionHandler extends OptionHandler<TopLevelItem> {
         String src = params.getParameter(0);
 
         TopLevelItem s = h.getItem(src);
-        if (s==null)
-            throw new CmdLineException(owner, "No such job '"+src+"' perhaps you meant "+ AbstractProject.findNearest(src)+"?");
+        if (s==null) {
+            String exceptionMessage = "No such job '"+src+"'";
+            AbstractProject nearest = AbstractProject.findNearest(src);
+            if (nearest!=null)
+                exceptionMessage += " perhaps you meant "+nearest.getName()+"?";
+            throw new CmdLineException(owner, exceptionMessage);
+        }
         setter.addValue(s);
         return 1;
     }


### PR DESCRIPTION
Use a prettier string representation of jobs.

Currently something like:

No such job 'foo' perhaps you meant hudson.model.FreeStyleProject@7fa5f230[foobar]?

is printed if an incorrect job name is passed.  Instead, we should call getName on the job object, returning:

No such job 'foo' perhaps you meant foobar?

I don't like the duplication across the two files edited, but don't know the jenkins code enough/have time to get to know it enough to tidy this up - this change doesn't make it any _worse_ :)
