### PR TITLE
Fix multi submit with shortcut key

### DIFF
--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -39,71 +39,14 @@ THE SOFTWARE.
       <!-- this is where the example goes -->
       <d:invokeBody />
 
-      <form action="script" method="post" name="form1">
-        <textarea id="script" name="script" style="width:100%; height:10em">${request.getParameter('script')}</textarea>
+      <form action="script" method="post">
+        <textarea id="script" name="script" class="script">${request.getParameter('script')}</textarea>
         <div align="right">
           <f:submit  value="${%Run}"/>
         </div>
-        <script>
-          $('script').focus();
-        </script>
       </form>
       <st:adjunct includes="org.kohsuke.stapler.codemirror.mode.clike.clike"/>
       <st:adjunct includes="org.kohsuke.stapler.codemirror.theme.default"/>
-      <script>
-        (function() {
-          var cmdKeyDown = false;
-          
-          var w = CodeMirror.fromTextArea(document.getElementById("script"),{
-            mode:"text/x-groovy",
-            lineNumbers: true,
-            onKeyEvent: function(editor, event){
-              function isGeckoCommandKey() {
-                return Prototype.Browser.Gecko &amp;&amp; event.keyCode == 224
-              }
-              function isOperaCommandKey() {
-                return Prototype.Browser.Opera &amp;&amp; event.keyCode == 17
-              }
-              function isWebKitCommandKey() {
-                return Prototype.Browser.WebKit &amp;&amp; (event.keyCode == 91 || event.keyCode == 93)
-              }
-              function isCommandKey() {
-                return isGeckoCommandKey() || isOperaCommandKey() || isWebKitCommandKey();
-              }
-              function isReturnKeyDown() {
-                return event.type == 'keydown' &amp;&amp; event.keyCode == Event.KEY_RETURN;
-              }
-              function saveAndSubmit() {
-                editor.save();
-                document.form1.submit();
-                event.stop();
-              }
-              
-              // Mac (Command + Enter)
-              if (navigator.userAgent.indexOf('Mac') > -1) {
-                if (event.type == 'keydown' &amp;&amp; isCommandKey()) {
-                  cmdKeyDown = true;
-                }
-                if (event.type == 'keyup' &amp;&amp; isCommandKey()) {
-                  cmdKeyDown = false;
-                }
-                if (cmdKeyDown &amp;&amp; isReturnKeyDown()) {
-                  saveAndSubmit();
-                  return true;
-                }
-                
-              // Windows, Linux (Ctrl + Enter)
-              } else {
-                if (event.ctrlKey &amp;&amp; isReturnKeyDown()) {
-                  saveAndSubmit();
-                  return true;
-                }
-              }
-            }
-          }).getWrapperElement();
-          w.setAttribute("style","border:1px solid black; margin-top: 1em; margin-bottom: 1em")
-        })();
-      </script>
       <j:if test="${output!=null}">
         <h2>${%Result}</h2>
         <pre><st:out value="${output}"/></pre>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -70,6 +70,9 @@ THE SOFTWARE.
               function isCommandKey() {
                 return isGeckoCommandKey() || isOperaCommandKey() || isWebKitCommandKey();
               }
+              function isReturnKeyDown() {
+                return event.type == 'keydown' &amp;&amp; event.keyCode == Event.KEY_RETURN;
+              }
               function saveAndSubmit() {
                 editor.save();
                 document.form1.submit();
@@ -84,14 +87,14 @@ THE SOFTWARE.
                 if (event.type == 'keyup' &amp;&amp; isCommandKey()) {
                   cmdKeyDown = false;
                 }
-                if (cmdKeyDown &amp;&amp; event.keyCode == Event.KEY_RETURN) {
+                if (cmdKeyDown &amp;&amp; isReturnKeyDown()) {
                   saveAndSubmit();
                   return true;
                 }
                 
               // Windows, Linux (Ctrl + Enter)
               } else {
-                if (event.ctrlKey &amp;&amp; event.keyCode == Event.KEY_RETURN) {
+                if (event.ctrlKey &amp;&amp; isReturnKeyDown()) {
                   saveAndSubmit();
                   return true;
                 }

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -751,10 +751,11 @@ var hudsonRules = {
     "TEXTAREA.script" : function(e) {
         (function() {
             var cmdKeyDown = false;
+            var mode = e.getAttribute("script-mode") || "text/x-groovy";
             var readOnly = eval(e.getAttribute("script-readOnly")) || false;
             
             var w = CodeMirror.fromTextArea(e,{
-              mode:"text/x-groovy",
+              mode: mode,
               lineNumbers: true,
               matchBrackets: true,
               readOnly: readOnly,

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -747,6 +747,71 @@ var hudsonRules = {
         scroller.style.height = h+"px";
     },
 
+    // Script Console : settings and shortcut key
+    "TEXTAREA.script" : function(e) {
+        (function() {
+            var cmdKeyDown = false;
+            var readOnly = eval(e.getAttribute("script-readOnly")) || false;
+            
+            var w = CodeMirror.fromTextArea(e,{
+              mode:"text/x-groovy",
+              lineNumbers: true,
+              matchBrackets: true,
+              readOnly: readOnly,
+              onKeyEvent: function(editor, event){
+                function isGeckoCommandKey() {
+                    return Prototype.Browser.Gecko && event.keyCode == 224
+                }
+                function isOperaCommandKey() {
+                    return Prototype.Browser.Opera && event.keyCode == 17
+                }
+                function isWebKitCommandKey() {
+                    return Prototype.Browser.WebKit && (event.keyCode == 91 || event.keyCode == 93)
+                }
+                function isCommandKey() {
+                    return isGeckoCommandKey() || isOperaCommandKey() || isWebKitCommandKey();
+                }
+                function isReturnKeyDown() {
+                    return event.type == 'keydown' && event.keyCode == Event.KEY_RETURN;
+                }
+                function getParentForm(element) {
+                    if (element == null) throw 'not found a parent form';
+                    if (element instanceof HTMLFormElement) return element;
+                    
+                    return getParentForm(element.parentNode);
+                }
+                function saveAndSubmit() {
+                    editor.save();
+                    getParentForm(e).submit();
+                    event.stop();
+                }
+                
+                // Mac (Command + Enter)
+                if (navigator.userAgent.indexOf('Mac') > -1) {
+                    if (event.type == 'keydown' && isCommandKey()) {
+                        cmdKeyDown = true;
+                    }
+                    if (event.type == 'keyup' && isCommandKey()) {
+                        cmdKeyDown = false;
+                    }
+                    if (cmdKeyDown && isReturnKeyDown()) {
+                        saveAndSubmit();
+                        return true;
+                    }
+                  
+                // Windows, Linux (Ctrl + Enter)
+                } else {
+                    if (event.ctrlKey && isReturnKeyDown()) {
+                        saveAndSubmit();
+                        return true;
+                    }
+                }
+              }
+            }).getWrapperElement();
+            w.setAttribute("style","border:1px solid black; margin-top: 1em; margin-bottom: 1em")
+        })();
+	},
+
 // deferred client-side clickable map.
 // this is useful where the generation of <map> element is time consuming
     "IMG[lazymap]" : function(e) {


### PR DESCRIPTION
I added a feature #248, which enables to submit with keyboard (Ctrl+Enter or Cmd+Enter) on script console.
But the feature included a multi submit bug, so I fixed it.

In addition, I move the code written in script console jelly to hudson-behavior.js.
Hereby, shortcut key on script console can be used at any other place, for example scriptler-plugin.
