### PR TITLE
[FIXED JENKINS-7280] Allow filtering of the Run parameter build list by result

### DIFF
--- a/core/src/main/java/hudson/model/RunParameterValue.java
+++ b/core/src/main/java/hudson/model/RunParameterValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  * 
- * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts, Geoff Cummings
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,6 +81,9 @@ public class RunParameterValue extends ParameterValue {
         env.put(name + "_NUMBER" , getNumber ());
         
         env.put(name + "_NAME",  run.getDisplayName());  // since 1.504
+
+        String buildResult = (null == run.getResult()) ? "UNKNOWN" : run.getResult().toString();
+        env.put(name + "_RESULT",  buildResult);  // since 1.517
 
         env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
 

--- a/core/src/main/java/hudson/util/RunList.java
+++ b/core/src/main/java/hudson/util/RunList.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  * 
- * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Geoff Cummings
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -236,6 +236,19 @@ public class RunList<R extends Run> extends AbstractList<R> {
         return filter(new Predicate<R>() {
             public boolean apply(R r) {
                 return r.getResult()!=Result.SUCCESS;
+            }
+        });
+    }
+
+    /**
+     * Filter the list to builds >= threshold.
+     * 
+     * @since 1.516
+     */
+    public RunList<R> overThresholdOnly(final Result threshold) {
+        return filter(new Predicate<R>() {
+            public boolean apply(R r) {
+                return (r.getResult() != null && r.getResult().isBetterOrEqualTo(threshold));
             }
         });
     }

--- a/core/src/main/resources/hudson/model/RunParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/RunParameterDefinition/config.jelly
@@ -35,4 +35,12 @@ THE SOFTWARE.
     <f:entry title="${%Description}" help="/help/parameter/description.html">
         <f:textarea name="parameter.description" value="${instance.description}" />
     </f:entry>
+    <f:entry name="filter" title="${%Filter}" help="/help/parameter/run-filter.html">
+        <select name="filter">
+            <f:option selected="${instance.filter=='ALL'}" value="ALL">${%All Builds}</f:option>
+            <f:option selected="${instance.filter=='COMPLETED'}" value="COMPLETED">${%Completed Builds Only}</f:option>
+            <f:option selected="${instance.filter=='SUCCESSFUL'}" value="SUCCESSFUL">${%Successful Builds Only}</f:option>
+            <f:option selected="${instance.filter=='STABLE'}" value="STABLE">${%Stable Builds Only}</f:option>
+        </select>
+    </f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/RunParameterDefinition/index.jelly
+++ b/core/src/main/resources/hudson/model/RunParameterDefinition/index.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
 		<div name="parameter" description="${it.description}">
 			<input type="hidden" name="name" value="${it.name}" />
             <select name="runId">
-              <j:forEach var="run" items="${it.project.builds}">
+              <j:forEach var="run" items="${it.builds}">
                 <option value="${run.externalizableId}">${run}</option>
               </j:forEach>
             </select>

--- a/test/src/test/java/hudson/model/ParametersTest.java
+++ b/test/src/test/java/hudson/model/ParametersTest.java
@@ -24,7 +24,7 @@ public class ParametersTest extends HudsonTestCase {
                 new StringParameterDefinition("string", "defaultValue", "string description"),
                 new BooleanParameterDefinition("boolean", true, "boolean description"),
                 new ChoiceParameterDefinition("choice", "Choice 1\nChoice 2", "choice description"),
-                new RunParameterDefinition("run", otherProject.getName(), "run description"));
+                new RunParameterDefinition("run", otherProject.getName(), "run description", null));
         project.addProperty(pdp);
         CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
         project.getBuildersList().add(builder);

--- a/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2013 Jesse Glick.
+ * Copyright 2013 Jesse Glick, Geoff Cummings
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,16 @@ package hudson.model;
 
 import hudson.EnvVars;
 import static org.junit.Assert.*;
