### PR TITLE
 ${BUILD_TAG} no longer unique when using hierarchical job model

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1894,7 +1894,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         env.put("HUDSON_SERVER_COOKIE",Util.getDigestOf("ServerID:"+ Jenkins.getInstance().getSecretKey())); // Legacy compatibility
         env.put("BUILD_NUMBER",String.valueOf(number));
         env.put("BUILD_ID",getId());
-        env.put("BUILD_TAG","jenkins-"+getParent().getName()+"-"+number);
+        env.put("BUILD_TAG","jenkins-"+getParent().getFullName().replace('/', '-')+"-"+number);
         env.put("JOB_NAME",getParent().getFullName());
         return env;
     }


### PR DESCRIPTION
sample : using cloudbees folder plugin
JOB_NAME = foo/bar/job
BUILD-TAG = jenkins-job-number
this change make later to be jenkins-foo-bar-job-number
