### PR TITLE
Fix German i18n for Maven deploy

### DIFF
--- a/maven-plugin/src/main/resources/hudson/maven/Messages_de.properties
+++ b/maven-plugin/src/main/resources/hudson/maven/Messages_de.properties
@@ -49,8 +49,8 @@ MavenProbeAction.DisplayName=Maven Prozess überwachen
 
 MavenProcessFactory.ClassWorldsNotFound=Datei classworlds*.jar in {0} nicht gefunden -- Ist dies ein gültiges Maven2-Verzeichnis?
 
-MavenRedeployer.DisplayName=In Maven-Repository ausbringen (deploy)
+MavenRedeployer.DisplayName=In Maven-Repository veröffentlichen (deploy)
 ProcessCache.Reusing=Bestehenden Maven-Prozess wiederverwenden
 
-RedeployPublisher.getDisplayName=Bringe Artefakte in Maven-Repository aus (deploy)
+RedeployPublisher.getDisplayName=Veröffentliche Artefakte in Maven-Repository (deploy)
 ReleaseAction.DisplayName=Neue Version veröffentlichen (release)

--- a/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/config_de.properties
+++ b/maven-plugin/src/main/resources/hudson/maven/RedeployPublisher/config_de.properties
@@ -23,4 +23,4 @@
 Repository\ ID=Repository-ID
 Repository\ URL=Repository-URL
 Assign\ unique\ versions\ to\ snapshots=Snapshots eindeutige Versionen zuordnen
-Deploy\ even\ if\ the\ build\ is\ unstable=Ausbringen (deploy), auch wenn der Build instabil ist.
+Deploy\ even\ if\ the\ build\ is\ unstable=Veröffentlichen (deploy), auch wenn der Build instabil ist.

--- a/maven-plugin/src/main/resources/hudson/maven/reporters/MavenAbstractArtifactRecord/index_de.properties
+++ b/maven-plugin/src/main/resources/hudson/maven/reporters/MavenAbstractArtifactRecord/index_de.properties
@@ -22,6 +22,6 @@
 
 This\ page\ allows\ you\ to\ redeploy\ the\ build\ artifacts\ to\ a\ repository\ after\ the\ fact.=\
   Auf dieser Seite können Sie Artefakte im Nachhinein (also nach Abschluss eines Builds) \
-  in ein Maven-Repository ausbringen.
-Redeploy\ Artifacts=Artefakte ausbringen (deploy)
+  in ein Maven-Repository veröffentlichen.
+Redeploy\ Artifacts=Artefakte veröffentlichen (deploy)
 OK=OK


### PR DESCRIPTION
"ausbringen" is not the correct word for deploy, use "veröffentlichen" instead.
This has some overlap with maven release, which is also translated as "veröffentlichen", but it's obvious from the target name that follows what is meant.
