### PR TITLE
[JENKINS-12177] Zero executors on master is no longer valid

### DIFF
--- a/core/src/main/resources/jenkins/model/MasterBuildConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/MasterBuildConfiguration/config.groovy
@@ -3,7 +3,7 @@ package jenkins.model.MasterBuildConfiguration
 def f=namespace(lib.FormTagLib)
 
 f.entry(title:_("# of executors"), field:"numExecutors") {
-    f.number(clazz:"positive-number", min:1, step:1)
+    f.number(clazz:"number", min:0, step:1)
 }
 if (!app.slaves.isEmpty() || !app.clouds.isEmpty()) {
     f.entry(title:_("Labels"),field:"labelString") {


### PR DESCRIPTION
This pull request allows zero executors on master.
I am sorry that #298 introduced a new issue [JENKINS-12177](https://issues.jenkins-ci.org/browse/JENKINS-12177).
