### PR TITLE
Don't call SCM#calcPollingingBaseline if SCM#checkout fails

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1193,7 +1193,9 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         workspace.mkdirs();
         
         boolean r = scm.checkout(build, launcher, workspace, listener, changelogFile);
-        calcPollingBaseline(build, launcher, listener);
+        if (r) { // Only calcRevisionsFromBuild is checkout was successful
+            calcPollingBaseline(build, launcher, listener);
+        }
         return r;
     }
 


### PR DESCRIPTION
In the JavaDocs for SCM#calcRevisionsFromBuild, if says:
This method is called after source code is checked out for the given build (that is, after SCM#checkout has finished successfully.)

This appears to make sense; after you have a known SCM state, you calculate the revisions.  It doesn't explicitly state it, but it
implies that it won't be called if checkout failed.  In those cases, the state may well not be known, and it doesn't make sense to
attempt to calculate the revisions.

The behavior in AbstractProject#checkout has been to always call calcPollingBaseline, regardless of whether checkout failed or
succeeded.  This is causing misleading error output for the mercurial plugin.  With this change, AbstractProject will only do the
calculations when checkout succeeds.
