### PR TITLE
Added MatrixDeleteStrategy extension point

### DIFF
--- a/core/src/main/java/hudson/matrix/DefaultMatrixDeleteStrategy.java
+++ b/core/src/main/java/hudson/matrix/DefaultMatrixDeleteStrategy.java
@@ -1,0 +1,55 @@
+package hudson.matrix;
+
+import hudson.Extension;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Default {@link MatrixDeleteStrategy} - deletes matrix build including all sub-builds if the build  
+ * or keep whole build including sub-builds if the build should be kept.
+ * 
+ * @author vjuranek
+ * @since 1.481
+ *
+ */
+public class DefaultMatrixDeleteStrategy extends MatrixDeleteStrategy {
+    
+    @DataBoundConstructor
+    public DefaultMatrixDeleteStrategy() {
+        
+    }
+    
+    public void doDelete(MatrixBuild b) throws MatrixDeleteException, IOException {
+        b.checkPermission(b.DELETE);
+
+        // We should not simply delete the build if it has been explicitly
+        // marked to be preserved, or if the build should not be deleted
+        // due to dependencies!
+        String why = b.getWhyKeepLog();
+        if (why!=null) {
+            throw new MatrixDeleteException(hudson.model.Messages.Run_UnableToDelete(toString(),why));
+        }
+        
+        List<MatrixRun> runs = b.getExactRuns();
+        for(MatrixRun run : runs){
+            why = run.getWhyKeepLog();
+            if (why!=null) {
+                throw new MatrixDeleteException(hudson.model.Messages.Run_UnableToDelete(toString(),why));
+            }
+            run.delete();
+        }
+        b.delete();
+    }
+    
+    @Extension
+    public static class DescriptorImpl extends MatrixDeleteStrategyDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Classic (delete or keep whole build)";
+        }
+    }
+
+}

--- a/core/src/main/java/hudson/matrix/MatrixDeleteStrategy.java
+++ b/core/src/main/java/hudson/matrix/MatrixDeleteStrategy.java
@@ -1,0 +1,52 @@
+package hudson.matrix;
+
+import java.io.IOException;
+
+import hudson.DescriptorExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+/**
+ * Controls how the {@link MatrixBuild} and its sub-builds are deleted. 
+ * 
+ * @author vjuranek
+ * @since 1.481
+ *
+ */
+public abstract class MatrixDeleteStrategy extends AbstractDescribableImpl<MatrixDeleteStrategy> implements ExtensionPoint {
+    
+    public abstract void doDelete(MatrixBuild b) throws MatrixDeleteException, IOException;
+    
+    @Override
+    public MatrixDeleteStrategyDescriptor getDescriptor() {
+        return (MatrixDeleteStrategyDescriptor)super.getDescriptor();
+    }
+
+    public static abstract class MatrixDeleteStrategyDescriptor extends Descriptor<MatrixDeleteStrategy> {
+        protected MatrixDeleteStrategyDescriptor(Class<? extends MatrixDeleteStrategy> clazz) {
+            super(clazz);
+        }
+
+        protected MatrixDeleteStrategyDescriptor() {
+        }
+
+        /**
+         * Returns all the registered {@link MatrixDeleteStrategyDescriptor}s.
+         */
+        public static DescriptorExtensionList<MatrixDeleteStrategy,MatrixDeleteStrategyDescriptor> all() {
+            return Jenkins.getInstance().<MatrixDeleteStrategy,MatrixDeleteStrategyDescriptor>getDescriptorList(MatrixDeleteStrategy.class);
+        }
+    }
+    
+    public static class MatrixDeleteException extends RuntimeException {
+        
+        public MatrixDeleteException(String message) {
+            super(message);
+        }
+        
+        private static final long serialVersionUID = 1L;
+    }
+    
+}

--- a/core/src/main/resources/hudson/matrix/DefaultMatrixDeleteStrategy/config.jelly
+++ b/core/src/main/resources/hudson/matrix/DefaultMatrixDeleteStrategy/config.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+  <!-- default delete strategy has no configuration -->
+</j:jelly>

