### PR TITLE
[JENKINS-16676] RelativePath dependent field validations do not work

### DIFF
--- a/test/src/test/java/hudson/util/FormFieldValidatorTest.java
+++ b/test/src/test/java/hudson/util/FormFieldValidatorTest.java
@@ -32,16 +32,12 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
-//import hudson.util.FormFieldValidatorTest.BrokenFormValidatorBuilder.DescriptorImpl;
 import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.HudsonTestCase.WebClient;
 import org.jvnet.hudson.test.recipes.WithPlugin;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 /**
  * @author Kohsuke Kawaguchi

--- a/test/src/test/resources/hudson/util/FormFieldValidatorTest/CompoundField/config.jelly
+++ b/test/src/test/resources/hudson/util/FormFieldValidatorTest/CompoundField/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<f:entry title="abc" field="abc">
+	  <f:textbox />
+	</f:entry>
+	<f:entry title="xyz" field="xyz">
+	  <f:textbox />
+	</f:entry>
+</j:jelly>

--- a/test/src/test/resources/hudson/util/FormFieldValidatorTest/CompoundFieldValidatorBuilder/config.jelly
+++ b/test/src/test/resources/hudson/util/FormFieldValidatorTest/CompoundFieldValidatorBuilder/config.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:nested>
+    <table style="width:100%">
+      <f:optionalProperty title="CompoundField" field="compoundField" />
+    </table>
+  </f:nested>
+
+  <f:entry title="foo" field="foo">
+    <f:textbox />
+  </f:entry>
+
+</j:jelly>


### PR DESCRIPTION
- test/src/test/java/hudson/util/FormFieldValidatorTest.java
  (testNegative): minor change to better identify the Descriptor class, given that two
  more are being added.
  
  (testOptionalCompoundFieldDependentValidation): new test for the bug. Uses helper classes:
  CompoundField and CompoundFieldValidatorBuilder which are similar to code found in the
  collabnet plugin.
- test/src/test/resources/hudson/util/FormFieldValidatorTest/CompoundField/config.jelly
- test/src/test/resources/hudson/util/FormFieldValidatorTest/CompoundFieldValidatorBuilder/config.jelly
  Simple form elements for the new test
- war/src/main/webapp/scripts/hudson-behavior.js
  (locate): optional fields will have the checkbox as parent and it will have a '._' prefixed name.
  
  optional-block and row-set related classes need to be intiialized prior to field validation
  registration in order for parent elements to be properly defined.
