### PR TITLE
[JENKINS-10593] Allow a job to block inheritance from the parent ACL

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -70,6 +70,9 @@ Upcoming changes</a>
   <li class="major bug">
     Jenkins kicks off the wrong downstream builds for Maven.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15367">issue 15367</a>)
+  <li class="rfe">
+    Allow the project-based matrix security strategory to block inheritance of the global matrix.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-10593">issue 10593</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/ProjectMatrixAuthorizationStrategy.java
@@ -52,7 +52,13 @@ public class ProjectMatrixAuthorizationStrategy extends GlobalMatrixAuthorizatio
     public ACL getACL(Job<?,?> project) {
         AuthorizationMatrixProperty amp = project.getProperty(AuthorizationMatrixProperty.class);
         if (amp != null) {
-            return amp.getACL().newInheritingACL(getACL(project.getParent()));
+            SidACL projectAcl = amp.getACL();
+
+            if (!amp.isBlocksInheritance()) {
+                projectAcl = projectAcl.newInheritingACL(getACL(project.getParent()));
+            }
+
+            return projectAcl;
         } else {
             return getACL(project.getParent());
         }

--- a/core/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.jelly
+++ b/core/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.jelly
@@ -25,6 +25,11 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:optionalBlock name="useProjectSecurity" title="${%Enable project-based security}" checked="${instance!=null}">
-    <st:include page="/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly" />
+    <f:block>
+      <f:optionalBlock name="blocksInheritance" checked="${instance.isBlocksInheritance()}"
+                       title="${%Block inheritance of global authorization matrix}"
+                       help="/help/security/projectMatrix-blocksInheritance.html" />
+      <st:include page="/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly" />
+    </f:block>
   </f:optionalBlock>
 </j:jelly>

--- a/war/src/main/webapp/help/security/projectMatrix-blocksInheritance.html
+++ b/war/src/main/webapp/help/security/projectMatrix-blocksInheritance.html
@@ -1,0 +1,9 @@
+<div>
+  If checked, the global configuration matrix will not be inherited.
+  This allows you to configure a job that has a more strict access control list than the rest of the global permission set.
+  <br />
+  <br />
+  <b>WARNING</b>:  because the parent ACL will not be inherited, it is possible to revoke your own configuration access accidentally.
+  If you enable this setting, please also remember to grant yourself or your group configuration access so that you do not lock yourself out of the job.
+  Otherwise the only ways to get back in will be to disable project-based security in global configuration, or manually edit the permissions list in the project's XML configuration.
+</div>


### PR DESCRIPTION
Currently, a job can enable project-based matrix authorization, but all ACL
entries from the parent (or the global matrix strategy) will automatically
be inherited. That means it is impossible to create a job that has a stricter
access control list than the global security.

This change adds the ability to block inheritance from the parent ACL, thus
allowing the job to truly define its own ACL, and allowing the job to have
tighter restrictions than other jobs.

This addresses issue https://issues.jenkins-ci.org/browse/JENKINS-10593
