### PR TITLE
CauseOfBlockage not displayed when build blocked by QueueTaskDispatcher.canRun()

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1493,6 +1493,13 @@ public class Queue extends ResourceController implements Saveable {
                     return CauseOfBlockage.fromMessage(Messages._Queue_InProgress());
                 return CauseOfBlockage.fromMessage(Messages._Queue_BlockedBy(r.getDisplayName()));
             }
+            
+            for (QueueTaskDispatcher d : QueueTaskDispatcher.all()) {
+                CauseOfBlockage cause = d.canRun(this);
+                if (cause != null)
+                    return cause;
+            }
+            
             return task.getCauseOfBlockage();
         }
     }

--- a/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
+++ b/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
@@ -1,0 +1,35 @@
+package hudson.model.queue;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Queue.Item;
+
+import org.jvnet.hudson.test.HudsonTestCase;
+
+public class QueueTaskDispatcherTest extends HudsonTestCase {
+
+    @SuppressWarnings("deprecation")
+    public void testCanRunBlockageIsDisplayed() throws Exception {
+        QueueTaskDispatcher.all().add(new QueueTaskDispatcher() {
+            @Override
+            public CauseOfBlockage canRun(Item item) {
+                return new CauseOfBlockage() {
+
+                    @Override
+                    public String getShortDescription() {
+                        return "blocked by canRun";
+                    }
+                };
+            }
+        });
+        FreeStyleProject project = createFreeStyleProject();
+        jenkins.getQueue().schedule(project);
+
+        Item item = jenkins.getQueue().getItem(project);
+        for (int i = 0; i < 4 * 60 && !item.isBlocked(); i++) {
+            Thread.sleep(250);
+            item = jenkins.getQueue().getItem(project);
+        }
+        assertTrue("Not blocked after 60 seconds", item.isBlocked());
+        assertEquals("Expected CauseOfBlockage to be returned", "blocked by canRun", item.getWhy());
+    }
+}


### PR DESCRIPTION
If a QueueTaskDispatcher returns a CauseOfBlockage for canRun(), the build is blocked, but no reason is given. This patch adds a test to verify the fix.

This bug highlights a problem in code reuse between Queue.isBuildBlocked() and Item.getCauseOfBlockage(), but such refactoring is beyond the scope of this patch.
