### PR TITLE
[JENKINS-12440]No proxy host configuration does not act correctly

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -129,12 +129,19 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
      * Returns the list of properly formatted no proxy host names.
      */
     public List<Pattern> getNoProxyHostPatterns() {
+        return getNoProxyHostPatterns(noProxyHost);
+    }
+
+    /**
+     * Returns the list of properly formatted no proxy host names.
+     */
+    public static List<Pattern> getNoProxyHostPatterns(String noProxyHost) {
         if (noProxyHost==null)  return Collections.emptyList();
 
         List<Pattern> r = Lists.newArrayList();
         for (String s : noProxyHost.split("[ \t\n,|]+")) {
             if (s.length()==0)  continue;
-            r.add(Pattern.compile(s.replace(".", "\\.").replace("*", "[^.]*")));
+            r.add(Pattern.compile(s.replace(".", "\\.").replace("*", ".*")));
         }
         return r;
     }
@@ -148,8 +155,12 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
     }
 
     public Proxy createProxy(String host) {
+        return createProxy(host, name, port, noProxyHost);
+    }
+
+    public static Proxy createProxy(String host, String name, int port, String noProxyHost) {
         if (host!=null && noProxyHost!=null) {
-            for (Pattern p : getNoProxyHostPatterns()) {
+            for (Pattern p : getNoProxyHostPatterns(noProxyHost)) {
                 if (p.matcher(host).matches())
                     return Proxy.NO_PROXY;
             }

--- a/core/src/test/java/hudson/ProxyConfigurationTest.java
+++ b/core/src/test/java/hudson/ProxyConfigurationTest.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Hayato ITO
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson;
+
+import junit.framework.TestCase;
+
+import java.net.Proxy;
+
+public class ProxyConfigurationTest extends TestCase {
+
+    public void testNoProxyHost() {
+        String noProxyHost = "*.example.com|192.168.*";
+        assertEquals(Proxy.Type.HTTP, ProxyConfiguration.createProxy("test.example.co.jp", "proxy.example.com", 8080, noProxyHost).type());
+        assertEquals(Proxy.Type.DIRECT, ProxyConfiguration.createProxy("test.example.com", "proxy.example.com", 8080, noProxyHost).type());
+        assertEquals(Proxy.Type.HTTP, ProxyConfiguration.createProxy("test.example.com.test.example.co.jp", "proxy.example.com", 8080, noProxyHost).type());
+        assertEquals(Proxy.Type.DIRECT, ProxyConfiguration.createProxy("test.test.example.com", "proxy.example.com", 8080, noProxyHost).type());
+        assertEquals(Proxy.Type.DIRECT, ProxyConfiguration.createProxy("192.168.10.10", "proxy.example.com", 8080, noProxyHost).type());
+        assertEquals(Proxy.Type.HTTP, ProxyConfiguration.createProxy("192.169.10.10", "proxy.example.com", 8080, noProxyHost).type());
+    }
+}


### PR DESCRIPTION
no proxy host config acts as follows now.

---

no proxy host => "*.example.com"

(1) target host => "test.example.com"
  => direct access

(2) target host => "test.test.example.com"
  => use proxy

---

I feel that direct access is appropriate both of case.

please merge this request.
