### PR TITLE
Url with contextPath for non-standalone installs.

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3070,7 +3070,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
     public ContextMenu doContextMenu(StaplerRequest request, StaplerResponse response) throws IOException, JellyException {
         ContextMenu menu = new ContextMenu().from(this, request, response);
         for (MenuItem i : menu.items) {
-            if (i.url.equals("/manage")) {
+            if (i.url.equals(request.getContextPath() + "/manage")) {
                 // add "Manage Jenkins" subitems
                 i.subMenu = new ContextMenu().from(this, request, response, "manage");
             }


### PR DESCRIPTION
When deployed to an application server the "Manage" subcontextmenu does not appear because the menu url contains the ContextPath.
