### PR TITLE
[JENKINS-17351] won't fix - clarified help text

### DIFF
--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-artifacts.html
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-artifacts.html
@@ -1,6 +1,7 @@
 <div>
-   Can use wildcards like 'module/dist/**/*.zip'.
+   You can use wildcards like 'module/dist/**/*.zip'.
    See <a href='http://ant.apache.org/manual/Types/fileset.html'>
-   the @includes of Ant fileset</a> for the exact format.
+   the includes attribute of Ant fileset</a> for the exact format.
    The base directory is <a href='ws/'>the workspace</a>.
+   You can only archive files that are located in your workspace.
 </div>

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-artifacts_de.html
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-artifacts_de.html
@@ -3,4 +3,5 @@
    Das unterstützte Format entspricht der Angabe des  
    <a href='http://ant.apache.org/manual/Types/fileset.html'>includes-Attributes eines Ant FileSets</a>.
    Das Basisverzeichnis ist der <a href='ws/'>Arbeitsbereich</a>.
+   Sie können nur Dateien arichivieren, die im Arbeitsbereich liegen.
 </div>


### PR DESCRIPTION
In [JENKINS-17351](https://issues.jenkins-ci.org/browse/JENKINS-17351), the issue reporter tried to archive files from outside the workspace.

To my understanding, this is not possible, see my comments in the issue. I'd like to close the issue with resolution _won't fix_. 

This pull request is an enhancement of the English and German help message that clarifies the subject.

Can someone please verify that my assumptions about artifact resoltution are correct?
