### PR TITLE
[JENKINS-13909] don't keep legacy *.hpi when uploading a plugin

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -704,6 +704,7 @@ public abstract class PluginManager extends AbstractModelObject {
                 throw new Failure(hudson.model.Messages.Hudson_NotAPlugin(fileName));
             }
             final String baseName = FilenameUtils.getBaseName(fileName);
+            new File(rootDir, baseName + ".hpi").delete(); // don't keep confusing legacy *.hpi
             fileItem.write(new File(rootDir, baseName + ".jpi")); // rename all new plugins to *.jpi
             fileItem.delete();
 


### PR DESCRIPTION
even jenkins takes care to load jpi first, this is confusing
