### PR TITLE
A fix for a failure at line 75 in the hudson.util.io.TarArchiverTest

### DIFF
--- a/core/src/test/java/hudson/util/io/TarArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/TarArchiverTest.java
@@ -70,7 +70,7 @@ public class TarArchiverTest extends TestCase {
             e.mkdirs();
 
             // extract via the tar command
-            assertEquals(0, new LocalLauncher(new StreamTaskListener(System.out)).launch().cmds("tar", "xvf", tar.getAbsolutePath()).pwd(e).join());
+            assertEquals(0, new LocalLauncher(new StreamTaskListener(System.out)).launch().cmds("tar", "xvpf", tar.getAbsolutePath()).pwd(e).join());
 
             assertEquals(0100755,e.child("a.txt").mode());
             assertEquals(dirMode,e.child("subdir").mode());


### PR DESCRIPTION
Fixed hudson.util.io.TarArchiverTest failure when user's umask is set to 007 (new files are rw-rw----). See http://pastebin.com/5HHF9F4W and http://pastebin.com/LL773uCd for failure logs.
