### PR TITLE
[FIXED JENKINS-15156] Initialize AbstractLazyLoadRunMap.dir for newly created jobs

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -162,7 +162,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * {@link Run#getPreviousBuild()}
      */
     @Restricted(NoExternalUse.class)
-    protected transient RunMap<R> builds = new RunMap<R>();
+    protected transient RunMap<R> builds;
 
     /**
      * The quiet period. Null to delegate to the system default.
@@ -271,6 +271,12 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         super.onCreatedFromScratch();
         // solicit initial contributions, especially from TransientProjectActionFactory
         updateTransientActions();
+        assert builds==null;
+        builds = new RunMap<R>(getBuildDir(), new Constructor<R>() {
+            public R create(File dir) throws IOException {
+        	return loadBuild(dir);
+            }
+        });
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -203,8 +203,8 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
     private void loadIdOnDisk() {
         String[] buildDirs = dir.list(createDirectoryFilter());
         if (buildDirs==null) {
+            // the job may just have been created
             buildDirs=EMPTY_STRING_ARRAY;
-            LOGGER.log(Level.WARNING, "failed to load list of builds from {0}", dir);
         }
         // wrap into ArrayList to enable mutation
         Arrays.sort(buildDirs);
@@ -625,6 +625,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
 
 
     protected R load(String id, Index editInPlace) {
+        assert dir != null;
         R v = load(new File(dir, id), editInPlace);
         if (v==null && editInPlace!=null) {
             // remember the failure.


### PR DESCRIPTION
Hi,

trying to debug [JENKINS-15156](https://issues.jenkins-ci.org/browse/JENKINS-15156) it seems that after creating a new job, the 'dir' member of its 'AbstractLazyLoadRunMap' of builds is null until Jenkins is restarted/reload. After the map's members get garbage-collected, reloading them fails because dir is null, giving
the missing builds.

This is a patch which for me seems to solve this.

This was originally sent to the jenkinsci-dev mailing list:
https://groups.google.com/forum/?fromgroups=#!topic/jenkinsci-dev/cJVw6pEHXKk

This is not really meant to be pulled verbatim. If anyone of the Jenkins developers likes to take up on this and fix this bug I'll be happy.

Regards,
Julian
