### PR TITLE
[FIXED JENKINS-11744] Debian/Ubuntu init script does not wait long enough

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -68,6 +68,9 @@ Upcoming changes</a>
 <h3><a name=v1.440>What's new in 1.440</a> <!--=DATE=--></h3>
 <ul class=image>
   <li class=bug>
+    Debian/Ubuntu init script does not wait long enough during stop operation
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11744">issue 11744</a>)
+  <li class=bug>
     Sorting "diff" in test result requires 2 clicks
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-5460">issue 5460</a>)
   <li class=bug>

--- a/debian/debian/jenkins.init
+++ b/debian/debian/jenkins.init
@@ -147,7 +147,7 @@ do_stop()
 	0) 
 	    $DAEMON $DAEMON_ARGS --stop || return 2
         # wait for the process to really terminate
-        for n in 1 2 3 4 5; do
+        for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
             sleep 1
             $DAEMON $DAEMON_ARGS --running || break
         done


### PR DESCRIPTION
... during stop operation

Increase stop timeout from 5 to 20 seconds.
