### PR TITLE
Add Ability to configure name length on executors and queue

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -1,8 +1,8 @@
 /*
  * The MIT License
  * 
- * Copyright (c) 2004-2011, Sun Microsystems, Inc., Kohsuke Kawaguchi,
- * Daniel Dyer, Tom Huybrechts, Yahoo!, Inc.
+ * Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi,
+ * Daniel Dyer, Tom Huybrechts, Yahoo!, Inc., Thomas Deruyter
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -320,6 +320,16 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         else                return n+'/'+getName();
     }
 
+    public final String getProcessedDisplayName() {
+        String n = getFullDisplayName();
+        if (Jenkins.getInstance().isUseShortDisplayName() && n.length() > Jenkins.getInstance().getShortDisplayNameLength()) {
+            String p = n.substring(0, Jenkins.getInstance().getShortDisplayNameLength()-3);
+            p = p.concat("...");
+            return p;
+        }
+        return n;
+    }
+    
     public final String getFullDisplayName() {
         String n = getParent().getFullDisplayName();
         if(n.length()==0)   return getDisplayName();

--- a/core/src/main/java/hudson/model/Item.java
+++ b/core/src/main/java/hudson/model/Item.java
@@ -1,8 +1,8 @@
 /*
  * The MIT License
  * 
- * Copyright (c) 2004-2011, Sun Microsystems, Inc., Kohsuke Kawaguchi, Yahoo! Inc.,
- * Manufacture Francaise des Pneumatiques Michelin, Romain Seguy
+ * Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi, Yahoo! Inc.,
+ * Manufacture Francaise des Pneumatiques Michelin, Romain Seguy, Thomas Deruyter
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -117,6 +117,18 @@ public interface Item extends PersistenceRoot, SearchableModelObject, AccessCont
      * of {@link #getParent() ancestor items}.
      */
     String getDisplayName();
+
+    /**
+     * According to the global configuration, return
+     * fixed length name of this item or full name.
+     *
+     * This method should try to return fixed size human
+     * readable string that describes this item or 
+     * the full path that includes all the display names
+     * of the ancestors.
+     * The string need not be unique.
+     */
+    String getProcessedDisplayName();
 
     /**
      * Works like {@link #getDisplayName()} but return

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -1,7 +1,8 @@
 /*
  * The MIT License
  * 
- * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ * Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ * Thomas Deruyter
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +41,11 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      * @see Item#getFullName() 
      */
     String getFullName();
+
+    /**
+     * @see Item#getProcessedDisplayName() 
+     */
+    String getProcessedDisplayName();
 
     /**
      * @see Item#getFullDisplayName() 

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1,8 +1,8 @@
 /*
  * The MIT License
  * 
- * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi,
- * Stephen Connolly, Tom Huybrechts, InfraDNA, Inc.
+ * Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi,
+ * Stephen Connolly, Tom Huybrechts, InfraDNA, Inc., Thomas Deruyter
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1087,6 +1087,11 @@ public class Queue extends ResourceController implements Saveable {
          */
         String getName();
 
+        /**
+         * @see hudson.model.Item#getProcessedDisplayName()
+         */
+        String getProcessedDisplayName();
+        
         /**
          * @see hudson.model.Item#getFullDisplayName()
          */

--- a/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2010, InfraDNA, Inc.
+ * Copyright (c) 2010-2012, InfraDNA, Inc., Thomas Deruyter
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -71,6 +71,10 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.getName();
     }
 
+    public String getProcessedDisplayName() {
+        return base.getProcessedDisplayName();
+    }
+    
     public String getFullDisplayName() {
         return base.getFullDisplayName();
     }

--- a/core/src/main/java/jenkins/model/GlobalDisplayConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalDisplayConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright  (c) 2012 Thomas Deruyter.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model;
+
+import hudson.Extension;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+
+/**
+ * Show choice of get job display at configuration level
+ * 
+ * @author Thomas Deruyter
+ */
+
+@Extension(ordinal=100)
+public class GlobalDisplayConfiguration extends GlobalConfiguration {
+
+    public Integer getShortDisplayNameLength() {
+        return Jenkins.getInstance().getShortDisplayNameLength();
+    }
+    
+    public Boolean isUseShortDisplayName() {
+        return Jenkins.getInstance().isUseShortDisplayName();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        if (json.has("useShortDisplayName")) {
+            JSONObject displayname = json.getJSONObject("useShortDisplayName");
+            try {
+                Jenkins.getInstance().setShortDisplayNameLength(displayname.getInt("shortDisplayNameLength"));
+            } catch (IOException e) {
+                throw new FormException(e, "shortDisplayNameLength");
+            }
+        } else {
+            try {
+                Jenkins.getInstance().setShortDisplayNameLength(-1);
+            } catch (IOException e) {
+                throw new FormException(e, "shortDisplayNameLength");
+            }
+        }
+        return true;
+    }
+}

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1,11 +1,11 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2004-2011, Sun Microsystems, Inc., Kohsuke Kawaguchi,
+ * Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi,
  * Erik Ramfelt, Koichi Fujikawa, Red Hat, Inc., Seiji Sogabe,
  * Stephen Connolly, Tom Huybrechts, Yahoo! Inc., Alan Harder, CloudBees, Inc.,
