### PR TITLE
Extension point for adding actions into build page

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -884,26 +884,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     public Calendar due() {
         return getTimestamp();
     }
-    
-     /**
-     * Add all transient action for this build
-     * 
-     */
-    protected List<Action> createTransientActions() {
-        Vector<Action> ta = new Vector<Action>();
-        for (TransientBuildActionFactory tpaf : TransientBuildActionFactory.all())
-            ta.addAll(Util.fixNull(tpaf.createFor(this)));
-        return ta;
-    }    
-
-    // commented out until fixed problem with adding actions, see discussion under https://github.com/jenkinsci/jenkins/pull/421
-/*    @Override
-    public List<Action> getActions() {
-        List<Action> actions = new CopyOnWriteArrayList<Action>(super.getActions());
-        actions.addAll(createTransientActions());
-        return actions;
-    }
-*/    
+      
     public List<Action> getPersistentActions(){
         return super.getActions();
     }

--- a/core/src/main/java/hudson/model/TransientBuildActionFactory.java
+++ b/core/src/main/java/hudson/model/TransientBuildActionFactory.java
@@ -7,7 +7,7 @@ import jenkins.model.Jenkins;
 import java.util.Collection;
 
 /**
- * Extension point for inserting transient {@link Action}s into {@link AbstractBuild}s.
+ * Extension point for inserting transient {@link Action}s into {@link Run}s.
  *
  * To register your implementation, put {@link Extension} on your subtype.
  *
@@ -20,10 +20,10 @@ public abstract class TransientBuildActionFactory implements ExtensionPoint {
     /**
      * Creates actions for the given build.
      *
-     * @param project for which the action objects are requested. Never null.
+     * @param Build for which the action objects are requested. Never null.
      * @return Can be empty but must not be null.
      */
-    public abstract Collection<? extends Action> createFor(AbstractBuild target);
+    public abstract Collection<? extends Action> createFor(Run target);
 
     /**
      * Returns all the registered {@link TransientBuildActionFactory}s.

--- a/core/src/main/resources/hudson/model/AbstractBuild/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/sidepanel.jelly
@@ -33,6 +33,15 @@ THE SOFTWARE.
       <j:set var="buildUrl" value="${h.decompose(request)}" />
       <st:include page="tasks.jelly"/>
       <st:include page="actions.jelly" />
+      <!-- add transient actions too -->
+      <j:forEach var="action" items="${it.transientActions}">          
+        <st:include page="action.jelly" from="${action}" optional="true">
+            <j:if test="${action.iconFileName!=null}">
+                <l:task icon="${h.getIconFilePath(action)}" title="${action.displayName}"
+                href="${h.getActionUrl(it.url,action)}" />
+            </j:if>
+        </st:include>
+      </j:forEach>
       <j:if test="${it.previousBuild!=null}">
         <l:task icon="images/24x24/previous.png" href="${buildUrl.previousBuildUrl}" title="${%Previous Build}" contextMenu="false"/>
       </j:if>


### PR DESCRIPTION
Solve previous problem with adding the transient build actions by override method getActions() in hudson.mode.AbstractBuild class.
More information about this problem is here https://github.com/jenkinsci/jenkins/pull/421
