### PR TITLE
JENKINS-13217 Build Status page continues to show flashing "building" icons

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,6 +55,9 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
+  <li class=bug>
+    Build Status page continues to show flashing "building" icons after build completion.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13217">issue 13217</a>)  
 	<li class=bug>
  		New Breadcrumb bar covers search suggestions
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13195">issue 13195</a>)  

--- a/core/src/main/resources/lib/hudson/buildCaption.jelly
+++ b/core/src/main/resources/lib/hudson/buildCaption.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
 	    </div>
 	  </j:if>
 	  
-	  <img src="buildStatus" width="48" height="48" alt="${it.iconColor.description}" tooltip="${it.iconColor.description}" />
+	  <img src="${imagesURL}/48x48/${it.buildStatusUrl}" width="48" height="48" alt="${it.iconColor.description}" tooltip="${it.iconColor.description}" />
 	  <d:invokeBody />
 	</h1>
 </j:jelly>


### PR DESCRIPTION
... after build completion.

In this case I've inlined the buildStatus icon URL in the page URL because the status is also encoded in the tooltips etc.

Medium term some thought needs to be given to hudson.model.Job#doBuildStatus() and similar methods that use sendRedirect especially now that icons are being given a much longer expires time etc.
