### PR TITLE
[FIXED JENKINS-7733] System Message - Doesnt appear on any view other than the default view - In the view object appended the system message to the view description so that the system message now displays in all views.

### DIFF
--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -44,6 +44,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.acegisecurity.AccessDeniedException;
+import org.apache.commons.lang.NotImplementedException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
@@ -255,5 +256,9 @@ public class MyViewsProperty extends UserProperty implements ViewGroup, Action {
 		}
 		
     }
+
+	public String getSystemMessage() {
+		return getSystemMessage();
+	}
 
 }

--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -44,7 +44,6 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.acegisecurity.AccessDeniedException;
-import org.apache.commons.lang.NotImplementedException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
@@ -256,9 +255,5 @@ public class MyViewsProperty extends UserProperty implements ViewGroup, Action {
 		}
 		
     }
-
-	public String getSystemMessage() {
-		return getSystemMessage();
-	}
 
 }

--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -255,5 +255,9 @@ public class MyViewsProperty extends UserProperty implements ViewGroup, Action {
 		}
 		
     }
+    
+    public String getSystemMessage() {
+		return getSystemMessage();
+	}
 
 }

--- a/core/src/main/java/hudson/model/TreeView.java
+++ b/core/src/main/java/hudson/model/TreeView.java
@@ -190,4 +190,8 @@ public class TreeView extends View implements ViewGroup {
     public List<Action> getViewActions() {
         return owner.getViewActions();
     }
+
+	public String getSystemMessage() {
+		return owner.getSystemMessage();
+	}
 }

--- a/core/src/main/java/hudson/model/TreeView.java
+++ b/core/src/main/java/hudson/model/TreeView.java
@@ -190,4 +190,8 @@ public class TreeView extends View implements ViewGroup {
     public List<Action> getViewActions() {
         return owner.getViewActions();
     }
+    
+    public String getSystemMessage() {
+		return owner.getSystemMessage();
+	}
 }

--- a/core/src/main/java/hudson/model/TreeView.java
+++ b/core/src/main/java/hudson/model/TreeView.java
@@ -190,8 +190,4 @@ public class TreeView extends View implements ViewGroup {
     public List<Action> getViewActions() {
         return owner.getViewActions();
     }
-
-	public String getSystemMessage() {
-		return owner.getSystemMessage();
-	}
 }

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -235,12 +235,18 @@ public abstract class View extends AbstractModelObject implements AccessControll
         return owner.getViewActions();
     }
 
+    private final String SYS_MSG_SPACER = "</br>";
+
     /**
      * Message displayed in the top page. Can be null. Includes HTML.
      */
     @Exported
     public String getDescription() {
-        return description;
+    	if(owner.getSystemMessage() != null && !owner.getSystemMessage().isEmpty()){
+    		return owner.getSystemMessage().concat(SYS_MSG_SPACER).concat(Util.fixNull(description));
+    	}else{
+    		return description;
+    	}   
     }
 
     /**

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -111,6 +111,11 @@ public abstract class View extends AbstractModelObject implements AccessControll
     protected String description;
     
     /**
+     * System Message displayed.
+     */
+    protected String systemmessage;
+    
+    /**
      * If true, only show relevant executors
      */
     protected boolean filterExecutors;
@@ -235,18 +240,23 @@ public abstract class View extends AbstractModelObject implements AccessControll
         return owner.getViewActions();
     }
 
