### PR TITLE
[JENKINS-15198] Add support for Maven Toolchains files via config-file-p...

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -118,7 +118,7 @@ THE SOFTWARE.
       <!-- this plugin is optional and is used to provide settigns.xml from a central UI -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>config-file-provider</artifactId>
-      <version>1.9.1</version>
+      <version>2.3-SNAPSHOT</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
@@ -253,10 +253,22 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
     private String globalSettingConfigId;
 
     /**
+     * @since 1.483
+     */
+    private String toolchainConfigId;
+
+    /**
      * used temporary during maven build to store file path
      * @since 1.426
      */
     protected transient String globalSettingConfigPath;
+    
+    /**
+     * used temporary during maven build to store toolchains file path
+     * @since 1.483
+     */
+    protected transient String toolchainsConfigPath;
+ 
     /**
      * Reporters configured at {@link MavenModuleSet} level. Applies to all {@link MavenModule} builds.
      */
@@ -573,6 +585,22 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
      */
     public void setGlobalSettingConfigId( String globalSettingConfigId ) {
         this.globalSettingConfigId = globalSettingConfigId;
+    }
+
+    /**
+     * @since 1.483
+     * @return
+     */
+    public String getToolchainConfigId() {
+        return toolchainConfigId;
+    }
+
+    /**
+     * @since 1.483
+     * @param toolchainConfigId
+     */
+    public void setToolchainConfigId( String toolchainConfigId ) {
+        this.toolchainConfigId = toolchainConfigId;
     }
 
     /**
@@ -965,6 +993,14 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
     }
 
     /**
+     * @since 1.483
+     * @return
+     */
+    public List<SettingConfig> getAllMavenToolchainsConfigs() {
+        return SettingsProviderUtils.getAllMavenToolchainsConfigs();
+    }
+
+    /**
      * Set mavenOpts.
      */
     public void setMavenOpts(String mavenOpts) {
@@ -1067,6 +1103,7 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         buildWrappers.rebuild(req,json,BuildWrappers.getFor(this));
         settingConfigId = req.getParameter( "maven.mavenSettingsConfigId" );
         globalSettingConfigId = req.getParameter( "maven.mavenGlobalSettingConfigId" );
+        toolchainConfigId = req.getParameter( "maven.mavenToolchainConfigId" );
 
         runPostStepsIfResult = Result.fromString(req.getParameter( "post-steps.runIfResult"));
         prebuilders.rebuildHetero(req,json, Builder.all(), "prebuilder");

--- a/maven-plugin/src/main/java/hudson/maven/settings/ConfigProviderFacade.java
+++ b/maven-plugin/src/main/java/hudson/maven/settings/ConfigProviderFacade.java
@@ -42,6 +42,14 @@ public interface ConfigProviderFacade {
      * @return list of all global settings
      */
     public List<SettingConfig> getAllGlobalMavenSettingsConfigs();
+    
+    /**
+     * Gets all maven toolchains
+     * 
+     * @since 1.483
+     * @return list of all global settings
+     */
+    public List<SettingConfig> getAllMavenToolchainsConfigs();
 
     /**
      * Gets a settings config by its id.

--- a/maven-plugin/src/main/java/hudson/maven/settings/ConfigProviderMediator.java
+++ b/maven-plugin/src/main/java/hudson/maven/settings/ConfigProviderMediator.java
@@ -26,6 +26,7 @@ package hudson.maven.settings;
 import hudson.ExtensionList;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import jenkins.model.Jenkins;
@@ -34,6 +35,7 @@ import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.maven.GlobalMavenSettingsConfig.GlobalMavenSettingsConfigProvider;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig.MavenSettingsConfigProvider;
+import org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig.MavenToolchainsConfigProvider;
 
 public class ConfigProviderMediator implements ConfigProviderFacade {
 
@@ -70,6 +72,14 @@ public class ConfigProviderMediator implements ConfigProviderFacade {
             }
         }
         return globalMavenSettingsConfigs;
+    }
+
+    /**
+     * @see hudson.maven.settings.ConfigProviderFacade#getAllMavenToolchainsConfigs()
+     */
+    @Override
+    public List<SettingConfig> getAllMavenToolchainsConfigs() {
+        return Collections.EMPTY_LIST;
     }
 
     /**

--- a/maven-plugin/src/main/java/hudson/maven/settings/ConfigProviderToolchainsEnabledMediator.java
+++ b/maven-plugin/src/main/java/hudson/maven/settings/ConfigProviderToolchainsEnabledMediator.java
@@ -1,0 +1,62 @@
+/*
+ The MIT License
+
+ Copyright (c) 2012, Dominik Bartholdi
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+package hudson.maven.settings;
+
+import hudson.ExtensionList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jenkins.model.Jenkins;
+
+import org.jenkinsci.lib.configprovider.ConfigProvider;
+import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig.MavenToolchainsConfigProvider;
+
+/**
+ * Config provider used when the version of the file provider plugin the one that supports
+ * Maven toolchains confguration files.
+ * 
+ * @since 1.483
+ */
+public class ConfigProviderToolchainsEnabledMediator extends ConfigProviderMediator {
+
+    /**
+     * @see hudson.maven.settings.ConfigProviderFacade#getAllMavenToolchainsConfigs()
+     */
+    @Override
+    public List<SettingConfig> getAllMavenToolchainsConfigs() {
+        final ExtensionList<MavenToolchainsConfigProvider> configProviders = Jenkins.getInstance()
+                .getExtensionList(MavenToolchainsConfigProvider.class);
+        List<SettingConfig> mavenToolchainsConfigs = new ArrayList<SettingConfig>();
+        if (configProviders.size() > 0) {
+            for (ConfigProvider configProvider : configProviders) {
+                for (Config config : configProvider.getAllConfigs()) {
+                  mavenToolchainsConfigs.add(new SettingConfig(config.id, config.name, config.comment, config.content));
+                }
+            }
+        }
+        return mavenToolchainsConfigs;
+    }
+}

--- a/maven-plugin/src/main/java/hudson/maven/settings/SettingsProviderUtils.java
+++ b/maven-plugin/src/main/java/hudson/maven/settings/SettingsProviderUtils.java
@@ -50,6 +50,15 @@ public class SettingsProviderUtils {
     public static List<SettingConfig> getAllGlobalMavenSettingsConfigs() {
         return configProvider.getAllGlobalMavenSettingsConfigs();
     }
+    
+    /**
+     * @since 1.483
+     * @return
+     */
+    public static List<SettingConfig> getAllMavenToolchainsConfigs() {
+        return configProvider.getAllMavenToolchainsConfigs();
+    }
+
 
     /**
      * utility method to retrieve Config of type (MavenSettingsProvider etc..)

--- a/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
@@ -139,6 +139,16 @@ THE SOFTWARE.
         </select>
       </f:entry>
 
+      <j:set var="mavenToolchainsConfigs" value="${it.allMavenToolchainsConfigs}" />
+      <f:entry title="${%Maven Toolchains Configs}">
+        <select class="setting-input" name="maven.mavenToolchainConfigId">
+          <f:option value="">- select -</f:option>
+          <j:forEach var="toolchainConfig" items="${mavenToolchainsConfigs}">
+            <f:option selected="${it.toolchainConfigId == toolchainConfig.id}" value="${toolchainConfig.id}">${toolchainConfig.name}</f:option>
+          </j:forEach>
+        </select>
+      </f:entry>
+ 
     </f:advanced>
   </f:section>
 


### PR DESCRIPTION
I added support based on the work done in file-provider-plugin.

Remarks:
1) it is based on the settings/global settings processing, however, there are some places (publisher, pom reader) where I did not add toolchains as I don't think this is necessary
2) I'm checking the version of the file provider plugin (at least 2.3) to switch to the proper mediator so it is not possible to test full support with the current version of the file provider plugin, but I tested it with test commented out
3) I did not support toolchains configuration based on a local file (but I don't think this is an issue as global settings don't) 
