### PR TITLE
[FIXED JENKINS-16776] surefire-reports not detected for android-maven-plugin

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=>
+  <li class=bug>
+    surefire-reports not detected for android-maven-plugin
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16776">issue 16776</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/maven-plugin/src/main/java/hudson/maven/reporters/TestMojo.java
+++ b/maven-plugin/src/main/java/hudson/maven/reporters/TestMojo.java
@@ -114,7 +114,7 @@ enum TestMojo {
         }
 
         // some plugins just default to this:        
-        File reportsDir = new File(pom.getBasedir(), pom.getBuild().getDirectory()+File.separator+"surefire-reports");
+        File reportsDir = new File(pom.getBuild().getDirectory(), "surefire-reports");
         if (reportsDir.exists()) {
             return getReportFiles(reportsDir, getFileSet(reportsDir));
         }

--- a/maven-plugin/src/test/java/hudson/maven/reporters/TestMojoTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/reporters/TestMojoTest.java
@@ -1,11 +1,15 @@
 package hudson.maven.reporters;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import hudson.maven.MojoInfo;
 import hudson.maven.MojoInfoBuilder;
 
 import java.io.File;
+import java.io.FileWriter;
 
 import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
@@ -33,4 +37,44 @@ public class TestMojoTest {
         }
     }
 
+    @Test
+    public void testGetReportFilesAndroidMavenPlugin() throws ComponentConfigurationException, Exception {
+        // no 'reportsDirectory' or so config value set:
+        MojoInfo mojoInfo = MojoInfoBuilder.mojoBuilder(
+        			"com.jayway.maven.plugins.android.generation2",
+        			"android-maven-plugin",
+        			"internal-integration-test")
+        	.version("3.3.0")
+        	.build();
+
+        final String testResultsName = "TEST-emulator-5554_device2.1_unknown_google_sdk.xml";
+		
+		File testDir = hudson.Util.createTempDir();
+		File targetDir = new File(testDir, "target");
+		File reportsDir = new File(targetDir, "surefire-reports");
+		assertTrue(reportsDir.mkdirs());
+		
+		File testResults = new File(reportsDir, testResultsName);
+		FileWriter fw = new FileWriter(testResults, false);
+		fw.write("this is a fake surefire reports output file");
+		fw.close();
+
+        MavenProject pom = mock(MavenProject.class);
+        when(pom.getBasedir()).thenReturn(testDir);
+        
+        Build build = mock(Build.class);
+        when(build.getDirectory()).thenReturn(targetDir.getAbsolutePath());
+        when(pom.getBuild()).thenReturn(build);
+        
+        TestMojo testMojo = TestMojo.ANDROID_MAVEN_PLUGIN;
+        Iterable<File> files = testMojo.getReportFiles(pom, mojoInfo);
+        assertNotNull("no report files returned", files);
+
+        boolean found = false;
+        for (File file : files) {
+        	assertEquals(testResultsName, file.getName());
+        	found = true;
+        }
+        assertTrue("report file not found", found);
+    }
 }


### PR DESCRIPTION
I've confirmed that this fixes my problem. 

I used the following to confirm that getDirectory on the build is the right thing to use. The Maven docs are not clear whether it includes the full pathname but a post on stackoverflow confirms that it does. This matches with my observations in practice.

http://maven.apache.org/ref/3.0.4/maven-model/apidocs/org/apache/maven/model/BuildBase.html
http://stackoverflow.com/questions/9318935/get-project-build-directory-from-mavenproject