-    private final String SYS_MSG_SPACER = "</br>";
-
     /**
      * Message displayed in the top page. Can be null. Includes HTML.
      */
     @Exported
     public String getDescription() {
+    	 return description;
+    }
+    
+    /**
+     * Gets the system message to be displayed at the top of the page on all views
+     */
+    @Exported
+    public String getSystemMessage(){
     	if(owner.getSystemMessage() != null && !owner.getSystemMessage().isEmpty()){
-    		return owner.getSystemMessage().concat(SYS_MSG_SPACER).concat(Util.fixNull(description));
-    	}else{
-    		return description;
-    	}   
+    		this.systemmessage = owner.getSystemMessage();
+    	}
+    	return systemmessage;
     }
 
     /**

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -234,13 +234,19 @@ public abstract class View extends AbstractModelObject implements AccessControll
     private List<Action> _getOwnerViewActions() {
         return owner.getViewActions();
     }
+    
+    private final String SYS_MSG_SPACER = "</br>";
 
     /**
      * Message displayed in the top page. Can be null. Includes HTML.
      */
     @Exported
     public String getDescription() {
-        return description;
+    	if(owner.getSystemMessage() != null && !owner.getSystemMessage().isEmpty()){
+    		return owner.getSystemMessage().concat(SYS_MSG_SPACER).concat(Util.fixNull(description));
+    	}else{
+    		return description;
+    	}   
     }
 
     /**

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -234,19 +234,13 @@ public abstract class View extends AbstractModelObject implements AccessControll
     private List<Action> _getOwnerViewActions() {
         return owner.getViewActions();
     }
-    
-    private final String SYS_MSG_SPACER = "</br>";
 
     /**
      * Message displayed in the top page. Can be null. Includes HTML.
      */
     @Exported
     public String getDescription() {
-    	if(owner.getSystemMessage() != null && !owner.getSystemMessage().isEmpty()){
-    		return owner.getSystemMessage().concat(SYS_MSG_SPACER).concat(Util.fixNull(description));
-    	}else{
-    		return description;
-    	}   
+        return description;
     }
 
     /**

--- a/core/src/main/java/hudson/model/ViewGroup.java
+++ b/core/src/main/java/hudson/model/ViewGroup.java
@@ -137,4 +137,16 @@ public interface ViewGroup extends Saveable, ModelObject, AccessControlled {
      * @since 1.417
      */
     List<Action> getViewActions();
+    
+    /**
+     * Returns the system message set on the rrot object.
+     * This enables the implemented {@link View} to access the system message on the root object so that it can be 
+     * displayed on each view.
+     * 
+     * @return
+     * 		system message as set on the root object 
+     * @since 1.450
+     */
+    String getSystemMessage();
+    
 }

--- a/core/src/main/java/hudson/model/ViewGroup.java
+++ b/core/src/main/java/hudson/model/ViewGroup.java
@@ -137,16 +137,4 @@ public interface ViewGroup extends Saveable, ModelObject, AccessControlled {
      * @since 1.417
      */
     List<Action> getViewActions();
-    
-    /**
-     * Returns the system message set on the rrot object.
-     * This enables the implemented {@link View} to access the system message on the root object so that it can be 
-     * displayed on each view.
-     * 
-     * @return
-     * 		system message as set on the root object 
-     * @since 1.450
-     */
-    String getSystemMessage();
-    
 }

--- a/core/src/main/java/hudson/model/ViewGroup.java
+++ b/core/src/main/java/hudson/model/ViewGroup.java
@@ -137,4 +137,15 @@ public interface ViewGroup extends Saveable, ModelObject, AccessControlled {
      * @since 1.417
      */
     List<Action> getViewActions();
+    
+    /**
+     * Returns the system message set on the rrot object.
+     * This enables the implemented {@link View} to access the system message on the root object so that it can be 
+     * displayed on each view.
+     * 
+     * @return
+     * 		system message as set on the root object 
+     * @since 1.450
+     */
+    String getSystemMessage();
 }

--- a/core/src/main/java/hudson/model/ViewGroup.java
+++ b/core/src/main/java/hudson/model/ViewGroup.java
@@ -139,7 +139,7 @@ public interface ViewGroup extends Saveable, ModelObject, AccessControlled {
     List<Action> getViewActions();
     
     /**
-     * Returns the system message set on the rrot object.
+     * Returns the system message set on the root object.
      * This enables the implemented {@link View} to access the system message on the root object so that it can be 
      * displayed on each view.
      * 

--- a/core/src/main/resources/lib/hudson/editableDescription.jelly
+++ b/core/src/main/resources/lib/hudson/editableDescription.jelly
@@ -34,6 +34,14 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 
+<j:if test="${it.class.name!='hudson.model.AllView'}">
+  <div id="systemmessage">
+	    <div>	     
+	      	<j:out value="${it.getSystemMessage()!=null ? app.markupFormatter.translate(it.getSystemMessage()) : ''}" />
+	    </div>
+	</div>
+</j:if>
+
   <div id="description">
     <div>
       <j:out value="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}" />


### PR DESCRIPTION
I tried to pick up d4047dc and merged it to master. but I found bug.
See https://issues.jenkins-ci.org/browse/JENKINS-7733 .

This is now fixed. Appedning the system message to the description didnt work due to the edit option so now the system message is displayed in a new div above the view description.
