### PR TITLE
Revised version of the Matrix Run checkout extension

### DIFF
--- a/core/src/main/java/hudson/matrix/DefaultMatrixRunCheckoutStrategyImpl.java
+++ b/core/src/main/java/hudson/matrix/DefaultMatrixRunCheckoutStrategyImpl.java
@@ -1,0 +1,35 @@
+package hudson.matrix;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.BuildListener;
+
+import java.io.IOException;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class DefaultMatrixRunCheckoutStrategyImpl extends MatrixRunCheckoutStrategy {
+
+    @DataBoundConstructor
+    public DefaultMatrixRunCheckoutStrategyImpl() {
+        }
+
+    @Override
+    protected boolean preCheckout(MatrixRun build, Launcher launcher, BuildListener listener)
+        throws IOException, InterruptedException {
+        return true;
+    }
+
+    @Override
+    protected boolean checkout(MatrixRun build, Launcher launcher, BuildListener listener) throws Exception {
+        return true;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends MatrixRunCheckoutStrategyDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Classic";
+        }
+    }
+}

--- a/core/src/main/java/hudson/matrix/MatrixProject.java
+++ b/core/src/main/java/hudson/matrix/MatrixProject.java
@@ -160,6 +160,8 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
 
     private MatrixExecutionStrategy executionStrategy;
 
+    private MatrixRunCheckoutStrategy matrixRunCheckoutStrategy;
+
     /**
      * Custom workspace location for {@link MatrixConfiguration}s.
      * 
@@ -277,6 +279,16 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
     public void setExecutionStrategy(MatrixExecutionStrategy executionStrategy) throws IOException {
         if (executionStrategy ==null)   throw new IllegalArgumentException();
         this.executionStrategy = executionStrategy;
+        save();
+    }
+
+    public MatrixRunCheckoutStrategy getMatrixRunCheckoutStrategy() {
+        return matrixRunCheckoutStrategy == null ? new DefaultMatrixRunCheckoutStrategyImpl() : matrixRunCheckoutStrategy;
+    }
+
+    public void setMatrixRunCheckoutStrategy(MatrixRunCheckoutStrategy matrixRunCheckoutStrategy) throws IOException {
+        if (matrixRunCheckoutStrategy ==null)   throw new IllegalArgumentException();
+        this.matrixRunCheckoutStrategy = matrixRunCheckoutStrategy;
         save();
     }
 
@@ -763,6 +775,19 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
         else
             executionStrategy = req.bindJSON(esd.get(0).clazz,json.getJSONObject("executionStrategy"));
 
+        try {
+            List<MatrixRunCheckoutStrategyDescriptor> mrcsd = MatrixRunCheckoutStrategyDescriptor
+                .all();
+            if (mrcsd.size() > 1)
+                matrixRunCheckoutStrategy = req.bindJSON(MatrixRunCheckoutStrategy.class,
+                    json.getJSONObject("matrixRunCheckoutStrategy"));
+            else
+                matrixRunCheckoutStrategy = req.bindJSON(mrcsd.get(0).clazz,
+                    json.getJSONObject("matrixRunCheckoutStrategy"));
+        } catch (Exception exc) {
+            matrixRunCheckoutStrategy = new DefaultMatrixRunCheckoutStrategyImpl();
+        }
+
         // parse system axes
         DescribableList<Axis,AxisDescriptor> newAxes = new DescribableList<Axis,AxisDescriptor>(this);
         newAxes.rebuildHetero(req, json, Axis.all(),"axis");
@@ -842,6 +867,10 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
 
         public List<MatrixExecutionStrategyDescriptor> getExecutionStrategyDescriptors() {
             return MatrixExecutionStrategyDescriptor.all();
+        }
+
+        public List<MatrixRunCheckoutStrategyDescriptor> getMatrixRunCheckoutStrategyDescriptors() {
+            return MatrixRunCheckoutStrategyDescriptor.all();
         }
     }
 

--- a/core/src/main/java/hudson/matrix/MatrixRun.java
+++ b/core/src/main/java/hudson/matrix/MatrixRun.java
@@ -25,10 +25,14 @@ package hudson.matrix;
 
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.model.TopLevelItem;
 import hudson.slaves.WorkspaceList;
 import hudson.slaves.WorkspaceList.Lease;
+import hudson.tasks.BuildWrapper;
 import hudson.model.Build;
 import hudson.model.Node;
 import org.kohsuke.stapler.Ancestor;
@@ -181,6 +185,25 @@ public class MatrixRun extends Build<MatrixConfiguration,MatrixRun> {
             // child workspace need no individual locks, whether or not we use custom workspace
             String childWs = mp.getChildCustomWorkspace();
             return Lease.createLinkedDummyLease(baseDir.child(env.expand(childWs)),baseLease);
+        }
+        @Override
+        protected void preCheckout(Launcher launcher, BuildListener listener)
+                throws IOException, InterruptedException {
+            MatrixProject mp = getParent().getParent();
+            MatrixRunCheckoutStrategy strategy = mp.getMatrixRunCheckoutStrategy();
+            boolean invokeSuper = strategy.preCheckout(MatrixRun.this, launcher, listener);
+            if(invokeSuper) {
+                super.preCheckout(launcher, listener);
+            }
+        }
+        @Override
+        protected void checkout(BuildListener listener) throws Exception {
+            MatrixProject mp = getParent().getParent();
+            MatrixRunCheckoutStrategy strategy = mp.getMatrixRunCheckoutStrategy();
+            boolean invokeSuper = strategy.checkout(MatrixRun.this, launcher, listener);
+            if(invokeSuper) {
+                super.checkout(listener);
+            }
         }
     }
 }

--- a/core/src/main/java/hudson/matrix/MatrixRunCheckoutStrategy.java
+++ b/core/src/main/java/hudson/matrix/MatrixRunCheckoutStrategy.java
@@ -1,0 +1,20 @@
+package hudson.matrix;
+
+import hudson.ExtensionPoint;
+import hudson.Launcher;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.BuildListener;
+
+import java.io.IOException;
+
+public abstract class MatrixRunCheckoutStrategy extends
+    AbstractDescribableImpl<MatrixRunCheckoutStrategy> implements ExtensionPoint {
+
+    protected abstract boolean preCheckout(MatrixRun build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException;
+    protected abstract boolean checkout(MatrixRun build, Launcher launcher, BuildListener listener) throws Exception;
+
+    @Override
+    public MatrixRunCheckoutStrategyDescriptor getDescriptor() {
+        return (MatrixRunCheckoutStrategyDescriptor)super.getDescriptor();
+    }
+}

--- a/core/src/main/java/hudson/matrix/MatrixRunCheckoutStrategyDescriptor.java
+++ b/core/src/main/java/hudson/matrix/MatrixRunCheckoutStrategyDescriptor.java
@@ -1,0 +1,23 @@
+package hudson.matrix;
+
+import hudson.DescriptorExtensionList;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+public abstract class MatrixRunCheckoutStrategyDescriptor extends Descriptor<MatrixRunCheckoutStrategy> {
+
+    protected MatrixRunCheckoutStrategyDescriptor(Class<? extends MatrixRunCheckoutStrategy> clazz) {
+        super(clazz);
+    }
+
+    protected MatrixRunCheckoutStrategyDescriptor() {
+    }
+
+    /**
+     * Returns all the registered {@link MatrixExecutionStrategyDescriptor}s.
+     */
+    public static DescriptorExtensionList<MatrixRunCheckoutStrategy,MatrixRunCheckoutStrategyDescriptor> all() {
+        return Jenkins.getInstance().<MatrixRunCheckoutStrategy,MatrixRunCheckoutStrategyDescriptor>getDescriptorList(MatrixRunCheckoutStrategy.class);
+    }
+
+}

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -568,7 +568,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
          * @throws IOException
          * @throws InterruptedException
          */
