### PR TITLE
Prototype.js: Ajax parameters option should not be a raw string

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
     <j:if test="${it.checkURIEncodingEnabled}">
       <script>
         var url='checkURIEncoding';
-        var params='value=\u57f7\u4e8b';
+        var params= {value : '\u57f7\u4e8b'};
         var checkAjax=new Ajax.Updater(
           'message', url,
           {


### PR DESCRIPTION
http://www.prototypejs.org/api/ajax/options

> This can be provided either as a URL-encoded string or as any Hash-compatible object (basically anything), with properties representing parameters.

Prototype 1.5.1.1 encodes parameters, but 1.7.0 does not. If Jenkins uses 1.7.0, he warns us of container's encoding regardless of container's configuration.
