### PR TITLE
Correction of queue and excutor filtering in view

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -24,6 +24,9 @@
  */
 package hudson.model;
 
+import java.util.Set;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixConfiguration;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.ExtensionPoint;
@@ -374,8 +377,16 @@ public abstract class View extends AbstractModelObject implements AccessControll
     	
     	boolean roam = false;
     	HashSet<Label> labels = new HashSet<Label>();
-    	for (Item item: getItems()) {
-    		if (item instanceof AbstractProject<?,?>) {
+        Set<Item> allItems = new HashSet<Item>();
+        for(Item i: getItems()){
+            allItems.add(i);
+            if(i instanceof MatrixProject){
+                MatrixProject p = (MatrixProject) i;
+                allItems.addAll(p.getActiveConfigurations()); // add matrix configurations
+            }
+        }
+    	for (Item item: allItems) {
+    		if (item instanceof AbstractProject<?,?> && !(item instanceof MatrixProject)) { //filtering is useless if contains Matrix project
     			AbstractProject<?,?> p = (AbstractProject<?, ?>) item;
     			Label l = p.getAssignedLabel();
     			if (l != null) {
@@ -385,7 +396,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     			}
     		}
     	}
-    	
+
     	for (Computer c: computers) {
     		Node n = c.getNode();
     		if (n != null) {
@@ -406,6 +417,12 @@ public abstract class View extends AbstractModelObject implements AccessControll
     	Collection<TopLevelItem> items = getItems(); 
     	List<Queue.Item> result = new ArrayList<Queue.Item>();
     	for (Queue.Item qi: Jenkins.getInstance().getQueue().getItems()) {
+                if(qi.task instanceof MatrixConfiguration){
+                    MatrixConfiguration config = (MatrixConfiguration) qi.task;
+                    if(items.contains(config.getParent())){
+                        result.add(qi); // add matrix configurations 
+                    }
+                }
     		if (items.contains(qi.task)) {
     			result.add(qi);
     		}


### PR DESCRIPTION
I change method getQueueItems() in class hudson.model.View, because it does not count on Matrix configurations - the filtered queue does not display configurations of matrix job, which are waiting in a queue.

The filtering of executors (method getComputers()), on which the jobs in view can be build, works for Matrix jobs incorrectly too. I add the labels of configurations and skip the Matrix job, because its build can run on all executors - the filtering would be useless.
