### PR TITLE
New Permissions for Update Center

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -34,6 +34,8 @@ import hudson.model.Descriptor;
 import hudson.model.Failure;
 import hudson.model.UpdateCenter;
 import hudson.model.UpdateSite;
+import hudson.security.Permission;
+import hudson.security.PermissionScope;
 import hudson.util.CyclicGraphDetector;
 import hudson.util.CyclicGraphDetector.CycleDetectedException;
 import hudson.util.IOException2;
@@ -689,7 +691,7 @@ public abstract class PluginManager extends AbstractModelObject {
      */
     public HttpResponse doUploadPlugin(StaplerRequest req) throws IOException, ServletException {
         try {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.getInstance().checkPermission(UPLOAD_PLUGINS);
 
             ServletFileUpload upload = new ServletFileUpload(new DiskFileItemFactory());
 
@@ -830,7 +832,9 @@ public abstract class PluginManager extends AbstractModelObject {
     private static final Logger LOGGER = Logger.getLogger(PluginManager.class.getName());
 
     public static boolean FAST_LOOKUP = !Boolean.getBoolean(PluginManager.class.getName()+".noFastLookup");
-
+    
+    public static final Permission UPLOAD_PLUGINS = new Permission(Jenkins.PERMISSIONS, "UploadPlugins", Messages._PluginManager_UploadPluginsPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
+    
     /**
      * Remembers why a plugin failed to deploy.
      */

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -611,7 +611,7 @@ public abstract class PluginManager extends AbstractModelObject {
     }
 
     public HttpResponse doUpdateSources(StaplerRequest req) throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.getInstance().checkPermission(CONFIGURE_UPDATECENTER);
 
         if (req.hasParameter("remove")) {
             UpdateCenter uc = Jenkins.getInstance().getUpdateCenter();
@@ -658,7 +658,7 @@ public abstract class PluginManager extends AbstractModelObject {
      */
     public HttpResponse doSiteConfigure(@QueryParameter String site) throws IOException {
         Jenkins hudson = Jenkins.getInstance();
-        hudson.checkPermission(Jenkins.ADMINISTER);
+        hudson.checkPermission(CONFIGURE_UPDATECENTER);
         UpdateCenter uc = hudson.getUpdateCenter();
         PersistedList<UpdateSite> sites = uc.getSites();
         for (UpdateSite s : sites) {
@@ -673,7 +673,7 @@ public abstract class PluginManager extends AbstractModelObject {
 
     public HttpResponse doProxyConfigure(StaplerRequest req) throws IOException, ServletException {
         Jenkins jenkins = Jenkins.getInstance();
-        jenkins.checkPermission(Jenkins.ADMINISTER);
+        jenkins.checkPermission(CONFIGURE_UPDATECENTER);
 
         ProxyConfiguration pc = req.bindJSON(ProxyConfiguration.class, req.getSubmittedForm());
         if (pc.name==null) {
@@ -834,6 +834,7 @@ public abstract class PluginManager extends AbstractModelObject {
     public static boolean FAST_LOOKUP = !Boolean.getBoolean(PluginManager.class.getName()+".noFastLookup");
     
     public static final Permission UPLOAD_PLUGINS = new Permission(Jenkins.PERMISSIONS, "UploadPlugins", Messages._PluginManager_UploadPluginsPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
+    public static final Permission CONFIGURE_UPDATECENTER = new Permission(Jenkins.PERMISSIONS, "ConfigureUpdateCenter", Messages._PluginManager_ConfigureUpdateCenterPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
     
     /**
      * Remembers why a plugin failed to deploy.

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -56,6 +56,9 @@ PluginManager.PortNotANumber=Port is not a number
 PluginManager.PortNotInRange=Port does''t range from {0} to {1}
 PluginManager.UploadPluginsPermission.Description=\
   The "upload plugin" permission allows a user to upload arbitrary plugins.
+PluginManager.ConfigureUpdateCenterPermission.Description=\
+  The "configure update center" permission allows a user to \
+configure update sites and proxy settings.
 
 AboutJenkins.DisplayName=About Jenkins
 AboutJenkins.Description=See the version and license information

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -54,5 +54,8 @@ FilePath.TildaDoesntWork=''~'' is only supported in a Unix shell and nowhere els
 PluginManager.DisplayName=Plugin Manager
 PluginManager.PortNotANumber=Port is not a number
 PluginManager.PortNotInRange=Port does''t range from {0} to {1}
+PluginManager.UploadPluginsPermission.Description=\
+  The "upload plugin" permission allows a user to upload arbitrary plugins.
+
 AboutJenkins.DisplayName=About Jenkins
 AboutJenkins.Description=See the version and license information

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -46,6 +46,7 @@ THE SOFTWARE.
             </f:block>
           </f:form>
 
+        <l:hasPermission permission="${app.pluginManager.UPLOAD_PLUGINS}">
           <h1>${%Upload Plugin}</h1>
           <f:form method="post" action="uploadPlugin" name="uploadPlugin" enctype="multipart/form-data">
             <f:block>
@@ -61,7 +62,7 @@ THE SOFTWARE.
               <f:submit value="${%Upload}" />
             </f:block>
           </f:form>
-
+        </l:hasPermission>
           <h1>${%Update Site}</h1>
           <f:form method="post" action="siteConfigure">
             <f:entry title="${%URL}" >

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -34,6 +34,7 @@ THE SOFTWARE.
     <table id="pluginsAdv" class="pane" style="margin-top:0; border-top:none">
       <tr style="border-top:none; white-space: normal">
         <td>
+        <l:hasPermission permission="${app.pluginManager.CONFIGURE_UPDATECENTER}">
           <h1>${%HTTP Proxy Configuration}</h1>
           <f:form method="post" action="proxyConfigure">
             <j:scope>
@@ -45,6 +46,7 @@ THE SOFTWARE.
               <f:submit value="${%Submit}" />
             </f:block>
           </f:form>
+	</l:hasPermission>
 
         <l:hasPermission permission="${app.pluginManager.UPLOAD_PLUGINS}">
           <h1>${%Upload Plugin}</h1>
@@ -63,6 +65,7 @@ THE SOFTWARE.
             </f:block>
           </f:form>
         </l:hasPermission>
+        <l:hasPermission permission="${app.pluginManager.CONFIGURE_UPDATECENTER}">
           <h1>${%Update Site}</h1>
           <f:form method="post" action="siteConfigure">
             <f:entry title="${%URL}" >
@@ -72,6 +75,7 @@ THE SOFTWARE.
               <f:submit value="${%Submit}" />
             </f:block>
           </f:form>
+       </l:hasPermission>
         </td>
       </tr>
     </table>

--- a/core/src/main/resources/hudson/PluginManager/tabBar.jelly
+++ b/core/src/main/resources/hudson/PluginManager/tabBar.jelly
@@ -32,6 +32,8 @@ THE SOFTWARE.
     <l:tab name="${%Available}" active="${page=='available'}" href="./available" />
     <l:tab name="${%Installed}" active="${page=='installed'}" href="./installed" />
     <!--<l:tab name="${%Sites}" active="${page=='sites'}" href="./sites" />-->
+  <j:if test="${h.hasPermission(app.pluginManager.UPLOAD_PLUGINS) || h.hasPermission(app.pluginManager.CONFIGURE_UPDATECENTER)}"> 
     <l:tab name="${%Advanced}" active="${page=='advanced'}" href="./advanced" />
+  </j:if>
   </l:tabBar>
 </j:jelly>


### PR DESCRIPTION
Introduce PluginManager.UPLOAD_PLUGIN and MANAGE_UPDATECENTER permissions.

This change allows these permissions to be isolated, such that ACL's can prevent someone with the ADMINISTER permission from uploading plugins or configuring update sites.

Existing configurations will work fine since these permissions are impliedBy ADMINSITER.

Only known impact is that some screens which display all permissions will scroll horizontally more.
