### PR TITLE
Add mime type for webm files.

### DIFF
--- a/war/src/main/webapp/WEB-INF/web.xml
+++ b/war/src/main/webapp/WEB-INF/web.xml
@@ -194,5 +194,9 @@ THE SOFTWARE.
     <extension>rar</extension>
     <mime-type>application/octet-stream</mime-type>
   </mime-mapping>
+  <mime-mapping>
+    <extension>webm</extension>
+    <mime-type>video/webm</mime-type>
+  </mime-mapping>
 
 </web-app>


### PR DESCRIPTION
Our build generates webm files (we record video for failing WebDriver tests), and it would be nice to see the video in the browser. Unfortunately, Firefox doesn't know what to do with the .webm extension if there is no provided mime type. We hacked our local Jenkins's web.xml with this change, but it'll break the next time we upgrade. :)

This pull request modifies the web.xml to add a mime type for .webm files. This is similar to the fix in https://issues.jenkins-ci.org/browse/JENKINS-3803. Please let me know if I need to do anything else to get this in the mainline.

Thanks,
George
