### PR TITLE
In ListView, wrap the list of jobs inside a scrollable div.

### DIFF
--- a/core/src/main/resources/hudson/model/ListView/configure-entries.jelly
+++ b/core/src/main/resources/hudson/model/ListView/configure-entries.jelly
@@ -38,10 +38,12 @@ THE SOFTWARE.
   </f:entry>
 
   <f:entry title="${%Jobs}">
-    <j:forEach var="job" items="${it.ownerItemGroup.items}">
-      <f:checkbox name="${job.name}" checked="${it.contains(job)}" title="${job.name}" />
-      <br/>
-    </j:forEach>
+    <div class="listview-jobs">
+      <j:forEach var="job" items="${it.ownerItemGroup.items}">
+        <f:checkbox name="${job.name}" checked="${it.contains(job)}" title="${job.name}" />
+        <br/>
+      </j:forEach>
+    </div>
   </f:entry>
 
   <f:optionalBlock name="useincluderegex" title="${%Use a regular expression to include jobs into the view}"

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -613,6 +613,12 @@ LABEL.attach-previous {
   text-align: left;
 }
 
+/* ============================ list view entries ======================== */
+div.listview-jobs {
+  max-height:300px;
+  overflow:auto;
+}
+
 /* ============================ parameters form ========================== */
 
 table.parameters {


### PR DESCRIPTION
When managing instances with lots of jobs, the size of the view
configuration screen becomes huge because there is one line per job on
the instance.
