### PR TITLE
Add German translation for TextParameterDefinition.DisplayName

### DIFF
--- a/core/src/main/resources/hudson/model/Messages_de.properties
+++ b/core/src/main/resources/hudson/model/Messages_de.properties
@@ -281,6 +281,7 @@ Permalink.LastUnsuccessfulBuild=Letzter erfolgloser Build
 ParameterAction.DisplayName=Parameter
 ParametersDefinitionProperty.DisplayName=Parameter
 StringParameterDefinition.DisplayName=Text-Parameter
+TextParameterDefinition.DisplayName=Textbox-Parameter
 FileParameterDefinition.DisplayName=Datei-Parameter
 BooleanParameterDefinition.DisplayName=Bool'scher Wert
 ChoiceParameterDefinition.DisplayName=Auswahl


### PR DESCRIPTION
The translation of TextParameterDefinition.DisplayName was missing. So that there came up some confusion since there is a quite similar translation for StringParameterDefinition.DisplayName in comparison to the english default for TextParameterDefinition.DisplayName.
