### PR TITLE
Breaking circular builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.10</version>
+          <version>2.12</version>
           <configuration>
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>


### PR DESCRIPTION
A small change that breaks circular builds. I'm checking that a downstream project is not one of the upstream causes before scheduling a build.
