### PR TITLE
FIXED JENKINS-4960: New option: Only one SCM checkout in parent workspac...

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixProject.java
+++ b/core/src/main/java/hudson/matrix/MatrixProject.java
@@ -146,6 +146,12 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
     
     private MatrixConfigurationSorter sorter;
 
+    /**
+     * Share SCM checkout for all matrix entries
+     * per-configuration builds use Master source (e.g. via NFS/SMB + custom workspace)
+     */
+    private boolean useSameScmCheckout;
+
     public MatrixProject(String name) {
         this(Jenkins.getInstance(), name);
     }
@@ -191,6 +197,14 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
     public void setRunSequentially(boolean runSequentially) throws IOException {
         this.runSequentially = runSequentially;
         save();
+    }
+
+    /**
+     * If true, {@link MatrixRun}s will skip the SCM checkout and just go to the build step.
+     *
+     */
+    public boolean isUseSameScmCheckout() {
+        return useSameScmCheckout;
     }
 
     /**
@@ -589,6 +603,7 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
         checkAxisNames(newAxes);
         this.axes = new AxisList(newAxes.toList());
         
+        useSameScmCheckout = json.has("useSameScmCheckout");
         runSequentially = json.optBoolean("runSequentially");
 
         // set sorter if any sorter is chosen

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -565,7 +565,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             }
         }
         
-        private void checkout(BuildListener listener) throws Exception {
+        protected void checkout(BuildListener listener) throws Exception {
                 for (int retryCount=project.getScmCheckoutRetryCount(); ; retryCount--) {
                     // for historical reasons, null in the scm field means CVS, so we need to explicitly set this to something
                     // in case check out fails and leaves a broken changelog.xml behind.

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -568,7 +568,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             }
         }
         
-        private void checkout(BuildListener listener) throws Exception {
+        protected void checkout(BuildListener listener) throws Exception {
                 for (int retryCount=project.getScmCheckoutRetryCount(); ; retryCount--) {
                     // for historical reasons, null in the scm field means CVS, so we need to explicitly set this to something
                     // in case check out fails and leaves a broken changelog.xml behind.

--- a/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
@@ -69,6 +69,8 @@ THE SOFTWARE.
       </j:if>
     </f:optionalBlock>
 
+    <f:optionalBlock field="useSameScmCheckout" title="${%Use same SCM checkout for all builds, each configuration uses master source via NFS/SMB}"/>
+    
     <f:optionalBlock name="hasCombinationFilter" title="${%Combination Filter}" checked="${!empty(it.combinationFilter)}"
         help="/help/matrix/combinationfilter.html">
 	    <f:entry title="${%Filter}">

--- a/core/src/main/resources/hudson/matrix/MatrixProject/help-useSameScmCheckout.html
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/help-useSameScmCheckout.html
@@ -1,0 +1,7 @@
+<div>
+    With this option checked, Jenkins will not do a checkout from the SCM system 
+    for each configuration.
+    This can be usefull if your configuration can build concurrent from the same 
+    master source (e.g. via network share or when all builds run on the same node), 
+    and it saves the time, bandwith and disk space of the SCM-checkout.
+ </div>


### PR DESCRIPTION
This pull request replaces pull/375 (JENKINS-4960 (Use same SCM checkout for all matrix entries)), which was also proposed by me. The reason for the new user name is that I made some mistake with my first fork as tho74 (I committed some modifications to master on my fork) and needed to fork again. Now I want to delete my old user account (and therefore the old fork). I took the opportunity to clean up and collect all modifications in one change-set, which hopefully makes review easier and avoids some useless modifications.

Here is the updated proposed patch for JENKINS-4960. Its based on revision 5461577 (branch master from main repo, updated 15th of February). Besides updating the patch to match the current master, I modified it in following ways:

```
Allow this feature even when different nodes are used (previous patch threw an exception in this case because without shared drive the sub projects would not have access to the repository; however, this is our dedicated usecase, and it is documented in config page)
Make the parent build executor name available to subseqent builds
Make the path to the root workspace available to subseqent builds
```

We need this feature badly, so if this patch is not acceptable for some reason please tell me how to fix this...
