### PR TITLE
JENKINS-13185: Fix Computer.getHostName() to return the host.name value from the slave rather than null

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -905,9 +905,8 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
 
         // allow the administrator to manually specify the host name as a fallback. HUDSON-5373
         cachedHostName = channel.call(new GetFallbackName());
-
         hostNameCached = true;
-        return null;
+        return cachedHostName;
     }
 
     /**


### PR DESCRIPTION
Right now, null is always returned if falling back into the fallback name, but it should return the name.
