### PR TITLE
[FIXED JENKINS-18011] Deadlock issue with slaves on Windows

### DIFF
--- a/core/src/main/java/hudson/Proc.java
+++ b/core/src/main/java/hudson/Proc.java
@@ -176,7 +176,7 @@ public abstract class Proc {
      */
     public static final class LocalProc extends Proc {
         private final Process proc;
-        private final Thread copier,copier2;
+        private final StreamCopyThread copier,copier2;
         private final OutputStream out;
         private final EnvVars cookie;
         private final String name;
@@ -320,31 +320,17 @@ public abstract class Proc {
                 // see http://wiki.jenkins-ci.org/display/JENKINS/Spawning+processes+from+build
                 // problems like that shows up as infinite wait in join(), which confuses great many users.
                 // So let's do a timed wait here and try to diagnose the problem
-                if (copier!=null)   copier.join(10*1000);
-                if(copier2!=null)   copier2.join(10*1000);
-                if((copier!=null && copier.isAlive()) || (copier2!=null && copier2.isAlive())) {
-                    // looks like handles are leaking.
-                    // closing these handles should terminate the threads.
-                    String msg = "Process leaked file descriptors. See http://wiki.jenkins-ci.org/display/JENKINS/Spawning+processes+from+build for more information";
-                    Throwable e = new Exception().fillInStackTrace();
-                    LOGGER.log(Level.WARNING,msg,e);
-
-                    // doing proc.getInputStream().close() hangs in FileInputStream.close0()
-                    // it could be either because another thread is blocking on read, or
-                    // it could be a bug in Windows JVM. Who knows.
-                    // so I'm abandoning the idea of closing the stream
-//                    try {
-//                        proc.getInputStream().close();
-//                    } catch (IOException x) {
-//                        LOGGER.log(Level.FINE,"stdin termination failed",x);
-//                    }
-//                    try {
-//                        proc.getErrorStream().close();
-//                    } catch (IOException x) {
-//                        LOGGER.log(Level.FINE,"stderr termination failed",x);
-//                    }
-                    out.write(msg.getBytes());
-                    out.write('\n');
+                if (copier != null) {
+                    copier.join(10 * 1000);
+                }
+                if (copier2 != null) {
+                    copier2.join(10 * 1000);
+                }
+                if (copier != null && copier.isAlive()) {
+                    copier.close(true);
+                }
+                if (copier2 != null && copier2.isAlive()) {
+                    copier2.close(true);
                 }
                 return r;
             } catch (InterruptedException e) {

--- a/core/src/main/java/hudson/util/StreamCopyThread.java
+++ b/core/src/main/java/hudson/util/StreamCopyThread.java
@@ -33,9 +33,9 @@ import java.io.OutputStream;
  * @author Kohsuke Kawaguchi
  */
 public class StreamCopyThread extends Thread {
-    private final InputStream in;
-    private final OutputStream out;
-    private final boolean closeOut;
+    private InputStream in;
+    private OutputStream out;
+    private boolean closeOut;
 
     public StreamCopyThread(String threadName, InputStream in, OutputStream out, boolean closeOut) {
         super(threadName);
@@ -54,20 +54,38 @@ public class StreamCopyThread extends Thread {
     @Override
     public void run() {
         try {
-            try {
-                byte[] buf = new byte[8192];
-                int len;
-                while ((len = in.read(buf)) >= 0)
-                    out.write(buf, 0, len);
-            } finally {
-                // it doesn't make sense not to close InputStream that's already EOF-ed,
-                // so there's no 'closeIn' flag.
-                in.close();
-                if(closeOut)
-                    out.close();
+            byte[] buf = new byte[8192];
+            int len;
+            while ((len = in.read(buf)) > 0) {
+                out.write(buf, 0, len);
             }
         } catch (IOException e) {
-            // TODO: what to do?
+        } finally {
+            // it doesn't make sense not to close InputStream that's already
+            // EOF-ed,
+            // so there's no 'closeIn' flag.
+            close(closeOut);
+        }
+
+    }
+
+    public void close(boolean closeOut) {
+        if (closeOut) {
+            try {
+                if (out != null) {
+                    out.close();
+                }
+                out = null;
+            } catch (IOException e) {
+            }
+        }
+
+        try {
+            if (in != null) {
+                in.close();
+            }
+            in = null;
+        } catch (IOException e) {
         }
     }
 }


### PR DESCRIPTION
...The error occures if we have several threads trying to write the output from the screen as well as when a slave has been running for a longer period with a lot of output. The problem was verified to exist in Jenkins LTS 1.509.1 and can reproduced with a overload plugin https://github.com/hanabishi/jenkins-overload. Used to work around [JENKINS-18011](https://issues.jenkins-ci.org/browse/JENKINS-18011).

(Supersedes #665.)
