### PR TITLE
[FIXED JENKINS-11759] Allow single user with multiple usernames, therefore allowing same person to be identified

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -69,6 +69,9 @@ Upcoming changes</a>
     Added REST API for view manipulation
   <li class="rfe">
     OS X installer now has an Uninstall tool (in /Library/Application Support/Jenkins).
+  <li class=rfe>
+    Added ability to let users specify alternate commit names.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-11759">issue 11759</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -58,6 +58,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
+import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
@@ -382,6 +383,11 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
      * Attempts to retrieve a user by their id or full name.  It will
      * try looking at any alternate commit names defined for users.
      * 
+     * @param Boolean create
+     *      If true, it will attempt to create a user so that
+     *      there is something returned.
+     *      If false, this method will potentially return null.
+     * 
      * @return User
      * @since 1.477
      */
@@ -419,8 +425,15 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
         u = get(idOrFullName, create);
         return u;
     }
-    
-    public static User getByCommitName(String idOrFullName) {
+
+    /**
+     * Attempts to retrieve a user by their id or full name.  It will
+     * try looking at any alternate commit names defined for users.
+     * 
+     * @return User
+     * @since 1.477
+     */
+    public static @Nonnull User getByCommitName(String idOrFullName) {
     	return getByCommitName(idOrFullName, true);
     }
 

--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2011, CloudBees, Inc.
+ * Copyright (c) 2011-2012, CloudBees, Inc., Daniel Khodaparast
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +40,8 @@ import java.io.IOException;
  */
 @Extension(ordinal=200)
 public class GlobalSecurityConfiguration extends GlobalConfiguration {
-    public MarkupFormatter getMarkupFormatter() {
+
+	public MarkupFormatter getMarkupFormatter() {
         return Jenkins.getInstance().getMarkupFormatter();
     }
     
@@ -68,6 +69,12 @@ public class GlobalSecurityConfiguration extends GlobalConfiguration {
                 j.setMarkupFormatter(req.bindJSON(MarkupFormatter.class, security.getJSONObject("markupFormatter")));
             } else {
                 j.setMarkupFormatter(null);
+            }
+
+            try {
+                j.setUseCommitNames(security.has("useCommitNames") ? true : null);
+            } catch (IOException e) {
+                throw new FormException(e,"useCommitNames");
             }
         } else {
             j.disableSecurity();

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -308,6 +308,14 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
                 si.errorMessage = "User name is already taken";
         }
 
+        // check if we utilize alternate commit name mapping
+        if (Jenkins.getInstance().isUseCommitNames() && si.errorMessage == null) {
+        	User user = User.getByCommitName(si.username, false);
+        	if (user != null) {
+        		si.errorMessage = "User name is already mapped to " + user.getId();
+        	}
+        }
+
         if(si.fullname==null || si.fullname.length()==0)
             si.fullname = si.username;
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1,10 +1,10 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2004-2011, Sun Microsystems, Inc., Kohsuke Kawaguchi,
+ * Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi,
  * Erik Ramfelt, Koichi Fujikawa, Red Hat, Inc., Seiji Sogabe,
  * Stephen Connolly, Tom Huybrechts, Yahoo! Inc., Alan Harder, CloudBees, Inc.,
- * Yahoo!, Inc.
+ * Yahoo!, Inc., Daniel Khodaparast
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -373,7 +373,15 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
      * @see #setSecurityRealm(SecurityRealm)
      */
     private volatile SecurityRealm securityRealm = SecurityRealm.NO_AUTHENTICATION;
-    
+
+    /**
+     * Whether alternate commit name mapping is being utilized.
+     * 
+     * @return Boolean
+     * @since 1.477
+     */
+    private Boolean useCommitNames;
+
     /**
      * The project naming strategy defines/restricts the names which can be given to a project/job. e.g. does the name have to follow a naming convention?
      */
@@ -1920,6 +1928,17 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
     }
 
     /**
+     * Determines if alternate commit name mapping is being utilized.
+     * 
+     * @return Boolean
+     * @since 1.477
+     */
+    @Exported
+    public boolean isUseCommitNames() {
+        return useCommitNames != null;
+    }
+
+    /**
      * If true, all the POST requests to Hudson would have to have crumb in it to protect
      * Hudson from CSRF vulnerabilities.
      */
@@ -1986,6 +2005,16 @@ public class Jenkins extends AbstractCIBase implements ModifiableItemGroup<TopLe
         setSecurityRealm(SecurityRealm.NO_AUTHENTICATION);
         authorizationStrategy = AuthorizationStrategy.UNSECURED;
         markupFormatter = null;
+    }
+
+    /**
+     * Defines if the utilization of alternate commit name mapping should be utilized.
+     * 
+     * @since 1.477
+     */
+    public void setUseCommitNames(Boolean useCommitNames) throws IOException {
+        this.useCommitNames = useCommitNames;
+        save();
     }
 
     public void setProjectNamingStrategy(ProjectNamingStrategy ns) {

--- a/core/src/main/java/jenkins/security/CommitNamesProperty.java
+++ b/core/src/main/java/jenkins/security/CommitNamesProperty.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Daniel Khodaparast
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Descriptor.FormException;
+import hudson.model.User;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.export.Exported;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Grants the ability to define an alternate list of commit names for a user.
+ * 
+ * @author Daniel Khodaparast
+ * @since 1.477
+ */
+public class CommitNamesProperty extends UserProperty {
+
+	private final String commitNames;
+
+	public CommitNamesProperty(String commitNames) {
+		if (commitNames != null) {
+			commitNames = commitNames.replaceAll("\\s*,\\s*", ",").toLowerCase(Locale.ENGLISH);
+
+			List<String> nameList = Arrays.asList(commitNames.split(","));
+			List<String> filtered = new ArrayList<String>();
+
+			for (String name : nameList) {
+				if ((User.get(name, false) != null) || filtered.contains(name)) {
+					continue;
+				}
+				filtered.add(name);
+			}
+
+			commitNames = StringUtils.join(filtered.toArray(), ",");
+		}
+		this.commitNames = commitNames;
+	}
+
+	@Exported
+	public String getNames() {
+		return Util.fixEmptyAndTrim(commitNames);
+	}
+
+	@Extension
+	public static final class DescriptorImpl extends UserPropertyDescriptor {
+		public String getDisplayName() {
+			if (Jenkins.getInstance().isUseCommitNames()) {
+				return Messages.CommitNamesProperty_DisplayName();
+			}
+			return null;
+		}
+
+		@Override
+		public UserProperty newInstance(User user) {
+			return new CommitNamesProperty(null);
+		}
+
+		@Override
+		public UserProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+			return new CommitNamesProperty(req.getParameter("commit.names"));
+		}
+	}
+}

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/config.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/config.groovy
@@ -18,4 +18,6 @@ f.optionalBlock( field:"useSecurity", title:_("Enable security"), checked:app.us
             f.descriptorRadioList(title:_("Authorization"), varName:"authorization", instance:app.authorizationStrategy, descriptors:AuthorizationStrategy.all())
         }
     }
