### PR TITLE
[FIXED JENKINS-18367] Use non-zero return code when list-jobs CLI fails

### DIFF
--- a/core/src/main/java/hudson/cli/ListJobsCommand.java
+++ b/core/src/main/java/hudson/cli/ListJobsCommand.java
@@ -75,7 +75,7 @@ public class ListJobsCommand extends CLICommand {
                 // No view and no item group with the given name found.
                 else {
                     stderr.println("No view or item group with the given name found");
-                    jobs = Collections.emptyList();
+                    return -1;
                 }
             }
         }

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -58,8 +58,7 @@ public class ListJobsCommandTest {
         when(jenkins.getView(null)).thenReturn(null);
         when(jenkins.getItemByFullName(null)).thenReturn(null);
 
-        // TODO: One would expect -1 here
-        assertThat(runWith("NoSuchViewOrItemGroup"), equalTo(0));
+        assertThat(runWith("NoSuchViewOrItemGroup"), equalTo(-1));
         assertThat(stdout, is(empty()));
         assertThat(stderr, is(not(empty())));
     }


### PR DESCRIPTION
Already discussed here: https://github.com/jenkinsci/jenkins/pull/793#discussion_r4713733
