### PR TITLE
[JENKINS-15297] Add explicit charset declaration to summary page to prevent stacktrace from being displayed mangled

### DIFF
--- a/core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
+++ b/core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:contentType value="text/plain"/>
+  <st:contentType value="text/plain;charset=UTF-8"/>
   <j:choose>
 		<j:when test="${it.errorDetails!=null}">
 			<h3>${%Error Details}</h3>


### PR DESCRIPTION
By applying this patch, summary page (loaded dynamically by clicking on the ">>>" link of the test report) now declares his charset (UTF-8) explicitly, instead of the default ISO-8859-1.

Without the explicit charset declaration, stacktrace is displayed mangled (moji-bake) when it contains non-ASCII characters such as Japanese.

Confirmed on Firefox 11.0 & IE 8.0, both running on Windows 7 (Japanese).
