### PR TITLE
Advertise the CLI TCP port even when we're going to show a 403

### DIFF
--- a/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
+++ b/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
@@ -23,6 +23,8 @@
  */
 package hudson.security;
 
+import jenkins.model.Jenkins;
+
 import com.google.common.base.Strings;
 import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.InsufficientAuthenticationException;
@@ -80,6 +82,15 @@ public class HudsonAuthenticationEntryPoint extends AuthenticationProcessingFilt
 
             rsp.setStatus(SC_FORBIDDEN);
             rsp.setContentType("text/html;charset=UTF-8");
+
+            // advertise the CLI TCP port
+            TcpSlaveAgentListener tal = Jenkins.getInstance().getTcpSlaveAgentListener();
+            if (tal!=null) {
+                rsp.setHeader("X-Hudson-CLI-Port", tal.getPort());
+                rsp.setHeader("X-Jenkins-CLI-Port", tal.getPort());
+                rsp.setHeader("X-Jenkins-CLI2-Port", tal.getPort());
+                rsp.setHeader("X-Jenkins-CLI-Host", TcpSlaveAgentListener.CLI_HOST_NAME);
+            }
 
             AccessDeniedException2 cause = null;
             // report the diagnosis information if possible


### PR DESCRIPTION
I can't use the CLI because all my pages are protected by the openid plugin. Because that plugin doesn't use the layout.jelly when it serves a 403, it breaks CLI support completely.

This is a fix.
