### PR TITLE
Show all searched results

### DIFF
--- a/core/src/main/java/hudson/model/AbstractModelObject.java
+++ b/core/src/main/java/hudson/model/AbstractModelObject.java
@@ -32,8 +32,10 @@ import java.io.IOException;
 
 import hudson.search.SearchableModelObject;
 import hudson.search.Search;
+import hudson.search.SearchAllResults;
 import hudson.search.SearchIndexBuilder;
 import hudson.search.SearchIndex;
+import hudson.search.UserSearchProperty;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
@@ -99,6 +101,9 @@ public abstract class AbstractModelObject implements SearchableModelObject {
     }
 
     public Search getSearch() {
+        if(UserSearchProperty.showAllPossibleResults()){ 
+            return new SearchAllResults();
+        }
         return new Search();
     }
 

--- a/core/src/main/java/hudson/search/SearchAllResults.java
+++ b/core/src/main/java/hudson/search/SearchAllResults.java
@@ -1,0 +1,288 @@
+package hudson.search;
+
+import hudson.Functions;
+import hudson.model.Computer;
+import hudson.model.Job;
+import hudson.model.TopLevelItem;
+import hudson.model.User;
+import hudson.search.Search.TokenList;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.servlet.ServletException;
+import jenkins.model.Jenkins;
+import jenkins.model.Jenkins.MasterComputer;
+import org.kohsuke.stapler.Ancestor;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+/**
+ * Search all possible results
+ * It is different from Search class - it display all searched results, not only suggestions or found item. 
+ * The results are categorized by five types and can be filtered by this type.
+ * 
+ * @author Lucie Votypkova
+ */
+public class SearchAllResults extends Search{
+
+    //class which contains informations about searched object
+    public class SearchedItem implements Comparable {
+        Ancestor ancestor;
+        Object object;
+        SearchItem item;
+        Type type;
+        
+
+        public SearchedItem(SearchItem item, Ancestor ancestor) {
+            this.ancestor=ancestor;
+            this.item=item;
+        }
+
+        public int compareTo(Object o) {
+            if (o instanceof SearchedItem) {
+                SearchedItem i = (SearchedItem) o;
+                if (!getName().equals(i.getName())) {
+                    return getName().compareTo(i.getName());
+                } else {
+                    return getUrl().compareTo(i.getUrl());
+                }
+            }
+            throw new IllegalArgumentException("Instance of class" + SearchedItem.class + " must be compared only with instance of the same class");
+        }
+
+        public String getName() {
+            return item.getSearchName();
+        }
+
+        public String getUrl() {
+            String ancestorUrl = ancestor.getUrl();
+            if ((!ancestorUrl.endsWith("/")) && (!item.getSearchUrl().startsWith("/"))) {
+                ancestorUrl = ancestorUrl + "/";
+            }
+            return ancestorUrl + item.getSearchUrl();
+        }
+        
+        public void setObject(Object object){
+            this.object=object;
+        }
+        
+        public void setType(Type type){
+            this.type=type;
+        }    
+
+        public String getDescription() {
+            return type.getDescription();
+        }        
+        
+        public String getIconUrl(){
+            return type.getIconUrl(object);
+        }
+        
+    }
+    
+    /**
+     * Set filter for searching
+     * 
+     * @return Set with included types of results
+     */
+    protected Set<String> getFilter(StaplerRequest req) throws ServletException, IllegalAccessException, IllegalArgumentException, InvocationTargetException{
+        Set<String> filter = new TreeSet<String>();
+        String values[] = {"other","job","view","computer","user"};
+        for(String s:values){
+            if(req.getParameter(s)!=null)
+                filter.add(s); 
+        }
+        return filter;
+    }
+
+    /**
+     * Return all searched items. This items are categorized into five 
+     * types (job, user, computer, view and other)
+     * 
+     * @return List with results
+     */
+    public List<SearchedItem> getAllSearchedItems(StaplerRequest req, String tokenList) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, ServletException {
+        Set<String> filteredItems= new TreeSet<String>();
+        if("Filter".equals(req.getParameter("submit"))){ //user wanto to change setting for this search
+            filteredItems = getFilter(req);
+        }
+        else{
+            filteredItems = User.current().getProperty(UserSearchProperty.class).getFilter();
+        }
+        req.setAttribute("filteredItems", filteredItems);
+        return getResolvedAndFilteredItems(tokenList, req, filteredItems);
+    }
+    
+    /**
+     * Return ser with items, but without categorization (type of searched item is not resolved)
+     * 
+     * @return Set with items
+     */
+    public Set<SearchedItem> getAllItems(StaplerRequest req, String tokenList){
+        List<Ancestor> ancestors = req.getAncestors();        
+        Set<SearchedItem> searchedItems = new TreeSet<SearchedItem>();
+        for (int i = 0; i < ancestors.size(); i++) {
+            Ancestor a = ancestors.get(i);
+            if (a.getObject() instanceof SearchableModelObject) {
+                SearchIndex index = ((SearchableModelObject) a.getObject()).getSearchIndex();
+                TokenList tokens = new TokenList(tokenList);
+                if (tokens.length() == 0) {
+                    return searchedItems;
+                }
+                List<SearchItem> items = new ArrayList<SearchItem>();
+                for (String token : tokens.subSequence(0)) {
+                    index.suggest(token, items);  
+                    searchedItems.addAll(createSearchItems(items, a));
+                }
+            }
+        }
+        return searchedItems;
+    }
+        
+    /**
+     * Create set of {@link SearchedItem} from list of {@link SearchItem}
+     * 
+     * @return Set of {@link SearchedItem}
+     */
+    private Set<SearchedItem> createSearchItems(List<SearchItem> items, Ancestor ancestor){
+        Set<SearchedItem> searchedItems= new TreeSet<SearchedItem>();
+        for(SearchItem si:items){
+            SearchedItem item = new SearchedItem(si, ancestor);
+            searchedItems.add(item);
+        }
+        return searchedItems;
+    }
+    
+    /**
+     * Resolve types of searched items
+     * 
+     * @return List of {@link SearchedItem}
+     */
+    protected List<SearchedItem> getResolvedAndFilteredItems(String tokens, StaplerRequest req, Set<String> filteredItems) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException{
+       Set<SearchedItem>  items = getAllItems(req,tokens);
+        List<SearchedItem> resolvedAndFileteredItems = new ArrayList<SearchedItem>();
+        for(SearchedItem si:items){
+            if(resolveType(si,si.ancestor) && filteredItems.contains(si.type.getDescription())){
+                resolvedAndFileteredItems.add(si);
+            }
+        }
+        return resolvedAndFileteredItems;
+    }
+    
+    @Override
+     public void doIndex(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        req.getView(this, "all-results.jelly").forward(req, rsp);
+     }
+    
+    private boolean _resolveType(Jenkins jenkins, SearchedItem item) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException{
+        String[] split = item.getUrl().split("/");
+        if(split.length==0){ //main view
+            item.setType(Type.VIEW);
+            return true;
+        }
+        if(split.length==3){
+            String type = split[1];
+            if(type.equals("job")){
+                item.setType(Type.JOB);
+                TopLevelItem job = jenkins.getItem(split[2]);
+                item.setObject(job);
+                return job!=null;
+            }
+            if(type.equals("user")){
+                User user = jenkins.getUser(split[2]);
+                item.setType(Type.USER);
+                item.setObject(user);
+                return user!=null;
+            }
+            if(type.equals("computer")){
+                item.setType(Type.COMPUTER);
+                Computer computer = jenkins.getComputer(split[2]);
+                item.setObject(computer);
+                return computer!=null;
+            }
+            if(type.equals("view")){
+                item.setType(Type.VIEW);
+                return jenkins.getView(split[2])!=null;
+            }     
+        }
+        item.setType(Type.OTHER);
+        return true;
+    }
+
+    /**
+     * Resolve which object is assigned to given URL. (It assigns the appropriate type to searched item)
+     * 
+     * @param SearchedItem item, Ancestor ancestor
+     * 
+     * @return return true if the resolving was successful and the searched item should be included, otherwise false;
+     */
+    private boolean resolveType(SearchedItem item,Ancestor ancestor) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        Object o = ancestor.getObject();
+        if (o instanceof Jenkins){
+            return _resolveType((Jenkins)o, item);
+        }
+        item.setType(Type.OTHER);
+        return true;
+    }
+
+    
+    public enum Type {
+
+        JOB {
+            String getIconUrl(Object o){
+                if (((Job)o).getBuilds().size() == 0) {
+                    return Functions.getResourcePath() + "/images/16x16/health-80plus.png";
+                } else {
+                    return Functions.getResourcePath() + "/images/16x16/" + ((Job)o).getBuildHealth().getIconUrl();
+                }
+            }
+            String getDescription(){
+                return "job";
+            }
+        },
+        COMPUTER {
+            String getIconUrl(Object o){
+                if(o instanceof MasterComputer){
+                    return Functions.getResourcePath() + "/images/16x16/computer.png"; 
+                }
+                return Functions.getResourcePath() + "/images/16x16/" + ((Computer)o).getIcon();
+            }
+            String getDescription(){
+                return "computer";
+            }
+        },
+        VIEW {
+            String getIconUrl(Object o){
+                return Functions.getResourcePath() + "/images/16x16/folder.png";
+            }
+            String getDescription(){
+                return "view";
+            }
+        },
+        USER{
+            String getIconUrl(Object o){
+                return Functions.getAvatar((User)o, "16x16");
+            }
+            String getDescription(){
+                return "user";
+            }
+        },
+        OTHER {
+            String getIconUrl(Object o){
+                return Functions.getResourcePath() + "/images/16x16/notepad.png";
+            }
+            String getDescription(){
+                return "other";
+            }
+        };
+        
+        abstract String getDescription();
+        
+        abstract String getIconUrl(Object o);
+    }
+
+}
+

