### PR TITLE
[JENKINS-18368]: Decorated Launcher Does Not Maintain "isUnix" for RemoteLauncher

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -665,6 +665,11 @@ public abstract class Launcher {
         final Launcher outer = this;
         return new Launcher(outer) {
             @Override
+            public boolean isUnix() {
+                return outer.isUnix();
+            }
+ 
+            @Override
             public Proc launch(ProcStarter starter) throws IOException {
                 starter.commands.addAll(0,Arrays.asList(prefix));
                 if (starter.masks != null) {
@@ -711,6 +716,11 @@ public abstract class Launcher {
         final EnvVars env = new EnvVars(_env);
         final Launcher outer = this;
         return new Launcher(outer) {
+            @Override
+            public boolean isUnix() {
+                return outer.isUnix();
+            }
+
             @Override
             public Proc launch(ProcStarter starter) throws IOException {
                 EnvVars e = new EnvVars(env);

--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -93,6 +93,7 @@ public class LauncherTest extends ChannelTestCase {
         assertTrue(log, log.contains("val1 val2"));
     }
 
+    @Bug(18368)
     public void testDecoratedByEnvMaintainsIsUnix() throws Exception {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         TaskListener listener = new StreamBuildListener(output);
@@ -104,6 +105,7 @@ public class LauncherTest extends ChannelTestCase {
         assertEquals(true, decorated.isUnix());
     }
 
+    @Bug(18368)
     public void testDecoratedByPrefixMaintainsIsUnix() throws Exception {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         TaskListener listener = new StreamBuildListener(output);

--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -24,6 +24,7 @@
 
 package hudson;
 
+import jenkins.model.Jenkins;
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
 import hudson.util.ProcessTree;
@@ -90,6 +91,28 @@ public class LauncherTest extends ChannelTestCase {
         String log = baos.toString();
         assertEquals(log, 0, res);
         assertTrue(log, log.contains("val1 val2"));
+    }
+
+    public void testDecoratedByEnvMaintainsIsUnix() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        TaskListener listener = new StreamBuildListener(output);
+        Launcher remoteLauncher = new Launcher.RemoteLauncher(listener, Jenkins.MasterComputer.localChannel, false);
+        Launcher decorated = remoteLauncher.decorateByEnv(new EnvVars());
+        assertEquals("not unix before decoration, unix after", false, decorated.isUnix());
+        remoteLauncher = new Launcher.RemoteLauncher(listener, Jenkins.MasterComputer.localChannel, true);
+        decorated = remoteLauncher.decorateByEnv(new EnvVars());
+        assertEquals("unix before decoration, not unix after", true, decorated.isUnix());
+    }
+
+    public void testDecoratedByPrefixMaintainsIsUnix() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        TaskListener listener = new StreamBuildListener(output);
+        Launcher remoteLauncher = new Launcher.RemoteLauncher(listener, Jenkins.MasterComputer.localChannel, false);
+        Launcher decorated = remoteLauncher.decorateByPrefix("test");
+        assertEquals("not unix before decoration, unix after", false, decorated.isUnix());
+        remoteLauncher = new Launcher.RemoteLauncher(listener, Jenkins.MasterComputer.localChannel, true);
+        decorated = remoteLauncher.decorateByPrefix("test");
+        assertEquals("unix before decoration, not unix after", true, decorated.isUnix());
     }
 
 }

--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -98,10 +98,10 @@ public class LauncherTest extends ChannelTestCase {
         TaskListener listener = new StreamBuildListener(output);
         Launcher remoteLauncher = new Launcher.RemoteLauncher(listener, Jenkins.MasterComputer.localChannel, false);
         Launcher decorated = remoteLauncher.decorateByEnv(new EnvVars());
-        assertEquals("not unix before decoration, unix after", false, decorated.isUnix());
+        assertEquals(false, decorated.isUnix());
         remoteLauncher = new Launcher.RemoteLauncher(listener, Jenkins.MasterComputer.localChannel, true);
         decorated = remoteLauncher.decorateByEnv(new EnvVars());
-        assertEquals("unix before decoration, not unix after", true, decorated.isUnix());
+        assertEquals(true, decorated.isUnix());
     }
 
     public void testDecoratedByPrefixMaintainsIsUnix() throws Exception {
@@ -109,10 +109,10 @@ public class LauncherTest extends ChannelTestCase {
         TaskListener listener = new StreamBuildListener(output);
         Launcher remoteLauncher = new Launcher.RemoteLauncher(listener, Jenkins.MasterComputer.localChannel, false);
         Launcher decorated = remoteLauncher.decorateByPrefix("test");
-        assertEquals("not unix before decoration, unix after", false, decorated.isUnix());
+        assertEquals(false, decorated.isUnix());
         remoteLauncher = new Launcher.RemoteLauncher(listener, Jenkins.MasterComputer.localChannel, true);
         decorated = remoteLauncher.decorateByPrefix("test");
-        assertEquals("unix before decoration, not unix after", true, decorated.isUnix());
+        assertEquals(true, decorated.isUnix());
     }
 
 }


### PR DESCRIPTION
This is a fix to override isUnix on wrapped Launchers when decorating by env or prefix. Currently this causes the state of isUnix on a RemoteLauncher to be lost when environment variables are also specified. 

JIRA: https://issues.jenkins-ci.org/browse/JENKINS-18368

Tests are included to check that the state of isUnix is maintained when wrapping a RemoteLauncher with these two methods. 
