### PR TITLE
added isFailed method to complement isPassed and isSkipped

### DIFF
--- a/core/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/core/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -479,6 +479,14 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
     public boolean isSkipped() {
         return skipped;
     }
+    
+    /**
+     * @return true if the test failed - i.e. was not skipped and did not pass.
+     * @since 1.520
+     */
+    public boolean isFailed() {
+        return !(isSkipped() || isPassed());
+    }
 
     /**
      * Provides the reason given for the test being being skipped.


### PR DESCRIPTION
I've seen people write

``` java
 !caseResult.isSkipped() && !caseResult.isPassed()
```

to check if a CaseResult has failed, so obviously 'isFailed' is missing
