### PR TITLE
[FIXED JENKINS-15439] Jenkins build records lazy-loading failed to load ...

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -69,6 +69,9 @@ Upcoming changes</a>
 <div id="rc" style="display:none;"><!--=BEGIN=-->
 <h3><a name=v1.486>What's new in 1.486</a> <!--=DATE=--></h3>
 <ul class=image>
+  <li class=bug>
+    Jenkins build records lazy-loading failed to load some of my jobs.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15439">issue 15439</a>)
   <li class="major bug">
     Build queue displayed as empty even when it is not. (Regression in 1.483.)
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15335">issue 15335</a>)

--- a/core/src/main/java/jenkins/model/lazy/SortedList.java
+++ b/core/src/main/java/jenkins/model/lazy/SortedList.java
@@ -38,7 +38,7 @@ class SortedList<T extends Comparable<T>> extends AbstractList<T> {
     private List<T> data;
 
     public SortedList(List<T> data) {
-        this.data = new ArrayList(data);
+        this.data = new ArrayList<T>(data);
         assert isSorted();
     }
 

--- a/core/src/main/java/jenkins/model/lazy/SortedList.java
+++ b/core/src/main/java/jenkins/model/lazy/SortedList.java
@@ -24,6 +24,7 @@
 package jenkins.model.lazy;
 
 import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -37,7 +38,7 @@ class SortedList<T extends Comparable<T>> extends AbstractList<T> {
     private List<T> data;
 
     public SortedList(List<T> data) {
-        this.data = data;
+        this.data = new ArrayList(data);
         assert isSorted();
     }
 

--- a/core/src/test/java/jenkins/model/lazy/SortedListTest.java
+++ b/core/src/test/java/jenkins/model/lazy/SortedListTest.java
@@ -99,4 +99,22 @@ public class SortedListTest extends Assert {
         assertEquals("D",l.get(0));
         assertEquals("F",l.get(1));
     }
+
+    @Test
+    public void testClone() {
+        final int originalSize = l.size();
+        SortedList<String> l2 = new SortedList<String>(l);
+        assertEquals(originalSize, l2.size());
+        assertEquals(originalSize, l.size());
+        for (int i = 0; i < originalSize; i++) {
+            assertEquals(l.get(i), l2.get(i));
+        }
+        l.remove(0);
+        assertEquals(originalSize - 1, l.size());
+        assertEquals(originalSize, l2.size());
+        l2.remove(1);
+        l2.remove(1);
+        assertEquals(originalSize - 1, l.size());
+        assertEquals(originalSize - 2, l2.size());
+    }
 }


### PR DESCRIPTION
...some of my jobs

Ensure that SortedList clones the underlying data list.
Without this changes to a clone also change the original list.
