### PR TITLE
Prevent Jenkins from over provisioning when there is only one slave, which is still connecting.

### DIFF
--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -193,7 +193,7 @@ public class NodeProvisioner {
 
         int idleSnapshot = stat.computeIdleExecutors();
         int totalSnapshot = stat.computeTotalExecutors();
-        boolean needSomeWhenNoneAtAll = ((totalSnapshot + plannedCapacitySnapshot) == 0) && (stat.computeQueueLength() > 0);
+        boolean needSomeWhenNoneAtAll = ((idleSnapshot + totalSnapshot + plannedCapacitySnapshot) == 0) && (stat.computeQueueLength() > 0);
         float idle = Math.max(stat.getLatestIdleExecutors(TIME_SCALE), idleSnapshot);
         if(idle<MARGIN || needSomeWhenNoneAtAll) {
             // make sure the system is fully utilized before attempting any new launch.


### PR DESCRIPTION
The needsSomeWhenNoneAtAll ought to take into account nodes which are coming online, especially when a cloud returns slaves which are not connected. This is fixed by adding the idleSnapshot, which takes connecting slaves into account (totalSnapshot does not).