-        private void preCheckout(Launcher launcher, BuildListener listener) throws IOException, InterruptedException{
+        protected void preCheckout(Launcher launcher, BuildListener listener) throws IOException, InterruptedException{
         	if (project instanceof BuildableItemWithBuildWrappers) {
                 BuildableItemWithBuildWrappers biwbw = (BuildableItemWithBuildWrappers) project;
                 for (BuildWrapper bw : biwbw.getBuildWrappersList())
@@ -576,7 +576,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             }
         }
         
-        private void checkout(BuildListener listener) throws Exception {
+        protected void checkout(BuildListener listener) throws Exception {
                 for (int retryCount=project.getScmCheckoutRetryCount(); ; retryCount--) {
                     // for historical reasons, null in the scm field means CVS, so we need to explicitly set this to something
                     // in case check out fails and leaves a broken changelog.xml behind.

--- a/core/src/main/resources/hudson/matrix/DefaultMatrixRunCheckoutStrategyImpl/config.jelly
+++ b/core/src/main/resources/hudson/matrix/DefaultMatrixRunCheckoutStrategyImpl/config.jelly
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!-- nothing to configure -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"/>

--- a/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
@@ -57,6 +57,18 @@ THE SOFTWARE.
 
   <p:config-scm/>
 
+  <f:section title="${%Advanced Source Code Management}">
+	<j:choose>
+		<j:when test="${descriptor.matrixRunCheckoutStrategyDescriptors.size() gt 1}">
+			<f:dropdownDescriptorSelector title="${%Matrix Run Checkout Strategy}" field="matrixRunCheckoutStrategy"/>
+		</j:when>
+		<j:otherwise>
+			<!-- for the default case when there's only one build checkout strategy, render it inline to simplify the UI -->
+			<f:property field="matrixRunCheckoutStrategy" propertyDescriptor="${descriptor.matrixRunCheckoutStrategyDescriptors.get(0)}"/>
+		</j:otherwise>
+	</j:choose>
+  </f:section>
+
   <p:config-trigger>
     <p:config-upstream-pseudo-trigger />
   </p:config-trigger>


### PR DESCRIPTION
Extension point needs to be created for defining a custom checkout strategy. It's extremely useful in Matrix builds, where there is no need to several checkouts to be made. E.g. same source code is used for build with diff parameters, in this case it's waste of space used. Another example is using a shared drive across several build executions.
