### PR TITLE
Allow plugins to disable usage of Ant default excludes.

### DIFF
--- a/core/src/main/java/hudson/util/DirScanner.java
+++ b/core/src/main/java/hudson/util/DirScanner.java
@@ -83,9 +83,16 @@ public abstract class DirScanner implements Serializable {
     public static class Glob extends DirScanner {
         private final String includes, excludes;
 
+        private boolean useDefaultExcludes = true;
+
         public Glob(String includes, String excludes) {
             this.includes = includes;
             this.excludes = excludes;
+        }
+
+        public Glob(String includes, String excludes, boolean useDefaultExcludes) {
+            this(includes, excludes);
+            this.useDefaultExcludes = useDefaultExcludes;
         }
 
         public void scan(File dir, FileVisitor visitor) throws IOException {
@@ -96,6 +103,7 @@ public abstract class DirScanner implements Serializable {
             }
 
             FileSet fs = Util.createFileSet(dir,includes,excludes);
+            fs.setDefaultexcludes(useDefaultExcludes);
 
             if(dir.exists()) {
                 DirectoryScanner ds = fs.getDirectoryScanner(new org.apache.tools.ant.Project());

--- a/core/src/test/java/hudson/util/DirScannerTest.java
+++ b/core/src/test/java/hudson/util/DirScannerTest.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2011, Christoph Thelen
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.util;
+
+import java.io.File;
+import java.io.IOException;
+
+import hudson.FilePath;
+import hudson.Util;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Christoph Thelen
+ */
+public class DirScannerTest extends TestCase {
+
+    public void testGlobShouldUseDefaultExcludes() throws Exception {
+        FilePath tmp = new FilePath(Util.createTempDir());
+        try {
+            tmp.child(".gitignore").touch(0);
+            FilePath git = tmp.child(".git");
+            git.mkdirs();
+            git.child("HEAD").touch(0);
+            
+            DirScanner glob1 = new DirScanner.Glob("**/*", null);
+            DirScanner glob2 = new DirScanner.Glob("**/*", null, true);
+            MatchingFileVisitor gitdir = new MatchingFileVisitor("HEAD");
+            MatchingFileVisitor gitignore = new MatchingFileVisitor(".gitignore");
+            
+            glob1.scan(new File(tmp.getRemote()), gitdir);
+            glob2.scan(new File(tmp.getRemote()), gitignore);
+            
+            assertFalse(gitdir.found);
+            assertFalse(gitignore.found);
+        } finally {
+            tmp.deleteRecursive();
+        }
+    }
+    
+    public void testGlobShouldIgnoreDefaultExcludesByRequest() throws Exception {
+        FilePath tmp = new FilePath(Util.createTempDir());
+        try {
+            tmp.child(".gitignore").touch(0);
+            FilePath git = tmp.child(".git");
+            git.mkdirs();
+            git.child("HEAD").touch(0);
+            
+            DirScanner glob = new DirScanner.Glob("**/*", null, false);
+            MatchingFileVisitor gitdir = new MatchingFileVisitor("HEAD");
+            MatchingFileVisitor gitignore = new MatchingFileVisitor(".gitignore");
+            
+            glob.scan(new File(tmp.getRemote()), gitdir);
+            glob.scan(new File(tmp.getRemote()), gitignore);
+            
+            assertTrue(gitdir.found);
+            assertTrue(gitignore.found);
+        } finally {
+            tmp.deleteRecursive();
+        }
+    }
+    
+    private static class MatchingFileVisitor extends FileVisitor {
+    
+        public boolean found = false;
+        
+        public final String filename;
+        
+        public MatchingFileVisitor(String filename) {
+            this.filename = filename;
+        }
+    
+        public void visit(File f, String relativePath) throws IOException {
+            if (relativePath.endsWith(filename)) {
+                found = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is related to [JENKINS-9778] and [JENKINS-13165].

I implemented this with an additional constructor on class DirScanner.Glob, so it will not interfere with existing code. Also added two test cases for the default and the new behaviour.
