### PR TITLE
Add expand all funkcionality for artifact tree view

### DIFF
--- a/core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/core/src/main/resources/lib/hudson/artifactList.jelly
@@ -74,7 +74,13 @@ THE SOFTWARE.
               <link rel="stylesheet" href="${resURL}/scripts/yui/treeview/assets/skins/sam/treeview.css" type="text/css"/>
               <link rel="stylesheet" href="${resURL}/scripts/yui/fonts/fonts-min.css" type="text/css"/>
               <style type="text/css">#artifact-tree td { vertical-align:middle; }</style>
+              <script>
+                function expandAll(){
+                YAHOO.widget.TreeView.getNode('artifact-tree',1).tree.expandAll();
+                }
+              </script>
               <div id="artifact-tree"></div>
+              <a href="javascript: expandAll()">Expand all</a>
               <script language="javascript">// &lt;![CDATA[
                 YAHOO.util.Event.onContentReady('artifact-tree', function () {
                 var artifactTree = new YAHOO.widget.TreeView('artifact-tree');


### PR DESCRIPTION
I add expand all link into tree view of artefacts, because our users often click on an artefact and return back for another artefact, so they have to expand all tree again.
