### PR TITLE
Disambiguate method JenkinsRule#configRoundtrip

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -937,11 +937,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * <p>
      * See http://wiki.jenkins-ci.org/display/JENKINS/Unit+Test#UnitTest-Configurationroundtriptesting
      */
-    public <P extends Job> P configRoundtrip(P job) throws Exception {
-        submit(createWebClient().getPage(job,"configure").getFormByName("config"));
-        return job;
-    }
-
     public <P extends Item> P configRoundtrip(P job) throws Exception {
         submit(createWebClient().getPage(job, "configure").getFormByName("config"));
         return job;


### PR DESCRIPTION
Delete &lt;P extends Job&gt; P configRoundtrip(P job) as
&lt;P extends Item&gt; P configRoundtrip(P job) already exists and do exactly
the same thing
