### PR TITLE
JENKINS-12397: Skip deploying of artifacts when release build is running...

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/RedeployPublisher.java
+++ b/maven-plugin/src/main/java/hudson/maven/RedeployPublisher.java
@@ -92,30 +92,48 @@ public class RedeployPublisher extends Recorder {
     public final String url;
     public final boolean uniqueVersion;
     public final boolean evenIfUnstable;
+    public final String releaseEnvVar;
 
     /**
      * For backward compatibility
      */
     @Deprecated
     public RedeployPublisher(String id, String url, boolean uniqueVersion) {
-    	this(id, url, uniqueVersion, false);
+    	this(id, url, uniqueVersion, false, null);
     }
     
     /**
      * @since 1.347
      */
-    @DataBoundConstructor
+    @Deprecated
     public RedeployPublisher(String id, String url, boolean uniqueVersion, boolean evenIfUnstable) {
+        this(id, url, uniqueVersion, evenIfUnstable, null);
+    }
+    
+    @DataBoundConstructor
+    public RedeployPublisher(String id, String url, boolean uniqueVersion, boolean evenIfUnstable, String releaseEnvVar) {
         this.id = id;
         this.url = Util.fixEmptyAndTrim(url);
         this.uniqueVersion = uniqueVersion;
         this.evenIfUnstable = evenIfUnstable;
+        this.releaseEnvVar = Util.fixEmptyAndTrim(releaseEnvVar);
     }
 
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         if (build.getResult().isWorseThan(getTreshold()))
             return true;    // build failed. Don't publish
 
+        /**
+         * Check if we should skip or not
+         */
+        if (releaseEnvVar != null) {
+        	String envVarValue = build.getEnvironment(listener).get(releaseEnvVar);
+        	if ("true".equals(envVarValue)) { // null or false are ignored
+        		listener.getLogger().println("[INFO] Skipping deploying artifact as release build is in progress.");
+        		return true; // skip the deploy
+        	}
+        }
+        
         List<MavenAbstractArtifactRecord> mavenAbstractArtifactRecords = getActions(build, listener);
         if (mavenAbstractArtifactRecords == null || mavenAbstractArtifactRecords.isEmpty()) {
             listener.getLogger().println("[ERROR] No artifacts are recorded. Is this a Maven project?");

--- a/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/config.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/config.jelly
@@ -34,6 +34,9 @@ THE SOFTWARE.
     <f:entry field="uniqueVersion">
       <f:checkbox title="${%Assign unique versions to snapshots}" default="true"/>
     </f:entry>
+    <f:entry title="${%Release environment variable}" field="releaseEnvVar" >
+      <f:textbox />
+    </f:entry>
     <j:if test="${descriptor.showEvenIfUnstableOption()}">
       <f:entry field="evenIfUnstable">
         <f:checkbox title="${%Deploy even if the build is unstable}" />

--- a/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/help-releaseEnvVar.html
+++ b/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/help-releaseEnvVar.html
@@ -1,0 +1,3 @@
+<div>
+  If the given variable name is set to "true" the deploy steps is skipped. Useful when using m2 release plugin.
+</div>


### PR DESCRIPTION
....

Monitor environment variable defined by user. If the variable is set to "true" the deployment is skipped. The M2 Release plugin expose this kind of variables.
