### PR TITLE
Don't let a single invalid email address stop us

### DIFF
--- a/core/src/main/java/hudson/tasks/MailSender.java
+++ b/core/src/main/java/hudson/tasks/MailSender.java
@@ -408,7 +408,11 @@ public class MailSender {
             if(debug)
                 listener.getLogger().println("  User "+a.getId()+" -> "+adrs);
             if (adrs != null)
-                r.add(Mailer.StringToAddress(adrs, charset));
+            	try {
+                    r.add(Mailer.StringToAddress(adrs, charset));
+                } catch(AddressException e) {
+                    listener.getLogger().println("Invalid address: " + adrs);
+                }
             else {
                 listener.getLogger().println(Messages.MailSender_NoAddress(a.getFullName()));
             }


### PR DESCRIPTION
Previously, if a commit had an invalid email address (for instance user@.) then Jenkins would not send email to anyone because of an unhandled exception.
