### PR TITLE
[FIXED JENKINS-17030] Enable word breaking for job names

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1716,4 +1716,20 @@ public class Functions {
         DecimalFormat format = new DecimalFormat("#0.00");
         return format.format(number) + " " + measure;
     }
+
+    /**
+     * Get a string that can be safely broken to several lines when necessary.
+     *
+     * This implementation inserts &lt;wbr> tags into string. It allows browsers
+     * to wrap line before any sequence of punctuation characters or anywhere
+     * in the middle of prolonged sequences of word characters.
+     *
+     * @since 1.516
+     */
+    public static String breakableString(final String plain) {
+
+        return plain.replaceAll("(\\p{Punct}+\\w)", "<wbr>$1")
+                .replaceAll("(\\w{10})(?=\\w{3})", "$1<wbr>")
+        ;
+    }
 }

--- a/core/src/main/resources/hudson/matrix/MatrixProject/index.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/index.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <l:layout title="${it.name}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <h1>${%Project} ${it.displayName}</h1>
+      <h1>${%Project} <l:breakable value="${it.displayName}"/></h1>
       <j:if test="${it.name!=it.displayName}">
         ${%Project name}: ${it.fullName}
       </j:if>

--- a/core/src/main/resources/hudson/model/Job/index.jelly
+++ b/core/src/main/resources/hudson/model/Job/index.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <h1>${it.pronoun} ${it.displayName}</h1>
+      <h1>${it.pronoun} <l:breakable value="${it.displayName}"/></h1>
       <j:if test="${(it.name!=it.displayName) and (it.class.name!='hudson.matrix.MatrixConfiguration')}">
         ${%Project name}: ${it.fullName}
       </j:if>

--- a/core/src/main/resources/lib/hudson/buildListTable.jelly
+++ b/core/src/main/resources/lib/hudson/buildListTable.jelly
@@ -53,7 +53,7 @@ THE SOFTWARE.
           </a>
         </td>
         <td>
-          <a href="${jobBaseUrl}${b.parent.url}" class="model-link">${b.parent.fullDisplayName}</a>
+          <a href="${jobBaseUrl}${b.parent.url}" class="model-link"><l:breakable value="${b.parent.fullDisplayName}"/></a>
           <st:nbsp/>
           <a href="${jobBaseUrl}${b.url}" class="model-link inside">${b.displayName}</a>
         </td>

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -79,7 +79,7 @@ THE SOFTWARE.
                       </j:invokeStatic>
                       <j:choose>
                         <j:when test="${h.hasPermission(exeparent,exeparent.READ)}">
-                          <a href="${rootURL}/${exeparent.url}">${exeparent.fullDisplayName}</a>&#160;<a href="${rootURL}/${exe.url}" class="model-link inside">#${exe.number}</a>
+                          <a href="${rootURL}/${exeparent.url}"><l:breakable value="${exeparent.fullDisplayName}"/></a>&#160;<a href="${rootURL}/${exe.url}" class="model-link inside">#${exe.number}</a>
                           <t:buildProgressBar build="${exe}" executor="${executor}"/>
                         </j:when>
                         <j:otherwise>

--- a/core/src/main/resources/lib/hudson/jobLink.jelly
+++ b/core/src/main/resources/lib/hudson/jobLink.jelly
@@ -32,5 +32,5 @@ THE SOFTWARE.
   </st:documentation>
 
 <img src="${imagesURL}/16x16/${job.buildStatusUrl}" alt="${job.iconColor.description}" height="16" width="16"/>
-<a href="${h.getRelativeLinkTo(job)}" class="model-link">${job.fullDisplayName}</a>
+<a href="${h.getRelativeLinkTo(job)}" class="model-link"><l:breakable value="${job.fullDisplayName}"/></a>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -63,7 +63,7 @@ THE SOFTWARE.
               <j:choose>
                 <j:when test="${h.hasPermission(item.task,item.task.READ)}">
                   <a href="${rootURL}/${item.task.url}" class="model-link inside tl-tr" tooltip="${item.why}${h.escape(item.params)}&lt;br&gt;${%WaitingFor(item.inQueueForString)}">
-                    ${item.task.fullDisplayName}
+                    <l:breakable value="${item.task.fullDisplayName}"/>
                   </a>
                   <!-- XXX include estimated number as in BuildHistoryWidget/entries.jelly if possible -->
                   <j:if test="${stuck}">

--- a/core/src/main/resources/lib/layout/breakable.jelly
+++ b/core/src/main/resources/lib/layout/breakable.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Martin Eigenbrodt
+Copyright (c) 2013 Red Hat, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,9 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <td style="${indenter.getCss(job)}">
-        <a href="${jobBaseUrl}${job.shortUrl}" class='model-link inside'> <l:breakable value="${h.getRelativeDisplayNameFrom(job,currentView.owner.itemGroup)}"/></a>
-    </td>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <st:documentation>
+    Send escaped value to output decorated to be safely broken into lines when necessary
+    <st:attribute name="value" use="required">
+      Unescaped value to output
+    </st:attribute>
+  </st:documentation>
+  ${h.breakableString(h.escape(value))}
 </j:jelly>

--- a/core/src/main/resources/lib/layout/breakable.jelly
+++ b/core/src/main/resources/lib/layout/breakable.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='false'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:documentation>
     Send escaped value to output decorated to be safely broken into lines when necessary

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -264,4 +264,11 @@ public class FunctionsTest {
         }
     }
 
+    @Test
+    public void testBreakableString() {
+
+        assertEquals("Hello world!", Functions.breakableString("Hello world!"));
+        assertEquals("H<wbr>,e<wbr>.l<wbr>/l<wbr>:o<wbr>-w<wbr>_o<wbr>=+|d", Functions.breakableString("H,e.l/l:o-w_o=+|d"));
+        assertEquals("ALongStrin<wbr>gThatCanNo<wbr>tBeBrokenB<wbr>yDefault", Functions.breakableString("ALongStringThatCanNotBeBrokenByDefault"));
+    }
 }


### PR DESCRIPTION
[JENKINS-17030](https://issues.jenkins-ci.org/browse/JENKINS-17030): #725 reworked.
