### PR TITLE
OpenSUSE packaging: Introduced new configuration parameter JENKINS_LISTEN_ADDRESS

### DIFF
--- a/opensuse/SOURCES/jenkins.init.in
+++ b/opensuse/SOURCES/jenkins.init.in
@@ -84,6 +84,7 @@ PARAMS="--javaHome=$JAVA_HOME --logfile=/var/log/jenkins/jenkins.log"
 [ -n "$JENKINS_HANDLER_STARTUP" ] && PARAMS="$PARAMS --handlerCountStartup=$JENKINS_HANDLER_STARTUP"
 [ -n "$JENKINS_HANDLER_MAX" ] && PARAMS="$PARAMS --handlerCountMax=$JENKINS_HANDLER_MAX"
 [ -n "$JENKINS_HANDLER_IDLE" ] && PARAMS="$PARAMS --handlerCountMaxIdle=$JENKINS_HANDLER_IDLE"
+[ -n "$JENKINS_ARGS" ] && PARAMS="$PARAMS $JENKINS_ARGS"
 
 if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
     PARAMS="$PARAMS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/jenkins/access_log"

--- a/opensuse/SOURCES/jenkins.sysconfig.in
+++ b/opensuse/SOURCES/jenkins.sysconfig.in
@@ -108,3 +108,12 @@ JENKINS_HANDLER_MAX="100"
 # Maximum number of idle HTTP worker threads.
 #
 JENKINS_HANDLER_IDLE="20"
+
+## Type: string
+## Default: ""
+## ServiceRestart: jenkins
+#
+# Pass arbitrary arguments to Jenkins.
+# Full option list: java -jar jenkins.war --help
+#
+JENKINS_ARGS=""


### PR DESCRIPTION
Currently there is no way to disable jenkins to listen on remote address. Proposed patch solves this. This is especially useful when using Jenkins behind nginx, when Jenkins is listening only on localhost.
