### PR TITLE
[FIXED JENKINS-15365] Invalid translation

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractBuild/tasks_pl.properties
+++ b/core/src/main/resources/hudson/model/AbstractBuild/tasks_pl.properties
@@ -26,5 +26,5 @@ Console\ Output=Podgl\u0105d konsoli
 View\ as\ plain\ text=Otw\u00F3rz jako zwyk\u0142y tekst
 Edit\ Build\ Information=Edycja informacji o budowaniu
 Status=Status
-View\ Build\ Information=Poka\u017C Informacje o build''zie
+View\ Build\ Information=Poka\u017C informacje o przebiegu budowania
 raw=czyste


### PR DESCRIPTION
fixed [JENKINS-15365](https://issues.jenkins-ci.org/browse/JENKINS-15365) by replacing an incorrect polish translation with the reporter's suggestion
