### PR TITLE
[FIXED JENKINS-13202] Try to use NIO.2 (Java 7) methods to work with symlinks.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=>
+  <li class=rfe>
+    Provide symlink support on all possible platforms when using Java 7+, including newer versions of Windows.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13202">issue 13202</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -311,7 +311,6 @@ public class Util {
      * Checks if the given file represents a symlink.
      */
     //Taken from http://svn.apache.org/viewvc/maven/shared/trunk/file-management/src/main/java/org/apache/maven/shared/model/fileset/util/FileSetManager.java?view=markup
-    @IgnoreJRERequirement
     public static boolean isSymlink(File file) throws IOException {
         try { // JDK 7
             Object path = File.class.getMethod("toPath").invoke(file);
@@ -995,7 +994,6 @@ public class Util {
      * @param symlinkPath
      *      Where to create a symlink in.
      */
-    @IgnoreJRERequirement
     public static void createSymlink(File baseDir, String targetPath, String symlinkPath, TaskListener listener) throws InterruptedException {
         try {
             try { // JDK 7


### PR DESCRIPTION
Fall back to JNA (or worse) only on Java 5–6. Ought to fully solve [JENKINS-13202](https://issues.jenkins-ci.org/browse/JENKINS-13202) for Java 7+ users, by providing symlink support on all platforms which can actually handle it: all Unix flavors, and Windows Vista and above on NTFS. (At least in adequately authorized accounts—Windows denies symlink creation to Joe User by default.)
