### PR TITLE
Fixing the timer-trigger help text

### DIFF
--- a/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.html
+++ b/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.html
@@ -58,7 +58,7 @@
     and <code>@hourly</code> are supported as convenient aliases.
     These use the hash system for automatic balancing.
     For example, <code>@hourly</code> is the same as <code>H * * * *</code> and could mean at any time during the hour.
-    <code>@midnight</code> actually means some time between 12:00 AM and 2:59 AM.
+    <code>@midnight</code> actually means some time between 12:00 AM and 12:59 AM.
   </p><p>
     Examples:
   </p>


### PR DESCRIPTION
The help text for the timer trigger says that @midnight means
some time between 12:00 AM and 2:59 AM, I believe this should
be 12:00 AM to 12:59 AM
