### PR TITLE
Add finalizePlannedNode() method to Cloud objects.

### DIFF
--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -106,15 +106,18 @@ public abstract class Cloud extends AbstractModelObject implements ExtensionPoin
      *      Always >= 1. For example, if this is 3, the implementation
      *      should launch 3 slaves with 1 executor each, or 1 slave with
      *      3 executors, etc.
-     *
      * @return
      *      {@link PlannedNode}s that represent asynchronous {@link Node}
      *      provisioning operations. Can be empty but must not be null.
-     *      {@link NodeProvisioner} will be responsible for adding the resulting {@link Node}
+     *      {@link NodeProvisioner} will be responsible for adding the resulting {@link Node}s
      *      into Hudson via {@link jenkins.model.Jenkins#addNode(Node)}, so a {@link Cloud} implementation
-     *      just needs to create a new node object.
+     *      just needs to return {@link PlannedNode}s that, when their call() methods are invoked,
+     *      return {@link Node} objects.
      */
     public abstract Collection<PlannedNode> provision(Label label, int excessWorkload);
+
+    public void finalizePlannedNode(PlannedNode node) {
+    }
 
     /**
      * Returns true if this cloud is capable of provisioning new nodes for the given label.

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -111,11 +111,22 @@ public abstract class Cloud extends AbstractModelObject implements ExtensionPoin
      *      provisioning operations. Can be empty but must not be null.
      *      {@link NodeProvisioner} will be responsible for adding the resulting {@link Node}s
      *      into Hudson via {@link jenkins.model.Jenkins#addNode(Node)}, so a {@link Cloud} implementation
-     *      just needs to return {@link PlannedNode}s that, when their call() methods are invoked,
-     *      return {@link Node} objects.
+     *      just needs to return {@link PlannedNode}s that each contain an object that implements {@link Future}.
+     *      When the {@link Future} has completed its work, {@link Future#get} will be called to obtain the
+     *      provisioned {@link Node} object.
      */
     public abstract Collection<PlannedNode> provision(Label label, int excessWorkload);
 
+    /**
+     * Indicate to this cloud that one of its {@link PlannedNode}s is being finalized.
+     *
+     * {@link NodeProvisioner} will call this method if the {@link PlannedNode#cloud} field
+     * points to this cloud. This indicates that the {@link PlannedNode}'s work has been completed
+     * (successfully or otherwise) and it is about to be removed from the list of pending
+     * {@link Node}s to be launched.
+     *
+     * @since 1.502
+     */
     public void finalizePlannedNode(PlannedNode node) {
     }
 

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -59,20 +59,57 @@ public class NodeProvisioner {
          * can be just a name of the template being provisioned (like the machine image ID.)
          */
         public final String displayName;
+
+	/**
+	 * Used to launch and return a {@link Node} object. {@link NodeProvisioner} will check
+	 * this {@link Future}'s isDone() method to determine when to finalize this object.
+	 */
         public final Future<Node> future;
+
+	/**
+	 * The number of executors that will be provided by the {@link Node} launched by
+	 * this object. This is used for capacity planning in {@link NodeProvisioner#update}.
+	 */
         public final int numExecutors;
+
+	/**
+	 * The {@link Cloud} instance that should be notified of this object's finalization, if any.
+	 * The {@link NodeProvisioner} will call {@link Cloud#finalizePlannedNode} and pass this object
+	 * when it has completed handling the object.
+	 *
+	 * @since 1.502
+	 */
         public final Cloud cloud;
+
+	/**
+	 * Data object provided by a {@link Cloud} instance, passed back to it for use during finalization of this object.
+	 *
+	 * @since 1.502
+	 */
         public final Object cloudData;
 
+	/**
+	 * Construct a PlannedNode instance without {@link Cloud} callback for finalization.
+	 *
+	 * @param displayName Used to display this object in the UI.
+	 * @param future Used to launch a @{link Node} object.
+	 * @param numExecutors The number of executors that will be provided by the launched {@link Node}.
+	 */
         public PlannedNode(String displayName, Future<Node> future, int numExecutors) {
-            if(displayName==null || future==null || numExecutors<1)  throw new IllegalArgumentException();
-            this.displayName = displayName;
-            this.future = future;
-            this.numExecutors = numExecutors;
-            this.cloud = null;
-            this.cloudData = null;
+	    this(displayName, future, numExecutors, null, null);
         }
 
+	/**
+	 * Construct a PlannedNode instance without {@link Cloud} callback for finalization.
+	 *
+	 * @param displayName Used to display this object in the UI.
+	 * @param future Used to launch a @{link Node} object.
+	 * @param numExecutors The number of executors that will be provided by the launched {@link Node}.
+	 * @param cloud A {@link Cloud} object that should be notified of this object's finalization.
+	 * @param cloudData Data that can be used by the {@link Cloud} object during this object's finalization.
+	 *
+	 * @since 1.502
+	 */
         public PlannedNode(String displayName, Future<Node> future, int numExecutors, Cloud cloud, Object cloudData) {
             if(displayName==null || future==null || numExecutors<1)  throw new IllegalArgumentException();
             this.displayName = displayName;

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -61,12 +61,25 @@ public class NodeProvisioner {
         public final String displayName;
         public final Future<Node> future;
         public final int numExecutors;
+        public final Cloud cloud;
+        public final Object cloudData;
 
         public PlannedNode(String displayName, Future<Node> future, int numExecutors) {
             if(displayName==null || future==null || numExecutors<1)  throw new IllegalArgumentException();
             this.displayName = displayName;
             this.future = future;
             this.numExecutors = numExecutors;
+            this.cloud = null;
+            this.cloudData = null;
+        }
+
+        public PlannedNode(String displayName, Future<Node> future, int numExecutors, Cloud cloud, Object cloudData) {
+            if(displayName==null || future==null || numExecutors<1)  throw new IllegalArgumentException();
+            this.displayName = displayName;
+            this.future = future;
+            this.numExecutors = numExecutors;
+            this.cloud = cloud;
+            this.cloudData = cloudData;
         }
     }
 
@@ -152,6 +165,11 @@ public class NodeProvisioner {
                 } catch (IOException e) {
                     LOGGER.log(Level.WARNING, "Provisioned slave "+f.displayName+" failed to launch",e);
                 }
+
+                if (f.cloud != null) {
+                    f.cloud.finalizePlannedNode(f);
+                }
+
                 itr.remove();
             } else
                 plannedCapacitySnapshot += f.numExecutors;


### PR DESCRIPTION
For plugins that implement Cloud objects, it can be important for them
to be notified when a PlannedNode instance is about to be destroyed (for
example, this can be used to track the number of active and planned instances
in the cloud reliably). This patch adds an optional method to the Cloud
class that is called by the NodeProvisioner, if the Cloud has requested it,
to indicate that the NodeProvisioner is finished with a PlannedNode object.
