### PR TITLE
[FIXES JENKINS-15889]

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -86,7 +86,10 @@ Upcoming changes</a>
   <li class=bug>
     "Disable Project" button breaks Free style project pages.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15887">issue 15887</a>)
-    
+  <li class=bug>
+    Saving the update center list after the metadata has been fetched results in 
+    the metadata being persisted twice
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15889">issue 15889</a>)
 
 </ul>
 </div><!--=TRUNK-END=-->

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -106,7 +106,7 @@ public class UpdateSite {
     /**
      * Latest data as read from the data file.
      */
-    private Data data;
+    private transient Data data;
 
     /**
      * ID string for this update source.


### PR DESCRIPTION
[FIXES JENKINS-15889] Saving the update center list after the metadata has been fetched results in the metadata being persisted twice
