### PR TITLE
Fixing typos on French translation (in the "Administrer Jenkins" page)

### DIFF
--- a/core/src/main/resources/jenkins/management/Messages_fr.properties
+++ b/core/src/main/resources/jenkins/management/Messages_fr.properties
@@ -23,18 +23,18 @@
 #
 
 ReloadLink.DisplayName=Recharger la configuration \u00E0 partir du disque
-ReloadLink.Description=Supprimer toutes les donn\u00E9es en m\u00E9moire et recharger tout \u00E0 partir du syst\u00EAme de fichiers.\n\
+ReloadLink.Description=Supprimer toutes les donn\u00E9es en m\u00E9moire et recharger tout \u00E0 partir du syst\u00E8me de fichiers.\n\
                        Utile quand vous modifiez les fichiers de configuration directement sur le disque.
 PluginsLink.DisplayName=Gestion des plugins
-SystemInfoLink.DisplayName=Informations sur le syst\u00EAme
-SystemInfoLink.Description=Affiche diverses informations relatives au syst\u00EAme pour aider \u00E0 la r\u00E9solution de probl\u00EAmes.
-SystemLogLink.Description=Le log syst\u00EAme capture la sortie <tt>java.util.logging</tt> relative \u00E0 Jenkins.
+SystemInfoLink.DisplayName=Informations sur le syst\u00E8me
+SystemInfoLink.Description=Affiche diverses informations relatives au syst\u00E8me pour aider \u00E0 la r\u00E9solution de probl\u00EAmes.
+SystemLogLink.Description=Le log syst\u00E8me capture la sortie <tt>java.util.logging</tt> relative \u00E0 Jenkins.
 ConsoleLink.DisplayName=Console de script
-ConsoleLink.Description=Ex\u00E9cute des scripts arbitraires pour l''''administration, la r\u00E9solution de probl\u00E8mes ou pour un diagnostic.
+ConsoleLink.Description=Ex\u00E9cute des scripts arbitraires pour l''administration, la r\u00E9solution de probl\u00E8mes ou pour un diagnostic.
 ShutdownLink.DisplayName_cancel=Annuler la fermeture
 ShutdownLink.DisplayName_prepare=Pr\u00E9parer \u00E0 la fermeture
 ShutdownLink.Description=Cesser d''ex\u00E9cuter de nouveaux builds, afin que le syst\u00E8me puisse se fermer.
-ConfigureLink.DisplayName=Configurer le syst\u00EAme
+ConfigureLink.DisplayName=Configurer le syst\u00E8me
 ConfigureLink.Description=Configurer les param\u00E8tres g\u00E9n\u00E9raux et les chemins de fichiers.
 PluginsLink.Description=Ajouter, supprimer, activer ou d\u00E9sactiver des plugins qui peuvent \u00E9tendre les fonctionnalit\u00E9s de Jenkins.
 CliLink.Description=Acc\u00E9der ou g\u00E9rer Jenkins depuis votre shell ou depuis votre script.


### PR DESCRIPTION
Fixed typos:
- "systême" --> "système" (5 times)
- double quotes
