### PR TITLE
Add support for REST based manipulation of views

### DIFF
--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -217,6 +217,9 @@ public class ListView extends View implements Saveable {
 
     public void doAddJobToView(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         checkPermission(View.CONFIGURE);
+        if (!req.getMethod().equals("POST")) {
+            throw new Failure("Request must be a POST request");
+        }
 
         String name = req.getParameter("name");
         if(name==null)
@@ -233,6 +236,9 @@ public class ListView extends View implements Saveable {
 
     public void doRemoveJobFromView(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         checkPermission(View.CONFIGURE);
+        if (!req.getMethod().equals("POST")) {
+            throw new Failure("Request must be a POST request");
+        }
 
         String name = req.getParameter("name");
         if(name==null)

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -39,6 +39,7 @@ import org.kohsuke.stapler.StaplerResponse;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -212,6 +213,35 @@ public class ListView extends View implements Saveable {
             return item;
         }
         return null;
+    }
+
+    public void doAddJobToView(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        checkPermission(View.CONFIGURE);
+
+        String name = req.getParameter("name");
+        if(name==null)
+            throw new Failure("Query parameter 'name' is required");
+
+        if (getOwnerItemGroup().getItem(name) == null)
+            throw new Failure("Query parameter 'name' does not correspond to a known item");
+
+        if (jobNames.add(name))
+            owner.save();
+
+        rsp.setStatus(HttpServletResponse.SC_OK);
+    }
+
+    public void doRemoveJobFromView(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        checkPermission(View.CONFIGURE);
+
+        String name = req.getParameter("name");
+        if(name==null)
+            throw new Failure("Query parameter 'name' is required");
+
+        if (jobNames.remove(name))
+            owner.save();
+
+        rsp.setStatus(HttpServletResponse.SC_OK);
     }
 
     @Override

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -24,15 +24,20 @@
  */
 package hudson.model;
 
+import com.thoughtworks.xstream.converters.ConversionException;
+import com.thoughtworks.xstream.io.StreamException;
+import com.thoughtworks.xstream.io.xml.XppDriver;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.ExtensionPoint;
 import hudson.Indenter;
 import hudson.Util;
+import hudson.XmlFile;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Node.Mode;
 import hudson.model.labels.LabelAtom;
 import hudson.model.labels.LabelAtomPropertyDescriptor;
+import hudson.model.listeners.SaveableListener;
 import hudson.scm.ChangeLogSet.Entry;
 import hudson.search.CollectionSearchIndex;
 import hudson.search.SearchIndexBuilder;
@@ -43,20 +48,37 @@ import hudson.security.PermissionGroup;
 import hudson.security.PermissionScope;
 import hudson.util.AlternativeUiTextProvider;
 import hudson.util.AlternativeUiTextProvider.Message;
+import hudson.util.AtomicFileWriter;
 import hudson.util.DescribableList;
 import hudson.util.DescriptorList;
+import hudson.util.IOException2;
+import hudson.util.IOUtils;
 import hudson.util.RunList;
+import hudson.util.XStream2;
 import hudson.views.ListViewColumn;
 import hudson.widgets.Widget;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -72,6 +94,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jenkins.model.Jenkins.*;
 
 /**
@@ -816,6 +839,68 @@ public abstract class View extends AbstractModelObject implements AccessControll
     }
 
     /**
+     * Accepts <tt>config.xml</tt> submission, as well as serve it.
+     */
+    @WebMethod(name = "config.xml")
+    public void doConfigDotXml(StaplerRequest req, StaplerResponse rsp)
+            throws IOException {
+        if (req.getMethod().equals("GET")) {
+            // read
+            checkPermission(READ);
+            rsp.setContentType("application/xml");
+            // pity we don't have a handy way to clone Jenkins.XSTREAM to temp add the omit Field
+            XStream2 xStream2 = new XStream2();
+            xStream2.omitField(View.class, "owner");
+            rsp.getOutputStream().write("<?xml version='1.0' encoding='UTF-8'?>\n".getBytes("UTF-8"));
+            xStream2.toXML(this,  rsp.getOutputStream());
+            return;
+        }
+        if (req.getMethod().equals("POST")) {
+            // submission
+            updateByXml((Source)new StreamSource(req.getReader()));
+            return;
+        }
+
+        // huh?
+        rsp.sendError(SC_BAD_REQUEST);
+    }
+
+    /**
+     * Updates Job by its XML definition.
+     */
+    public void updateByXml(Source source) throws IOException {
+        checkPermission(CONFIGURE);
+        StringWriter out = new StringWriter();
+        try {
+            // this allows us to use UTF-8 for storing data,
+            // plus it checks any well-formedness issue in the submitted
+            // data
+            Transformer t = TransformerFactory.newInstance()
+                    .newTransformer();
+            t.transform(source,
+                    new StreamResult(out));
+            out.close();
+        } catch (TransformerException e) {
+            throw new IOException2("Failed to persist configuration.xml", e);
+        }
+
+        // try to reflect the changes by reloading
+        InputStream in = new BufferedInputStream(new ByteArrayInputStream(out.toString().getBytes("UTF-8")));
+        try {
+            Jenkins.XSTREAM.unmarshal(new XppDriver().createReader(in), this);
+        } catch (StreamException e) {
+            throw new IOException2("Unable to read",e);
+        } catch(ConversionException e) {
+            throw new IOException2("Unable to read",e);
+        } catch(Error e) {// mostly reflection errors
+            throw new IOException2("Unable to read",e);
+        } finally {
+            in.close();
+        }
+    }
+
+
+    /**
      * A list of available view types.
      * @deprecated as of 1.286
      *      Use {@link #all()} for read access, and use {@link Extension} for registration.
@@ -859,14 +944,28 @@ public abstract class View extends AbstractModelObject implements AccessControll
     
     public static View create(StaplerRequest req, StaplerResponse rsp, ViewGroup owner)
             throws FormException, IOException, ServletException {
+        String requestContentType = req.getContentType();
+        if(requestContentType==null)
+            throw new Failure("No Content-Type header set");
+
+        boolean isXmlSubmission = requestContentType.startsWith("application/xml") || requestContentType.startsWith("text/xml");
+
         String name = req.getParameter("name");
         checkGoodName(name);
         if(owner.getView(name)!=null)
             throw new FormException(Messages.Hudson_ViewAlreadyExists(name),"name");
 
         String mode = req.getParameter("mode");
-        if (mode==null || mode.length()==0)
-            throw new FormException(Messages.View_MissingMode(),"mode");
+        if (mode==null || mode.length()==0) {
+            if(isXmlSubmission) {
+                View v;
+                v = createViewFromXML(name, req.getInputStream());
+                v.owner = owner;
+                rsp.setStatus(HttpServletResponse.SC_OK);
+                return v;
+            } else
+                throw new FormException(Messages.View_MissingMode(),"mode");
+        }
 
         // create a view
         View v = all().findByName(mode).newInstance(req,req.getSubmittedForm());
@@ -876,6 +975,23 @@ public abstract class View extends AbstractModelObject implements AccessControll
         rsp.sendRedirect2(req.getContextPath()+'/'+v.getUrl()+v.getPostConstructLandingPage());
 
         return v;
+    }
+
+    public static View createViewFromXML(String name, InputStream xml) throws IOException {
+        InputStream in = new BufferedInputStream(xml);
+        try {
+            View v = (View) Jenkins.XSTREAM.fromXML(in);
+            v.name = name;
+            return v;
+        } catch(StreamException e) {
+            throw new IOException2("Unable to read",e);
+        } catch(ConversionException e) {
+            throw new IOException2("Unable to read",e);
+        } catch(Error e) {// mostly reflection errors
+            throw new IOException2("Unable to read",e);
+        } finally {
+            in.close();
+        }
     }
 
     public static class PropertyList extends DescribableList<ViewProperty,ViewPropertyDescriptor> {

--- a/core/src/main/resources/hudson/model/ListView/_api.jelly
+++ b/core/src/main/resources/hudson/model/ListView/_api.jelly
@@ -1,0 +1,40 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <h2>Add Job to View</h2>
+  <p>
+    To add a job to this view, send a POST request to <a href="../addJobToView">this URL</a> with
+    query parameter <tt>name=<i>JOBNAME</i></tt>. You'll get 200 status code if the job was successfully added to
+    this view, or 4xx/5xx code if it fails.
+  </p>
+
+  <h2>Remove Job from View</h2>
+  <p>
+    To remove a job from this view, send a POST request to <a href="../removeJobFromView">this URL</a> with
+    query parameter <tt>name=<i>JOBNAME</i></tt>. You'll get 200 status code if the job was successfully removed
+    from this view, or 4xx/5xx code if it fails.
+  </p>
+</j:jelly>

--- a/core/src/main/resources/hudson/model/View/_api.jelly
+++ b/core/src/main/resources/hudson/model/View/_api.jelly
@@ -30,18 +30,4 @@ THE SOFTWARE.
     You can also POST an updated <tt>config.xml</tt> to the same URL to programmatically
     update the configuration of a view.
   </p>
-
-  <h2>Add Job to View</h2>
-  <p>
-    To add a job to this view, send a POST request to <a href="../addJobToView">this URL</a> with
-    query parameter <tt>name=<i>JOBNAME</i></tt>. You'll get 200 status code if the job was successfully added to
-    this view, or 4xx/5xx code if it fails.
-  </p>
-
-  <h2>Remove Job from View</h2>
-  <p>
-    To remove a job from this view, send a POST request to <a href="../removeJobFromView">this URL</a> with
-    query parameter <tt>name=<i>JOBNAME</i></tt>. You'll get 200 status code if the job was successfully removed
-    from this view, or 4xx/5xx code if it fails.
-  </p>
 </j:jelly>


### PR DESCRIPTION
Adds support for the following REST actions

POST -> $JENKINS_URL/createView?name=___
GET/POST -> $JENKINS_URL/view/**_/config.xml
POST -> $JENKINS_URL/view/_**/addJobToView?name=___
POST -> $JENKINS_URL/view/**_/removeJobFromView?name=**_
