### PR TITLE
[FIXES JENKINS-15976] Correclty de-serialized settings were overwritten

### DIFF
--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -435,10 +435,7 @@ public class Maven extends Builder {
 
         @Override
         public Builder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            Maven m = req.bindJSON(Maven.class,formData);
-            m.setSettings(GlobalMavenConfig.get().getSettingsProvider());
-            m.setGlobalSettings(GlobalMavenConfig.get().getGlobalSettingsProvider());
-            return m;
+            return req.bindJSON(Maven.class,formData);
         }
     }
 


### PR DESCRIPTION
 After de-serializing changed job settings after "Save", the maven settings done by config-file-provider-plugin were overwritten blindly (presumably with fallback values). These fallback values should be set correctly in the constructor of the "Maven" class and do not need to be set explicitly after deserialization.
