### PR TITLE
Fix XStreamDOMTest for Windows

### DIFF
--- a/core/src/test/java/jenkins/util/xstream/XStreamDOMTest.java
+++ b/core/src/test/java/jenkins/util/xstream/XStreamDOMTest.java
@@ -23,6 +23,7 @@
  */
 package jenkins.util.xstream;
 
+import hudson.Functions;
 import hudson.util.XStream2;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -58,7 +59,11 @@ public class XStreamDOMTest {
         Foo foo = createSomeFoo();
         String xml = xs.toXML(foo);
         System.out.println(xml);
-        assertEquals(IOUtils.toString(getClass().getResourceAsStream("XStreamDOMTest.data1.xml")).trim(),xml.trim());
+        String expected = IOUtils.toString(getClass().getResourceAsStream("XStreamDOMTest.data1.xml"));
+        if (Functions.isWindows()) {
+            expected = expected.replaceAll("\r\n", "\n");
+        }
+        assertEquals(expected.trim(), xml.trim());
     }
 
     private Foo createSomeFoo() {
@@ -84,7 +89,11 @@ public class XStreamDOMTest {
 
         String xml = xs.toXML(foo);
         System.out.println(xml);
-        assertEquals(IOUtils.toString(getClass().getResourceAsStream("XStreamDOMTest.data1.xml")).trim(),xml.trim());
+        String expected = IOUtils.toString(getClass().getResourceAsStream("XStreamDOMTest.data1.xml"));
+        if (Functions.isWindows()) {
+            expected = expected.replaceAll("\r\n", "\n");
+        }
+        assertEquals(expected.trim(), xml.trim());
     }
 
     @Test


### PR DESCRIPTION
On Windows, git recommends to automatically convert line breaks. As a result, the line breaks in XStreamDOMTest.data1.xml are converted to \r\n locally, and the tests XStreamDOMTest.testMarshal() and testWriteToDOM() are broken because the actual XStream marshalled xml string has \n for line breaks.

This fix replaces \r\n by \n in the control string before comparing with the marshalled xml. An alternative is to add a .gitattributes file specifying to use Linux line breaks, either for the whole of Jenkins, or only for the test resources.

This pull request is meant to trigger the discussion: should we use .gitattributes, or add more Windows-specific code to tests?