+import hudson.Launcher;
+import hudson.model.RunParameterDefinition.RunParameterFilter;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import hudson.util.LogTaskListener;
+
+import java.util.Collections;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
@@ -34,7 +44,10 @@ import org.jvnet.hudson.test.MockFolder;
 
 public class RunParameterDefinitionTest {
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    private static final Logger LOGGER = Logger.getLogger(Run.class.getName());
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     @Bug(16462)
     @Test public void inFolders() throws Exception {
@@ -47,7 +60,7 @@ public class RunParameterDefinitionTest {
         String id = build2.getExternalizableId();
         assertEquals("dir/sub dir/some project#2", id);
         assertEquals(build2, Run.fromExternalizableId(id));
-        RunParameterDefinition def = new RunParameterDefinition("build", "dir/sub dir/some project", "my build");
+        RunParameterDefinition def = new RunParameterDefinition("build", "dir/sub dir/some project", "my build", null);
         assertEquals("dir/sub dir/some project", def.getProjectName());
         assertEquals(p, def.getProject());
         EnvVars env = new EnvVars();
@@ -65,4 +78,188 @@ public class RunParameterDefinitionTest {
         assertEquals("2", env.get("build_NUMBER"));
     }
 
+    @Test
+    public void testNULLFilter() throws Exception {
+
+        FreeStyleProject project = j.createFreeStyleProject("project");
+        FreeStyleBuild successfulBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.UNSTABLE)));
+        FreeStyleBuild unstableBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.FAILURE)));
+        FreeStyleBuild failedBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.NOT_BUILT)));
+        FreeStyleBuild notBuiltBuild = project.scheduleBuild2(0).get();
+        
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.ABORTED)));
+        FreeStyleBuild abortedBuild = project.scheduleBuild2(0).get();
+
+        FreeStyleProject paramProject = j.createFreeStyleProject("paramProject");
+        ParametersDefinitionProperty pdp = 
+                new ParametersDefinitionProperty(new RunParameterDefinition("RUN", 
+                                                                             project.getName(),
+                                                                             "run description",
+                                                                             null));
+        paramProject.addProperty(pdp);
+
+        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        assertEquals(Integer.toString(project.getLastBuild().getNumber()),
+                     build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
+    }
+
+    
+    @Test
+    public void testALLFilter() throws Exception {
+
+        FreeStyleProject project = j.createFreeStyleProject("project");
+        FreeStyleBuild successfulBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.UNSTABLE)));
+        FreeStyleBuild unstableBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.FAILURE)));
+        FreeStyleBuild failedBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.NOT_BUILT)));
+        FreeStyleBuild notBuiltBuild = project.scheduleBuild2(0).get();
+        
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.ABORTED)));
+        FreeStyleBuild abortedBuild = project.scheduleBuild2(0).get();
+
+        FreeStyleProject paramProject = j.createFreeStyleProject("paramProject");
+        ParametersDefinitionProperty pdp = 
+                new ParametersDefinitionProperty(new RunParameterDefinition("RUN", 
+                                                                             project.getName(),
+                                                                             "run description",
+                                                                             RunParameterFilter.ALL));
+        paramProject.addProperty(pdp);
+
+        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        assertEquals(Integer.toString(project.getLastBuild().getNumber()),
+                     build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
+    }
+
+    @Test
+    public void testCOMPLETEDFilter() throws Exception {
+
+        FreeStyleProject project = j.createFreeStyleProject("project");
+        FreeStyleBuild successfulBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.UNSTABLE)));
+        FreeStyleBuild unstableBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.FAILURE)));
+        FreeStyleBuild failedBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.NOT_BUILT)));
+        FreeStyleBuild notBuiltBuild = project.scheduleBuild2(0).get();
+        
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.ABORTED)));
+        FreeStyleBuild abortedBuild = project.scheduleBuild2(0).get();
+
+        FreeStyleProject paramProject = j.createFreeStyleProject("paramProject");
+        ParametersDefinitionProperty pdp = 
+                new ParametersDefinitionProperty(new RunParameterDefinition("RUN", 
+                                                                             project.getName(),
+                                                                             "run description",
+                                                                             RunParameterFilter.COMPLETED));
+        paramProject.addProperty(pdp);
+
+        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        assertEquals(Integer.toString(abortedBuild.getNumber()),
+                     build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
+    }
+    
+    @Test
+    public void testSUCCESSFULFilter() throws Exception {
+
+        FreeStyleProject project = j.createFreeStyleProject("project");
+        FreeStyleBuild successfulBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.UNSTABLE)));
+        FreeStyleBuild unstableBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.FAILURE)));
+        FreeStyleBuild failedBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.NOT_BUILT)));
+        FreeStyleBuild notBuiltBuild = project.scheduleBuild2(0).get();
+        
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.ABORTED)));
+        FreeStyleBuild abortedBuild = project.scheduleBuild2(0).get();
+
+        FreeStyleProject paramProject = j.createFreeStyleProject("paramProject");
+        ParametersDefinitionProperty pdp = 
+                new ParametersDefinitionProperty(new RunParameterDefinition("RUN", 
+                                                                             project.getName(),
+                                                                             "run description",
+                                                                             RunParameterFilter.SUCCESSFUL));
+        paramProject.addProperty(pdp);
+
+        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        assertEquals(Integer.toString(unstableBuild.getNumber()),
+                     build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
+    }
+    
+    
+    @Test
+    public void testSTABLEFilter() throws Exception {
+
+        FreeStyleProject project = j.createFreeStyleProject("project");
+        FreeStyleBuild successfulBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.UNSTABLE)));
+        FreeStyleBuild unstableBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.FAILURE)));
+        FreeStyleBuild failedBuild = project.scheduleBuild2(0).get();
+
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.NOT_BUILT)));
+        FreeStyleBuild notBuiltBuild = project.scheduleBuild2(0).get();
+        
+        project.getPublishersList().replaceBy(Collections.singleton(new ResultPublisher(Result.ABORTED)));
+        FreeStyleBuild abortedBuild = project.scheduleBuild2(0).get();
+
+        FreeStyleProject paramProject = j.createFreeStyleProject("paramProject");
+        ParametersDefinitionProperty pdp = 
+                new ParametersDefinitionProperty(new RunParameterDefinition("RUN", 
+                                                                             project.getName(),
+                                                                             "run description",
+                                                                             RunParameterFilter.STABLE));
+        paramProject.addProperty(pdp);
+
+        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        assertEquals(Integer.toString(successfulBuild.getNumber()),
+                     build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
+    }
+    
+    
+    static class ResultPublisher extends Publisher {
+
+        private Result result = Result.FAILURE;
+
+        public ResultPublisher(Result result) {
+            this.result = result;
+        }
+
+        public @Override
+        boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+            build.setResult(result);
+            return true;
+        }
+
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.NONE;
+        }
+
+        public Descriptor<Publisher> getDescriptor() {
+            return new Descriptor<Publisher>(ResultPublisher.class) {
+                public String getDisplayName() {
+                    return "ResultPublisher";
+                }
+            };
+        }
+    }
 }

