### PR TITLE
[JENKINS-11513] Use HTML5 <input type=number>

### DIFF
--- a/core/src/main/java/hudson/util/jelly/MorphTagLibrary.java
+++ b/core/src/main/java/hudson/util/jelly/MorphTagLibrary.java
@@ -83,7 +83,7 @@ public class MorphTagLibrary extends TagLibrary {
                         String key = e.getKey();
                         // @see jelly.impl.DynamicTag.setAttribute() -- ${attrs} has duplicates with "Attr" suffix
                         if (key.endsWith("Attr") && meta.containsKey(key.substring(0, key.length()-4))) continue;
-                        // @see http://github.com/hudson/jelly/commit/4ae67d15957b5b4d32751619997a3cb2a6ad56ed
+                        // @see http://github.com/jenkinsci/jelly/commit/4ae67d15957b5b4d32751619997a3cb2a6ad56ed
                         if (key.equals("ownerTag")) continue;
                         if (!exclusions.contains(key)) {
                             Object v = e.getValue();

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -41,7 +41,7 @@ THE SOFTWARE.
                 <f:textbox name="proxy.server" value="${app.proxy.name}" />
               </f:entry>
               <f:entry title="${%Port}" help="/help/update-center/proxy-port.html">
-                <f:textbox name="proxy.port" value="${app.proxy.port}" 
+                <f:number name="proxy.port" value="${app.proxy.port}" clazz="number" min="0" max="65535" step="1"
                            checkUrl="'${rootURL}/pluginManager/checkProxyPort?value='+escape(this.value)" />
               </f:entry>
             </f:block>

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/config.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/config.groovy
@@ -14,8 +14,9 @@ f.optionalBlock( field:"useSecurity", title:_("Enable security"), checked:app.us
                 checked:port>0, onclick:"\$('sat.port').disabled=false")
         label("for":"sat.fixed", _("Fixed"))
         text(" : ")
-        input(type:"text", "class":"number", name:"slaveAgentPort", id:"sat.port",
-                value: port>0 ? port : null, disabled: port>0 ? null : "true" )
+        input(type:"number", "class":"number", name:"slaveAgentPort", id:"sat.port",
+                value: port>0 ? port : null, disabled: port>0 ? null : "true",
+                min:0, max:65535, step:1)
 
         raw("&nbsp;") ////////////////////////////
 

--- a/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
+++ b/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
   </f:entry>
 
   <f:entry title="${%# of executors}" field="numExecutors">
-    <f:textbox />
+    <f:number clazz="positive-number" min="1" step="1" />
   </f:entry>
 
   <f:entry title="${%Remote FS root}" field="remoteFS">

--- a/core/src/main/resources/hudson/slaves/RetentionStrategy/Demand/config.jelly
+++ b/core/src/main/resources/hudson/slaves/RetentionStrategy/Demand/config.jelly
@@ -26,12 +26,12 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%In demand delay}" help="/help/system-config/master-slave/demand/inDemandDelay.html">
-      <f:textbox clazz="required number"
+      <f:number clazz="required number" min="0"
         name="retentionStrategy.inDemandDelay" value="${instance.inDemandDelay}"
         checkMessage="${%In demand delay is mandatory and must be a number.}"/>
     </f:entry>
     <f:entry title="${%Idle delay}" help="/help/system-config/master-slave/demand/idleDelay.html">
-      <f:textbox clazz="required number"
+      <f:number clazz="required number" min="0"
         name="retentionStrategy.idleDelay" value="${instance.idleDelay}"
         checkMessage="${%Idle delay is mandatory and must be a number.}"/>
     </f:entry>

--- a/core/src/main/resources/hudson/slaves/SimpleScheduledRetentionStrategy/config.jelly
+++ b/core/src/main/resources/hudson/slaves/SimpleScheduledRetentionStrategy/config.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
     </f:entry>
     <f:entry title="${%Scheduled Uptime}"
              description="${%uptime.description}">
-        <f:textbox clazz="required number"
+        <f:number clazz="required number" min="0"
                name="retentionStrategy.upTimeMins" value="${instance.upTimeMins}"
                checkMessage="${%Scheduled Uptime is mandatory and must be a number.}"/>
     </f:entry>

--- a/core/src/main/resources/hudson/tasks/LogRotator/config.jelly
+++ b/core/src/main/resources/hudson/tasks/LogRotator/config.jelly
@@ -26,23 +26,23 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Days to keep builds}"
     description="${%if not empty, build records are only kept up to this number of days}">
