### PR TITLE
Reduce the noise caused by MavenArtifactArchiver when Maven artifact archiving is disabled.

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/reporters/MavenArtifact.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/MavenArtifact.java
@@ -221,7 +221,7 @@ public final class MavenArtifact implements Serializable {
      */
     public void archive(MavenBuildProxy build, File file, BuildListener listener) throws IOException, InterruptedException {
         if (build.isArchivingDisabled()) {
-            listener.getLogger().println("[JENKINS] Archiving disabled - not archiving " + file);
+            LOGGER.fine("Archiving disabled - not archiving " + file);
         }
         else {
             FilePath target = getArtifactArchivePath(build,groupId,artifactId,version);

--- a/maven-plugin/src/main/java/hudson/maven/reporters/MavenArtifactArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/MavenArtifactArchiver.java
@@ -153,19 +153,16 @@ public class MavenArtifactArchiver extends MavenReporter {
         // do we have any assembly artifacts?
 //        System.out.println("Considering "+assemblies+" at "+MavenArtifactArchiver.this);
 //        new Exception().fillInStackTrace().printStackTrace();
-        if (assemblies!=null) {
+        if (build.isArchivingDisabled()) {
+          listener.getLogger().println("[JENKINS] Archiving disabled");
+        } else if (assemblies!=null) {
             for (File assembly : assemblies) {
                 if(mavenArtifacts.contains(assembly))
                     continue;   // looks like this is already archived
-                if (build.isArchivingDisabled()) {
-                    listener.getLogger().println("[JENKINS] Archiving disabled - not archiving " + assembly);
-                }
-                else {
-                    FilePath target = build.getArtifactsDir().child(assembly.getName());
-                    listener.getLogger().println("[JENKINS] Archiving "+ assembly+" to "+target);
-                    new FilePath(assembly).copyTo(target);
-                    // TODO: fingerprint
-                }
+                FilePath target = build.getArtifactsDir().child(assembly.getName());
+                listener.getLogger().println("[JENKINS] Archiving "+ assembly+" to "+target);
+                new FilePath(assembly).copyTo(target);
+                // TODO: fingerprint
             }
         }
 


### PR DESCRIPTION
Only display one line per execution instead of displaying one line per non-archived file.
