### PR TITLE
Enable ant default excludes to be turned off.

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1368,9 +1368,24 @@ public final class FilePath implements Serializable {
      * @since 1.407
      */
     public FilePath[] list(final String includes, final String excludes) throws IOException, InterruptedException {
+        return list(includes, excludes, true);
+    }
+
+    /**
+     * List up files in this directory that matches the given Ant-style filter.
+     *
+     * @param includes
+     * @param excludes
+     *      See {@link FileSet} for the syntax. String like "foo/*.zip" or "foo/*&#42;/*.xml"
+     * @param defaultExcludes whether to use the ant default excludes
+     * @return
+     *      can be empty but always non-null.
+     * @since 1.465
+     */
+    public FilePath[] list(final String includes, final String excludes, final boolean defaultExcludes) throws IOException, InterruptedException {
         return act(new FileCallable<FilePath[]>() {
             public FilePath[] invoke(File f, VirtualChannel channel) throws IOException {
-                String[] files = glob(f,includes,excludes);
+                String[] files = glob(f, includes, excludes, defaultExcludes);
 
                 FilePath[] r = new FilePath[files.length];
                 for( int i=0; i<r.length; i++ )
@@ -1387,10 +1402,11 @@ public final class FilePath implements Serializable {
      * @return
      *      A set of relative file names from the base directory.
      */
-    private static String[] glob(File dir, String includes, String excludes) throws IOException {
+    private static String[] glob(File dir, String includes, String excludes, boolean defaultExcludes) throws IOException {
         if(isAbsolute(includes))
             throw new IOException("Expecting Ant GLOB pattern, but saw '"+includes+"'. See http://ant.apache.org/manual/Types/fileset.html for syntax");
         FileSet fs = Util.createFileSet(dir,includes,excludes);
+        fs.setDefaultexcludes(defaultExcludes);
         DirectoryScanner ds = fs.getDirectoryScanner(new Project());
         String[] files = ds.getIncludedFiles();
         return files;

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -301,7 +301,23 @@ public class FilePathTest extends ChannelTestCase {
             Util.deleteRecursive(baseDir);
         }
     }
-    
+
+    public void testListWithDefaultExcludes() throws Exception {
+        File baseDir = Util.createTempDir();
+        try {
+            final Set<FilePath> expected = new HashSet<FilePath>();
+            expected.add(createFilePath(baseDir, "top", "sub", "backup~"));
+            expected.add(createFilePath(baseDir, "top", "CVS", "somefile,v"));
+            expected.add(createFilePath(baseDir, "top", ".git", "config"));
+            // none of the files are included by default (default includes true)
+            assertEquals(0, new FilePath(baseDir).list("**", "").length);
+            final FilePath[] result = new FilePath(baseDir).list("**", "", false);
+            assertEquals(expected, new HashSet<FilePath>(Arrays.asList(result)));
+        } finally {
+            Util.deleteRecursive(baseDir);
+        }
+    }
+
     @Bug(11073)
     public void testIsUnix() {
         FilePath winPath = new FilePath(new LocalChannel(null),


### PR DESCRIPTION
Add a new overload method to list files that include the files that ant excludes by default.
