### PR TITLE
JENKINS-7096 - Stop users being created in memory if registration fails

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -63,6 +63,9 @@ Upcoming changes</a>
   <li class="rfe">
   OS X installer can optionally create a new user &quot;jenkins&quot; and use
   it. This user has a writable home directory, making it possible to set up ssh for Jenkins.
+  <li class="bug">
+  Stop users being created in memory if they failed to provide all the required registration information correctly.
+   (<a href="https://issues.jenkins-ci.org/browse/JENKINS-7096">issue 7096</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -302,9 +302,9 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         if(si.username==null || si.username.length()==0)
             si.errorMessage = "User name is required";
         else {
-            User user = User.get(si.username);
-            if(user.getProperty(Details.class)!=null)
-                si.errorMessage = "User name is already taken. Did you forget the password?";
+            User user = User.get(si.username, false);
+            if (null != user)
+                si.errorMessage = "User name is already taken";
         }
 
         if(si.fullname==null || si.fullname.length()==0)


### PR DESCRIPTION
If a user fails to enter all the fields in the registration page when they're shown an error but a user account is still created with the partial details. This change prevent that.
