### PR TITLE
Executor filtering in view

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixProject.java
+++ b/core/src/main/java/hudson/matrix/MatrixProject.java
@@ -167,10 +167,9 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
     @Override
     public Set<Label> getRelevantLabels() {
         Set<Label> r = new HashSet<Label>();
-        r.add(getAssignedLabel());
         for (MatrixConfiguration c : getActiveConfigurations())
             r.add(c.getAssignedLabel());
-        return super.getRelevantLabels();
+        return r;
     }
 
     public void setSorter(MatrixConfigurationSorter sorter) throws IOException {


### PR DESCRIPTION
The method getRelevantLabels() in hudson.model.MatrixProject class is not correct.
I wrote an explanation here https://github.com/jenkinsci/jenkins/pull/394#issuecomment-4337371
