### PR TITLE
[Fixed JENKINS-18024] Avoid NPE

### DIFF
--- a/core/src/main/java/hudson/matrix/DefaultMatrixExecutionStrategyImpl.java
+++ b/core/src/main/java/hudson/matrix/DefaultMatrixExecutionStrategyImpl.java
@@ -314,7 +314,7 @@ public class DefaultMatrixExecutionStrategyImpl extends MatrixExecutionStrategy 
             if(qi!=null) {
                 // if the build seems to be stuck in the queue, display why
                 String why = qi.getWhy();
-                if(!why.equals(whyInQueue) && System.currentTimeMillis()-startTime>5000) {
+                if(!whyInQueue.equals(why) && System.currentTimeMillis()-startTime>5000) {
                     listener.getLogger().print("Configuration " + ModelHyperlinkNote.encodeTo(c)+" is still in the queue: ");
                     qi.getCauseOfBlockage().print(listener); //this is still shown on the same line
                     whyInQueue = why;


### PR DESCRIPTION
Reoson why item is in the queue can be null and in such cases we will hit NPE. As whyInQueue is local variable initialized as empty string and is assigned only when the reason is not null, this should prevent NPE.
