### PR TITLE
JENKINS-12875 use valid default header name

### DIFF
--- a/core/src/main/java/hudson/security/csrf/CrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbIssuer.java
@@ -36,6 +36,7 @@ import hudson.util.MultipartFormDataParser;
 public abstract class CrumbIssuer implements Describable<CrumbIssuer>, ExtensionPoint {
 
     private static final String CRUMB_ATTRIBUTE = CrumbIssuer.class.getName() + "_crumb";
+    public static final String DEFAULT_CRUMB_HEADER_NAME = "crumb";
 
     /**
      * Get the name of the request parameter the crumb will be stored in. Exposed

--- a/core/src/main/java/hudson/security/csrf/CrumbIssuerDescriptor.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbIssuerDescriptor.java
@@ -67,7 +67,7 @@ public abstract class CrumbIssuerDescriptor<T extends CrumbIssuer> extends Descr
      */
     public void setCrumbRequestField(String requestField) {
         if (Util.fixEmptyAndTrim(requestField) == null) {
-            crumbRequestField = ".crumb";
+            crumbRequestField = CrumbIssuer.DEFAULT_CRUMB_HEADER_NAME;
         } else {
             crumbRequestField = requestField;
         }

--- a/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
@@ -118,7 +118,7 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
     public static final class DescriptorImpl extends CrumbIssuerDescriptor<DefaultCrumbIssuer> implements ModelObject {
 
         public DescriptorImpl() {
-            super(Jenkins.getInstance().getSecretKey(), System.getProperty("hudson.security.csrf.requestfield", ".crumb"));
+            super(Jenkins.getInstance().getSecretKey(), System.getProperty("hudson.security.csrf.requestfield", "crumb"));
             load();
         }
 

--- a/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
@@ -118,7 +118,7 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
     public static final class DescriptorImpl extends CrumbIssuerDescriptor<DefaultCrumbIssuer> implements ModelObject {
 
         public DescriptorImpl() {
-            super(Jenkins.getInstance().getSecretKey(), System.getProperty("hudson.security.csrf.requestfield", "crumb"));
+            super(Jenkins.getInstance().getSecretKey(), System.getProperty("hudson.security.csrf.requestfield", CrumbIssuer.DEFAULT_CRUMB_HEADER_NAME));
             load();
         }
 

--- a/test/src/test/groovy/hudson/model/SlaveTest.groovy
+++ b/test/src/test/groovy/hudson/model/SlaveTest.groovy
@@ -72,7 +72,7 @@ public class SlaveTest extends GroovyHudsonTestCase {
         HttpURLConnection con = new URL(this.getURL(),url).openConnection();
         con.requestMethod = "POST"
         con.setRequestProperty("Content-Type","application/xml;charset=UTF-8")
-        con.setRequestProperty(".crumb","test")
+        con.setRequestProperty("crumb","test")
         con.doOutput = true;
         con.outputStream.write(xml.getBytes("UTF-8"))
         con.outputStream.close();


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-12875

"kinder" default header name for crumb.
