### PR TITLE
IE compatibility for "INPUT.auto-complete"

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -743,7 +743,7 @@ var jenkinsRules = {
     "INPUT.auto-complete": function(e) {// form field with auto-completion support 
         // insert the auto-completion container
         var div = document.createElement("DIV");
-        e.parentNode.insertBefore(div,$(e).next());
+        e.parentNode.insertBefore(div,$(e).next()||null);
         e.style.position = "relative"; // or else by default it's absolutely positioned, making "width:100%" break
 
         var ds = new YAHOO.util.XHRDataSource(e.getAttribute("autoCompleteUrl"));


### PR DESCRIPTION
`$(e).next()` may return `undefined`.
If 2nd argument of `insertBefore` is `undefined`,
IE9 complains "SCRIPT87: Invalid argument".
To insert newChild at the end, 2nd argument should be `null`.

http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-952280727
