### PR TITLE
debian: Fill in gecos field for jenkins user

### DIFF
--- a/debian/debian/jenkins.postinst
+++ b/debian/debian/jenkins.postinst
@@ -30,6 +30,7 @@ case "$1" in
         if ! id $JENKINS_USER > /dev/null 2>&1 ; then
             adduser --system --home /var/lib/jenkins --no-create-home \
                 --ingroup nogroup --disabled-password --shell /bin/bash \
+                --gecos 'Jenkins' \
                 $JENKINS_USER
         fi
 	


### PR DESCRIPTION
Otherwise when Jenkins runs git, git will complain that the identity is
not set up correctly and will fail.
