### PR TITLE
https://issues.jenkins-ci.org/browse/JENKINS-14113

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3519,7 +3519,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
 
             for (Action a : getActions()) {
                 if (a instanceof UnprotectedRootAction) {
-                    if (rest.startsWith("/"+a.getUrlName()+"/"))
+                    if (rest.startsWith("/"+a.getUrlName()))
                         return this;
                 }
             }


### PR DESCRIPTION
The tokenised URL would always drop any trailing '/' characters which were explicitly required for an UnprotectedRootAction which caused them not to work.
