### PR TITLE
[FIXED JENKINS-12251]

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1933,7 +1933,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
         return new File(Util.replaceMacro(base, ImmutableMap.of(
                 "JENKINS_HOME", getRootDir().getPath(),
                 "ITEM_ROOTDIR", item.getRootDir().getPath(),
-                "ITEM_FULLNAME", item.getFullName())));
+                "ITEM_FULLNAME", item.getFullName().replace(':', '$'))));
     }
     
     public String getRawWorkspaceDir() {


### PR DESCRIPTION
For maven modules ${ITEM_FULLNAME} contains colon (like JobName/groupId:artifactId), which is not allowed as a file/directory name under windows, so it should be replaced to $ sign.
