### PR TITLE
Test result page keeps identifying tests as age 1

### DIFF
--- a/core/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/core/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -299,7 +299,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
         if (failedSince==0 && getFailCount()==1) {
             CaseResult prev = getPreviousResult();
             if(prev!=null && !prev.isPassed())
-                this.failedSince = prev.failedSince;
+                this.failedSince = prev.getFailedSince();
             else if (getOwner() != null) {
                 this.failedSince = getOwner().getNumber();
             } else {


### PR DESCRIPTION
If a test has not been viewed, the age will keep being '1'.
This is because getFailedSince()/failedSince is lazy loaded.
Without having viewed the CaseResult that method is never
called and the prev.failedSince returns '0' which may or may
not be accurate.
Example: http://jenkins.361315.n4.nabble.com/Problem-with-Age-column-on-Test-Results-tab-td3172208.html
