### PR TITLE
Fix typo or miss in trigger messages fr

### DIFF
--- a/core/src/main/resources/hudson/triggers/Messages_fr.properties
+++ b/core/src/main/resources/hudson/triggers/Messages_fr.properties
@@ -24,4 +24,4 @@ SCMTrigger.DisplayName=Scruter l''outil de gestion de version
 SCMTrigger.getDisplayName=Log du dernier accès à {0}
 SCMTrigger.SCMTriggerCause.ShortDescription=Un changement dans la base de code a provoqué le lancement de ce job
 TimerTrigger.DisplayName=Construire périodiquement
-TimerTrigger.TimerTriggerCause.ShortDescription=L''\u00e9\u00e9ch\u00e9ance d''une alarme p\u00e9riodique a provoqu\u00e9 le lancement de ce job
+TimerTrigger.TimerTriggerCause.ShortDescription=L''échéance d''une alarme périodique a provoqué le lancement de ce job

--- a/core/src/main/resources/hudson/triggers/Messages_fr.properties
+++ b/core/src/main/resources/hudson/triggers/Messages_fr.properties
@@ -20,8 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-SCMTrigger.DisplayName=Scruter l''outil de gestion de version
+SCMTrigger.DisplayName=Scrutation de l''outil de gestion de version
 SCMTrigger.getDisplayName=Log du dernier accès à {0}
-SCMTrigger.SCMTriggerCause.ShortDescription=Un changement dans la base de code a provoqué le lancement de ce job
+SCMTrigger.BuildAction.DisplayName=Log de scrutation
+SCMTrigger.SCMTriggerCause.ShortDescription=Lancé par un changement dans la base de code
 TimerTrigger.DisplayName=Construire périodiquement
-TimerTrigger.TimerTriggerCause.ShortDescription=L''échéance d''une alarme périodique a provoqué le lancement de ce job
+TimerTrigger.MissingWhitespace=Il semble manquer un espace entre * et *.
+TimerTrigger.TimerTriggerCause.ShortDescription=Lancé par une alarme périodique
+Trigger.init=Initialisation des minuteurs des déclencheurs


### PR DESCRIPTION
Updading french translation (there was missing keys).

At first, I just wanted to fix "ééchéance", and then I ended up updating the whole file with the keys of the english version.

Cheers
