### PR TITLE
extension point to intercept FileCallable.act

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -868,13 +868,14 @@ public final class FilePath implements Serializable {
      */
     public abstract class AbstractInterceptorCallableWrapper<T> implements DelegatingCallable<T, IOException> {
 
-        protected DelegatingCallable<T, IOException> callable;
+        private final DelegatingCallable<T, IOException> callable;
 
         public AbstractInterceptorCallableWrapper(DelegatingCallable<T, IOException> callable) {
             this.callable = callable;
         }
 
-        public ClassLoader getClassLoader() {
+        @Override
+        public final ClassLoader getClassLoader() {
             return callable.getClassLoader();
         }
 

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -898,7 +898,7 @@ public final class FilePath implements Serializable {
         protected void before() {}
 
         /**
-         * Executed after the actual FileCallable is invoked (whenever this one failed). This code will run on remote
+         * Executed after the actual FileCallable is invoked (even if this one failed). This code will run on remote
          */
         protected void after() {}
     }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -859,7 +859,7 @@ public final class FilePath implements Serializable {
      * @since 1.482
      * @see AbstractInterceptorCallableWrapper
      */
-    public static abstract class FileCallableWrapperFactory extends AbstractDescribableImpl<FileCallableWrapperFactory> implements ExtensionPoint {
+    public static abstract class FileCallableWrapperFactory implements ExtensionPoint {
 
         public abstract <T> DelegatingCallable<T,IOException> wrap(DelegatingCallable<T,IOException> callable);
 

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -852,7 +852,9 @@ public final class FilePath implements Serializable {
 
     /**
      * This extension point allows to contribute a wrapper around a fileCallable so that a plugin can "intercept" a
-     * call. Code in wrapper will be executed on remote.
+     * call.
+     * <p>The {@link #wrap(hudson.remoting.DelegatingCallable)} method itself will be executed on master
+     * (and may collect contextual data if needed) and the returned wrapper will be executed on remote.
      */
     public static abstract class FileCallableWrapperFactory extends AbstractDescribableImpl<FileCallableWrapperFactory> implements ExtensionPoint {
 
@@ -876,7 +878,7 @@ public final class FilePath implements Serializable {
             return callable.getClassLoader();
         }
 
-        public T call() throws IOException {
+        public final T call() throws IOException {
             before();
             try {
                 return callable.call();
@@ -885,7 +887,14 @@ public final class FilePath implements Serializable {
             }
         }
 
+        /**
+         * Executed before the actual FileCallable is invoked. This code will run on remote
+         */
         protected void before() {}
+
+        /**
+         * Executed after the actual FileCallable is invoked (whenever this one failed). This code will run on remote
+         */
         protected void after() {}
     }
 

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -855,6 +855,9 @@ public final class FilePath implements Serializable {
      * call.
      * <p>The {@link #wrap(hudson.remoting.DelegatingCallable)} method itself will be executed on master
      * (and may collect contextual data if needed) and the returned wrapper will be executed on remote.
+     *
+     * @since 1.482
+     * @see AbstractInterceptorCallableWrapper
      */
     public static abstract class FileCallableWrapperFactory extends AbstractDescribableImpl<FileCallableWrapperFactory> implements ExtensionPoint {
 
@@ -865,6 +868,7 @@ public final class FilePath implements Serializable {
     /**
      * Abstract {@link DelegatingCallable} that exposes an Before/After pattern for
      * {@link hudson.FilePath.FileCallableWrapperFactory} that want to implement AOP-style interceptors
+     * @since 1.482
      */
     public abstract class AbstractInterceptorCallableWrapper<T> implements DelegatingCallable<T, IOException> {
 


### PR DESCRIPTION
This extension point let a plugin intercept FileCallable#act by providing a wrapper. This allows such a plugin to introduce some additional code to be executed before/after the callable on the remote node, for example for logging purpose.

This contribution has been developed during Jenkins User Event DK '12 
