### PR TITLE
Fix for JENKINS-13200: 1.455: Block build when downstream project is building doesn't work

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1089,7 +1089,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
 
     public CauseOfBlockage getCauseOfBlockage() {
         // Block builds until they are done with post-production
-        if (isLogUpdated() && !isConcurrentBuild())
+        if (( isBuilding() || isLogUpdated() ) && !isConcurrentBuild())
             return new BecauseOfBuildInProgress(getLastBuild());
         if (blockBuildWhenDownstreamBuilding()) {
             AbstractProject<?,?> bup = getBuildingDownstream();


### PR DESCRIPTION
Fix blocking of builds unless job and any of its decendants are done (and if this options set in config). [JENKINS-13200]

I think the commit https://github.com/jenkinsci/jenkins/commit/d6a92f37f9111a68a5f13dc938fe60889eb7273 for Jenkins 1.455 broke that behavior.
