### PR TITLE
Add run display name as an environment variable when RunParameter is used as a parameter.

### DIFF
--- a/core/src/main/java/hudson/model/RunParameterValue.java
+++ b/core/src/main/java/hudson/model/RunParameterValue.java
@@ -69,7 +69,9 @@ public class RunParameterValue extends ParameterValue {
      */
     @Override
     public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
-        String value = Jenkins.getInstance().getRootUrl() + getRun().getUrl();
+        Run run = getRun();
+        
+        String value = Jenkins.getInstance().getRootUrl() + run.getUrl();
         env.put(name, value);
 
         env.put(name + ".jobName", getJobName());   // undocumented, left for backward compatibility
@@ -77,6 +79,8 @@ public class RunParameterValue extends ParameterValue {
 
         env.put(name + ".number" , getNumber ());   // same as above
         env.put(name + "_NUMBER" , getNumber ());
+        
+        env.put(name + "_NAME",  run.getDisplayName());  // since 1.504
 
         env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
 

--- a/war/src/main/webapp/help/parameter/run-project.html
+++ b/war/src/main/webapp/help/parameter/run-project.html
@@ -5,5 +5,6 @@
 PARAMETER_NAME=<i>&lt;jenkins_url&gt;</i>/job/<i>&lt;job_name&gt;/&lt;run_number&gt;</i>/
 PARAMETER_NAME_JOBNAME=<i>&lt;job_name&gt;</i>
 PARAMETER_NAME_NUMBER=<i>&lt;run_number&gt;</i>
+PARAMETER_NAME_NAME=<i>&lt;display_name&gt;</i>
 </pre>
 </div>


### PR DESCRIPTION
The environment variable will be named "PARAM_NAME"_NAME and will
contain the display name of the target build.
