### PR TITLE
Queue should keep consistence in pendings 

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -828,6 +828,13 @@ public class Queue extends ResourceController implements Saveable {
             if (offer != null && offer.workUnit != null) {
                 // we are already assigned a project, but now we can't handle it.
                 offer.workUnit.context.abort(new AbortException());
+                if(offer.workUnit.context.item!=null && pendings.contains(offer.workUnit.context.item)){
+                    //we are already assigned a project and moved it into pendings, but something wrong had happened before an executor could take it. 
+                    pendings.remove(offer.workUnit.context.item);
+                    //return it into queue, it does not have to cause this problem, it can be caused by another item.
+                    buildables.add(offer.workUnit.context.item);
+                }
+                    
             }
 
             // since this executor might have been chosen for

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -60,6 +60,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 /**
@@ -309,5 +310,61 @@ public class QueueTest extends HudsonTestCase {
         ev.signal();    // let the build complete
         FreeStyleBuild b2 = assertBuildStatusSuccess(v);
         assertSame(b,b2);
+    }
+    
+    public void testPendingsConsistenceAfterErrorDuringMaintain() throws IOException, ExecutionException, InterruptedException{
+        FreeStyleProject project1 = createFreeStyleProject();
+        FreeStyleProject project2 = createFreeStyleProject();
+        TopLevelItemDescriptor descriptor = new TopLevelItemDescriptor(FreeStyleProject.class){
+         @Override
+            public FreeStyleProject newInstance(ItemGroup parent, String name) {
+                return (FreeStyleProject) new FreeStyleProject(parent,name){
+                     @Override
+                    public Label getAssignedLabel(){
+                        throw new IllegalArgumentException("Test exception"); //cause dead of executor
+                    }   
+                     
+                    @Override
+                     public void save(){
+                         //do not need save
+                     }
+            };
+        }
+
+            @Override
+            public String getDisplayName() {
+                return "simulate-error";
+            }
+        };
+        FreeStyleProject projectError = (FreeStyleProject) jenkins.createProject(descriptor, "throw-error");
+        project1.setAssignedLabel(jenkins.getSelfLabel());
+        project2.setAssignedLabel(jenkins.getSelfLabel());
+        project1.getBuildersList().add(new Shell("sleep 2"));
+        project1.scheduleBuild2(0);
+        QueueTaskFuture<FreeStyleBuild> v = project2.scheduleBuild2(0);
+        projectError.scheduleBuild2(0);
+        Executor e = jenkins.toComputer().getExecutors().get(0);
+        Thread.sleep(2000);
+        while(project2.getLastBuild()==null){
+             if(!e.isAlive()){
+                    break; // executor is dead due to exception
+             }
+             if(e.isIdle()){
+                 assertTrue("Node went to idle before project had" + project2.getDisplayName() + " been started", v.isDone());   
+             }
+                Thread.sleep(1000);
+        }
+        if(project2.getLastBuild()!=null)
+            return;
+        Queue.getInstance().cancel(projectError); // cancel job which cause dead of executor
+        e.doYank(); //restart executor
+        while(!e.isIdle()){ //executor should take project2 from queue
+            Thread.sleep(1000); 
+        }
+        //project2 should not be in pendings
+        List<Queue.BuildableItem> items = Queue.getInstance().getPendingItems();
+        for(Queue.BuildableItem item : items){
+            assertFalse("Project " + project2.getDisplayName() + " stuck in pendings",item.task.getName().equals(project2.getName())); 
+        }
     }
 }


### PR DESCRIPTION
During bug which is corrected here https://github.com/jenkinsci/jenkins/pull/730 I catch another bad behaviour. If the exception is thrown after item is added into pendings and before slave takes it, the item stuck in pendings forever.

Example with label bug: method maintain was item with quoted label. During cycle another(previous item in buildables list) item was added into pending and should be taken, but next item with quoted label cause ClassCastException. In method pop was abort job offer but item stays in the pendings.
