### PR TITLE
[FIXED JENKINS-13429] Nested views not showing up with just read perms for View

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -61,6 +61,9 @@ Upcoming changes</a>
   <li class=bug>
     Fixed a regression in 1.462 that introduced Java6 dependency.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13659">issue 13659</a>)
+  <li class=bug>
+    Fixed nested view not showing up with just read perm for View
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13429">issue 13429</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/security/AuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/AuthorizationStrategy.java
@@ -99,11 +99,12 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
             public boolean hasPermission(Authentication a, Permission permission) {
                 ACL base = item.getOwner().getACL();
 
-                if (permission==View.READ) {
+                boolean hasPermission = base.hasPermission(a, permission);
+                if (!hasPermission && permission == View.READ) {
                     return base.hasPermission(a,View.CONFIGURE) || !item.getItems().isEmpty();
                 }
 
-                return base.hasPermission(a, permission);
+                return hasPermission;
             }
         };
     }


### PR DESCRIPTION
Backward compatibility is preventing the View.READ permission to apply
correctly. It actually overrides the View.READ instead of complementing
it.

This change only applies default READ right if the View.READ is not
available, and the user has View.CONFIGURE + the view is not empty.
