### PR TITLE
[FIXED JENKINS-10569] When installing plugins with overlapping dependencies, Jenkins downloads the duplicate plugins multiple times

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -741,8 +741,13 @@ public class UpdateSite {
             Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
             UpdateCenter uc = Jenkins.getInstance().getUpdateCenter();
             for (Plugin dep : getNeededDependencies()) {
-                LOGGER.log(Level.WARNING, "Adding dependent install of " + dep.name + " for plugin " + name);
-                dep.deploy(dynamicLoad);
+                UpdateCenter.InstallationJob job = uc.getJob(dep);
+                if (job == null || job.status instanceof UpdateCenter.DownloadJob.Failure) {
+                    LOGGER.log(Level.WARNING, "Adding dependent install of " + dep.name + " for plugin " + name);
+                    dep.deploy(dynamicLoad);
+                } else {
+                    LOGGER.log(Level.WARNING, "Dependent install of " + dep.name + " for plugin " + name + " already added, skipping");
+                }
             }
             return uc.addJob(uc.new InstallationJob(this, UpdateSite.this, Jenkins.getAuthentication(), dynamicLoad));
         }


### PR DESCRIPTION
[FIXED JENKINS-10569] When installing plugins with overlapping dependencies, Jenkins downloads the duplicate plugins multiple times
