### PR TITLE
Wrong url after renaming job

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1221,8 +1221,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         // send to the new job page
         // note we can't use getUrl() because that would pick up old name in the
         // Ancestor.getUrl()
-        rsp.sendRedirect2(req.getContextPath() + '/' + getParent().getUrl()
-                + getShortUrl());
+        rsp.sendRedirect2("../" + newName);
     }
 
     public void doRssAll(StaplerRequest req, StaplerResponse rsp)


### PR DESCRIPTION
If the user is in some view and click on some project in this view and rename this project, renaming action does not keep him in view, where was before.
Method doDoRename in hudson.model.Job send wrong url - rsp.sendRedirect2(req.getContextPath() + '/' + getParent().getUrl()  + getShortUrl()), this view is jenkins "default" view, but I think that a user wants stay in the view where was before.