-    <f:textbox clazz="positive-number"
+    <f:number clazz="positive-number" min="1" step="1"
       name="logrotate_days" value="${it.logRotator.daysToKeepStr}"/>
   </f:entry>
   <f:entry title="${%Max # of builds to keep}"
     description="${%if not empty, only up to this number of build records are kept}">
-    <f:textbox clazz="positive-number"
+    <f:number clazz="positive-number" min="1" step="1"
       name="logrotate_nums" value="${it.logRotator.numToKeepStr}"/>
   </f:entry>
   <f:advanced>
     <f:entry title="${%Days to keep artifacts}"
              description="${%if not empty, artifacts from builds older than this number of days will be deleted, but the logs, history, reports, etc for the build will be kept}">
-      <f:textbox clazz="positive-number"
+      <f:number clazz="positive-number" min="1" step="1"
                  name="logrotate_artifact_days" value="${it.logRotator.artifactDaysToKeepStr}" />
     </f:entry>
     <f:entry title="${%Max # of builds to keep with artifacts}"
              description="${%if not empty, only up to this number of builds have their artifacts retained}">
-      <f:textbox clazz="positive-number"
+      <f:number clazz="positive-number" min="1" step="1"
                  name="logrotate_artifact_nums" value="${it.logRotator.artifactNumToKeepStr}" />
     </f:entry>
   </f:advanced>

--- a/core/src/main/resources/hudson/triggers/SCMTrigger/global.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/global.jelly
@@ -31,7 +31,8 @@ THE SOFTWARE.
     -->
     <f:section title="${%SCM Polling}">
       <f:entry title="${%Max # of concurrent polling}" field="pollingThreadCount">
-        <f:textbox value="${descriptor.pollingThreadCount==0 ? '' : descriptor.pollingThreadCount}"/>
+        <f:number value="${descriptor.pollingThreadCount==0 ? '' : descriptor.pollingThreadCount}"
+           clazz="positive-number" min="1" step="1"/>
       </f:entry>
     </f:section>
   </j:if>

--- a/core/src/main/resources/jenkins/model/GlobalQuietPeriodConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/GlobalQuietPeriodConfiguration/config.groovy
@@ -3,5 +3,5 @@ package jenkins.model.GlobalQuietPeriodConfiguration
 def f=namespace(lib.FormTagLib)
 
 f.entry(title:_("Quiet period"), field:"quietPeriod") {
-    f.textbox(clazz:"number")
+    f.number(clazz:"number", min:0)
 }

--- a/core/src/main/resources/jenkins/model/GlobalSCMRetryCountConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/GlobalSCMRetryCountConfiguration/config.groovy
@@ -3,5 +3,5 @@ package jenkins.model.GlobalSCMRetryCountConfiguration
 def f=namespace(lib.FormTagLib)
 
 f.entry(title:_("SCM checkout retry count"), field:"scmCheckoutRetryCount") {
-    f.textbox(clazz:"number")
+    f.number(clazz:"number", min:0)
 }

