### PR TITLE
Fix X-Text-Size header description

### DIFF
--- a/core/src/main/resources/hudson/model/Run/_api.jelly
+++ b/core/src/main/resources/hudson/model/Run/_api.jelly
@@ -50,8 +50,8 @@ THE SOFTWARE.
     The <tt>start</tt> parameter controls the byte offset of where you start.
   </p><p>
     The response will contain a chunk of the console output, as well as the <tt>X-Text-Size</tt> header that represents
-    the number of bytes (in the raw log file) the response served.
-    This is the number you want to add to the <tt>start</tt> parameter before making the next call.
+    the bytes offset (of the raw log file).
+    This is the number you want to use as the <tt>start</tt> parameter for the next call.
   </p><p>
     If the response also contains the <tt>X-More-Data: true</tt> header, the server is indicating that the build
     is in progress, and you need to repeat the request after some delay. The Jenkins UI waits 5 seconds before making


### PR DESCRIPTION
X-Text-Size actually contains the offset to be used for the next start parameter, this header does not contain the chunk size itself, and hence the client only needs to pass X-Text-Size header value as the next start.

The value of X-Text-Size header is the return value of writeLogTo method, which is the chunk size + the previous start. https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/LargeText.java#L171

@kohsuke

This means X-Text-Size is not the correct header name to represent the offset value, but I think it's worth keeping it for backward compatibility reason.

I have verified and tested this against 3 different versions of Jenkins while implementing progressive output support in Nestor (Node.js CLI). https://github.com/cliffano/nestor/commit/d7988254d9066ece2774f571a9c395494961a945
