### PR TITLE
[JENKINS-16069] Remove wrapping of JSON with ( )

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -71,6 +71,9 @@ Upcoming changes</a>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-1295">issue 1295</a>)
   <li class=bug>
     Context menu and tooltip of the queue items were colliding with each other
+    <li class=bug>
+    Fix combobox ui component
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16069">issue 16069</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/util/ComboBoxModel.java
+++ b/core/src/main/java/hudson/util/ComboBoxModel.java
@@ -62,8 +62,6 @@ public class ComboBoxModel extends ArrayList<String> implements HttpResponse {
     public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
         rsp.setContentType(Flavor.JSON.contentType);
         PrintWriter w = rsp.getWriter();
-        w.print('(');
         JSONArray.fromObject(this).write(w);
-        w.print(')');
     }
 }


### PR DESCRIPTION
now it is done properly on Javascript side so the current server
implementation triggers javascript errors.

Result can be observed on DynamicComboBox within ui-samples-plugin
