### PR TITLE
Improve build queue and executor project name display

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -320,6 +320,17 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         else                return n+'/'+getName();
     }
 
+    public final String getShortDisplayName() {
+        String n = getFullDisplayName();
+        if(n.length()> 38) {
+            String p = n.substring(0, 35);
+            p=p.concat("...");
+            return p;
+        } 
+        else 
+            return n;
+    }
+
     public final String getFullDisplayName() {
         String n = getParent().getFullDisplayName();
         if(n.length()==0)   return getDisplayName();

--- a/core/src/main/java/hudson/model/Item.java
+++ b/core/src/main/java/hudson/model/Item.java
@@ -119,6 +119,15 @@ public interface Item extends PersistenceRoot, SearchableModelObject, AccessCont
     String getDisplayName();
 
     /**
+     * Gets a fixed length name of this item.
+     *
+     * This method should try to return fixed size human
+     * readable string that describes this item.
+     * The string need not be unique.
+     */
+    String getShortDisplayName();
+
+    /**
      * Works like {@link #getDisplayName()} but return
      * the full path that includes all the display names
      * of the ancestors.

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -42,6 +42,11 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
     String getFullName();
 
     /**
+     * @see Item#getShortDisplayName() 
+     */
+    String getShortDisplayName();
+
+    /**
      * @see Item#getFullDisplayName() 
      */
     String getFullDisplayName();

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1088,6 +1088,11 @@ public class Queue extends ResourceController implements Saveable {
         String getName();
 
         /**
+         * @see hudson.model.Item#getShortDisplayName()
+         */
+        String getShortDisplayName();
+        
+        /**
          * @see hudson.model.Item#getFullDisplayName()
          */
         String getFullDisplayName();

--- a/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
@@ -71,6 +71,10 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.getName();
     }
 
+    public String getShortDisplayName() {
+        return base.getShortDisplayName();
+    }
+    
     public String getFullDisplayName() {
         return base.getFullDisplayName();
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1195,6 +1195,10 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
         return "";
     }
 
+    public String getShortDisplayName() {
+        return "";
+    }
+    
     public String getFullDisplayName() {
         return "";
     }

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -79,7 +79,7 @@ THE SOFTWARE.
                       </j:invokeStatic>
                       <j:choose>
                         <j:when test="${h.hasPermission(exeparent,exeparent.READ)}">
-                          <a href="${rootURL}/${exeparent.url}">${exeparent.fullDisplayName}</a>&#160;<a href="${rootURL}/${exe.url}">#${exe.number}</a>
+                          <a href="${rootURL}/${exeparent.url}">${exeparent.shortDisplayName}</a>&#160;<a href="${rootURL}/${exe.url}">#${exe.number}</a>
                           <t:buildProgressBar build="${exe}" executor="${executor}"/>
                         </j:when>
                         <j:otherwise>

--- a/core/src/main/resources/lib/hudson/executors_fr.properties
+++ b/core/src/main/resources/lib/hudson/executors_fr.properties
@@ -20,13 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Build\ Executor\ Status=\u00C9tat du lanceur de constructions
+Build\ Executor\ Status=\u00c9tat du lanceur de constructions
 Status=Statut
-Master=Maître
-offline=d\u00E9connect\u00E9
+Master=Ma\u00eetre
+offline=d\u00e9connect\u00e9
 Dead=Hors service
 Idle=En attente
-Building=En cours d''\u00E9xecution
-terminate\ this\ build=arr\u00EAter ce build
+Building=Execution
+terminate\ this\ build=arr\u00eater ce build
 suspended=suspendu
-Offline=Déconnecté
+Offline=D\u00e9connect\u00e9

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -63,7 +63,7 @@ THE SOFTWARE.
               <j:choose>
                 <j:when test="${h.hasPermission(item.task,item.task.READ)}">
                   <a href="${rootURL}/${item.task.url}">
-                    ${item.task.fullDisplayName}
+                    ${item.task.shortDisplayName}
                   </a>
                   <j:if test="${stuck}">
                     &#160;


### PR DESCRIPTION
When working with very large project name full name is displayed in the left pane in executors and queue leading to a lake of visibility by shifting the main table on the right side of the screen.
This development aims at reducing the job name size to a fixed size (38 characters)
