### PR TITLE
[FIXED JENKINS-17774] Plugin tests often fails in Windows.

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -509,11 +509,6 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         context.setClassLoader(getClass().getClassLoader());
         context.setConfigurations(new Configuration[]{new WebXmlConfiguration(), new NoListenerConfiguration()});
         context.setMimeTypes(MIME_TYPES);
-        if(Functions.isWindows()) {
-            // this is only needed on Windows because of the file
-            // locking issue as described in JENKINS-12647
-            context.setCopyWebDir(true);
-        }
         return context;
     }
 

--- a/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -495,23 +495,37 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     }
 
     /**
-     * Prepares a webapp hosting environment to get {@link ServletContext} implementation
-     * that we need for testing.
+     * Prepares a Jenkins webapp context for testing.
+     * 
+     * You can override this to customize the webapp context.
+     * 
+     * @return WebAppContext of Jenkins
+     * @throws Exception
      */
-    protected ServletContext createWebServer() throws Exception {
-        server = new Server();
-
+    protected WebAppContext createWebAppContext() throws Exception
+    {
         explodedWarDir = WarExploder.getExplodedDir();
         WebAppContext context = new WebAppContext(explodedWarDir.getPath(), contextPath);
         context.setClassLoader(getClass().getClassLoader());
         context.setConfigurations(new Configuration[]{new WebXmlConfiguration(), new NoListenerConfiguration()});
-        server.setHandler(context);
         context.setMimeTypes(MIME_TYPES);
         if(Functions.isWindows()) {
             // this is only needed on Windows because of the file
             // locking issue as described in JENKINS-12647
             context.setCopyWebDir(true);
         }
+        return context;
+    }
+
+    /**
+     * Prepares a webapp hosting environment to get {@link ServletContext} implementation
+     * that we need for testing.
+     */
+    protected ServletContext createWebServer() throws Exception {
+        server = new Server();
+
+        WebAppContext context = createWebAppContext();
+        server.setHandler(context);
 
         SocketConnector connector = new SocketConnector();
         connector.setHeaderBufferSize(12*1024); // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL


### PR DESCRIPTION
For details, please refer to [JENKINS-17774](https://issues.jenkins-ci.org/browse/JENKINS-17774).

Plugin tests using WebClient often fails in Windows 8 with TortoiseGit installed.
Those failures are caused by Jetty failing to overwrite jenkins-for-test onto a webapps directory, which is caused for Windows often stay holding file handles.

This Jetty overwriting behavior in Windows is introduced in [JENKINS-12467](https://issues.jenkins-ci.org/browse/JENKINS-12647) and 7ae303f88191a540491a21484316d63dff775e21.
But as far as I tested, the problem reported on JENKINS-12467 is not caused by Jetty behavior, so changes in JENKINS-12467 can be reverted.

This patch does followings to HudsonTestCase:
- reverts JENKINS-12467.
- Extract createWebAppContext from createWebServer. This makes it easy for developers to customize WebAppContext if needed.
