### PR TITLE
[FIXED JENKINS-13202] Don't set mtime or mode on symlinks

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1812,12 +1812,12 @@ public final class FilePath implements Serializable {
                         new FilePath(f).symlinkTo(te.getLinkName(), TaskListener.NULL);
                     } else {
                         IOUtils.copy(t,f);
+
+                        f.setLastModified(te.getModTime().getTime());
+                        int mode = te.getMode()&0777;
+                        if(mode!=0 && !Functions.isWindows()) // be defensive
+                            _chmod(f,mode);
                     }
-                    
-                    f.setLastModified(te.getModTime().getTime());
-                    int mode = te.getMode()&0777;
-                    if(mode!=0 && !Functions.isWindows()) // be defensive
-                        _chmod(f,mode);
                 }
             }
         } catch(IOException e) {

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -365,8 +365,8 @@ public class FilePathTest extends ChannelTestCase {
         try {
             FilePath in = tmp.child("in");
             in.mkdirs();
-            in.child("a").touch(0);
-            in.child("b").symlinkTo("a", TaskListener.NULL);
+            in.child("c").touch(0);
+            in.child("b").symlinkTo("c", TaskListener.NULL);
                         
             FilePath tar = tmp.child("test.tar");
             in.tar(tar.write(), "**/*");
@@ -374,7 +374,7 @@ public class FilePathTest extends ChannelTestCase {
             FilePath dst = in.child("dst");
             tar.untar(dst, TarCompression.NONE);
 
-            assertEquals("a",dst.child("b").readLink());
+            assertEquals("c",dst.child("b").readLink());
         } finally {
             tmp.deleteRecursive();
         }


### PR DESCRIPTION
Previously, the untar code tries to set the last modified time and mode
on every untarred file.  However, if the tar contains a broken symlink,
or a symlink that points to a file that has not been untarred yet, the
time/mode setting would fail on the broken symlink.

Symlinks don't have meaningful modified times or modes of their own, so
only set these values on non-symlinks.

Rename the file "a" in the test to expose the bug.
