### PR TITLE
Jenkins 11130 SEVERE: I/O error in channel Chunked connection when using jenkins-cli.jar

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,6 +55,9 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
+  <li class=bug>
+  java.io.IOException: Unexpected termination of the channel - SEVERE: I/O error in channel Chunked connection when using jenkins-cli.jar (works on older Hudson version)
+  (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11130">issue 11130</a>)
   <li class=>
 </ul>
 </div><!--=TRUNK-END=-->

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -122,7 +122,7 @@ public class CLI {
         FullDuplexHttpStream con = new FullDuplexHttpStream(jenkins);
         Channel ch = new Channel("Chunked connection to "+jenkins,
                 pool,con.getInputStream(),con.getOutputStream());
-        new PingThread(ch,30*1000) {
+        new PingThread(ch,15*1000) {
             protected void onDead() {
                 // noop. the point of ping is to keep the connection alive
                 // as most HTTP servers have a rather short read time out

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -47,6 +47,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.Socket;
 import java.net.URL;
 import java.net.URLConnection;
@@ -153,8 +154,35 @@ public class CLI {
             throw (IOException)new IOException("Failed to connect to "+url).initCause(e);
         }
         String p = head.getHeaderField("X-Hudson-CLI-Port");
+        flushURLConnection(head);
         if(p==null) return -1;
         return Integer.parseInt(p);
+    }
+
+    /**
+     * Flush the supplied {@link URLConnection} input and close the
+     * connection nicely.
+     * @param conn the connection to flush/close
+     */
+    private void flushURLConnection(URLConnection conn) {
+        byte[] buf = new byte[1024];
+        try {
+            InputStream is = conn.getInputStream();
+            while (is.read(buf) > 0) {
+                // Ignore
+            }
+            is.close();
+        } catch (IOException e) {
+            try {
+                InputStream es = ((HttpURLConnection)conn).getErrorStream();
+                while (es.read(buf) > 0) {
+                    // Ignore
+                }
+                es.close();
+            } catch (IOException ex) {
+                // Ignore
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
When using HTTP full duplex connections the upstream channel can be idle for long periods of time and the webserver will time the connection out. Jenkins sees this and terminates the downstream channel causing the unexpected closure of the read channel in the CLI client.

Timeout of 15 seconds is based on the 20 second default timeout as seen in Ubuntu Oneiric Tomcat 6 installations.

I also added some code to read the body of the Jenkins instance homepage. This allows the Jenkins webserver to recycle the connection more quickly. This is not required to fix Jenkins-11130 but it is good practice anyway.

Regards

Richard
