### PR TITLE
Minimized serialization profile of Maven build proxy

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/MavenBuild.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenBuild.java
@@ -50,7 +50,6 @@ import hudson.util.ArgumentListBuilder;
 import hudson.util.DescribableList;
 import hudson.util.IOUtils;
 import org.apache.maven.BuildFailureException;
-import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ReactorManager;
 import org.apache.maven.lifecycle.LifecycleExecutionException;


### PR DESCRIPTION
Previously, the 'FilterImpl' build proxy had the whole MavenBuilder object attached when it was serialized to the master. This is now reduced to the minimal necessary information.

Additionally, this pull request contains some removal of duplicated code and minor optimizations.
