### PR TITLE
[JENKINS-18259] Fixed "Unable to delete slave.log" in Windows

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -57,6 +57,7 @@ import hudson.model.*;
 import hudson.model.Executor;
 import hudson.model.Node.Mode;
 import hudson.model.Queue.Executable;
+import hudson.remoting.VirtualChannel;
 import hudson.remoting.Which;
 import hudson.security.ACL;
 import hudson.security.AbstractPasswordBasedSecurityRealm;
@@ -69,6 +70,7 @@ import hudson.slaves.ComputerListener;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
+import hudson.slaves.SlaveComputer;
 import hudson.tasks.Ant;
 import hudson.tasks.Ant.AntInstallation;
 import hudson.tasks.BuildWrapper;
@@ -378,6 +380,45 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         sites.add(new UpdateSite("default", updateCenterUrl));
     }
 
+    /**
+     * Disconnect all slaves.
+     * 
+     * Wait for disconnecting commands are sent to remote slaves.
+     * This should be called before calling Jenkins.cleanup().
+     * Though Jenkins.cleanup() also disconnects slaves,
+     * it does not wait for slaves shut down.
+     */
+    private void purgeSlaves() {
+        List<Computer> disconnectingComputers = new ArrayList<Computer>();
+        List<VirtualChannel> closingChannels = new ArrayList<VirtualChannel>();
+        for (Computer computer: jenkins.getComputers()) {
+            if (!(computer instanceof SlaveComputer)) {
+                continue;
+            }
+            // disconnect slaves.
+            // retrieve the channel before disconnecting.
+            // even a computer gets offline, channel delays to close.
+            if (!computer.isOffline()) {
+                VirtualChannel ch = computer.getChannel();
+                computer.disconnect(null);
+                disconnectingComputers.add(computer);
+                closingChannels.add(ch);
+            }
+        }
+        
+        try {
+            // Wait for all computers disconnected and all channels closed.
+            for (Computer computer: disconnectingComputers) {
+                computer.waitUntilOffline();
+            }
+            for (VirtualChannel ch: closingChannels) {
+                ch.join();
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
     @Override
     protected void tearDown() throws Exception {
         try {
@@ -400,8 +441,10 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             for (LenientRunnable r : tearDowns)
                 r.run();
 
-            if (jenkins!=null)
+            if (jenkins!=null) {
+                purgeSlaves();
                 jenkins.cleanUp();
+            }
             env.dispose();
             ExtensionList.clearLegacyInstances();
             DescriptorExtensionList.clearLegacyInstances();

--- a/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -57,8 +57,6 @@ import hudson.model.*;
 import hudson.model.Executor;
 import hudson.model.Node.Mode;
 import hudson.model.Queue.Executable;
-import hudson.remoting.Channel;
-import hudson.remoting.VirtualChannel;
 import hudson.remoting.Which;
 import hudson.security.ACL;
 import hudson.security.AbstractPasswordBasedSecurityRealm;
@@ -233,11 +231,6 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     private List<WebClient> clients = new ArrayList<WebClient>();
 
     /**
-     * Remember channels that are created, to release them at the end.
-     */
-    private List<Channel> channels = new ArrayList<Channel>();
-
-    /**
      * JavaScript "debugger" that provides you information about the JavaScript call stack
      * and the current values of the local variables in those stack frame.
      *
@@ -401,14 +394,6 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             }
             clients.clear();
 
-            synchronized(channels) {
-                for (Channel c : channels)
-                    c.close();
-                for (Channel c : channels)
-                    c.join();
-                channels.clear();
-            }
-
         } finally {
             if (server!=null)
                 server.stop();
@@ -543,22 +528,6 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         return realm;
     }
 
-    @TestExtension
-    public static class ComputerListenerImpl extends ComputerListener {
-        @Override
-        public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
-            VirtualChannel ch = c.getChannel();
-            if (ch instanceof Channel)
-            TestEnvironment.get().testCase.addChannel((Channel)ch);
-        }
-    }
-
-    private void addChannel(Channel ch) {
-        synchronized (channels) {
-            channels.add(ch);
-        }
-    }
-    
     /**
      * Returns the older default Maven, while still allowing specification of other bundled Mavens.
      */

--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -88,8 +88,6 @@ import hudson.model.TaskListener;
 import hudson.model.UpdateSite;
 import hudson.model.User;
 import hudson.model.View;
-import hudson.remoting.Channel;
-import hudson.remoting.VirtualChannel;
 import hudson.remoting.Which;
 import hudson.security.ACL;
 import hudson.security.AbstractPasswordBasedSecurityRealm;
@@ -264,11 +262,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     private List<WebClient> clients = new ArrayList<WebClient>();
 
     /**
-     * Remember channels that are created, to release them at the end.
-     */
-    private List<Channel> channels = new ArrayList<Channel>();
-
-    /**
      * JavaScript "debugger" that provides you information about the JavaScript call stack
      * and the current values of the local variables in those stack frame.
      *
@@ -409,20 +402,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
                 client.closeAllWindows();
             }
             clients.clear();
-
-            for (Channel c : channels)
-                try {
-                    c.close();
-                } catch (IOException e) {
-                    // ignore
-                }
-            for (Channel c : channels)
-                try {
-                    c.join();
-                } catch (InterruptedException e) {
-                    // ignore
-                }
-            channels.clear();
 
         } finally {
             try {
@@ -613,17 +592,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
         return realm;
     }
-
-    @TestExtension
-    public static class ComputerListenerImpl extends ComputerListener {
-        @Override
-        public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
-            VirtualChannel ch = c.getChannel();
-            if (ch instanceof Channel)
-                CURRENT.channels.add((Channel)ch);
-        }
-    }
-
 
     /**
      * Returns the older default Maven, while still allowing specification of other bundled Mavens.

--- a/test/src/test/java/org/jvnet/hudson/test/HudsonTestCaseShutdownSlaveTest.java
+++ b/test/src/test/java/org/jvnet/hudson/test/HudsonTestCaseShutdownSlaveTest.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2013 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jvnet.hudson.test;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.labels.LabelExpression;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.SlaveComputer;
+
+/**
+ * Test that slaves are cleanly shutdown when test finishes.
+ * 
+ * In Windows, temporary directories fail to be deleted
+ * if log files of slaves are not closed.
+ * This causes failures of tests using HudsonTestCase,
+ * for an exception occurs in tearDown().
+ * 
+ * When using JenkinsRule, the exception is squashed in after(),
+ * and does not cause failures.
+ */
+@Bug(18259)
+public class HudsonTestCaseShutdownSlaveTest extends HudsonTestCase {
+    public void testShutdownSlave() throws Exception {
+        DumbSlave slave1 = createOnlineSlave(); // online, and a build finished.
+        DumbSlave slave2 = createOnlineSlave(); // online, and a build finished, and disconnected.
+        DumbSlave slave3 = createOnlineSlave(); // online, and a build still running.
+        DumbSlave slave4 = createOnlineSlave(); // online, and not used.
+        DumbSlave slave5 = createSlave();   // offline.
+        
+        assertNotNull(slave1);
+        assertNotNull(slave2);
+        assertNotNull(slave3);
+        assertNotNull(slave4);
+        assertNotNull(slave5);
+        
+        // A build runs on slave1 and finishes.
+        {
+            FreeStyleProject project1 = createFreeStyleProject();
+            project1.setAssignedLabel(LabelExpression.parseExpression(slave1.getNodeName()));
+            project1.getBuildersList().add(new SleepBuilder(1 * 1000));
+            assertBuildStatusSuccess(project1.scheduleBuild2(0));
+        }
+        
+        // A build runs on slave2 and finishes, then disconnect slave2 
+        {
+            FreeStyleProject project2 = createFreeStyleProject();
+            project2.setAssignedLabel(LabelExpression.parseExpression(slave2.getNodeName()));
+            project2.getBuildersList().add(new SleepBuilder(1 * 1000));
+            assertBuildStatusSuccess(project2.scheduleBuild2(0));
+            
+            SlaveComputer computer2 = slave2.getComputer();
+            computer2.disconnect(null);
+            computer2.waitUntilOffline();
+        }
+        
+        // A build runs on slave3 and does not finish.
+        // This build will be interrupted in tearDown().
+        {
+            FreeStyleProject project3 = createFreeStyleProject();
+            project3.setAssignedLabel(LabelExpression.parseExpression(slave3.getNodeName()));
+            project3.getBuildersList().add(new SleepBuilder(10 * 60 * 1000));
+            project3.scheduleBuild2(0);
+            FreeStyleBuild build;
+            while((build = project3.getLastBuild()) == null) {
+                Thread.sleep(500);
+            }
+            assertTrue(build.isBuilding());
+        }
+    }
+}


### PR DESCRIPTION
When running plugin tests using slaves on Windows, they fail with following message:

```
hudson.util.IOException2: Failed to clean up temp dirs
...
Caused by: java.io.IOException: Unable to delete C:\Users\ikedam\AppData\Local\Temp\hudson4683007175849200528test\logs\slaves\slave0\slave.log
```

This is caused by:
- In `HudsonTestCase#tearDown` and `JenkinsRule#after`, slaves are still running and hold handles of log files.
- There are codes to close handles of slaves in `HudsonTestCase#tearDown` and `JenkinsRule#after`, but they does not work.
  - a code in `HudsonTestCase` does not work since Jenkins 1.482.
    - `@TestExtension` for an inner class of `HudsonTestCase` no longer works after 5dd905f2a2 and 4557a436bf .
  - a code in `JenkinsRule` does not work from the beginning.
    - `@TestExtension` for an inner class of `JenkinsRule` does not work from the beginning.

This patch do followings:
- Removed existing codes to close slave handles, which do not work.
- Close channels of running slaves in `HudsonTestCase#tearDown` or `JenkinsRule#after`.
