### PR TITLE
Don't try to chmod symlinks when unpacking tars

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1801,7 +1801,8 @@ public final class FilePath implements Serializable {
                     if (parent != null) parent.mkdirs();
 
                     byte linkFlag = (Byte) LINKFLAG_FIELD.get(te);
-                    if (linkFlag==TarEntry.LF_SYMLINK) {
+                    boolean isSymlink = (linkFlag==TarEntry.LF_SYMLINK);
+                    if (isSymlink) {
                         new FilePath(f).symlinkTo(te.getLinkName(), TaskListener.NULL);
                     } else {
                         IOUtils.copy(t,f);
@@ -1810,7 +1811,8 @@ public final class FilePath implements Serializable {
                     f.setLastModified(te.getModTime().getTime());
                     int mode = te.getMode()&0777;
                     if(mode!=0 && !Functions.isWindows()) // be defensive
-                        _chmod(f,mode);
+                        if (!isSymlink) // symlinks don't have modes, fixes 13280
+                            _chmod(f,mode);
                 }
             }
         } catch(IOException e) {


### PR DESCRIPTION
Fix for Jenkins 13280: https://issues.jenkins-ci.org/browse/JENKINS-13280

Symlinks don't have their own file modes; chmod-ing a symlink sets the mode on the link target.  If the link target doesn't exist (which is very likely in a tar extract if the target is 'later') then this blows up.

Just skip chmod on symlinks; the target will presumably have its own chmod set when it is extracted.
