### PR TITLE
[FIXED JENKINS-7403], [FIXED JENKINS-11834], and a little convenience feature

### DIFF
--- a/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
+++ b/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
     <j:invokeStatic var="tz" className="java.util.TimeZone" method="getDefault"/>
     var tz = ${tz.rawOffset / 3600000};
     <![CDATA[
-    window.addEventListener('load', function() {
+    function doLoad() {
         var tl_el = document.getElementById("tl");
         var eventSource1 = new Timeline.DefaultEventSource();
         eventSource1.loaded = {};
@@ -107,14 +107,31 @@ THE SOFTWARE.
 
         // if resized, redo layout
         var resizeTimerID = null;
-        window.addEventListener('resize',function() {
+        function doResize() {
             if (resizeTimerID == null) {
                 resizeTimerID = window.setTimeout(function() {
                     resizeTimerID = null;
                     tl.layout();
                 }, 500);
             }
-        },false);
-    },false);
+        }
+        
+        if (window.addEventListener) { 
+            window.addEventListener( "resize", doResize, false );
+        }else if (window.attachEvent) { 
+            window.attachEvent( "onresize", doResize);
+        }else if (window.onResize) {
+           window.onresize = doResize;
+        }
+        
+    };
+    
+    if (window.addEventListener) { 
+        window.addEventListener( "load", doLoad, false );
+    }else if (window.attachEvent) { 
+        window.attachEvent( "onload", doLoad );
+    }else if (window.onLoad) {
+           window.onload = doLoad;
+    }
   ]]></script>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
+++ b/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
@@ -29,11 +29,18 @@ THE SOFTWARE.
 
   <st:adjunct includes="org.kohsuke.stapler.simile.timeline" />
 
-  <div id="tl" style="height:250px; border:1px solid black;" />
+  <div id="resizeContainer" style="height: 300px; border:1px solid black; padding-bottom: 5px;">
+    <div id="tl" style="height:100%;"/>
+  </div>
   <div id="status" />
+  
+  <link rel="stylesheet" type="text/css" href="/scripts/yui/assets/skins/sam/resize.css"/>
+  <script type="text/javascript" src="/scripts/yui/resize/resize-min.js"></script>
+  
   <script>
     <j:invokeStatic var="tz" className="java.util.TimeZone" method="getDefault"/>
     var tz = ${tz.rawOffset / 3600000};
+    var tl = null;
     <![CDATA[
     function doLoad() {
         var tl_el = document.getElementById("tl");
@@ -75,7 +82,7 @@ THE SOFTWARE.
         var bandInfos = [
             // the bar that shows outline
             Timeline.createBandInfo({
-                width:          "50px", // set to a minimum, autoWidth will then adjust
+                width:          "20%",
                 intervalUnit:   Timeline.DateTime.DAY,
                 intervalPixels: 200,
                 eventSource:    eventSource1,
@@ -85,7 +92,7 @@ THE SOFTWARE.
             }),
             // the main area
             Timeline.createBandInfo({
-                width:          "200px",
+                width:          "80%",
                 eventSource:    eventSource1,
                 timeZone:       tz,
                 theme:          theme1,
@@ -97,7 +104,7 @@ THE SOFTWARE.
         bandInfos[0].syncWith = 1;
 
         // create the Timeline
-        var tl = Timeline.create(tl_el, bandInfos, Timeline.HORIZONTAL);
+        tl = Timeline.create(tl_el, bandInfos, Timeline.HORIZONTAL);
 
         tl.getBand(0).addOnScrollListener(function(band) {
             eventSource1.ensureVisible(band);
@@ -133,5 +140,23 @@ THE SOFTWARE.
     }else if (window.onLoad) {
            window.onload = doLoad;
     }
+    
+    //add resize handle
+    (function() {
+        var Dom = YAHOO.util.Dom,
+            Event = YAHOO.util.Event;
+
+        var resize = new YAHOO.util.Resize('resizeContainer', {
+             handles: 'b',
+             minHeight: 300 // this should be the same as the height of the container div,
+                            // to fix a issue when it's resized to be smaller than the original height
+        });
+
+        //update timeline after resizing
+        resize.on('endResize', function() { 
+            tl.layout(); 
+        }, null, true); 
+    
+    })();
   ]]></script>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/buildListTable.jelly
+++ b/core/src/main/resources/lib/hudson/buildListTable.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
           <st:nbsp/>
           <a href="${jobBaseUrl}${b.url}">${b.displayName}</a>
         </td>
-        <td data="${b.timestampString2}">
+        <td data="${b.timestampString2}" tooltip="${%Click to center timeline on event}" onclick="javascript:tl.getBand(0).scrollToCenter(Timeline.DateTime.parseGregorianDateTime('${b.timestampString2}'))">
           ${b.timestampString}
         </td>
         <td>


### PR DESCRIPTION
I hope it's alright to bundle three commits in one pull request.

The code which was used to fix the timeline widget in IE8 could be refactored into a more abstract javascript class (eg. hudson-behavior.js?). The same goes for the resize functionality provided by the YUI library.

I can't be bothered to make the "Click to center timeline on event" work with IE right now. Works fine with Chrome and Firefox.
