### PR TITLE
Case insensitive searching

### DIFF
--- a/core/src/main/java/hudson/search/CollectionSearchIndex.java
+++ b/core/src/main/java/hudson/search/CollectionSearchIndex.java
@@ -54,7 +54,7 @@ public abstract class CollectionSearchIndex<SMT extends SearchableModelObject> i
         Collection<SMT> items = all();
         if(items==null)     return;
         for (SMT o : items) {
-            if(o!=null && getName(o).contains(token))
+            if(o!=null && getName(o).toLowerCase().contains(token.toLowerCase()))
                 result.add(o);
         }
     }

--- a/core/src/main/java/hudson/search/CollectionSearchIndex.java
+++ b/core/src/main/java/hudson/search/CollectionSearchIndex.java
@@ -26,6 +26,7 @@ package hudson.search;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import hudson.model.User;
 
 /**
  * {@link SearchIndex} built on a {@link Map}.
@@ -51,10 +52,19 @@ public abstract class CollectionSearchIndex<SMT extends SearchableModelObject> i
     }
 
     public void suggest(String token, List<SearchItem> result) {
-        Collection<SMT> items = all();
+         Collection<SMT> items = all();
+        User user = User.current();
+        boolean caseSensitive = false;
+        if(user!=null && user.getProperty(Search.UserProperty.class).getInsensitiveSearch()){ //Searching for anonymous user is case-sensitive
+          token = token.toLowerCase();
+          caseSensitive=true;
+        }
         if(items==null)     return;
         for (SMT o : items) {
-            if(o!=null && getName(o).toLowerCase().contains(token.toLowerCase()))
+            String name = getName(o);
+            if(caseSensitive)
+                name=name.toLowerCase();
+            if(o!=null && name.contains(token))
                 result.add(o);
         }
     }

--- a/core/src/main/java/hudson/search/FixedSet.java
+++ b/core/src/main/java/hudson/search/FixedSet.java
@@ -45,13 +45,13 @@ public class FixedSet implements SearchIndex {
 
     public void find(String token, List<SearchItem> result) {
         for (SearchItem i : items)
-            if(token.equals(i.getSearchName()))
+            if(token.toLowerCase().equals(i.getSearchName().toLowerCase()))
                 result.add(i);
     }
 
     public void suggest(String token, List<SearchItem> result) {
         for (SearchItem i : items)
-            if(i.getSearchName().contains(token))
+            if(i.getSearchName().toLowerCase().contains(token.toLowerCase()))
                 result.add(i);
     }
 }

--- a/core/src/main/java/hudson/search/FixedSet.java
+++ b/core/src/main/java/hudson/search/FixedSet.java
@@ -23,6 +23,7 @@
  */
 package hudson.search;
 
+import hudson.model.User;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -44,14 +45,37 @@ public class FixedSet implements SearchIndex {
     }
 
     public void find(String token, List<SearchItem> result) {
-        for (SearchItem i : items)
-            if(token.toLowerCase().equals(i.getSearchName().toLowerCase()))
+        boolean caseSensitive = getCaseSensitivity();
+        for (SearchItem i : items){
+            String name = i.getSearchName();
+            if(caseSensitive){
+                token=token.toLowerCase();
+                name=name.toLowerCase();
+            }
+            if(token.equals(i.getSearchName()))
                 result.add(i);
+        }
+    }
+    
+    public boolean getCaseSensitivity(){
+        User user = User.current();
+        boolean caseSensitive = false;
+        if(user!=null && user.getProperty(Search.UserProperty.class).getInsensitiveSearch()){//Searching for anonymous user is case-sensitive
+          caseSensitive=true;
+        }
+        return caseSensitive;
     }
 
     public void suggest(String token, List<SearchItem> result) {
-        for (SearchItem i : items)
-            if(i.getSearchName().toLowerCase().contains(token.toLowerCase()))
+        boolean caseSensitive = getCaseSensitivity();
+        for (SearchItem i : items){
+            String name = i.getSearchName();
+            if(caseSensitive){
+                token=token.toLowerCase();
+                name=name.toLowerCase();
+            }
+            if(name.contains(token))
                 result.add(i);
+        }
     }
 }

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -24,9 +24,12 @@
  */
 package hudson.search;
 
+import hudson.Extension;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 import hudson.Util;
+import hudson.model.User;
+import hudson.model.UserPropertyDescriptor;
 import hudson.util.EditDistance;
 import java.io.IOException;
 import java.util.AbstractList;
@@ -39,6 +42,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
+import net.sf.json.JSONObject;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -349,4 +353,35 @@ public class Search {
     }
     
     private final static Logger LOGGER = Logger.getLogger(Search.class.getName());
+    
+    //User`s setting of case-sensitivity for searching
+    public static class UserProperty extends hudson.model.UserProperty {
+         
+        private final boolean insensitiveSearch;
+
+        public UserProperty(boolean insensitiveSearch) {
+            this.insensitiveSearch = insensitiveSearch;
+        }
+
+        @Exported
+        public boolean getInsensitiveSearch() {
+            return insensitiveSearch;
+        }
+
+        @Extension
+        public static final class DescriptorImpl extends UserPropertyDescriptor {
+            public String getDisplayName() {
+                return "Setting for search";
+            }
+
+            public UserProperty newInstance(User user) {
+                return new UserProperty(false); //default setting is case-sensitive searching
+            }
+
+            @Override
+            public UserProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+                return new UserProperty(formData.optBoolean("insensitiveSearch"));
+            }
+        }
+    }
 }

--- a/core/src/main/resources/hudson/search/Search/UserProperty/config.jelly
+++ b/core/src/main/resources/hudson/search/Search/UserProperty/config.jelly
@@ -1,0 +1,30 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Daniel Dyer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="Case-sensitivity">
+    <f:checkbox name="insensitiveSearch" checked="${instance.insensitiveSearch}" title="Insensitive search tool"/>
+  </f:entry>
+</j:jelly>

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1917,6 +1917,7 @@ function createSearchBox(searchURL) {
     };
     var ac = new YAHOO.widget.AutoComplete("search-box","search-box-completion",ds);
     ac.typeAhead = false;
+    ac.autoHighlight = false;
 
     var box   = $("search-box");
     var sizer = $("search-box-sizer");


### PR DESCRIPTION
Improving search tool in Jenkins that the searching will be case-insensitive.
I change the behaviour of search in hudson-behaviour.js too. Original behaviour shows results in auto-complete div, and whenever user press enter, it uses the currently selected auto-complete item instead of string typed by user. It is quite annoying, so I changed it - after pressing enter, the string typed by user is used.
