### PR TITLE
Hide context menu when a mouse move from given reference

### DIFF
--- a/core/src/main/resources/lib/layout/breadcrumbs.js
+++ b/core/src/main/resources/lib/layout/breadcrumbs.js
@@ -117,12 +117,22 @@ var breadcrumbs = (function() {
     jenkinsRules["#breadcrumbs LI"] = function (e) {
         // when the mouse hovers over LI, activate the menu
         $(e).observe("mouseover", function () { handleHover(e.firstChild,0) });
+        $(e).observe("mouseout",function() { hideMenu(document.getElementById("breadcrumb-menu"),0) });
     };
 
     jenkinsRules["A.model-link"] = function (a) {
         // ditto for model-link, but give it a larger delay to avoid unintended menus to be displayed
         $(a).observe("mouseover", function () { handleHover(a,500); });
+        $(a).observe("mouseout",function() { hideMenu(document.getElementById("breadcrumb-menu"),400); });
     };
+    
+    function hideMenu(e, delay){
+        window.setTimeout(function() {
+            if(!(Dom.getRegion(e).contains(mouse))){
+                menu.hide();
+            }
+        },delay);
+    }
 
     /**
      * @namespace breadcrumbs


### PR DESCRIPTION
Our users has one problem. If a user move a mouse on a link which has context menu, a context menu appears. If user move a mouse on this context menu and after move out from the context menu (can be one move over context menu),the  context menu disappears. It is correct behaviour. But if user move on the link which has context menu and move out in the way that a mouse does not meet the context menu, the context menu does not disappear. So I add mouseout to link. 
I add delay 400 to A.model-link, because there is some space between link and context menu (without delay it would be impossible to move on a context menu, because a mouse is moved on a place where is not a link nor a context menu).
