### PR TITLE
Make sure that change log annotation cannot result into exception

### DIFF
--- a/core/src/main/java/hudson/scm/ChangeLogSet.java
+++ b/core/src/main/java/hudson/scm/ChangeLogSet.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * Represents SCM change list.
@@ -207,7 +208,11 @@ public abstract class ChangeLogSet<T extends ChangeLogSet.Entry> implements Iter
         public String getMsgAnnotated() {
             MarkupText markup = new MarkupText(getMsg());
             for (ChangeLogAnnotator a : ChangeLogAnnotator.all())
-                a.annotate(parent.build,this,markup);
+                try {
+                    a.annotate(parent.build,this,markup);
+                } catch(Exception e) {
+                    LOGGER.fine("ChangeLogAnnotator " + a.toString() + " failed to annotate message '" + getMsg() + "'; " + e.getMessage());
+                }
 
             return markup.toString(false);
         }
@@ -218,6 +223,8 @@ public abstract class ChangeLogSet<T extends ChangeLogSet.Entry> implements Iter
         public String getMsgEscaped() {
             return Util.escape(getMsg());
         }
+        
+        static final Logger LOGGER = Logger.getLogger(ChangeLogSet.Entry.class.getName());
     }
     
     /**


### PR DESCRIPTION
Although javadoc for ChangeLogAnnotator#annotate() states that any exception should be caught in this method and it should return normally, some implementation don't respect it or e.g. in case of missing some dependecy (resulting into NoClassDefFoundError) plugin itself can hardly ensure that no exption is thrown. We should ensure it on the core level.
