### PR TITLE
Fix UtilTest and replace ampersand in method encode too

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -678,7 +678,7 @@ public class Util {
 
             for (int i = 0; i < s.length(); i++) {
                 int c = s.charAt(i);
-                if (c<128 && c!=' ') {
+                if (c<128 && (c!=' ' && c!='&')) {
                     out.append((char) c);
                 } else {
                     // 1 char -> UTF8

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -122,13 +122,22 @@ public class UtilTest extends TestCase {
     }
     
     /**
+     * Test that Strings that contain ampersand are correctly URL encoded.
+     */
+    public void testEncodeAmpersand() {
+        final String urlWithAmpersand = "http://hudson/job/Hudson-job/label1&&label2";
+        String encoded = Util.encode(urlWithAmpersand);
+        assertEquals(encoded, "http://hudson/job/Hudson-job/label1%26%26label2");
+    }
+    
+    /**
      * Test the rawEncode() method.
      */
     public void testRawEncode() {
         String[] data = {  // Alternating raw,encoded
             "abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz",
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-            "01234567890!@$&*()-_=+',.", "01234567890!@$&*()-_=+',.",
+            "01234567890!@$*()-_=+',.", "01234567890!@$*()-_=+',.",
             " \"#%/:;<>?", "%20%22%23%25%2F%3A%3B%3C%3E%3F",
             "[\\]^`{|}~", "%5B%5C%5D%5E%60%7B%7C%7D%7E",
             "d\u00E9velopp\u00E9s", "d%C3%A9velopp%C3%A9s",


### PR DESCRIPTION
I forgot change test class UtilTest. The test testRawEncode() fails due to my commit which avoids ampersand in url. I correct this test and add a test for ampersand encoding (it is the same as as UtilTest.testEncodeSpaces()), and modify encode() method to encode ampersand in the same way as space too.
