### PR TITLE
[FIXED JENKINS-15587] NTFS symlink handling in build records

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -340,10 +340,12 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
     /*package*/ static long parseTimestampFromBuildDir(File buildDir) throws IOException {
         try {
-            // "Utils.resolveSymlink(file)" does with NTFS symlinks what "file.getCanonicalFile()" is unable to 
-            // leaving original getCanonicalFile in case it is there for any additional reason
             if(Util.isSymlink(buildDir)) {
-                buildDir = new File(Util.resolveSymlink(buildDir));
+                // "Util.resolveSymlink(file)" resolves NTFS symlinks. 
+                String resolvedSymlink = Util.resolveSymlink(buildDir);
+                if(resolvedSymlink != null) {
+                	buildDir = new File(resolvedSymlink);
+                }
             }
             // canonicalization to ensure we are looking at the ID in the directory name
             // as opposed to build numbers which are used in symlinks
@@ -352,6 +354,8 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             throw new IOException2("Invalid directory name "+buildDir,e);
         } catch (NumberFormatException e) {
             throw new IOException2("Invalid directory name "+buildDir,e);
+        } catch (InterruptedException e) {
+            throw new IOException2("Interrupted while resolving symlink directory "+buildDir,e);
         }
     }
 

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -340,6 +340,11 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
     /*package*/ static long parseTimestampFromBuildDir(File buildDir) throws IOException {
         try {
+            // "Utils.resolveSymlink(file)" does with NTFS symlinks what "file.getCanonicalFile()" is unable to 
+            // leaving original getCanonicalFile in case it is there for any additional reason
+            if(Util.isSymlink(buildDir)) {
+                buildDir = new File(Util.resolveSymlink(buildDir));
+            }
             // canonicalization to ensure we are looking at the ID in the directory name
             // as opposed to build numbers which are used in symlinks
             return ID_FORMATTER.get().parse(buildDir.getCanonicalFile().getName()).getTime();

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -76,5 +76,33 @@ public class RunTest {
             TimeZone.setDefault(origTZ);
         }
     }
+    
+
+    @Bug(15587)
+    @Test 
+    public void testParseTimestampFromBuildDir() throws Exception {
+        //Assume.assumeTrue(!Functions.isWindows() || (NTFS && JAVA7) || ...);
+        
+        String buildDateTime = "2012-12-21_14-02-28";
+        long buildTimestamp = 1356091348000L;
+        int buildNumber = 155;
+        
+         ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         StreamTaskListener l = new StreamTaskListener(baos);
+         
+         File tempDir = Util.createTempDir();    
+    	 File buildDir = new File(tempDir, buildDateTime);  
+         assertEquals(buildDir.mkdir(), true);  
+    	 File buildDirSymLink = new File(tempDir, Integer.toString(buildNumber));
+    	 
+         try {
+        	 buildDir.mkdir();
+        	 
+             Util.createSymlink(tempDir, buildDir.getAbsolutePath(), buildDirSymLink.getName(), l);
+             assertEquals(Run.parseTimestampFromBuildDir(buildDirSymLink), buildTimestamp);
+         } finally {
+             Util.deleteRecursive(tempDir);
+         }
+    }
 
 }

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -24,10 +24,19 @@
 
 package hudson.model;
 
+import hudson.Util;
+import hudson.util.StreamTaskListener;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.charset.Charset;
 import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import javax.xml.stream.events.Characters;
+
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
@@ -87,22 +96,22 @@ public class RunTest {
         long buildTimestamp = 1356091348000L;
         int buildNumber = 155;
         
-         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-         StreamTaskListener l = new StreamTaskListener(baos);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        StreamTaskListener l = new StreamTaskListener(baos, Charset.defaultCharset());
+        
+        File tempDir = Util.createTempDir();    
+        File buildDir = new File(tempDir, buildDateTime);
+        assertEquals(true, buildDir.mkdir());
+        File buildDirSymLink = new File(tempDir, Integer.toString(buildNumber));
+        
+        try {
+        	buildDir.mkdir();
          
-         File tempDir = Util.createTempDir();    
-    	 File buildDir = new File(tempDir, buildDateTime);  
-         assertEquals(buildDir.mkdir(), true);  
-    	 File buildDirSymLink = new File(tempDir, Integer.toString(buildNumber));
-    	 
-         try {
-        	 buildDir.mkdir();
-        	 
-             Util.createSymlink(tempDir, buildDir.getAbsolutePath(), buildDirSymLink.getName(), l);
-             assertEquals(Run.parseTimestampFromBuildDir(buildDirSymLink), buildTimestamp);
-         } finally {
-             Util.deleteRecursive(tempDir);
-         }
+            Util.createSymlink(tempDir, buildDir.getAbsolutePath(), buildDirSymLink.getName(), l);
+            assertEquals(buildTimestamp, Run.parseTimestampFromBuildDir(buildDirSymLink));
+        } finally {
+            Util.deleteRecursive(tempDir);
+        }
     }
 
 }


### PR DESCRIPTION
Handling NTFS symlinks introduced via Util.resolveSymlink.
Should fix [JENKINS-15587](https://issues.jenkins-ci.org/browse/JENKINS-15587).
Also probably culprit for [JENKINS-13972](https://issues.jenkins-ci.org/browse/JENKINS-13972).
