### PR TITLE
[FIXED JENKINS-15839] wrong unicode characters on german Manage Jenkins page

### DIFF
--- a/core/src/main/resources/jenkins/management/Messages_de.properties
+++ b/core/src/main/resources/jenkins/management/Messages_de.properties
@@ -23,22 +23,22 @@
 #
 
 ReloadLink.DisplayName=Konfiguration von Festplatte neu laden
-ReloadLink.Description=Verwirft alle Daten im Speicher und l\u2030dt die Konfigurationsdateien erneut aus dem Dateisystem.\n\
-                       Dies ist n\u00B8tzlich, wenn Sie Konfigurationsdateien direkt editiert haben.
+ReloadLink.Description=Verwirft alle Daten im Speicher und l\u00E4dt die Konfigurationsdateien erneut aus dem Dateisystem.\n\
+                       Dies ist n\u00FCtzlich, wenn Sie Konfigurationsdateien direkt editiert haben.
 PluginsLink.DisplayName=Plugins verwalten
 SystemInfoLink.DisplayName=Systeminformationen
-SystemInfoLink.Description=Zeigt Umgebungsinformationen an, z.B. zur Unterst\u00B8tzung bei der Fehlersuche.
+SystemInfoLink.Description=Zeigt Umgebungsinformationen an, z.B. zur Unterst\u00FCtzung bei der Fehlersuche.
 SystemLogLink.Description=Zeigt protokollierte Ereignisse im Jenkins Systemlog an.
 ConsoleLink.DisplayName=Skript-Konsole
-ConsoleLink.Description=F\u00B8hrt ein beliebiges Skript aus zur Administration/Fehlersuche/Diagnose.
+ConsoleLink.Description=F\u00FChrt ein beliebiges Skript aus zur Administration/Fehlersuche/Diagnose.
 ShutdownLink.DisplayName_cancel=Herunterfahren abbrechen
 ShutdownLink.DisplayName_prepare=Herunterfahren vorbereiten
 ShutdownLink.Description=Verhindert die Ausf\u00FChrung neuer Builds, so dass Jenkins sicher heruntergefahren werden kann.
 ConfigureLink.DisplayName=System konfigurieren
 ConfigureLink.Description=Globale Einstellungen und Pfade konfigurieren.
-PluginsLink.Description=Plugins installieren, deinstallieren, aktivieren oder deaktivieren, welche die Funktionalit\u2030t von Jenkins erweitern.
+PluginsLink.Description=Plugins installieren, deinstallieren, aktivieren oder deaktivieren, welche die Funktionalit\u00E4t von Jenkins erweitern.
 StatisticsLink.DisplayName=Nutzungsstatistiken
-StatisticsLink.Description=Ressourcenauslastung \u00B8berwachen und \u00B8berpr\u00B8fen, ob weitere Build-Knoten sinnvoll w\u2030ren.
+StatisticsLink.Description=Ressourcenauslastung \u00FCberwachen und \u00FCberpr\u00FCfen, ob weitere Build-Knoten sinnvoll w\u00E4ren.
 NodesLink.DisplayName=Knoten verwalten
-NodesLink.Description=Knoten hinzuf\u00B8gen, entfernen, steuern und \u00B8berwachen, auf denen Jenkins Jobs verteilt ausf\u00B8hren kann.
+NodesLink.Description=Knoten hinzuf\u00FCgen, entfernen, steuern und \u00FCberwachen, auf denen Jenkins Jobs verteilt ausf\u00FChren kann.
 CliLink.Description=Jenkins aus der Kommandozeile oder skriptgesteuert nutzen und verwalten.


### PR DESCRIPTION
In pull request #588, a series of refactorings turned some links into ManagementLinks. 

Although the german translations were not changed by these refactorings, some wrong unicode characters contained therein suddenly started to mess up the german Manage Jenkins page.
I got no idea why this page displayed well before.
