### PR TITLE
JENKINS-14102 - Fix build state for maven builds 

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/Maven3Builder.java
+++ b/maven-plugin/src/main/java/hudson/maven/Maven3Builder.java
@@ -24,6 +24,7 @@
 package hudson.maven;
 
 import hudson.maven.MavenBuild.ProxyImpl2;
+import hudson.maven.reporters.TestFailureDetector;
 import hudson.maven.util.ExecutionEventLogger;
 import hudson.model.BuildListener;
 import hudson.model.Result;
@@ -53,6 +54,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
 import static hudson.Util.*;
@@ -120,7 +122,12 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
             
             PrintStream logger = listener.getLogger();
             
-            if(r==0 && mavenExecutionResult.getThrowables().isEmpty()) return Result.SUCCESS;
+            if(r==0 && mavenExecutionResult.getThrowables().isEmpty()) {
+                if(mavenExecutionListener.hasTestFailures()){
+                    return Result.UNSTABLE;    
+                }
+                return Result.SUCCESS;
+            }
             
             if (!mavenExecutionResult.getThrowables().isEmpty()) {
                 logger.println( "mavenExecutionResult exceptions not empty");
@@ -137,6 +144,9 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
 
             if(markAsSuccess) {
                 listener.getLogger().println(Messages.MavenBuilder_Failed());
+                if(mavenExecutionListener.hasTestFailures()){
+                    return Result.UNSTABLE;    
+                }
                 return Result.SUCCESS;
             }
             return Result.FAILURE;
@@ -158,6 +168,8 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
         private static final long serialVersionUID = 4942789836756366116L;
 
         private final Maven3Builder maven3Builder;
+        
+        private AtomicBoolean hasTestFailures = new AtomicBoolean();
        
         /**
          * Number of total nanoseconds {@link Maven3Builder} spent.
@@ -183,6 +195,10 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
             }
             this.reporters = new ConcurrentHashMap<ModuleName, List<MavenReporter>>(maven3Builder.reporters);
             this.eventLogger = new ExecutionEventLogger( new PrintStreamLogger( maven3Builder.listener.getLogger() ) );
+        }
+        
+        public boolean hasTestFailures(){
+            return hasTestFailures.get();
         }
         
         private MavenBuildProxy2 getMavenBuildProxy2(MavenProject mavenProject) {
@@ -419,6 +435,15 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
             for (MavenReporter mavenReporter : fixNull(mavenReporters)) {
                 try {
                     mavenReporter.postExecute( mavenBuildProxy2, mavenProject, mojoInfo, maven3Builder.listener, problem);
+                    if (mavenReporter instanceof TestFailureDetector) {
+                        TestFailureDetector detector = (TestFailureDetector) mavenReporter;
+                        if(detector.hasTestFailures()) {
+                            System.out.println("+++++++>>>>"+mavenReporter.getClass());
+                            hasTestFailures.compareAndSet(false, true);
+                        }else{
+                            System.out.println("------->>>>"+mavenReporter.getClass());
+                        }
+                    }
                 } catch ( InterruptedException e ) {
                     e.printStackTrace();
                 } catch ( IOException e ) {

--- a/maven-plugin/src/main/java/hudson/maven/Maven3Builder.java
+++ b/maven-plugin/src/main/java/hudson/maven/Maven3Builder.java
@@ -436,12 +436,8 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
                 try {
                     mavenReporter.postExecute( mavenBuildProxy2, mavenProject, mojoInfo, maven3Builder.listener, problem);
                     if (mavenReporter instanceof TestFailureDetector) {
-                        TestFailureDetector detector = (TestFailureDetector) mavenReporter;
-                        if(detector.hasTestFailures()) {
-                            System.out.println("+++++++>>>>"+mavenReporter.getClass());
+                        if(((TestFailureDetector) mavenReporter).hasTestFailures()) {
                             hasTestFailures.compareAndSet(false, true);
-                        }else{
-                            System.out.println("------->>>>"+mavenReporter.getClass());
                         }
                     }
                 } catch ( InterruptedException e ) {

--- a/maven-plugin/src/main/java/hudson/maven/MavenBuilder.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenBuilder.java
@@ -43,6 +43,8 @@ import java.text.NumberFormat;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.maven.BuildFailureException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ReactorManager;
@@ -169,10 +171,18 @@ public abstract class MavenBuilder extends AbstractMavenBuilder implements Deleg
                 logger.println("Resource loading "+format(n,ch.resourceLoadingTime.get())+"ms, "+ch.resourceLoadingCount+" times");                
             }
 
-            if(r==0)    return Result.SUCCESS;
+            if(r==0){
+                if(a.hasBuildFailures()){
+                    return Result.UNSTABLE;
+                }
+                return Result.SUCCESS;
+            }
 
             if(markAsSuccess) {
                 listener.getLogger().println(Messages.MavenBuilder_Failed());
+                if(a.hasBuildFailures()){
+                    return Result.UNSTABLE;
+                }
                 return Result.SUCCESS;
             }
             return Result.FAILURE;
@@ -264,6 +274,7 @@ public abstract class MavenBuilder extends AbstractMavenBuilder implements Deleg
         private MavenProject lastModule;
 
         private final MavenBuilder listener;
+        private final AtomicBoolean hasTestFailures = new AtomicBoolean();
 
         /**
          * Number of total nanoseconds {@link MavenBuilder} spent.
@@ -308,6 +319,8 @@ public abstract class MavenBuilder extends AbstractMavenBuilder implements Deleg
         public void postExecute(MavenProject project, MojoExecution exec, Mojo mojo, PlexusConfiguration mergedConfig, ExpressionEvaluator eval, Exception exception) throws IOException, InterruptedException {
             long startTime = System.nanoTime();
             listener.postExecute(project, new MojoInfo(exec, mojo, mergedConfig, eval),exception);
+            if(listener.hasBuildFailures())
+                hasTestFailures.compareAndSet(false, true);
             overheadTime += System.nanoTime()-startTime;
         }
 
@@ -327,6 +340,10 @@ public abstract class MavenBuilder extends AbstractMavenBuilder implements Deleg
                 listener.postModule(lastModule);
                 lastModule = null;
             }
+        }
+        
+        public boolean hasBuildFailures() {
+            return hasTestFailures.get();
         }
     }
 
@@ -351,4 +368,6 @@ public abstract class MavenBuilder extends AbstractMavenBuilder implements Deleg
     public static boolean markAsSuccess;
 
     private static final long serialVersionUID = 1L;
+
+    public abstract boolean hasBuildFailures();
 }

--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
@@ -398,6 +398,10 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         return postbuilders;
     }
 	
+	void addPostBuilder(Builder builder) throws IOException{
+	    postbuilders.add(builder);
+	}
+	
 	/**
      * {@link #postbuilders} are run if the result is better or equal to this threshold.
      *

--- a/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
@@ -64,8 +65,9 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
  * Records the surefire test result.
  * @author Kohsuke Kawaguchi
  */
-public class SurefireArchiver extends MavenReporter {
+public class SurefireArchiver extends TestFailureDetector {
     private transient TestResult result;
+    private final AtomicBoolean hasTestFailures = new AtomicBoolean();
     
     /**
      * Store the filesets here as we want to track ignores between multiple runs of this class<br/>
@@ -73,6 +75,11 @@ public class SurefireArchiver extends MavenReporter {
      * we track multiple {@link FileSet}s for each encountered <tt>reportsDir</tt>
      */
     private transient ConcurrentMap<File, FileSet> fileSets = new ConcurrentHashMap<File,FileSet>();
+    
+    @Override
+    public boolean hasTestFailures() {
+        return hasTestFailures.get();
+    }
 
     public boolean preExecute(MavenBuildProxy build, MavenProject pom, MojoInfo mojo, BuildListener listener) throws InterruptedException, IOException {
         if (isTestMojo(mojo)) {
@@ -161,6 +168,7 @@ public class SurefireArchiver extends MavenReporter {
                 // intercept that (or otherwise build will be marked as failure)
                 if(failCount>0) {
                     markBuildAsSuccess(error,build.getMavenBuildInformation());
+                    hasTestFailures.compareAndSet(false, true);
                 }
             }
         }

--- a/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
@@ -168,7 +168,7 @@ public class SurefireArchiver extends TestFailureDetector {
                 // intercept that (or otherwise build will be marked as failure)
                 if(failCount>0) {
                     markBuildAsSuccess(error,build.getMavenBuildInformation());
-                    hasTestFailures.compareAndSet(false, true);
+                    hasTestFailures.set(true);
                 }
             }
         }

--- a/maven-plugin/src/main/java/hudson/maven/reporters/TestFailureDetector.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/TestFailureDetector.java
@@ -1,0 +1,21 @@
+package hudson.maven.reporters;
+
+import hudson.maven.MavenReporter;
+
+/**
+ * A maven reporter expressing whether he found test failures and the build should be marked as UNSTABLE.
+ * 
+ * @author Dominik Bartholdi (imod)
+ */
+public abstract class TestFailureDetector extends MavenReporter {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Have any test failures been detected?
+     * 
+     * @return <code>true</code> if there ar test failures
+     */
+    public abstract boolean hasTestFailures();
+
+}

--- a/maven-plugin/src/main/java/hudson/maven/reporters/TestFailureDetector.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/TestFailureDetector.java
@@ -14,7 +14,7 @@ public abstract class TestFailureDetector extends MavenReporter {
     /**
      * Have any test failures been detected?
      * 
-     * @return <code>true</code> if there ar test failures
+     * @return <code>true</code> if there are test failures
      */
     public abstract boolean hasTestFailures();
 

--- a/test/src/test/java/hudson/maven/MavenBuildSurefireFailedTest.java
+++ b/test/src/test/java/hudson/maven/MavenBuildSurefireFailedTest.java
@@ -52,12 +52,23 @@ public class MavenBuildSurefireFailedTest extends HudsonTestCase {
     public void testMaven3SkipPostBuilder() throws Exception {
         MavenModuleSet m = createMavenProject();
         m.setMaven( configureMaven3().getName() );
-        m.setGoals( "test -Dmaven.test.failure.ignore=false" );
+        m.setGoals( "test" );
         m.setScm(new ExtractResourceSCM(getClass().getResource("maven-multimodule-unit-failure.zip")));
         // run dummy command only if build state is SUCCESS
         m.setRunPostStepsIfResult(Result.SUCCESS);
-        m.addPostBuilder(new Shell("no-command"));
+        m.addPostBuilder(new Shell("no-valid-command"));
         assertBuildStatus(Result.UNSTABLE, m.scheduleBuild2(0).get());
     }        
     
+    @Bug(14102)
+    public void testMaven2SkipPostBuilder() throws Exception {
+        configureDefaultMaven();
+        MavenModuleSet m = createMavenProject();
+        m.setGoals( "test" );
+        m.setScm(new ExtractResourceSCM(getClass().getResource("maven-multimodule-unit-failure.zip")));
+        // run dummy command only if build state is SUCCESS
+        m.setRunPostStepsIfResult(Result.SUCCESS);
+        m.addPostBuilder(new Shell("no-valid-command"));        
+        assertBuildStatus(Result.UNSTABLE, m.scheduleBuild2(0).get());
+    }    
 }

--- a/test/src/test/java/hudson/maven/MavenBuildSurefireFailedTest.java
+++ b/test/src/test/java/hudson/maven/MavenBuildSurefireFailedTest.java
@@ -1,6 +1,7 @@
 package hudson.maven;
 
 import hudson.model.Result;
+import hudson.tasks.Shell;
 
 import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.ExtractResourceSCM;
@@ -47,5 +48,16 @@ public class MavenBuildSurefireFailedTest extends HudsonTestCase {
         assertBuildStatus(Result.FAILURE, m.scheduleBuild2(0).get());
     }    
     
+    @Bug(14102)
+    public void testMaven3SkipPostBuilder() throws Exception {
+        MavenModuleSet m = createMavenProject();
+        m.setMaven( configureMaven3().getName() );
+        m.setGoals( "test -Dmaven.test.failure.ignore=false" );
+        m.setScm(new ExtractResourceSCM(getClass().getResource("maven-multimodule-unit-failure.zip")));
+        // run dummy command only if build state is SUCCESS
+        m.setRunPostStepsIfResult(Result.SUCCESS);
+        m.addPostBuilder(new Shell("no-command"));
+        assertBuildStatus(Result.UNSTABLE, m.scheduleBuild2(0).get());
+    }        
     
 }


### PR DESCRIPTION
Even though the final build state of a maven project with test failures was correct or better the icon/ball had the correct color (yellow) - the build internally did not expose the correct state to post build steps.
This causes issues with post build steps and publishers relying on the correct state of the build.

This pull request fixes the issue by publishing the correct state detected by the of the SurefireArchiver. 
