### PR TITLE
Prevent to exception which causes that build will not be saved.

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1530,12 +1530,11 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
                 try {
                     job.cleanUp(listener);
+                    RunListener.fireCompleted(this,listener);
                 } catch (Exception e) {
                     handleFatalBuildProblem(listener,e);
                     // too late to update the result now
                 }
-
-                RunListener.fireCompleted(this,listener);
 
                 if(listener!=null)
                     listener.finished(result);


### PR DESCRIPTION
RunListener  class is extension point. If some plugin has class which extends RunListener and throws exception in method onCompleted, it causes that build will not be saved.