--- a/war/src/main/webapp/help/parameter/run-filter.html
+++ b/war/src/main/webapp/help/parameter/run-filter.html
@@ -1,0 +1,9 @@
+<div>
+Filter the list of builds which are included in the drop-down list.
+<pre>
+'All Builds' - List all builds including in-progress builds.
+'Completed Builds Only' - List all completed builds.
+'Successful Builds Only' - List all Successful builds (Stable and Unstable)
+'Stable Builds Only' - List all Stable builds.
+</pre>
+</div>

--- a/war/src/main/webapp/help/parameter/run-project.html
+++ b/war/src/main/webapp/help/parameter/run-project.html
@@ -6,5 +6,6 @@ PARAMETER_NAME=<i>&lt;jenkins_url&gt;</i>/job/<i>&lt;job_name&gt;/&lt;run_number
 PARAMETER_NAME_JOBNAME=<i>&lt;job_name&gt;</i>
 PARAMETER_NAME_NUMBER=<i>&lt;run_number&gt;</i>
 PARAMETER_NAME_NAME=<i>&lt;display_name&gt;</i>
+PARAMETER_NAME_RESULT=<i>&lt;run_result&gt;</i>
 </pre>
 </div>


### PR DESCRIPTION
Filter Run Parameter list by configurable Build Result threshold.

This is a change to address the following issues:
https://issues.jenkins-ci.org/browse/JENKINS-7280 - run parameters show builds that have not completed or have failed / unstable
https://issues.jenkins-ci.org/browse/JENKINS-6744 - Need "Good Run" parameter

It adds a new 'Threshold' dropdown to allow you to select the minimum result which a build must satisfy to be included in the dropdown for selection.
It also includes and defaults to an 'ALL' option to retain existing behaviour.

Please review and provide feedback.
I am new at this so all feedback welcome :)

thanks
Geoff
