### PR TITLE
maven compiler plugin config and fixed ambiguous function in test/JenkinsRule

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,7 +55,9 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
-  <li class=>
+  <li class=bug>
+    Harmless but noisy exception running builds on some Windows systems in non-English locale.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15316">issue 15316</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1071,7 +1071,7 @@ public class Util {
             if (x2 instanceof UnsupportedOperationException) {
                 return true; // no symlinks on this platform
             }
-            if (Functions.isWindows() && String.valueOf(x2).contains("A required privilege is not held by the client.")) {
+            if (Functions.isWindows() && String.valueOf(x2).contains("java.nio.file.FileSystemException")) {
                 if (warnedSymlinks.compareAndSet(false, true)) {
                     LOGGER.warning("Symbolic links enabled on this platform but disabled for this user; run as administrator or use Local Security Policy > Security Settings > Local Policies > User Rights Assignment > Create symbolic links");
                 }

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -193,6 +193,9 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
 
         public Descriptor getItemTypeDescriptorOrDie() {
             Class it = getItemType();
+            if (it == null) {
+                throw new AssertionError(clazz + " is not an array/collection type in " + displayName + ". See https://wiki.jenkins-ci.org/display/JENKINS/My+class+is+missing+descriptor");
+            }
             Descriptor d = Jenkins.getInstance().getDescriptor(it);
             if (d==null)
                 throw new AssertionError(it +" is missing its descriptor in "+displayName+". See https://wiki.jenkins-ci.org/display/JENKINS/My+class+is+missing+descriptor");

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2450,7 +2450,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
 
     private synchronized TaskBuilder loadTasks() throws IOException {
         File projectsDir = new File(root,"jobs");
-        if(!projectsDir.isDirectory() && !projectsDir.mkdirs()) {
+        if(!projectsDir.getCanonicalFile().isDirectory() && !projectsDir.mkdirs()) {
             if(projectsDir.exists())
                 throw new IOException(projectsDir+" is not a directory");
             throw new IOException("Unable to create "+projectsDir+"\nPermission issue? Please create this directory manually.");

--- a/maven-plugin/src/main/java/hudson/maven/RedeployPublisher.java
+++ b/maven-plugin/src/main/java/hudson/maven/RedeployPublisher.java
@@ -209,7 +209,7 @@ public class RedeployPublisher extends Recorder {
         String privateRepository = null;
         FilePath remoteSettingsFromConfig = null;
         
-        File tmpSettings = null;
+        File tmpSettings = File.createTempFile( "jenkins", "temp-settings.xml" );
         try {
             AbstractProject project = build.getProject();
             
@@ -269,25 +269,29 @@ public class RedeployPublisher extends Recorder {
                     // assume that build was made on master
                     buildNode = Jenkins.getInstance();
                 }
-                m = mavenModuleSet.getMaven().forNode(buildNode, listener);
 
                 if (StringUtils.isBlank( altSettingsPath ) ) {
                     // get userHome from the node where job has been executed
                     String remoteUserHome = build.getWorkspace().act( new GetUserHome() );
                     altSettingsPath = remoteUserHome + "/.m2/settings.xml";
                 }
-
-                // we copy this file in the master in a temporary file
+                
+                // we copy this file in the master in a  temporary file 
+                FilePath filePath = new FilePath( tmpSettings );
                 FilePath remoteSettings = build.getWorkspace().child( altSettingsPath );
-                if (remoteSettings != null) {
-                    listener.getLogger().println( "Maven RedeployPublisher use " + (buildNode != null ? buildNode.getNodeName() : "local" )
-                                                + " maven settings from : " + remoteSettings.getRemote() );
-                    tmpSettings = File.createTempFile( "jenkins", "temp-settings.xml" );
-                    FilePath filePath = new FilePath( tmpSettings );
-                    remoteSettings.copyTo( filePath );
-                    settingsLoc = tmpSettings;
+                if (!remoteSettings.exists()) {
+                    // JENKINS-9084 we finally use $M2_HOME/conf/settings.xml as maven do
+                    
+                    String mavenHome = 
+                        ((MavenModuleSet) project).getMaven().forNode(buildNode, listener ).getHome();
+                    String settingsPath = mavenHome + "/conf/settings.xml";
+                    remoteSettings = build.getWorkspace().child( settingsPath);
                 }
-
+                listener.getLogger().println( "Maven RedeployPublisher use remote " + (buildNode != null ? buildNode.getNodeName() : "local" )
+                                              + " maven settings from : " + remoteSettings.getRemote() );
+                remoteSettings.copyTo( filePath );
+                settingsLoc = tmpSettings;
+                
             }
 
             MavenEmbedderRequest mavenEmbedderRequest = new MavenEmbedderRequest(listener,

--- a/pom.xml
+++ b/pom.xml
@@ -610,8 +610,8 @@ THE SOFTWARE.
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration><!-- we specify this in the parent POM, so this is redundant, but otherwise IntelliJ is unhappy -->
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <!-- default reuseCreated is more performant 
           feel free to uncomment if you have any issues on your platform
           <compilerReuseStrategy>alwaysNew</compilerReuseStrategy>

--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -946,11 +946,11 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * <p>
      * See http://wiki.jenkins-ci.org/display/JENKINS/Unit+Test#UnitTest-Configurationroundtriptesting
      */
-    public <P extends Job> P configRoundtrip(P job) throws Exception {
-        submit(createWebClient().getPage(job,"configure").getFormByName("config"));
-        return job;
-    }
-
+//    public <P extends Job> P configRoundtrip(P job) throws Exception {
+//        submit(createWebClient().getPage(job,"configure").getFormByName("config"));
+//        return job;
+//    }
+//
     public <P extends Item> P configRoundtrip(P job) throws Exception {
         submit(createWebClient().getPage(job, "configure").getFormByName("config"));
         return job;

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2012 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model;
+
+import hudson.model.Descriptor.PropertyType;
+import hudson.tasks.Shell;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class DescriptorTest {
+
+    public @Rule JenkinsRule rule = new JenkinsRule();
+
+    @Bug(12307)
+    @Test public void getItemTypeDescriptorOrDie() throws Exception {
+        Describable<?> instance = new Shell("echo hello");
+        Descriptor<?> descriptor = instance.getDescriptor();
+        PropertyType propertyType = descriptor.getPropertyType(instance, "command");
+        try {
+            propertyType.getItemTypeDescriptorOrDie();
+            fail("not supposed to succeed");
+        } catch (AssertionError x) {
+            for (String text : new String[] {"hudson.tasks.CommandInterpreter", "getCommand", "java.lang.String", "collection"}) {
+                assertTrue(text + " mentioned in " + x, x.toString().contains(text));
+            }
+        }
+    }
+
+}

--- a/test/src/test/java/hudson/triggers/TriggerStartTest.java
+++ b/test/src/test/java/hudson/triggers/TriggerStartTest.java
@@ -24,18 +24,22 @@
 
 package hudson.triggers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import hudson.model.AbstractProject;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Items;
+
 import java.io.ByteArrayInputStream;
 import java.io.ObjectStreamException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
-import static org.junit.Assert.*;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Bug;


### PR DESCRIPTION
setting the compiler config params to 1.6 makes m2e happy, because the code contains Override annotations on functions that implement an interface which the 1.5 compiler doesn´t like

I got an ambiguous function error in test/JenkinsRule. The underlyig code seems to do the same thing

The other commits I fetched and rebased from jenkinsci:master
