### PR TITLE
JENKINS-12735 - Maven Version Ranges and Up/Downstream Resolution

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/MavenModule.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModule.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- *
+ * 
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, id:cactusman
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -62,8 +62,6 @@ import javax.servlet.ServletException;
 
 import jenkins.model.Jenkins;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
 import org.apache.maven.project.MavenProject;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -71,7 +69,7 @@ import org.kohsuke.stapler.export.Exported;
 
 /**
  * {@link Job} that builds projects based on Maven2.
- *
+ * 
  * @author Kohsuke Kawaguchi
  */
 public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> implements Saveable {
@@ -90,16 +88,16 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
      * This field can be null if Jenkins loaded old data
      * that didn't record this information, so that situation
      * needs to be handled gracefully.
-     *
+     * 
      * @since 1.199
      */
     private String version;
-
+    
     /**
      * Packaging type of the module.
-     *
+     * 
      * pom, jar, maven-plugin, ejb, war, ear, rar, par or other custom types.
-     *
+     * 
      * @since 1.425
      */
     private String packaging;
@@ -128,7 +126,7 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
      * Used to determine parent/child relationship of modules.
      * <p>
      * For compatibility reason, this field may be null when loading data from old hudson.
-     *
+     * 
      * @since 1.133
      */
     @CopyOnWrite
@@ -147,7 +145,7 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
     }
 
     /**
-     * {@link MavenModule} follows the same log rotation schedule as its parent.
+     * {@link MavenModule} follows the same log rotation schedule as its parent. 
      */
     @Override
     public LogRotator getLogRotator() {
@@ -218,7 +216,7 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
             }
         }
     }
-
+    
     /**
      * Returns if the given POM likely describes the same module with the same dependencies.
      * Implementation needs not be 100% accurate in the true case, but it MUST return false
@@ -364,7 +362,7 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
      * <p>
      * This method returns null if this information is not recorded. This happens
      * for compatibility reason.
-     *
+     * 
      * @since 1.133
      */
     public List<MavenModule> getChildren() {
@@ -428,7 +426,7 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
         boolean hasDependenciesWithUnknownVersion = hasDependenciesWithUnknownVersion();
         if (data == null) {
             Map<ModuleDependency,MavenModule> modules = new HashMap<ModuleDependency,MavenModule>();
-
+    
             for (MavenModule m : getAllMavenModules()) {
                 if(!m.isBuildable())  continue;
                 ModuleDependency moduleDependency = m.asDependency();
@@ -456,14 +454,14 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
 
         // In case two modules with the same name are defined, modules in the same MavenModuleSet
         // take precedence.
-
+        
         // Can lead to OOME, if remembered in the computational data and there are lot big multi-module projects
         // TODO: try to use soft references to clean the heap when needed
         Map<ModuleDependency,MavenModule> myParentsModules; // = data.modulesPerParent.get(getParent());
-
+        
         //if (myParentsModules == null) {
             myParentsModules = new HashMap<ModuleDependency, MavenModule>();
-
+            
             for (MavenModule m : getParent().getModules()) {
                 if(m.isDisabled())  continue;
                 ModuleDependency moduleDependency = m.asDependency();
@@ -472,7 +470,7 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
                     myParentsModules.put(moduleDependency.withUnknownVersion(),m);
                 }
             }
-
+            
             //data.modulesPerParent.put(getParent(), myParentsModules);
         //}
 
@@ -481,32 +479,30 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
         AbstractProject<?, ?> dest = getParent().isAggregatorStyleBuild() ? getParent() : this;
 
         for (ModuleDependency d : dependencies) {
-            MavenModule src = findMatchingDependentModule(data.allModules, d);
+            MavenModule src = myParentsModules.get(d);
             if (src==null) {
                 src = data.allModules.get(d);
             }
-
+            
             if(src!=null) {
                 DependencyGraph.Dependency dep = new MavenModuleDependency(
-                        src.getParent().isAggregatorStyleBuild()
-                        ? src.getParent()
-                        : src,dest);
+                        src.getParent().isAggregatorStyleBuild() ? src.getParent() : src,dest);
                 if (!dep.pointsItself())
                     graph.addDependency(dep);
             }
         }
     }
-
+    
     /**
      * Returns all Maven modules in this Jenkins instance.
      */
     protected Collection<MavenModule> getAllMavenModules() {
         return Jenkins.getInstance().getAllItems(MavenModule.class);
     }
