### PR TITLE
[FIXED JENKINS-17774] Plugin tests often fails in Windows (just reverting JENKINS-12647).

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -507,11 +507,6 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         context.setConfigurations(new Configuration[]{new WebXmlConfiguration(), new NoListenerConfiguration()});
         server.setHandler(context);
         context.setMimeTypes(MIME_TYPES);
-        if(Functions.isWindows()) {
-            // this is only needed on Windows because of the file
-            // locking issue as described in JENKINS-12647
-            context.setCopyWebDir(true);
-        }
 
         SocketConnector connector = new SocketConnector();
         connector.setHeaderBufferSize(12*1024); // use a bigger buffer as Stapler traces can get pretty large on deeply nested URL


### PR DESCRIPTION
For details, please refer to [JENKINS-17774](https://issues.jenkins-ci.org/browse/JENKINS-17774).
This is an alternate pull request to #773 (already abandoned by myself).

Plugin tests using WebClient often fails in Windows8 with TortoiseGit installed.
Those failures are caused by Jetty failing to overwrite jenkins-for-test onto a webapps directory, which is caused for Windows often stay holding file handles.

This Jetty overwriting behavior in Windows is introduced in JENKINS-12467 and 7ae303f.
But as far as I tested, the problem reported on JENKINS-12467 is not caused by Jetty behavior, so changes in JENKINS-12467 can be reverted.
And this behavior is only with `HudsonTestCase`, but not with `JenkinsRule`.

This patch reverts JENKINS-12467.
