### PR TITLE
Prevent processing hetero-list twice.

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list/hetero-list.js
+++ b/core/src/main/resources/lib/form/hetero-list/hetero-list.js
@@ -14,8 +14,12 @@ Behaviour.list.unshift({
         YAHOO.util.Dom.insertAfter(menu,btn);
 
         var prototypes = $(e.lastChild);
-        while(!prototypes.hasClassName("prototypes"))
+        while(prototypes && !prototypes.hasClassName("prototypes"))
             prototypes = prototypes.previous();
+
+        // prototypes can be null if the element has already been processed
+        if(prototypes == null)
+            return;
         var insertionPoint = prototypes.previous();    // this is where the new item is inserted.
 
         // extract templates


### PR DESCRIPTION
Check for null prototype occuring if we end up calling the function
multiple times on the list. the type error that it causes means other
behaviours are not applied to the rest of the container.
[FIXED JENKINS-14495]

Full details of investigation in the issue
https://issues.jenkins-ci.org/browse/JENKINS-14495
