### PR TITLE
Build checkout ext

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixConfiguration.java
+++ b/core/src/main/java/hudson/matrix/MatrixConfiguration.java
@@ -32,6 +32,7 @@ import hudson.model.CauseAction;
 import hudson.model.DependencyGraph;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
+import hudson.model.BuildCheckoutStrategy;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.JDK;
@@ -160,6 +161,14 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
     @Override
     public int getScmCheckoutRetryCount() {
         return getParent().getScmCheckoutRetryCount();
+    }
+    
+    /**
+     * Inherit the value from the parent.
+     */
+    @Override
+    public BuildCheckoutStrategy getBuildCheckoutStrategy() {
+        return getParent().getBuildCheckoutStrategy();
     }
 
     @Override

--- a/core/src/main/java/hudson/matrix/MatrixProject.java
+++ b/core/src/main/java/hudson/matrix/MatrixProject.java
@@ -41,6 +41,7 @@ import hudson.model.Items;
 import hudson.model.JDK;
 import hudson.model.Job;
 import hudson.model.Label;
+import hudson.model.BuildCheckoutStrategyDescriptor;
 import hudson.model.Queue.FlyweightTask;
 import hudson.model.Result;
 import hudson.model.SCMedItem;
@@ -790,6 +791,10 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
 
         public List<MatrixExecutionStrategyDescriptor> getExecutionStrategyDescriptors() {
             return MatrixExecutionStrategyDescriptor.all();
+        }
+        
+        public List<BuildCheckoutStrategyDescriptor> getBuildCheckoutStrategyDescriptors() {
+            return BuildCheckoutStrategyDescriptor.all();
         }
     }
 

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -26,6 +26,7 @@ package hudson.model;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import hudson.AbortException;
+import hudson.BulkChange;
 import hudson.EnvVars;
 import hudson.Functions;
 import hudson.Launcher;
@@ -39,8 +40,12 @@ import hudson.slaves.WorkspaceList;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.WorkspaceList.Lease;
 import hudson.matrix.MatrixConfiguration;
+import hudson.matrix.MatrixExecutionStrategy;
+import hudson.matrix.MatrixExecutionStrategyDescriptor;
+import hudson.model.Descriptor.FormException;
 import hudson.model.Fingerprint.BuildPtr;
 import hudson.model.Fingerprint.RangeSet;
+import hudson.model.Run.RunnerAbortedException;
 import hudson.model.listeners.SCMListener;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.ChangeLogSet;
@@ -61,10 +66,15 @@ import hudson.util.Iterators;
 import hudson.util.LogTaskListener;
 import hudson.util.VariableResolver;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.xml.sax.SAXException;
 
 import javax.servlet.ServletException;
@@ -128,9 +138,9 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
      * SCM used for this build.
      * Maybe null, for historical reason, in which case CVS is assumed.
      */
-    private ChangeLogParser scm;
+    private ChangeLogParser scm;   
 
-    /**
+	/**
      * Changes in this build.
      */
     private volatile transient WeakReference<ChangeLogSet<? extends Entry>> changeSet;
@@ -155,7 +165,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
      * {@link BuildWrapper}. This design is bit ugly but forced due to compatibility.
      */
     protected transient List<Environment> buildEnvironments;
-
+    
     protected AbstractBuild(P job) throws IOException {
         super(job);
     }
@@ -222,6 +232,14 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     public AbstractBuild<?,?> getRootBuild() {
         return this;
     }
+    
+    protected ChangeLogParser getScm() {
+		return scm;
+	}
+
+	protected void setScm(ChangeLogParser scm) {
+		this.scm = scm;
+	}
 
     /**
      * Used to render the side panel "Back to project" link.
@@ -409,7 +427,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     private void createSymlink(TaskListener listener, String name) throws InterruptedException {
         Util.createSymlink(getProject().getBuildDir(),"builds/"+getId(),"../"+name,listener);
     }
-
+        
     protected abstract class AbstractRunner extends Runner {
         /**
          * Since configuration can be changed while a build is in progress,
@@ -470,7 +488,8 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 
                 for (WorkspaceListener wl : WorkspaceListener.all()) {
                     wl.beforeUse(AbstractBuild.this, lease.path, listener);
-                }
+                }                            
+                
                 preCheckout(launcher,listener);
                 checkout(listener);
 
@@ -567,48 +586,12 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
          * @throws IOException
          * @throws InterruptedException
          */
