### PR TITLE
FIXED JENKINS-12778: Allow multiple touchstone combinations in order to ...

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pom</artifactId>
     <groupId>org.jenkins-ci.main</groupId>
-    <version>1.452-SNAPSHOT</version>
+    <version>1.452</version>
   </parent>
 
   <artifactId>cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.main</groupId>
     <artifactId>pom</artifactId>
-    <version>1.452-SNAPSHOT</version>
+    <version>1.452</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/core/src/main/java/hudson/matrix/MatrixBuild.java
@@ -44,6 +44,7 @@ import org.kohsuke.stapler.export.Exported;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -262,7 +263,71 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
 
     private class RunnerImpl extends AbstractRunner {
         private final List<MatrixAggregator> aggregators = new ArrayList<MatrixAggregator>();
+        /**
+         * This method groups the active configurations according to the touchstone
+         * combination list. The list must not be empty. Last element must  be the empty
+         * string, so the last group of active combinations will always receive all
+         * configurations not matched by any specific filter.
+         *
+         * @param p Matrix project
+         * @param touchStoneFilterList contains a list of combination filters. Must not be empty,
+         * must end with empty string to catch all remaining configurations
+         * @return list of collections of active configurations
+         */
+        private List<Collection<MatrixConfiguration>>  getGroupedActiveConfigurations(MatrixProject p, List<String> touchStoneFilterList) {
+            List<Collection<MatrixConfiguration>> groupedActiveConfigurations = new ArrayList<Collection<MatrixConfiguration>>();
+            Collection<MatrixConfiguration> activeConfigurations = p.getActiveConfigurations();
+            for (int i = 0; i<touchStoneFilterList.size(); i++) {
+                groupedActiveConfigurations.add(new HashSet<MatrixConfiguration>());
+            }
 
+            for (MatrixConfiguration c: activeConfigurations) {
+                Boolean groupFound = false;
+                if (!MatrixBuildListener.buildConfiguration(MatrixBuild.this, c))
+                    continue; // skip rebuild
+                for (int i = 0; i < touchStoneFilterList.size() && !groupFound; i++) {
+                    /**
+                     * Since the last element of touchStoneFilterList is the
+                     * empty string, it will catch all remainders.
+                     */
+                    if (c.getCombination().evalGroovyExpression(p.getAxes(), touchStoneFilterList.get(i))) {
+                        groupedActiveConfigurations.get(i).add(c);
+                        groupFound = true;
+                        break; // exit for loop
+                    }
+                }
+                /*
+                 * The following assertion is justified because the last element
+                 * of touchStoneFilterList is always "", which is catch all
+                 */
+                assert(groupFound);
+            }
+            return groupedActiveConfigurations;
+        }
+        /**
+         * This method checks if touchstone configuration is active. If so, the
+         * semicolon separated, not-empty combination filters are collected in a
+         * list. Afterwards an empty string is appended to the list, making sure
+         * it is never empty and all active configurations are matched by a
+         * list element.
+         * @param p
+         * @return Non-empty string list where the last element is an empty string
+         */
+        private List<String> getTouchstoneFilterList(MatrixProject p) {
+            Collection<MatrixConfiguration> activeConfigurations = p.getActiveConfigurations();
+            List<String> touchStoneFilterList = new ArrayList<String>();
+            String touchStoneFilterField = p.getTouchStoneCombinationFilter();
+            if (null == touchStoneFilterField)
+                touchStoneFilterField = "";
+            for (String filter: touchStoneFilterField.split("\\s*;\\s*"))
+                if (filter.length() > 0)
+                    touchStoneFilterList.add(filter);
+                else
+                    break;
+
+            touchStoneFilterList.add(""); // if last list item is not empty, add empty string as catch-all
+            return touchStoneFilterList;
+        }
         protected Result doRun(BuildListener listener) throws Exception {
             MatrixProject p = getProject();
             PrintStream logger = listener.getLogger();
@@ -272,63 +337,48 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
             listUpAggregators(listener, p.getProperties().values());
             listUpAggregators(listener, p.getBuildWrappers().values());
 
-            axes = p.getAxes();
-            Collection<MatrixConfiguration> activeConfigurations = p.getActiveConfigurations();
             final int n = getNumber();
-            
-            String touchStoneFilter = p.getTouchStoneCombinationFilter();
-            Collection<MatrixConfiguration> touchStoneConfigurations = new HashSet<MatrixConfiguration>();
-            Collection<MatrixConfiguration> delayedConfigurations = new HashSet<MatrixConfiguration>();
-            for (MatrixConfiguration c: activeConfigurations) {
-                if (!MatrixBuildListener.buildConfiguration(MatrixBuild.this, c))
-                    continue; // skip rebuild
-                if (touchStoneFilter != null && c.getCombination().evalGroovyExpression(p.getAxes(), p.getTouchStoneCombinationFilter())) {
-                    touchStoneConfigurations.add(c);
-                } else {
-                    delayedConfigurations.add(c);
-                }
-            }
-
+            Collection<MatrixConfiguration> activeConfigurations = p.getActiveConfigurations();
+            List<String> touchStoneFilterList = getTouchstoneFilterList(p);
+            List<Collection<MatrixConfiguration>> groupedActiveConfigurations = getGroupedActiveConfigurations(p,touchStoneFilterList);
             for (MatrixAggregator a : aggregators)
                 if(!a.startBuild())
                     return Result.FAILURE;
 
             MatrixConfigurationSorter sorter = p.getSorter();
+
             if (sorter != null) {
-                touchStoneConfigurations = createTreeSet(touchStoneConfigurations, sorter);
-                delayedConfigurations    = createTreeSet(delayedConfigurations,sorter);
+                logger.print( "Start sorting..." );
+                for ( int i = 0; i < groupedActiveConfigurations.size(); i++ ) {
+                    groupedActiveConfigurations.set(
+                            i,
+                            createTreeSet(groupedActiveConfigurations.get(i),
+                            sorter)
+                    );
+                }
             }
 
             try {
-                if(!p.isRunSequentially())
-                    for(MatrixConfiguration c : touchStoneConfigurations)
-                        scheduleConfigurationBuild(logger, c);
-
                 Result r = Result.SUCCESS;
-                for (MatrixConfiguration c : touchStoneConfigurations) {
-                    if(p.isRunSequentially())
-                        scheduleConfigurationBuild(logger, c);
-                    Result buildResult = waitForCompletion(listener, c);
-                    r = r.combine(buildResult);
-                }
-                
-                if (p.getTouchStoneResultCondition() != null && r.isWorseThan(p.getTouchStoneResultCondition())) {
-                    logger.printf("Touchstone configurations resulted in %s, so aborting...%n", r);
-                    return r;
-                }
-                
-                if(!p.isRunSequentially())
-                    for(MatrixConfiguration c : delayedConfigurations)
-                        scheduleConfigurationBuild(logger, c);
+                for (int i = 0; i < groupedActiveConfigurations.size(); i++) {
+                    if(!p.isRunSequentially())
+                        for(MatrixConfiguration c : groupedActiveConfigurations.get(i) )
+                            scheduleConfigurationBuild(logger, c);
 
-                for (MatrixConfiguration c : delayedConfigurations) {
-                    if(p.isRunSequentially())
-                        scheduleConfigurationBuild(logger, c);
-                    Result buildResult = waitForCompletion(listener, c);
-                    logger.println(Messages.MatrixBuild_Completed(HyperlinkNote.encodeTo('/'+ c.getUrl(),c.getDisplayName()), buildResult));
-                    r = r.combine(buildResult);
+                    for (MatrixConfiguration c : groupedActiveConfigurations.get(i) ) {
+                        if(p.isRunSequentially())
+                            scheduleConfigurationBuild(logger, c);
+                        Result buildResult = waitForCompletion(listener, c);
+                        r = r.combine(buildResult);
+                    }
+                
+                    if (i < groupedActiveConfigurations.size() - 1 && p.getTouchStoneResultCondition() != null && r.isWorseThan(p.getTouchStoneResultCondition())) {
+                        logger.printf("Touchstone configuration %d (%s) resulted in %s, so aborting...%n", i, touchStoneFilterList.get(i), r);
+                        return r;
+                    } else {
+                        logger.printf("Touchstone configuration %d (%s) finished...%n", i, touchStoneFilterList.get(i));
+                    }
                 }
-
                 return r;
             } catch( InterruptedException e ) {
                 logger.println("Aborted");

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.main</groupId>
     <artifactId>pom</artifactId>
-    <version>1.452-SNAPSHOT</version>
+    <version>1.452</version>
   </parent>
 
   <artifactId>maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>pom</artifactId>
-  <version>1.452-SNAPSHOT</version>
+  <version>1.452</version>
   <packaging>pom</packaging>
 
   <name>Jenkins main module</name>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <parent>
     <artifactId>pom</artifactId>
     <groupId>org.jenkins-ci.main</groupId>
-    <version>1.452-SNAPSHOT</version>
+    <version>1.452</version>
   </parent>
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>jenkins-test-harness</artifactId>

--- a/ui-samples-plugin/pom.xml
+++ b/ui-samples-plugin/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.main</groupId>
     <artifactId>pom</artifactId>
-    <version>1.452-SNAPSHOT</version>
+    <version>1.452</version>
   </parent>
 
   <artifactId>ui-samples-plugin</artifactId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.main</groupId>
     <artifactId>pom</artifactId>
-    <version>1.452-SNAPSHOT</version>
+    <version>1.452</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/war/src/main/webapp/help/matrix/touchstone.html
+++ b/war/src/main/webapp/help/matrix/touchstone.html
@@ -1,5 +1,19 @@
 <div>
-  Use a touchstone build if you want to run a sanity check before building all the combinations.
-  You can select a number of combinations using a combination filter. These will be built first.
-  If the result satisfies the result condition, the rest of the combinations will be built. 
+  Use a touchstone if you want to run a sanity check before building the remaining combinations.
+  A touchstone can be defined using a combination filter. All builds matching this filter
+  will be executed first. If the result satisfies the result condition, the remaining
+  active combinations are built.<p />
+  You can also define multiple touchstones by specifying several semicolon separated touchstones.
+  This might be helpful when you have multiple steps for multiple platforms, and you want to
+  make sure that all platforms take step n before occupying your infrastructure with step n+1.<p />
+
+  Example:<p />
+  Label expression PLATFORM = "win32 linuxX86"<br>
+  Label expression STEP = "build unit_test feature_test deploy"<p />
+  hgTouchstone = STEP="build"; STEP="unit_test"; STEP="feature_test"<br>
+
+  Unit tests will only be started for any platform if the build was successful
+  for all platforms. Likewise for feature tests depending on successful unit
+  tests for all platforms, deployment depending on successful feature tests for
+  all platforms.
 </div>

--- a/war/src/main/webapp/help/matrix/touchstone_de.html
+++ b/war/src/main/webapp/help/matrix/touchstone_de.html
@@ -1,10 +1,16 @@
 <div>
-  Ein "Touchstone"-Build ist ein besonderer Build, der Sie besonders frühzeitig auf Probleme
-  in Ihrem Code hinweist, z.B. durch Ausführung essentieller Plausibilitätstests.
-    
-  <p>
-  Wenn angewählt, führt Jenkins zunächst die Touchstone-Builds aus, bevor dann alle weiteren
-  Kombinationen gebaut werden. Sie können über einen Kombinationsfilter auch mehrere Builds
-  als Touchstone-Build kennzeichnen. Nur wenn das Ergebnis der Touchstone-Builds die
-  Ergebnisbedingung erfüllt, werden alle weiteren Kombinationen gebaut.
+  Ein "Touchstone" wird durch einen Kombinationsfilter definiert. Alle Builds,
+  die diesem Filter entsprechen, werden zuerst ausgeführt. Nur wenn das Ergebnis
+  die Ergebnis bedingung entspricht, werden die verbleibenden Builds ausgeführt.
+  <p />
+  Es ist auch möglich, mehrere Touchstones durch Semikolon getrennt zu definieren.
+  Dies ist sinnvoll, wenn man mehrere Schritte (build, unit test, functional test)
+  für mehrere Platformen ausführt, und sicherstellen möchte, dass ein Schritt
+  für alle Platformen erfolgreich war, bevor man die Infrastruktur mit dem nächsten
+  Schritt für irgendeine Platform belastet.
+  <p />
+  Beispiel:<p />
+  Label expression PLATFORM = "win32 linuxX86"<br>
+  Label expression SCHRITT = "build unit_test feature_test deploy"<p />
+  hgTouchstone = SCHRITT="build"; SCHRITT="unit_test"; SCHRITT="feature_test"<br>
 </div>


### PR DESCRIPTION
This pull request replaces pull/377 (Jenkins 12778 fixed), which was also proposed by me. The reason for the new user name is that I made some mistake with my first fork as tho74 (I committed some modifications to master on my fork) and needed to fork again. Now I want to delete my old user account (and therefore the old fork). I took the opportunity to clean up and collect all modifications in one change-set.)

This branch implements http:://issues.jenkins.org/browseJENKINS-12778, support for multiple touchstones in matrix builds. Motivation is to organize build, test and deployment for multiple platforms in separated groups and to execute each group only if the preceding group matches expectations. For me this feature would have a huge positive impact. (More detailed description is in the ticket)

Summery of implementation:
In MatrixBuild::RunnerImpl::doRun
- I replaced the destinct groups touchStoneConfigurations and delayedConfigurations by the list groupedActiveConfigurations.
- The text configuration field touchStoneCombinationFilter is split using semicolon as separators.
- The duplicate code to execute touchStoneConfigurations and delayedConfigurations is replaced by a loop executing each member of groupedActiveConfigurations
- Updated help text on config page accordingly.

I tested manually Matrix builds:

```
with inactive touchstone option
with active touchstone option but empty touchStoneCombinationFilter
with touchStoneCombinationFilter contains multiple semicolon only
with one combination, no semicolon at end
with one combination, semicolon at end
with multiple combination, no semicolon at end
with multiple combination, semicolon at end
with multiple combination, one step expected to fail the build
```

A tar archive with these job configurations is attached to the ticket.

The japanese help text for touchstone builds is not updated, I don't have the expertize.
