### PR TITLE
[JENKINS-13423] Environment Variables documentation missing GIT_COMMIT and GIT_BRANCH

### DIFF
--- a/war/src/main/webapp/env-vars.html
+++ b/war/src/main/webapp/env-vars.html
@@ -60,6 +60,15 @@
     <dt>CVS_BRANCH</dt>
     <dd>For CVS-based projects, this variable contains the branch of the module.
         If CVS is configured to check out the trunk, this environment variable will not be set.</dd>
+
+    <dt>GIT_COMMIT</dt>
+    <dd>For Git-based projects, this variable contains the SHA-1 hash of the commit checked out for
+        the build.</dd>
+
+    <dt>GIT_BRANCH</dt>
+    <dd>For Git-based projects, this variable contains the Git branch that was checked out for
+        the build (normally master).</dd>
+
 </dl>
 
 


### PR DESCRIPTION
This commit adds documentation for these, copied from the [Jenkins Wiki](https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables) but with "Gitish" replaced with "SHA-1 hash".
