### PR TITLE
[FIXED JENKINS-13655] Enable transparent log decompression support (Jenkins v1.485)

### DIFF
--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -3,6 +3,8 @@
  *
  * Copyright (c) 2004-2010, Sun Microsystems, Inc.
  *
+ * Copyright (c) 2012, Martin Schroeder, Intel Mobile Communications GmbH
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -77,7 +77,7 @@ public class AnnotatedLargeText<T> extends LargeText {
     private T context;
 
     public AnnotatedLargeText(File file, Charset charset, boolean completed, T context) {
-        super(file, charset, completed);
+        super(file, charset, completed, true);
         this.context = context;
     }
 

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1161,7 +1161,16 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * Returns the log file.
      */
     public File getLogFile() {
-        return new File(getRootDir(),"log");
+        File rawF = new File(getRootDir(), "log");
+        if (rawF.isFile()) {
+            return rawF;
+        }
+        File gzF = new File(getRootDir(), "log.gz");
+        if (gzF.isFile()) {
+            return gzF;
+        }
+        //If both fail, return the standard, uncompressed log file
+        return rawF;
     }
 
     /**
@@ -1174,13 +1183,15 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */
     public InputStream getLogInputStream() throws IOException {
     	File logFile = getLogFile();
-    	if (logFile.exists() ) {
-            return new FileInputStream(logFile);
-    	}
-
-    	File compressedLogFile = new File(logFile.getParentFile(), logFile.getName()+ ".gz");
-    	if (compressedLogFile.exists()) {
-            return new GZIPInputStream(new FileInputStream(compressedLogFile));
+    	
+    	if (logFile != null && logFile.exists() ) {
+    	    // Checking if a ".gz" file was return
+    	    FileInputStream fis = new FileInputStream(logFile);
+    	    if (logFile.getName().endsWith(".gz")) {
+    	        return new GZIPInputStream(fis);
+    	    } else {
+    	        return fis;
+    	    }
     	}
     	
     	return new NullInputStream(0);

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -4,6 +4,8 @@
  * Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi,
  * Daniel Dyer, Red Hat, Inc., Tom Huybrechts, Romain Seguy, Yahoo! Inc.,
  * Darek Ostolski, CloudBees, Inc.
+ *
+ * Copyright (c) 2012, Martin Schroeder, Intel Mobile Communications GmbH
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -3,6 +3,8 @@ The MIT License
 
 Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
 
+Copyright (c) 2012, Martin Schroeder, Intel Mobile Communications GmbH
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
       </t:buildCaption>
       <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />
       <!-- Show at most last 150KB (can override with system property) unless consoleFull is set -->
-      <j:set var="offset" value="${empty(consoleFull) ? it.logFile.length()-threshold*1024 : 0}" />
+      <j:set var="offset" value="${empty(consoleFull) ? it.logText.length()-threshold*1024 : 0}" />
       <j:choose>
         <j:when test="${offset > 0}">
           ${%skipSome(offset/1024,"consoleFull")}


### PR DESCRIPTION
This change enables use of the Stapler transparent decompression support that was added by another pull-request to the Stapler project:

https://github.com/stapler/stapler/issues/10

This means, that this change will raise the minimum Stapler version needed by Jenkins to  v1.196. This dependency is already fulfilled by the newest Jenkins versions.

Additionally, the console.jelly was modified to make use of the stream instead of the raw file, which is necessary to get the correct uncompressed size of the file for skipping bytes.

This submission fixes the following bugs in the JIRA bug tracker:
 [JENKINS-2551]
 [JENKINS-10400]
 [JENKINS-13655]

This pull request is a re-submission of:
https://github.com/jenkinsci/jenkins/pull/549

It was re-submitted, because the other pull request has become unmergeable.
