### PR TITLE
Add CANCEL permission that can be granted independently from BUILD perm.

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1640,7 +1640,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * Cancels a scheduled build.
      */
     public void doCancelQueue( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
-        checkPermission(BUILD);
+        checkPermission(ABORT);
 
         Jenkins.getInstance().getQueue().cancel(this);
         rsp.forwardToPreviousPage(req);
@@ -2008,9 +2008,9 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     private static final Logger LOGGER = Logger.getLogger(AbstractProject.class.getName());
 
     /**
-     * Permission to abort a build. For now, let's make it the same as {@link #BUILD}
+     * Permission to abort a build
      */
-    public static final Permission ABORT = BUILD;
+    public static final Permission ABORT = CANCEL;
 
     /**
      * Replaceable "Build Now" text.

--- a/core/src/main/java/hudson/model/Item.java
+++ b/core/src/main/java/hudson/model/Item.java
@@ -228,4 +228,5 @@ public interface Item extends PersistenceRoot, SearchableModelObject, AccessCont
     Permission BUILD = new Permission(PERMISSIONS, "Build", Messages._AbstractProject_BuildPermission_Description(),  Permission.UPDATE, PermissionScope.ITEM);
     Permission WORKSPACE = new Permission(PERMISSIONS, "Workspace", Messages._AbstractProject_WorkspacePermission_Description(), Permission.READ, PermissionScope.ITEM);
     Permission WIPEOUT = new Permission(PERMISSIONS, "WipeOut", Messages._AbstractProject_WipeOutPermission_Description(), null, Functions.isWipeOutPermissionEnabled(), new PermissionScope[]{PermissionScope.ITEM});
+    Permission CANCEL = new Permission(PERMISSIONS, "Cancel", Messages._AbstractProject_CancelPermission_Description(), BUILD, PermissionScope.ITEM);
 }

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -59,6 +59,8 @@ AbstractProject.ExtendedReadPermission.Description=\
   exposed to a wider audience by granting this permission.
 AbstractProject.WipeOutPermission.Description=\
   This permission grants the ability to wipe out the contents of a workspace.
+AbstractProject.CancelPermission.Description=\
+  This permission grants the ability to cancel a build.
 AbstractProject.AssignedLabelString.InvalidBooleanExpression=\
   Invalid boolean expression: {0}
 AbstractProject.AssignedLabelString.NoMatch=\


### PR DESCRIPTION
Hi,

please have a look at the change. The use-case is that users don't have the build permission. Instead, they have another permission that allows them to trigger a build only via a custom plugin. Up to now, they weren't able to cancel builds because the build permission was checked.

Sascha
