### PR TITLE
Human readable size of files

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -93,6 +93,7 @@ import java.lang.reflect.ParameterizedType;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -1493,5 +1494,31 @@ public class Functions {
      */
     public String getUserAvatar(User user, String avatarSize) {
         return getAvatar(user,avatarSize);
+    }
+    
+    
+    /**
+     * Returns human readable information about file size
+     * 
+     * @param file size in bytes
+     * @return file size in appropriate unit
+     */
+    public static String humanReadableByteSize(long size){
+        String measure = "B";
+        Double number = new Double(size);
+        if(number>=1024){
+            number = number/1024;
+            measure = "KB";
+            if(number>=1024){
+                number = number/1024;
+                measure = "MB";
+                if(number>=1024){
+                    number=number/1024;
+                    measure = "GB";
+                }
+            }
+        }
+        DecimalFormat format = new DecimalFormat("##.00");
+        return format.format(number) + " " + measure;
     }
 }

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1096,6 +1096,10 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         public String getLength() {
             return length;
         }
+        
+        public long getFileSize(){
+            return Long.decode(length);
+        }
 
         public String getTreeNodeId() {
             return treeNodeId;

--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -71,7 +71,7 @@ THE SOFTWARE.
                   </td>
                   <j:if test="${!x.folder}">
                     <td class="fileSize">
-                      ${x.getSize()}
+                      ${h.humanReadableByteSize(x.getSize())}
                     </td>
                     <td>
                       <j:if test="${x.readable}">

--- a/core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/core/src/main/resources/lib/hudson/artifactList.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
                     <a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
                   </td>
                   <td class="fileSize">
-                    ${f.length}
+                    ${h.humanReadableByteSize(f.getFileSize())}
                   </td>
                   <td>
                     <a href="${baseURL}artifact/${f.href}/*fingerprint*/">


### PR DESCRIPTION
Displaying file size only in bytes is not very user friendly. It will be better to display size in more human readable way.
