### PR TITLE
[FIXED JENKINS-4409] Use a fixed directory for TestPluginManager.

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/TestPluginManager.java
+++ b/test/src/main/java/org/jvnet/hudson/test/TestPluginManager.java
@@ -57,7 +57,12 @@ public class TestPluginManager extends PluginManager {
 
     private TestPluginManager() throws IOException {
         // TestPluginManager outlives a Jetty server, so can't pass in ServletContext.
-        super(null, Util.createTempDir());
+        this(Util.createTempDir());
+    }
+
+    private TestPluginManager(File dir) throws IOException {
+        // TestPluginManager outlives a Jetty server, so can't pass in ServletContext.
+        super(null, dir);
     }
 
     @Override
@@ -123,7 +128,14 @@ public class TestPluginManager extends PluginManager {
 
     static {
         try {
-            INSTANCE = new TestPluginManager();
+            File rootDir = new File("./target/plugin-manager-for-test").getAbsoluteFile();
+            if(rootDir.exists()) {
+                // Cleanup rootDir if already exists.
+                // It is created in the last test execution and contains old plugins.
+                // This often happens in Windows.
+                Util.deleteRecursive(rootDir);
+            }
+            INSTANCE = new TestPluginManager(rootDir);
             Runtime.getRuntime().addShutdownHook(new Thread("delete " + INSTANCE.rootDir) {
                 @Override public void run() {
                     try {


### PR DESCRIPTION
TestPluginManager expands plugins to a temporary directory at the start of all tests. This temporary directory is deleted with a shutdown hook of JVM. 

In Windows, for JVM holds the handle of jar files bundled with plugins, it always fails to delete the temporary directory where plugins expanded. That is, ${java.io.tmpdir}/hudson*tmp is left even after the test finishes. Every time a test runs, the size of the temporary directory grows up.

TestPluginManager seems not need to use a different directory every time. Using a fixed directory prevents the size of the temporary directory growing up.

[JENKINS-4409](https://issues.jenkins-ci.org/browse/JENKINS-4409)
