### PR TITLE
User friendly response if deletion of a build fails

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -117,6 +117,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 
+import java.io.StringWriter;
 import static java.util.logging.Level.*;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -1996,7 +1997,16 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             return;
         }
 
-        delete();
+        try{
+            delete();
+        }
+        catch(IOException ex){
+            StringWriter writer = new StringWriter();
+            ex.printStackTrace(new PrintWriter(writer));
+            req.setAttribute("stackTraces", writer);
+            req.getView(this, "delete-retry.jelly").forward(req, rsp);  
+            return;
+        } 
         rsp.sendRedirect2(req.getContextPath()+'/' + getParent().getUrl());
     }
 

--- a/core/src/main/resources/hudson/model/Run/delete-retry.jelly
+++ b/core/src/main/resources/hudson/model/Run/delete-retry.jelly
@@ -1,0 +1,28 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:layout title="${it.fullDisplayName}" norefresh="true">
+    <st:include page="sidepanel.jelly" />
+    <l:main-panel>
+      <table>
+        <tr><td>
+          <form method="post" action="doDelete">
+            <div class="error">
+              ${%Not successful}
+            </div>
+            <f:submit name="now" value="${%Retry delete}" />
+          </form>
+        </td></tr>
+        <tr><td>
+          <a onclick="document.getElementById('delete-error').style.display='block';return false" href="">${%Show reason}</a>
+        </td></tr>
+        <tr><td>
+          <div id="delete-error" style="display: none">
+            <pre>
+              ${request.getAttribute('stackTraces')}
+            </pre>
+          </div>
+        </td></tr>
+      </table>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/core/src/main/resources/hudson/model/Run/delete-retry.properties
+++ b/core/src/main/resources/hudson/model/Run/delete-retry.properties
@@ -1,0 +1,25 @@
+# The MIT License
+# 
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Frederic Gurr
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Not\ successful = Deletion  of the build failed
+Retry\ delete = Retry delete
+Show\ reason = Show reason


### PR DESCRIPTION
If a build is deleted shortly after stopping, sometime the deletion fails and users see page with stack trace (probably due to longer clean up, after a few seconds max 1 minute users can delete it without problems). It will better to show information that deletion fails and retry button.
