### PR TITLE
List Jobs recursively in hudson.cli.ListJobsCommand

### DIFF
--- a/core/src/main/java/hudson/cli/ListJobsCommand.java
+++ b/core/src/main/java/hudson/cli/ListJobsCommand.java
@@ -24,7 +24,9 @@
 package hudson.cli;
 
 import java.util.Collection;
+
 import java.util.Collections;
+
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;

--- a/core/src/main/java/hudson/cli/ListJobsCommand.java
+++ b/core/src/main/java/hudson/cli/ListJobsCommand.java
@@ -24,12 +24,14 @@
 package hudson.cli;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 
 import java.util.Collections;
 
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
+import hudson.model.ViewGroup;
 import hudson.model.View;
 import hudson.Extension;
 import jenkins.model.Jenkins;
@@ -59,7 +61,7 @@ public class ListJobsCommand extends CLICommand {
             View view = h.getView(name);
 
             if (view != null) {
-                jobs = view.getItems();
+                jobs = getViewItems(view);
             }
             // If no view was found, try with an item group.
             else {
@@ -88,5 +90,21 @@ public class ListJobsCommand extends CLICommand {
         }
 
         return 0;
+    }
+
+    private Collection<TopLevelItem> getViewItems(View view) {
+
+        final Collection<TopLevelItem> jobs = new LinkedHashSet<TopLevelItem>(
+                view.getItems()
+        );
+
+        if (view instanceof ViewGroup) {
+
+            for(View subview: ((ViewGroup) view).getViews()) {
+
+                jobs.addAll(getViewItems(subview));
+            }
+        }
+        return jobs;
     }
 }

--- a/core/src/main/java/hudson/cli/ListJobsCommand.java
+++ b/core/src/main/java/hudson/cli/ListJobsCommand.java
@@ -61,7 +61,7 @@ public class ListJobsCommand extends CLICommand {
             View view = h.getView(name);
 
             if (view != null) {
-                jobs = getViewItems(view);
+                jobs = view.getAllItems();
             }
             // If no view was found, try with an item group.
             else {
@@ -90,21 +90,5 @@ public class ListJobsCommand extends CLICommand {
         }
 
         return 0;
-    }
-
-    private Collection<TopLevelItem> getViewItems(View view) {
-
-        final Collection<TopLevelItem> jobs = new LinkedHashSet<TopLevelItem>(
-                view.getItems()
-        );
-
-        if (view instanceof ViewGroup) {
-
-            for(View subview: ((ViewGroup) view).getViews()) {
-
-                jobs.addAll(getViewItems(subview));
-            }
-        }
-        return jobs;
     }
 }

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -93,6 +93,7 @@ import java.util.Comparator;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -175,6 +176,27 @@ public abstract class View extends AbstractModelObject implements AccessControll
      */
     @Exported(name="jobs")
     public abstract Collection<TopLevelItem> getItems();
