### PR TITLE
Exclude the extraneous xmlpull and xpp3_min dependencies in jenkins-core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -234,6 +234,16 @@ THE SOFTWARE.
       <groupId>org.jvnet.hudson</groupId>
       <artifactId>xstream</artifactId>
       <version>1.4.4-jenkins-2</version>
+        <exclusions>
+            <exclusion>
+                <groupId>xmlpull</groupId>
+                <artifactId>xmlpull</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>xpp3</groupId>
+                <artifactId>xpp3_min</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>jfree</groupId>


### PR DESCRIPTION
The xpp3_min artifact causes a "JBAS015893: Encountered invalid class name" error on deployment in JBoss AS7 due to a malformed manifest in the artifact.

When I researched further I discovered that the `xpp3_min` artifact is extraneous since the `xpp3` library is a direct dependency for jenkins-core. The xpp3 library also replaces the `xmlpull` library.

jenkins-core passed all unit tests. Installed a WAR into my local system and I haven't encountered any issues.