--- a/core/src/main/java/hudson/search/UserSearchProperty.java
+++ b/core/src/main/java/hudson/search/UserSearchProperty.java
@@ -4,6 +4,8 @@ import hudson.Extension;
 import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
+import java.util.Set;
+import java.util.TreeSet;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.StaplerRequest;
@@ -12,9 +14,15 @@ import org.kohsuke.stapler.export.Exported;
 public class UserSearchProperty extends hudson.model.UserProperty {
     
     private final boolean insensitiveSearch;
+    
+    private final boolean showAllPossibleResults; //show all possible result not only suggestion or founded item
+    
+    private final Set<String> filter; //Set of result types , which will be diesplayed
 
-    public UserSearchProperty(boolean insensitiveSearch) {
+    public UserSearchProperty(boolean insensitiveSearch, boolean showAllPossibleResults, Set<String> filter) {
         this.insensitiveSearch = insensitiveSearch;
+        this.showAllPossibleResults=showAllPossibleResults;
+        this.filter=filter;
     }
 
     @Exported
@@ -31,7 +39,25 @@ public class UserSearchProperty extends hudson.model.UserProperty {
         return caseInsensitive;
     }
     
-
+    public Set<String> getFilter(){
+        return filter;
+    }
+    
+    public boolean getShowAllPossibleResults(){
+        return showAllPossibleResults;
+    }
+    
+    public static boolean showAllPossibleResults(){
+        User user = User.current();
+        //Searching for anonymous user shows all result only if there is not any instance of SearchableModelObject whith 
+        //the same search name as the searched query
+        boolean allSuggestedResults = false;
+        if(user!=null && user.getProperty(UserSearchProperty.class).getShowAllPossibleResults()){
+          allSuggestedResults=true;
+        }
+        return allSuggestedResults;
+    }
+    
     @Extension
     public static final class DescriptorImpl extends UserPropertyDescriptor {
         public String getDisplayName() {
@@ -39,12 +65,22 @@ public class UserSearchProperty extends hudson.model.UserProperty {
         }
 
         public UserProperty newInstance(User user) {
-            return new UserSearchProperty(false); //default setting is case-sensitive searching
+            return new UserSearchProperty(false, false, null); //default setting is case-sensitive searching
         }
 
         @Override
         public UserProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return new UserSearchProperty(formData.optBoolean("insensitiveSearch"));
+            boolean showAllPossibleResults = req.getParameter("showAllPossibleResults") !=null;
+            if(showAllPossibleResults){
+                Set<String> filter = new TreeSet<String>();
+                String values[] = {"other","job","build","view","computer","user"};
+                for(String s:values){
+                   if(req.getParameter(s)!=null)
+                      filter.add(s); 
+                }
+                return new UserSearchProperty(formData.optBoolean("insensitiveSearch"), showAllPossibleResults,filter);
+            }
+            return new UserSearchProperty(formData.optBoolean("insensitiveSearch"),false, null);
         }
 
     }

--- a/core/src/main/resources/hudson/search/SearchAllResults/all-results.jelly
+++ b/core/src/main/resources/hudson/search/SearchAllResults/all-results.jelly
@@ -1,0 +1,40 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <j:set var="q" value="${request.getParameter('q')}"/>
+  <j:set var="items" value="${it.getAllSearchedItems(request,q)}"/>
+  <j:set var="filteredItems" value="${request.getAttribute('filteredItems')}"/>  
+  <j:new var="h" className="hudson.Functions" /><!-- needed for printing title. -->
+  <l:layout title="${%Search for} '${q}'">
+    <l:main-panel>
+      <h1>${%All possible results for} '${q}'</h1>
+      
+      <!-- filter -->
+        <f:form method="post" action="?q=${q}">	   	      
+                <tr>
+                    <td><f:checkbox name="job" checked="${filteredItems.contains('all') || filteredItems.contains('job')}"/>  jobs
+                    <f:checkbox name="user" checked="${filteredItems.contains('all') || filteredItems.contains('user')}"/>  users
+                    <f:checkbox name="computer" checked="${filteredItems.contains('all') || filteredItems.contains('computer')}"/>  computers
+                    <f:checkbox name="view" checked="${filteredItems.contains('all') || filteredItems.contains('view')}"/>  views
+                    <f:checkbox name="other" checked="${filteredItems.contains('all') || filteredItems.contains('other')}"/>  others    
+                    <input type="submit" name="submit" value="Filter"/></td> 
+                </tr>              
+        </f:form>    
+        <j:choose>
+            <j:when test="${items.size()==0}">
+            <div class='error'>
+                ${%Nothing seems to match.}
+            </div>
+        </j:when>
+            <j:otherwise>
+                <ol>
+                <j:forEach var="i" items="${items}" >
+                    <li title="${i.getDescription()}">
+                    <img src="${i.getIconUrl()}" alt="${i.getDescription()}" /><a href="${i.getUrl()}"><b style="padding: 4px">${i.name}</b></a> <i style="color: #888; padding: 4px">(${i.getDescription()})</i>
+                   </li>
+                </j:forEach>
+                </ol>
+            </j:otherwise>
+        </j:choose>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/core/src/main/resources/hudson/search/UserSearchProperty/config.jelly
+++ b/core/src/main/resources/hudson/search/UserSearchProperty/config.jelly
@@ -27,4 +27,17 @@ THE SOFTWARE.
   <f:entry title="Case-sensitivity">
     <f:checkbox name="insensitiveSearch" checked="${instance.insensitiveSearch}" title="Insensitive search tool"/>
   </f:entry>
+  <f:entry title="Showed results">
+      <table width="100%">
+        <f:optionalBlock name="showAllPossibleResults" checked="${instance.showAllPossibleResults()}" title="Show all possible result">
+          <f:entry title="Filter: ">
+	    <f:checkbox name="job" checked="${instance.filter ==null ? 'true' : instance.filter.contains('job')}" title="jobs"/>
+            <f:checkbox name="user" checked="${instance.filter ==null ? 'true' : instance.filter.contains('user')}" title="users"/>
+            <f:checkbox name="computer" checked="${instance.filter ==null ? 'true' : instance.filter.contains('computer')}" title="computers"/>
+            <f:checkbox name="view" checked="${instance.filter ==null ? 'true' : instance.filter.contains('view')}" title="view"/>
+            <f:checkbox name="other" checked="${instance.filter ==null ? 'true' : instance.filter.contains('other')}" title="others"/>   
+          </f:entry>
+       </f:optionalBlock>
+     </table>
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
Now the search box is used for finding item with given search name or display suggestion. But we can search all possible result for given query (but it is not used), so I add functionality for display all items for given query and categorization of them (because now it can returns more items for the same search name). This functionality is optional. The user can set it in its configuration page.