+
+    /**
+     * Gets all the items recursively contained in this collection in a read-only view.
+     * @since 1.520
+     */
+    public Collection<TopLevelItem> getAllItems() {
+
+        final Collection<TopLevelItem> items = new LinkedHashSet<TopLevelItem>(
+                getItems()
+        );
+
+        if (this instanceof ViewGroup) {
+
+            for(final View view: ((ViewGroup) this).getViews()) {
+
+                items.addAll(view.getAllItems());
+            }
+        }
+
+        return Collections.unmodifiableCollection(items);
+    }
 
     /**
      * Gets the {@link TopLevelItem} of the given name.

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -9,6 +9,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import hudson.model.TopLevelItem;
 import hudson.model.ViewGroup;
+import hudson.model.ViewTest.CompositeView;
 import hudson.model.View;
 
 import java.io.ByteArrayOutputStream;
@@ -84,7 +85,7 @@ public class ListJobsCommandTest {
                 job("some-job"), job("some-other-job")
         );
 
-        final View customView = mock(View.class);
+        final View customView = view();
         when(customView.getItems()).thenReturn(viewJobs);
 
         when(jenkins.getView("CustomView")).thenReturn(customView);
@@ -98,8 +99,9 @@ public class ListJobsCommandTest {
     public void getJobsRecursivelyFromViewGroup() throws Exception {
 
         final CompositeView rootView = mock(CompositeView.class);
-        final View leftView = mock(View.class);
-        final View rightView = mock(View.class);
+        when(rootView.getAllItems()).thenCallRealMethod();
+        final View leftView = view();
+        final View rightView = view();
 
         final TopLevelItem rootJob = job("rootJob");
         final TopLevelItem leftJob = job("leftJob");
@@ -116,6 +118,15 @@ public class ListJobsCommandTest {
         assertThat(runWith("Root"), equalTo(0));
         assertThat(stderr, is(empty()));
         assertThat(stdout, listsJobs("rootJob", "leftJob", "rightJob", "sharedJob"));
+    }
+
+    private View view() {
+
+        final View view = mock(View.class);
+
+        when(view.getAllItems()).thenCallRealMethod();
+
+        return view;
     }
 
     private TopLevelItem job(final String name) {
@@ -172,12 +183,5 @@ public class ListJobsCommandTest {
                 description.appendText("Job listing of " + Arrays.toString(expected));
             }
         };
-    }
-
-    private abstract static class CompositeView extends View implements ViewGroup {
-
-        protected CompositeView(String name) {
-            super(name);
-        }
     }
 }

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -1,0 +1,165 @@
+package hudson.cli;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import hudson.model.TopLevelItem;
+import hudson.model.ViewGroup;
+import hudson.model.View;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import jenkins.model.Jenkins;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Jenkins.class)
+@SuppressStaticInitializationFor("hudson.cli.CLICommand")
+public class ListJobsCommandTest {
+
+    private /*final*/ Jenkins jenkins;
+    private /*final*/ ListJobsCommand command;
+    private final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+    @Before
+    public void setUp() {
+
+        jenkins = mock(Jenkins.class);
+        mockStatic(Jenkins.class);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+        command = mock(ListJobsCommand.class, Mockito.CALLS_REAL_METHODS);
+        command.stdout = new PrintStream(stdout);
+        command.stderr = new PrintStream(stderr);
+    }
+
+    @Test
+    public void getNullForNonexistingName() throws Exception {
+
+        when(jenkins.getView(null)).thenReturn(null);
+        when(jenkins.getItemByFullName(null)).thenReturn(null);
+
+        // TODO: One would expect -1 here
+        assertThat(runWith("NoSuchViewOrItemGroup"), equalTo(0));
+        assertThat(stdout, is(empty()));
+        assertThat(stderr, is(not(empty())));
+    }
+
+    @Test
+    public void getAllJobsForEmptyName() throws Exception {
+
+        final Collection<TopLevelItem> jenkinsJobs = Arrays.asList(
+                job("some-job"), job("some-other-job")
+        );
+
+        when(jenkins.getItems()).thenReturn((List<TopLevelItem>) jenkinsJobs);
+
+        assertThat(runWith(null), equalTo(0));
+        assertThat(stderr, is(empty()));
+        assertThat(stdout, listsJobs("some-job", "some-other-job"));
+    }
+
+    @Test
+    public void getJobsFromView() throws Exception {
+
+        final Collection<TopLevelItem> viewJobs = Arrays.asList(
+                job("some-job"), job("some-other-job")
+        );
+
+        final View customView = mock(View.class);
+        when(customView.getItems()).thenReturn(viewJobs);
+
+        when(jenkins.getView("CustomView")).thenReturn(customView);
+
+        assertThat(runWith("CustomView"), equalTo(0));
+        assertThat(stderr, is(empty()));
+        assertThat(stdout, listsJobs("some-job", "some-other-job"));
+    }
+
+    private TopLevelItem job(final String name) {
+
+        final TopLevelItem item = mock(TopLevelItem.class);
+
+        when(item.getDisplayName()).thenReturn(name);
+
+        return item;
+    }
+
+    private int runWith(final String name) throws Exception {
+
+        command.name = name;
+
+        return command.run();
+    }
+
+    private <T> BaseMatcher<ByteArrayOutputStream> empty() {
+
+        return new BaseMatcher<ByteArrayOutputStream>() {
+
+            @Override
+            public boolean matches(Object item) {
+
+                if (!(item instanceof ByteArrayOutputStream)) throw new IllegalArgumentException();
+
+                return ((ByteArrayOutputStream) item).toString().isEmpty();
+            }
+
+            @Override
+            public void describeTo(Description description) {
+
+                description.appendText("Empty output");
+            }
+        };
+    }
+
+    private BaseMatcher<ByteArrayOutputStream> listsJobs(final String... expected) {
+
+        return new BaseMatcher<ByteArrayOutputStream>() {
+
+            @Override
+            public boolean matches(Object item) {
+
+                if (!(item instanceof ByteArrayOutputStream)) return false;
+
+                final ByteArrayOutputStream actual = (ByteArrayOutputStream) item;
+
+                final HashSet<String> jobs = new HashSet<String>(
+                        Arrays.asList(actual.toString().split("\n"))
+                );
+
+                return new HashSet<String>(Arrays.asList(expected)).equals(jobs);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+
+                description.appendText("Job listing of " + Arrays.toString(expected));
+            }
+        };
+    }
+
+    private abstract static class CompositeView extends View implements ViewGroup {
+
+        protected CompositeView(String name) {
+            super(name);
+        }
+    }
+}

