### PR TITLE
German translation for permission descriptions

### DIFF
--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -59,7 +59,7 @@ PluginManager.UploadPluginsPermission.Description=\
   The "upload plugin" permission allows a user to upload arbitrary plugins.
 PluginManager.ConfigureUpdateCenterPermission.Description=\
   The "configure update center" permission allows a user to \
-configure update sites and proxy settings.
+  configure update sites and proxy settings.
 
 AboutJenkins.DisplayName=About Jenkins
 AboutJenkins.Description=See the version and license information.

--- a/core/src/main/resources/hudson/Messages_de.properties
+++ b/core/src/main/resources/hudson/Messages_de.properties
@@ -49,5 +49,10 @@ Util.year  ={0} {0,choice,0#Jahre|1#Jahr|1<Jahre}
 Util.pastTime={0}
 FilePath.TildaDoesntWork=''~'' wird nur in einer Unix-Shell unterstützt - sonst nirgends.
 
+PluginManager.UploadPluginsPermission.Description=\
+  Dieses Recht erlaubt, beliebige Plugins hochzuladen.
+PluginManager.ConfigureUpdateCenterPermission.Description=\
+  Dieses Recht ist notwendig, um Aktualisierungsserver und Proxy-Einstellungen zu konfigurieren.
+
 AboutJenkins.DisplayName=\u00DCber Jenkins
 AboutJenkins.Description=Versions- und Lizenzinformationen anzeigen.

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -61,7 +61,8 @@ AbstractProject.DiscoverPermission.Description=\
   This permission grants discover access to jobs. Lower than read permissions, it allows you to \
   redirect anonymous users to the login page when they try to access a job url. \
   Without it they would get a 404 error and wouldn't be able to discover project names.
-# WipeOutPermission is only visible in security configuration if hudson.security.WipeOutPermission=true
+# WipeOutPermission is only visible in the security configuration if the system property
+# hudson.security.WipeOutPermission is set to true
 AbstractProject.WipeOutPermission.Description=\
   This permission grants the ability to wipe out the contents of a workspace.
 AbstractProject.CancelPermission.Description=\

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -61,6 +61,7 @@ AbstractProject.DiscoverPermission.Description=\
   This permission grants discover access to jobs. Lower than read permissions, it allows you to \
   redirect anonymous users to the login page when they try to access a job url. \
   Without it they would get a 404 error and wouldn't be able to discover project names.
+# WipeOutPermission is only visible in security configuration if hudson.security.WipeOutPermission=true
 AbstractProject.WipeOutPermission.Description=\
   This permission grants the ability to wipe out the contents of a workspace.
 AbstractProject.CancelPermission.Description=\

--- a/core/src/main/resources/hudson/model/Messages_de.properties
+++ b/core/src/main/resources/hudson/model/Messages_de.properties
@@ -48,6 +48,15 @@ AbstractProject.ExtendedReadPermission.Description=\
   Dieses Recht erlaubt Nur-Lese-Zugriff auf Projektkonfigurationen. Bedenken Sie, \
   dass dadurch sensible Informationen aus Ihren Builds, z.B. Passw\u00f6rter, f\u00fcr einen \
   erweiterten Personenkreis einsehbar werden.
+AbstractProject.DiscoverPermission.Description=\
+  Dieses Recht erlaubt, zugriffsgesch\u00fctzte Jobs \u00fcber URLs aufzurufen. \
+  Wenn ein anonymer Benutzer mit Discover-Recht einen gesch\u00fctzten Job aufruft, \
+  wird er zur Login-Seite weitergeleitet. \
+  Ohne dieses Recht w\u00fcrde er einen 404-Fehler erhalten und k\u00f6nnte keine Job-Namen ermitteln.
+AbstractProject.WipeOutPermission.Description=\
+  Dieses Recht erlaubt, den Inhalt des Arbeitsbereiches zu l\u00f6schen.
+AbstractProject.CancelPermission.Description=\
+  Dieses Recht erlaubt, laufende Builds abzubrechen.
 
 Api.MultipleMatch=XPath "{0}" stimmt mit {1} Knoten \u00fcberein. \
     Erstellen Sie einen XPath-Ausdruck, der mit genau einem Knoten \u00fcbereinstimmt, oder verwenden Sie den "Wrapper" Abfrageparameter, um alle Knoten unterhalb eines gemeinsamen Elternknotens zusammenzufassen.
@@ -83,6 +92,9 @@ Computer.Caption=Slave {0}
 Computer.Permissions.Title=Slave
 Computer.ConfigurePermission.Description=Dieses Recht erlaubt, Slaves zu konfigurieren.
 Computer.DeletePermission.Description=Dieses Recht erlaubt, bestehende Slaves zu l\u00f6schen.
+Computer.CreatePermission.Description=Dieses Recht erlaubt, neue Slaves zu erstellen.
+Computer.ConnectPermission.Description=Dieses Recht erlaubt, Slaves zu verbinden oder als verf\u00fcgbar zu markieren.
+Computer.DisconnectPermission.Description=Dieses Recht erlaubt, bestehende Slaves zu entfernen oder als vor\u00fcbergehend nicht verf\u00fcgbar zu markieren.
 
 ComputerSet.NoSuchSlave=Slave ''{0}'' existiert nicht.
 ComputerSet.SlaveAlreadyExists=Ein Slave mit Namen ''{0}'' existiert bereits.
@@ -134,9 +146,18 @@ Hudson.ReadPermission.Description=\
   auf Jenkins-Seiten verweigern m\u00f6chten &mdash; entziehen Sie dazu dem Benutzer \
   anonymous dieses Recht, f\u00fcgen Sie dann einen Pseudo-Benutzer authenticated hinzu \
   und erteilen Sie diesem dieses Recht f\u00fcr Lese-Zugriff.
+Hudson.RunScriptsPermission.Description=\
+  Dieses Recht ist notwendig, um Groovy-Skripte \u00fcber die Skript-Konsole oder das \
+  Jenkins CLI aufzurufen.
 Hudson.NodeDescription=Jenkins Master-Knoten
 
 Item.Permissions.Title=Job
+Item.CREATE.description=Dieses Recht erlaubt, neue Jobs anzulegen.
+Item.DELETE.description=Dieses Recht erlaubt, bestehende Jobs zu l\u00f6schen.
+Item.CONFIGURE.description=Dieses Recht erlaubt, bestehende Jobs zu konfigurieren.
+Item.READ.description=Dieses Recht erlaubt, Jobs zu sehen. (Sie k\u00f6nnen dieses Recht \
+  entziehen und stattdessen nur das Discover-Recht erteilen. Ein anonym auf den Job zugreifender \
+  Benutzer wird dann zur Authentifizierung aufgefordert.)
 
 Job.AllRecentBuildFailed=In letzter Zeit schlugen alle Builds fehl.
 Job.BuildStability=Build-Stabilit\u00e4t: {0}
@@ -216,6 +237,8 @@ View.DeletePermission.Description=\
   Dieses Recht erlaubt, bestehende Ansichten zu l\u00f6schen.
 View.ConfigurePermission.Description=\
   Dieses Recht erlaubt, bestehende Ansichten zu konfigurieren.
+View.ReadPermission.Description=\
+  Dieses Recht erlaubt, Ansichten zu sehen (im allgemeinen Read-Recht enthalten).
 
 UpdateCenter.Status.CheckingInternet=\u00dcberpr\u00fcfe Zugang zum Internet
 UpdateCenter.Status.CheckingJavaNet=\u00dcberpr\u00fcfe Zugang zu jenkins-ci.org-Server


### PR DESCRIPTION
some permissions lacked German translations on Configure Global Security page
