### PR TITLE
[FIXED JENKINS-17451] "projects tied to slave" shows unrelated maven

### DIFF
--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -339,7 +339,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     public List<AbstractProject> getTiedJobs() {
         List<AbstractProject> r = new ArrayList<AbstractProject>();
         for (AbstractProject<?,?> p : Jenkins.getInstance().getAllItems(AbstractProject.class)) {
-            if(this.equals(p.getAssignedLabel()))
+            if(p instanceof TopLevelItem && this.equals(p.getAssignedLabel()))
                 r.add(p);
         }
         return r;


### PR DESCRIPTION
module jobs. shows TopLevelItem only.

Restricts displayed projects to TopLevelItem only as it has been proposed by jglick in the first fix attempt for this issue (https://github.com/jenkinsci/jenkins/commit/3a6de84f6746d54dd0f3048312db067c835ee727)
