### PR TITLE
Util/Iterators: find the first subset of consecutive elements matching a...

### DIFF
--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -365,10 +365,10 @@ public class Iterators {
     }
 
     /**
-     * Returns the elements in the base iterator, optionaly starting at the first one that satisfies the filter, until it hits any element that doesn't satisfy the filter.
+     * Returns the elements in the base iterator, optionally starting at the first one that satisfies the filter, until it hits any element that doesn't satisfy the filter.
      * Then the rest of the elements in the base iterator gets ignored.
      *
-     * @since 1.500
+     * @since 1.502
      */
     public static <T> Iterator<T> limit(final Iterator<? extends T> base, final CountingPredicate<? super T> filter, final boolean startsAtFirst) {
         return new Iterator<T>() {

--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -361,10 +361,22 @@ public class Iterators {
      * @since 1.485
      */
     public static <T> Iterator<T> limit(final Iterator<? extends T> base, final CountingPredicate<? super T> filter) {
+        return limit(base, filter, false);
+    }
+
+    /**
+     * Returns the elements in the base iterator, optionaly starting at the first one that satisfies the filter, until it hits any element that doesn't satisfy the filter.
+     * Then the rest of the elements in the base iterator gets ignored.
+     *
+     * @since 1.500
+     */
+    public static <T> Iterator<T> limit(final Iterator<? extends T> base, final CountingPredicate<? super T> filter, final boolean startsAtFirst) {
         return new Iterator<T>() {
             private T next;
             private boolean end;
             private int index=0;
+            private boolean foundFirst = false;
+
             public boolean hasNext() {
                 fetch();
                 return next!=null;
@@ -383,7 +395,13 @@ public class Iterators {
                         next = base.next();
                         if (!filter.apply(index++,next)) {
                             next = null;
-                            end = true;
+                            if (startsAtFirst && !foundFirst) {
+                                fetch();
+                            } else {
+                                end = true;
+                            }
+                        } else {
+                            foundFirst = true;
                         }
                     } else {
                         end = true;

--- a/core/src/test/java/hudson/util/IteratorsTest.java
+++ b/core/src/test/java/hudson/util/IteratorsTest.java
@@ -71,6 +71,13 @@ public class IteratorsTest extends TestCase {
         assertEquals("[]", com.google.common.collect.Iterators.toString(Iterators.limit(asList(1,2,4,6).iterator(), EVEN)));
     }
 
+    public void testLimitStartsAtFirst() {
+        assertEquals("[]",com.google.common.collect.Iterators.toString(Iterators.limit(asList(1,3,5).iterator(), EVEN, true)));
+        assertEquals("[2]",com.google.common.collect.Iterators.toString(Iterators.limit(asList(1,2,3,4).iterator(), EVEN, true)));
+        assertEquals("[2, 4, 6]", com.google.common.collect.Iterators.toString(Iterators.limit(asList(1,2,4,6).iterator(), EVEN, true)));
+        assertEquals("[2, 4, 6]", com.google.common.collect.Iterators.toString(Iterators.limit(asList(1,2,4,6,7).iterator(), EVEN, true)));
+    }
+
     public static final CountingPredicate<Integer> EVEN = new CountingPredicate<Integer>() {
         public boolean apply(int index, Integer input) {
             return input % 2 == 0;


### PR DESCRIPTION
... predicate, also when this subset isn't at the start of the original set.

In Pull request #663, the optimized byTimestamp implementation can become more inefficient than a simple filter for certain values of start & end dates, by forcing 2 passes. This new limit implementation would allow a simple pass. I am not committing it directly as I think a better name could be found instead of this overloaded method.

Feedback appreciated.
