### PR TITLE
[FIXED JENKINS-16630] Human readable file size method returns ",00" for files with byte length 0

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1548,6 +1548,9 @@ public class Functions {
      */
     public static String humanReadableByteSize(long size){
         String measure = "B";
+        if(size < 1024){
+            return size + " " + measure;
+        }
         Double number = new Double(size);
         if(number>=1024){
             number = number/1024;
@@ -1561,7 +1564,7 @@ public class Functions {
                 }
             }
         }
-        DecimalFormat format = new DecimalFormat("##.00");
+        DecimalFormat format = new DecimalFormat("#0.00");
         return format.format(number) + " " + measure;
     }
 }

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -23,6 +23,9 @@
  */
 package hudson;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+
 import hudson.model.Action;
 import static org.junit.Assert.*;
 import org.junit.Test;
@@ -117,4 +120,21 @@ public class FunctionsTest {
         when(req.getContextPath()).thenReturn(contextPath);
         return req;
     }
+
+    @Test
+    @Bug(16630)
+    public void testhumanReadableFileSize(){
+        DecimalFormat format = (DecimalFormat) DecimalFormat.getInstance();
+        DecimalFormatSymbols symbols = format.getDecimalFormatSymbols();
+        char sep = symbols.getDecimalSeparator();
+        assertEquals("0 B", Functions.humanReadableByteSize(0));
+        assertEquals("1023 B", Functions.humanReadableByteSize(1023));
+        assertEquals("1"+sep+"00 KB", Functions.humanReadableByteSize(1024));
+        assertEquals("1"+sep+"50 KB", Functions.humanReadableByteSize(1536));
+        assertEquals("20"+sep+"00 KB", Functions.humanReadableByteSize(20480));
+        assertEquals("1023"+sep+"00 KB", Functions.humanReadableByteSize(1047552));
+        assertEquals("1"+sep+"00 MB", Functions.humanReadableByteSize(1048576));
+        assertEquals("1"+sep+"50 GB", Functions.humanReadableByteSize(1610612700));
+    }
+
 }

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -23,8 +23,7 @@
  */
 package hudson;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 import hudson.model.Action;
 import static org.junit.Assert.*;
@@ -123,18 +122,21 @@ public class FunctionsTest {
 
     @Test
     @Bug(16630)
-    public void testhumanReadableFileSize(){
-        DecimalFormat format = (DecimalFormat) DecimalFormat.getInstance();
-        DecimalFormatSymbols symbols = format.getDecimalFormatSymbols();
-        char sep = symbols.getDecimalSeparator();
-        assertEquals("0 B", Functions.humanReadableByteSize(0));
-        assertEquals("1023 B", Functions.humanReadableByteSize(1023));
-        assertEquals("1"+sep+"00 KB", Functions.humanReadableByteSize(1024));
-        assertEquals("1"+sep+"50 KB", Functions.humanReadableByteSize(1536));
-        assertEquals("20"+sep+"00 KB", Functions.humanReadableByteSize(20480));
-        assertEquals("1023"+sep+"00 KB", Functions.humanReadableByteSize(1047552));
-        assertEquals("1"+sep+"00 MB", Functions.humanReadableByteSize(1048576));
-        assertEquals("1"+sep+"50 GB", Functions.humanReadableByteSize(1610612700));
+    public void testHumanReadableFileSize(){
+        Locale defaultLocale = Locale.getDefault();
+        try{
+            Locale.setDefault(Locale.ENGLISH);
+            assertEquals("0 B", Functions.humanReadableByteSize(0));
+            assertEquals("1023 B", Functions.humanReadableByteSize(1023));
+            assertEquals("1.00 KB", Functions.humanReadableByteSize(1024));
+            assertEquals("1.50 KB", Functions.humanReadableByteSize(1536));
+            assertEquals("20.00 KB", Functions.humanReadableByteSize(20480));
+            assertEquals("1023.00 KB", Functions.humanReadableByteSize(1047552));
+            assertEquals("1.00 MB", Functions.humanReadableByteSize(1048576));
+            assertEquals("1.50 GB", Functions.humanReadableByteSize(1610612700));
+        }finally{
+            Locale.setDefault(defaultLocale);
+        }
     }
 
 }


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-16630 for a screenshot of what it looks like before and after.

I'll let this pull request simmer for a week, before merging it in - if there are no objections, of course.
