### PR TITLE
[JENKINS-9258] "Remember me on this computer", still getting asked to log in after a few hours

### DIFF
--- a/war/src/main/webapp/WEB-INF/web.xml
+++ b/war/src/main/webapp/WEB-INF/web.xml
@@ -29,6 +29,9 @@ THE SOFTWARE.
          version="2.4">
   <display-name>Jenkins v${project.version}</display-name>
   <description>Build management system</description>
+  <session-config>
+    <session-timeout>2880</session-timeout> 
+  </session-config>
 
   <servlet>
     <servlet-name>Stapler</servlet-name>


### PR DESCRIPTION
This addresses JENKINS-9258, at least partially.  In my instance of Jenkins, when using AD-backed authentication, we would see session timeouts every couple of hours (even when "remember me" was checked).  This was incredibly inconvenient.  A commenter on the Jira issue suggested increasing the session timeout in the web.xml.  I made the change by directly modifying the war in our case and it worked well.  Ideally, we'd have something more configurable, but for now, this alleviates the immediate pain by setting the session timeout to two days.

In addition to testing in a very active Jenkins instance with tens of slaves, hundreds of jobs, and over a hundred active users, I also made the modification to the source, rebuilt jenkins and ran it locally.  I observed that I was not logged out using my locally built Jenkins before the session timeout.
