### PR TITLE
Don't remove /var/lib/jenkins

### DIFF
--- a/debian/debian/jenkins.postrm
+++ b/debian/debian/jenkins.postrm
@@ -5,7 +5,7 @@ set -e
 case "$1" in
     purge)
         userdel jenkins || true
-        rm -rf /var/lib/jenkins /var/log/jenkins \
+        rm -rf /var/log/jenkins \
                /var/run/jenkins /var/cache/jenkins
     ;;
 


### PR DESCRIPTION
Don't remove /var/lib/jenkins when purging on debian as it may contain crucial non-configuration data
