### PR TITLE
Fix ListJobsCommandTest failed on Windows by replace line ending

### DIFF
--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -170,7 +170,7 @@ public class ListJobsCommandTest {
             protected boolean matchesSafely(ByteArrayOutputStream item) {
 
                 final HashSet<String> jobs = new HashSet<String>(
-                        Arrays.asList(item.toString().split("\n"))
+                        Arrays.asList(item.toString().split(System.getProperty("line.separator")))
                 );
 
                 return new HashSet<String>(Arrays.asList(expected)).equals(jobs);


### PR DESCRIPTION
Test case on Windows has such errors.
Running hudson.cli.ListJobsCommandTest
Tests run: 4, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 15.121 sec <<< FAILURE! - in hudson.cli.ListJobsCommandTest
getAllJobsForEmptyName(hudson.cli.ListJobsCommandTest) Time elapsed: 0.062 sec <<< FAILURE!
java.lang.AssertionError: 
Expected: Job listing of [some-job, some-other-job]
but: was <some-job
some-other-job
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
at hudson.cli.ListJobsCommandTest.getAllJobsForEmptyName(ListJobsCommandTest.java:77)
getJobsFromView(hudson.cli.ListJobsCommandTest) Time elapsed: 0.322 sec <<< FAILURE!
java.lang.AssertionError: 
Expected: Job listing of [some-job, some-other-job]
but: was <some-job
some-other-job
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
at hudson.cli.ListJobsCommandTest.getJobsFromView(ListJobsCommandTest.java:94)
getJobsRecursivelyFromViewGroup(hudson.cli.ListJobsCommandTest) Time elapsed: 0.15 sec <<< FAILURE!
java.lang.AssertionError: 
Expected: Job listing of [rootJob, leftJob, rightJob, sharedJob]
but: was <rootJob
sharedJob
leftJob
rightJob
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
at hudson.cli.ListJobsCommandTest.getJobsRecursivelyFromViewGroup(ListJobsCommandTest.java:119)
