### PR TITLE
Enable to create slave error log locally.

### DIFF
--- a/core/src/main/java/hudson/slaves/CommandLauncher.java
+++ b/core/src/main/java/hudson/slaves/CommandLauncher.java
@@ -97,6 +97,7 @@ public class CommandLauncher extends ComputerLauncher {
             ProcessBuilder pb = new ProcessBuilder(Util.tokenize(getCommand()));
             final EnvVars cookie = _cookie = EnvVars.createCookie();
             pb.environment().putAll(cookie);
+            pb.environment().put("WORKSPACE", computer.getNode().getRemoteFS()); //path for local slave log
 
             {// system defined variables
                 String rootUrl = Jenkins.getInstance().getRootUrl();


### PR DESCRIPTION
It sets the variable WORKSPACE for local slave log (directory, where the class hudson.remoting.Launcher saves a slave local error log).
