### PR TITLE
[JENKINS-15865] Jenkins build fails with fatal error for Maven 2 build

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -80,6 +80,9 @@ Upcoming changes</a>
   <li class=bug>
     Duplicated / multiple "Jenkins CLI" entries under "Manage Jenkins".
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15732">issue 15732</a>)
+  <li class=bug>
+    Maven2 job fails when using maven-failsafe-plugin
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15865">issue 15865</a>)
 
 </ul>
 </div><!--=TRUNK-END=-->

--- a/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
@@ -319,7 +319,6 @@ public class SurefireArchiver extends MavenReporter {
 
     private boolean isSurefireOrFailsafeMojo(MojoInfo mojo) {
       return mojo.is("org.apache.maven.plugins", "maven-surefire-plugin", "test")
-          || mojo.is("org.apache.maven.plugins", "maven-failsafe-plugin", "integration-test")
           || mojo.is("org.apache.maven.plugins", "maven-failsafe-plugin", "verify");
     }
     


### PR DESCRIPTION
of project with maven-failsafe-plugin

Do not inject testFailureIgnore to
maven-failsafe-plugin:integration-test because it doesn't exist and
causes an NPE with Maven2.
Only insert it for maven-failsafe-plugin:verify.
