### PR TITLE
[JENKINS-13190] Add ACLPermissionOverride extension point

### DIFF
--- a/core/src/main/java/hudson/security/ACLPermissionOverride.java
+++ b/core/src/main/java/hudson/security/ACLPermissionOverride.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2012, Michael O'Cleirigh
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.security;
+
+import org.acegisecurity.Authentication;
+
+import hudson.ExtensionPoint;
+
+/**
+ * An ACLPermissionOverride provides a permission check that is applied within the base {@link ACL} class
+ * ahead of the ACL's own permision checking logic.
+ *
+ * <p>
+ * It provides a mechanism to grant requests that would normally be denied by the standard ACL.  For example to authorize
+ * certain plugin callback URL's without having to subclass the AuthorizationStrategy directly.
+ *
+ * <p>
+ * To create a custom permission override type, extend this class and put {@link Extension} on it.
+ *
+ * @author Michael O'Cleirigh
+ *
+ */
+public abstract class ACLPermissionOverride implements ExtensionPoint {
+
+        /**
+         * Checks if the given principle has the given permission.
+         *
+         * <p>
+         * @return true only if you want to override the default ACL permission check.
+         */
+        public abstract boolean checkPermission (Authentication a, Permission p);
+
+}


### PR DESCRIPTION
This is a new extension as documented in this jira issue: https://issues.jenkins-ci.org/browse/JENKINS-13190

It provides a way to override/grant additional permissions than are provided by a given ACL.

I plan to use it with the github-oauth-plugin to allow things like the github-webhook to work with any AuthorizationStrategy.  
