### PR TITLE
[JENKINS-13526] use '@' prefix to force PAM to interpret the user/group ...

### DIFF
--- a/core/src/main/java/hudson/security/PAMSecurityRealm.java
+++ b/core/src/main/java/hudson/security/PAMSecurityRealm.java
@@ -104,12 +104,18 @@ public class PAMSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 
     @Override
     public GroupDetails loadGroupByGroupname(final String groupname) throws UsernameNotFoundException, DataAccessException {
-        if(CLibrary.libc.getgrnam(groupname)==null)
-            throw new UsernameNotFoundException(groupname);
+        final String group;
+        if(groupname.startsWith("@")) {
+            group = groupname.substring(1);
+        } else {
+            group = groupname;
+        }
+        if(CLibrary.libc.getgrnam(group)==null)
+            throw new UsernameNotFoundException(group);
         return new GroupDetails() {
             @Override
             public String getName() {
-                return groupname;
+                return group;
             }
         };
     }


### PR DESCRIPTION
...as a group

This is a very basic patch that will let PAM interpret user/groups that begin with '@' as a group.
For example, if I have a unix user named 'dev' and a unix group named 'dev', I will be able to explicitly select the group in matrix authorization configs by specifying '@dev'. Without this patch, there would be no way to select the group instead of the user.

I wasn't sure where to document this in the built-in help docs, so there isn't any documentation for this new feature so far. Another idea might be a good idea to move this code up a level, so that all security realms can benefit instead of just PAM, but I'm unsure as to what the repercussions would be.
