### PR TITLE
Fix minor typo in javadocs.

### DIFF
--- a/core/src/main/java/hudson/tasks/UserAvatarResolver.java
+++ b/core/src/main/java/hudson/tasks/UserAvatarResolver.java
@@ -64,7 +64,7 @@ public abstract class UserAvatarResolver implements ExtensionPoint {
      *
      * <p>
      * When multiple resolvers are installed, they are consulted in order and
-     * the search will be over when an avatar is found by someoene.
+     * the search will be over when an avatar is found by someone.
      *
      * <p>
      * Since {@link UserAvatarResolver} is singleton, this method can be invoked concurrently


### PR DESCRIPTION
Fix of a single typo.  If I currently had core commit access, I would commit it myself.
