### PR TITLE
[JENKINS-18641] <st:bind> tag adds <script> tag. This extra tag caused syntax error.

### DIFF
--- a/core/src/main/resources/lib/layout/progressiveRendering.jelly
+++ b/core/src/main/resources/lib/layout/progressiveRendering.jelly
@@ -38,5 +38,6 @@ THE SOFTWARE.
     <!-- TODO generate an ID so we can use this more than once per page -->
     <t:progressBar id="status" pos="0" tooltip="${tooltip ?: '%progressMessage'}"/>
     <j:invoke method="start" on="${handler}"/>
-    <script>progressivelyRender(<st:bind value="${handler}"/>, ${callback});</script>
+    <st:bind var="proxy" value="${handler}" />
+    <script>progressivelyRender(proxy, ${callback});</script>
 </j:jelly>


### PR DESCRIPTION
This stapler change [1] changed the behavior of st;bind tag.

[1] https://github.com/stapler/stapler/commit/48cdf0f3242c6a79bb398e9115c0db7526c42a50
