### PR TITLE
Use 'duck-typing' approach for detecting test mojos

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/Maven3Builder.java
+++ b/maven-plugin/src/main/java/hudson/maven/Maven3Builder.java
@@ -218,8 +218,10 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
             return reporters.get( new ModuleName( mavenProject ) );
         }        
         
-        private void initMojoStartTime( MavenProject mavenProject) {
-            this.currentMojoStartPerModuleName.put( new ModuleName( mavenProject), System.currentTimeMillis());
+        private long initMojoStartTime( MavenProject mavenProject) {
+            long mojoStartTime = System.currentTimeMillis();
+            this.currentMojoStartPerModuleName.put( new ModuleName( mavenProject), mojoStartTime);
+            return mojoStartTime;
         }
         
         private Long getMojoStartTime(MavenProject mavenProject) {
@@ -395,10 +397,10 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
         }
         
         private void recordMojoStarted(ExecutionEvent event) {
-            initMojoStartTime( event.getProject() );
+            long startTime = initMojoStartTime( event.getProject() );
             
             MavenProject mavenProject = event.getProject();
-            MojoInfo mojoInfo = new MojoInfo(event);
+            MojoInfo mojoInfo = new MojoInfo(event,startTime);
 
             List<MavenReporter> mavenReporters = getMavenReporters( mavenProject );                
             
@@ -426,7 +428,7 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
         
         private void recordMojoEnded(ExecutionEvent event, Exception problem) {
             MavenProject mavenProject = event.getProject();
-            MojoInfo mojoInfo = new MojoInfo(event);
+            MojoInfo mojoInfo = new MojoInfo(event,getMojoStartTime(event.getProject()));
 
             recordExecutionTime(event,mojoInfo);
 

--- a/maven-plugin/src/main/java/hudson/maven/MavenReportInfo.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenReportInfo.java
@@ -49,8 +49,9 @@ public final class MavenReportInfo extends MojoInfo {
      */
     public final MavenReport report;
 
-    public MavenReportInfo(MojoExecution mojoExecution, MavenReport mojo, PlexusConfiguration configuration, ExpressionEvaluator expressionEvaluator) {
-        super(mojoExecution, (Mojo)mojo, configuration, expressionEvaluator);
+    public MavenReportInfo(MojoExecution mojoExecution, MavenReport mojo, PlexusConfiguration configuration, ExpressionEvaluator expressionEvaluator,
+            long mojoStartTime) {
+        super(mojoExecution, (Mojo)mojo, configuration, expressionEvaluator,mojoStartTime);
         this.report = mojo;
     }
 }

--- a/maven-plugin/src/main/java/hudson/maven/MojoInfo.java
+++ b/maven-plugin/src/main/java/hudson/maven/MojoInfo.java
@@ -148,7 +148,7 @@ public class MojoInfo {
      *      the configuration in POM is syntactically incorrect. 
      */
     public <T> T getConfigurationValue(String configName, Class<T> type) throws ComponentConfigurationException {
-        PlexusConfiguration child = configuration.getChild(configName);
+        PlexusConfiguration child = configuration.getChild(configName,false);
         if(child==null) return null;    // no such config
        
         final ClassLoader cl;

--- a/maven-plugin/src/main/java/hudson/maven/MojoInfo.java
+++ b/maven-plugin/src/main/java/hudson/maven/MojoInfo.java
@@ -103,7 +103,10 @@ public class MojoInfo {
      */
     private final ConverterLookup converterLookup = new DefaultConverterLookup();
 
-    public MojoInfo(MojoExecution mojoExecution, Mojo mojo, PlexusConfiguration configuration, ExpressionEvaluator expressionEvaluator) {
+    private long startTime;
+
+    public MojoInfo(MojoExecution mojoExecution, Mojo mojo, PlexusConfiguration configuration, ExpressionEvaluator expressionEvaluator,
+            long startTime) {
         // in Maven3 there's no easy way to get the Mojo instance that's being executed,
         // so we just can't pass it in.
         if (mojo==null) mojo = new Maven3ProvidesNoAccessToMojo();
@@ -112,12 +115,13 @@ public class MojoInfo {
         this.configuration = configuration;
         this.expressionEvaluator = expressionEvaluator;
         this.pluginName = new PluginName(mojoExecution.getMojoDescriptor().getPluginDescriptor());
+        this.startTime = startTime;
     }
 
-    public MojoInfo(ExecutionEvent event) {
+    public MojoInfo(ExecutionEvent event, long startTime) {
         this(event.getMojoExecution(), null,
                 new XmlPlexusConfiguration( event.getMojoExecution().getConfiguration() ),
-                new PluginParameterExpressionEvaluator( event.getSession(), event.getMojoExecution() ));
+                new PluginParameterExpressionEvaluator( event.getSession(), event.getMojoExecution() ), startTime);
     }
 
     /**
@@ -277,5 +281,9 @@ public class MojoInfo {
         public void execute() throws MojoExecutionException, MojoFailureException {
             throw new UnsupportedOperationException();
         }
+    }
+
+    public long getStartTime() {
+        return this.startTime;
     }
 }

--- a/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
@@ -253,7 +253,7 @@ public class SurefireArchiver extends TestFailureDetector {
         }
     }
 
-    private boolean isTestMojo(MojoInfo mojo) {
+    boolean isTestMojo(MojoInfo mojo) {
         if ((!mojo.is("com.sun.maven", "maven-junit-plugin", "test"))
             && (!mojo.is("org.sonatype.flexmojos", "flexmojos-maven-plugin", "test-run"))
             && (!mojo.is("org.eclipse.tycho", "tycho-surefire-plugin", "test"))

--- a/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
@@ -133,7 +133,7 @@ public class SurefireArchiver extends TestFailureDetector {
         if (reportsDir == null) {
             // if test mojo doesn't have such config value, still almost all
             // default to target/surefire-reports
-            reportsDir = new File(pom.getBasedir(), "target/surefire-reports");
+            reportsDir = new File(pom.getBasedir(), pom.getBuild().getDirectory()+File.separator+"surefire-reports");
         }
 
         if(reportsDir.exists()) {
@@ -153,8 +153,12 @@ public class SurefireArchiver extends TestFailureDetector {
     
                 if(result==null)    result = new TestResult();
                 
-                Iterable<File> reportFilesFiltered = getFilesBetween(reportsDir, reportFiles, mojo.getStartTime(), System.currentTimeMillis());
-                result.parse(reportFilesFiltered);
+                result.parse(System.currentTimeMillis() - build.getMilliSecsSinceBuildStart(), reportsDir, reportFiles);
+                
+                // TODO kutzi: the following is a 'more correct' way to get the reports associated to a mojo,
+                // but needs more testing
+//                Iterable<File> reportFilesFiltered = getFilesBetween(reportsDir, reportFiles, mojo.getStartTime(), System.currentTimeMillis());
+//                result.parse(reportFilesFiltered);
                 
                 // final reference in order to serialize it:
                 final TestResult r = result;
@@ -187,11 +191,6 @@ public class SurefireArchiver extends TestFailureDetector {
         return true;
     }
     
-    private static Iterable<File> getFilesBetween(final File reportsDir,
-            final String[] reportFiles, final long from, final long to) {
-        return new FilteredReportsFileIterable(reportsDir, reportFiles, from, to);
-    }
-
     @Override
     public boolean end(MavenBuild build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         //Discard unneeded test result objects so they can't waste memory
@@ -260,6 +259,11 @@ public class SurefireArchiver extends TestFailureDetector {
         }
     }
 
+//    private static Iterable<File> getFilesBetween(final File reportsDir,
+//            final String[] reportFiles, final long from, final long to) {
+//        return new FilteredReportsFileIterable(reportsDir, reportFiles, from, to);
+//    }
+    
     /**
      * Provides an {@link Iterable} view on the reports files while filtering out all files
      * which don't have a lastModified time in between from and to.
@@ -306,52 +310,6 @@ public class SurefireArchiver extends TestFailureDetector {
                             }
                         }),
                     fileWithinFromAndTo);
-//            return new Iterator<File>() {
-//                File next;
-//                int nextIndex=-1;
-//
-//                {
-//                    getNext();
-//                }
-//
-//                private void getNext() {
-//                    nextIndex++;
-//                    File n = null;
-//                    while(n == null) {
-//                        if (nextIndex >= reportFiles.length) {
-//                            break;
-//                        }
-//                        File f = getFile(reportsDir,reportFiles[nextIndex]);
-//                        long lastModified = f.lastModified();
-//                        if (lastModified>=from && lastModified<=to) {
-//                            n=f;
-//                        } else {
-//                            nextIndex++;
-//                        }
-//                    }
-//                    next=n;
-//                }
-//                
-//                @Override
-//                public boolean hasNext() {
-//                    return next != null;
-//                }
-//
-//                @Override
-//                public File next() {
-//                    File n = next;
-//                    if (n == null) {
-//                        throw new NoSuchElementException();
-//                    }
-//                    getNext();
-//                    return n;
-//                }
-//
-//                @Override
-//                public void remove() {
-//                    throw new UnsupportedOperationException();
-//                }
-//            };
         }
         
         // here for mocking purposes:

--- a/maven-plugin/src/main/java/hudson/maven/reporters/TestMojo.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/TestMojo.java
@@ -1,0 +1,223 @@
+package hudson.maven.reporters;
+
+import hudson.Util;
+import hudson.maven.MojoInfo;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.apache.maven.project.MavenProject;
+import org.apache.tools.ant.types.FileSet;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
+
+/**
+ * Description of a mojo which can run tests.
+ * 
+ * @author kutzi
+ */
+enum TestMojo {
+    
+    /**
+     * Fallback to this if we have no exact match
+     */
+    FALLBACK("","","","reportsDirectory") {
+        @Override
+        protected boolean is(String artifactId, String groupId, String goal) {
+            // never match anything implicitly
+            return false;
+        }
+    },
+    
+    MAVEN_SUREFIRE("org.apache.maven.plugins", "maven-surefire-plugin","test","reportsDirectory"),
+    MAVEN_FAILSAFE("org.apache.maven.plugins", "maven-failsafe-plugin", "verify","reportsDirectory"),
+    
+    MAVEN_JUNIT("com.sun.maven", "maven-junit-plugin", "test","reportsDirectory"),
+    FLEXMOJOS("org.sonatype.flexmojos", "flexmojos-maven-plugin", "test-run",null),
+    
+    MAVEN_OSGI_TEST("org.sonatype.tycho", "maven-osgi-test-plugin", "test","reportsDirectory"),
+    TYCHO_SUREFIRE("org.eclipse.tycho", "tycho-surefire-plugin", "test","reportsDirectory"),
+    
+    MAVEN_ANDROID_PLUGIN("com.jayway.maven.plugins.android.generation2", "maven-android-plugin",
+            "internal-integration-test",null,"3.0.0-alpha-6"),
+    ANDROID_MAVEN_PLUGIN("com.jayway.maven.plugins.android.generation2", "android-maven-plugin",
+            "internal-integration-test",null,"3.0.0-alpha-6"),
+            
+    GWT_MAVEN_PLUGIN("org.codehaus.mojo", "gwt-maven-plugin", "test","reportsDirectory","1.2"),
+    
+    MAVEN_SOAPUI_PLUGIN("eviware", "maven-soapui-plugin", "test", "outputFolder"),
+    MAVEN_SOAPUI_PRO_PLUGIN("eviware", "maven-soapui-pro-plugin", "test","outputFolder"),
+    
+    JASMINE("com.github.searls","jasmine-maven-plugin","test",null) {
+        @Override
+        public Collection<File> getReportFiles(MavenProject pom,MojoInfo mojo)
+                throws ComponentConfigurationException {
+            // jasmine just creates a single JUnit result file
+            File reportsDir = mojo.getConfigurationValue("jasmineTargetDir", File.class);
+            String junitFileName = mojo.getConfigurationValue("junitXmlReportFileName", String.class);
+            
+            return Collections.singleton(new File(reportsDir,junitFileName));
+        }
+    },
+    TOOLKIT_RESOLVER_PLUGIN("org.terracotta.maven.plugins", "toolkit-resolver-plugin", "toolkit-resolve-test","reportsDirectory");
+
+    private String reportDirectoryConfigKey;
+    private Key key;
+    private String minimalRequiredVersion;
+    
+    private TestMojo(String artifactId, String groupId, String goal,
+            String reportDirectoryConfigKey) {
+        this.key = new Key(artifactId,groupId,goal);
+        this.reportDirectoryConfigKey = reportDirectoryConfigKey;
+    }
+    
+    private TestMojo(String artifactId, String groupId, String goal,
+            String reportDirectoryConfigKey,String minimalRequiredVersion) {
+        this.key = new Key(artifactId,groupId,goal);
+        this.reportDirectoryConfigKey = reportDirectoryConfigKey;
+        this.minimalRequiredVersion = minimalRequiredVersion;
+    }
+    
+    public Key getKey() {
+        return this.key;
+    }
+    
+    /**
+     * Says if this mojo can run tests.
+     * Can e.g. return false if the version of the plugin is too old to create output in JUnit format.
+     */
+    public boolean canRunTests(MojoInfo mojo) {
+        if (this.minimalRequiredVersion == null) {
+            return true;
+        }
+        
+        return mojo.pluginName.version.compareTo(this.minimalRequiredVersion) >= 0;
+    }
+    
+    public Iterable<File> getReportFiles(MavenProject pom, MojoInfo mojo) throws ComponentConfigurationException {
+        if (this.reportDirectoryConfigKey != null) {
+            File reportsDir = mojo.getConfigurationValue(this.reportDirectoryConfigKey, File.class);
+            if (reportsDir.exists()) {
+                return getReportFiles(reportsDir, getFileSet(reportsDir));
+            } 
+            
+        }
+
+        // some plugins just default to this:        
+        File reportsDir = new File(pom.getBasedir(), pom.getBuild().getDirectory()+File.separator+"surefire-reports");
+        if (reportsDir.exists()) {
+            return getReportFiles(reportsDir, getFileSet(reportsDir));
+        }
+        
+        return null;
+    }
+    
+    private Iterable<File> getReportFiles(final File baseDir, FileSet set) {
+        final String[] includedFiles = set.getDirectoryScanner().getIncludedFiles();
+        
+        return new Iterable<File>() {
+            public Iterator<File> iterator() {
+                return Iterators.transform(
+                    Iterators.forArray(includedFiles),
+                    new Function<String, File>() {
+                        @Override
+                        public File apply(String file) {
+                            return new File(baseDir,file);
+                        }
+                    });
+            }
+        };
+    }
+    
+    /**
+     * Returns the appropriate FileSet for the selected baseDir
+     * @param baseDir
+     * @return
+     */
+    private FileSet getFileSet(File baseDir) {
+        return Util.createFileSet(baseDir, "*.xml","testng-results.xml,testng-failed.xml");
+    }
+    
+    protected boolean is(String artifactId, String groupId, String goal) {
+        return key.artifactId.equals(artifactId) && key.groupId.equals(groupId)
+                && key.goal.equals(goal);
+    }
+    
+    public static TestMojo lookup(String artifactId, String groupId, String goal) {
+        for (TestMojo mojo : values()) {
+            if (mojo.is(artifactId,groupId,goal)) {
+                return mojo;
+            }
+        }
+        
+        if (goal.equals("test") || goal.equals("test-run")) {
+            return FALLBACK;
+        }
+        
+        return null;
+    }
+    
+    public static TestMojo lookup(MojoInfo mojo) {
+        TestMojo testMojo = lookup(mojo.pluginName.groupId, mojo.pluginName.artifactId, mojo.getGoal());
+        if (testMojo != null && testMojo.canRunTests(mojo)) {
+            return testMojo;
+        }
+        return null;
+    }
+    
+    static class Key {
+        private String artifactId;
+        private String groupId;
+        private String goal;
+        
+        public Key(String artifactId, String groupId, String goal) {
+            super();
+            this.artifactId = artifactId;
+            this.groupId = groupId;
+            this.goal = goal;
+        }
+        
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result
+                    + ((artifactId == null) ? 0 : artifactId.hashCode());
+            result = prime * result + ((goal == null) ? 0 : goal.hashCode());
+            result = prime * result
+                    + ((groupId == null) ? 0 : groupId.hashCode());
+            return result;
+        }
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Key other = (Key) obj;
+            if (artifactId == null) {
+                if (other.artifactId != null)
+                    return false;
+            } else if (!artifactId.equals(other.artifactId))
+                return false;
+            if (goal == null) {
+                if (other.goal != null)
+                    return false;
+            } else if (!goal.equals(other.goal))
+                return false;
+            if (groupId == null) {
+                if (other.groupId != null)
+                    return false;
+            } else if (!groupId.equals(other.groupId))
+                return false;
+            return true;
+        }
+    }
+
+}

--- a/maven-plugin/src/test/java/hudson/maven/ExecutedMojoTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/ExecutedMojoTest.java
@@ -53,7 +53,7 @@ public class ExecutedMojoTest {
         // Faking JUnit's Assert to be the plugin class
         this.mojoDescriptor.setImplementation(Assert.class.getName());
         MojoExecution execution = new MojoExecution(this.mojoDescriptor);
-        MojoInfo info = new MojoInfo(execution, null, null, null);
+        MojoInfo info = new MojoInfo(execution, null, null, null, -1);
         
         ExecutedMojo executedMojo = new ExecutedMojo(info, 1L);
         
@@ -66,7 +66,7 @@ public class ExecutedMojoTest {
         // Faking this class as the mojo impl:
         this.mojoDescriptor.setImplementation(getClass().getName());
         MojoExecution execution = new MojoExecution(this.mojoDescriptor);
-        MojoInfo info = new MojoInfo(execution, null, null, null);
+        MojoInfo info = new MojoInfo(execution, null, null, null, -1);
         
         ExecutedMojo executedMojo = new ExecutedMojo(info, 1L);
         

--- a/maven-plugin/src/test/java/hudson/maven/MojoInfoBuilder.java
+++ b/maven-plugin/src/test/java/hudson/maven/MojoInfoBuilder.java
@@ -20,6 +20,7 @@ public class MojoInfoBuilder {
     private String goalName;
     private String version = "1.0";
     private Map<String, String> configValues = new HashMap<String, String>();
+    private long startTime = System.currentTimeMillis();
     
     public static MojoInfoBuilder mojoBuilder(String groupId, String artifactId, String goalName) {
         return new MojoInfoBuilder(groupId, artifactId, goalName);
@@ -40,6 +41,11 @@ public class MojoInfoBuilder {
     
     public MojoInfoBuilder version(String version) {
         this.version = version;
+        return this;
+    }
+    
+    public MojoInfoBuilder startTime(long startTime) {
+        this.startTime = startTime;
         return this;
     }
     
@@ -77,7 +83,7 @@ public class MojoInfoBuilder {
             }
         };
         
-        MojoInfo info = new MojoInfo(mojoExecution, null, configuration, evaluator);
+       MojoInfo info = new MojoInfo(mojoExecution, null, configuration, evaluator, startTime);
         return info;
     }
     

--- a/maven-plugin/src/test/java/hudson/maven/MojoInfoBuilder.java
+++ b/maven-plugin/src/test/java/hudson/maven/MojoInfoBuilder.java
@@ -1,0 +1,85 @@
+package hudson.maven;
+
+import hudson.maven.MojoInfo;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.DefaultPlexusConfiguration;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+
+public class MojoInfoBuilder {
+
+    private String groupId;
+    private String artifactId;
+    private String goalName;
+    private String version = "1.0";
+    private Map<String, String> configValues = new HashMap<String, String>();
+    
+    public static MojoInfoBuilder mojoBuilder(String groupId, String artifactId, String goalName) {
+        return new MojoInfoBuilder(groupId, artifactId, goalName);
+    }
+    
+    private MojoInfoBuilder(String groupId, String artifactId, String goalName) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.goalName = goalName;
+    }
+    
+    public MojoInfoBuilder copy() {
+        MojoInfoBuilder copy = new MojoInfoBuilder(this.groupId, this.artifactId, this.goalName)
+            .version(this.version);
+        copy.configValues.putAll(this.configValues);
+        return copy;
+    }
+    
+    public MojoInfoBuilder version(String version) {
+        this.version = version;
+        return this;
+    }
+    
+    public MojoInfoBuilder configValue(String key,String value) {
+        configValues.put(key, value);
+        return this;
+    }
+    
+    public MojoInfo build() {
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        pluginDescriptor.setGroupId(groupId);
+        pluginDescriptor.setArtifactId(artifactId);
+        pluginDescriptor.setVersion(version);
+        
+        MojoDescriptor mojoDescriptor = new MojoDescriptor();
+        mojoDescriptor.setPluginDescriptor(pluginDescriptor);
+        mojoDescriptor.setGoal(goalName);
+        
+        MojoExecution mojoExecution = new MojoExecution(mojoDescriptor);
+        
+        PlexusConfiguration configuration = new DefaultPlexusConfiguration("configuration");
+        for (Map.Entry<String, String> e : this.configValues.entrySet()) {
+            configuration.addChild(e.getKey(),e.getValue());
+        }
+        
+        ExpressionEvaluator evaluator = new ExpressionEvaluator() {
+            @Override
+            public Object evaluate(String expression) {
+                return expression;
+            }
+            
+            @Override
+            public File alignToBaseDirectory(File file) {
+                return file;
+            }
+        };
+        
+        MojoInfo info = new MojoInfo(mojoExecution, null, configuration, evaluator);
+        return info;
+    }
+    
+    
+}

--- a/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverDetectTestMojosTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverDetectTestMojosTest.java
@@ -1,0 +1,163 @@
+package hudson.maven.reporters;
+
+import static hudson.maven.MojoInfoBuilder.mojoBuilder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import hudson.maven.MojoInfo;
+import hudson.maven.MojoInfoBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression test for the detection of test mojos in {@link SurefireArchiver}.
+ * 
+ * @author kutzi
+ */
+public class SurefireArchiverDetectTestMojosTest {
+    
+    private SurefireArchiver surefireArchiver;
+
+    @Before
+    public void before() {
+        this.surefireArchiver = new SurefireArchiver();
+    }
+    
+    @Test
+    public void shouldDetectMavenSurefire() {
+        MojoInfo mojo = mojoBuilder("org.apache.maven.plugins", "maven-surefire-plugin", "test").build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+    }
+    
+    @Test
+    public void shouldDetectMavenFailsafe() {
+        MojoInfo mojo = mojoBuilder("org.apache.maven.plugins", "maven-failsafe-plugin", "verify").build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+    }
+    
+    @Test
+    public void shouldDetectMavenSurefireSkip() {
+        MojoInfoBuilder builder = mojoBuilder("org.apache.maven.plugins", "maven-surefire-plugin", "test");
+        MojoInfo mojo = builder.copy()
+                .configValue("skip", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy()
+                .version("2.4")
+                .configValue("skipTests", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy()
+                .version("2.3")
+                .configValue("skipExec", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+
+        // That's not a valid skip property:
+        mojo = builder.copy()
+                .configValue("skip--Exec", "true").build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+    }
+
+    @Test
+    public void shouldDetectMavenJunitPlugin() {
+        MojoInfoBuilder builder = mojoBuilder("com.sun.maven", "maven-junit-plugin", "test");
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy()
+                .configValue("skipTests", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
+    
+    @Test
+    public void shouldDetectFlexMojoMavenPlugin() {
+        MojoInfoBuilder builder = mojoBuilder("org.sonatype.flexmojos", "flexmojos-maven-plugin", "test-run");
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy()
+                .configValue("skipTest", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
+    
+    @Test
+    public void shouldDetectOsgiTestPlugin() {
+        MojoInfoBuilder builder = mojoBuilder("org.sonatype.tycho", "maven-osgi-test-plugin", "test"); 
+        
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy().configValue("skipTest", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
+    
+    @Test
+    public void shouldDetectTychoSurefirePlugin() {
+        MojoInfoBuilder builder = mojoBuilder("org.eclipse.tycho", "tycho-surefire-plugin", "test"); 
+        
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy().configValue("skipTest", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
+    
+    @Test
+    public void shouldDetectMavenAndroidPlugin() {
+        MojoInfoBuilder builder = mojoBuilder("com.jayway.maven.plugins.android.generation2", "maven-android-plugin", "internal-integration-test")
+                .version("3.0.0-alpha-6");
+        
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy().configValue("skipTests", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
+    
+    @Test
+    public void shouldDetectAndroidMavenPlugin() {
+        MojoInfoBuilder builder = mojoBuilder("com.jayway.maven.plugins.android.generation2", "android-maven-plugin", "internal-integration-test")
+                .version("3.0.0-alpha-6");
+        
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy().configValue("skipTests", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
+    
+    @Test
+    public void shouldDetectGwtMavenPlugin() {
+        MojoInfoBuilder builder = mojoBuilder("org.codehaus.mojo", "gwt-maven-plugin", "test")
+                .version("1.2");
+        
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        // that version of the plugin is too old
+        mojo = builder.copy().version("1.1").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
+    
+    @Test
+    public void shouldDetectSoapUiMavenPlugin() {
+        MojoInfoBuilder builder = mojoBuilder("eviware", "maven-soapui-plugin", "test");
+        
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy().configValue("skip", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
+    
+    @Test
+    public void shouldDetectSoapUiProMavenPlugin() {
+        MojoInfoBuilder builder = mojoBuilder("eviware", "maven-soapui-pro-plugin", "test");
+        
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy().configValue("skip", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
+}

--- a/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverDetectTestMojosTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverDetectTestMojosTest.java
@@ -160,4 +160,15 @@ public class SurefireArchiverDetectTestMojosTest {
         mojo = builder.copy().configValue("skip", "true").build();
         assertFalse(this.surefireArchiver.isTestMojo(mojo));
     }
+    
+    @Test
+    public void shouldDetectToolkitResolverPlugin() {
+        MojoInfoBuilder builder = mojoBuilder("org.terracotta.maven.plugins", "toolkit-resolver-plugin", "toolkit-resolve-test");
+        
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+        
+        mojo = builder.copy().configValue("skipTests", "true").build();
+        assertFalse(this.surefireArchiver.isTestMojo(mojo));
+    }
 }

--- a/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverDetectTestMojosTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverDetectTestMojosTest.java
@@ -171,4 +171,12 @@ public class SurefireArchiverDetectTestMojosTest {
         mojo = builder.copy().configValue("skipTests", "true").build();
         assertFalse(this.surefireArchiver.isTestMojo(mojo));
     }
+    
+    @Test
+    public void shouldDetectAnyMojoWithATestGoal() {
+        MojoInfoBuilder builder = mojoBuilder("some.weird.internal","test-mojo", "test");
+        
+        MojoInfo mojo = builder.build();
+        assertTrue(this.surefireArchiver.isTestMojo(mojo));
+    }
 }

--- a/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverFilterReportsFileTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverFilterReportsFileTest.java
@@ -1,0 +1,101 @@
+package hudson.maven.reporters;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import hudson.maven.reporters.SurefireArchiver.FilteredReportsFileIterable;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+
+public class SurefireArchiverFilterReportsFileTest {
+    
+    @Test
+    public void shouldIncludeAllReportFiles() {
+        File reportsDir = new File("bla");
+        String[] reportFiles = { "a", "b", "c" };
+        FilteredReportsFileIterable iterable = new FilteredReportsFileIterable(reportsDir, reportFiles, 0, 1000);
+        
+        iterable = spy(iterable);
+        File file = mock(File.class);
+        when(file.lastModified()).thenReturn(500L);
+        
+        when(iterable.getFile(any(File.class), anyString())).thenReturn(file);
+        
+        Iterator<File> iterator = iterable.iterator();
+        
+        iterator.next();
+        iterator.next();
+        iterator.next();
+        
+        try {
+            iterator.next();
+            fail("Iterator should only have 3 elements");
+        } catch (NoSuchElementException e) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void shouldExcludeReportFileTooOld() {
+        File reportsDir = new File("bla");
+        String[] reportFiles = { "a", "b", "c" };
+        FilteredReportsFileIterable iterable = new FilteredReportsFileIterable(reportsDir, reportFiles, 5000, 10000);
+        
+        iterable = spy(iterable);
+        File included = mock(File.class);
+        when(included.lastModified()).thenReturn(6000L);
+        
+        File tooOld = mock(File.class);
+        when(tooOld.lastModified()).thenReturn(500L);
+        
+        when(iterable.getFile(any(File.class), anyString())).thenReturn(included, tooOld, included);
+        
+        Iterator<File> iterator = iterable.iterator();
+        
+        iterator.next();
+        iterator.next();
+        
+        try {
+            iterator.next();
+            fail("Iterator should only have 2 elements");
+        } catch (NoSuchElementException e) {
+            // expected
+        }
+    }
+    
+    @Test
+    public void shouldExcludeReportFileTooYoung() {
+        File reportsDir = new File("bla");
+        String[] reportFiles = { "a", "b", "c" };
+        FilteredReportsFileIterable iterable = new FilteredReportsFileIterable(reportsDir, reportFiles, 5000, 10000);
+        
+        iterable = spy(iterable);
+        File included = mock(File.class);
+        when(included.lastModified()).thenReturn(5000L);
+        
+        File tooYoung = mock(File.class);
+        when(tooYoung.lastModified()).thenReturn(20000L);
+        
+        when(iterable.getFile(any(File.class), anyString())).thenReturn(included, included, tooYoung);
+        
+        Iterator<File> iterator = iterable.iterator();
+        
+        iterator.next();
+        iterator.next();
+        
+        try {
+            iterator.next();
+            fail("Iterator should only have 2 elements");
+        } catch (NoSuchElementException e) {
+            // expected
+        }
+    }
+
+}

--- a/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverUnitTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverUnitTest.java
@@ -51,8 +51,6 @@ public class SurefireArchiverUnitTest {
     @Before
     @SuppressWarnings("unchecked")
     public void before() throws ComponentConfigurationException, URISyntaxException {
-        //suppress(constructor(MavenBuild.class, new Class[0]));
-        
         this.archiver = new SurefireArchiver();
         this.build = mock(MavenBuild.class);
         when(build.getAction(Matchers.any(Class.class))).thenCallRealMethod();
@@ -92,6 +90,7 @@ public class SurefireArchiverUnitTest {
     public void testArchiveResults() throws InterruptedException, IOException, URISyntaxException, ComponentConfigurationException {
         URL resource = SurefireArchiverUnitTest.class.getResource("/surefire-archiver-test2");
         File reportsDir = new File(resource.toURI().getPath());
+        
         doReturn(reportsDir).when(this.mojoInfo).getConfigurationValue("reportsDirectory", File.class);
         touchReportFiles(reportsDir);
         
@@ -194,7 +193,7 @@ public class SurefireArchiverUnitTest {
     private void touchReportFiles(File reportsDir) {
         File[] files = reportsDir.listFiles();
         for(File f : files) {
-            f.setLastModified(System.currentTimeMillis());
+            f.setLastModified(this.mojoInfo.getStartTime());
         }
     }
 

--- a/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverUnitTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/reporters/SurefireArchiverUnitTest.java
@@ -13,6 +13,7 @@ import hudson.maven.MavenBuildProxy;
 import hudson.maven.MavenProjectActionBuilder;
 import hudson.maven.MavenReporter;
 import hudson.maven.MojoInfo;
+import hudson.maven.MojoInfoBuilder;
 import hudson.model.BuildListener;
 import hudson.model.Cause;
 import hudson.model.Result;
@@ -28,9 +29,6 @@ import java.util.Calendar;
 import java.util.List;
 
 import org.apache.commons.io.output.NullOutputStream;
-import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.plugin.descriptor.MojoDescriptor;
-import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.tools.ant.types.FileSet;
 import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.junit.Assert;
@@ -69,17 +67,8 @@ public class SurefireArchiverUnitTest {
     }
 
     private MojoInfo createMojoInfo() throws ComponentConfigurationException {
-        PluginDescriptor pluginDescriptor = new PluginDescriptor();
-        pluginDescriptor.setGroupId("org.apache.maven.plugins");
-        pluginDescriptor.setArtifactId("maven-surefire-plugin");
-        pluginDescriptor.setVersion("2.9");
-        
-        MojoDescriptor mojoDescriptor = new MojoDescriptor();
-        mojoDescriptor.setPluginDescriptor(pluginDescriptor);
-        mojoDescriptor.setGoal("test");
-        
-        MojoExecution mojoExecution = new MojoExecution(mojoDescriptor);
-        MojoInfo info = new MojoInfo(mojoExecution, null, null, null);
+        MojoInfo info = MojoInfoBuilder.mojoBuilder("org.apache.maven.plugins", "maven-surefire-plugin", "test")
+                .version("2.9").build();
         
         MojoInfo spy = spy(info);
         


### PR DESCRIPTION
This is a proposed fix for https://issues.jenkins-ci.org/browse/JENKINS-8334

I think there may be additional changes needed - like preventing too many 'false positives' resp. making sure that the same report files are not parsed multiple times.
But I'd like to get some feedback for this already
