### PR TITLE
Fixing the synchronize in Actionable#getActions() 

### DIFF
--- a/core/src/main/java/hudson/model/Actionable.java
+++ b/core/src/main/java/hudson/model/Actionable.java
@@ -68,12 +68,17 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
      * @return
      *      may be empty but never null.
      */
-    @Exported
-    public synchronized List<Action> getActions() {
-        if(actions==null)
-            actions = new CopyOnWriteArrayList<Action>();
-        return actions;
-    }
+	@Exported
+	public List<Action> getActions() {
+		if(actions == null) {
+			synchronized (this) {
+				if(actions == null) {
+					actions = new CopyOnWriteArrayList<Action>();
+				}
+			}
+		}
+		return actions;
+	}
 
     /**
      * Gets all actions of a specified type that contributed to this build.


### PR DESCRIPTION
The Actionable#getActions() method only needs to be synchronized when lazy loading. After that, the synchronization is superfluous and impacts performance.
Since the field is volatile, the double-check block works in JDK5+. See http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html for more in
Analyzing various thread dumps, many threads (including requests) stall on this method waiting for the lock. Since the lock isn't necessary in most cases anyway, change it to only lock when the value hasn't been initialized.
