### PR TITLE
[FIXED JENKINS-17858] allow <f:dropdownDescriptorSelector> to be defaulting to an instance

### DIFF
--- a/core/src/main/resources/lib/form/dropdownDescriptorSelector.jelly
+++ b/core/src/main/resources/lib/form/dropdownDescriptorSelector.jelly
@@ -39,7 +39,8 @@ THE SOFTWARE.
       If unspecified, inferred from the type of the field.
     </st:attribute>
     <st:attribute name="default">
-      If specified, this will be chosen as the default value in case the current selection is null.
+      If specified, this will be chosen as the default value in case the current selection is null. The default can be an specific instance or a descriptor e.g. 
+      ${descriptor.defaultSettingsProvider} or ${descriptor.defaultSettingsProvider.descriptor}. In the later case, the from input fields will be empty.
     </st:attribute>
   </st:documentation>
   <f:prepareDatabinding /> 
@@ -49,6 +50,7 @@ THE SOFTWARE.
     <d:invokeBody />
 
     <j:set var="current" value="${instance[attrs.field]}"/>
+    <j:set var="current" value="${current!=null ? current : (default.descriptor!=null ? default : null)}"/>
     <j:forEach var="descriptor" items="${attrs.descriptors}" varStatus="loop">
       <f:dropdownListBlock value="${loop.index}" title="${descriptor.displayName}"
         selected="${current.descriptor==descriptor || (current==null and descriptor==attrs.default)}" staplerClass="${descriptor.clazz.name}"


### PR DESCRIPTION
fixes https://issues.jenkins-ci.org/browse/JENKINS-17858 and is a prerequisite to https://issues.jenkins-ci.org/browse/JENKINS-17723, which I'll send an other request shortly

In addition to a default descriptor, this change allows to define a default instance in a <f:dropdownDescriptorSelector> 
