### PR TITLE
Fix ProcessTree test on Windows

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -395,6 +395,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         Windows() {
             for (final WinProcess p : WinProcess.all()) {
                 int pid = p.getPid();
+                if(pid == 0 || pid == 4) continue; // skip the System Idle and System processes
                 super.processes.put(pid,new OSProcess(pid) {
                     private EnvVars env;
                     private List<String> args;


### PR DESCRIPTION
The System Idle (PID0) and System (PID4) processes do not have environments assigned to them, so they need to be skipped. Otherwise you get an error 87 when running the test on Windows.
