### PR TITLE
[FIXED JENKINS-13735]

### DIFF
--- a/core/src/main/java/hudson/slaves/RetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/RetentionStrategy.java
@@ -218,7 +218,7 @@ public abstract class RetentionStrategy<T extends Computer> extends AbstractDesc
                         }
                     }
 
-                    if (needExecutor) {
+                    if (needExecutor && (c.getNode().canTake(item) == null)) {
                         demandMilliseconds = System.currentTimeMillis() - item.buildableStartMilliseconds;
                         needComputer = demandMilliseconds > inDemandDelay * 1000 * 60 /*MINS->MILLIS*/;
                         break;


### PR DESCRIPTION
Added test whether the currently checked slave computer actually can take the buildable item before flagging it as needed (avoids powering up and connecting to slaves for jobs they can't build).
