### PR TITLE
Fix translation: build=construction!=compilation.

### DIFF
--- a/core/src/main/resources/hudson/model/View/sidepanel_fr.properties
+++ b/core/src/main/resources/hudson/model/View/sidepanel_fr.properties
@@ -22,7 +22,7 @@
 
 NewJob=Nouveau {0}
 People=Utilisateurs
-Build\ History=Historique des compilations
+Build\ History=Historique des constructions
 Edit\ View=\u00C9diter la vue
 Delete\ View=Supprimer la vue
 Project\ Relationship=Relations entre les projets


### PR DESCRIPTION
Or build if you don't wanna translate.
That's actually what we did for the Jenkins Definitive Guide French Translation.

Here I used the french word construction... If you think we should go onto build, let me know.
