### PR TITLE
German translations for AboutJenkins and OldDataMonitor links

### DIFF
--- a/core/src/main/resources/hudson/Messages_de.properties
+++ b/core/src/main/resources/hudson/Messages_de.properties
@@ -48,3 +48,6 @@ Util.year  ={0} {0,choice,0#Jahre|1#Jahr|1<Jahre}
 # we often want to add "ago" there
 Util.pastTime={0}
 FilePath.TildaDoesntWork=''~'' wird nur in einer Unix-Shell unterstützt - sonst nirgends.
+
+AboutJenkins.DisplayName=\u00DCber Jenkins
+AboutJenkins.Description=Versions- und Lizenzinformationen anzeigen.

--- a/core/src/main/resources/hudson/diagnosis/Messages_de.properties
+++ b/core/src/main/resources/hudson/diagnosis/Messages_de.properties
@@ -22,4 +22,5 @@
 
 MemoryUsageMonitor.USED=Verwendet
 MemoryUsageMonitor.TOTAL=Total
-OldDataMonitor.DisplayName=Veraltete Daten
+OldDataMonitor.DisplayName=Veraltete Daten verwalten
+OldDataMonitor.Description=Konfiguration bereinigen, um \u00DCberbleibsel alter Plugins und fr\u00FCherer Versionen zu entfernen.


### PR DESCRIPTION
I added German translations for the last two non-localized items on the Manage Jenkins page so that it is now fully translated. Looks even more professional to me now!

I adjusted the existing AboutJenkins.DisplayName to match the associated page title.
