### PR TITLE
Correction of returned url

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixBuild.java
+++ b/core/src/main/java/hudson/matrix/MatrixBuild.java
@@ -123,6 +123,16 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
         public MatrixRun getRun() {
             return MatrixBuild.this.getRun(combination);
         }
+        
+        /**
+        * Return absolute url of run {@link MatrixRun} which belongs to a given build {@link MatrixBuild}. 
+        * If there is no run which belongs to the build, return url of run, which belongs to the nearest previous build.
+        *
+        */
+        public String getNearestRunUrl(){           
+            String url = Jenkins.getInstance().getRootUrl() + getRun().getUrl();
+            return url;
+        }
 
         public String getShortUrl() {
             return Util.rawEncode(combination.toString());
@@ -235,7 +245,7 @@ public class MatrixBuild extends AbstractBuild<MatrixProject,MatrixBuild> {
     public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
         try {
             MatrixRun item = getRun(Combination.fromString(token));
-            if(item!=null)
+            if(item!=null && item.getNumber()==this.getNumber()) //do not return run of other matrix build
                 return item;
         } catch (IllegalArgumentException _) {
             // failed to parse the token as Combination. Must be something else

--- a/core/src/main/resources/hudson/matrix/MatrixBuild/ajaxMatrix.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixBuild/ajaxMatrix.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
           <img src="${imagesURL}/24x24/grey.png" tooltip="${%Not run}" alt="${%Not run}" height="24" width="24"/>
         </j:when>
         <j:otherwise>
-          <a href="${p.shortUrl}/" class="model-link">
+          <a href="${p.nearestRunUrl}/" class="model-link">
             <img src="${imagesURL}/24x24/${b.buildStatusUrl}" tooltip="${p.tooltip} ${it.number!=b.number?(it.isBuilding()?'- pending' : '- skipped'):''}" alt="${p.tooltip}" style="${it.number!=b.number?'opacity:0.5':''}" height="24" width="24"/>
             <j:if test="${empty(o.x) and empty(o.y)}">
               ${p.combination.toString(o.z)}


### PR DESCRIPTION
Jelly file hudson.matrix.MatrixBuild.ajaxMatrix.jelly has wrong url for matrix run. 
If a job is runnig and a user click on the build, the page of MatrixBuild contains configurations which has an image like a link to the run. This link is wrong, but return page for right object.
For example we have matrix job with name Matrix and option "run sequentially", and we ran 5. build. We click on the link to 5. build and see configurations with names a,b,c,d and the configuration a is running. We click on the configuration b and see the url is /job/Matrix/5/label=b, but there can not be run 5 for configuration b (because does not exist), there is run 4 for configuration label=b, it is misleading. And another problem is that method getDynamic() return for run url run which does not belong to this build.
So I add condition to method getDynamic() and create method getNearestRunUrl() which return right url.
