### PR TITLE
[FIXED JENKINS-4409] release class loaders when each test finishes

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/TestPluginManager.java
+++ b/test/src/main/java/org/jvnet/hudson/test/TestPluginManager.java
@@ -113,12 +113,6 @@ public class TestPluginManager extends PluginManager {
         return names;
     }
     
-    @Override
-    public void stop() {
-        for (PluginWrapper p : activePlugins)
-            p.stop();
-    }
-
     private static final Logger LOGGER = Logger.getLogger(TestPluginManager.class.getName());
 
     static {


### PR DESCRIPTION
When Jenkins stops, `PluginManager#stop` is called. It stops plugins and releases class loaders.
`TestPluginManager`, which is used when running tests, overrides `stop` and does not release class loaders. This results JVM not to release handles of jar files, and in Windows, temporary directories fail to be deleted when test finishes.

This patch removes `TestPluginManager#stop`, and `PluginManager#stop` is called instead.

I'm not sure why `TestPluginManager` masked `PluginManager#stop`. As far as I tested, no errors happen even running multiple test methods, or tests does not get slow.
