### PR TITLE
Repetitive http 404 Not Found on some breadcrumbs without a contextmenu

### DIFF
--- a/core/src/main/resources/lib/layout/breadcrumbBar.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumbBar.jelly
@@ -58,7 +58,7 @@ THE SOFTWARE.
           <ul id="breadcrumbs">
             <j:forEach var="anc" items="${request.ancestors}">
               <j:if test="${h.isModel(anc.object) and anc.prev.url!=anc.url}">
-                <li class="${h.isModelWithContextMenu(anc.object)}?null:'no-context-menu'}">
+                <li class="${h.isModelWithContextMenu(anc.object)?null:'no-context-menu'}">
                   <a href="${anc.url}/">
                     ${anc.object.displayName}
                   </a>


### PR DESCRIPTION
fix a lot of http 404 Not Found on some breadcrumbs without a contextmenu, such as .../testReport or .../pollingLog
