### PR TITLE
[FIXED JENKINS-18671] Clock Difference broken on Manage Nodes page

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class=bug>
+    Clock Difference broken on Manage Nodes page
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18671">issue 18671</a>)
+  <li class=bug>
     Fixed another possible cause of an NPE from MatrixConfiguration.newBuild.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-17728">issue 17728</a>)
 </ul>

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -457,7 +457,7 @@ public abstract class Slave extends Node implements Serializable {
          * Capture the time on the master when this object is sent to remote, which is when
          * {@link GetClockDifference1#writeReplace()} is run.
          */
-        private final long startTime = System.nanoTime();
+        private final long startTime = System.currentTimeMillis();
 
         public GetClockDifference3 call() {
             return new GetClockDifference3(startTime);
@@ -467,7 +467,7 @@ public abstract class Slave extends Node implements Serializable {
     }
 
     private static final class GetClockDifference3 implements Serializable {
-        private final long remoteTime = System.nanoTime();
+        private final long remoteTime = System.currentTimeMillis();
         private final long startTime;
 
         public GetClockDifference3(long startTime) {
@@ -475,8 +475,8 @@ public abstract class Slave extends Node implements Serializable {
         }
 
         private Object readResolve() {
-            long endTime = System.nanoTime();
-            return new ClockDifference(TimeUnit2.NANOSECONDS.toMillis((startTime + endTime)/2-remoteTime));
+            long endTime = System.currentTimeMillis();
+            return new ClockDifference((startTime + endTime)/2-remoteTime);
         }
     }
 

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -113,7 +113,7 @@ public class ResponseTimeMonitor extends NodeMonitor {
 
     private static final class Step2 implements Callable<Step3,IOException> {
         private final Data cur;
-        private final long start = System.nanoTime();
+        private final long start = System.currentTimeMillis();
 
         public Step2(Data cur) {
             this.cur = cur;
@@ -137,8 +137,8 @@ public class ResponseTimeMonitor extends NodeMonitor {
         }
 
         private Object readResolve() {
-            long end = System.nanoTime();
-            return new Data(cur,TimeUnit2.NANOSECONDS.toMillis(end-start));
+            long end = System.currentTimeMillis();
+            return new Data(cur,(end-start));
         }
 
         private static final long serialVersionUID = 1L;

--- a/test/src/test/java/hudson/node_monitors/ClockMonitorDescriptorTest.java
+++ b/test/src/test/java/hudson/node_monitors/ClockMonitorDescriptorTest.java
@@ -1,0 +1,32 @@
+package hudson.node_monitors;
+
+import org.jvnet.hudson.test.HudsonTestCase;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.SlaveComputer;
+import hudson.util.ClockDifference;
+import hudson.util.TimeUnit2;
+
+/**
+ * @author Richard Mortimer
+ */
+public class ClockMonitorDescriptorTest extends HudsonTestCase {
+    /**
+     * Makes sure that it returns sensible values.
+     */
+    public void testClockMonitor() throws Exception {
+        DumbSlave s = createSlave();
+        SlaveComputer c = s.getComputer();
+        c.connect(false).get(); // wait until it's connected
+        if(c.isOffline())
+            fail("Slave failed to go online: "+c.getLog());
+
+        ClockDifference cd = ClockMonitor.DESCRIPTOR.monitor(c);
+        long diff = cd.diff;
+        assertTrue(diff < TimeUnit2.SECONDS.toMillis(5));
+        assertTrue(diff > TimeUnit2.SECONDS.toMillis(-5));
+        assertTrue(cd.abs() >= 0);
+        assertTrue(cd.abs() < TimeUnit2.SECONDS.toMillis(5));
+        assertFalse(cd.isDangerous());
+        assertTrue("html output too short", cd.toHtml().length() > 0);
+    }
+}


### PR DESCRIPTION
System.nanos() returns a monotonically increasing value that is not related
to wallclock time. Use System.currentTimeMillis() instead.

Tested on both Linux and Windows slaves. All now report "sensible" clock differences of a few minutes/seconds.
