### PR TITLE
When calculating idle executors, only include Computers which are accepting tasks.

### DIFF
--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -167,7 +167,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     public int getIdleExecutors() {
         int r=0;
         for (Computer c : get_all())
-            if(c.isOnline() || c.isConnecting())
+            if((c.isOnline() || c.isConnecting()) && c.isAcceptingTasks())
                 r += c.countIdle();
         return r;
     }

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -276,7 +276,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
         int r=0;
         for (Node n : getNodes()) {
             Computer c = n.toComputer();
-            if(c!=null && (c.isOnline() || c.isConnecting()))
+            if(c!=null && (c.isOnline() || c.isConnecting()) && c.isAcceptingTasks())
                 r += c.countIdle();
         }
         return r;


### PR DESCRIPTION
So that suspended computers don't prevent new Cloud nodes from being provisioned.