- * Yahoo!, Inc.
- *
+ * Yahoo!, Inc., Thomas Deruyter
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -491,6 +491,14 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
     /*package*/ Integer quietPeriod;
 
     /**
+     * Short Display Name.
+     *
+     * This is {@link Integer}.
+     */
+    private Integer useShortDisplayName;
+
+    
+    /**
      * Global default for {@link AbstractProject#getScmCheckoutRetryCount()}
      */
     /*package*/ int scmCheckoutRetryCount;
@@ -652,7 +660,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
      * True if the user opted out from the statistics tracking. We'll never send anything if this is true.
      */
     private Boolean noUsageStatistics;
-
+    
     /**
      * HTTP proxy configuration.
      */
@@ -898,6 +906,20 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
         save();
     }
 
+    public Integer getShortDisplayNameLength() {
+        return useShortDisplayName;
+    }
+
+    public boolean isUseShortDisplayName() {
+        return useShortDisplayName!=null && useShortDisplayName>0;
+    }
+   
+    public void setShortDisplayNameLength(int useShortDisplayName) throws IOException {
+        if (useShortDisplayName > 0) this.useShortDisplayName = useShortDisplayName;
+        else this.useShortDisplayName = null;
+        save();
+    }
+    
     public View.People getPeople() {
         return new View.People(this);
     }
@@ -1195,6 +1217,10 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
         return "";
     }
 
+    public String getProcessedDisplayName() {
+        return "";
+    }
+    
     public String getFullDisplayName() {
         return "";
     }

--- a/core/src/main/resources/jenkins/model/GlobalDisplayConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/GlobalDisplayConfiguration/config.groovy
@@ -1,0 +1,10 @@
+package jenkins.model.GlobalDisplayConfiguration
+
+def f=namespace(lib.FormTagLib)
+
+f.optionalBlock( field:"useShortDisplayName", checked:app.useShortDisplayName, title:_("Use short name display")) {
+    f.entry(title:_("Max job name length to display"), field:"shortDisplayNameLength") {
+        f.number(clazz:"number", min:0)
+    }
+}
+

--- a/core/src/main/resources/jenkins/model/GlobalDisplayConfiguration/help-useShortDisplayName.html
+++ b/core/src/main/resources/jenkins/model/GlobalDisplayConfiguration/help-useShortDisplayName.html
@@ -1,0 +1,4 @@
+<div>
+  If set, Fix length string will be used to display project names in build queue 
+  and executors. Length provided in number of characters
+</div>

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -1,8 +1,8 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi,
-Stephen Connolly, id:cactusman, Yahoo! Inc., Alan Harder
+Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi,
+Stephen Connolly, id:cactusman, Yahoo! Inc., Alan Harder, Thomas Deruyter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -79,7 +79,7 @@ THE SOFTWARE.
                       </j:invokeStatic>
                       <j:choose>
                         <j:when test="${h.hasPermission(exeparent,exeparent.READ)}">
-                          <a href="${rootURL}/${exeparent.url}">${exeparent.fullDisplayName}</a>&#160;<a href="${rootURL}/${exe.url}">#${exe.number}</a>
+                          <a href="${rootURL}/${exeparent.url}">${exeparent.processedDisplayName}</a>&#160;<a href="${rootURL}/${exe.url}">#${exe.number}</a>
                           <t:buildProgressBar build="${exe}" executor="${executor}"/>
                         </j:when>
                         <j:otherwise>

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -1,7 +1,8 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts, Yahoo! Inc.
+Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts, Yahoo! Inc., 
+Thomas Deruyter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -63,7 +64,7 @@ THE SOFTWARE.
               <j:choose>
                 <j:when test="${h.hasPermission(item.task,item.task.READ)}">
                   <a href="${rootURL}/${item.task.url}">
-                    ${item.task.fullDisplayName}
+                    ${item.task.processedDisplayName}
                   </a>
                   <j:if test="${stuck}">
                     &#160;


### PR DESCRIPTION
If activated from the main control panel, change the Job name displayed in the build queue and on executors from the full name to a fixed size name.
This is to avoid very large names in the left side panel that reduce the visibility of the main table .
Length is defined in configuration panel
