### PR TITLE
add http header for under firewall enviroment and proxy to cache

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -54,6 +54,7 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 <st:header name="Expires" value="0" />
+<st:header name="Cache-Control" value="no-cache,must-revalidate" />
 <st:header name="X-Hudson-Theme" value="default" />
 <st:contentType value="text/html;charset=UTF-8" />
 <!-- The path starts with a "/" character but does not end with a "/" character. -->


### PR DESCRIPTION
background:

I use Jenkins over the http proxy server.
The proxy server is caching contents, including Jenkins job configure.

  Server: CentOS 5.x, Apache 2.2.x, Jenkins 1.454
  Client: Windows XP SP3, Chrome 17

symptom:

I open the Job configuration page, sometime displayed configuration is too old.
And reload page, displayed current configuration.

expected:

Always display current configuration no reload.

fix:

add http header "cache-control".
I test this patch on the 1.455, I looked imploved.