+
+    f.optionalBlock( field:"useCommitNames", title:_("Utilize commit name mapping to prevent duplicate user creation"), checked:app.useCommitNames )
 }

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/help-useCommitNames.html
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/help-useCommitNames.html
@@ -1,0 +1,5 @@
+<div>
+	As a result of the automatic creation of multiple user accounts for one person due to version
+	control, this grants the ability to define a list of alternate commit names that a particular
+	user is likely to commit under.
+</div>

--- a/core/src/main/resources/jenkins/security/CommitNamesProperty/config.jelly
+++ b/core/src/main/resources/jenkins/security/CommitNamesProperty/config.jelly
@@ -1,0 +1,32 @@
+<!--
+The MIT License
+
+Copyright (c) 2012, Daniel Khodaparast
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<j:if test="${app.useCommitNames}">
+		<f:entry title="${%displayName}" description="${%description}">
+			<f:textbox name="commit.names" value="${instance.names}"/>
+		</f:entry>
+	</j:if>
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/CommitNamesProperty/config.properties
+++ b/core/src/main/resources/jenkins/security/CommitNamesProperty/config.properties
@@ -1,17 +1,17 @@
 # The MIT License
-#
-# Copyright (c) 2011-2012, Seiji Sogabe, Daniel Khodaparast
-#
+# 
+# Copyright (c) 2012, Daniel Khodaparast
+# 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#
+# 
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-#
+# 
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,6 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-ApiTokenProperty.DisplayName=API Token
-ApiTokenProperty.ChangeToken.Success=<div>Updated</div>
-CommitNamesProperty.DisplayName=Commit Name Mapping
+displayName=Commit Names
+description=A list of alternate names utilized for this one user, like <tt>john.doe,johnathan.doe</tt>

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
@@ -1,16 +1,23 @@
 package hudson.security;
 
+import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.WithoutJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
+import hudson.model.User;
+import hudson.security.AuthorizationStrategy;
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
 import static hudson.security.HudsonPrivateSecurityRealm.*;
 
