### PR TITLE
Create a marker interface for actions to beable to pass matrix configura...

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixChildAction.java
+++ b/core/src/main/java/hudson/matrix/MatrixChildAction.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Chris Johnson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.matrix;
+
+import hudson.model.Action;
+
+/**
+ * Optional interface for {@link Action}s to indicate that they
+ * want to be passed to the individual build jobs from the parent in am matrix job.
+ *
+ * @author Chris Johnson
+ */
+public interface MatrixChildAction extends Action {
+
+}

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Jean-Baptiste Quenot, Seiji Sogabe, Tom Huybrechts
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,7 @@ package hudson.model;
 import hudson.Util;
 import hudson.EnvVars;
 import hudson.diagnosis.OldDataMonitor;
+import hudson.matrix.MatrixChildAction;
 import hudson.model.Queue.QueueAction;
 import hudson.model.labels.LabelAssignmentAction;
 import hudson.model.queue.SubTask;
@@ -52,7 +53,7 @@ import java.util.Set;
  * that were specified when scheduling.
  */
 @ExportedBean
-public class ParametersAction implements Action, Iterable<ParameterValue>, QueueAction, EnvironmentContributingAction, LabelAssignmentAction {
+public class ParametersAction implements Action, Iterable<ParameterValue>, QueueAction, EnvironmentContributingAction, LabelAssignmentAction, MatrixChildAction {
 
     private final List<ParameterValue> parameters;
 
@@ -64,7 +65,7 @@ public class ParametersAction implements Action, Iterable<ParameterValue>, Queue
     public ParametersAction(List<ParameterValue> parameters) {
         this.parameters = parameters;
     }
-    
+
     public ParametersAction(ParameterValue... parameters) {
         this(Arrays.asList(parameters));
     }
@@ -92,7 +93,7 @@ public class ParametersAction implements Action, Iterable<ParameterValue>, Queue
      * Creates an {@link VariableResolver} that aggregates all the parameters.
      *
      * <p>
-     * If you are a {@link BuildStep}, most likely you should call {@link AbstractBuild#getBuildVariableResolver()}. 
+     * If you are a {@link BuildStep}, most likely you should call {@link AbstractBuild#getBuildVariableResolver()}.
      */
     public VariableResolver<String> createVariableResolver(AbstractBuild<?,?> build) {
         VariableResolver[] resolvers = new VariableResolver[parameters.size()+1];

--- a/test/src/test/groovy/hudson/matrix/MatrixProjectTest.groovy
+++ b/test/src/test/groovy/hudson/matrix/MatrixProjectTest.groovy
@@ -53,6 +53,13 @@ import hudson.model.FileParameterDefinition
 import hudson.model.Cause.LegacyCodeCause
 import hudson.model.ParametersAction
 import hudson.model.FileParameterValue
+import hudson.model.StringParameterDefinition
+import hudson.model.StringParameterValue
+import hudson.scm.SubversionSCM.SvnInfo;
+import hudson.scm.RevisionParameterAction;
+import java.util.List;
+import java.util.ArrayList;
+import hudson.model.Action;
 
 import java.util.concurrent.CountDownLatch
 
@@ -151,11 +158,11 @@ public class MatrixProjectTest extends HudsonTestCase {
     @Email("http://www.nabble.com/1.286-version-and-fingerprints-option-broken-.-td22236618.html")
     public void testFingerprinting() throws Exception {
         MatrixProject p = createMatrixProject();
-        if (Functions.isWindows()) 
+        if (Functions.isWindows())
            p.getBuildersList().add(new BatchFile("echo \"\" > p"));
-        else 
+        else
            p.getBuildersList().add(new Shell("touch p"));
-        
+
         p.getPublishersList().add(new ArtifactArchiver("p",null,false));
         p.getPublishersList().add(new Fingerprinter("",true));
         buildAndAssertSuccess(p);
@@ -295,7 +302,7 @@ public class MatrixProjectTest extends HudsonTestCase {
             fail()
         } catch (TimeoutException e) {
             // expected
-        }        
+        }
     }
 
     @Bug(9009)
@@ -326,7 +333,7 @@ public class MatrixProjectTest extends HudsonTestCase {
                 return v;
             }
         ))
-        
+
         assertBuildStatusSuccess(f.get(10,TimeUnit.SECONDS));
     }
 
@@ -343,7 +350,7 @@ public class MatrixProjectTest extends HudsonTestCase {
         p.concurrentBuild = true;
         def latch = new CountDownLatch(4)
         def dirs = Collections.synchronizedSet(new HashSet())
-        
+
         p.buildersList.add(new TestBuilder() {
             boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
                 dirs << build.workspace.getRemote()
@@ -366,4 +373,62 @@ public class MatrixProjectTest extends HudsonTestCase {
 
         assertEquals 4, dirs.size()
     }
+
+
+    /**
+     * Test that Actions are passed to configurations
+     */
+    public void testParameterActions() throws Exception {
+        MatrixProject p = createMatrixProject();
+
+        ParametersDefinitionProperty pdp = new ParametersDefinitionProperty(
+            new StringParameterDefinition("PARAM_A","default_a"),
+            new StringParameterDefinition("PARAM_B","default_b"),
+        );
+
+        p.addProperty(pdp);
+        ParametersAction pa = new ParametersAction( pdp.getParameterDefinitions().collect { return it.getDefaultParameterValue() } )
+
+        MatrixBuild build = p.scheduleBuild2(0,new LegacyCodeCause(), pa).get();
+
+        assertEquals(4, build.getRuns().size());
+
+        for(MatrixRun run : build.getRuns()) {
+            ParametersAction pa1 = run.getAction(ParametersAction.class);
+            assertNotNull(pa1);
+            ["PARAM_A","PARAM_B"].each{ assertNotNull(pa1.getParameter(it)) }
+        }
+    }
+
+    /**
+     * Test that other Actions are passed to configurations
+     * requires supported version of subversion plugin 1.43+
+     */
+
+    //~ public void testMatrixChildActions() throws Exception {
+        //~ MatrixProject p = createMatrixProject();
+
+        //~ ParametersDefinitionProperty pdp = new ParametersDefinitionProperty(
+            //~ new StringParameterDefinition("PARAM_A","default_a"),
+            //~ new StringParameterDefinition("PARAM_B","default_b"),
+        //~ );
+
+        //~ p.addProperty(pdp);
+
+        //~ List<Action> actions = new ArrayList<Action>();
+        //~ actions.add(new RevisionParameterAction(new SvnInfo("http://example.com/svn/repo/",1234)));
+        //~ actions.add(new ParametersAction( pdp.getParameterDefinitions().collect { return it.getDefaultParameterValue() } ));
+
+        //~ MatrixBuild build = p.scheduleBuild2(0,new LegacyCodeCause(), actions).get();
+
+        //~ assertEquals(4, build.getRuns().size());
+
+        //~ for(MatrixRun run : build.getRuns()) {
+            //~ ParametersAction pa1 = run.getAction(ParametersAction.class);
+            //~ assertNotNull(pa1);
+            //~ ["PARAM_A","PARAM_B"].each{ assertNotNull(pa1.getParameter(it)) };
+
+            //~ assertNotNull(run.getAction(RevisionParameterAction.class));
+        //~ }
+    //~ }
 }


### PR DESCRIPTION
...tions

Create a Interface that Actions can implement to indicat that they should be passed from
the matrix parent to the indiviual configurations.
This means that the SVN Parameters can be passed to them.
Partial fix for [JENKINS-14619] also needs changes in SVN SCM plugin to fix completely.

This Pull implements the solution that I think is more flexible, in that an action is explicitly declared that it will be passed from the parent build to the configuration builds.

There is also a pull request for passing all actions only one of these should be used.
