### PR TITLE
Bugfix: show links in the failed test results summary

### DIFF
--- a/core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
+++ b/core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
 		<j:otherwise>
 			<j:if test="${it.errorStackTrace!=null}">
 				<h3>${%Stack Trace}</h3>
-				<pre><st:out value="${it.errorStackTrace}"/></pre>
+				<pre><j:out value="${it.annotate(it.errorStackTrace)}"/></pre>
 			</j:if>
 		</j:otherwise>
   </j:choose>


### PR DESCRIPTION
In JUnit failed results jenkins extracts URLs and makes them links. It happens on case result pages (urls like: /job/particular_job/7/testReport/particular_testcase/), but it doesn't on test results summary pages when we click arrows ">>>" to see brief failure message (urls like: /job/particular_job/7/testReport/).
