### PR TITLE
users can now update the node offline message

### DIFF
--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -36,6 +36,9 @@ THE SOFTWARE.
               <form method="post" action="toggleOffline">
                 <f:submit value="${%submit.temporarilyOffline}"  />
               </form>
+              <form method="post" action="setOfflineCause">
+              <f:submit value="${%submit.updateOfflineCause}"  />
+              </form>
             </l:hasPermission>
           </j:when>
           <j:otherwise>

--- a/core/src/main/resources/hudson/model/Computer/index.properties
+++ b/core/src/main/resources/hudson/model/Computer/index.properties
@@ -1,17 +1,17 @@
 # The MIT License
-# 
+#
 # Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe, Stephen Connolly
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,6 +22,7 @@
 
 submit.temporarilyOffline=Bring this node back online
 submit.not.temporarilyOffline=Mark this node temporarily offline
+submit.updateOfflineCause=Update offline reason
 title.projects_tied_on=Projects tied to {0}
 title.no_manual_launch=This node has an availability policy that will "{0}". Currently, this mandates that the node be offline.
 

--- a/core/src/main/resources/hudson/model/Computer/setOfflineCause.jelly
+++ b/core/src/main/resources/hudson/model/Computer/setOfflineCause.jelly
@@ -1,0 +1,44 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe, Stephen Connolly, Tom Huybrechts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:layout title="${%title(it.displayName)}" norefresh="true">
+    <st:include page="sidepanel.jelly" />
+    <l:main-panel>
+      <l:hasPermission permission="${it.DISCONNECT}">
+        <h2>${%title(it.displayName)}</h2>
+        <p>
+          ${%blurb}
+        </p>
+        <form method="post" action="changeOfflineCause">
+          <f:textarea name="offlineMessage" value="${it.getOfflineCauseReason()}"/>
+          <p>
+            <f:submit value="${%submit}"  />
+          </p>
+        </form>
+      </l:hasPermission>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/core/src/main/resources/hudson/model/Computer/setOfflineCause.properties
+++ b/core/src/main/resources/hudson/model/Computer/setOfflineCause.properties
@@ -1,0 +1,3 @@
+title=Set {0} Offline Reason
+blurb=You can set or update the reason why this node offline, so that others can see why:
+submit=Update reason


### PR DESCRIPTION
Users are now able to update node offline messages without
bringing the node back online and offline.

Example images of new interface: 
  https://img.skitch.com/20120807-ni5wwdy897a3j8rxwxpnpjd19n.jpg
    - shows new "Update offline reason" button
  https://img.skitch.com/20120807-fen87p74muyt9ycsmkk3qx3mci.jpg
    - shows interface for setting new note
