### PR TITLE
JENKINS-17508 possible fix

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSetBuild.java
@@ -398,6 +398,14 @@ public class MavenModuleSetBuild extends AbstractMavenBuild<MavenModuleSet,Maven
     }
 
     @Override
+    public synchronized void deleteArtifacts() throws IOException {
+    	super.deleteArtifacts();
+    	for (List<MavenBuild> list : getModuleBuilds().values())
+            for (MavenBuild build : list)
+                build.deleteArtifacts();
+    }
+    
+    @Override
     public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
         // map corresponding module build under this object
         if(token.indexOf('$')>0) {


### PR DESCRIPTION
As this is my first look inside Jenkins codebase I not sure it's correct but perhaps artifacts for modulebuilds should be deleted just as logs
are deleted. see https://issues.jenkins-ci.org/browse/JENKINS-17508
I did not fully test it yet, all unit tests ran fine, but due to classloader issues while running
Jenkins in Jetty I didn't succeed to run jobs inside Jenkins to verify deletion
