### PR TITLE
Avoid failure when the readlink command is executed against AIX

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1071,7 +1071,12 @@ public class Util {
         } catch (LinkageError e) {
             // if JNA is unavailable, fall back.
             // we still prefer to try JNA first as PosixAPI supports even smaller platforms.
-            return PosixAPI.get().readlink(filename);
+            try {
+                return PosixAPI.get().readlink(filename);
+            }
+            catch (IOException readlinkException) {
+                return null; // treat as not a symlink
+            }
         }
     }
 


### PR DESCRIPTION
Avoid failure when the readlink command is executed against an unsupported architecture, like AIX. This is a stopgap measure that attempts to get AIX/HP-UX systems working again, pending proper fixes to issues JENKINS-13614 JENKINS-14021 JENKINS-13241 and JENKINS-13202

https://issues.jenkins-ci.org/browse/JENKINS-13614
https://issues.jenkins-ci.org/browse/JENKINS-14021
https://issues.jenkins-ci.org/browse/JENKINS-13241
https://issues.jenkins-ci.org/browse/JENKINS-13202
