### PR TITLE
Remove XML string writer from IOException2 when XPath error occurs.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=bug>
+    Fixed: XML API Logs Too Much Information When Invalid Char is Present
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13378">issue 13378</a>)
+  <li class=bug>
     Fixed: tests with the same name are no longer counted correctly.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13214">issue 13214</a>)
   <li class=rfe>

--- a/core/src/main/java/hudson/model/Api.java
+++ b/core/src/main/java/hudson/model/Api.java
@@ -44,6 +44,8 @@ import java.io.OutputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Used to expose remote access API for ".../api/"
@@ -139,7 +141,8 @@ public class Api extends AbstractModelObject {
             }
 
         } catch (DocumentException e) {
-            throw new IOException2("Failed to do XPath/wrapper handling.",e);
+            LOGGER.log(Level.FINER, "Failed to do XPath/wrapper handling. XML is as follows:"+sw, e);
+            throw new IOException2("Failed to do XPath/wrapper handling. Turn on FINER logging to view XML.",e);
         }
 
         OutputStream o = rsp.getCompressedOutputStream(req);
@@ -188,5 +191,6 @@ public class Api extends AbstractModelObject {
         rsp.serveExposedBean(req,bean, Flavor.PYTHON);
     }
 
+    private static final Logger LOGGER = Logger.getLogger(Api.class.getName());
     private static final ModelBuilder MODEL_BUILDER = new ModelBuilder();
 }

--- a/core/src/main/java/hudson/model/Api.java
+++ b/core/src/main/java/hudson/model/Api.java
@@ -139,7 +139,7 @@ public class Api extends AbstractModelObject {
             }
 
         } catch (DocumentException e) {
-            throw new IOException2("Failed to do XPath/wrapper handling. XML is as follows:"+sw,e);
+            throw new IOException2("Failed to do XPath/wrapper handling.",e);
         }
 
         OutputStream o = rsp.getCompressedOutputStream(req);


### PR DESCRIPTION
Remove XML string writer from IOException2 message when XPath error
occurs in /api/xml request.

The XML string writer has the potential to be very large (many
megabytes or even gigabytes) and these exceptions will be logged to
the default jenkins logfile by winstone. This has the potential to
quickly use all available disk space if, for example, a jenkins poller
(i.e. a chrome extension) makes frequent calls to the API that causes
errors.

This is a quick fix to address a specific issue I am having. It doesn't
address the issue of managing very long log messages in general.

Thanks for the consideration!
