### PR TITLE
Use NOTBUILT rather than GREY when a job has not yet been built

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -933,7 +933,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         if (lastBuild != null)
             return lastBuild.getIconColor();
         else
-            return BallColor.GREY;
+            return BallColor.NOTBUILT;
     }
 
     /**

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -688,7 +688,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         BallColor baseColor;
         RunT pb = getPreviousBuild();
         if(pb==null)
-            baseColor = BallColor.GREY;
+            baseColor = BallColor.NOTBUILT;
         else
             baseColor = pb.getIconColor();
 


### PR DESCRIPTION
Before this patch, the tool tip for the grey ball next to a newly created job with no builds would show _Pending_, which seems odd. Now it will show _Not built_ which seems more intuitive.

Technically a change to the remote API, which exposes ball color (though never with a documented meaning). I checked that at least the NetBeans client is not harmed.
