### PR TITLE
Actually rebuild the axes at the beginning of the matrix build

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixProject.java
+++ b/core/src/main/java/hudson/matrix/MatrixProject.java
@@ -590,7 +590,7 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
         if (context!=null) {
             List<Set<String>> axesList = Lists.newArrayList();
             for (Axis axis : axes)
-                axesList.add(new LinkedHashSet<String>(axis.getValues()));
+                axesList.add(Sets.newLinkedHashSet(axis.rebuild(context)));
 
             activeCombinations = Iterables.transform(Sets.cartesianProduct(axesList), new Function<List<String>, Combination>() {
                 public Combination apply(@Nullable List<String> strings) {


### PR DESCRIPTION
This should fix the current problem with dynamic axes such as GroovyAxis.

The problem is exposed as a unit test in the Groovy Axis plugin: https://github.com/jenkinsci/groovyaxis-plugin/commit/914f875e542bb6e80bac49a0641ba8b0da2fcfa0
