### PR TITLE
Make security tables nowrap on both ends. Just looks prettier.

### DIFF
--- a/core/src/main/resources/hudson/security/table.css
+++ b/core/src/main/resources/hudson/security/table.css
@@ -49,10 +49,12 @@
 .global-matrix-authorization-strategy-table TD.left-most {
   text-align: left;
   border-left: none;
+  white-space: nowrap;
 }
 
 .global-matrix-authorization-strategy-table TD.stop {
   border-top: 1px solid white;
   border-right: 1px solid white;
   border-bottom: 1px solid white;
+  white-space: nowrap;
 }


### PR DESCRIPTION
This CSS change makes the left-most and stop elements of the security table white-space: nowrap; which removes a lot of noise in the browser when the table gets wide.
