### PR TITLE
Fix TestResult.toPrettyString() pass count

### DIFF
--- a/core/src/main/java/hudson/tasks/test/TestResult.java
+++ b/core/src/main/java/hudson/tasks/test/TestResult.java
@@ -246,7 +246,7 @@ public abstract class TestResult extends TestObject {
         sb.append("Total Count: ").append(this.getTotalCount()).append(", ");
         sb.append("Fail: ").append(this.getFailCount()).append(", ");
         sb.append("Skipt: ").append(this.getSkipCount()).append(", ");
-        sb.append("Pass: ").append(this.getSkipCount()).append(",\n");
+        sb.append("Pass: ").append(this.getPassCount()).append(",\n");
         sb.append("Test Result Class: " ).append(this.getClass().getName()).append(" }\n");
         return sb.toString(); 
     }


### PR DESCRIPTION
TestResult.toPrettyString() actually used skip count, when reporting pass count, probably a copy-paste error. Fixed to report pass count.
