### PR TITLE
[FIXED JENKINS-14067] Polish localization breaks permalink descriptions

### DIFF
--- a/core/src/main/resources/hudson/model/PermalinkProjectAction/Permalink/link_pl.properties
+++ b/core/src/main/resources/hudson/model/PermalinkProjectAction/Permalink/link_pl.properties
@@ -20,4 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-format=0} ({1}), {2} temu
+format={0} ({1}), {2} temu


### PR DESCRIPTION
fixed [JENKINS-14067](https://issues.jenkins-ci.org/browse/JENKINS-14067) by correcting a broken format string
