### PR TITLE
[FIX JENKINS-16198] Redeploy Artifacts functionality add ability to change build's status according to redeploy status.

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -374,6 +374,12 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         return result;
     }
 
+
+    public void setResultForce(Result r) {
+        result = r;
+        LOGGER.log(WARNING, toString()+" : result is set to "+r,new Exception());
+    }
+
     public void setResult(Result r) {
         // state can change only when we are building
         assert state==State.BUILDING;

--- a/maven-plugin/src/main/java/hudson/maven/reporters/MavenAbstractArtifactRecord.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/MavenAbstractArtifactRecord.java
@@ -202,7 +202,11 @@ public abstract class MavenAbstractArtifactRecord<T extends AbstractBuild<?,?>> 
     }
 
     public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
-        return records.get(Integer.valueOf(token));
+        try {
+            return records.get(Integer.valueOf(token));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
     }
 
     /**

--- a/maven-plugin/src/main/java/hudson/maven/reporters/MavenAbstractArtifactRecord.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/MavenAbstractArtifactRecord.java
@@ -237,7 +237,7 @@ public abstract class MavenAbstractArtifactRecord<T extends AbstractBuild<?,?>> 
                         // Since we can redeploy failed build due to redeploy problem or user want to redeploy specific artifact,
                         // need to calculate result from the build itself (cycle between all modules and check it's status)
                         Result buildResult = calculateBuildStatus(getBuild(), listener);
-                        getBuild().setResult(buildResult);
+                        getBuild().setResultForce(buildResult);
                         listener.getLogger().println("[INFO] Changed build status to " + buildResult);
                     }
 
@@ -270,7 +270,10 @@ public abstract class MavenAbstractArtifactRecord<T extends AbstractBuild<?,?>> 
             // If one of module have status ABORTED, FAILURE or UNSTABLE return this status as status of whole build
             // else return SUCCESS
             for (MavenAbstractArtifactRecord module : actions) {
-                if (module.getBuild().getResult().equals(Result.ABORTED) || module.getBuild().getResult().equals(Result.FAILURE) || module.getBuild().getResult().equals(Result.UNSTABLE)) {
+                if (module.getBuild().getResult().equals(Result.ABORTED) ||
+                    module.getBuild().getResult().equals(Result.FAILURE) ||
+                    module.getBuild().getResult().equals(Result.UNSTABLE)
+                   ) {
                     return module.getBuild().getResult();
                 }
             }

--- a/maven-plugin/src/main/resources/hudson/maven/reporters/MavenAbstractArtifactRecord/index.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/reporters/MavenAbstractArtifactRecord/index.jelly
@@ -49,6 +49,9 @@ THE SOFTWARE.
 
           <f:form method="post" action="redeploy">
             <st:include page="/hudson/maven/RedeployPublisher/config.jelly" />
+            <f:entry field="changeBuildStatus">
+               <f:checkbox title="${%Change maven build status according to redeploy status}" default="false"/>
+            </f:entry>
             <f:block>
               <f:submit value="${%OK}" style="margin-top:1em;" />
             </f:block>


### PR DESCRIPTION
This pull request include possible fix for [JENKINS-16198](https://issues.jenkins-ci.org/browse/JENKINS-16198) with small fix for catching NumberFormatException in getDynamic() method.

Also please note that we still have existing issue for main buid page - [JENKINS-14590](https://issues.jenkins-ci.org/browse/JENKINS-14590)
