### PR TITLE
Fix NPE during loading matrix job

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixProject.java
+++ b/core/src/main/java/hudson/matrix/MatrixProject.java
@@ -427,9 +427,11 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
     @Override
     protected void updateTransientActions(){
         super.updateTransientActions();
-        // update all transient actions in configurations too.
-        for(MatrixConfiguration configuration: getActiveConfigurations()){
-            configuration.updateTransientActions();
+        if(getActiveConfigurations() !=null){
+            // update all transient actions in configurations too.
+            for(MatrixConfiguration configuration: getActiveConfigurations()){
+                configuration.updateTransientActions();
+            }
         }
     }
 


### PR DESCRIPTION
I am sorry my pull request 508 broke loading of MatrixProject. I did not realize that a method updateTransientActions() is called during loading of a MatrixProject before its configurations are established (an attribute activeConfiguratins is transient) so method getActiveConfigurations() return null.
