### PR TITLE
Allow projects to be blocked while downstream projects are also blocked.

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -203,7 +203,11 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * building. False by default to keep from breaking existing behavior.
      */
     protected volatile boolean blockBuildWhenDownstreamBuilding = false;
-
+    /**
+     * True to keep builds of this project in queue when downstream projects are
+     * blocked. False by default to keep from breaking existing behavior.
+     */
+    protected volatile boolean blockBuildWhenDownstreamBuildingAll = false;
     /**
      * True to keep builds of this project in queue when upstream projects are
      * building. False by default to keep from breaking existing behavior.
@@ -576,6 +580,10 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
 
     public boolean blockBuildWhenDownstreamBuilding() {
         return blockBuildWhenDownstreamBuilding;
+    }
+
+    public boolean blockBuildWhenDownstreamBuildingAll() {
+        return blockBuildWhenDownstreamBuildingAll;
     }
 
     public void setBlockBuildWhenDownstreamBuilding(boolean b) throws IOException {
@@ -1139,6 +1147,11 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             AbstractProject<?,?> bup = getBuildingDownstream();
             if (bup!=null)
                 return new BecauseOfDownstreamBuildInProgress(bup);
+            if(blockBuildWhenDownstreamBuildingAll()) {
+                bup = getBlockedBuildingDownstream();
+                if (bup!=null)
+                    return new BecauseOfDownstreamBuildInProgress(bup);
+            }
         }
         if (blockBuildWhenUpstreamBuilding()) {
             AbstractProject<?,?> bup = getBuildingUpstream();
@@ -1164,6 +1177,17 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         }
         return null;
     }
+
+    public AbstractProject getBlockedBuildingDownstream() {
+        Set<Task> blockedTasks = Jenkins.getInstance().getQueue().getBlockedTasks();
+
+        for (AbstractProject tup : getTransitiveDownstreamProjects()) {
+			if (tup!=this && (tup.isBuilding() || blockedTasks.contains(tup)))
+                return tup;
+        }
+        return null;
+    }
+
 
     /**
      * Returns the project if any of the upstream project is either
@@ -1761,6 +1785,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             scmCheckoutRetryCount = null;
         }
         blockBuildWhenDownstreamBuilding = req.getParameter("blockBuildWhenDownstreamBuilding")!=null;
+        blockBuildWhenDownstreamBuildingAll = req.getParameter("blockBuildWhenDownstreamBuildingAll")!=null;
         blockBuildWhenUpstreamBuilding = req.getParameter("blockBuildWhenUpstreamBuilding")!=null;
 
         if(req.hasParameter("customWorkspace")) {

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -678,6 +678,28 @@ public class Queue extends ResourceController implements Saveable {
             unblockedTasks.add(t.task);
         return unblockedTasks;
     }
+    /**
+     * Gets all items that are in the queue that are blocked
+     *
+     * @since 1.xxx
+     */
+    public synchronized List<Item> getBlockedItems() {
+    	List<Item> queuedBlocked = new ArrayList<Item>();
+        queuedBlocked.addAll(blockedProjects);
+        return queuedBlocked;
+    }
+    /**
+     * Works just like {@link #getBlockedItems()} but return tasks.
+     *
+     * @since 1.xxx
+     */
+    public synchronized Set<Task> getBlockedTasks() {
+        List<Item> items = getBlockedItems();
+        Set<Task> blockedTasks = new HashSet<Task>(items.size());
+        for (Queue.Item t : items)
+            blockedTasks.add(t.task);
+        return blockedTasks;
+    }
 
     /**
      * Is the given task currently pending execution?

--- a/core/src/main/resources/lib/hudson/project/config-blockWhenDownstreamBuilding.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-blockWhenDownstreamBuilding.jelly
@@ -28,5 +28,13 @@ THE SOFTWARE.
   <f:optionalBlock name="blockBuildWhenDownstreamBuilding"
 		   title="${%Block build when downstream project is building}"
 		   help="/help/project-config/block-downstream-building.html"
-		   checked="${it.blockBuildWhenDownstreamBuilding()}" />
+		   checked="${it.blockBuildWhenDownstreamBuilding()}" >
+    <f:entry help="/help/project-config/block-downstream-building-blocked.html">
+      <f:checkbox name="blockBuildWhenDownstreamBuildingAll"
+		   title="${%Block build when downstream projects are also blocked}"
+		   checked="${it.blockBuildWhenDownstreamBuildingAll()}"
+
+           default="false" />
+    </f:entry>
+  </f:optionalBlock>
 </j:jelly>

--- a/war/src/main/webapp/help/project-config/block-downstream-building-blocked.html
+++ b/war/src/main/webapp/help/project-config/block-downstream-building-blocked.html
@@ -1,0 +1,7 @@
+<div>
+ Due to changes made for <a href="https://issues.jenkins-ci.org/browse/JENKINS-8929" target="_blank">JENKINS-8929</a>
+ this project will not wait for downstream jobs if they are blocked waiting for resource or slave to run.<br/>
+ When this option is checked, this project will be blocked if any downstream projects are also blocked.<br/>
+ allowing all downstream jobs to run.<br/>
+ Warning: May cause deadlocks if this or downstream jobs are triggered from different places. Use with care.
+</div>


### PR DESCRIPTION
Adds an extra option to the configuration to allow projects to be blocked when downstream jobs are also blocked.
This is critical if a chain of jobs must run once for an entire chain
and there is a diamond pattern at any point in the chain.
as the job after the parallel will be blocked if it is waiting for the upstream jobs to finish,
and the start job may then run again as the joining job is not in a state to run.
[FIXED JENKINS-14918]
