### PR TITLE
Take subtasks into account when deciding to provision new nodes

### DIFF
--- a/core/src/main/java/hudson/model/LoadStatistics.java
+++ b/core/src/main/java/hudson/model/LoadStatistics.java
@@ -26,6 +26,8 @@ package hudson.model;
 import hudson.Extension;
 import hudson.model.MultiStageTimeSeries.TimeScale;
 import hudson.model.MultiStageTimeSeries.TrendChart;
+import hudson.model.queue.SubTask;
+import hudson.model.queue.Tasks;
 import hudson.util.ColorPalette;
 import hudson.util.NoOverlapCategoryAxis;
 import jenkins.model.Jenkins;
@@ -232,6 +234,9 @@ public abstract class LoadStatistics {
             for (Queue.BuildableItem bi : bis) {
                 if(bi.task.getAssignedLabel()==l)
                     q++;
+                for (SubTask st : Tasks.getSubTasksOf(bi.task))
+                    if (st != bi.task && st.getAssignedLabel()==l)
+                        q++;
             }
             return q;
         }

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -756,11 +756,19 @@ public class Queue extends ResourceController implements Saveable {
     public synchronized int countBuildableItemsFor(Label l) {
         int r = 0;
         for (BuildableItem bi : buildables.values())
-            if(bi.getAssignedLabel()==l)
+            if(null==l || bi.getAssignedLabel()==l) {
                 r++;
+                for (SubTask st : bi.task.getSubTasks())
+                    if (st != bi.task && (null==l || st.getAssignedLabel()==l))
+                        r++;
+            }
         for (BuildableItem bi : pendings.values())
-            if(bi.getAssignedLabel()==l)
+            if(bi.getAssignedLabel()==l) {
                 r++;
+                for (SubTask st : bi.task.getSubTasks())
+                    if (st != bi.task && (null==l || st.getAssignedLabel()==l))
+                        r++;
+            }
         return r;
     }
 
@@ -768,7 +776,7 @@ public class Queue extends ResourceController implements Saveable {
      * Counts all the {@link BuildableItem}s currently in the queue.
      */
     public synchronized int countBuildableItems() {
-        return buildables.size()+pendings.size();
+        return countBuildableItemsFor(null);
     }
 
     /**


### PR DESCRIPTION
My use case is about jobs that span multiple nodes, for distributed testing. With this purpose I extended heavy-job-plugin and installed jclouds-plugin to be able to spin up new slaves as needed. 

The only problem is that Jenkins doesn't take subtasks into account when checking if there's a need to spin up new slaves. So when I have a build with 2 subtasks in the queue and 1 available executor, nothing happens as the job can't start and Jenkins doesn't see that there's a need for an additional executor. 

I'm proposing to take subtasks into account. Per my understanding of the code it shouldn't have any downsides. The modified version is working well for me currently.
