### PR TITLE
This might be the correct fix for https://issues.jenkins-ci.org/browse/JENKINS-11416

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -181,6 +181,11 @@ THE SOFTWARE.
             <artifactId>ant</artifactId>
             <version>1.8.0</version>
           </dependency>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant-launcher</artifactId>
+            <version>1.8.0</version>
+          </dependency>
         </dependencies>
       </plugin>
     </plugins>


### PR DESCRIPTION
Adding the ant-launcher jar to the maven plugin.  On my environment without it gmaven is unable to locate the org.apache.tools.ant.launch.AntMain class
