### PR TITLE
Fix prematurely re-drawing graph for matrix build.

### DIFF
--- a/core/src/main/java/hudson/tasks/test/TestResultProjectAction.java
+++ b/core/src/main/java/hudson/tasks/test/TestResultProjectAction.java
@@ -77,7 +77,7 @@ public class TestResultProjectAction implements Action {
         AbstractBuild<?,?> b=project.getLastBuild();
         while(b!=null) {
             AbstractTestResultAction a = b.getTestResultAction();
-            if(a!=null) return a;
+            if(a!=null && (!b.isBuilding())) return a;
             if(b==tb)
                 // if even the last successful build didn't produce the test result,
                 // that means we just don't have any tests configured.


### PR DESCRIPTION
The Trend test result graph is re-drawn prematurely for matrix build. It is due to condition in method getLastTestResultAction() of TestResultProjectAction class. The condition which chooses build (and its AbstractTestResultAction) for which the graph will be re-drawn is not correct for matrix build.

public AbstractTestResultAction getLastTestResultAction() {
        final AbstractBuild<?,?> tb = project.getLastSuccessfulBuild();

```
    AbstractBuild<?,?> b=project.getLastBuild();
    while(b!=null) {
        AbstractTestResultAction a = b.getTestResultAction();
        if(a!=null) return a;
        if(b==tb)
            // if even the last successful build didn't produce the test result,
            // that means we just don't have any tests configured.
            return null;
        b = b.getPreviousBuild();
    }

    return null;
}
```

It chooses the matrix build which is building, because it has always action with type AbstractTestResultAction (MatrixTestResult) during its building.But Free style job never has action with type AbstractTestResultAction during building and it is the reason why it works for Free style job correctly, but for Matrix job not. If the job page is refreshed, it find out the last build of this job (by choosing the last build which has action with AbstractTestResultAction) and if the timestamp of this build is higher than timestamp of the last re-drawing (in method doGraph() of AbstractTestResultAction class), the graph will be re-drawn.if user refreshes matrix job page and no build of this job is building, it works fine, but if the user refreshes the matrix job page during building a build of this job, the graph will be redrawn with number of tests = 0 for the building build (because the building does not end). The graph will not be re-drawn with correct data until the next build is building.

I modify the condition (a!=null && (!b.isBuilding())) to prevent this situation.