-        private void preCheckout(Launcher launcher, BuildListener listener) throws IOException, InterruptedException{
-        	if (project instanceof BuildableItemWithBuildWrappers) {
-                BuildableItemWithBuildWrappers biwbw = (BuildableItemWithBuildWrappers) project;
-                for (BuildWrapper bw : biwbw.getBuildWrappersList())
-                    bw.preCheckout(AbstractBuild.this,launcher,listener);
-            }
+        protected void preCheckout(Launcher launcher, BuildListener listener) throws IOException, InterruptedException{
+        	project.getBuildCheckoutStrategy().preCheckout(AbstractBuild.this, launcher, listener);
         }
         
-        private void checkout(BuildListener listener) throws Exception {
-                for (int retryCount=project.getScmCheckoutRetryCount(); ; retryCount--) {
-                    // for historical reasons, null in the scm field means CVS, so we need to explicitly set this to something
-                    // in case check out fails and leaves a broken changelog.xml behind.
-                    // see http://www.nabble.com/CVSChangeLogSet.parse-yields-SAXParseExceptions-when-parsing-bad-*AccuRev*-changelog.xml-files-td22213663.html
-                    AbstractBuild.this.scm = NullChangeLogParser.INSTANCE;
-
-                    try {
-                        if (project.checkout(AbstractBuild.this,launcher,listener,new File(getRootDir(),"changelog.xml"))) {
-                            // check out succeeded
-                            SCM scm = project.getScm();
-
-                            AbstractBuild.this.scm = scm.createChangeLogParser();
-                            AbstractBuild.this.changeSet = new WeakReference<ChangeLogSet<? extends Entry>>(AbstractBuild.this.calcChangeSet());
-
-                            for (SCMListener l : Jenkins.getInstance().getSCMListeners())
-                                l.onChangeLogParsed(AbstractBuild.this,listener,getChangeSet());
-                            return;
-                        }
-                    } catch (AbortException e) {
-                        listener.error(e.getMessage());
-                    } catch (InterruptedIOException e) {
-                        throw (InterruptedException)new InterruptedException().initCause(e);
-                    } catch (IOException e) {
-                        // checkout error not yet reported
-                        e.printStackTrace(listener.getLogger());
-                    }
-
-                    if (retryCount == 0)   // all attempts failed
-                        throw new RunnerAbortedException();
-
-                    listener.getLogger().println("Retrying after 10 seconds");
-                    Thread.sleep(10000);
-                }
+        protected void checkout(BuildListener listener) throws Exception {
+        	project.getBuildCheckoutStrategy().checkout(AbstractBuild.this, launcher, listener);
         }
 
         /**
@@ -765,6 +748,10 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
      */
     private transient Object changeSetLock = new Object();
     
+    protected void setChangeSet(WeakReference<ChangeLogSet<? extends Entry>> changeSet) {
+    	this.changeSet = changeSet;
+    }
+    
     /**
      * Gets the changes incorporated into this build.
      *
@@ -816,7 +803,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         return changelogFile.exists();
     }
 
-    private ChangeLogSet<? extends Entry> calcChangeSet() {
+    protected ChangeLogSet<? extends Entry> calcChangeSet() {
         File changelogFile = new File(getRootDir(), "changelog.xml");
         if (!changelogFile.exists())
             return ChangeLogSet.createEmpty(this);

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -23,67 +23,42 @@
  */
 package hudson.model;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedSet;
-import hudson.AbortException;
-import hudson.BulkChange;
 import hudson.EnvVars;
+import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.Util;
-import hudson.FilePath;
 import hudson.console.AnnotatedLargeText;
 import hudson.console.HyperlinkNote;
 import hudson.console.ExpandableDetailsNote;
-import hudson.model.listeners.RunListener;
-import hudson.slaves.WorkspaceList;
-import hudson.slaves.NodeProperty;
-import hudson.slaves.WorkspaceList.Lease;
 import hudson.matrix.MatrixConfiguration;
-import hudson.matrix.MatrixExecutionStrategy;
-import hudson.matrix.MatrixExecutionStrategyDescriptor;
-import hudson.model.Descriptor.FormException;
 import hudson.model.Fingerprint.BuildPtr;
 import hudson.model.Fingerprint.RangeSet;
-import hudson.model.Run.RunnerAbortedException;
-import hudson.model.listeners.SCMListener;
+import hudson.model.listeners.RunListener;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
-import hudson.scm.SCM;
 import hudson.scm.NullChangeLogParser;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.WorkspaceList;
+import hudson.slaves.WorkspaceList.Lease;
 import hudson.tasks.BuildStep;
+import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.Builder;
-import hudson.tasks.Fingerprinter.FingerprintAction;
 import hudson.tasks.Publisher;
-import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.BuildTrigger;
-import hudson.tasks.test.AbstractTestResultAction;
+import hudson.tasks.Fingerprinter.FingerprintAction;
 import hudson.tasks.test.AggregatedTestResultAction;
+import hudson.tasks.test.AbstractTestResultAction;
 import hudson.util.AdaptedIterator;
 import hudson.util.Iterators;
 import hudson.util.LogTaskListener;
 import hudson.util.VariableResolver;
-import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
 
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.HttpResponses;
-import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.interceptor.RequirePOST;
-import org.xml.sax.SAXException;
-
-import javax.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.io.StringWriter;
-import java.lang.ref.Reference;
-import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.text.MessageFormat;
 import java.util.AbstractSet;
@@ -97,10 +72,21 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Vector;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+
+import jenkins.model.Jenkins;
+
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.export.Exported;
+import org.xml.sax.SAXException;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
 
 /**
  * Base implementation of {@link Run}s that build software.

--- a/core/src/main/java/hudson/model/BuildCheckoutStrategy.java
+++ b/core/src/main/java/hudson/model/BuildCheckoutStrategy.java
@@ -1,0 +1,18 @@
+package hudson.model;
+
+import hudson.ExtensionPoint;
+import hudson.Launcher;
+
+import java.io.IOException;
+
+public abstract class BuildCheckoutStrategy extends
+		AbstractDescribableImpl<BuildCheckoutStrategy> implements ExtensionPoint {
+	
+	protected abstract void preCheckout(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException;
+	protected abstract void checkout(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws Exception;
+	
+	@Override
+    public BuildCheckoutStrategyDescriptor getDescriptor() {
+        return (BuildCheckoutStrategyDescriptor)super.getDescriptor();
+    }
+}

--- a/core/src/main/java/hudson/model/BuildCheckoutStrategyDescriptor.java
+++ b/core/src/main/java/hudson/model/BuildCheckoutStrategyDescriptor.java
@@ -14,7 +14,7 @@ public abstract class BuildCheckoutStrategyDescriptor extends Descriptor<BuildCh
     }
 
     /**
-     * Returns all the registered {@link MatrixExecutionStrategyDescriptor}s.
+     * Returns all the registered {@link BuildCheckoutStrategyDescriptor}s.
      */
     public static DescriptorExtensionList<BuildCheckoutStrategy,BuildCheckoutStrategyDescriptor> all() {
         return Jenkins.getInstance().<BuildCheckoutStrategy,BuildCheckoutStrategyDescriptor>getDescriptorList(BuildCheckoutStrategy.class);

--- a/core/src/main/java/hudson/model/BuildCheckoutStrategyDescriptor.java
+++ b/core/src/main/java/hudson/model/BuildCheckoutStrategyDescriptor.java
@@ -1,0 +1,23 @@
+package hudson.model;
+
+import hudson.DescriptorExtensionList;
+import hudson.matrix.MatrixExecutionStrategyDescriptor;
+import jenkins.model.Jenkins;
+
+public abstract class BuildCheckoutStrategyDescriptor extends Descriptor<BuildCheckoutStrategy> {
+	
+	protected BuildCheckoutStrategyDescriptor(Class<? extends BuildCheckoutStrategy> clazz) {
+        super(clazz);
+    }
+
+    protected BuildCheckoutStrategyDescriptor() {
+    }
+
+    /**
+     * Returns all the registered {@link MatrixExecutionStrategyDescriptor}s.
+     */
+    public static DescriptorExtensionList<BuildCheckoutStrategy,BuildCheckoutStrategyDescriptor> all() {
+        return Jenkins.getInstance().<BuildCheckoutStrategy,BuildCheckoutStrategyDescriptor>getDescriptorList(BuildCheckoutStrategy.class);
+    }
+
+}

--- a/core/src/main/java/hudson/model/DefaultBuildCheckoutStrategyImpl.java
+++ b/core/src/main/java/hudson/model/DefaultBuildCheckoutStrategyImpl.java
@@ -1,0 +1,84 @@
+package hudson.model;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.Run.RunnerAbortedException;
+import hudson.model.listeners.SCMListener;
+import hudson.scm.ChangeLogSet;
+import hudson.scm.ChangeLogSet.Entry;
+import hudson.scm.NullChangeLogParser;
+import hudson.scm.SCM;
+import hudson.tasks.BuildWrapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.lang.ref.WeakReference;
+
+import jenkins.model.Jenkins;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class DefaultBuildCheckoutStrategyImpl extends BuildCheckoutStrategy {
+	
+	@DataBoundConstructor
+	public DefaultBuildCheckoutStrategyImpl() {		
+	}
+
+	@Override
+	protected void preCheckout(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener)
+			throws IOException, InterruptedException {		
+		if (build.getProject() instanceof BuildableItemWithBuildWrappers) {
+            BuildableItemWithBuildWrappers biwbw = (BuildableItemWithBuildWrappers) build.getProject();
+            for (BuildWrapper bw : biwbw.getBuildWrappersList())
+                bw.preCheckout(build,launcher,listener);
+        }
+		
+	}
+
+	@Override
+	protected void checkout(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws Exception {
+		for (int retryCount=build.getProject().getScmCheckoutRetryCount(); ; retryCount--) {
+            // for historical reasons, null in the scm field means CVS, so we need to explicitly set this to something
+            // in case check out fails and leaves a broken changelog.xml behind.
+            // see http://www.nabble.com/CVSChangeLogSet.parse-yields-SAXParseExceptions-when-parsing-bad-*AccuRev*-changelog.xml-files-td22213663.html
+            build.setScm(NullChangeLogParser.INSTANCE);
+
+            try {
+                if (build.getProject().checkout(build,launcher,listener,new File(build.getRootDir(),"changelog.xml"))) {
+                    // check out succeeded
+                    SCM scm = build.getProject().getScm();
+
+                    build.setScm(scm.createChangeLogParser());
+                    build.setChangeSet(new WeakReference<ChangeLogSet<? extends Entry>>(build.calcChangeSet()));
+
+                    for (SCMListener l : Jenkins.getInstance().getSCMListeners())
+                        l.onChangeLogParsed(build,listener,build.getChangeSet());
+                    return;
+                }
+            } catch (AbortException e) {
+                listener.error(e.getMessage());
+            } catch (InterruptedIOException e) {
+                throw (InterruptedException)new InterruptedException().initCause(e);
+            } catch (IOException e) {
+                // checkout error not yet reported
+                e.printStackTrace(listener.getLogger());
+            }
+
+            if (retryCount == 0)   // all attempts failed
+                throw new RunnerAbortedException();
+
+            listener.getLogger().println("Retrying after 10 seconds");
+            Thread.sleep(10000);
+        }		
+	}
+	
+	@Extension
+    public static class DescriptorImpl extends BuildCheckoutStrategyDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Classic";
+        }
+    }
+}

--- a/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
@@ -44,19 +44,19 @@ THE SOFTWARE.
     </f:advanced>
   </f:section>
 
-	<p:config-scm/>
-	
-	<f:section title="${%Advanced Source Code Management}">
-		<j:choose>
-		  <j:when test="${descriptor.buildCheckoutStrategyDescriptors.size() gt 1}">
-			<f:dropdownDescriptorSelector title="${%Build Checkout Strategy}" field="buildCheckoutStrategy"/>
-		  </j:when>
-		  <j:otherwise>
-			<!-- for the default case when there's only one build checkout strategy, render it inline to simplify the UI -->
-			<f:property field="buildCheckoutStrategy" propertyDescriptor="${descriptor.buildCheckoutStrategyDescriptors.get(0)}"/>
-		  </j:otherwise>
-		</j:choose>
-	</f:section>
+  <p:config-scm/>
+  
+  <f:section title="${%Advanced Source Code Management}">
+    <j:choose>
+      <j:when test="${descriptor.buildCheckoutStrategyDescriptors.size() gt 1}">
+      <f:dropdownDescriptorSelector title="${%Build Checkout Strategy}" field="buildCheckoutStrategy"/>
+      </j:when>
+      <j:otherwise>
+        <!-- for the default case when there's only one build checkout strategy, render it inline to simplify the UI -->
+        <f:property field="buildCheckoutStrategy" propertyDescriptor="${descriptor.buildCheckoutStrategyDescriptors.get(0)}"/>
+      </j:otherwise>
+    </j:choose>
+  </f:section>
 
   <p:config-trigger>
     <p:config-upstream-pseudo-trigger />

--- a/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
@@ -44,7 +44,19 @@ THE SOFTWARE.
     </f:advanced>
   </f:section>
 
-  <p:config-scm/>
+	<p:config-scm/>
+	
+	<f:section title="${%Advanced Source Code Management}">
+		<j:choose>
+		  <j:when test="${descriptor.buildCheckoutStrategyDescriptors.size() gt 1}">
+			<f:dropdownDescriptorSelector title="${%Build Checkout Strategy}" field="buildCheckoutStrategy"/>
+		  </j:when>
+		  <j:otherwise>
+			<!-- for the default case when there's only one build checkout strategy, render it inline to simplify the UI -->
+			<f:property field="buildCheckoutStrategy" propertyDescriptor="${descriptor.buildCheckoutStrategyDescriptors.get(0)}"/>
+		  </j:otherwise>
+		</j:choose>
+	</f:section>
 
   <p:config-trigger>
     <p:config-upstream-pseudo-trigger />

--- a/core/src/main/resources/hudson/model/DefaultBuildCheckoutStrategyImpl/config.jelly
+++ b/core/src/main/resources/hudson/model/DefaultBuildCheckoutStrategyImpl/config.jelly
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!-- nothing to configure -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"/>


### PR DESCRIPTION
Extension point needs to be created for defining a custom checkout strategy. It's extremely useful in Matrix builds, where there is no need to several checkouts to be made. E.g. same source code is used for build with diff parameters, in this case it's waste of space used. Another example is using a shared drive across several build executions.