--- a/core/src/test/java/hudson/model/ViewTest.java
+++ b/core/src/test/java/hudson/model/ViewTest.java
@@ -5,6 +5,7 @@ import hudson.search.SearchIndexBuilder;
 import hudson.search.SearchItem;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -64,5 +65,46 @@ public class ViewTest {
         actual = result.get(0);
         Assert.assertEquals(actual.getSearchName(), item2.getDisplayName());
         Assert.assertEquals(actual.getSearchUrl(), item2.getSearchUrl());
+    }
+
+    /*
+     * Get all items recursively when View implements ViewGroup at the same time
+     */
+    @Test
+    public void getAllItems() throws Exception {
+
+        final CompositeView rootView = Mockito.mock(CompositeView.class);
+        final View leftView = Mockito.mock(View.class);
+        final View rightView = Mockito.mock(View.class);
+
+        Mockito.when(rootView.getAllItems()).thenCallRealMethod();
+        Mockito.when(leftView.getAllItems()).thenCallRealMethod();
+        Mockito.when(rightView.getAllItems()).thenCallRealMethod();
+
+        final TopLevelItem rootJob = Mockito.mock(TopLevelItem.class);
+        final TopLevelItem leftJob = Mockito.mock(TopLevelItem.class);
+        final TopLevelItem rightJob = Mockito.mock(TopLevelItem.class);
+        final TopLevelItem sharedJob = Mockito.mock(TopLevelItem.class);
+
+        Mockito.when(rootJob.getDisplayName()).thenReturn("rootJob");
+        Mockito.when(leftJob.getDisplayName()).thenReturn("leftJob");
+        Mockito.when(rightJob.getDisplayName()).thenReturn("rightJob");
+        Mockito.when(sharedJob.getDisplayName()).thenReturn("sharedJob");
+
+        Mockito.when(rootView.getViews()).thenReturn(Arrays.asList(leftView, rightView));
+        Mockito.when(rootView.getItems()).thenReturn(Arrays.asList(rootJob, sharedJob));
+        Mockito.when(leftView.getItems()).thenReturn(Arrays.asList(leftJob, sharedJob));
+        Mockito.when(rightView.getItems()).thenReturn(Arrays.asList(rightJob));
+
+        final TopLevelItem[] expected = new TopLevelItem[] {rootJob, sharedJob, leftJob, rightJob};
+
+        Assert.assertArrayEquals(expected, rootView.getAllItems().toArray());
+    }
+
+    public static abstract class CompositeView extends View implements ViewGroup {
+
+        protected CompositeView(final String name) {
+            super(name);
+        }
     }
 }


### PR DESCRIPTION
Currently, `list-jobs` simply lists all jobs associated with particular view. I propose to traverse all subviews that might be associated. This situation occurs when `View` implements `ViewGroup` as well.

This change is apparent when Nested View Plugin is used. A top level view appears empty prior this change while after this change it lists all the jobs transitively contained in the view.

Reworked #787.
