### PR TITLE
[FIXED 10539] Preserve backslash in Matrix buildstep properties

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1346,14 +1346,16 @@ public class Util {
      */
     @IgnoreJRERequirement
     public static Properties loadProperties(String properties) throws IOException {
+        // Replace single backslashes with double ones so they won't be removed by Property.load()
+        String escapedProperties = properties.replaceAll("(?<=[^\\\\])\\\\(?=[^\\\\])", "\\\\\\\\");
         Properties p = new Properties();
         try {
-            p.load(new StringReader(properties));
+            p.load(new StringReader(escapedProperties));
         } catch (NoSuchMethodError e) {
             // load(Reader) method is only available on JDK6.
             // this fall back version doesn't work correctly with non-ASCII characters,
             // but there's no other easy ways out it seems.
-            p.load(new ByteArrayInputStream(properties.getBytes()));
+            p.load(new ByteArrayInputStream(escapedProperties.getBytes()));
         }
         return p;
     }

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -195,12 +195,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      * @since 1.262
      */
     public ArgumentListBuilder addKeyValuePairsFromPropertyString(String prefix, String properties, VariableResolver vr) throws IOException {
-        if(properties==null)    return this;
-
-        for (Entry<Object,Object> entry : Util.loadProperties(properties).entrySet()) {
-            addKeyValuePair(prefix, (String)entry.getKey(), Util.replaceMacro(entry.getValue().toString(),vr), false);
-        }
-        return this;
+        return addKeyValuePairsFromPropertyString(prefix, properties, vr, null);
     }
 
     /**
@@ -222,7 +217,9 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
         if(properties==null)    return this;
 
         for (Entry<Object,Object> entry : Util.loadProperties(properties).entrySet()) {
-            addKeyValuePair(prefix, (String)entry.getKey(), Util.replaceMacro(entry.getValue().toString(),vr), (propsToMask == null) ? false : propsToMask.contains((String)entry.getKey()));
+            String value = Util.replaceMacro(entry.getValue().toString(), vr);
+            boolean propertyMask = (propsToMask == null) ? false : propsToMask.contains(entry.getKey());
+            addKeyValuePair(prefix, (String)entry.getKey(), value, propertyMask);
         }
         return this;
     }

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -338,5 +338,11 @@ public class UtilTest {
         Properties p = Util.loadProperties("k.e.y=va.l.ue");
         assertEquals(p.toString(), "va.l.ue", p.get("k.e.y"));
         assertEquals(p.toString(), 1, p.size());
+
+        p = Util.loadProperties("path=C:\\Windows");
+        assertEquals("Single backslash should be preserved", "C:\\Windows", p.get("path"));
+
+        p = Util.loadProperties("prop=escaped\\\\slashes");
+        assertEquals("Double backslash should collaps to one", "escaped\\slashes", p.get("prop"));
     }
 }

--- a/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
+++ b/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
@@ -23,6 +23,7 @@
  */
 package hudson.util;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -182,5 +183,22 @@ public class ArgumentListBuilderTest extends Assert {
         boolean[] array = builder.toMaskArray();
         assertNotNull("The mask array should not be null", array);
         assertArrayEquals("The mask array was incorrect", new boolean[]{false,false,false}, array);
+    }
+
+    @Test
+    public void addKeyValuePairsFromPropertyString() throws IOException {
+        final Map<String, String> map = new HashMap<String, String>();
+        map.put("PATH", "C:\\Windows");
+        final VariableResolver<String> resolver = new VariableResolver.ByMap<String>(map);
+
+        final String properties = "my.path=$PATH";
+
+        ArgumentListBuilder builder = new ArgumentListBuilder();
+        builder.addKeyValuePairsFromPropertyString("", properties, resolver);
+        assertEquals("my.path=C:\\Windows", builder.toString());
+
+        builder = new ArgumentListBuilder();
+        builder.addKeyValuePairsFromPropertyString("", properties, resolver, null);
+        assertEquals("my.path=C:\\Windows", builder.toString());
     }
 }


### PR DESCRIPTION
Fix for https://issues.jenkins-ci.org/browse/JENKINS-10539

Not sure if this should be fixed in `Util.loadProperties` or in `ArgumentListBuilder.addKeyValuePairsFromPropertyString` (or `Maven.perform` perhaps) so let's start with the former.
