### PR TITLE
[FIXED JENKINS-12529] M2 job: create links to codehaus maven plugins and their goals

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/ExecutedMojo.java
+++ b/maven-plugin/src/main/java/hudson/maven/ExecutedMojo.java
@@ -187,12 +187,16 @@ public final class ExecutedMojo implements Serializable {
             return Stapler.getCurrentRequest().getContextPath()+m.getUrl();
         if(groupId.equals("org.apache.maven.plugins"))
             return "http://maven.apache.org/plugins/"+artifactId+'/';
+        if (groupId.equals("org.codehaus.mojo"))
+            return "http://mojo.codehaus.org/"+artifactId+'/';
         return null;
     }
 
     public String getGoalLink(Cache c) {
         if(groupId.equals("org.apache.maven.plugins"))
             return "http://maven.apache.org/plugins/"+artifactId+'/'+goal+"-mojo.html";
+        if (groupId.equals("org.codehaus.mojo"))
+            return "http://mojo.codehaus.org/"+artifactId+'/'+goal+"-mojo.html";
         return null;
     }
 


### PR DESCRIPTION
With Maven2 jobs we get a nice overview of executed Mojos in a table, e.g. http://huschteguzzel.de/hudson/job/testlink-junit/lastStableBuild/net.oneandone.testlinkjunit$tljunit-parent/executedMojos

```
org.apache.maven.plugins:maven-clean-plugin     2.4.1   clean   default-clean   0.97 sec    fingerprint
```

For maven.apache.org plugins links to the plugin start page and the goal description page are rendered. As codehaus mojos are used almost as often as apache mojos (at least findbugs and cobertura are probably standard) it would be good to have these link to the corresponding pages at mojo.codehaus.org as well.
