### PR TITLE
Mac: Load and run Jenkins unconditionally to prevent user confusion.

### DIFF
--- a/osx/scripts/postinstall-launchd
+++ b/osx/scripts/postinstall-launchd
@@ -9,4 +9,4 @@ mkdir -p /Users/Shared/Jenkins
 find /Users/Shared/Jenkins -not -user daemon -or -not -group daemon -print0 | xargs -0 chown daemon:daemon
 
 # Load and start the launch daemon
-/bin/launchctl load ${JENKINS_PLIST}
+/bin/launchctl load -w ${JENKINS_PLIST}


### PR DESCRIPTION
Sometimes users unload Jenkins using the launchctl -w option.
This permanently disables the Jenkins launchd job.
When the user re-installs Jenkins, he gets confused when
Jenkins doesn't load and run automatically and there is no
good error message from launchctl when it ignores the
Jenkins job because it is permanently disabled.
("nothing found to load")

Always forcing Jenkins to run after installation seems to be
the way of minimum confusion. The user is installing Jenkins
because he wants to run Jenkins, right?
