### PR TITLE
Improve Job Name Display in Queue and Executors

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -320,6 +320,17 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         else                return n+'/'+getName();
     }
 
+    public final String getShortDisplayName() {
+        String n = getFullDisplayName();
+        if(n.length()> 38) {
+            String p = n.substring(0, 35);
+            p=p.concat("...");
+            return p;
+        } 
+        else 
+            return n;
+    }
+
     public final String getFullDisplayName() {
         String n = getParent().getFullDisplayName();
         if(n.length()==0)   return getDisplayName();

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -320,17 +320,16 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         else                return n+'/'+getName();
     }
 
-    public final String getShortDisplayName() {
+    public final String getProcessedDisplayName() {
         String n = getFullDisplayName();
-        if(n.length()> 38) {
+        if (Jenkins.getInstance().isUseShortDisplayName() && n.length() > 38) {
             String p = n.substring(0, 35);
-            p=p.concat("...");
+            p = p.concat("...");
             return p;
-        } 
-        else 
-            return n;
+        }
+        return n;
     }
-
+    
     public final String getFullDisplayName() {
         String n = getParent().getFullDisplayName();
         if(n.length()==0)   return getDisplayName();

--- a/core/src/main/java/hudson/model/Item.java
+++ b/core/src/main/java/hudson/model/Item.java
@@ -119,6 +119,15 @@ public interface Item extends PersistenceRoot, SearchableModelObject, AccessCont
     String getDisplayName();
 
     /**
+     * Gets a fixed length name of this item.
+     *
+     * This method should try to return fixed size human
+     * readable string that describes this item.
+     * The string need not be unique.
+     */
+    String getShortDisplayName();
+
+    /**
      * Works like {@link #getDisplayName()} but return
      * the full path that includes all the display names
      * of the ancestors.

--- a/core/src/main/java/hudson/model/Item.java
+++ b/core/src/main/java/hudson/model/Item.java
@@ -119,13 +119,16 @@ public interface Item extends PersistenceRoot, SearchableModelObject, AccessCont
     String getDisplayName();
 
     /**
-     * Gets a fixed length name of this item.
+     * According to the global configuration, return
+     * fixed length name of this item or full name.
      *
      * This method should try to return fixed size human
-     * readable string that describes this item.
+     * readable string that describes this item or 
+     * the full path that includes all the display names
+     * of the ancestors.
      * The string need not be unique.
      */
-    String getShortDisplayName();
+    String getProcessedDisplayName();
 
     /**
      * Works like {@link #getDisplayName()} but return

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -42,6 +42,11 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
     String getFullName();
 
     /**
+     * @see Item#getShortDisplayName() 
+     */
+    String getShortDisplayName();
+
+    /**
      * @see Item#getFullDisplayName() 
      */
     String getFullDisplayName();

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -42,9 +42,9 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
     String getFullName();
 
     /**
-     * @see Item#getShortDisplayName() 
+     * @see Item#getProcessedDisplayName() 
      */
-    String getShortDisplayName();
+    String getProcessedDisplayName();
 
     /**
      * @see Item#getFullDisplayName() 

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1088,6 +1088,11 @@ public class Queue extends ResourceController implements Saveable {
         String getName();
 
         /**
+         * @see hudson.model.Item#getShortDisplayName()
+         */
+        String getShortDisplayName();
+        
+        /**
          * @see hudson.model.Item#getFullDisplayName()
          */
         String getFullDisplayName();

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1088,9 +1088,9 @@ public class Queue extends ResourceController implements Saveable {
         String getName();
 
         /**
-         * @see hudson.model.Item#getShortDisplayName()
+         * @see hudson.model.Item#getProcessedDisplayName()
          */
-        String getShortDisplayName();
+        String getProcessedDisplayName();
         
         /**
          * @see hudson.model.Item#getFullDisplayName()

--- a/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
@@ -71,8 +71,8 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.getName();
     }
 
-    public String getShortDisplayName() {
-        return base.getShortDisplayName();
+    public String getProcessedDisplayName() {
+        return base.getProcessedDisplayName();
     }
     
     public String getFullDisplayName() {

--- a/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
@@ -71,6 +71,10 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.getName();
     }
 
+    public String getShortDisplayName() {
+        return base.getShortDisplayName();
+    }
+    
     public String getFullDisplayName() {
         return base.getFullDisplayName();
     }

--- a/core/src/main/java/jenkins/model/GlobalDisplayConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalDisplayConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2012 dt25.
+ * Copyright 2012 Thomas Deruyter.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/main/java/jenkins/model/GlobalDisplayConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalDisplayConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2012 dt25.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model;
+
+import hudson.Extension;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+
+/**
+ * Show choice of get job display at configuration level
+ * 
+ * @author Thomas Deruyter
+ */
+
+@Extension(ordinal=100)
+public class GlobalDisplayConfiguration extends GlobalConfiguration {
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        try {
+            // for backward compatibility reasons, this configuration is stored in Jenkins
+            Jenkins.getInstance().setShortDisplayNameUsage(json.has("useShortDisplayName") ? true : false);
+            return true;
+        } catch (IOException e) {
+            throw new FormException(e,"useShortDisplayName");
+        }
+    }
+   
+}

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -491,6 +491,14 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
     /*package*/ Integer quietPeriod;
 
     /**
+     * Short Display Name.
+     *
+     * This is {@link Boolean}.
+     */
+    private Boolean useShortDisplayName;
+
+    
+    /**
      * Global default for {@link AbstractProject#getScmCheckoutRetryCount()}
      */
     /*package*/ int scmCheckoutRetryCount;
@@ -652,7 +660,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
      * True if the user opted out from the statistics tracking. We'll never send anything if this is true.
      */
     private Boolean noUsageStatistics;
-
+    
     /**
      * HTTP proxy configuration.
      */
@@ -898,6 +906,20 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
         save();
     }
 
+    @Exported
+    public Boolean getUseShortDisplayName() {
+        return useShortDisplayName;
+    }
+
+    public boolean isUseShortDisplayName() {
+        return useShortDisplayName!=null && useShortDisplayName;
+    }
+   
+    public void setShortDisplayNameUsage(Boolean useShortDisplayName) throws IOException {
+        this.useShortDisplayName = useShortDisplayName;
+        save();
+    }
+    
     public View.People getPeople() {
         return new View.People(this);
     }
@@ -1195,7 +1217,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
         return "";
     }
 
