### PR TITLE
getOfflineCauseReason handles localization

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -267,12 +267,15 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         if (offlineCause == null) {
             return "";
         }
-        // remove header string from offline cause when a comment was set
-        String newString = offlineCause.toString().replaceAll(
-                "^Disconnected by [\\w]* \\: ","");
-        // remove header string from offline cause when no comment was set
-        return newString.replaceAll(
-                "^Disconnected by [\\w]*","");
+        // fetch the localized string for "Disconnected By"
+        String gsub_base = hudson.slaves.Messages.SlaveComputer_DisconnectedBy("","");
+        // regex to remove commented reason base string
+        String gsub1 = "^" + gsub_base + "[\\w\\W]* \\: ";
+        // regex to remove non-commented reason base string
+        String gsub2 = "^" + gsub_base + "[\\w\\W]*";
+
+        String newString = offlineCause.toString().replaceAll(gsub1, "");
+        return newString.replaceAll(gsub2, "");
     }
 
     /**


### PR DESCRIPTION
also handles usernames that are emails

///

This is a followup to my earlier pull request (https://github.com/jenkinsci/jenkins/pull/535). I've recently switched to using Google for authentication and if the username has an @ symbol the editing of the existing message doesn't work properly. This fixes the issue and adds localized string support.

Andy
