### PR TITLE
[JENKINS-18585] Plot Plugin crashes configuration pages

### DIFF
--- a/core/src/main/resources/lib/form/textarea/textarea.js
+++ b/core/src/main/resources/lib/form/textarea/textarea.js
@@ -15,9 +15,11 @@ Behaviour.specify("TEXTAREA.codemirror", 'textarea', 0, function(e) {
         scroller.style.height = h+"px";
 
         // the form needs to be populated before the "Apply" button
-    Element.on(e.up('form'),"jenkins:apply", function() {
-            e.value = codemirror.getValue()
-        })
+        if(e.up('form')) { // Protect against undefined element
+    		Element.on(e.up('form'),"jenkins:apply", function() {
+			e.value = codemirror.getValue()
+		})
+	}
     });
 
 Behaviour.specify("DIV.textarea-preview-container", 'textarea', 100, function (e) {


### PR DESCRIPTION
[Issue 18585](https://issues.jenkins-ci.org/browse/JENKINS-18585), configuration page crashes, was fixed for most plugins by [Kohsuke's commit](https://github.com/jenkinsci/jenkins/commit/059e6081d0be21a3a92d705c43c9e1f658347797). There is still at least one incompatibility remaining with [Plot Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Plot+Plugin), and this commit addresses that case. As of 1.522, a project with Plot Plugin added to the configuration will block further configuration page loads with the 'Loading' overlay until the plugin is disabled.

This commit does not address root cause of why this function is being called with an object without an up method, however, which would be the preferable solution.

For spin-off issues, see [Issue 18644](https://issues.jenkins-ci.org/browse/JENKINS-18644), [Issue 18674](https://issues.jenkins-ci.org/browse/JENKINS-18674).
