### PR TITLE
CLIConnectionFactory.basicAuth was defined but never used

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -440,7 +440,13 @@ public class CLI {
         if (candidateKeys.isEmpty())
             addDefaultPrivateKeyLocations(candidateKeys);
 
-        CLI cli = new CLIConnectionFactory().url(url).httpsProxyTunnel(httpProxy).connect();
+        CLIConnectionFactory factory = new CLIConnectionFactory().url(url).httpsProxyTunnel(httpProxy);
+        String userInfo = new URL(url).getUserInfo();
+        if (userInfo != null) {
+            factory = factory.basicAuth(userInfo);
+        }
+
+        CLI cli = factory.connect();
         try {
             if (!candidateKeys.isEmpty()) {
                 try {

--- a/cli/src/main/java/hudson/cli/CLIConnectionFactory.java
+++ b/cli/src/main/java/hudson/cli/CLIConnectionFactory.java
@@ -61,7 +61,11 @@ public class CLIConnectionFactory {
      * Convenience method to call {@link #authorization} with the HTTP basic authentication.
      */
     public CLIConnectionFactory basicAuth(String username, String password) {
-        return authorization("Basic " + new String(Base64.encodeBase64((username+':'+password).getBytes())));
+        return basicAuth(username+':'+password);
+    }
+
+    public CLIConnectionFactory basicAuth(String userInfo) {
+        return authorization("Basic " + new String(Base64.encodeBase64((userInfo).getBytes())));
     }
     
     public CLI connect() throws IOException, InterruptedException {

--- a/cli/src/main/java/hudson/cli/FullDuplexHttpStream.java
+++ b/cli/src/main/java/hudson/cli/FullDuplexHttpStream.java
@@ -37,6 +37,7 @@ public class FullDuplexHttpStream {
         return output;
     }
 
+    @Deprecated
     public FullDuplexHttpStream(URL target) throws IOException {
         this(target,basicAuth(target.getUserInfo()));
     }


### PR DESCRIPTION
Fixed to pass basic auth to HTTP connections when included in user info portion of URL (e.g. as API token).

`FullDuplexHttpStream` 1-arg ctor deprecated because `CLI` actually passes whatever auth it has computed and so does not use this duplicated logic path.