+import jenkins.security.CommitNamesProperty;
+
 /**
- * @author Kohsuke Kawaguchi
+ * @author Kohsuke Kawaguchi, Daniel Khodaparast
  */
 public class HudsonPrivateSecurityRealmTest extends HudsonTestCase {
     /**
@@ -48,5 +55,33 @@ public class HudsonPrivateSecurityRealmTest extends HudsonTestCase {
         assertTrue(PASSWORD_ENCODER.isPasswordValid(old,"hello world",null));
 
         assertTrue(!secure.equals(old));
+    }
+
+    @Test
+    public void testUserMappedError() throws Exception {
+        hudson.setAuthorizationStrategy(new FullControlOnceLoggedInAuthorizationStrategy());
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+        hudson.setSecurityRealm(realm);
+        hudson.setUseCommitNames(true);
+
+        User u = realm.createAccount("test1", "test1");
+        u.addProperty(new CommitNamesProperty("test2,    test3"));
+        u.save();
+
+        WebClient wc = createWebClient();
+        wc.login("test1", "test1");
+
+        HtmlPage page1 = wc.goTo("securityRealm/addUser");
+        HtmlForm form = page1.getFirstByXPath("//form[@action='/securityRealm/createAccountByAdmin']");
+
+        form.getInputByName("username").setValueAttribute("test3");
+        form.getInputByName("password1").setValueAttribute("password3");
+        form.getInputByName("password2").setValueAttribute("password3");
+        form.getInputByName("fullname").setValueAttribute("Test User3");
+        form.getInputByName("email").setValueAttribute("test.user3@example.com");
+
+        HtmlPage page2 = submit(form);
+        String pageText = page2.asText();
+        assertTrue(pageText.contains("User name is already mapped to test1"));
     }
 }

--- a/test/src/test/java/jenkins/security/CommitNamesPropertyTest.java
+++ b/test/src/test/java/jenkins/security/CommitNamesPropertyTest.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Daniel Khodaparast
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import hudson.model.User;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+/**
+ * @author Daniel Khodaparast
+ * @since 1.477
+ */
+public class CommitNamesPropertyTest extends HudsonTestCase {
+
+	@Test
+	public void testNotDefined() throws Exception {
+		jenkins.setUseCommitNames(true);
+		User u = User.get("test");
+
+		HtmlPage config = createWebClient().goTo(u.getUrl() + "/configure");
+		HtmlForm form = config.getFormByName("config");
+
+		assertEquals("", form.getInputByName("commit.names").getValueAttribute());
+	}
+
+	@Test
+	public void testNotDuplicate() throws Exception {
+		jenkins.setUseCommitNames(true);
+		User u = User.get("test");
+
+		WebClient wc = createWebClient();
+		HtmlPage config = wc.goTo(u.getUrl() + "/configure");
+		HtmlForm form = config.getFormByName("config");
+
+		form.getInputByName("commit.names").setValueAttribute("foo,bar,foo");
+		submit(form);
+
+		CommitNamesProperty c = u.getProperty(CommitNamesProperty.class);
+		assertEquals("foo,bar", c.getNames());
+	}
+
+	@Test
+	public void testNotEnabled() throws Exception {
+		jenkins.setUseCommitNames(false);
+		User u = User.get("test");
+
+		HtmlPage config = createWebClient().goTo(u.getUrl() + "/configure");
+		HtmlForm form = config.getFormByName("config");
+
+		assertEquals("", form.getInputByName("commit.names").getValueAttribute());
+	}
+
+
+	@Test
+	public void testUserExists() throws Exception {
+		jenkins.setUseCommitNames(true);
+		User u1 = User.get("test1");
+		User u2 = User.get("test2");
+
+		WebClient wc = createWebClient();
+		HtmlPage config = wc.goTo(u1.getUrl() + "/configure");
+		HtmlForm form = config.getFormByName("config");
+
+		form.getInputByName("commit.names").setValueAttribute("foo,test2");
+		submit(form);
+
+		CommitNamesProperty c = u1.getProperty(CommitNamesProperty.class);
+		assertEquals("foo", c.getNames());
+	}
+
+	@Test
+	public void testUserTrimmed() throws Exception {
+		jenkins.setUseCommitNames(true);
+		User u = User.get("test");
+
+		WebClient wc = createWebClient();
+		HtmlPage config = wc.goTo(u.getUrl() + "/configure");
+		HtmlForm form = config.getFormByName("config");
+
+		form.getInputByName("commit.names").setValueAttribute("   foo      ,       bar,foo.bar   ,   bar.foo,    ");
+		submit(form);
+
+		CommitNamesProperty c = u.getProperty(CommitNamesProperty.class);
+		assertEquals("foo,bar,foo.bar,bar.foo", c.getNames());
+	}
+}


### PR DESCRIPTION
This adds an option to global security settings that permits the definition of alternate commit names for Jenkins users.  If you have user "john" committing from location one as "j.doe" and location two as "john.doe", it is now possible to prevent automatic new Jenkins user creation by mapping both of those commit names.