--- a/core/src/main/resources/hudson/matrix/MatrixBuild/confirmDeleteAll.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixBuild/confirmDeleteAll.jelly
@@ -26,18 +26,28 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.fullDisplayName}" norefresh="true">
-		<st:include page="sidepanel.jelly" />
-		<l:main-panel>
-      <j:set var="msg" value="${it.whyKeepLog}"/>
-      <j:if test="${msg!=null}">
-		    <b>${%Warning}</b>: ${%cannotMsg(msg)}
-		  </j:if>		  
-		  <j:if test="${msg==null}">
-		    <form method="post" action="doDeleteAll">
-		      ${%Are you sure about deleting the build and all configurations in this build?}
-		      <f:submit value="${%Yes}" />
-		    </form>
-		  </j:if>
-		</l:main-panel>
-	</l:layout>
+    <st:include page="sidepanel.jelly" />
+    <l:main-panel>
+    <j:choose>
+      <j:when test="${it.parent.descriptor.deleteStrategyDescriptors.size() gt 1}">
+      	<form method="post" action="doDeleteAll">
+          ${%Are you sure about deleting the build according to} ${it.parent.deleteStrategy.descriptor.displayName}?
+          <f:submit value="${%Yes}" />
+        </form>
+      </j:when>
+      <j:otherwise>
+        <j:set var="msg" value="${it.whyKeepLog}"/>
+        <j:if test="${msg!=null}">
+          <b>${%Warning}</b>: ${%cannotMsg(msg)}
+        </j:if>		  
+        <j:if test="${msg==null}">
+          <form method="post" action="doDeleteAll">
+            ${%Are you sure about deleting the build and all configurations in this build?}
+            <f:submit value="${%Yes}" />
+          </form>
+        </j:if>
+      </j:otherwise>
+    </j:choose>
+    </l:main-panel>
+  </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/matrix/MatrixBuild/delete.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixBuild/delete.jelly
@@ -29,6 +29,17 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:if test="${!it.keepLog and !it.building}">
     <l:task icon="images/24x24/edit-delete.png" href="${buildUrl.baseUrl}/confirmDelete" title="${%Delete Build}" permission="${it.DELETE}" />
-  	<l:task icon="images/24x24/edit-delete.png" href="${buildUrl.baseUrl}/confirmDeleteAll" title="${%Delete this build and all configurations in this build}" permission="${it.DELETE}" />
   </j:if>
+  <j:choose>
+    <j:when test="${it.parent.descriptor.deleteStrategyDescriptors.size() gt 1}">
+      <j:if test="${!it.building}">
+  	    <l:task icon="images/24x24/edit-delete.png" href="${buildUrl.baseUrl}/confirmDeleteAll" title="${%Delete by configured strategy}" permission="${it.DELETE}" />
+      </j:if>
+    </j:when>
+    <j:otherwise>
+      <j:if test="${!it.keepLog and !it.building}">
+  	    <l:task icon="images/24x24/edit-delete.png" href="${buildUrl.baseUrl}/confirmDeleteAll" title="${%Delete this build and all configurations in this build}" permission="${it.DELETE}" />
+      </j:if>
+    </j:otherwise>
+  </j:choose>
 </j:jelly>

--- a/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
@@ -90,6 +90,14 @@ THE SOFTWARE.
         <f:property field="executionStrategy" propertyDescriptor="${descriptor.executionStrategyDescriptors.get(0)}"/>
       </j:otherwise>
     </j:choose>
+    
+    <j:choose>
+      <!-- for the default case there's no configuration, if this is the only one strategy present, we don't need to render selector -->
+      <j:when test="${descriptor.deleteStrategyDescriptors.size() gt 1}">
+        <f:dropdownDescriptorSelector title="${%Delete Strategy}" field="deleteStrategy"/>
+      </j:when>
+    </j:choose>
+    
   </f:section>
 
   <p:config-buildWrappers />


### PR DESCRIPTION
This extension point allows plugins define new strategies how to delete matrix builds - e.g. keep sub-builds which are linked by another builds but delete all other (unneeded) sub-builds.
