### PR TITLE
Maven RedeployPublisher: fix promoted-builds deployment to Maven (JENKINS-11766)

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,10 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=bug>
+    Fixed "Deploy artifacts to Maven repository" as a promotion action.
+    Requires promoted-builds plugin 2.5+.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11766">issue 11766</a>)
+  <li class=bug>
     If running as a daemon, don't daemonize one more time during restart.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11742">issue 11742</a>)
   <li class=bug>

--- a/maven-plugin/src/main/java/hudson/maven/RedeployPublisher.java
+++ b/maven-plugin/src/main/java/hudson/maven/RedeployPublisher.java
@@ -314,20 +314,23 @@ public class RedeployPublisher extends Recorder {
     
     
     /**
-     * Obtains the {@link MavenAbstractArtifactRecord} that we'll work on.
+     * Obtains the {@link MavenModuleSetBuild} that we'll work on, or null.
      * <p>
      * This allows promoted-builds plugin to reuse the code for delayed deployment. 
      */
-    protected MavenAbstractArtifactRecord getAction(AbstractBuild<?, ?> build) {
-        return build.getAction(MavenAbstractArtifactRecord.class);
+    protected MavenModuleSetBuild getMavenBuild(AbstractBuild<?, ?> build) {
+        return (build instanceof MavenModuleSetBuild)
+            ? (MavenModuleSetBuild) build
+            : null;
     }
     
     protected List<MavenAbstractArtifactRecord> getActions(AbstractBuild<?, ?> build, BuildListener listener) {
         List<MavenAbstractArtifactRecord> actions = new ArrayList<MavenAbstractArtifactRecord>();
-        if (!(build instanceof MavenModuleSetBuild)) {
+        MavenModuleSetBuild mavenBuild = getMavenBuild(build);
+        if (mavenBuild == null) {
             return actions;
         }
-        for (Entry<MavenModule, MavenBuild> e : ((MavenModuleSetBuild)build).getModuleLastBuilds().entrySet()) {
+        for (Entry<MavenModule, MavenBuild> e : mavenBuild.getModuleLastBuilds().entrySet()) {
             MavenAbstractArtifactRecord a = e.getValue().getAction( MavenAbstractArtifactRecord.class );
             if (a == null) {
                 listener.getLogger().println("No artifacts are recorded for module" + e.getKey().getName() + ". Is this a Maven project?");


### PR DESCRIPTION
Add some indirection to allow the promoted-builds plugin's
RedeployBatchTaskPublisher to override getMavenBuild() and return the
promotion target's MavenModuleSetBuild object.

Also requires a fix in promoted-builds.

Signed-off-by: Michael Smith msmith@cbnco.com
