### PR TITLE
Tune the Jenkins OS X installer

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -64,6 +64,8 @@ Upcoming changes</a>
     Make the draggable component more obvious by providing a border.
   <li class=rfe>
     Added REST API for view manipulation
+  <li class=rfe>
+    Changed defaults for the Mac installer to make iOS codesigning easier.
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/osx/JenkinsInstaller.pmdoc/index.xml
+++ b/osx/JenkinsInstaller.pmdoc/index.xml
@@ -17,10 +17,10 @@
     <choice title="Jenkins" id="jenkins-war" tooltip="jenkins.war file" description="The jenkins.war file." starts_selected="true" starts_enabled="false" starts_hidden="false">
       <pkgref id="org.jenkins-ci.jenkins.osx.pkg"/>
     </choice>
-    <choice title="Start at boot as &quot;daemon&quot;" id="jenkins-launchd" tooltip="Run as daemon" description="Install a launchd config file so Jenkins will start at boot. Jenkins will run as user &quot;daemon&quot;." starts_selected="true" starts_enabled="true" starts_hidden="false">
+    <choice title="Start at boot as &quot;daemon&quot;" id="jenkins-launchd" tooltip="Run as daemon" description="Install a launchd config file so Jenkins will start at boot. Jenkins will run as user &quot;daemon&quot;." starts_selected="false" starts_enabled="true" starts_hidden="false">
       <pkgref id="org.jenkins-ci.launchd.pkg"/>
     </choice>
-    <choice title="Start at boot as &quot;jenkins&quot;" id="jenkins-launchd-jenkins" tooltip="Run as jenkins" description="Install a launchd config file so Jenkins will start at boot. Jenkins will run as user &quot;jenkins&quot;. This user has a writable home dir, which makes it possible to set up things like ssh." starts_selected="false" starts_enabled="true" starts_hidden="false">
+    <choice title="Start at boot as &quot;jenkins&quot;" id="jenkins-launchd-jenkins" tooltip="Run as jenkins" description="Install a launchd config file so Jenkins will start at boot. Jenkins will run as user &quot;jenkins&quot;. This user has a writable home dir, which makes it possible to set up things like ssh." starts_selected="true" starts_enabled="true" starts_hidden="false">
       <pkgref id="org.jenkins-ci.launchd-jenkins.pkg"/>
     </choice>
     <choice title="Jenkins Support Files" id="choice6" tooltip="Support files for Jenkins" description="Contains files required by the Launch Daemon." starts_selected="true" starts_enabled="true" starts_hidden="false">

--- a/osx/launchd_conf_jenkins/org.jenkins-ci.plist
+++ b/osx/launchd_conf_jenkins/org.jenkins-ci.plist
@@ -22,5 +22,7 @@
 	<true/>
 	<key>UserName</key>
 	<string>jenkins</string>
+        <key>SessionCreate</key>
+	<true />
 </dict>
 </plist>

--- a/osx/scripts/postinstall-launchd-jenkins
+++ b/osx/scripts/postinstall-launchd-jenkins
@@ -29,7 +29,7 @@ if ! dscl . -list /Users/jenkins; then
 
     dscl . -create /Groups/jenkins PrimaryGroupID $gid
 
-    dscl . -create /Users/jenkins UserShell /usr/bin/false
+    dscl . -create /Users/jenkins UserShell /bin/bash
     dscl . -create /Users/jenkins Password '*'
     dscl . -create /Users/jenkins UniqueID $uid
     dscl . -create /Users/jenkins PrimaryGroupID $gid


### PR DESCRIPTION
This pull request does three things:
- it switches the default install from running as 'daemon' to running as 'jenkins'
- it gives the jenkins user a shell, so people can su to jenkins and fiddle with Developer Certificates. 
- includes a modified LaunchDaemon plist, to enable Jenkins to use keychains while running as daemon, although some caveats (that are system behaviour) still apply.
