### PR TITLE
Fixes for breadcrumbs and prototype 1.7

### DIFF
--- a/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
@@ -49,7 +49,7 @@ THE SOFTWARE.
                       var div = document.createElement('div');
                       div.innerHTML = rsp.responseText;
 
-                      var rows = div.firstChild.rows;
+                      var rows = div.children[0].rows;
                       for(var i=0; i<rows.length; i++ ) {
                         var row = rows[i];
                         var target = document.getElementById(row.id);

--- a/core/src/main/resources/lib/layout/breadcrumbs.js
+++ b/core/src/main/resources/lib/layout/breadcrumbs.js
@@ -42,7 +42,7 @@ var breadcrumbs = (function() {
     });
 
 
-    Event.observe(window,"mousemove",function (ev){
+    Event.observe(document,"mousemove",function (ev){
         mouse = new YAHOO.util.Point(ev.pageX,ev.pageY);
     });
 

--- a/core/src/main/resources/lib/layout/rightspace.jelly
+++ b/core/src/main/resources/lib/layout/rightspace.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     Creates a space for the right-hand side of the page.
     This sticks to the right of the page even when the content overflows.
   </st:documentation>
-  <div style="position:absolute; top:2em; right:0px; padding-top:2em; padding-right:1em">
+  <div style="position:absolute; top:4em; right:0px; padding-top:2em; padding-right:1em">
     <d:invokeBody/>
   </div>
 </j:jelly>


### PR DESCRIPTION
This pull request contains 3 fixes for 1.455:
- [JENKINS-13082](https://issues.jenkins-ci.org/browse/JENKINS-13082): Breadcrumb popup menu gives javascript error on Internet Explorer 8
- Ajax on Update Center does not work in prototype 1.7
- 'View as plain text' in Console Output is hidden by the new breadcrums bar
