### PR TITLE
[FIXED JENKINS-7162] Add missing parameters as defaults when called from...

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -91,7 +91,7 @@ public class BuildCommand extends CLICommand {
             if (pdp==null)
                 throw new AbortException(job.getFullDisplayName()+" is not parameterized but the -p option was specified");
 
-            List<ParameterValue> values = new ArrayList<ParameterValue>(); 
+            List<ParameterValue> values = new ArrayList<ParameterValue>();
 
             for (Entry<String, String> e : parameters.entrySet()) {
                 String name = e.getKey();
@@ -101,7 +101,16 @@ public class BuildCommand extends CLICommand {
                             name, EditDistance.findNearest(name, pdp.getParameterDefinitionNames())));
                 values.add(pd.createValue(this,e.getValue()));
             }
-            
+
+            // handle missing parameters by adding as default values ISSUE JENKINS-7162
+            for(ParameterDefinition pd :  pdp.getParameterDefinitions()) {
+                if (parameters.containsKey(pd.getName()))
+                    continue;
+
+                // not passed in use default
+                values.add(pd.getDefaultParameterValue());
+            }
+
             a = new ParametersAction(values);
         }
 
@@ -145,17 +154,17 @@ public class BuildCommand extends CLICommand {
     }
 
     public static class CLICause extends UserIdCause {
-    	
+
     	private String startedBy;
-    	
+
     	public CLICause(){
     		startedBy = "unknown";
     	}
-    	
+
     	public CLICause(String startedBy){
     		this.startedBy = startedBy;
     	}
-    	
+
         @Override
         public String getShortDescription() {
             return Messages.BuildCommand_CLICause_ShortDescription(startedBy);

--- a/test/src/test/groovy/hudson/cli/BuildCommandTest.groovy
+++ b/test/src/test/groovy/hudson/cli/BuildCommandTest.groovy
@@ -98,6 +98,21 @@ public class BuildCommandTest extends HudsonTestCase {
         }
     }
 
+    void testDefaultParameters() {
+        def p = createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty([new StringParameterDefinition("key","default"), new StringParameterDefinition("key2","default2") ]));
+
+        def cli = new CLI(getURL())
+        try {
+            cli.execute(["build","-s","-p","key=foobar",p.name])
+            def b = assertBuildStatusSuccess(p.getBuildByNumber(1))
+            assertEquals("foobar",b.getAction(ParametersAction.class).getParameter("key").value)
+            assertEquals("default2",b.getAction(ParametersAction.class).getParameter("key2").value)
+        } finally {
+            cli.close();
+        }
+    }
+
     void testConsoleOutput() {
         def p = createFreeStyleProject()
         def cli = new CLI(getURL())


### PR DESCRIPTION
... CLI

Add all the job defined Parameters to the ParameterAction using Defaults
if not passed via the command line.

If this breaks backwards compatibility where these are not expected to be passed, we can introduce a new option  to use the defaults for parameters which triggers this behaviour.

@Option(name="-d",usage="Use defaults for parameters not specified, only valid when -p is used")
    public boolean parameterDefaults = false;
