### PR TITLE
List jobs from view recursively when queried by `list-jobs` CLI command

### DIFF
--- a/core/src/main/java/hudson/cli/ListJobsCommand.java
+++ b/core/src/main/java/hudson/cli/ListJobsCommand.java
@@ -49,9 +49,23 @@ public class ListJobsCommand extends CLICommand {
     public String name;
 
     protected int run() throws Exception {
-        Jenkins h = Jenkins.getInstance();
-        final Collection<TopLevelItem> jobs;
+        final Collection<TopLevelItem> jobs = getJobs(Jenkins.getInstance());
 
+        if (jobs.isEmpty()) {
+            stderr.println("No view or item group with the given name found");
+        }
+
+        // Print all jobs.
+        for (TopLevelItem item : jobs) {
+            stdout.println(item.getDisplayName());
+        }
+
+        return 0;
+    }
+
+    /*package*/ Collection<TopLevelItem> getJobs(final Jenkins h) {
+
+        final Collection<TopLevelItem> jobs;
         // If name is given retrieve jobs for the given view.
         if (name != null) {
             View view = h.getView(name);
@@ -70,7 +84,7 @@ public class ListJobsCommand extends CLICommand {
                 }
                 // No view and no item group with the given name found.
                 else {
-                    stderr.println("No view or item group with the given name found");
+
                     jobs = Collections.emptyList();
                 }
             }
@@ -79,12 +93,6 @@ public class ListJobsCommand extends CLICommand {
         else {
             jobs = h.getItems();
         }
-
-        // Print all jobs.
-        for (TopLevelItem item : jobs) {
-            stdout.println(item.getDisplayName());
-        }
-
-        return 0;
+        return jobs;
     }
 }

--- a/core/src/main/java/hudson/cli/ListJobsCommand.java
+++ b/core/src/main/java/hudson/cli/ListJobsCommand.java
@@ -25,10 +25,14 @@ package hudson.cli;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
 import hudson.model.View;
+import hudson.model.ViewGroup;
 import hudson.Extension;
 import jenkins.model.Jenkins;
 import org.kohsuke.args4j.Argument;
@@ -71,7 +75,7 @@ public class ListJobsCommand extends CLICommand {
             View view = h.getView(name);
 
             if (view != null) {
-                jobs = view.getItems();
+                jobs = getViewItems(view);
             }
             // If no view was found, try with an item group.
             else {
@@ -93,6 +97,23 @@ public class ListJobsCommand extends CLICommand {
         else {
             jobs = h.getItems();
         }
+        return jobs;
+    }
+
+    private Collection<TopLevelItem> getViewItems(View view) {
+
+        final Collection<TopLevelItem> jobs = new LinkedHashSet<TopLevelItem>(
+                view.getItems()
+        );
+
+        if (view instanceof ViewGroup) {
+
+            for(View subview: ((ViewGroup) view).getViews()) {
+
+                jobs.addAll(getViewItems(subview));
+            }
+        }
+
         return jobs;
     }
 }

--- a/core/src/test/java/hudson/cli/ListAllJobsTest.java
+++ b/core/src/test/java/hudson/cli/ListAllJobsTest.java
@@ -1,19 +1,21 @@
 package hudson.cli;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertSame;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import hudson.model.TopLevelItem;
+import hudson.model.ViewGroup;
 import hudson.model.View;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import jenkins.model.Jenkins;
 
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -33,25 +35,55 @@ public class ListAllJobsTest {
     @Test
     public void getAllJobsForEmptyName() {
 
-        final List<TopLevelItem> jenkinsJobs = Collections.emptyList();
+        final Collection<TopLevelItem> jenkinsJobs = Arrays.asList(
+                mock(TopLevelItem.class)
+        );
 
-        when(jenkins.getItems()).thenReturn(jenkinsJobs);
+        when(jenkins.getItems()).thenReturn((List<TopLevelItem>)jenkinsJobs);
 
         // Display whatever Jenkins.getItems() returns
-        assertSame(jenkinsJobs, getJobsFor(null));
+        assertThat(getJobsFor(null), equalToInAnyOrder(jenkinsJobs));
     }
 
     @Test
     public void getJobsFromView() {
 
-        final List<TopLevelItem> viewJobs = Collections.emptyList();
+        final Collection<TopLevelItem> viewJobs = Arrays.asList(
+                mock(TopLevelItem.class)
+        );
 
         final View customView = mock(View.class);
         when(customView.getItems()).thenReturn(viewJobs);
 
         when(jenkins.getView("CustomView")).thenReturn(customView);
 
-        assertSame(viewJobs, getJobsFor("CustomView"));
+        assertThat(getJobsFor("CustomView"), equalToInAnyOrder(viewJobs));
+    }
+
+    @Test
+    public void getJobsRecursivelyFromViewGroup() {
+
+        final CompositeView rootView = mock(CompositeView.class);
+        final View leftView = mock(View.class);
+        final View rightView = mock(View.class);
+
+        final TopLevelItem rootJob = mock(TopLevelItem.class);
+        final TopLevelItem leftJob = mock(TopLevelItem.class);
+        final TopLevelItem rightJob = mock(TopLevelItem.class);
+        final TopLevelItem sharedJob = mock(TopLevelItem.class);
+
+        when(rootView.getViews()).thenReturn(Arrays.asList(leftView, rightView));
+        when(rootView.getItems()).thenReturn(Arrays.asList(rootJob, sharedJob));
+        when(leftView.getItems()).thenReturn(Arrays.asList(leftJob, sharedJob));
+        when(rightView.getItems()).thenReturn(Arrays.asList(rightJob));
+
+        when(jenkins.getView("Root")).thenReturn(rootView);
+
+        final Collection<TopLevelItem> allJobs = Arrays.asList(
+                rootJob, sharedJob, leftJob, rightJob
+        );
+
+        assertThat(getJobsFor("Root"), equalToInAnyOrder(allJobs));
     }
 
     private Collection<TopLevelItem> getJobsFor(final String name) {
@@ -59,5 +91,37 @@ public class ListAllJobsTest {
         command.name = name;
 
         return command.getJobs(jenkins);
+    }
+
+    private <T> BaseMatcher<Collection<T>> equalToInAnyOrder(
+            final Collection<T> expected
+    ) {
+
+        return new BaseMatcher<Collection<T>>() {
+
+            @Override
+            public boolean matches(Object item) {
+
+                if (!(item instanceof Collection)) return false;
+
+                @SuppressWarnings("unchecked")
+                final Collection<T> actual = (Collection<T>) item;
+
+                return new HashSet<T>(expected).equals(new HashSet<T>(actual));
+            }
+
+            @Override
+            public void describeTo(Description description) {
+
+                description.appendText("Collection containing in any order " + expected);
+            }
+        };
+    }
+
+    private abstract static class CompositeView extends View implements ViewGroup {
+
+        protected CompositeView(String name) {
+            super(name);
+        }
     }
 }

--- a/core/src/test/java/hudson/cli/ListAllJobsTest.java
+++ b/core/src/test/java/hudson/cli/ListAllJobsTest.java
@@ -1,0 +1,63 @@
+package hudson.cli;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import hudson.model.TopLevelItem;
+import hudson.model.View;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import jenkins.model.Jenkins;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ListAllJobsTest {
+
+    @Mock private Jenkins jenkins;
+    private final ListJobsCommand command = new ListJobsCommand();
+
+    @Before
+    public void setUp() {
+
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void getAllJobsForEmptyName() {
+
+        final List<TopLevelItem> jenkinsJobs = Collections.emptyList();
+
+        when(jenkins.getItems()).thenReturn(jenkinsJobs);
+
+        // Display whatever Jenkins.getItems() returns
+        assertSame(jenkinsJobs, getJobsFor(null));
+    }
+
+    @Test
+    public void getJobsFromView() {
+
+        final List<TopLevelItem> viewJobs = Collections.emptyList();
+
+        final View customView = mock(View.class);
+        when(customView.getItems()).thenReturn(viewJobs);
+
+        when(jenkins.getView("CustomView")).thenReturn(customView);
+
+        assertSame(viewJobs, getJobsFor("CustomView"));
+    }
+
+    private Collection<TopLevelItem> getJobsFor(final String name) {
+
+        command.name = name;
+
+        return command.getJobs(jenkins);
+    }
+}


### PR DESCRIPTION
Currently, `list-jobs` simply lists all jobs associated with particular view. I propose to traverse all subviews that might be associated. This situation occurs when `View` implements `ViewGroup` as well.

This change is apparent when Nested View Plugin is used. A top level view appears empty prior this change while after this change it lists all the jobs transitively contained in the view.