-
+    
     /**
      * Check if this module has dependencies recorded without a concrete version -
-     * which shouldn't happen for any module which was at least build once with Jenkins >= 1.207.
+     * which shouldn't happen for any module which was at least build once with Jenkins >= 1.207. 
      */
     private boolean hasDependenciesWithUnknownVersion() {
         for (ModuleDependency dep : dependencies) {
@@ -516,21 +512,21 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
         }
         return false;
     }
-
+    
     private MavenModule chooseMoreRelevantModule(MavenModule mm1, MavenModule mm2, ModuleDependency moduleDependency) {
-
+        
         if (mm1 == null) {
             return mm2;
         }
         if (mm2 == null) {
             return mm1;
         }
-
+        
         final MavenModule moreRelevant;
         final MavenModule lessRelevant;
         int relevancy1 = getDependencyRelevancy(mm1);
         int relevancy2 = getDependencyRelevancy(mm2);
-
+        
         if (relevancy1 > relevancy2) {
             moreRelevant = mm1;
             lessRelevant = mm2;
@@ -547,43 +543,43 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
                 lessRelevant = mm2;
             }
         }
-
+        
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.finer("Choosing " + moreRelevant.getParent().getName() + " over " + lessRelevant.getParent().getName()
-                    + " for module " + moduleDependency.getName() + ". Relevancies: " + relevancy1 + ", " + relevancy2);
+                    + " for module " + moduleDependency.getName() + ". Relevancies: " + relevancy1 + ", " + relevancy2); 
         }
         return moreRelevant;
     }
 
     private int getDependencyRelevancy(MavenModule mm) {
-
+        
         int relevancy = 0;
-
+        
         for (String goal : Util.tokenize(mm.getGoals())) {
             if ("deploy".equals(goal) || "deploy:deploy".equals(goal)) {
                 return 2;
             }
-
+            
             if ("install".equals(goal)) {
                 relevancy = 1;
             }
         }
-
+        
         for (Publisher publisher : mm.getParent().getPublishers()) {
             if (publisher instanceof RedeployPublisher) {
                 return 2;
             }
         }
-
+        
         return relevancy;
     }
 
     private static class MavenDependencyComputationData {
         boolean withUnknownVersions = false;
         Map<ModuleDependency,MavenModule> allModules;
-
+        
         //Map<MavenModuleSet, Map<ModuleDependency,MavenModule>> modulesPerParent = new HashMap<MavenModuleSet, Map<ModuleDependency,MavenModule>>();
-
+        
         public MavenDependencyComputationData(
                 Map<ModuleDependency, MavenModule> modules) {
             this.allModules = modules;
@@ -655,7 +651,7 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
 
         return reporterList;
     }
-
+    
     /**
      * for debug purpose
      */
@@ -663,35 +659,6 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
         return super.toString()+'['+getFullName()+']'+"[relativePath:"+getRelativePath()+']';
     }
 
-    /**
-     * ModuleDependency objects have a string as a version. To support Maven2 version ranges,
-     * string comparison of these versions are not sufficient.
-     *
-     * The ModuleDependency objects in the modules map contain the version identifier of the
-     * modules/projects itself. In these cases, no version ranges are allowed. The second
-     * argument is a ModuleDependency coming from parsing the dependency section of a Maven POM.
-     * In here, version ranges are allowed. This method will perform a lookup in the modules
-     * collection, but based on the VersionRange.containsVersion(ArtifactVersion) method.
-     *
-     * @param modules the map matching a ModuleDependency with the corresponding MavenModule
-     * @param dependencyDescription a ModuleDependency describing the version
-     * @return the Hudson MavenModule that matches the dependency.
-     */
-    private MavenModule findMatchingDependentModule(
-            final Map<ModuleDependency, MavenModule> modules,
-            final ModuleDependency dependencyDescription) {
-
-        Set<ModuleDependency> modulesVersionInfo = modules.keySet();
-        Predicate predicate = new Predicate() {
-            public boolean evaluate(Object moduleInfo) {
-                ModuleDependency moduleVersionInfo = (ModuleDependency) moduleInfo;
-                return dependencyDescription.contains(moduleVersionInfo);
-            }
-        };
-
-        ModuleDependency matchingDependency = (ModuleDependency) CollectionUtils.find(modulesVersionInfo, predicate);
-        return modules.get(matchingDependency);
-    }
-
     private static final Logger LOGGER = Logger.getLogger(MavenModule.class.getName());
+    
 }

--- a/maven-plugin/src/main/java/hudson/maven/ModuleDependency.java
+++ b/maven-plugin/src/main/java/hudson/maven/ModuleDependency.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- *
+ * 
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Olivier Lamy
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,22 +23,17 @@
  */
 package hudson.maven;
 
