### PR TITLE
JENKINS-15918 - RunParameter environment variabes contain . character

### DIFF
--- a/core/src/main/java/hudson/model/RunParameterValue.java
+++ b/core/src/main/java/hudson/model/RunParameterValue.java
@@ -71,8 +71,13 @@ public class RunParameterValue extends ParameterValue {
     public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
         String value = Jenkins.getInstance().getRootUrl() + getRun().getUrl();
         env.put(name, value);
+
         env.put(name + ".jobName", getJobName());
+        env.put(name + "_jobName", getJobName());
+
         env.put(name + ".number" , getNumber ());
+        env.put(name + "_number" , getNumber ());
+
         env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
 
     }

--- a/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
@@ -60,7 +60,9 @@ public class RunParameterDefinitionTest {
         val.buildEnvVars(null, env);
         assertEquals(j.jenkins.getRootUrl() + "job/dir/job/sub%20dir/job/some%20project/2/", env.get("build"));
         assertEquals("dir/sub dir/some project", env.get("build.jobName"));
+        assertEquals("dir/sub dir/some project", env.get("build_jobName"));
         assertEquals("2", env.get("build.number"));
+        assertEquals("2", env.get("build_number"));
     }
 
 }

--- a/war/src/main/webapp/help/parameter/run-project.html
+++ b/war/src/main/webapp/help/parameter/run-project.html
@@ -1,3 +1,13 @@
 <div>
-    Defines the job from which the user can pick runs. The last run will be the default.
+    Defines the job from which the user can pick runs. The last run will be the default.<br/>
+    <br/>
+    These parameters are exposed to build as environment variables:<br/>
+    <br/>
+    PARAMETER_NAME=&lt;jenkins_url&gt;/job/&lt;job_name&gt;/&lt;run_number/<br/>
+    <br/>
+    PARAMETER_NAME.jobName=&lt;job_name&gt;<br/>
+    PARAMETER_NAME_jobName=&lt;job_name&gt;<br/>
+    <br/>
+    PARAMETER_NAME.number=&lt;run_number&gt;<br/>
+    PARAMETER_NAME_number=&lt;run_number&gt;
 </div>


### PR DESCRIPTION
Hi,

Adding run parameters using "_" character as well as the "." character.
Environment variables containing "." character cannot be used as easily.

thanks
Geoff
