### PR TITLE
[JENKINS-11383] "Changes" in Build Summary broken in IE standard mode since 1.434

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,7 +55,9 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
-  <li class=>
+  <li class=bug>
+    "Changes" in Build Summary broken in IE standard mode since 1.434
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11383">issue 11383</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/resources/lib/hudson/summary.jelly
+++ b/core/src/main/resources/lib/hudson/summary.jelly
@@ -45,15 +45,30 @@ THE SOFTWARE.
     <j:if test="${attrs.icon!=null}">
       <tr>
         <td>
-          <a href="${attrs.href}">
-            <img src="${icon.startsWith('/') ? rootURL+icon : imagesURL+'/48x48/'+icon}"
-                 alt="" width="48" height="48" style="margin-right:1em" />
-          </a>
+          <j:choose>
+            <j:when test="${attrs.href!=null}">
+              <a href="${attrs.href}">
+                <img src="${icon.startsWith('/') ? rootURL+icon : imagesURL+'/48x48/'+icon}"
+                     alt="" width="48" height="48" style="margin-right:1em" />
+              </a>
+            </j:when>
+            <j:otherwise>
+              <img src="${icon.startsWith('/') ? rootURL+icon : imagesURL+'/48x48/'+icon}"
+                   alt="" width="48" height="48" style="margin-right:1em" />
+            </j:otherwise>
+          </j:choose>
         </td>
         <td style="vertical-align:middle">
-          <a href="${attrs.iconOnly==null ? attrs.href : null}">
-            <d:invokeBody />
-          </a>
+          <j:choose>
+            <j:when test="${attrs.href!=null &amp;&amp; !attrs.iconOnly}">
+              <a href="${attrs.href}">
+                <d:invokeBody />
+              </a>
+            </j:when>
+            <j:otherwise>
+              <d:invokeBody />
+            </j:otherwise>
+          </j:choose>
         </td>
       </tr>
     </j:if>


### PR DESCRIPTION
This pull request fixes [JENKINS-11383](https://issues.jenkins-ci.org/browse/JENKINS-11383).
Similar to #282, this problem was actualized by DOCTYPE (#260).
