### PR TITLE
[FIXED JENKINS-11366] Jenkins takes up too much space in /var/run

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=bug>
+    Jenkins takes up too much space in /var/run
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11366">issue 11366</a>)
+  <li class=bug>
     Fixed NPE in Subversion polling of Maven jobs.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11592">issue 11592</a>)
   <li class=rfe>

--- a/debian/debian/dirs
+++ b/debian/debian/dirs
@@ -11,3 +11,6 @@ var/run/jenkins
 # Store jenkins log file in it's own directory since they can become rather large and in the future
 # rotating logs can be easily added.
 var/log/jenkins
+
+# Cache directory for the unpacked jenkins.war file.
+var/cache/jenkins

--- a/debian/debian/jenkins.default
+++ b/debian/debian/jenkins.default
@@ -51,4 +51,4 @@ AJP_PORT=-1
 # --argumentsRealm.passwd.$ADMIN_USER=[password]
 # --argumentsRealm.$ADMIN_USER=admin
 # --webroot=~/.jenkins/war
-JENKINS_ARGS="--webroot=/var/run/jenkins/war --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT"
+JENKINS_ARGS="--webroot=/var/cache/jenkins/war --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT"

--- a/debian/debian/jenkins.postinst
+++ b/debian/debian/jenkins.postinst
@@ -47,9 +47,11 @@ case "$1" in
         # we don't do "chmod 750" so that the user can choose the pemission for g and o on their own
         chmod u+rwx /var/lib/jenkins /var/log/jenkins
 
-        # make sure jenkins can delete everything in /var/run/jenkins to re-explode war
-        chown -R jenkins:adm /var/run/jenkins
-        chmod -R 750         /var/run/jenkins
+        # make sure jenkins can delete everything in /var/cache/jenkins to
+        # re-explode war. older installations may use /var/run/jenkins
+        # so make sure that they can delete too.
+        chown -R jenkins:adm /var/cache/jenkins /var/run/jenkins
+        chmod -R 750         /var/cache/jenkins /var/run/jenkins
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/debian/jenkins.postrm
+++ b/debian/debian/jenkins.postrm
@@ -5,7 +5,8 @@ set -e
 case "$1" in
     purge)
         userdel jenkins || true
-        rm -rf /var/lib/jenkins /var/log/jenkins /var/run/jenkins
+        rm -rf /var/lib/jenkins /var/log/jenkins \
+               /var/run/jenkins /var/cache/jenkins
     ;;
 
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)


### PR DESCRIPTION
Use /var/cache/jenkins to hold the unpacked jenkins.war file at runtime.

A number of users with smaller memory systems are reporting that their /var/run partition (actually /run on newer installs) is filling up due to the unpacked jenkins war file. Use /var/cache instead of /var/run to hold the unpacked war. This is the same that the Debian/Ubuntu tomcat6 packaging uses.

Existing installs will not be changed from /var/run to /var/cache if /etc/default/jenkins has been customized. This is inline with standard Debian policy. During upgrade the user will be prompted to resolve the changes in the configuration file. However the configuration will still continue to work if the user chooses to keep /var/run rather than moving to /var/cache.