-import org.apache.maven.artifact.versioning.ArtifactVersion;
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
-import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.ReportPlugin;
 import org.apache.maven.model.Extension;
 
 import java.io.Serializable;
-import java.util.logging.Logger;
 
 import hudson.Functions;
 
 /**
- * group id + artifact id + version and a flag to know if it's a plugin
+ * group id + artifact id + version and a flag to know if it's a plugin 
  *
  * @author Kohsuke Kawaguchi
  * @see ModuleName
@@ -47,7 +42,7 @@ public final class ModuleDependency implements Serializable {
     public final String groupId;
     public final String artifactId;
     public final String version;
-
+    
     /**
      * @since 1.395
      */
@@ -56,7 +51,7 @@ public final class ModuleDependency implements Serializable {
     public ModuleDependency(String groupId, String artifactId, String version) {
         this(groupId, artifactId, version, false);
     }
-
+    
     public ModuleDependency(String groupId, String artifactId, String version, boolean plugin) {
         this.groupId = groupId.intern();
         this.artifactId = artifactId.intern();
@@ -70,7 +65,7 @@ public final class ModuleDependency implements Serializable {
     public ModuleDependency(ModuleName name, String version) {
         this(name.groupId,name.artifactId,version,false);
     }
-
+    
     public ModuleDependency(ModuleName name, String version, boolean plugin) {
         this(name.groupId,name.artifactId,version,plugin);
     }
@@ -104,7 +99,7 @@ public final class ModuleDependency implements Serializable {
         this.version = UNKNOWN;
         this.plugin = plugin;
     }
-
+    
     public ModuleName getName() {
         return new ModuleName(groupId,artifactId);
     }
@@ -168,44 +163,4 @@ public final class ModuleDependency implements Serializable {
     public static final String NONE = "-";
 
     private static final long serialVersionUID = 1L;
-
-    /**
-     * If my version string comes from a dependency in the Maven POM, it can
-     * represent a version range. If the argument represents a real version,
-     * this method will check if the group and artifact ID are the same,
-     * and if my version, converted to a VersionRange, contains the the version
-     * from the argument.
-     *
-     * @param otherDependency The dependency to check for.
-     * @return true if contained false otherwise.
-     */
-    public boolean contains(ModuleDependency otherDependency) {
-        if (otherDependency == null) {
-            return false;
-        }
-
-        boolean result = false;
-        if (groupId.equals(otherDependency.groupId) && artifactId.equals(otherDependency.artifactId)) {
-
-            try {
-                VersionRange myRange = VersionRange.createFromVersionSpec(version);
-                ArtifactVersion otherVersion = new DefaultArtifactVersion(otherDependency.version);
-                result = myRange.containsVersion(otherVersion);
-            } catch (InvalidVersionSpecificationException ivse) {
-                result = false;
-            }
-        }
-
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "ModuleDependency{" +
-               "groupId='" + groupId + '\'' +
-               ", artifactId='" + artifactId + '\'' +
-               ", version='" + version + '\'' +
-               ", plugin=" + plugin +
-               '}';
-    }
 }

--- a/maven-plugin/src/main/java/hudson/maven/ModuleDependency.java
+++ b/maven-plugin/src/main/java/hudson/maven/ModuleDependency.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Olivier Lamy
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,17 +23,22 @@
  */
 package hudson.maven;
 
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.ReportPlugin;
 import org.apache.maven.model.Extension;
 
 import java.io.Serializable;
+import java.util.logging.Logger;
 
 import hudson.Functions;
 
 /**
- * group id + artifact id + version and a flag to know if it's a plugin 
+ * group id + artifact id + version and a flag to know if it's a plugin
  *
  * @author Kohsuke Kawaguchi
  * @see ModuleName
@@ -42,7 +47,7 @@ public final class ModuleDependency implements Serializable {
     public final String groupId;
     public final String artifactId;
     public final String version;
-    
+
     /**
      * @since 1.395
      */
@@ -51,7 +56,7 @@ public final class ModuleDependency implements Serializable {
     public ModuleDependency(String groupId, String artifactId, String version) {
         this(groupId, artifactId, version, false);
     }
-    
+
     public ModuleDependency(String groupId, String artifactId, String version, boolean plugin) {
         this.groupId = groupId.intern();
         this.artifactId = artifactId.intern();
@@ -65,7 +70,7 @@ public final class ModuleDependency implements Serializable {
     public ModuleDependency(ModuleName name, String version) {
         this(name.groupId,name.artifactId,version,false);
     }
-    
+
     public ModuleDependency(ModuleName name, String version, boolean plugin) {
         this(name.groupId,name.artifactId,version,plugin);
     }
@@ -99,7 +104,7 @@ public final class ModuleDependency implements Serializable {
         this.version = UNKNOWN;
         this.plugin = plugin;
     }
-    
+
     public ModuleName getName() {
         return new ModuleName(groupId,artifactId);
     }
@@ -163,4 +168,44 @@ public final class ModuleDependency implements Serializable {
     public static final String NONE = "-";
 
     private static final long serialVersionUID = 1L;
+
+    /**
+     * If my version string comes from a dependency in the Maven POM, it can
+     * represent a version range. If the argument represents a real version,
+     * this method will check if the group and artifact ID are the same,
+     * and if my version, converted to a VersionRange, contains the the version
+     * from the argument.
+     *
+     * @param otherDependency The dependency to check for.
+     * @return true if contained false otherwise.
+     */
+    public boolean contains(ModuleDependency otherDependency) {
+        if (otherDependency == null) {
+            return false;
+        }
+
+        boolean result = false;
+        if (groupId.equals(otherDependency.groupId) && artifactId.equals(otherDependency.artifactId)) {
+
+            try {
+                VersionRange myRange = VersionRange.createFromVersionSpec(version);
+                ArtifactVersion otherVersion = new DefaultArtifactVersion(otherDependency.version);
+                result = myRange.containsVersion(otherVersion);
+            } catch (InvalidVersionSpecificationException ivse) {
+                result = false;
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ModuleDependency{" +
+               "groupId='" + groupId + '\'' +
+               ", artifactId='" + artifactId + '\'' +
+               ", version='" + version + '\'' +
+               ", plugin=" + plugin +
+               '}';
+    }
 }

--- a/maven-plugin/src/main/java/hudson/maven/ModuleDependency.java
+++ b/maven-plugin/src/main/java/hudson/maven/ModuleDependency.java
@@ -23,6 +23,10 @@
  */
 package hudson.maven;
 
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.ReportPlugin;
@@ -163,4 +167,41 @@ public final class ModuleDependency implements Serializable {
     public static final String NONE = "-";
 
     private static final long serialVersionUID = 1L;
+
+    /**
+     * Checks whether this ModuleDependency has a dependency on the given one.
+     * This caters for versions where the version string defines a version range.
+     *
+     * @param otherDependency The dependency to check for.
+     * @return true if contained false otherwise.
+     */
+    public boolean hasDependency(ModuleDependency otherDependency) {
+        if (otherDependency == null) {
+            return false;
+        }
+
+        boolean result = false;
+        if (groupId.equals(otherDependency.groupId) && artifactId.equals(otherDependency.artifactId)) {
+
+            try {
+                VersionRange myRange = VersionRange.createFromVersionSpec(version);
+                ArtifactVersion otherVersion = new DefaultArtifactVersion(otherDependency.version);
+                result = myRange.containsVersion(otherVersion);
+            } catch (InvalidVersionSpecificationException ivse) {
+                result = false;
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ModuleDependency{" +
+               "groupId='" + groupId + '\'' +
+               ", artifactId='" + artifactId + '\'' +
+               ", version='" + version + '\'' +
+               ", plugin=" + plugin +
+               '}';
+    }
 }

--- a/maven-plugin/src/test/java/hudson/maven/MavenModuleTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/MavenModuleTest.java
@@ -1,6 +1,5 @@
 package hudson.maven;
 
-import static junit.framework.Assert.assertEquals;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -11,16 +10,12 @@ import hudson.model.AbstractProject;
 import hudson.model.DependencyGraph;
 import hudson.model.MockHelper;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import hudson.util.Graph;
 import junit.framework.Assert;
 
 import org.apache.maven.model.Build;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
@@ -36,29 +31,29 @@ import com.google.common.collect.Lists;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest( { MavenModuleSet.class, DescriptorImpl.class, AbstractProject.class})
 public class MavenModuleTest {
-
+    
     private MavenModule module;
 
     private MavenProject project;
-
+    
     @Before
     public void before() {
         suppress(constructor(AbstractProject.class));
         suppress(constructor(DescriptorImpl.class));
-
+        
         this.module = mock(MavenModule.class);
         basicMocking(this.module);
-
+        
         this.project = new MavenProject();
         project.setGroupId("test");
         project.setArtifactId("testmodule");
         project.setVersion("2.0-SNAPSHOT");
         project.setPackaging("jar");
-
+        
         this.module.reconfigure(new PomInfo(project, null, "relPath"));
         this.module.doSetName("test$testmodule");
     }
-
+    
     /**
      * Tests that a {@link MavenModule} which builds a plugin is recognized as a snapshot
      * dependency in another module using that plugin.
@@ -67,15 +62,15 @@ public class MavenModuleTest {
     @Bug(10530)
     public void testMavenModuleAsPluginDependency() {
         MavenModule pluginModule = createPluginProject();
-
+        
         addModuleAsPluginDependency(this.module, pluginModule);
-
+        
         when(this.module.getAllMavenModules()).thenReturn(Lists.newArrayList(this.module, pluginModule));
-
+        
         DependencyGraph graph = MockHelper.mockDependencyGraph(
                 Lists.<AbstractProject<?,?>>newArrayList(this.module, pluginModule));
         graph.build();
-
+        
         @SuppressWarnings("rawtypes")
         List<AbstractProject> downstream = graph.getDownstream(pluginModule);
         Assert.assertEquals(1, downstream.size());
@@ -89,21 +84,21 @@ public class MavenModuleTest {
         plugin.setArtifactId(pluginModule.getModuleName().artifactId);
         plugin.setVersion(pluginModule.getVersion());
         build.setPlugins(Collections.singletonList(plugin));
-
+        
         MavenProject project = new MavenProject();
         project.setGroupId(module.getModuleName().groupId);
         project.setArtifactId(module.getModuleName().artifactId);
         project.setVersion(module.getVersion());
         project.setPackaging("jar");
         project.setBuild(build);
-
+        
         module.reconfigure(new PomInfo(project, null, "relPath"));
     }
 
     private static MavenModule createPluginProject() {
         MavenModule pluginModule = mock(MavenModule.class);
         basicMocking(pluginModule);
-
+        
         MavenProject proj = new MavenProject();
         proj.setGroupId("test");
         proj.setArtifactId("pluginmodule");
@@ -112,10 +107,10 @@ public class MavenModuleTest {
         PomInfo info = new PomInfo(proj, null, "relPath");
         pluginModule.reconfigure(info);
         pluginModule.doSetName("test$pluginmodule");
-
+        
         return pluginModule;
     }
-
+    
     private static void basicMocking(MavenModule mock) {
         when(mock.isBuildable()).thenReturn(Boolean.TRUE);
         doCallRealMethod().when(mock).reconfigure(Matchers.any(PomInfo.class));
@@ -124,141 +119,11 @@ public class MavenModuleTest {
         doCallRealMethod().when(mock).doSetName(Matchers.anyString());
         when(mock.getModuleName()).thenCallRealMethod();
         when(mock.getVersion()).thenCallRealMethod();
-
+        
         MavenModuleSet parent = mock(MavenModuleSet.class);
         when(parent.isAggregatorStyleBuild()).thenReturn(Boolean.FALSE);
         when(mock.getParent()).thenReturn(parent);
-
+        
         when(parent.getModules()).thenReturn(Collections.singleton(mock));
-    }
-
-    /**
-     * This test is a standard project that has a versioned dependency.
-     */
-    @Test
-    public void testSimpleVersion() {
-        TestComponents testComponents = createTestComponents("1.0.1-SNAPSHOT");
-
-        DependencyGraph graph = testComponents.graph;
-        MavenModule appMavenModule = testComponents.applicationMavenModule;
-        MavenModule libMavenModule = testComponents.libraryMavenModule;
-
-        graph.build();
-
-        List<AbstractProject> appDownstream = graph.getDownstream(appMavenModule);
-        List<AbstractProject> appUpstream = graph.getUpstream(appMavenModule);
-        List<AbstractProject> libDownstream = graph.getDownstream(libMavenModule);
-        List<AbstractProject> libUpstream = graph.getUpstream(libMavenModule);
-
-        assertEquals(0, appDownstream.size());
-        assertEquals(1, appUpstream.size());
-        assertEquals(1, libDownstream.size());
-        assertEquals(0, libUpstream.size());
-    }
-
-    /**
-     * This tests that a version range declaration in the dependency of a top level project
-     * resolves the up and downstream correctly.
-     */
-    @Test
-    public void testSimpleVersionRange() {
-        TestComponents testComponents = createTestComponents("[1.0.0, )");
-
-        DependencyGraph graph = testComponents.graph;
-        MavenModule appMavenModule = testComponents.applicationMavenModule;
-        MavenModule libMavenModule = testComponents.libraryMavenModule;
-
-        graph.build();
-
-        List<AbstractProject> appDownstream = graph.getDownstream(appMavenModule);
-        List<AbstractProject> appUpstream = graph.getUpstream(appMavenModule);
-        List<AbstractProject> libDownstream = graph.getDownstream(libMavenModule);
-        List<AbstractProject> libUpstream = graph.getUpstream(libMavenModule);
-
-        assertEquals(0, appDownstream.size());
-        assertEquals(1, appUpstream.size());
-        assertEquals(1, libDownstream.size());
-        assertEquals(0, libUpstream.size());
-    }
-
-    private TestComponents createTestComponents(String libraryVersion) {
-        MavenProject appProject = createApplication();
-        Dependency dependency = createDependency(libraryVersion);
-        appProject.getDependencies().add(dependency);
-
-        PomInfo appInfo = new PomInfo(appProject, null, "relPath");
-        MavenModule appMavenModule = mock(MavenModule.class);
-        basicMocking(appMavenModule);
-        appMavenModule.doSetName("test$application");
-        appMavenModule.reconfigure(appInfo);
-
-        MavenProject libProject = createLibrary();
-        PomInfo libInfo = new PomInfo(libProject, null, "relPath");
-        MavenModule libMavenModule = mock(MavenModule.class);
-        basicMocking(libMavenModule);
-        libMavenModule.doSetName("test$library");
-        libMavenModule.reconfigure(libInfo);
-
-        MavenModuleSet parent = mock(MavenModuleSet.class);
-        when(parent.isAggregatorStyleBuild()).thenReturn(Boolean.FALSE);
-        when(appMavenModule.getParent()).thenReturn(parent);
-        when(libMavenModule.getParent()).thenReturn(parent);
-
-        Collection<MavenModule> projects = Lists.newArrayList(appMavenModule, libMavenModule);
-        when(parent.getModules()).thenReturn(projects);
-        when(appMavenModule.getAllMavenModules()).thenReturn(projects);
-        when(libMavenModule.getAllMavenModules()).thenReturn(projects);
-
-        DependencyGraph graph = MockHelper.mockDependencyGraph(Lists.<AbstractProject<?,?>>newArrayList(appMavenModule, libMavenModule));
-        doCallRealMethod().when(graph).getDownstream(Matchers.any(AbstractProject.class));
-        doCallRealMethod().when(graph).getUpstream(Matchers.any(AbstractProject.class));
-
-        TestComponents testComponents = new TestComponents();
-        testComponents.graph = graph;
-        testComponents.applicationMavenModule = appMavenModule;
-        testComponents.libraryMavenModule = libMavenModule;
-
-        return testComponents;
-    }
-
-    private static MavenProject createApplication() {
-        MavenProject proj = new MavenProject();
-        proj.setName("testapp");
-        proj.setGroupId("test");
-        proj.setArtifactId("application");
-        proj.setVersion("1.0-SNAPSHOT");
-        proj.setPackaging("jar");
-
-        return proj;
-    }
-
-    private static Dependency createDependency(String version) {
-        Dependency dependency = new Dependency();
-        dependency.setGroupId("test");
-        dependency.setArtifactId("library");
-        dependency.setVersion(version);
-        return dependency;
-    }
-
-    private static MavenProject createLibrary() {
-        MavenProject proj = new MavenProject();
-        proj.setName("testlib");
-        proj.setGroupId("test");
-        proj.setArtifactId("library");
-        proj.setVersion("1.0.1-SNAPSHOT");
-        proj.setPackaging("jar");
-
-        Dependency dependency = new Dependency();
-        dependency.setArtifactId("log4j");
-        dependency.setGroupId("log4j");
-        dependency.setVersion("1.6.15");
-        proj.getDependencies().add(dependency);
-        return proj;
-    }
-
-    private static class TestComponents {
-        public DependencyGraph graph;
-        public MavenModule applicationMavenModule;
-        public MavenModule libraryMavenModule;
     }
 }

--- a/maven-plugin/src/test/java/hudson/maven/MavenModuleTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/MavenModuleTest.java
@@ -1,5 +1,6 @@
 package hudson.maven;
 
+import static junit.framework.Assert.assertEquals;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -10,12 +11,16 @@ import hudson.model.AbstractProject;
 import hudson.model.DependencyGraph;
 import hudson.model.MockHelper;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import hudson.util.Graph;
 import junit.framework.Assert;
 
 import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
@@ -31,29 +36,29 @@ import com.google.common.collect.Lists;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest( { MavenModuleSet.class, DescriptorImpl.class, AbstractProject.class})
 public class MavenModuleTest {
-    
+
     private MavenModule module;
 
     private MavenProject project;
-    
+
     @Before
     public void before() {
         suppress(constructor(AbstractProject.class));
         suppress(constructor(DescriptorImpl.class));
-        
+
         this.module = mock(MavenModule.class);
         basicMocking(this.module);
-        
+
         this.project = new MavenProject();
         project.setGroupId("test");
         project.setArtifactId("testmodule");
         project.setVersion("2.0-SNAPSHOT");
         project.setPackaging("jar");
-        
+
         this.module.reconfigure(new PomInfo(project, null, "relPath"));
         this.module.doSetName("test$testmodule");
     }
-    
+
     /**
      * Tests that a {@link MavenModule} which builds a plugin is recognized as a snapshot
      * dependency in another module using that plugin.
@@ -62,15 +67,15 @@ public class MavenModuleTest {
     @Bug(10530)
     public void testMavenModuleAsPluginDependency() {
         MavenModule pluginModule = createPluginProject();
-        
+
         addModuleAsPluginDependency(this.module, pluginModule);
-        
+
         when(this.module.getAllMavenModules()).thenReturn(Lists.newArrayList(this.module, pluginModule));
-        
+
         DependencyGraph graph = MockHelper.mockDependencyGraph(
                 Lists.<AbstractProject<?,?>>newArrayList(this.module, pluginModule));
         graph.build();
-        
+
         @SuppressWarnings("rawtypes")
         List<AbstractProject> downstream = graph.getDownstream(pluginModule);
         Assert.assertEquals(1, downstream.size());
@@ -84,21 +89,21 @@ public class MavenModuleTest {
         plugin.setArtifactId(pluginModule.getModuleName().artifactId);
         plugin.setVersion(pluginModule.getVersion());
         build.setPlugins(Collections.singletonList(plugin));
-        
+
         MavenProject project = new MavenProject();
         project.setGroupId(module.getModuleName().groupId);
         project.setArtifactId(module.getModuleName().artifactId);
         project.setVersion(module.getVersion());
         project.setPackaging("jar");
         project.setBuild(build);
-        
+
         module.reconfigure(new PomInfo(project, null, "relPath"));
     }
 
     private static MavenModule createPluginProject() {
         MavenModule pluginModule = mock(MavenModule.class);
         basicMocking(pluginModule);
-        
+
         MavenProject proj = new MavenProject();
         proj.setGroupId("test");
         proj.setArtifactId("pluginmodule");
@@ -107,10 +112,10 @@ public class MavenModuleTest {
         PomInfo info = new PomInfo(proj, null, "relPath");
         pluginModule.reconfigure(info);
         pluginModule.doSetName("test$pluginmodule");
-        
+
         return pluginModule;
     }
-    
+
     private static void basicMocking(MavenModule mock) {
         when(mock.isBuildable()).thenReturn(Boolean.TRUE);
         doCallRealMethod().when(mock).reconfigure(Matchers.any(PomInfo.class));
@@ -119,11 +124,141 @@ public class MavenModuleTest {
         doCallRealMethod().when(mock).doSetName(Matchers.anyString());
         when(mock.getModuleName()).thenCallRealMethod();
         when(mock.getVersion()).thenCallRealMethod();
-        
+
         MavenModuleSet parent = mock(MavenModuleSet.class);
         when(parent.isAggregatorStyleBuild()).thenReturn(Boolean.FALSE);
         when(mock.getParent()).thenReturn(parent);
-        
+
         when(parent.getModules()).thenReturn(Collections.singleton(mock));
+    }
+
+    /**
+     * This test is a standard project that has a versioned dependency.
+     */
+    @Test
+    public void testSimpleVersion() {
+        TestComponents testComponents = createTestComponents("1.0.1-SNAPSHOT");
+
+        DependencyGraph graph = testComponents.graph;
+        MavenModule appMavenModule = testComponents.applicationMavenModule;
+        MavenModule libMavenModule = testComponents.libraryMavenModule;
+
+        graph.build();
+
+        List<AbstractProject> appDownstream = graph.getDownstream(appMavenModule);
+        List<AbstractProject> appUpstream = graph.getUpstream(appMavenModule);
+        List<AbstractProject> libDownstream = graph.getDownstream(libMavenModule);
+        List<AbstractProject> libUpstream = graph.getUpstream(libMavenModule);
+
+        assertEquals(0, appDownstream.size());
+        assertEquals(1, appUpstream.size());
+        assertEquals(1, libDownstream.size());
+        assertEquals(0, libUpstream.size());
+    }
+
+    /**
+     * This tests that a version range declaration in the dependency of a top level project
+     * resolves the up and downstream correctly.
+     */
+    @Test
+    public void testSimpleVersionRange() {
+        TestComponents testComponents = createTestComponents("[1.0.0, )");
+
+        DependencyGraph graph = testComponents.graph;
+        MavenModule appMavenModule = testComponents.applicationMavenModule;
+        MavenModule libMavenModule = testComponents.libraryMavenModule;
+
+        graph.build();
+
+        List<AbstractProject> appDownstream = graph.getDownstream(appMavenModule);
+        List<AbstractProject> appUpstream = graph.getUpstream(appMavenModule);
+        List<AbstractProject> libDownstream = graph.getDownstream(libMavenModule);
+        List<AbstractProject> libUpstream = graph.getUpstream(libMavenModule);
+
+        assertEquals(0, appDownstream.size());
+        assertEquals(1, appUpstream.size());
+        assertEquals(1, libDownstream.size());
+        assertEquals(0, libUpstream.size());
+    }
+
+    private TestComponents createTestComponents(String libraryVersion) {
+        MavenProject appProject = createApplication();
+        Dependency dependency = createDependency(libraryVersion);
+        appProject.getDependencies().add(dependency);
+
+        PomInfo appInfo = new PomInfo(appProject, null, "relPath");
+        MavenModule appMavenModule = mock(MavenModule.class);
+        basicMocking(appMavenModule);
+        appMavenModule.doSetName("test$application");
+        appMavenModule.reconfigure(appInfo);
+
+        MavenProject libProject = createLibrary();
+        PomInfo libInfo = new PomInfo(libProject, null, "relPath");
+        MavenModule libMavenModule = mock(MavenModule.class);
+        basicMocking(libMavenModule);
+        libMavenModule.doSetName("test$library");
+        libMavenModule.reconfigure(libInfo);
+
+        MavenModuleSet parent = mock(MavenModuleSet.class);
+        when(parent.isAggregatorStyleBuild()).thenReturn(Boolean.FALSE);
+        when(appMavenModule.getParent()).thenReturn(parent);
+        when(libMavenModule.getParent()).thenReturn(parent);
+
+        Collection<MavenModule> projects = Lists.newArrayList(appMavenModule, libMavenModule);
+        when(parent.getModules()).thenReturn(projects);
+        when(appMavenModule.getAllMavenModules()).thenReturn(projects);
+        when(libMavenModule.getAllMavenModules()).thenReturn(projects);
+
+        DependencyGraph graph = MockHelper.mockDependencyGraph(Lists.<AbstractProject<?,?>>newArrayList(appMavenModule, libMavenModule));
+        doCallRealMethod().when(graph).getDownstream(Matchers.any(AbstractProject.class));
+        doCallRealMethod().when(graph).getUpstream(Matchers.any(AbstractProject.class));
+
+        TestComponents testComponents = new TestComponents();
+        testComponents.graph = graph;
+        testComponents.applicationMavenModule = appMavenModule;
+        testComponents.libraryMavenModule = libMavenModule;
+
+        return testComponents;
+    }
+
+    private static MavenProject createApplication() {
+        MavenProject proj = new MavenProject();
+        proj.setName("testapp");
+        proj.setGroupId("test");
+        proj.setArtifactId("application");
+        proj.setVersion("1.0-SNAPSHOT");
+        proj.setPackaging("jar");
+
+        return proj;
+    }
+
+    private static Dependency createDependency(String version) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId("test");
+        dependency.setArtifactId("library");
+        dependency.setVersion(version);
+        return dependency;
+    }
+
+    private static MavenProject createLibrary() {
+        MavenProject proj = new MavenProject();
+        proj.setName("testlib");
+        proj.setGroupId("test");
+        proj.setArtifactId("library");
+        proj.setVersion("1.0.1-SNAPSHOT");
+        proj.setPackaging("jar");
+
+        Dependency dependency = new Dependency();
+        dependency.setArtifactId("log4j");
+        dependency.setGroupId("log4j");
+        dependency.setVersion("1.6.15");
+        proj.getDependencies().add(dependency);
+        return proj;
+    }
+
+    private static class TestComponents {
+        public DependencyGraph graph;
+        public MavenModule applicationMavenModule;
+        public MavenModule libraryMavenModule;
     }
 }


### PR DESCRIPTION
There is a unit test to test a normal project with a static declared version dependency (testSimpleVersion). This passes before and after the version range change.

I have applied and tweaked the patch for version ranges from JENKINS-2787 and an created an associated unit test (testSimpleVersionRange).