-    public String getShortDisplayName() {
+    public String getProcessedDisplayName() {
         return "";
     }
     

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1195,6 +1195,10 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
         return "";
     }
 
+    public String getShortDisplayName() {
+        return "";
+    }
+    
     public String getFullDisplayName() {
         return "";
     }

--- a/core/src/main/resources/jenkins/model/GlobalDisplayConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/GlobalDisplayConfiguration/config.groovy
@@ -1,0 +1,8 @@
+package jenkins.model.GlobalDisplayConfiguration
+
+import hudson.Functions
+
+def f=namespace(lib.FormTagLib)
+
+f.optionalBlock( field:"useShortDisplayName", checked:app.useShortDisplayName, title:_("Use short name display"))
+

--- a/core/src/main/resources/jenkins/model/GlobalDisplayConfiguration/help-useShortDisplayName.html
+++ b/core/src/main/resources/jenkins/model/GlobalDisplayConfiguration/help-useShortDisplayName.html
@@ -1,0 +1,4 @@
+<div>
+  If set, Fix length string  will be used to display project names in build queue 
+  and executors
+</div>

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -79,7 +79,7 @@ THE SOFTWARE.
                       </j:invokeStatic>
                       <j:choose>
                         <j:when test="${h.hasPermission(exeparent,exeparent.READ)}">
-                          <a href="${rootURL}/${exeparent.url}">${exeparent.shortDisplayName}</a>&#160;<a href="${rootURL}/${exe.url}">#${exe.number}</a>
+                          <a href="${rootURL}/${exeparent.url}">${exeparent.processedDisplayName}</a>&#160;<a href="${rootURL}/${exe.url}">#${exe.number}</a>
                           <t:buildProgressBar build="${exe}" executor="${executor}"/>
                         </j:when>
                         <j:otherwise>

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -79,7 +79,7 @@ THE SOFTWARE.
                       </j:invokeStatic>
                       <j:choose>
                         <j:when test="${h.hasPermission(exeparent,exeparent.READ)}">
-                          <a href="${rootURL}/${exeparent.url}">${exeparent.fullDisplayName}</a>&#160;<a href="${rootURL}/${exe.url}">#${exe.number}</a>
+                          <a href="${rootURL}/${exeparent.url}">${exeparent.shortDisplayName}</a>&#160;<a href="${rootURL}/${exe.url}">#${exe.number}</a>
                           <t:buildProgressBar build="${exe}" executor="${executor}"/>
                         </j:when>
                         <j:otherwise>

--- a/core/src/main/resources/lib/hudson/executors_fr.properties
+++ b/core/src/main/resources/lib/hudson/executors_fr.properties
@@ -20,13 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Build\ Executor\ Status=\u00C9tat du lanceur de constructions
+Build\ Executor\ Status=\u00c9tat du lanceur de constructions
 Status=Statut
-Master=Maître
-offline=d\u00E9connect\u00E9
+Master=Ma\u00eetre
+offline=d\u00e9connect\u00e9
 Dead=Hors service
 Idle=En attente
-Building=En cours d''\u00E9xecution
-terminate\ this\ build=arr\u00EAter ce build
+Building=Execution
+terminate\ this\ build=arr\u00eater ce build
 suspended=suspendu
-Offline=Déconnecté
+Offline=D\u00e9connect\u00e9

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -63,7 +63,7 @@ THE SOFTWARE.
               <j:choose>
                 <j:when test="${h.hasPermission(item.task,item.task.READ)}">
                   <a href="${rootURL}/${item.task.url}">
-                    ${item.task.fullDisplayName}
+                    ${item.task.shortDisplayName}
                   </a>
                   <j:if test="${stuck}">
                     &#160;

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -63,7 +63,7 @@ THE SOFTWARE.
               <j:choose>
                 <j:when test="${h.hasPermission(item.task,item.task.READ)}">
                   <a href="${rootURL}/${item.task.url}">
-                    ${item.task.shortDisplayName}
+                    ${item.task.processedDisplayName}
                   </a>
                   <j:if test="${stuck}">
                     &#160;


### PR DESCRIPTION
If activated from the main control panel, change the Job name displayed in the build queue and on executors from the full name to a fixed size name.
This is to avoid very large names in the left side panel that reduce the visibility of the main table .
