### PR TITLE
Prevent NullPointerException

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -383,7 +383,12 @@ public abstract class View extends AbstractModelObject implements AccessControll
         for (Computer c : computers) {
             Node n = c.getNode();
             if (n != null) {
-                if (labels.contains(null) && n.getMode() == Mode.NORMAL || !Collections.disjoint(n.getAssignedLabels(), labels)) {
+                if(labels.contains(null)){
+                    if(n.getMode()==Mode.NORMAL)
+                        result.add(c);
+                    continue;
+                }
+                if(!Collections.disjoint(n.getAssignedLabels(), labels)) {
                     result.add(c);
                 }
             }


### PR DESCRIPTION
The method getComputers() in class hudson.model.View can throw NullPointerException.
Variable labels is created by method getRelevantLabels() which return set of labels and this set can contains null element. 
So if this set contains null element and mode of node is not NORMAL it cause NullPointerException.
