### PR TITLE
Allows Jenkins administrator to define where to store Maven private

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/MavenBuild.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenBuild.java
@@ -675,10 +675,12 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
                         getParent().getParent(), launcher, envVars, getMavenOpts(listener, envVars), null ));
 
             ArgumentListBuilder margs = new ArgumentListBuilder("-N","-B");
-            if(mms.usesPrivateRepository())
+            if(mms.usesPrivateRepository()) {
                 // use the per-project repository. should it be per-module? But that would cost too much in terms of disk
                 // the workspace must be on this node, so getRemote() is safe.
-                margs.add("-Dmaven.repo.local="+getWorkspace().child(".repository").getRemote());
+                String privateRepository = getPrivateRepository(listener, envVars);
+                margs.add("-Dmaven.repo.local="+getBuiltOn().getRootPath().child(privateRepository).absolutize().getRemote());
+            }
 
             if (mms.getAlternateSettings() != null) {
                 if (IOUtils.isAbsolute(mms.getAlternateSettings())) {
@@ -744,6 +746,10 @@ public class MavenBuild extends AbstractMavenBuild<MavenModule,MavenBuild> {
 
     public String getMavenOpts(TaskListener listener, EnvVars envVars) {
         return envVars.expand(expandTokens(listener, getProject().getParent().getMavenOpts()));
+    }
+
+    public String getPrivateRepository(TaskListener listener, EnvVars envVars) {
+        return envVars.expand(expandTokens(listener, getProject().getParent().getDescriptor().getPrivateRepository()));
     }
 
     private static final int MAX_PROCESS_CACHE = 5;

--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
@@ -1063,8 +1063,18 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
          * Globally-defined MAVEN_OPTS.
          */
         private String globalMavenOpts;
-        
+
         /**
+         * Default value for Use private repository
+         */
+        private boolean usePrivateRepository = false;
+
+        /**
+         * Default value for storage location of private repository
+         */
+        private String privateRepository = "${WORKSPACE}/.repository";
+
+				/**
          * @since 1.394
          */
         private Map<String, Integer> mavenValidationLevels = new LinkedHashMap<String, Integer>();
@@ -1086,6 +1096,24 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
 
         public void setGlobalMavenOpts(String globalMavenOpts) {
             this.globalMavenOpts = globalMavenOpts;
+            save();
+        }
+
+        public boolean usesPrivateRepository() {
+            return usePrivateRepository;
+        }
+
+        public void setUsePrivateRepository(boolean usePrivateRepository) {
+            this.usePrivateRepository = usePrivateRepository;
+            save();
+        }
+
+        public String getPrivateRepository() {
+            return privateRepository;
+        }
+
+        public void setPrivateRepository(String privateRepository) {
+            this.privateRepository = privateRepository;
             save();
         }
 
@@ -1112,6 +1140,8 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         @Override
         public boolean configure( StaplerRequest req, JSONObject o ) {
             globalMavenOpts = Util.fixEmptyAndTrim(o.getString("globalMavenOpts"));
+            usePrivateRepository = o.getBoolean("usePrivateRepository");
+            privateRepository = o.getString("privateRepository");
             save();
 
             return true;

--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -706,9 +706,10 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                                                                                            pom.getParent() ) );
                         }
                         ArgumentListBuilder margs = new ArgumentListBuilder().add("-B").add("-f", pom.getRemote());
-                        if(project.usesPrivateRepository())
-                            margs.add("-Dmaven.repo.local="+getWorkspace().child(".repository"));
-
+                        if(project.usesPrivateRepository()) {
+                            FilePath privateRepo = getBuiltOn().getRootPath().child(envVars.expand(expandTokens(listener, project.getDescriptor().getPrivateRepository())));
+                            margs.add("-Dmaven.repo.local=" + privateRepo.absolutize().getRemote());
+                        }
                         if (project.globalSettingConfigPath != null)
                             margs.add("-gs" , project.globalSettingConfigPath);
 

--- a/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
@@ -97,9 +97,13 @@ THE SOFTWARE.
       <f:optionalBlock name="maven.perModuleBuild" title="${%Build modules in parallel}" help="/plugin/maven-plugin/aggregator.html"
         checked="${!it.aggregatorStyleBuild}" />
       <f:optionalBlock name="maven.usePrivateRepository" title="${%Use private Maven repository}" help="/plugin/maven-plugin/private-repository.html"
-        checked="${it.usesPrivateRepository()}" />
-      <f:optionalBlock name="maven.resolveDependencies" title="${%Resolve Dependencies during Pom parsing}" 
-        checked="${it.isResolveDependencies()}" /> 
+        checked="${h.defaulted(it.usesPrivateRepository(),descriptor.usesPrivateRepository())}">
+        <f:entry title="">
+          Local repository will be in ${descriptor.privateRepository}
+        </f:entry>
+      </f:optionalBlock>
+      <f:optionalBlock name="maven.resolveDependencies" title="${%Resolve Dependencies during Pom parsing}"
+        checked="${it.isResolveDependencies()}" />
       <f:optionalBlock name="maven.runHeadless" title="${%Run Headless}" help="/plugin/maven-plugin/run-headless.html"
         checked="${it.runHeadless()}" />
       <f:optionalBlock name="maven.processPlugins" title="${%Process Plugins during Pom parsing}"

--- a/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/global.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/global.jelly
@@ -31,5 +31,11 @@ THE SOFTWARE.
     <f:entry title="${%Global MAVEN_OPTS}" help="/plugin/maven-plugin/maven-opts.html">
       <f:expandableTextbox name="globalMavenOpts" value="${descriptor.globalMavenOpts}" />
     </f:entry>
+    <f:entry title="${%Use private repository}" help="/plugin/maven-plugin/private-repository.html">
+      <f:checkbox name="usePrivateRepository" checked="${descriptor.usesPrivateRepository()}"/>
+    </f:entry>
+    <f:entry title="${%Private repository location}" help="/plugin/maven-plugin/private-repository-location.html">
+      <f:textbox name="privateRepository" value="${descriptor.privateRepository}"/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/maven-plugin/src/main/webapp/private-repository-location.html
+++ b/maven-plugin/src/main/webapp/private-repository-location.html
@@ -1,0 +1,20 @@
+<div>
+  <p>
+  This field defines the location of the private local repository if you use this option in your jobs.
+  By default, the private repository will be created under the current workspace (<tt>${WORKSPACE}/.repository</tt>)
+  but if you wish, you can override this value.
+  </p>
+
+  <p>
+  For instance, by using <tt>m2repo/${EXECUTOR_NUMBER}</tt>, one private local repository per executor will be created,
+  which will use less storage than having a private repository per job while ensuring only one instance
+  of Maven accesses it.
+  </p>
+  <p>
+  This enables you as well to relocate private local repository to a different storage with more space.
+  </p>
+  <p>
+  You can specify either a path that is relative to the instance home (JENKINS_HOME for master, BASE for slaves) or an absolute path.
+  You also have access to <a href="env-vars.html">environment variables</a> provided by Jenkins.
+  </p>
+</div>

--- a/maven-plugin/src/main/webapp/private-repository-location_fr.html
+++ b/maven-plugin/src/main/webapp/private-repository-location_fr.html
@@ -1,0 +1,19 @@
+﻿<div>
+  <p>
+  Ce champ définit l'emplacement du repository local privé si vous activez cette option dans vos jobs.
+  Par défaut, le repository local privé sera créé a l'intérieur de l'espace de travail courant (<tt>${WORKSPACE}/.repository</tt>)
+  mais si vous le souhaitez vous pouvez la surcharger.
+  </p>
+
+  <p>
+  Par exemple, en utilisant <tt>m2repo/${EXECUTOR_NUMBER}</tt>, un repository local privé par exécuteur sera créé,
+  ce qui consommera moins d'espace que d'avoir un repository privé par job tout en assurant qu'un seul process Maven puisse y accéder à la fois.
+  </p>
+  <p>
+  Cela vous permet également de relocaliser le repository local privé à un endroit différent disposant de plus d'espace.
+  </p>
+  <p>
+  Vous pouvez spécifier soit un chemin relatif a la racine l'instance (JENKINS_HOME pour le maître, BASE pour les esclaves) ou bien un chemin absolu.
+  Vous avez également accès aux variables d'environnement fournies par Jenkins.'You also have access to <a href="env-vars.html">environment variables</a> provided by Jenkins.
+  </p>
+</div>

--- a/maven-plugin/src/main/webapp/private-repository.html
+++ b/maven-plugin/src/main/webapp/private-repository.html
@@ -1,7 +1,9 @@
 <div>
+  <p>
   Normally, Jenkins uses the local Maven repository as determined by Maven &mdash; the exact process
   seems to be undocumented, but it's <tt>~/.m2/repository</tt> and can be overridden by
   &lt;localRepository> in <tt>~/.m2/settings.xml</tt> (see <a  href="http://maven.apache.org/settings.html">the reference</a> for more details.)
+  </p>
 
   <p>
   This normally means that all the jobs that are executed on the same node shares a single Maven repository.
@@ -9,22 +11,26 @@
   builds could interfere with each other. For example, you might end up having builds incorrectly succeed,
   just because your have all the dependencies in your local repository, despite that fact that none of the
   repositories in POM might have them.
+  </p>
 
   <p>
   There are also some reported problems regarding having concurrent Maven processes trying to use the same local
   repository.
-
+  </p>
 
   <p>
-  When this option is checked, Jenkins will tell Maven to use <tt>$WORKSPACE/.repository</tt> as the local Maven repository.
+  When this option is checked, Jenkins will tell Maven to use the location defined in settings (<tt>${WORKSPACE}/.repository</tt> by default) as the local Maven repository.
   This means each job will get its own isolated Maven repository just for itself. It fixes the above problems,
   at the expense of additional disk space consumption.
+  </p>
 
   <p>
   When using this option, consider setting up a Maven artifact manager so that you don't have to hit
   remote Maven repositories too often.
+  </p>
 
   <p>
   If you'd prefer to activate this mode in all the Maven jobs executed on Jenkins, refer to the technique described
   <a href="http://jenkins.361315.n4.nabble.com/Hudson-on-2-4-8-16-core-boxes-td371215.html#a371217">here</a>.
+  </p>
 </div>

--- a/maven-plugin/src/main/webapp/private-repository_fr.html
+++ b/maven-plugin/src/main/webapp/private-repository_fr.html
@@ -17,7 +17,7 @@
   repository local.
 
   <p>
-  Quand cette option est sélectionnée, Jenkins demandera à Maven d'utiliser <tt>$WORKSPACE/.repository</tt>
+  Quand cette option est sélectionnée, Jenkins demandera à Maven d'utiliser l'emplacement défini dans la configuration globale (par défaut <tt>$WORKSPACE/.repository</tt>)
   comme répertoire local Maven.
   Du coup, chaque job aura son propre repository Maven parfaitement isolé. Cela règle les problèmes
   cités ci-dessus, en échange de plus d'espace disque.


### PR DESCRIPTION
repositories in global configuration screen.
Default usage of private local repository can also be defined from
global administration screen

This enables the following use cases :
- have local repository per executor instead of per job workspace. It
  takes less storage while remaining thread safe since there can be only
  one instance of Maven running per executor.
  One can specify m2repo/%{EXECUTOR_NUMBER} in the private repository
  location field to do so.
- Relocation of private local repository to a separate place (with more
  storage for instance)
