### PR TITLE
Add MVN arguments interceptor extension

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -68,6 +68,8 @@ Upcoming changes</a>
     CLI jar now has the version number in the manifest as well as the "-version" option.
   <li class=rfe>
     Upgrade aether version to 1.13 and sisu to 2.3.0 .
+  <li class=rfe>
+    add new action type to enable plugins to intercept the maven 'goals and options'
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/maven-plugin/src/main/java/hudson/maven/MavenArgumentInterceptorAction.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenArgumentInterceptorAction.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2011, Dominik Bartholdi
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.maven;
+
+import hudson.model.Action;
+import hudson.util.ArgumentListBuilder;
+
+/**
+ * Provides a hook to change the arguments passed to the maven execution. This
+ * enables plugins to transiently change the arguments of a maven build (e.g.
+ * change the arguments for a release build).
+ * 
+ * @author Dominik Bartholdi (imod)
+ * 
+ */
+public interface MavenArgumentInterceptorAction extends Action {
+
+	/**
+	 * Provides maven goals and options to start the build with. This is the
+	 * preferred way to provide other goals then the default ones to a build.
+	 * The goals and options returned by this method will not be persist and do
+	 * not affect the default configuration.
+	 * <p>
+	 * This method will be called on one and only one action during a build. If
+	 * there are two actions present in the build, the second will be ignored.
+	 * 
+	 * @return the maven goals and options to start maven with. Result is
+	 *         ignored if <code>null</code> or empty. Variables will be expanded
+	 *         by the caller.
+	 */
+	public String getGoalsAndOptions();
+
+	/**
+	 * Change/add arguments to any needs, but special care has to be taken, as
+	 * the list contains every argument needed for the default execution (e.g.
+	 * -f /path/to/pom.xml or -B). <br />
+	 * An easy example would be to add "<code>-DskipTests</code>" to skip the
+	 * test execution on request.
+	 * 
+	 * <p>
+	 * This method is called on all present MavenArgumentInterceptorAction
+	 * during a build (kind of chaining, each action can add the arguments it
+	 * thinks are missing).
+	 * 
+	 * @param mavenargs
+	 *            the calculated default maven arguments (never
+	 *            <code>null</code>).
+	 * @return the new arguments to be used.
+	 */
+	public ArgumentListBuilder intercept(ArgumentListBuilder mavenargs);
+
+}

--- a/maven-plugin/src/main/java/hudson/maven/MavenArgumentInterceptorAction.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenArgumentInterceptorAction.java
@@ -45,16 +45,19 @@ public interface MavenArgumentInterceptorAction extends Action {
 	 * This method will be called on one and only one action during a build. If
 	 * there are two actions present in the build, the second will be ignored.
 	 * 
+	 * @param build
+	 *            reference to the current build, might be used for some
+	 *            calculations for the correct arguments
 	 * @return the maven goals and options to start maven with. Result is
 	 *         ignored if <code>null</code> or empty. Variables will be expanded
 	 *         by the caller.
 	 */
-	public String getGoalsAndOptions();
+	public String getGoalsAndOptions(MavenModuleSetBuild build);
 
 	/**
 	 * Change/add arguments to any needs, but special care has to be taken, as
 	 * the list contains every argument needed for the default execution (e.g.
-	 * -f /path/to/pom.xml or -B). <br />
+	 * <code>-f /path/to/pom.xml</code> or <code>-B</code>). <br />
 	 * An easy example would be to add "<code>-DskipTests</code>" to skip the
 	 * test execution on request.
 	 * 
@@ -66,8 +69,11 @@ public interface MavenArgumentInterceptorAction extends Action {
 	 * @param mavenargs
 	 *            the calculated default maven arguments (never
 	 *            <code>null</code>).
+	 * @param build
+	 *            reference to the current build, might be used for some
+	 *            calculations for the correct arguments
 	 * @return the new arguments to be used.
 	 */
-	public ArgumentListBuilder intercept(ArgumentListBuilder mavenargs);
+	public ArgumentListBuilder intercept(ArgumentListBuilder mavenargs, MavenModuleSetBuild build);
 
 }