--- a/core/src/main/resources/jenkins/model/MasterBuildConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/MasterBuildConfiguration/config.groovy
@@ -3,7 +3,7 @@ package jenkins.model.MasterBuildConfiguration
 def f=namespace(lib.FormTagLib)
 
 f.entry(title:_("# of executors"), field:"numExecutors") {
-    f.textbox()
+    f.number(clazz:"positive-number", min:1, step:1)
 }
 if (!app.slaves.isEmpty() || !app.clouds.isEmpty()) {
     f.entry(title:_("Labels"),field:"labelString") {

--- a/core/src/main/resources/lib/form/number.jelly
+++ b/core/src/main/resources/lib/form/number.jelly
@@ -1,0 +1,78 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2011, Sun Microsystems, Inc., Kohsuke Kawaguchi, Yahoo! Inc., Andrew Bayer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
+  <st:documentation>
+    Generates an input field <tt>&lt;input type="number" ... /></tt> to be
+    used inside &lt;f:entry/>
+
+    <st:attribute name="field">
+      Used for databinding. TBD.
+    </st:attribute>
+    <st:attribute name="name">
+      This becomes @name of the &lt;input> tag.
+      If @field is specified, this value is inferred from it.
+    </st:attribute>
+    <st:attribute name="value">
+      The initial value of the field. This becomes the @value of the &lt;input> tag.
+      If @field is specified, the current property from the "instance" object
+      will be set as the initial value automatically,
+      which is the recommended approach.
+    </st:attribute>
+    <st:attribute name="default">
+      The default value of the text box, in case both @value is and 'instance[field]' is null.
+    </st:attribute>
+    <!-- Tomcat doesn't like us using the attribute called 'class' -->
+    <st:attribute name="clazz">
+      Additional CSS class(es) to add (such as client-side validation clazz="required",
+      "number" or "positive-number"; these may be combined, as clazz="required number").
+    </st:attribute>
+    <st:attribute name="checkMessage">
+      Override the default error message when client-side validation fails,
+      as with clazz="required", etc.
+    </st:attribute>
+    <st:attribute name="checkUrl">
+      If specified, the value entered in this input field will be checked (via AJAX)
+      against this URL, and errors will be rendered under the text field.
+
+      If @field is specified, this will be inferred automatically,
+      which is the recommended approach.
+    </st:attribute>
+  </st:documentation>
+  <f:prepareDatabinding />
+
+  <!-- mostly pass-through all the attributes -->
+  <!--
+    Do not add 'number' class name by default.
+    INPUT.number (defined in hudson-behavior.js) is a class for integers.
+    On the other hand, HTML5 <input> permits floating-point numbers.
+  -->
+  <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
+         class="setting-input ${attrs.checkUrl!=null?'validated':''} ${attrs.clazz}"
+         name="${attrs.name ?: '_.'+attrs.field}"
+         value="${attrs.value ?: instance[attrs.field] ?: attrs.default}"
+         type="number"
+         ATTRIBUTES="${attrs}" EXCEPT="field clazz" />
+</j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-quietPeriod.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-quietPeriod.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
       help="/descriptor/jenkins.model.GlobalQuietPeriodConfiguration/help/quietPeriod">
     <f:entry title="${%Quiet period}"
       description="${%Number of seconds}">
-      <f:textbox clazz="number" name="quiet_period" value="${it.quietPeriod}"/>
+      <f:number clazz="number" name="quiet_period" value="${it.quietPeriod}" min="0" step="1"/>
     </f:entry>
   </f:optionalBlock>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-retryCount.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-retryCount.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <f:optionalBlock name="hasCustomScmCheckoutRetryCount" title="${%Retry Count}" checked="${it.hasCustomScmCheckoutRetryCount()}"
       help="/help/project-config/scmCheckoutRetryCount.html">
     <f:entry title="${%SCM checkout retry count}">
-      <f:textbox clazz="number" name="scmCheckoutRetryCount" value="${it.scmCheckoutRetryCount}"/>
+      <f:number clazz="number" name="scmCheckoutRetryCount" value="${it.scmCheckoutRetryCount}" min="0" step="1"/>
     </f:entry>
   </f:optionalBlock>
 </j:jelly>

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -666,10 +666,10 @@ var hudsonRules = {
 // validate required form values
     "INPUT.required" : function(e) { registerRegexpValidator(e,/./,"Field is required"); },
 
-// validate form values to be a number
-    "INPUT.number" : function(e) { registerRegexpValidator(e,/^(\d+|)$/,"Not a number"); },
+// validate form values to be an integer
+    "INPUT.number" : function(e) { registerRegexpValidator(e,/^(\d+|)$/,"Not an integer"); },
     "INPUT.positive-number" : function(e) {
-        registerRegexpValidator(e,/^(\d*[1-9]\d*|)$/,"Not a positive number");
+        registerRegexpValidator(e,/^(\d*[1-9]\d*|)$/,"Not a positive integer");
     },
 
     "INPUT.auto-complete": function(e) {// form field with auto-completion support 


### PR DESCRIPTION
This pull request implements [JENKINS-11513](https://issues.jenkins-ci.org/browse/JENKINS-11513). Browsers which support &lt;input type=number> will provide a better GUI and validation. There is no changes for browsers which do not support &lt;input type=number>.

I am worried about which is the better way to provide &lt;input type=number>.
1. A new jelly file /lib/form/number.jelly. It's similar to /lib/form/password.jelly.
2. Add a way for /lib/form/textbox.jelly to overwrite its type attribute. If type attribute is specified, use it. If not, type attribute will be "text".

I picked 1, because some other types introduced in HTML5 such as type=range are not textboxes and they won't cooperate with textbox-specific feature such as auto-complete.

Any suggestions?
