### PR TITLE
Documented the use of literal_eval for the Python API

### DIFF
--- a/core/src/main/resources/hudson/model/Api/index.jelly
+++ b/core/src/main/resources/hudson/model/Api/index.jelly
@@ -66,12 +66,18 @@ THE SOFTWARE.
 
         <dt><a href="python">Python API</a></dt>
         <dd>
-          Access the same data as Python for Python clients. This can be parsed into Python
-          object as <tt>eval(urllib.urlopen("...").read())</tt> and the resulting object
-          tree is identical to that of JSON.
+         <p>
+           Access the same data as Python for Python clients. This can be parsed into Python
+           object as <tt>eval(urllib.urlopen("...").read())</tt> and the resulting object
+           tree is identical to that of JSON.
 
-          However, when you do this, beware of the security implication. If you are connecting
-          to a non-trusted Jenkins, the server can send you malicious Python programs. 
+           However, when you do this, beware of the security implication. If you are connecting
+           to a non-trusted Jenkins, the server can send you malicious Python programs. 
+         </p>
+         <p>
+           In Python 2.6 or later you can safely parse this output using 
+           <tt>ast.literal_eval(urllib.urlopen("...").read())</tt>
+         </p>
         </dd>
       </dl>
 


### PR DESCRIPTION
literal_eval is a safer way to parse the API output that's immune to code execution vulnerabilities. In Python 2.6 or higher it's the preferred way to parse stringified Python data structures.
