### PR TITLE
Fixed French Translation

### DIFF
--- a/core/src/main/resources/hudson/util/HudsonIsRestarting/index_fr.properties
+++ b/core/src/main/resources/hudson/util/HudsonIsRestarting/index_fr.properties
@@ -20,5 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Please\ wait\ while\ Jenkins\ is\ restarting=Veuillez attendre pendant que Jenkins se relance
+Please\ wait\ while\ Jenkins\ is\ restarting=Veuillez attendre pendant que Jenkins redémarre
 Your\ browser\ will\ reload\ automatically\ when\ Jenkins\ is\ ready.=Votre navigateur se connectera automatiquement quand Jenkins sera prêt


### PR DESCRIPTION
According to Google Translate, the current text for Jenkins Restarting is: "Veuillez attendre pendant que Jenkins se relance", which translates to Please wait while Jenkins stimulus. This code will fix the issue.
https://issues.jenkins-ci.org/browse/JENKINS-12470
