### PR TITLE
Fixing ClassCastException

### DIFF
--- a/core/src/main/java/hudson/security/WhoAmI.java
+++ b/core/src/main/java/hudson/security/WhoAmI.java
@@ -62,12 +62,12 @@ public class WhoAmI implements UnprotectedRootAction {
     public String[] getAuthorities() {
         List <String> authorities = new ArrayList<String>();
         if (auth().getAuthorities() == null) {
-            return (String[]) authorities.toArray();
+            return new String[0];
         }
         for (GrantedAuthority a : auth().getAuthorities()) {
             authorities.add(a.getAuthority());
         }
-        return (String[]) authorities.toArray(new String[0]);
+        return (String[]) authorities.toArray(new String[authorities.size()]);
     }
 
     @Override


### PR DESCRIPTION
casting the toArray result will sometimes cause ClassCastExceptions.
i.e.:
Caused by: java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to [Ljava.lang.String;
    at hudson.security.WhoAmI.getAuthorities(WhoAmI.java:65)
