### PR TITLE
Update transient actions of configurations in the same way as actions of matrix project

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixConfiguration.java
+++ b/core/src/main/java/hudson/matrix/MatrixConfiguration.java
@@ -77,6 +77,13 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
         // directory name is not a name for us --- it's taken from the combination name
         super.onLoad(parent, combination.toString());
     }
+    
+    @Override
+    protected void updateTransientActions(){
+        // This method is exactly the same as in {@link #AbstractProject}. 
+        // Enabling to call this method from MatrixProject is the only reason for overriding.
+        super.updateTransientActions();
+    }
 
     /**
      * Used during loading to set the combination back.

--- a/core/src/main/java/hudson/matrix/MatrixProject.java
+++ b/core/src/main/java/hudson/matrix/MatrixProject.java
@@ -370,6 +370,15 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
 
         return r;
     }
+    
+    @Override
+    protected void updateTransientActions(){
+        super.updateTransientActions();
+        // update all transient actions in configurations too.
+        for(MatrixConfiguration configuration: getActiveConfigurations()){
+            configuration.updateTransientActions();
+        }
+    }
 
     /**
      * Gets the subset of {@link AxisList} that are not system axes.


### PR DESCRIPTION
If class which extends from Recorder override method  public Action getProjectAction(AbstractProject<?, ?> project),an action (if not null) which returns will be displayed as link in the left menu in the Job page. In case of matrix project it works only for matrix project not for its configuration. So after build there is no action for recorder in page of matrix configuration. I think that if the transient actions is updated in Matrix Project, transient actions of its configurations should be updated too.
