### PR TITLE
JENKINS-16770 missing build title in /rssAll when build has no test result

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -63,6 +63,9 @@ Upcoming changes</a>
 <div id="rc" style="display:none;"><!--=BEGIN=-->
 <h3><a name=v1.502>What's new in 1.502</a> <!--=DATE=--></h3>
 <ul class=image>
+  <li class=bug>
+    Missing build title in /rssAll when build has no test result.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16770">issue 16770</a>)
   <li class='major bug'>
     Builds disappear from build history after completion.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15156">issue 15156</a>)

--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=>
+  <li class=bug>
+    Missing build title in /rssAll when build has no test result.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16770">issue 16770</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 
@@ -63,9 +66,6 @@ Upcoming changes</a>
 <div id="rc" style="display:none;"><!--=BEGIN=-->
 <h3><a name=v1.502>What's new in 1.502</a> <!--=DATE=--></h3>
 <ul class=image>
-  <li class=bug>
-    Missing build title in /rssAll when build has no test result.
-    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16770">issue 16770</a>)
   <li class='major bug'>
     Builds disappear from build history after completion.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15156">issue 15156</a>)

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1835,7 +1835,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                     return new Summary(worseOverride != null ? worseOverride : true,
                             Messages.Run_Summary_TestFailures(trN.getFailCount()));
             } else {
-                if(trN.getFailCount()!= 0) {
+                if(trN!=null && trN.getFailCount()!= 0) {
                     if(trP.getFailCount()==0)
                         return new Summary(worseOverride != null ? worseOverride : true,
                                 Messages.Run_Summary_TestsStartedToFail(trN.getFailCount()));

--- a/core/src/test/java/hudson/model/BuildStatusSummaryTest.java
+++ b/core/src/test/java/hudson/model/BuildStatusSummaryTest.java
@@ -178,6 +178,28 @@ public class BuildStatusSummaryTest {
         assertTrue(summary.isWorse);
         assertEquals(Messages.Run_Summary_TestsStartedToFail(1), summary.message);
     }
+
+    @Test
+    public void testBuildGotNoTests() {
+        // previous build has no tests at all
+        mockBuilds(AbstractBuild.class);
+
+        when(this.build.getResult()).thenReturn(Result.UNSTABLE);
+        when(this.prevBuild.getResult()).thenReturn(Result.UNSTABLE);
+        // Null test result action recorded
+        when(((AbstractBuild) this.build).getTestResultAction()).thenReturn(null);
+
+        Summary summary = this.build.getBuildStatusSummary();
+
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_Unstable(), summary.message);
+
+        // same thing should happen if previous build has tests, but no failing ones:
+        buildHasTestResult((AbstractBuild) this.prevBuild, 0);
+        summary = this.build.getBuildStatusSummary();
+        assertFalse(summary.isWorse);
+        assertEquals(Messages.Run_Summary_Unstable(), summary.message);
+    }
     
     @Test
     public void testBuildEqualAmountOfTestsFailing() {


### PR DESCRIPTION
Observed when jenkins failed to pick up the unit test results of a maven android project (I still have to investigate that).

Tested against current head. The RSS feed now contains a suitable "unstable" title and no exceptions are generated in the logs.
