### PR TITLE
Fix for JENKINS-14393: Expose more information about who triggered a build via jenkins-cli.jar

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -146,12 +146,10 @@ public class BuildCommand extends CLICommand {
     	private String startedBy;
     	
     	public CLICause(){
-            super();
     		startedBy = "unknown";
     	}
     	
     	public CLICause(String startedBy){
-            super();
     		this.startedBy = startedBy;
     	}
     	

--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -25,7 +25,7 @@ package hudson.cli;
 
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.Cause;
+import hudson.model.Cause.UserIdCause;
 import hudson.model.ParametersAction;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersDefinitionProperty;
@@ -141,18 +141,21 @@ public class BuildCommand extends CLICommand {
         );
     }
 
-    public static class CLICause extends Cause {
+    public static class CLICause extends UserIdCause {
     	
     	private String startedBy;
     	
     	public CLICause(){
-    		startedBy = "unknown"; 
+            super();
+    		startedBy = "unknown";
     	}
     	
     	public CLICause(String startedBy){
+            super();
     		this.startedBy = startedBy;
     	}
     	
+        @Override
         public String getShortDescription() {
             return "Started by command line by " + startedBy;
         }


### PR DESCRIPTION
Not enough information is exposed about the build executor when a job is started via the Jenkins CLI Jar.

Change the CLICause to extend the UserIdCause class because it provides us with more information: namely, the userId and userName properties.

See https://issues.jenkins-ci.org/browse/JENKINS-14393 for more information.
