### PR TITLE
Expose a new beforeUse callback on WorkspaceListener for performing actions on a workspace before it's used by a build.

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -452,7 +452,10 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             try {
                 workspace = lease.path.getRemote();
                 node.getFileSystemProvisioner().prepareWorkspace(AbstractBuild.this,lease.path,listener);
-
+                
+                for (WorkspaceListener wl : WorkspaceListener.all()) {
+                    wl.beforeUse(AbstractBuild.this, lease.path, listener);
+                }
                 preCheckout(launcher,listener);
                 checkout(listener);
 

--- a/core/src/main/java/hudson/model/WorkspaceListener.java
+++ b/core/src/main/java/hudson/model/WorkspaceListener.java
@@ -2,6 +2,7 @@ package hudson.model;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.FilePath;
 
 public abstract class WorkspaceListener implements ExtensionPoint {
     
@@ -10,6 +11,16 @@ public abstract class WorkspaceListener implements ExtensionPoint {
      * @param project
      */
     public void afterDelete(AbstractProject project) {
+        
+    }
+
+    /**
+     * Called before a build uses a workspace. IE, before any SCM checkout.
+     * @param r
+     * @param workspace
+     * @param listener 
+     */
+    public void beforeUse(AbstractBuild b, FilePath workspace, BuildListener listener) {
         
     }
     


### PR DESCRIPTION
I need access to the workspace from a listener before a build begins to use it. No other extension points currently support this use-case as far as I can tell.
