### PR TITLE
Deactivate plugins with cyclic dependencies

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -826,7 +826,7 @@ public abstract class PluginManager extends AbstractModelObject {
     }
     
     /**
-     * {@link AdministrativeMonitor} that checks if there's Jenkins update.
+     * {@link AdministrativeMonitor} that checks if there are any plugins with cycle dependencies.
      */
     @Extension
     public static final class PluginCycleDependenciesMonitor extends AdministrativeMonitor {

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -125,6 +125,8 @@ public class PluginWrapper implements Comparable<PluginWrapper> {
      * The snapshot of <tt>disableFile.exists()</tt> as of the start up.
      */
     private final boolean active;
+    
+    private boolean hasCycleDependency = false;
 
     private final List<Dependency> dependencies;
     private final List<Dependency> optionalDependencies;
@@ -276,6 +278,8 @@ public class PluginWrapper implements Comparable<PluginWrapper> {
 
         return null;
     }
+    
+    
 
     @Override
     public String toString() {
@@ -379,9 +383,17 @@ public class PluginWrapper implements Comparable<PluginWrapper> {
      * Returns true if this plugin is enabled for this session.
      */
     public boolean isActive() {
-        return active;
+        return active && !hasCycleDependency();
+    }
+    
+    public boolean hasCycleDependency(){
+        return hasCycleDependency;
     }
 
+    public void setHasCycleDependency(boolean hasCycle){
+        hasCycleDependency = hasCycle;
+    }
+    
     public boolean isBundled() {
         return isBundled;
     }

--- a/core/src/main/java/hudson/util/CyclicGraphDetector.java
+++ b/core/src/main/java/hudson/util/CyclicGraphDetector.java
@@ -23,8 +23,9 @@ public abstract class CyclicGraphDetector<N> {
     private final List<N> topologicalOrder = new ArrayList<N>();
 
     public void run(Iterable<? extends N> allNodes) throws CycleDetectedException {
-        for (N n : allNodes)
+        for (N n : allNodes){
             visit(n);
+        }
     }
 
     /**
@@ -62,8 +63,18 @@ public abstract class CyclicGraphDetector<N> {
     private void detectedCycle(N q) throws CycleDetectedException {
         int i = path.indexOf(q);
         path.push(q);
-        throw new CycleDetectedException(path.subList(i, path.size()));
+        reactOnCycle(q, path.subList(i, path.size()));
     }
+    
+    /**
+     * React on detected cycles - default implementation throws an exception.
+     * @param q
+     * @param cycle
+     * @throws CycleDetectedException
+     */
+    protected void reactOnCycle(N q, List<N> cycle) throws CycleDetectedException{
+        throw new CycleDetectedException(cycle);
+    }    
 
     public static final class CycleDetectedException extends Exception {
         public final List cycle;

--- a/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/message.jelly
+++ b/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/message.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi
+Copyright (c) 2012, Dominik Bartholdi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/message.jelly
+++ b/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/message.jelly
@@ -1,0 +1,35 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <div class="error">
+    ${%PluginCycles}
+    <ul>
+	    <j:forEach var="p" items="${it.pluginsWithCycle}">
+	        <li><j:out value="${p}"/></li>
+	    </j:forEach>
+    </ul>
+  </div>
+</j:jelly>

--- a/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/message.properties
+++ b/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/message.properties
@@ -1,0 +1,24 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2012, Dominik Bartholdi
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+PluginCycles=The following plugins are deactivated because of cyclic dependencies, most likely you can resolve the issue by updating these to a newer version.


### PR DESCRIPTION
This pull stops Jenkins from failing to start if it detects a cycle in the plugin dependencies.
Instead it deactivates the plugins and informs the administrator about the failure. As Jenkins still comes up and runs, he is now able to use the UI to update the failing Plugins to a different version.

With this a plugin developer will no also be able to do some redesign if he found that his dependencies where in the wrong direction - but where afraid to make the update to hard for an enduser.
With this I will be able to fix an issue with an other pull I have: https://github.com/jenkinsci/config-provider-model/pull/1
