### PR TITLE
Update guava to 11.0.1 so for jclouds 1.4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>10.0.1</version>
+        <version>11.0.1</version>
       </dependency>
       
       <dependency>


### PR DESCRIPTION
From Adrian Cole:
"the jclouds-plugin wants to be dependent on jclouds 1.4, which is at guava
v11.0.1. jclouds 1.4 has lots of features and more cloud support than
others, including clouds in sweden!

Can we bump jenkins, too! Until then, we are rev-locked to jclouds 1.2"
