### PR TITLE
Add query parameter name to custom field check

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1917,7 +1917,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             return FormValidation.ok();
         }
 
-        public FormValidation doCheckCustomWorkspace(@QueryParameter String customWorkspace){
+        public FormValidation doCheckCustomWorkspace(@QueryParameter(value="customWorkspace.directory") String customWorkspace){
         	if(Util.fixEmptyAndTrim(customWorkspace)==null)
         		return FormValidation.error("Custom workspace is empty");
         	else


### PR DESCRIPTION
I've noticed in 1.457 that the custom workspace check kept saying it was empty, even after I've filled some value. Tested against the trunk today, and this seems to be a simple issue. 

I tested locally and it fixed the issue, could someone confirm if this commits is fine? Please :)

Thank you in advance, 
Bruno
