### PR TITLE
Add option to apply workspace concurrency code to custom workspaces

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -458,8 +458,16 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         protected Lease decideWorkspace(Node n, WorkspaceList wsl) throws InterruptedException, IOException {
             String customWorkspace = getProject().getCustomWorkspace();
             if (customWorkspace != null) {
-                // we allow custom workspaces to be concurrently used between jobs.
-                return Lease.createDummyLease(n.getRootPath().child(getEnvironment(listener).expand(customWorkspace)));
+		//Pass the custom workspace through the concurrency codepath if job settings tell us to
+            	if (getProject().customWorkspaceConcurrent())
+            	{
+            		return wsl.allocate(n.getRootPath().child(getEnvironment(listener).expand(customWorkspace)), getBuild());
+            	}
+		//Otherwise, allow custom workspaces to be concurrently used between jobs (default)
+            	else
+            	{
+            		return Lease.createDummyLease(n.getRootPath().child(getEnvironment(listener).expand(customWorkspace)));
+            	}
             }
             // TODO: this cast is indicative of abstraction problem
             return wsl.allocate(n.getWorkspaceFor((TopLevelItem)getProject()), getBuild());

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -251,6 +251,10 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * @since 1.410
      */
     private String customWorkspace;
+    /**
+     * See {@link #setCustomWorkspaceConcurrent(boolean)}.
+     */
+    private boolean customWorkspaceConcurrent;
     
     protected AbstractProject(ItemGroup parent, String name) {
         super(parent,name);
@@ -1741,6 +1745,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         } else {
             customWorkspace = null;
         }
+        
+        customWorkspaceConcurrent = req.getParameter("customWorkspaceConcurrent")!=null;
 
         if (json.has("scmCheckoutStrategy"))
             scmCheckoutStrategy = req.bindJSON(SCMCheckoutStrategy.class,
@@ -2095,6 +2101,10 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     public String getCustomWorkspace() {
         return customWorkspace;
     }
+    
+    public boolean customWorkspaceConcurrent() {
+    	return customWorkspaceConcurrent;
+    }
 
     /**
      * User-specified workspace directory, or null if it's up to Jenkins.
@@ -2115,6 +2125,20 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     public void setCustomWorkspace(String customWorkspace) throws IOException {
         this.customWorkspace= Util.fixEmptyAndTrim(customWorkspace);
         save();
+    }
+    
+    /**
+     * If set to true, the custom workspace will be passed through the same concurrency mechanism
+     * as is done for normal jobs for which concurrent execution is allowed. This is useful if you
+     * have more than one job using the same custom workspace - as many custom workspaces will be
+     * created as are needed for the number of jobs running concurrently. Workspaces will be reused,
+     * so the maximum number of workspace instances will be the number of executors on the box. This
+     * is useful if you have a lot of jobs working off the same large source repository, and you
+     * don't want to incur the disk penalty of having a separate workspace for each job.
+     */
+    public void setCustomWorkspaceConcurrent(boolean customWorkspaceConcurrent) throws IOException {
+    	this.customWorkspaceConcurrent=customWorkspaceConcurrent;
+    	save();
     }
     
 }

--- a/core/src/main/resources/lib/hudson/project/config-customWorkspace.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-customWorkspace.jelly
@@ -29,5 +29,6 @@ THE SOFTWARE.
     <f:entry title="${%Directory}">
       <f:textbox name="customWorkspace.directory" field="customWorkspace" />
     </f:entry>
+    <f:optionalBlock name="customWorkspaceConcurrent" title="${%Create multiple workspaces in case of concurrency}" checked="${it.customWorkspaceConcurrent()}" />
   </f:optionalBlock>
 </j:jelly>


### PR DESCRIPTION
This change adds a checkbox to the custom workspace settings section to pass the workspace through the concurrency code. We have many jobs that use the same large Perforce repository, and to have a separate checkout of it for each job would use a large amount of disk space. This setup allows us to have one checkout for each executor with the jobs sharing the checkouts, which keeps the disk usage to an acceptable and constant level.
