### PR TITLE
Fix for JENKINS-13865

### DIFF
--- a/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
+++ b/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
@@ -103,7 +103,7 @@ public abstract class CauseOfBlockage {
         }
 
         public String getShortDescription() {
-            return Messages.Queue_WaitingForNextAvailableExecutorOn(HyperlinkNote.encodeTo("/computer/"+ node.getNodeName(), node.getNodeName()));
+            return Messages.Queue_WaitingForNextAvailableExecutorOn(node.getNodeName());
         }
     }
 


### PR DESCRIPTION
Removes the HyperlinkNote markup on builds where the node is busy.
This was causing the /queue/api/json markup to be invalid and users
were unable to parse as the markup PRE/POST AMBLE appends 
ansi control codes to the string.  As the ansi control codes utilize a 
square-left-bracket '[' this invalidates the JSON output. 

This reverts the prior commit.
