### PR TITLE
[FIXED JENKINS-17478] Add extension point to rewrite JUnit test names

### DIFF
--- a/core/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/core/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -214,7 +214,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
     }
 
     public String getDisplayName() {
-        return testName;
+        return TestNameTransformer.getTransformedName(testName);
     }
 
     /**
@@ -233,7 +233,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
      */
     @Override
     public String getTitle() {
-        return "Case Result: " + getName();
+        return "Case Result: " + getDisplayName();
     }
 
     /**
@@ -285,11 +285,14 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
         if(idx<0)       return "(root)";
         else            return className.substring(0,idx);
     }
-
+    
     public String getFullName() {
-        return className+'.'+getName();
+    	return className+'.'+getName();
     }
-
+    
+    public String getFullDisplayName() {
+    	return TestNameTransformer.getTransformedName(getFullName());
+    }
 
     @Override
     public int getFailCount() {

--- a/core/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/core/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -98,7 +98,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
     }
 
     public String getTitle() {
-        return Messages.ClassResult_getTitle(getName());
+        return Messages.ClassResult_getTitle(getDisplayName());
     }
 
     @Override
@@ -223,11 +223,15 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
     }
 
     public String getDisplayName() {
-        return getName();
+        return TestNameTransformer.getTransformedName(getName());
     }
     
     public String getFullName() {
-    	return getParent().getDisplayName() + "." + className;
+    	return getParent().getName() + "." + className;
+    }
+    
+    public String getFullDisplayName() {
+    	return getParent().getDisplayName() + "." + TestNameTransformer.getTransformedName(className);
     }
 
     /**

--- a/core/src/main/java/hudson/tasks/junit/PackageResult.java
+++ b/core/src/main/java/hudson/tasks/junit/PackageResult.java
@@ -110,7 +110,7 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
 
     @Override
     public String getTitle() {
-        return Messages.PackageResult_getTitle(getName());
+        return Messages.PackageResult_getTitle(getDisplayName());
     }
 
     @Override
@@ -303,6 +303,6 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
     }
 
     public String getDisplayName() {
-        return packageName;
+        return TestNameTransformer.getTransformedName(packageName);
     }
 }

--- a/core/src/main/java/hudson/tasks/junit/TestNameTransformer.java
+++ b/core/src/main/java/hudson/tasks/junit/TestNameTransformer.java
@@ -1,0 +1,42 @@
+package hudson.tasks.junit;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import jenkins.model.Jenkins;
+
+/**
+ * Allow extensions to transform the class/package/method name for JUnit test
+ * cases which will be displayed on the test result page.
+ *
+ * This is useful for alternative JVM languages like Scala that allow
+ * identifiers with invalid characters by encoding them: an extension can
+ * decode the identifier so it is displayed correctly.
+ *
+ * @since 1.515
+ */
+
+public abstract class TestNameTransformer implements ExtensionPoint {
+    /**
+     * Transform the class/package/method name.
+     *
+     * @param name
+     *      Class name (may be simple or fully qualified), package name, or
+     *      method name from a JUnit test.
+     * @return
+     *      The transformed name, or the name that was passed in if it doesn't
+     *      need to be changed.
+     */
+    public abstract String transformName(String name);
+    
+    public static String getTransformedName(String name) {
+        String transformedName = name;
+        for (TestNameTransformer transformer : all()) {
+            transformedName = transformer.transformName(transformedName);
+        }
+        return transformedName;
+    }
+
+    public static ExtensionList<TestNameTransformer> all() {
+        return Jenkins.getInstance().getExtensionList(TestNameTransformer.class);
+    }
+}

--- a/core/src/main/resources/hudson/tasks/junit/CaseResult/index.jelly
+++ b/core/src/main/resources/hudson/tasks/junit/CaseResult/index.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
       </h1>
       <p>
         <span style="font-weight:bold">
-          <st:out value="${it.fullName}"/>
+          <st:out value="${it.fullDisplayName}"/>
         </span>
         <j:if test="${it.suiteResult != null &amp;&amp; it.className != it.suiteResult.name}">
           (from <st:out value="${it.suiteResult.name}"/>)

--- a/core/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
+++ b/core/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
         <j:forEach var="p" items="${it.children}" varStatus="status">
           <tr>
             <td class="pane">
-              <a href="${p.safeName}" class="model-link inside"><span style="${p.previousResult==null?'font-weight:bold':''}"><st:out value="${p.name}" /></span></a>
+              <a href="${p.safeName}" class="model-link inside"><span style="${p.previousResult==null?'font-weight:bold':''}"><st:out value="${p.displayName}" /></span></a>
               <j:forEach var="badge" items="${p.testActions}">
                 <st:include it="${badge}" page="badge.jelly" optional="true"/>
               </j:forEach>

--- a/core/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
+++ b/core/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
@@ -66,7 +66,7 @@ THE SOFTWARE.
             <!-- child test results are referenced from their parent builds -->
             <j:set var="build" value="${testObject.owner}" />
             <a href="${it.getTestResultPath(testObject)}">
