### PR TITLE
Add support for scalatest-maven-plugin test results.

### DIFF
--- a/maven-plugin/src/test/java/hudson/maven/reporters/TestMojoTest.java
+++ b/maven-plugin/src/test/java/hudson/maven/reporters/TestMojoTest.java
@@ -2,6 +2,8 @@ package hudson.maven.reporters;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -80,5 +82,147 @@ public class TestMojoTest {
         } finally {
             testResults.delete();
         }
+    }
+
+    @Test
+    public void testScalatestMavenPluginNoJunitxml() throws Exception {
+        runScalatestPluginTestNoEntries(null);
+    }
+
+    @Test
+    public void testScalatestMavenPluginEmptyJunitxml() throws Exception {
+        runScalatestPluginTestNoEntries("");
+    }
+
+    @Test
+    public void testScalatestMavenPluginJunitxmlHasListOfEmptyEntries() throws Exception {
+        runScalatestPluginTestNoEntries(", ");
+    }
+
+    @Test
+    public void testScalatestMavenPluginJunitxmlEntryDoesntExist() throws Exception {
+        runScalatestPluginTestNoEntries("foo");
+    }
+
+    @Test
+    public void testScalatestMavenPluginJunitxmlHasOneEntry() throws Exception {
+        runScalatestPluginTestOneEntry("ut-xml", "ut-xml");
+    }
+
+    @Test
+    public void testScalatestMavenPluginJunitxmlHasOneEntryAndTrailingDummy() throws Exception {
+        runScalatestPluginTestOneEntry("ut-xml,", "ut-xml");
+    }
+
+    @Test
+    public void testScalatestMavenPluginJunitxmlHasOneEntryAndLeadingDummy() throws Exception {
+        runScalatestPluginTestOneEntry(",ut-xml", "ut-xml");
+    }
+
+    @Test
+    public void testScalatestMavenPluginJunitxmlHasOneEntryAndDummiesOnBothEnds() throws Exception {
+        runScalatestPluginTestOneEntry(",ut-xml,", "ut-xml");
+    }
+
+    @Test
+    public void testScalatestMavenPluginJunitxmlHasMultipleEntries() throws Exception {
+        runScalatestPluginTestOneEntry("ut-xml, foo, baz", "ut-xml");
+    }
+
+    @Test
+    public void testScalatestMavenPluginJunitxmlHasMultipleEntriesAndFirstOneInvalid()
+            throws Exception {
+        runScalatestPluginTestOneEntry("foo, ut-xml, baz", "ut-xml");
+    }
+
+    @Test
+    public void testScalatestMavenPluginJunitxmlHasMultipleEntriesWithEscapedCommas()
+            throws Exception {
+        runScalatestPluginTestOneEntry("ut\\,xml, foo, baz", "ut,xml");
+    }
+
+    @Test
+    public void testScalatestMavenPluginJunitxmlHasMultipleEntriesWithFormat()
+            throws Exception {
+        runScalatestPluginTestOneEntry("F\\,mt ut-xml, foo, baz", "ut-xml");
+    }
+
+    private void runScalatestPluginTestNoEntries(final String junitxml) throws Exception {
+        runScalatestPluginTest("", new ScalatestPluginTest() {
+            public void run(MojoInfoBuilder mojoBuilder, MavenProject pom,
+                            String testResultsName) throws Exception {
+                if (junitxml != null)
+                    mojoBuilder = mojoBuilder.configValue("junitxml", junitxml);
+                MojoInfo mojoInfo = mojoBuilder.build();
+
+                Iterable<File> files =
+                        TestMojo.SCALATEST_MAVEN_PLUGIN.getReportFiles(pom, mojoInfo);
+                assertNull("unexpected report files returned", files);
+            }
+        });
+    }
+
+    private void runScalatestPluginTestOneEntry(final String junitxml, String expectedDir)
+            throws Exception {
+        runScalatestPluginTest(expectedDir, new ScalatestPluginTest() {
+            public void run(MojoInfoBuilder mojoBuilder, MavenProject pom,
+                            String testResultsName) throws Exception {
+                MojoInfo mojoInfo = mojoBuilder.configValue("junitxml", junitxml).build();
+
+                Iterable<File> files =
+                        TestMojo.SCALATEST_MAVEN_PLUGIN.getReportFiles(pom, mojoInfo);
+                assertHasOneFile(files, testResultsName);
+            }
+        });
+    }
+
+    private void assertHasOneFile(Iterable<File> files, String expectedFile) {
+        assertNotNull("no report files returned", files);
+
+        boolean found = false;
+        for (File file : files) {
+            assertFalse("unexpected report files returned: " + file, found);
+            assertEquals(expectedFile, file.getName());
+            found = true;
+        }
+        assertTrue("report file not found", found);
+    }
+
+    private void runScalatestPluginTest(String junitXmlDirName, ScalatestPluginTest test)
+            throws Exception {
+        final String testResultsName = "TEST-are-we-foobared.xml";
+
+        File testDir = hudson.Util.createTempDir();
+        File targetDir = new File(testDir, "target");
+        File reportsDir = new File(targetDir, "scalatest-reports");
+        File junitXmlDir = new File(reportsDir, junitXmlDirName);
+        assertTrue(junitXmlDir.mkdirs());
+
+        MojoInfoBuilder mojoBuilder =
+                MojoInfoBuilder.mojoBuilder("org.scalatest", "scalatest-maven-plugin", "test")
+                               .configValue("reportsDirectory", reportsDir.toString());
+
+        File testResults = new File(junitXmlDir, testResultsName);
+        try {
+            FileWriter fw = new FileWriter(testResults, false);
+            fw.write("this is a fake junit reports file");
+            fw.close();
+
+            MavenProject pom = mock(MavenProject.class);
+            when(pom.getBasedir()).thenReturn(testDir);
+
+            Build build = mock(Build.class);
+            when(build.getDirectory()).thenReturn(targetDir.getAbsolutePath());
+            when(pom.getBuild()).thenReturn(build);
+
+            test.run(mojoBuilder, pom, testResultsName);
+        } finally {
+            testResults.delete();
+        }
+    }
+
+    private static interface ScalatestPluginTest {
+        public void run(MojoInfoBuilder mojoBuilder, MavenProject pom,
+                        String testResultsName) throws Exception;
     }
 }


### PR DESCRIPTION
This is version 2 of the patch for https://issues.jenkins-ci.org/browse/JENKINS-18086 and supersedes https://github.com/jenkinsci/jenkins/pull/789 .
