### PR TITLE
Using mojo extra-enforcer-rules enforceBytecodeVersion.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,9 @@ THE SOFTWARE.
     <slf4jVersion>1.6.2</slf4jVersion> <!-- < 1.6.x version didn't specify the license (MIT) -->
     <netbeans.compile.on.save>none</netbeans.compile.on.save> <!-- we rely on Maven source generation -->
     <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>
+
+    <mcompiler.source>1.5</mcompiler.source>
+    <mcompiler.target>${mcompiler.source}</mcompiler.target>
   </properties>
 
 
@@ -625,7 +628,7 @@ THE SOFTWARE.
                   <version>3.0</version>
                 </requireMavenVersion>
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>1.6</maxJdkVersion>
+                  <maxJdkVersion>${mcompiler.target}</maxJdkVersion>
                 </enforceBytecodeVersion>
               </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -624,10 +624,20 @@ THE SOFTWARE.
                 <requireMavenVersion>
                   <version>3.0</version>
                 </requireMavenVersion>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.6</maxJdkVersion>
+                </enforceBytecodeVersion>
               </rules>
             </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.0-alpha-4</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
This rule enforces a bytecode version in dependencies.
This would prevent cases like [JENKINS-8914](https://issues.jenkins-ci.org/browse/JENKINS-8914) where someone had
introduced a dependency compiled with JDK1.6 at a time where
Jenkins was still on 1.5.

With 1.7 already here and 1.8 coming, this should help no to do that
again.
