### PR TITLE
[FIXED JENKINS-7806] changed wording of "slave back online" button

### DIFF
--- a/core/src/main/resources/hudson/model/Computer/index.properties
+++ b/core/src/main/resources/hudson/model/Computer/index.properties
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-submit.temporarilyOffline=This node is back online
+submit.temporarilyOffline=Bring this node back online
 submit.not.temporarilyOffline=Mark this node temporarily offline
 title.projects_tied_on=Projects tied to {0}
-title.no_manual_launch=This node has an availability policy that will "{0}". Currently, this mandates that the node be off-line.
+title.no_manual_launch=This node has an availability policy that will "{0}". Currently, this mandates that the node be offline.
 


### PR DESCRIPTION
Changed from
  "This node is back online"
to
  "Bring this node back online"
