### PR TITLE
Allow projects to be configurable and buildable, but disallow builds by the user.

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -511,6 +511,14 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      * Returns true if we should display "build now" icon
      */
     @Exported
+    public boolean isUserBuildable() {
+        return isBuildable();
+    }
+
+    /**
+     * Returns true if this project can be built.
+     */
+    @Exported
     public abstract boolean isBuildable();
 
     /**

--- a/core/src/main/resources/hudson/model/AbstractProject/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/sidepanel.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
         <l:task icon="images/24x24/folder-delete.png"  href="${url}/wipeOutWorkspace" title="${%Wipe Out Workspace}" permission="${h.isWipeOutPermissionEnabled() ? it.WIPEOUT : it.BUILD}" />
       </l:task>
       <j:if test="${it.configurable}">
-        <j:if test="${it.buildable}">
+        <j:if test="${it.userBuildable}">
           <l:task icon="images/24x24/clock.png" href="${url}/build?delay=0sec" title="${it.buildNowText}"
                   onclick="${it.parameterized?null:'return build(this)'}" permission="${it.BUILD}" />
           <script>

--- a/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
+++ b/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
       <td>
-          <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
+          <j:if test="${job.userBuildable and job.hasPermission(job.BUILD)}">
               <a href="${jobBaseUrl}${job.shortUrl}build?delay=0sec">
                   <img src="${imagesURL}/${subIconSize}/clock.png"
                        title="${%Schedule a build}" alt="${%Schedule a build}"


### PR DESCRIPTION
Right now, if a project is configurable and buildable, the "Build Now" button will always appear.

If you subclass from project and override isBuildable to be false, then the button won't appear, but it also becomes impossible to build the project since scheduling a build will result in null being returned.

This adds an additional function that can be overridden to allow builds of a project to be scheduled, but the "Build Now" button won't appear so users can't schedule a build.

This is helpful if you're trying to write a project that contains other projects, where each of the projects is configurable, but don't want people to invoke builds of those projects directly.
