### PR TITLE
FIXES JENKINS-17723 - Default maven settings

### DIFF
--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -38,8 +38,6 @@ import hudson.model.Computer;
 import hudson.model.EnvironmentSpecific;
 import hudson.model.Node;
 import jenkins.model.Jenkins;
-import jenkins.mvn.DefaultGlobalSettingsProvider;
-import jenkins.mvn.DefaultSettingsProvider;
 import jenkins.mvn.GlobalMavenConfig;
 import jenkins.mvn.GlobalSettingsProvider;
 import jenkins.mvn.SettingsProvider;
@@ -130,13 +128,13 @@ public class Maven extends Builder {
      * Provides access to the settings.xml to be used for a build.
      * @since 1.491
      */
-    private SettingsProvider settings = new DefaultSettingsProvider();
+    private SettingsProvider settings;
     
     /**
      * Provides access to the global settings.xml to be used for a build.
      * @since 1.491
      */
-    private GlobalSettingsProvider globalSettings = new DefaultGlobalSettingsProvider();
+    private GlobalSettingsProvider globalSettings;
 
     private final static String MAVEN_1_INSTALLATION_COMMON_FILE = "bin/maven";
     private final static String MAVEN_2_INSTALLATION_COMMON_FILE = "bin/mvn";
@@ -164,8 +162,8 @@ public class Maven extends Builder {
         this.properties = Util.fixEmptyAndTrim(properties);
         this.jvmOptions = Util.fixEmptyAndTrim(jvmOptions);
         this.usePrivateRepository = usePrivateRepository;
-        this.settings = settings;
-        this.globalSettings = globalSettings;
+        this.settings = settings != null ? settings : GlobalMavenConfig.get().getSettingsProvider();
+        this.globalSettings = globalSettings != null ? globalSettings : GlobalMavenConfig.get().getGlobalSettingsProvider();
     }
 
     public String getTargets() {
@@ -406,6 +404,14 @@ public class Maven extends Builder {
 
         public String getDisplayName() {
             return Messages.Maven_DisplayName();
+        }
+        
+        public GlobalSettingsProvider getDefaultGlobalSettingsProvider() {
+            return GlobalMavenConfig.get().getGlobalSettingsProvider();
+        }
+        
+        public SettingsProvider getDefaultSettingsProvider() {
+            return GlobalMavenConfig.get().getSettingsProvider();
         }
 
         public MavenInstallation[] getInstallations() {

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -40,6 +40,7 @@ import hudson.model.Node;
 import jenkins.model.Jenkins;
 import jenkins.mvn.DefaultGlobalSettingsProvider;
 import jenkins.mvn.DefaultSettingsProvider;
+import jenkins.mvn.GlobalMavenConfig;
 import jenkins.mvn.GlobalSettingsProvider;
 import jenkins.mvn.SettingsProvider;
 import hudson.model.TaskListener;
@@ -163,8 +164,8 @@ public class Maven extends Builder {
         this.properties = Util.fixEmptyAndTrim(properties);
         this.jvmOptions = Util.fixEmptyAndTrim(jvmOptions);
         this.usePrivateRepository = usePrivateRepository;
-        this.settings = settings != null ? settings : new DefaultSettingsProvider();
-        this.globalSettings = globalSettings != null ? globalSettings : new DefaultGlobalSettingsProvider();
+        this.settings = settings;
+        this.globalSettings = globalSettings;
     }
 
     public String getTargets() {
@@ -175,14 +176,22 @@ public class Maven extends Builder {
      * @since 1.491
      */
     public SettingsProvider getSettings() {
-        return settings != null ? settings : new DefaultSettingsProvider();
+        return settings != null ? settings : GlobalMavenConfig.get().getSettingsProvider();
+    }
+    
+    protected void setSettings(SettingsProvider settings) {
+        this.settings = settings;
     }
     
     /**
      * @since 1.491
      */
     public GlobalSettingsProvider getGlobalSettings() {
-        return globalSettings != null ? globalSettings : new DefaultGlobalSettingsProvider();
+        return globalSettings != null ? globalSettings : GlobalMavenConfig.get().getGlobalSettingsProvider();
+    }
+    
+    protected void setGlobalSettings(GlobalSettingsProvider globalSettings) {
+        this.globalSettings = globalSettings;
     }
 
     public void setUsePrivateRepository(boolean usePrivateRepository) {
@@ -420,7 +429,10 @@ public class Maven extends Builder {
 
         @Override
         public Builder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return req.bindJSON(Maven.class,formData);
+            Maven m = req.bindJSON(Maven.class,formData);
+            m.setSettings(GlobalMavenConfig.get().getSettingsProvider());
+            m.setGlobalSettings(GlobalMavenConfig.get().getGlobalSettingsProvider());
+            return m;
         }
     }
 

--- a/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java
+++ b/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java
@@ -1,0 +1,47 @@
+package jenkins.mvn;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.StaplerRequest;
+
+//as close as it gets to the global Maven Project configuration
+@Extension(ordinal = 50)
+public class GlobalMavenConfig extends GlobalConfiguration {
+    private SettingsProvider settingsProvider;
+    private GlobalSettingsProvider globalSettingsProvider;
+
+    public GlobalMavenConfig() {
+        load();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        return true;
+    }
+
+    public void setGlobalSettingsProvider(GlobalSettingsProvider globalSettingsProvider) {
+        this.globalSettingsProvider = globalSettingsProvider;
+        save();
+    }
+
+    public void setSettingsProvider(SettingsProvider settingsProvider) {
+        this.settingsProvider = settingsProvider;
+        save();
+    }
+
+    public GlobalSettingsProvider getGlobalSettingsProvider() {
+        return globalSettingsProvider != null ? globalSettingsProvider : new DefaultGlobalSettingsProvider();
+    }
+
+    public SettingsProvider getSettingsProvider() {
+        return settingsProvider != null ? settingsProvider : new DefaultSettingsProvider();
+    }
+
+    public static GlobalMavenConfig get() {
+        return GlobalConfiguration.all().get(GlobalMavenConfig.class);
+    }
+
+}

--- a/core/src/main/resources/hudson/tasks/Maven/config.jelly
+++ b/core/src/main/resources/hudson/tasks/Maven/config.jelly
@@ -50,7 +50,8 @@ THE SOFTWARE.
     <f:entry field="usePrivateRepository" title="${%Use private Maven repository}" help="/plugin/maven-plugin/private-repository.html">
       <f:checkbox checked="${it.usesPrivateRepository()}" />
     </f:entry>
-    <f:dropdownDescriptorSelector title="${%Settings file}" descriptors="${descriptor.settingsProviders}" field="settings"/>
+    
+    <f:dropdownDescriptorSelector title="${%Settings file}"  field="settings" default="${descriptor.defaultSettingsProvider}"/>
 <!--
     <f:entry   help="/help/tasks/maven/maven-settings.html">
 
@@ -58,6 +59,6 @@ THE SOFTWARE.
     <f:entry   help="/help/tasks/maven/maven-settings.html">
     </f:entry>
 -->
-    <f:dropdownDescriptorSelector title="${%Global Settings file}" field="globalSettings" descriptors="${descriptor.globalSettingsProviders}"/>
+	<f:dropdownDescriptorSelector title="${%Global Settings file}" field="globalSettings"  default="${descriptor.defaultGlobalSettingsProvider}"/>    
   </f:advanced>
 </j:jelly>

--- a/core/src/main/resources/jenkins/mvn/GlobalMavenConfig/config.groovy
+++ b/core/src/main/resources/jenkins/mvn/GlobalMavenConfig/config.groovy
@@ -1,0 +1,8 @@
+package jenkins.mvn.GlobalMavenConfig;
+
+def f = namespace(lib.FormTagLib)
+
+f.section(title:_("Maven Configuration")) {
+    f.dropdownDescriptorSelector(title:_("Default settings provider"), field:"settingsProvider")
+    f.dropdownDescriptorSelector(title:_("Default global settings provider"), field:"globalSettingsProvider")
+}

--- a/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
@@ -94,6 +94,7 @@ import jenkins.model.ModelObjectWithChildren;
 import jenkins.mvn.DefaultGlobalSettingsProvider;
 import jenkins.mvn.DefaultSettingsProvider;
 import jenkins.mvn.FilePathSettingsProvider;
+import jenkins.mvn.GlobalMavenConfig;
 import jenkins.mvn.GlobalSettingsProvider;
 import jenkins.mvn.GlobalSettingsProviderDescriptor;
 import jenkins.mvn.SettingsProvider;
@@ -284,12 +285,12 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
     /**
      * @since 1.491
      */
-    private SettingsProvider settings = new DefaultSettingsProvider();
+    private SettingsProvider settings;
     
     /**
      * @since 1.491
      */
-    private GlobalSettingsProvider globalSettings = new DefaultGlobalSettingsProvider();
+    private GlobalSettingsProvider globalSettings;
 
 
     /**
@@ -650,14 +651,14 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
      * @since 1.481
      */
     public SettingsProvider getSettings() {
-        return settings != null ? settings : new DefaultSettingsProvider();
+        return settings != null ? settings : GlobalMavenConfig.get().getSettingsProvider();
     }
 
     /**
      * @since 1.481
      */
     public GlobalSettingsProvider getGlobalSettings() {
-        return globalSettings != null ? globalSettings : new DefaultGlobalSettingsProvider();
+        return globalSettings != null ? globalSettings : GlobalMavenConfig.get().getGlobalSettingsProvider();
     }
 
     /**
@@ -1260,7 +1261,10 @@ public class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,MavenMod
         }
 
         public MavenModuleSet newInstance(ItemGroup parent, String name) {
-            return new MavenModuleSet(parent,name);
+            MavenModuleSet mms = new MavenModuleSet(parent,name);
+            mms.setSettings(GlobalMavenConfig.get().getSettingsProvider());
+            mms.setGlobalSettings(GlobalMavenConfig.get().getGlobalSettingsProvider());
+            return mms;
         }
 
         public Maven.DescriptorImpl getMavenDescriptor() {

--- a/test/src/test/java/hudson/maven/MavenProjectTest.java
+++ b/test/src/test/java/hudson/maven/MavenProjectTest.java
@@ -33,6 +33,11 @@ import hudson.tasks.Shell;
 import java.io.File;
 
 import jenkins.model.Jenkins;
+import jenkins.mvn.DefaultGlobalSettingsProvider;
+import jenkins.mvn.DefaultSettingsProvider;
+import jenkins.mvn.FilePathGlobalSettingsProvider;
+import jenkins.mvn.FilePathSettingsProvider;
+import jenkins.mvn.GlobalMavenConfig;
 
 import org.junit.Assert;
 import org.jvnet.hudson.test.Bug;
@@ -207,6 +212,29 @@ public class MavenProjectTest extends HudsonTestCase {
             m.setRunPostStepsIfResult(r);
             configRoundtrip((Item)m);
             assertEquals(r,m.getRunPostStepsIfResult());
+        }
+    }
+    
+    
+    public void testDefaultSettingsProvider() throws Exception {
+        {
+            MavenModuleSet m = createMavenProject();
+    
+            assertNotNull(m);
+            assertEquals(DefaultSettingsProvider.class, m.getSettings().getClass());
+            assertEquals(DefaultGlobalSettingsProvider.class, m.getGlobalSettings().getClass());
+        }
+        
+        {
+            GlobalMavenConfig globalMavenConfig = GlobalMavenConfig.get();
+            assertNotNull("No global Maven Config available", globalMavenConfig);
+            globalMavenConfig.setSettingsProvider(new FilePathSettingsProvider("/tmp/settigns.xml"));
+            globalMavenConfig.setGlobalSettingsProvider(new FilePathGlobalSettingsProvider("/tmp/global-settigns.xml"));
+            
+            MavenModuleSet m = createMavenProject();
+            assertEquals(FilePathSettingsProvider.class, m.getSettings().getClass());
+            assertEquals("/tmp/settigns.xml", ((FilePathSettingsProvider)m.getSettings()).getPath());
+            assertEquals("/tmp/global-settigns.xml", ((FilePathGlobalSettingsProvider)m.getGlobalSettings()).getPath());
         }
     }
 }


### PR DESCRIPTION
This change allows to define a global default definition for maven settings (user and global) - see here https://issues.jenkins-ci.org/browse/JENKINS-17723

In order to have this implementation fully working, the pull request https://github.com/jenkinsci/jenkins/pull/771 must be pulled too.
