### PR TITLE
[FIXED JENKINS-17025] NPE when checking if the executor is interrupted

### DIFF
--- a/core/src/main/java/hudson/model/Build.java
+++ b/core/src/main/java/hudson/model/Build.java
@@ -200,7 +200,9 @@ public abstract class Build <P extends Project<P,B>,B extends Build<P,B>>
                     LOGGER.fine(MessageFormat.format("{0} : {1} failed", Build.this.toString(), bs));
                     return false;
                 }
-                if (getExecutor().isInterrupted()) {
+                
+                Executor executor = getExecutor();
+                if (executor != null && executor.isInterrupted()) {
                     // someone asked build interruption, let stop the build before trying to run another build step
                     throw new InterruptedException();
                 }


### PR DESCRIPTION
29426012ce introduced an NPE.
If a build's project implements Queue.FlyweightTask, build.getExecutor() returns null.
This prevents any flyweight build from finishing successfully.
