### PR TITLE
Exporting executor via @Exported to allow easier navigation in remote API

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -421,6 +421,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * an executor holds on to {@lnk Run} some more time even after the build is finished (for example to
      * perform {@linkplain State#POST_PRODUCTION post-production processing}.)
      */
+    @Exported 
     public Executor getExecutor() {
         for( Computer c : Jenkins.getInstance().getComputers() ) {
             for (Executor e : c.getExecutors()) {


### PR DESCRIPTION
Currently it's hard to get information on running jobs via the REST API. By providing access to the Executor more information will be available on this
