### PR TITLE
JENKINS-15178: Enabled log rotation on Mac OSX

### DIFF
--- a/osx/Library/Application Support/Jenkins/Uninstall.command
+++ b/osx/Library/Application Support/Jenkins/Uninstall.command
@@ -12,6 +12,7 @@ sudo rm /Library/LaunchDaemons/org.jenkins-ci.plist
 sudo rm -rf /Applications/Jenkins "/Library/Application Support/Jenkins" /Library/Documentation/Jenkins
 sudo rm -rf /Users/Shared/Jenkins
 sudo rm -rf /var/log/jenkins
+sudo rm -f /etc/newsyslog.d/jenkins.conf
 sudo dscl . -delete /Users/jenkins
 sudo dscl . -delete /Groups/jenkins
 pkgutil --pkgs | grep 'org\.jenkins-ci\.' | xargs -n 1 sudo pkgutil --forget

--- a/osx/scripts/postinstall-launchd
+++ b/osx/scripts/postinstall-launchd
@@ -12,6 +12,13 @@ find /Users/Shared/Jenkins \( -not -user daemon -or -not -group daemon \) -print
 mkdir -p /var/log/jenkins
 chown daemon:daemon /var/log/jenkins
 
+# Enable log rotation by newsyslog
+cat <<_EOT_ > /etc/newsyslog.d/jenkins.conf
+# logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
+# Rotate jenkins log at midnight, and preserve old logs in 3 days
+/var/log/jenkins/jenkins.log            644  3     *    \$D0   J
+_EOT_
+
 # Load and start the launch daemon
 /bin/launchctl load -w ${JENKINS_PLIST}
 

--- a/osx/scripts/postinstall-launchd-jenkins
+++ b/osx/scripts/postinstall-launchd-jenkins
@@ -49,6 +49,13 @@ find "$JENKINS_HOMEDIR" \( -not -user jenkins -or -not -group jenkins \) -print0
 mkdir -p /var/log/jenkins
 chown jenkins:jenkins /var/log/jenkins
 
+# Enable log rotation by newsyslog
+cat <<_EOT_ > /etc/newsyslog.d/jenkins.conf
+# logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
+# Rotate jenkins log at midnight, and preserve old logs in 3 days
+/var/log/jenkins/jenkins.log            644  3     *    \$D0   J
+_EOT_
+
 # Load and start the launch daemon
 /bin/launchctl load -w ${JENKINS_PLIST}
 


### PR DESCRIPTION
Enabled log rotation on Mac OS X, that fixes problem pointed out at [#15178 Comment](https://issues.jenkins-ci.org/browse/JENKINS-15178?focusedCommentId=172644&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-172644)
