### PR TITLE
[FIXED JENKINS-8663] Flag -U is not used during the parsing step of a Maven Job

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=bug>
+    Flag -U is not used during the parsing step of a Maven Job
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-8663">issue 8663</a>)
+  <li class=bug>
     Custom workspace validation not working.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13404">issue 13404</a>)
 </ul>

--- a/maven-plugin/src/main/java/hudson/maven/MavenEmbedderRequest.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenEmbedderRequest.java
@@ -83,6 +83,11 @@ public class MavenEmbedderRequest
      * @since 1.426
      */
     private File globalSettings;
+
+    /**
+     * @since 1.461
+     */
+    private boolean updateSnapshots;
     
     /**
      * @param listener
@@ -223,5 +228,14 @@ public class MavenEmbedderRequest
     public MavenEmbedderRequest setGlobalSettings( File globalSettings ) {
         this.globalSettings = globalSettings;
         return this;
+    }
+
+    public MavenEmbedderRequest setUpdateSnapshots(boolean updateSnapshots) {
+      this.updateSnapshots = updateSnapshots;
+      return this;
+    }
+    
+    public boolean isUpdateSnapshots() {
+      return updateSnapshots;
     }
 }

--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -1069,6 +1069,8 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
         
         private int mavenValidationLevel = -1;
         
+        private boolean updateSnapshots = false;
+        
         String rootPOMRelPrefix;
         
         public PomParser(BuildListener listener, MavenInstallation mavenHome, String mavenVersion, EnvVars envVars, MavenModuleSetBuild build) {
@@ -1079,6 +1081,7 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
             this.rootPOM = project.getRootPOM();
             this.profiles = project.getProfiles();
             this.properties = project.getMavenProperties();
+            this.updateSnapshots = isUpdateSnapshots(project.getGoals());
             ParametersDefinitionProperty parametersDefinitionProperty = project.getProperty( ParametersDefinitionProperty.class );
             if (parametersDefinitionProperty != null && parametersDefinitionProperty.getParameterDefinitions() != null) {
                 for (ParameterDefinition parameterDefinition : parametersDefinitionProperty.getParameterDefinitions()) {
@@ -1121,6 +1124,10 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
         }
 
         
+        private boolean isUpdateSnapshots(String goals) {
+          return StringUtils.contains(goals, "-U") || StringUtils.contains(goals, "--update-snapshots");
+        }
+
         public List<PomInfo> invoke(File ws, VirtualChannel channel) throws IOException {
             File pom;
             
@@ -1186,6 +1193,7 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
                                                                                       profiles, properties,
                                                                                       privateRepository, settingsLoc );
                 mavenEmbedderRequest.setTransferListener( new SimpleTransferListener(listener) );
+                mavenEmbedderRequest.setUpdateSnapshots( this.updateSnapshots );
                 
                 mavenEmbedderRequest.setProcessPlugins( this.processPlugins );
                 mavenEmbedderRequest.setResolveDependencies( this.resolveDependencies );

--- a/maven-plugin/src/main/java/hudson/maven/MavenUtil.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenUtil.java
@@ -176,6 +176,8 @@ public class MavenUtil {
             mavenRequest.setWorkspaceReader( mavenEmbedderRequest.getWorkspaceReader() );
         }
         
+        mavenRequest.setUpdateSnapshots(mavenEmbedderRequest.isUpdateSnapshots());
+
         // TODO olamy check this sould be userProperties 
         mavenRequest.setSystemProperties(mavenEmbedderRequest.getSystemProperties());
 


### PR DESCRIPTION
If the -U flag is specified in the goals/options of the build step of a
Maven job, it should be used as well in the parsing step. The current implementation can lead to failing builds, only because the parsing step doesn't update snapshots, despite the -U option being set in the goals list.
