### PR TITLE
Archived artifacts compression

### DIFF
--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -70,6 +70,11 @@ public class ArtifactArchiver extends Recorder {
     */
     private final boolean compressed;
     
+    /**
+     * File name of the the archive where compressed artifacts will be stored 
+     */
+    public static final String archiveName = "archive.zip";
+    
     private static final Boolean allowEmptyArchive = 
     	Boolean.getBoolean(ArtifactArchiver.class.getName()+".warnOnEmpty");
 
@@ -130,7 +135,7 @@ public class ArtifactArchiver extends Recorder {
             String artifacts = build.getEnvironment(listener).expand(this.artifacts);
             int archived = 0;
             if(compressed)
-                archived = ws.zip(new FilePath(new FilePath(dir),"archive.zip").write(), new DirScanner.Glob(artifacts, excludes));
+                archived = ws.zip(new FilePath(new FilePath(dir),archiveName).write(), new DirScanner.Glob(artifacts, excludes));
             else
                 archived = ws.copyRecursiveTo(artifacts,excludes,new FilePath(dir));
             if(archived==0) {

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -31,6 +31,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Result;
+import hudson.util.DirScanner;
 import hudson.util.FormValidation;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -64,14 +65,24 @@ public class ArtifactArchiver extends Recorder {
      */
     private final boolean latestOnly;
     
+    /**
+    * Compress all artifacts into one archive file
+    */
+    private final boolean compressed;
+    
     private static final Boolean allowEmptyArchive = 
     	Boolean.getBoolean(ArtifactArchiver.class.getName()+".warnOnEmpty");
 
-    @DataBoundConstructor
     public ArtifactArchiver(String artifacts, String excludes, boolean latestOnly) {
+    	this(artifacts, excludes, latestOnly, false);
+    }
+    
+    @DataBoundConstructor
+    public ArtifactArchiver(String artifacts, String excludes, boolean latestOnly, boolean compressed) {
         this.artifacts = artifacts.trim();
         this.excludes = Util.fixEmptyAndTrim(excludes);
         this.latestOnly = latestOnly;
+        this.compressed = compressed;
     }
 
     public String getArtifacts() {
@@ -84,6 +95,10 @@ public class ArtifactArchiver extends Recorder {
 
     public boolean isLatestOnly() {
         return latestOnly;
+    }
+    
+    public boolean isCompressed() {
+    	return compressed;
     }
     
     private void listenerWarnOrError(BuildListener listener, String message) {
@@ -113,7 +128,12 @@ public class ArtifactArchiver extends Recorder {
             }
 
             String artifacts = build.getEnvironment(listener).expand(this.artifacts);
-            if(ws.copyRecursiveTo(artifacts,excludes,new FilePath(dir))==0) {
+            int archived = 0;
+            if(compressed)
+                archived = ws.zip(new FilePath(new FilePath(dir),"archive.zip").write(), new DirScanner.Glob(artifacts, excludes));
+            else
+                archived = ws.copyRecursiveTo(artifacts,excludes,new FilePath(dir));
+            if(archived==0) {
                 if(build.getResult().isBetterOrEqualTo(Result.UNSTABLE)) {
                     // If the build failed, don't complain that there was no matching artifact.
                     // The build probably didn't even get to the point where it produces artifacts. 
@@ -131,7 +151,7 @@ public class ArtifactArchiver extends Recorder {
                 	build.setResult(Result.FAILURE);
                 }
                 return true;
-            }
+            } 
         } catch (IOException e) {
             Util.displayIOException(e,listener);
             e.printStackTrace(listener.error(

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
@@ -34,5 +34,8 @@ THE SOFTWARE.
     <f:entry title="" field="latestOnly" >
       <f:checkbox title="${%lastBuildOnly}"/>
     </f:entry>
+    <f:entry title="" field="compressed" >
+      <f:checkbox title="${%compressedArtifacts}"/>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.properties
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.properties
@@ -21,3 +21,4 @@
 # THE SOFTWARE.
 
 lastBuildOnly=Discard all but the last successful/stable artifact to save disk space
+compressedArtifacts=Compress all archived artifacts to save disk space


### PR DESCRIPTION
Added possibility to compress archived artifacts. The main purpose is to reduce occupied disk space, especially in cases when e.g. huge log files need to archived for long time
