### PR TITLE
[JENKINS-1295] Disable trigger downstream for maven jobs

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -60,6 +60,9 @@ Upcoming changes</a>
   <li class=bug>
     WARNING: Caught exception evaluating: descriptor.getHelpFile(attrs.field). Reason: java.lang.NullPointerException. 
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15940">issue 15940</a>)
+    <li class=rfe>
+    Allows to disable triggering of downstream jobs (for a maven job)
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-1295">issue 1295</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/maven-plugin/src/main/java/hudson/maven/MavenModule.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModule.java
@@ -488,7 +488,7 @@ public class MavenModule extends AbstractMavenProject<MavenModule,MavenBuild> im
                 src = data.allModules.get(winner);
             }
 
-            if(src!=null) {
+            if(src!=null && !src.getParent().isDisableTriggerDownstreamProjects()) {
                 DependencyGraph.Dependency dep = new MavenModuleDependency(nodeOf(src),nodeOf(this));
                 if (!dep.pointsItself())
                     graph.addDependency(dep);

--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
@@ -265,6 +265,12 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
      * @deprecated since 1.484 settings are provided by {@link #globalSettings}
      */
     private String globalSettingConfigId;
+    
+    /**
+     * Whether to participate in triggering downstream projects.
+     * @since 1.494
+     */
+    private boolean disableTriggerDownstreamProjects;
 
     /**
      * used temporary during maven build to store file path
@@ -851,6 +857,14 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         prebuilders.buildDependencyGraph(this,graph);
         postbuilders.buildDependencyGraph(this,graph);
     }
+    
+    public boolean isDisableTriggerDownstreamProjects() {
+      return disableTriggerDownstreamProjects;
+    }
+
+    public void setDisableTriggerDownstreamProjects(boolean disableTriggerDownstreamProjects) {
+      this.disableTriggerDownstreamProjects = disableTriggerDownstreamProjects;
+    }
 
     public MavenModule getRootModule() {
         if(rootModule==null)    return null;
@@ -1119,6 +1133,7 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         reporters.rebuild(req,json,MavenReporters.getConfigurableList());
         publishers.rebuildHetero(req, json, Publisher.all(), "publisher");
         buildWrappers.rebuild(req,json,BuildWrappers.getFor(this));
+        disableTriggerDownstreamProjects = req.hasParameter("maven.disableTriggerDownstreamProjects");
 
         runPostStepsIfResult = Result.fromString(req.getParameter( "post-steps.runIfResult"));
         prebuilders.rebuildHetero(req,json, Builder.all(), "prebuilder");

--- a/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
@@ -88,6 +88,10 @@ THE SOFTWARE.
                        title="${%Disable automatic artifact archiving}"
                        help="/plugin/maven-plugin/archivingDisabled.html"
                        checked="${it.isArchivingDisabled()}" />
+      <f:optionalBlock name="maven.disableTriggerDownstreamProjects"
+                       title="${%Disable triggering of downstream projects}"
+                       help="/plugin/maven-plugin/downstreamDisabled.html"
+                       checked="${it.isDisableTriggerDownstreamProjects()}" />
       <f:optionalBlock name="maven.perModuleBuild" title="${%Build modules in parallel}" help="/plugin/maven-plugin/aggregator.html"
         checked="${!it.aggregatorStyleBuild}" />
       <f:optionalBlock name="maven.usePrivateRepository" title="${%Use private Maven repository}" help="/plugin/maven-plugin/private-repository.html"

--- a/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/configure-entries_fr.properties
+++ b/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/configure-entries_fr.properties
@@ -45,3 +45,4 @@ Add\ pre-build\ step=Ajouter une \u00E9tape pr\u00E9-build
 Post-Build\ Run\ Criteria=Crit\u00E8re pour ex\u00E9cuter le post-build
 Steps\ to\ run\ after\ mvn\ build=\u00C9tapes \u00E0 lancer apr\u00E8s le build maven
 Steps\ to\ run\ before\ mvn\ build=\u00C9tapes \u00E0 lancer avant le build maven
+Disable\ triggering\ of\ downstream\ projects=D\u00e9sactive le lancement des projets en aval


### PR DESCRIPTION
This is meant to allow to declare sonar jobs which don't take part into the dependency graph and avoid to run extra builds for nothing.
