### PR TITLE
[JENKINS-16836] UpdateCenter REST API crashes when plugin installation failed

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -924,6 +924,10 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         }
 
         @Exported
+        public String getErrorMessage() {
+            return error != null ? error.getMessage() : null;
+        }
+        
         public Throwable getError() {
             return error;
         }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-16836

When plugin installation failed for some reason, http://localhost:8080/updateCenter/api/json?tree=jobs[error] returns 500 Error.
Since UpdateCenter#UpdateCenterJob#getError returns Throwable instance, we should expose Throwable#getErrorMessage instead of itself.

This happens since https://github.com/jenkinsci/jenkins/commit/76832379d8c3ed019b7ef8f36935df31ea23d261 is released.

```
Status Code: 500
Exception: org.kohsuke.stapler.export.NotExportableException: class java.net.UnknownHostException doesn't have @ExportedBean
Stacktrace:

javax.servlet.ServletException: org.kohsuke.stapler.export.NotExportableException: class java.net.UnknownHostException doesn't have @ExportedBean
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:615)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:658)
    at org.kohsuke.stapler.MetaClass$4.doDispatch(MetaClass.java:203)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:573)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:658)
    at org.kohsuke.stapler.MetaClass$4.doDispatch(MetaClass.java:203)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:573)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:658)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:487)
    at org.kohsuke.stapler.Stapler.service(Stapler.java:164)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:848)
    at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:598)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1367)
    at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:95)
    at hudson.util.PluginServletFilter.doFilter(PluginServletFilter.java:101)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1338)
    at hudson.security.csrf.CrumbFilter.doFilter(CrumbFilter.java:47)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1338)
    at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:84)
    at hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:90)
    at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:164)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1338)
    at org.kohsuke.stapler.compression.CompressionFilter.doFilter(CompressionFilter.java:50)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1338)
    at hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:81)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1338)
    at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:484)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:119)
    at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:499)
    at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:231)
    at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1065)
    at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:413)
    at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:192)
    at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:999)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:117)
    at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:250)
    at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:149)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:111)
    at org.eclipse.jetty.server.Server.handle(Server.java:350)
    at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:454)
    at org.eclipse.jetty.server.AbstractHttpConnection.headerComplete(AbstractHttpConnection.java:890)
    at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.headerComplete(AbstractHttpConnection.java:944)
    at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:630)
    at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:230)
    at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:77)
    at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:620)
    at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:46)
    at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:603)
    at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:538)
    at java.lang.Thread.run(Thread.java:680)
Caused by: org.kohsuke.stapler.export.NotExportableException: class java.net.UnknownHostException doesn't have @ExportedBean
    at org.kohsuke.stapler.export.Model.<init>(Model.java:71)
    at org.kohsuke.stapler.export.ModelBuilder.get(ModelBuilder.java:48)
    at org.kohsuke.stapler.export.Property.writeValue(Property.java:225)
    at org.kohsuke.stapler.export.Property.writeValue(Property.java:137)
    at org.kohsuke.stapler.export.Property.writeTo(Property.java:114)
    at org.kohsuke.stapler.export.Model.writeNestedObjectTo(Model.java:187)
    at org.kohsuke.stapler.export.Model.writeNestedObjectTo(Model.java:182)
    at org.kohsuke.stapler.export.Property.writeValue(Property.java:232)
    at org.kohsuke.stapler.export.Property.writeValue(Property.java:182)
    at org.kohsuke.stapler.export.Property.writeValue(Property.java:137)
    at org.kohsuke.stapler.export.Property.writeTo(Property.java:114)
    at org.kohsuke.stapler.export.Model.writeNestedObjectTo(Model.java:187)
    at org.kohsuke.stapler.export.Model.writeTo(Model.java:154)
    at org.kohsuke.stapler.ResponseImpl.serveExposedBean(ResponseImpl.java:222)
    at hudson.model.Api.doJson(Api.java:192)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:288)
    at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:151)
    at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:90)
    at org.kohsuke.stapler.MetaClass$1.doDispatch(MetaClass.java:111)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:573)
    ... 51 more
```
