### PR TITLE
simplify RestartListener.Default using getBusyExecutors()

### DIFF
--- a/core/src/main/java/hudson/model/RestartListener.java
+++ b/core/src/main/java/hudson/model/RestartListener.java
@@ -51,8 +51,7 @@ public abstract class RestartListener implements ExtensionPoint {
     public static class Default extends RestartListener {
         @Override
         public boolean isReadyToRestart() throws IOException, InterruptedException {
-            Jenkins h = Jenkins.getInstance();
-            return h.overallLoad.computeTotalExecutors() <= h.overallLoad.computeIdleExecutors();
+            return new ComputerSet().getBusyExecutors() != 0;
         }
     }
 }


### PR DESCRIPTION
computeIdleExecutors includes connecting slaves, that seems to be the root cause of a bug I'm trying to fix : overalLoadStatistics repport more idle executors than total, so safe restart don't wait for builds to complete.
isReadyToRestart seems unecessary complex to compute idle vs total considering there's already a ComputerSet method to return the busy executor count.