-              <st:out value="${testObject.fullName}" />
+              <st:out value="${testObject.fullDisplayName}" />
             </a>
           </li>
         </j:while>

--- a/core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -63,7 +63,7 @@ THE SOFTWARE.
             <a id="test-${f.fullName}-hidelink" style="display:none"
                href="javascript:hideStackTrace('test-${h.jsStringEscape(f.fullName)}')">&lt;&lt;&lt;</a>
             <st:nbsp/>
-            <a href="${f.getRelativePathFrom(it)}" class="model-link inside"><st:out value="${f.fullName}"/></a>
+            <a href="${f.getRelativePathFrom(it)}" class="model-link inside"><st:out value="${f.fullDisplayName}"/></a>
             <j:forEach var="badge" items="${f.testActions}">
               <st:include it="${badge}" page="badge.jelly" optional="true"/>
             </j:forEach>
@@ -102,7 +102,7 @@ THE SOFTWARE.
           <j:set var="prev" value="${prevAll.findCorrespondingResult(p.id)}" />
           <tr>
             <td class="pane">
-              <a href="${p.safeName}/" class="model-link inside"><span style="${prev==null?'font-weight:bold':''}"><st:out value="${p.name}" /></span></a>
+              <a href="${p.safeName}/" class="model-link inside"><span style="${prev==null?'font-weight:bold':''}"><st:out value="${p.displayName}" /></span></a>
               <j:forEach var="badge" items="${p.testActions}">
                 <st:include it="${badge}" page="badge.jelly" optional="true"/>
               </j:forEach>

--- a/core/src/test/java/hudson/tasks/junit/SuiteResultTest.java
+++ b/core/src/test/java/hudson/tasks/junit/SuiteResultTest.java
@@ -82,7 +82,7 @@ public class SuiteResultTest extends TestCase {
 
         List<CaseResult> cases = result.getCases();
         for (CaseResult caseResult : cases) {
-            assertEquals("Test class name is incorrect in " + caseResult.getDisplayName(), "WLI-FI-Tests-Fake", caseResult.getClassName());            
+            assertEquals("Test class name is incorrect in " + caseResult.getName(), "WLI-FI-Tests-Fake", caseResult.getClassName());            
         }
         assertEquals("Test name is incorrect", "IF_importTradeConfirmationToDwh", cases.get(0).getName());
         assertEquals("Test name is incorrect", "IF_getAmartaDisbursements", cases.get(1).getName());
@@ -119,7 +119,7 @@ public class SuiteResultTest extends TestCase {
 
         List<CaseResult> cases = result.getCases();
         for (CaseResult caseResult : cases) {
-            assertEquals("Test class name is incorrect in " + caseResult.getDisplayName(), "some.package.somewhere.WhooHoo", caseResult.getClassName());
+            assertEquals("Test class name is incorrect in " + caseResult.getName(), "some.package.somewhere.WhooHoo", caseResult.getClassName());
         }
         assertEquals("this normally has the string like, expected mullet, but got bream", cases.get(0).getErrorDetails());
     }

--- a/test/src/test/java/hudson/tasks/junit/TestNameTransformerTest.java
+++ b/test/src/test/java/hudson/tasks/junit/TestNameTransformerTest.java
@@ -1,0 +1,27 @@
+package hudson.tasks.junit;
+
+import hudson.Extension;
+
+import org.jvnet.hudson.test.HudsonTestCase;
+
+public class TestNameTransformerTest extends HudsonTestCase {
+
+    private static final String UniqueNameForTest = "unique-name-to-test-name-transformer";
+
+    @Extension
+    public static class TestTransformer extends TestNameTransformer {
+        @Override
+        public String transformName(String name) {
+            if (UniqueNameForTest.equals(name)) {
+                return name + "-transformed";
+            }
+            return name;
+        }
+    }
+
+    public void testNameIsTransformed() {
+        assertEquals(UniqueNameForTest + "-transformed", TestNameTransformer.getTransformedName(UniqueNameForTest));
+    }
+
+}
+

--- a/test/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
+++ b/test/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
@@ -286,7 +286,7 @@ public class TestResultPublishingTest extends HudsonTestCase {
     }
 
     void assertPaneDiffText(String msg, int expectedValue, Object paneObj) { 
-        assertTrue( "paneObj should be an HtmlElement", paneObj instanceof HtmlElement );
+        assertTrue( "paneObj should be an HtmlElement, it was " + paneObj.getClass(), paneObj instanceof HtmlElement );
         String paneText = ((HtmlElement) paneObj).asText();
         if (expectedValue==0) {
             assertStringEmptyOrNull(msg, paneText);


### PR DESCRIPTION
This adds an extension point, TestNameTransformer, which is called to transform JUnit test case names.
This is useful for JVM languages like scala which are more flexible than java with identifier naming.
Scala, for example, allows you to write test names between back ticks, and then encodes the name using valid java identifiers.
This extension point would allow a plugin to transform those names back in to readable names when they are displayed on the test result page.

This is essentially the same as https://github.com/jenkinsci/jenkins/pull/751 (I'm closing that one and opening this one) because there are build problems I don't know how to resolve.
