### PR TITLE
Using the default e-mail suffix for notifications

### DIFF
--- a/core/src/main/java/hudson/tasks/MailSender.java
+++ b/core/src/main/java/hudson/tasks/MailSender.java
@@ -312,6 +312,7 @@ public class MailSender {
         msg.setSentDate(new Date());
 
         Set<InternetAddress> rcp = new LinkedHashSet<InternetAddress>();
+        String defaultSuffix = Mailer.descriptor().getDefaultSuffix();
         StringTokenizer tokens = new StringTokenizer(recipients);
         while (tokens.hasMoreTokens()) {
             String address = tokens.nextToken();
@@ -326,10 +327,17 @@ public class MailSender {
                 includeCulpritsOf(up, build, listener, rcp);
             } else {
                 // ordinary address
+            	
+            	// if not a valid address (i.e. no '@'), then try adding suffix
+            	if (!address.contains("@") && defaultSuffix != null && defaultSuffix.contains("@")) {
+            		address += defaultSuffix;
+            	}
+            	
                 try {
                     rcp.add(new InternetAddress(address));
                 } catch (AddressException e) {
                     // report bad address, but try to send to other addresses
+                    listener.getLogger().println("Unable to send to address: " + address);
                     e.printStackTrace(listener.error(e.getMessage()));
                 }
             }


### PR DESCRIPTION
Hello,

My understanding of the "default user e-mail suffix" setting was that it would be applied to the "E-mail Notification" section of a build configuration.  E.g. if I specify the default suffix as "@acme.org", then I should be able to set the e-mail addresses for notification as "john paul george ringo" and it would just add "@acme.org" to the end of each one.  Instead, I get a javax.mail.SendFailedException (Invalid Addresses), because of course "john" by itself is not a valid address.

I modified the code to give you an idea of what I'm talking about.  I would be thrilled if you pulled my changes, because I think it's a pretty straightforward use-case, and it would help make my own build configurations a lot more concise.

Thank you,
Nolan
