### PR TITLE
Refactor handling of test mojos

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,7 +55,8 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
-  <li class=>
+  <li class=rfe>
+    Support failsafe the same way as surefire in maven2 jobs
 </ul>
 </div><!--=TRUNK-END=-->
 


### PR DESCRIPTION
maven-failsafe-plugin deserves the same level of integration
as maven-surefire-plugin.

A failed IT should mark the build as unstable, not failed.
