### PR TITLE
Fixed JENKINS-15293

### DIFF
--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -353,7 +353,7 @@ public class Maven extends Builder {
 			if(installations != null) {
 				Collections.addAll(tmpList, installations);
 				for(MavenInstallation installation : installations) {
-					if(Util.fixEmptyAndTrim(installation.getName()) == null || Util.fixEmptyAndTrim(installation.getHome()) == null) {
+					if(Util.fixEmptyAndTrim(installation.getName()) == null) {
 						tmpList.remove(installation);
 					}
 				}


### PR DESCRIPTION
Do not remove maven installation which does not have a home, like maven installation with automatic installer (bug associated with JENKINS-14510 fix ... sorry..)
