### PR TITLE
[FIXED JENKINS-15567] Ubuntu /etc/default/jenkins contains syntax error in sample command line arg

### DIFF
--- a/debian/debian/jenkins.default
+++ b/debian/debian/jenkins.default
@@ -52,7 +52,7 @@ PREFIX=/jenkins
 # --httpsPort=$HTTP_PORT
 # --ajp13Port=$AJP_PORT
 # --argumentsRealm.passwd.$ADMIN_USER=[password]
-# --argumentsRealm.roles.$ADMIN_USER=admin
+# --argumentsRealm.$ADMIN_USER=admin
 # --webroot=~/.jenkins/war
 # --prefix=$PREFIX
 

--- a/debian/debian/jenkins.default
+++ b/debian/debian/jenkins.default
@@ -52,7 +52,7 @@ PREFIX=/jenkins
 # --httpsPort=$HTTP_PORT
 # --ajp13Port=$AJP_PORT
 # --argumentsRealm.passwd.$ADMIN_USER=[password]
-# --argumentsRealm.$ADMIN_USER=admin
+# --argumentsRealm.roles.$ADMIN_USER=admin
 # --webroot=~/.jenkins/war
 # --prefix=$PREFIX
 


### PR DESCRIPTION
Minor typo fix in sample.

Screwed up with file editor in first commit, which showed entire file diff (line breaks & tabs) rather than just single line just.

Thus, the revert and 3rd commit with the appropriate diff of single line change.
