### PR TITLE
[FIXED JENKINS-11767] missing break in getValues@RegistryKey

### DIFF
--- a/core/src/main/java/hudson/util/jna/RegistryKey.java
+++ b/core/src/main/java/hudson/util/jna/RegistryKey.java
@@ -259,6 +259,8 @@ public class RegistryKey {
                 default:
                     break; // not supported yet
                 }
+                break;
+
             default:
                 check(result);
             }


### PR DESCRIPTION
Switch-case handle the result (ERROR_MORE_DATA), but after drop a JnaException, because a break is missing.
