### PR TITLE
Pass all actions from matrix parent to configurations.

### DIFF
--- a/core/src/main/java/hudson/matrix/DefaultMatrixExecutionStrategyImpl.java
+++ b/core/src/main/java/hudson/matrix/DefaultMatrixExecutionStrategyImpl.java
@@ -147,12 +147,12 @@ public class DefaultMatrixExecutionStrategyImpl extends MatrixExecutionStrategy 
             notifyEndBuild(run,execution.getAggregators());
             r = r.combine(getResult(run));
         }
-        
+
         if (touchStoneResultCondition != null && r.isWorseThan(touchStoneResultCondition)) {
             logger.printf("Touchstone configurations resulted in %s, so aborting...%n", r);
             return r;
         }
-        
+
         if(!runSequentially)
             for(MatrixConfiguration c : delayedConfigurations)
                 scheduleConfigurationBuild(execution, c);
@@ -187,17 +187,26 @@ public class DefaultMatrixExecutionStrategyImpl extends MatrixExecutionStrategy 
             if(!a.endRun(b))
                 throw new AbortException();
     }
-    
+
     private <T> TreeSet<T> createTreeSet(Collection<T> items, Comparator<T> sorter) {
         TreeSet<T> r = new TreeSet<T>(sorter);
         r.addAll(items);
         return r;
     }
 
+    /** Function to start schedule a single configuration
+     *
+     * This function schedule a build of a configuration passing all of the actions
+     * that are present in the parent build.
+     *
+     * @param exec  Matrix build that is the parent of the configuration
+     * @param c     Configuration to schedule
+     */
     private void scheduleConfigurationBuild(MatrixBuildExecution exec, MatrixConfiguration c) {
         MatrixBuild build = exec.getBuild();
         exec.getListener().getLogger().println(Messages.MatrixBuild_Triggering(ModelHyperlinkNote.encodeTo(c)));
-        c.scheduleBuild(build.getAction(ParametersAction.class), new UpstreamCause((Run)build));
+
+        c.scheduleBuild(build.getActions(), new UpstreamCause((Run)build));
     }
 
     private MatrixRun waitForCompletion(MatrixBuildExecution exec, MatrixConfiguration c) throws InterruptedException, IOException {
@@ -244,7 +253,7 @@ public class DefaultMatrixExecutionStrategyImpl extends MatrixExecutionStrategy 
                     whyInQueue = why;
                 }
             }
-            
+
             Thread.sleep(1000);
         }
     }

--- a/core/src/main/java/hudson/matrix/MatrixConfiguration.java
+++ b/core/src/main/java/hudson/matrix/MatrixConfiguration.java
@@ -53,6 +53,8 @@ import hudson.tasks.LogRotator;
 import hudson.tasks.Publisher;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -359,13 +361,33 @@ public class MatrixConfiguration extends Project<MatrixConfiguration,MatrixRun> 
     	return scheduleBuild(parameters, new LegacyCodeCause());
     }
 
-    /**
+    /** Starts the build with the ParametersAction that are passed in.
      *
      * @param parameters
      *      Can be null.
+     * @deprecated
+	 *    Use {@link #scheduleBuild(List<? extends Action>, Cause)}.  Since 1.480
      */
     public boolean scheduleBuild(ParametersAction parameters, Cause c) {
-        return Jenkins.getInstance().getQueue().schedule(this, getQuietPeriod(), parameters, new CauseAction(c), new ParentBuildAction())!=null;
+
+        return scheduleBuild(Collections.singletonList(parameters), c);
+    }
+    /**
+     * Starts the build with the actions that are passed in.
+     *
+     * @param actions   Can be null.
+     * @param cause     Reason for starting the build
+     */
+    public boolean scheduleBuild(List<? extends Action> actions, Cause c) {
+        List<Action> allActions = new ArrayList<Action>();
+
+        if(actions != null)
+            allActions.addAll(actions);
+
+        allActions.add(new ParentBuildAction());
+        allActions.add(new CauseAction(c));
+
+        return Jenkins.getInstance().getQueue().schedule(this, getQuietPeriod(), allActions )!=null;
     }
 
     /**


### PR DESCRIPTION
Pass all actions from the parent matrix build to the individual configurations,
this allows the configurations to use the SVN SCM actions from the paramerter trigger
correctly so that the same version is checked out on the configurations as on the parent.
[FIXED JENKINS-14619]

This Pull implements the solution that passes all actions from the parent build to the configuration builds.

There is also a pull request for passing only actions explicitly stating that they want to passed to child configurations. Only one of these should be used. https://github.com/jenkinsci/jenkins/pull/543
