### PR TITLE
Refactored Run#getBuildStatusSummary and fixed some inconsistencies in 'isWorse'

### DIFF
--- a/core/src/main/java/hudson/model/ResultTrend.java
+++ b/core/src/main/java/hudson/model/ResultTrend.java
@@ -61,7 +61,7 @@ public enum ResultTrend {
     STILL_FAILING(Messages._ResultTrend_StillFailing()),
     /**
      * Previous build (if there is one) was {@link Result#SUCCESS} or {@link Result#UNSTABLE}
-     * and current build is {@link Result#UNSTABLE}.
+     * and current build is {@link Result#FAILURE}.
      */
     FAILURE(Messages._ResultTrend_Failure()),
     /**

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1616,59 +1616,77 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     }
 
     /**
-     * Gets an object that computes the single line summary of this build.
+     * Gets an object which represents the single line summary of this build.
      */
     public Summary getBuildStatusSummary() {
-        Run prev = getPreviousBuild();
-
-        if(getResult()==Result.SUCCESS) {
-            if(prev==null || prev.getResult()== Result.SUCCESS)
+        ResultTrend trend = ResultTrend.getResultTrend(this);
+        
+        switch (trend) {
+            case ABORTED : return new Summary(false, Messages.Run_Summary_Aborted());
+            
+            case NOT_BUILT : return new Summary(false, Messages.Run_Summary_NotBuilt());
+            
+            case FAILURE : return new Summary(true, Messages.Run_Summary_BrokenSinceThisBuild());
+            
+            case STILL_FAILING : 
+                RunT since = getPreviousNotFailedBuild();
+                if(since==null)
+                    return new Summary(false, Messages.Run_Summary_BrokenForALongTime());
+                RunT failedBuild = since.getNextBuild();
+                return new Summary(false, Messages.Run_Summary_BrokenSince(failedBuild.getDisplayName()));
+           
+            case NOW_UNSTABLE:
+                return determineDetailedUnstableSummary(Boolean.FALSE);
+            case UNSTABLE :
+                return determineDetailedUnstableSummary(Boolean.TRUE);
+            case STILL_UNSTABLE :
+                return determineDetailedUnstableSummary(null);
+                
+            case SUCCESS :
                 return new Summary(false, Messages.Run_Summary_Stable());
-            else
+            
+            case FIXED :
                 return new Summary(false, Messages.Run_Summary_BackToNormal());
+                
         }
+        
+        return new Summary(false, Messages.Run_Summary_Unknown());
+    }
 
-        if(getResult()==Result.FAILURE) {
-            RunT since = getPreviousNotFailedBuild();
-            if(since==null)
-                return new Summary(false, Messages.Run_Summary_BrokenForALongTime());
-            if(since==prev)
-                return new Summary(true, Messages.Run_Summary_BrokenSinceThisBuild());
-            RunT failedBuild = since.getNextBuild();
-            return new Summary(false, Messages.Run_Summary_BrokenSince(failedBuild.getDisplayName()));
-        }
-
-        if(getResult()==Result.ABORTED)
-            return new Summary(false, Messages.Run_Summary_Aborted());
-
-        if(getResult()==Result.NOT_BUILT)
-            return new Summary(false, Messages.Run_Summary_NotBuilt());
-
-        if(getResult()==Result.UNSTABLE) {
-            if(((Run)this) instanceof AbstractBuild) {
-                AbstractTestResultAction trN = ((AbstractBuild)(Run)this).getTestResultAction();
-                AbstractTestResultAction trP = prev==null ? null : ((AbstractBuild) prev).getTestResultAction();
-                if(trP==null) {
-                    if(trN!=null && trN.getFailCount()>0)
-                        return new Summary(false, Messages.Run_Summary_TestFailures(trN.getFailCount()));
-                } else {
-                    if(trN.getFailCount()!= 0) {
-                        if(trP.getFailCount()==0)
-                            return new Summary(true, Messages.Run_Summary_TestsStartedToFail(trN.getFailCount()));
-                        if(trP.getFailCount() < trN.getFailCount())
-                            return new Summary(true, Messages.Run_Summary_MoreTestsFailing(trN.getFailCount()-trP.getFailCount(), trN.getFailCount()));
-                        if(trP.getFailCount() > trN.getFailCount())
-                            return new Summary(false, Messages.Run_Summary_LessTestsFailing(trP.getFailCount()-trN.getFailCount(), trN.getFailCount()));
-                        
-                        return new Summary(false, Messages.Run_Summary_TestsStillFailing(trN.getFailCount()));
-                    }
+    /**
+     * @param worseOverride override the 'worse' parameter to this value.
+     *   May be null in which case 'worse' is calculated based on the number of failed tests.
+     */
+    private Summary determineDetailedUnstableSummary(Boolean worseOverride) {
+        Run prev = getPreviousBuild();
+        
+        if(((Run)this) instanceof AbstractBuild) {
+            AbstractTestResultAction trN = ((AbstractBuild)(Run)this).getTestResultAction();
+            AbstractTestResultAction trP = prev==null ? null : ((AbstractBuild) prev).getTestResultAction();
+            if(trP==null) {
+                if(trN!=null && trN.getFailCount()>0)
+                    return new Summary(worseOverride != null ? worseOverride : true,
+                            Messages.Run_Summary_TestFailures(trN.getFailCount()));
+            } else {
+                if(trN.getFailCount()!= 0) {
+                    if(trP.getFailCount()==0)
+                        return new Summary(worseOverride != null ? worseOverride : true,
+                                Messages.Run_Summary_TestsStartedToFail(trN.getFailCount()));
+                    if(trP.getFailCount() < trN.getFailCount())
+                        return new Summary(worseOverride != null ? worseOverride : true,
+                                Messages.Run_Summary_MoreTestsFailing(trN.getFailCount()-trP.getFailCount(), trN.getFailCount()));
+                    if(trP.getFailCount() > trN.getFailCount())
+                        return new Summary(worseOverride != null ? worseOverride : false,
+                                Messages.Run_Summary_LessTestsFailing(trP.getFailCount()-trN.getFailCount(), trN.getFailCount()));
+                    
+                    return new Summary(worseOverride != null ? worseOverride : false,
+                            Messages.Run_Summary_TestsStillFailing(trN.getFailCount()));
                 }
             }
-            
-            return new Summary(false, Messages.Run_Summary_Unstable());
         }
-
-        return new Summary(false, Messages.Run_Summary_Unknown());
+        
+        return new Summary(worseOverride != null ? worseOverride : false,
+                Messages.Run_Summary_Unstable());
     }
 
     /**

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1658,10 +1658,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      *   May be null in which case 'worse' is calculated based on the number of failed tests.
      */
     private Summary determineDetailedUnstableSummary(Boolean worseOverride) {
-        Run prev = getPreviousBuild();
-        
         if(((Run)this) instanceof AbstractBuild) {
             AbstractTestResultAction trN = ((AbstractBuild)(Run)this).getTestResultAction();
+            Run prev = getPreviousBuild();
             AbstractTestResultAction trP = prev==null ? null : ((AbstractBuild) prev).getTestResultAction();
             if(trP==null) {
                 if(trN!=null && trN.getFailCount()>0)

--- a/core/src/test/java/hudson/model/BuildStatusSummaryTest.java
+++ b/core/src/test/java/hudson/model/BuildStatusSummaryTest.java
@@ -42,7 +42,12 @@ public class BuildStatusSummaryTest {
         when(this.prevBuild.getResult()).thenReturn(Result.SUCCESS);
         
         Summary summary = this.build.getBuildStatusSummary();
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_Stable(), summary.message);
         
+        // same if there is no previous build
+        when(this.build.getPreviousBuild()).thenReturn(null);
+        summary = this.build.getBuildStatusSummary();
         assertFalse(summary.isWorse);
         assertEquals(Messages.Run_Summary_Stable(), summary.message);
         
@@ -50,7 +55,6 @@ public class BuildStatusSummaryTest {
         when(this.prevBuild.getResult()).thenReturn(Result.NOT_BUILT);
         
         summary = this.build.getBuildStatusSummary();
-        
         assertFalse(summary.isWorse);
         assertEquals(Messages.Run_Summary_Stable(), summary.message);
         
@@ -59,7 +63,6 @@ public class BuildStatusSummaryTest {
         when(this.prevBuild.getResult()).thenReturn(Result.ABORTED);
         
         summary = this.build.getBuildStatusSummary();
-        
         assertFalse(summary.isWorse);
         assertEquals(Messages.Run_Summary_Stable(), summary.message);
     }
@@ -131,6 +134,17 @@ public class BuildStatusSummaryTest {
         
         assertTrue(summary.isWorse);
         //assertEquals(Messages.Run_Summary_Stable(), summary.message);
+    }
+    
+    @Test
+    public void testUnstableAfterFailure() {
+        when(this.build.getResult()).thenReturn(Result.UNSTABLE);
+        when(this.prevBuild.getResult()).thenReturn(Result.FAILURE);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_Unstable(), summary.message);
     }
 
     @Test

--- a/core/src/test/java/hudson/model/BuildStatusSummaryTest.java
+++ b/core/src/test/java/hudson/model/BuildStatusSummaryTest.java
@@ -1,0 +1,253 @@
+package hudson.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import hudson.model.Run.Summary;
+import hudson.tasks.test.AbstractTestResultAction;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests {@link Run#getBuildStatusSummary()}.
+ * 
+ * @author kutzi
+ */
+@SuppressWarnings("rawtypes")
+public class BuildStatusSummaryTest {
+
+    private Run build;
+    private Run prevBuild;
+
+    @Before
+    public void before() {
+        mockBuilds(Run.class);
+    }
+    
+    private void mockBuilds(Class<? extends Run> buildClass) {
+        this.build = mock(buildClass);
+        this.prevBuild = mock(buildClass);
+        
+        when(this.build.getPreviousBuild()).thenReturn(prevBuild);
+        
+        when(this.build.getBuildStatusSummary()).thenCallRealMethod();
+    }
+    
+    @Test
+    public void testSuccess() {
+        when(this.build.getResult()).thenReturn(Result.SUCCESS);
+        when(this.prevBuild.getResult()).thenReturn(Result.SUCCESS);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_Stable(), summary.message);
+        
+        // from NOT_BUILD should also mean normal success and not 'back to normal'
+        when(this.prevBuild.getResult()).thenReturn(Result.NOT_BUILT);
+        
+        summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_Stable(), summary.message);
+        
+        
+        // same if previous one was aborted
+        when(this.prevBuild.getResult()).thenReturn(Result.ABORTED);
+        
+        summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_Stable(), summary.message);
+    }
+    
+    @Test
+    public void testFixed() {
+        when(this.build.getResult()).thenReturn(Result.SUCCESS);
+        when(this.prevBuild.getResult()).thenReturn(Result.FAILURE);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_BackToNormal(), summary.message);
+        
+        // same from unstable:
+        when(this.prevBuild.getResult()).thenReturn(Result.UNSTABLE);
+        
+        summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_BackToNormal(), summary.message);
+    }
+    
+    @Test
+    public void testFailure() {
+        when(this.build.getResult()).thenReturn(Result.FAILURE);
+        when(this.prevBuild.getResult()).thenReturn(Result.FAILURE);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_BrokenForALongTime(), summary.message);
+    }
+    
+    @Test
+    public void testBecameFailure() {
+        when(this.build.getResult()).thenReturn(Result.FAILURE);
+        when(this.prevBuild.getResult()).thenReturn(Result.SUCCESS);
+        when(this.build.getPreviousNotFailedBuild()).thenReturn(this.prevBuild);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertTrue(summary.isWorse);
+        assertEquals(Messages.Run_Summary_BrokenSinceThisBuild(), summary.message);
+    }
+    
+    @Test
+    public void testFailureSince() {
+        when(this.build.getResult()).thenReturn(Result.FAILURE);
+        when(this.prevBuild.getResult()).thenReturn(Result.FAILURE);
+        when(this.prevBuild.getDisplayName()).thenReturn("prevBuild");
+        
+        Run prevPrevBuild = mock(Run.class);
+        when(prevPrevBuild.getNextBuild()).thenReturn(prevBuild);
+        when(this.build.getPreviousNotFailedBuild()).thenReturn(prevPrevBuild);        
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_BrokenSince(this.prevBuild.getDisplayName()), summary.message);
+    }
+    
+    @Test
+    public void testBecameUnstable() {
+        when(this.build.getResult()).thenReturn(Result.UNSTABLE);
+        when(this.prevBuild.getResult()).thenReturn(Result.SUCCESS);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertTrue(summary.isWorse);
+        //assertEquals(Messages.Run_Summary_Stable(), summary.message);
+    }
+
+    @Test
+    public void testBuildGotAFailingTest() {
+        // previous build has no tests at all
+        mockBuilds(AbstractBuild.class);
+        
+        when(this.build.getResult()).thenReturn(Result.UNSTABLE);
+        when(this.prevBuild.getResult()).thenReturn(Result.SUCCESS);
+        
+        buildHasTestResult((AbstractBuild) this.build, 1);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertTrue(summary.isWorse);
+        assertEquals(Messages.Run_Summary_TestFailures(1), summary.message);
+        
+        
+        // same thing should happen if previous build has tests, but no failing ones:
+        buildHasTestResult((AbstractBuild) this.prevBuild, 0);
+        summary = this.build.getBuildStatusSummary();
+        assertTrue(summary.isWorse);
+        assertEquals(Messages.Run_Summary_TestsStartedToFail(1), summary.message);
+    }
+    
+    @Test
+    public void testBuildEqualAmountOfTestsFailing() {
+        mockBuilds(AbstractBuild.class);
+        
+        when(this.build.getResult()).thenReturn(Result.UNSTABLE);
+        when(this.prevBuild.getResult()).thenReturn(Result.UNSTABLE);
+        
+        buildHasTestResult((AbstractBuild) this.prevBuild, 1);
+        buildHasTestResult((AbstractBuild) this.build, 1);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_TestsStillFailing(1), summary.message);
+    }
+    
+    @Test
+    public void testBuildGotMoreFailingTests() {
+        mockBuilds(AbstractBuild.class);
+        
+        when(this.build.getResult()).thenReturn(Result.UNSTABLE);
+        when(this.prevBuild.getResult()).thenReturn(Result.UNSTABLE);
+        
+        buildHasTestResult((AbstractBuild) this.prevBuild, 1);
+        buildHasTestResult((AbstractBuild) this.build, 2);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertTrue(summary.isWorse);
+        assertEquals(Messages.Run_Summary_MoreTestsFailing(1, 2), summary.message);
+    }
+    
+    @Test
+    public void testBuildGotLessFailingTests() {
+        mockBuilds(AbstractBuild.class);
+        
+        when(this.build.getResult()).thenReturn(Result.UNSTABLE);
+        when(this.prevBuild.getResult()).thenReturn(Result.UNSTABLE);
+        
+        buildHasTestResult((AbstractBuild) this.prevBuild, 2);
+        buildHasTestResult((AbstractBuild) this.build, 1);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_LessTestsFailing(1, 1), summary.message);
+    }
+    
+    @Test
+    public void testNonTestRelatedUnstable() {
+        when(this.build.getResult()).thenReturn(Result.UNSTABLE);
+        when(this.prevBuild.getResult()).thenReturn(Result.UNSTABLE);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_Unstable(), summary.message);
+    }
+    
+    @Test
+    public void testNonTestRelatedBecameUnstable() {
+        when(this.build.getResult()).thenReturn(Result.UNSTABLE);
+        when(this.prevBuild.getResult()).thenReturn(Result.SUCCESS);
+        
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertTrue(summary.isWorse);
+        //assertEquals(Messages.Run_Summary_Unstable(), summary.message);
+    }
+    
+    @Test
+    public void testAborted() {
+        when(this.build.getResult()).thenReturn(Result.ABORTED);
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_Aborted(), summary.message);
+    }
+    
+    @Test
+    public void testNotBuilt() {
+        when(this.build.getResult()).thenReturn(Result.NOT_BUILT);
+        Summary summary = this.build.getBuildStatusSummary();
+        
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_NotBuilt(), summary.message);
+    }
+    
+    private void buildHasTestResult(AbstractBuild build, int failedTests) {
+        AbstractTestResultAction testResult = mock(AbstractTestResultAction.class);
+        when(testResult.getFailCount()).thenReturn(failedTests);
+        
+        when(build.getTestResultAction()).thenReturn(testResult);
+    }
+}


### PR DESCRIPTION
There has been some unfortunate code duplication between stuff which did something failure similar in ResultTrend and  Run#getBuildStatusSummary.

Also there has been what I would call inconsistencies in the inWorse handling of getBuildStatusSummary.
Some of them were IMO clear bugs, e.g. a build without tests which became unstable (e.g. because of the warnings plugin) wasn't determined as isWorse.
On the other hand, a build which became UNSTABLE after a failure could be determined as 'isWorse'

Some others are not so clear errors resp. debatable. E.g. SUCCESS builds after ABORTED/NOT_BUILD builds are now not anymore declared as 'back to normal'
