### PR TITLE
[FIXED JENKINS-8614] ProcessTreeTest fails on Windows 

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -67,6 +67,7 @@ import java.util.logging.Logger;
 
 import static com.sun.jna.Pointer.NULL;
 import static hudson.util.jna.GNUCLibrary.LIBC;
+import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
 import static java.util.logging.Level.FINEST;
 
@@ -431,7 +432,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                                 env = new EnvVars(p.getEnvironmentVariables());
                             } catch (WinpException e)
                             {
-                                LOGGER.log(FINEST, "Failed to get environment variable ", e);
+                                LOGGER.log(FINE, "Failed to get environment variable ", e);
                             }                          
                         }
                         return env;

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -425,16 +425,17 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
 
                     @Override
                     public synchronized EnvVars getEnvironmentVariables() {
-                        if(env==null)  
+                        if(env !=null)
+                          return env;
+                        env = new EnvVars();   
+                        
+                        try 
                         {
-                            try
-                            {
-                                env = new EnvVars(p.getEnvironmentVariables());
-                            } catch (WinpException e)
-                            {
-                                LOGGER.log(FINE, "Failed to get environment variable ", e);
-                            }                          
-                        }
+                           env.putAll(p.getEnvironmentVariables());
+                        } catch (WinpException e)
+                        {
+                           LOGGER.log(FINE, "Failed to get environment variable ", e);
+                        }                          
                         return env;
                     }
                 });

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -424,7 +424,16 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
 
                     @Override
                     public synchronized EnvVars getEnvironmentVariables() {
-                        if(env==null)   env = new EnvVars(p.getEnvironmentVariables());
+                        if(env==null)  
+                        {
+                            try
+                            {
+                                env = new EnvVars(p.getEnvironmentVariables());
+                            } catch (WinpException e)
+                            {
+                                LOGGER.log(FINEST, "Failed to get environment variable ", e);
+                            }                          
+                        }
                         return env;
                     }
                 });


### PR DESCRIPTION
[Fixed JENKINS-8614](https://issues.jenkins-ci.org/browse/JENKINS-8614)
Add exception handler for getEnvironmentVariables().
