### PR TITLE
[JENKINS-18734] - Call perform(AbstractBuild build, Launcher launcher, BuildListener listener) if implemented in BuildStep

### DIFF
--- a/core/src/main/java/hudson/tasks/BuildStepCompatibilityLayer.java
+++ b/core/src/main/java/hudson/tasks/BuildStepCompatibilityLayer.java
@@ -31,9 +31,12 @@ import hudson.model.Action;
 import hudson.model.Project;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.util.ReflectionUtils;
 import hudson.Launcher;
+import hudson.Util;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -118,8 +121,13 @@ public abstract class BuildStepCompatibilityLayer implements BuildStep {
      *      Use {@link #perform(AbstractBuild, Launcher, BuildListener)} instead.
      */
     @Deprecated
-    public boolean perform(Build<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        throw new UnsupportedOperationException();
+    public boolean perform(Build<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {       
+        if (build instanceof AbstractBuild && Util.isOverridden(BuildStepCompatibilityLayer.class, this.getClass(),
+                "perform", AbstractBuild.class, Launcher.class, BuildListener.class)) {
+            return perform((AbstractBuild<?, ?>) build, launcher, listener);
+        }
+        throw new AbstractMethodError();
     }
 
     /**

--- a/core/src/test/java/hudson/tasks/BuildStepCompatibilityLayerTest.java
+++ b/core/src/test/java/hudson/tasks/BuildStepCompatibilityLayerTest.java
@@ -1,0 +1,54 @@
+package hudson.tasks;
+
+import static org.junit.Assert.assertTrue;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.mockito.Mockito;
+
+public class BuildStepCompatibilityLayerTest {
+
+    @Issue("JENKINS-18734")
+    @Test(expected = AbstractMethodError.class)
+    public void testPerformExpectAbstractMethodError() throws InterruptedException, IOException {
+
+        FreeStyleBuild mock = Mockito.mock(FreeStyleBuild.class, Mockito.CALLS_REAL_METHODS);
+        BuildStepCompatibilityLayer bscl = new BuildStepCompatibilityLayer() {
+            @Override
+            public BuildStepMonitor getRequiredMonitorService() {
+                return null;
+            }
+        };
+        bscl.perform(mock, null, null);
+
+    }
+
+    @Issue("JENKINS-18734")
+    @Test
+    public void testPerform() throws InterruptedException, IOException {
+
+        FreeStyleBuild mock = Mockito.mock(FreeStyleBuild.class, Mockito.CALLS_REAL_METHODS);
+        BuildStepCompatibilityLayer bscl = new BuildStepCompatibilityLayer() {
+
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
+                return true;
+            }
+
+            @Override
+            public BuildStepMonitor getRequiredMonitorService() {
+                return null;
+            }
+        };
+        assertTrue(bscl.perform(mock, null, null));
+
+    }
+
+}


### PR DESCRIPTION
[JENKINS-18734](https://issues.jenkins-ci.org/browse/JENKINS-18734)

Call perform(AbstractBuild build, Launcher launcher, BuildListener listener) if implemented in BuildStep
