### PR TITLE
Cancel configurations for adding to a queue

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/core/src/main/java/hudson/matrix/MatrixBuild.java
@@ -269,7 +269,10 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
             listUpAggregators(listener, p.getBuildWrappers().values());
 
             axes = p.getAxes();
-
+            
+            for(MatrixConfiguration c: getParent().getActiveConfigurations()){
+                c.setWaiting(true); // configuration waiting for adding to a queue
+            }           
             try {
                 return p.getExecutionStrategy().run(MatrixBuild.this, aggregators, listener);
             } catch( InterruptedException e ) {

--- a/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
@@ -23,6 +23,7 @@
  */
 package hudson.widgets;
 
+import hudson.matrix.MatrixConfiguration;
 import jenkins.model.Jenkins;
 import hudson.model.Queue.Item;
 import hudson.model.Queue.Task;
@@ -63,5 +64,14 @@ public class BuildHistoryWidget<T> extends HistoryWidget<Task,T> {
     	List<Item> list = new ArrayList<Item>(Jenkins.getInstance().getQueue().getItems(owner));
     	Collections.reverse(list);
     	return list;
+    }
+    
+    /**
+     * Returns true if the configuration waiting for adding to a queue
+     */
+    public boolean isWaiting(){
+        if(owner instanceof MatrixConfiguration)
+            return ((MatrixConfiguration)owner).isWaiting();        
+        return false;
     }
 }

--- a/core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
+++ b/core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
@@ -63,6 +63,25 @@ THE SOFTWARE.
       </tr>
     </j:forEach>
   </j:if>
+  <j:if test="${it.isWaiting()}">
+      <tr class="build-row transitive" id="${id}">
+        <td nowrap="nowrap">
+          <img width="16" height="16" src="${imagesURL}/16x16/grey.png" alt="${%pending}"/>
+          <st:nbsp/>
+          #${it.owner.getParent().getLastBuild().getNumber()}
+        </td>
+        <td style="white-space:normal;" colspan="2">
+          <div style="float:right">
+           <j:if test="${empty(it.owner.ABORT) ? h.hasPermission(app.ADMINISTER) : it.owner.hasPermission(it.owner.ABORT)}">
+              <a href="${rootURL}/${it.owner.getUrl()}/cancelWaiting">
+                <img src="${imagesURL}/16x16/stop.png" alt="stop waiting" height="16" width="16"/>
+              </a>
+           </j:if>
+          </div>
+          (waiting until other configuration is build)
+        </td>
+      </tr>
+  </j:if>
 
   <st:include page="/hudson/widgets/HistoryWidget/entries.jelly" />
 </j:jelly>


### PR DESCRIPTION
If the configurations are run sequentially, it is not possible to cancel a configuration before it is added into a queue. I think the the user should be able to cancel configuration waiting for adding into a queue as he can cancel configuration waiting in a queue for executor.

I add attribut waiting into class MatrixConfiguration. This attribut has value true if a configuration will be added into a queue (the build start) and value false if the configuration was added into a queue, the build was stopped, or a user cancel the configuration.
