### PR TITLE
[JENKINS-14575]: handle non expected Exceptions as well example: GitException

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -689,6 +689,9 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 } catch (IOException e) {
                     // checkout error not yet reported
                     e.printStackTrace(listener.getLogger());
+                // handle all other exceptions e.g.: GitException and retry
+                } catch (Exception e) {
+                    listener.error(e.getMessage());
                 }
 
                 if (retryCount == 0)   // all attempts failed


### PR DESCRIPTION
The current logic did not support the GitException, so the retry did not work. With this patch, it is going to catch the other exceptions generated from the different SCM plugins so the retry will work with them as well.
