### PR TITLE
Add more control of Java heap and perm sizing on OSX and set defaults. 

### DIFF
--- a/osx/Library/Application Support/Jenkins/jenkins-runner.sh
+++ b/osx/Library/Application Support/Jenkins/jenkins-runner.sh
@@ -15,8 +15,12 @@ defaults="defaults read /Library/Preferences/org.jenkins-ci"
 war=`$defaults war` || war="/Applications/Jenkins/jenkins.war"
 
 javaArgs=""
-heapSize=`$defaults heapSize` && javaArgs="$javaArgs -Xmx${heapSize}"
+
+minPermGen=`$defaults minPermGen` && javaArgs="$javaArgs -XX:PermSize=${minPermGen}"
 permGen=`$defaults permGen` && javaArgs="$javaArgs -XX:MaxPermSize=${permGen}"
+
+minHeapSize=`$defaults minHeapSize` && javaArgs="$javaArgs -Xms${minHeapSize}"
+heapSize=`$defaults heapSize` && javaArgs="$javaArgs -Xmx${heapSize}"
 
 home=`$defaults JENKINS_HOME` && export JENKINS_HOME="$home"
 

--- a/osx/Library/Documentation/Jenkins/command-line-preferences.html
+++ b/osx/Library/Documentation/Jenkins/command-line-preferences.html
@@ -43,12 +43,13 @@
 <p>Additionally, you can set also these:
 
 <ul>
-  <li>war (Full path name to jenkins.war file.)
-  <li>heapSize (Passed to java command-line -Xmx parameter.)
-  <li>JENKINS_HOME (Full path to JENKINS_HOME directory where Jenkins
-  keeps its files)
+  <li>war (Full path name to jenkins.war file. Defaults to <tt>/Applications/Jenkins/jenkins.war</tt>)
+  <li>JENKINS_HOME (Full path to JENKINS_HOME directory where Jenkins keeps its files. Defaults to <tt>/Users/Shared/Jenkins</tt>)
+  <li>minHeapSize (Passed to java command-line <tt>-Xms</tt> parameter. Defaults to 256m on 64bit architectures and 64m on 32bit)
+  <li>heapSize (Passed to java command-line <tt>-Xmx</tt> parameter. Defaults to 512m on 64bit architectures and 128m on 32bit)
+  <li>minPermGen (Passed to java command-line <tt>-XX:PermSize</tt> parameter. Defaults to 256m on 64bit architectures and 64m on 32bit)
+  <li>permGen (Passed to java command-line <tt>-XX:MaxPermSize</tt> parameter. Defaults to 512m on 64bit architectures and 128m on 32bit)
 </ul>
-  
 
 </body>
 </html>

--- a/osx/scripts/postinstall-launchd-jenkins
+++ b/osx/scripts/postinstall-launchd-jenkins
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 JENKINS_PLIST="/Library/LaunchDaemons/org.jenkins-ci.plist"
+DEFAULTS_PLIST="/Library/Preferences/org.jenkins-ci.plist"
 
 # Because PackageMaker just copies the components, we need to fix the permissions
 chown root:wheel ${JENKINS_PLIST}
@@ -44,6 +45,21 @@ else
 fi
 
 find "$JENKINS_HOMEDIR" \( -not -user jenkins -or -not -group jenkins \) -print0 | xargs -0 chown jenkins:jenkins
+
+# Add defaults for heap sizing
+arch=$(uname -m)
+if [ $arch = 'x86_64' ]; then
+    defaults write $DEFAULTS_PLIST heapSize 512m
+    defaults write $DEFAULTS_PLIST permGen 512m
+    defaults write $DEFAULTS_PLIST minHeapSize 256m
+    defaults write $DEFAULTS_PLIST minPermGen 256m
+else
+    # i386
+    defaults write $DEFAULTS_PLIST heapSize 128m
+    defaults write $DEFAULTS_PLIST permGen 128m
+    defaults write $DEFAULTS_PLIST minHeapSize 64m
+    defaults write $DEFAULTS_PLIST minPermGen 64m    
+fi
 
 # Create log directory, which can be written by Jenkins daemon
 mkdir -p /var/log/jenkins


### PR DESCRIPTION
Recommend that the defaults in osx/scripts/postinstall-launchd-jenkins be reviewed by a Java/OSX dev for sanity.