--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -760,7 +760,7 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
 						// find the correct maven goals and options, there might by an action overruling the defaults
                         String goals = project.getGoals(); // default
                         for (MavenArgumentInterceptorAction mavenArgInterceptor : argInterceptors) {
-                        	final String goalsAndOptions = mavenArgInterceptor.getGoalsAndOptions();
+                        	final String goalsAndOptions = mavenArgInterceptor.getGoalsAndOptions(this.getBuild());
 							if(StringUtils.isNotBlank(goalsAndOptions)){
                         		goals = goalsAndOptions;
                                 // only one interceptor is allowed to overwrite the whole "goals and options" string
@@ -772,7 +772,7 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
 						// enable the interceptors to change the whole command argument list
 						// all available interceptors are allowed to modify the argument list
 						for (MavenArgumentInterceptorAction mavenArgInterceptor : argInterceptors) {
-							final ArgumentListBuilder newMargs = mavenArgInterceptor.intercept(margs);
+							final ArgumentListBuilder newMargs = mavenArgInterceptor.intercept(margs, this.getBuild());
 							if (newMargs != null) {
 								margs = newMargs;
 							}

--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -760,8 +760,9 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
 						// find the correct maven goals and options, there might by an action overruling the defaults
                         String goals = project.getGoals(); // default
                         for (MavenArgumentInterceptorAction mavenArgInterceptor : argInterceptors) {
-                        	if(StringUtils.isNotBlank(mavenArgInterceptor.getGoalsAndOptions())){
-                        		goals = mavenArgInterceptor.getGoalsAndOptions();
+                        	final String goalsAndOptions = mavenArgInterceptor.getGoalsAndOptions();
+							if(StringUtils.isNotBlank(goalsAndOptions)){
+                        		goals = goalsAndOptions;
                                 // only one interceptor is allowed to overwrite the whole "goals and options" string
                         		break;
                         	}

--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -754,17 +754,22 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                             }
                         }
 
+                        
+                        final List<MavenArgumentInterceptorAction> argInterceptors = this.getBuild().getActions(MavenArgumentInterceptorAction.class);
+                        
 						// find the correct maven goals and options, there might by an action overruling the defaults
-                        // only one action is allowed to overwrite the hole "goals and options" string
-						final MavenArgumentInterceptorAction interceptorAction = this.getBuild().getAction(MavenArgumentInterceptorAction.class);
-						final String goals = interceptorAction != null && StringUtils.isNotBlank(interceptorAction.getGoalsAndOptions()) ? interceptorAction
-								.getGoalsAndOptions() : project.getGoals();
-								
+                        String goals = project.getGoals(); // default
+                        for (MavenArgumentInterceptorAction mavenArgInterceptor : argInterceptors) {
+                        	if(StringUtils.isNotBlank(mavenArgInterceptor.getGoalsAndOptions())){
+                        		goals = mavenArgInterceptor.getGoalsAndOptions();
+                                // only one interceptor is allowed to overwrite the whole "goals and options" string
+                        		break;
+                        	}
+						}
 						margs.addTokenized(envVars.expand(goals));
 
 						// enable the interceptors to change the whole command argument list
 						// all available interceptors are allowed to modify the argument list
-						final List<MavenArgumentInterceptorAction> argInterceptors = this.getBuild().getActions(MavenArgumentInterceptorAction.class);
 						for (MavenArgumentInterceptorAction mavenArgInterceptor : argInterceptors) {
 							final ArgumentListBuilder newMargs = mavenArgInterceptor.intercept(margs);
 							if (newMargs != null) {

--- a/test/src/test/java/hudson/maven/MavenArgumentInterceptorTest.java
+++ b/test/src/test/java/hudson/maven/MavenArgumentInterceptorTest.java
@@ -105,11 +105,11 @@ public class MavenArgumentInterceptorTest extends HudsonTestCase {
 			return null;
 		}
 
-		public String getGoalsAndOptions() {
+		public String getGoalsAndOptions(MavenModuleSetBuild build) {
 			return goalsAndOptions;
 		}
 
-		public ArgumentListBuilder intercept(ArgumentListBuilder mavenargs) {
+		public ArgumentListBuilder intercept(ArgumentListBuilder mavenargs, MavenModuleSetBuild build) {
 			if (args != null) {
 				for (String arg : this.args) {
 					mavenargs.add(arg);

--- a/test/src/test/java/hudson/maven/MavenArgumentInterceptorTest.java
+++ b/test/src/test/java/hudson/maven/MavenArgumentInterceptorTest.java
@@ -1,0 +1,171 @@
+package hudson.maven;
+
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2011, Dominik Bartholdi
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.tasks.BuildWrapper;
+import hudson.tasks.BuildWrapperDescriptor;
+import hudson.tasks.Maven.MavenInstallation;
+import hudson.util.ArgumentListBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import net.sf.json.JSONObject;
+
+import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * @author Dominik Bartholdi (imod)
+ */
+public class MavenArgumentInterceptorTest extends HudsonTestCase {
+
+	public void testSimpleMaven3BuildWithArgInterceptor_Goals() throws Exception {
+
+		MavenModuleSet m = createMavenProject();
+		MavenInstallation mavenInstallation = configureMaven3();
+		m.setMaven(mavenInstallation.getName());
+		m.setScm(new ExtractResourceSCM(getClass().getResource("maven3-project.zip")));
+		m.setGoals("dummygoal"); // build would fail with this goal
+
+		// add an action to build, redefining the goals and options to be
+		// executed
+		m.getBuildWrappersList().add(new TestMvnBuildWrapper("clean"));
+
+		MavenModuleSetBuild b = buildAndAssertSuccess(m);
+		assertTrue(MavenUtil.maven3orLater(b.getMavenVersionUsed()));
+	}
+
+	public void testSimpleMaven3BuildWithArgInterceptor_ArgBuilder() throws Exception {
+
+		MavenModuleSet m = createMavenProject();
+		MavenInstallation mavenInstallation = configureMaven3();
+		m.setMaven(mavenInstallation.getName());
+		m.setScm(new ExtractResourceSCM(getClass().getResource("maven-multimodule-unit-failure.zip")));
+		m.setGoals("clean install"); // build would fail because of failing unit
+										// tests
+
+		// add an action to build, adding argument to skip the test execution
+		m.getBuildWrappersList().add(new TestMvnBuildWrapper(Arrays.asList("-DskipTests")));
+
+		MavenModuleSetBuild b = buildAndAssertSuccess(m);
+		assertTrue(MavenUtil.maven3orLater(b.getMavenVersionUsed()));
+	}
+
+	private static class TestMvnArgInterceptor implements MavenArgumentInterceptorAction {
+		private String goalsAndOptions;
+		private List<String> args;
+
+		public TestMvnArgInterceptor(String goalsAndOptions) {
+			this.goalsAndOptions = goalsAndOptions;
+		}
+
+		public TestMvnArgInterceptor(List<String> args) {
+			this.args = args;
+		}
+
+		public String getIconFileName() {
+			return null;
+		}
+
+		public String getDisplayName() {
+			return null;
+		}
+
+		public String getUrlName() {
+			return null;
+		}
+
+		public String getGoalsAndOptions() {
+			return goalsAndOptions;
+		}
+
+		public ArgumentListBuilder intercept(ArgumentListBuilder mavenargs) {
+			if (args != null) {
+				for (String arg : this.args) {
+					mavenargs.add(arg);
+				}
+			}
+			return mavenargs;
+		}
+	}
+
+	public static class TestMvnBuildWrapper extends BuildWrapper {
+		public Result buildResultInTearDown;
+		private String goalsAndOptions;
+		private List<String> args;
+
+		public TestMvnBuildWrapper(String goalsAndOptions) {
+			this.goalsAndOptions = goalsAndOptions;
+		}
+
+		public TestMvnBuildWrapper(List<String> args) {
+			this.args = args;
+		}
+
+		@Override
+		public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+
+			if (goalsAndOptions != null) {
+				build.addAction(new TestMvnArgInterceptor(goalsAndOptions));
+			} else if (args != null) {
+				build.addAction(new TestMvnArgInterceptor(args));
+			}
+
+			return new BuildWrapper.Environment() {
+				@Override
+				public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
+					buildResultInTearDown = build.getResult();
+					return true;
+				}
+			};
+		}
+
+		@Extension
+		public static class TestMvnBuildWrapperDescriptor extends BuildWrapperDescriptor {
+			@Override
+			public boolean isApplicable(AbstractProject<?, ?> project) {
+				return true;
+			}
+
+			@Override
+			public BuildWrapper newInstance(StaplerRequest req, JSONObject formData) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public String getDisplayName() {
+				return this.getClass().getName();
+			}
+		}
+	}
+}


### PR DESCRIPTION
I'd like to have someone else have a look at this before I/someone pushes it the core...

I add a new action type to enable a plugin to intercept the goals and options used within a build.
This enables to resolve some showstopper issues within the "M2 release plugin". e.g.:
- JENKINS-8524 - maven release build exposes users' username and password

and makes it possible to have a cleaner integration of the plugin as a whole.

The pull contains the new action type 'MavenArgumentInterceptorAction' and testcases for it.
