### PR TITLE
Fix Windows Symlink Detection

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -68,6 +68,8 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import hudson.util.jna.Kernel32Utils;
+
 import static hudson.util.jna.GNUCLibrary.LIBC;
 
 /**
@@ -308,6 +310,9 @@ public class Util {
      */
     //Taken from http://svn.apache.org/viewvc/maven/shared/trunk/file-management/src/main/java/org/apache/maven/shared/model/fileset/util/FileSetManager.java?view=markup
     public static boolean isSymlink(File file) throws IOException {
+        if (Functions.isWindows()) {
+          return Kernel32Utils.isJunctionOrSymlink(file);
+        }
         String name = file.getName();
         if (name.equals(".") || name.equals(".."))
             return false;

--- a/core/src/main/java/hudson/util/jna/Kernel32.java
+++ b/core/src/main/java/hudson/util/jna/Kernel32.java
@@ -26,6 +26,7 @@ package hudson.util.jna;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.WString;
 import com.sun.jna.Native;
 
 /**
@@ -47,8 +48,11 @@ public interface Kernel32 extends StdCallLibrary {
     int MOVEFILE_FAIL_IF_NOT_TRACKABLE = 32;
     int MOVEFILE_REPLACE_EXISTING = 1;
     int MOVEFILE_WRITE_THROUGH = 8;
+    
+    int FILE_ATTRIBUTE_REPARSE_POINT = 0x400;
 
     int WaitForSingleObject(Pointer handle, int milliseconds);
+    int GetFileAttributesW(WString lpFileName);
     boolean GetExitCodeProcess(Pointer handle, IntByReference r);
 
     int STILL_ACTIVE = 259;

--- a/core/src/main/java/hudson/util/jna/Kernel32Utils.java
+++ b/core/src/main/java/hudson/util/jna/Kernel32Utils.java
@@ -23,8 +23,11 @@
  */
 package hudson.util.jna;
 
+import java.io.*;
+
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.WString;
 
 /**
  *
@@ -49,5 +52,13 @@ public class Kernel32Utils {
                 return v;
             }
         }
+    }
+
+    public static int getWin32FileAttributes(File file) throws IOException {
+      return Kernel32.INSTANCE.GetFileAttributesW(new WString(file.getCanonicalPath()));
+    }
+
+    public static boolean isJunctionOrSymlink(File file) throws IOException {
+      return (file.exists() && (Kernel32.INSTANCE.FILE_ATTRIBUTE_REPARSE_POINT & getWin32FileAttributes(file)) != 0);
     }
 }


### PR DESCRIPTION
On Windows platforms hudson.Util.isSymlink code does not properly detect symlinks or directory junctions. One major problem that this causes is jenkins following symlinks created during the build process when deleting the previous workspace on a new build. This is a problem when symlinks exist to files outside of the main workspace directory, as this modifies the underlying system by attempting to delete the symlinked folders/files rather than the symlinks themselves. This commit fixes symlink detection by using jna on Windows.
