### PR TITLE
Improve search to look for items inside ItemGroup

### DIFF
--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -25,9 +25,9 @@
 package hudson.search;
 
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-
 import hudson.Util;
 import hudson.util.EditDistance;
+
 import java.io.IOException;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -39,6 +39,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
+
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -340,7 +341,7 @@ public class Search {
             items.clear();
             m.find(index,token,items);
             for (SearchItem si : items) {
-                paths[w].add(new SuggestedItem(si));
+                paths[w].add(SuggestedItem.build(si));
                 LOGGER.log(Level.FINE, "found search item: {0}", si.getSearchName());
             }
             w++;

--- a/core/src/main/java/hudson/search/SuggestedItem.java
+++ b/core/src/main/java/hudson/search/SuggestedItem.java
@@ -23,6 +23,9 @@
  */
 package hudson.search;
 
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+
 /**
  * One item of a search result.
  *
@@ -74,6 +77,29 @@ public class SuggestedItem {
         StringBuilder buf = new StringBuilder();
         getUrl(buf);
         return buf.toString();
+    }
+    
+    private static SuggestedItem build(Item top) {
+        ItemGroup<? extends Item> parent = top.getParent();
+        if (parent instanceof Item) {
+            Item parentItem = (Item)parent;
+                return new SuggestedItem(build(parentItem), top);
+        }
+        return new SuggestedItem(top);
+    }
+    
+    /**
+     * Given a SearchItem, builds a SuggestedItem hierarchy by looking up parent items (if applicable).
+     * This allows search results for items not contained within the same ItemGroup to be distinguished.
+     * @param si
+     * @return 
+     * @since XXX
+     */
+    public static SuggestedItem build(SearchItem si) {
+        if (si instanceof Item) {
+            return build((Item)si);
+        }
+        return new SuggestedItem(si);
     }
 
     private void getUrl(StringBuilder buf) {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1821,8 +1821,8 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
             .add("manage")
             .add("log")
             .add(new CollectionSearchIndex<TopLevelItem>() {
-                protected SearchItem get(String key) { return getItem(key); }
-                protected Collection<TopLevelItem> all() { return getItems(); }
+                protected SearchItem get(String key) { return getItemByFullName(key, TopLevelItem.class); }
+                protected Collection<TopLevelItem> all() { return getAllItems(TopLevelItem.class); }
             })
             .add(getPrimaryView().makeSearchIndex())
             .add(new CollectionSearchIndex() {// for computers

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -23,34 +23,45 @@
  */
 package hudson.search;
 
-import hudson.model.ListView;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import hudson.model.FreeStyleProject;
+import hudson.model.ListView;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import com.gargoylesoftware.htmlunit.Page;
-import com.gargoylesoftware.htmlunit.AlertHandler;
+import java.util.ArrayList;
+import java.util.List;
 
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 
 import org.junit.Assert;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.gargoylesoftware.htmlunit.AlertHandler;
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.Page;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class SearchTest extends HudsonTestCase {
+public class SearchTest {
+  
+    @Rule public JenkinsRule j = new JenkinsRule();
+    
     /**
      * No exact match should result in a failure status code.
      */
+    @Test
     public void testFailure() throws Exception {
         try {
-            search("no-such-thing");
+            j.search("no-such-thing");
             fail("404 expected");
         } catch (FailingHttpStatusCodeException e) {
             assertEquals(404,e.getResponse().getStatusCode());
@@ -61,9 +72,10 @@ public class SearchTest extends HudsonTestCase {
      * Makes sure the script doesn't execute.
      */
     @Bug(3415)
+    @Test
     public void testXSS() throws Exception {
         try {
-            WebClient wc = new WebClient();
+            WebClient wc = j.createWebClient();
             wc.setAlertHandler(new AlertHandler() {
                 public void handleAlert(Page page, String message) {
                     throw new AssertionError();
@@ -76,35 +88,38 @@ public class SearchTest extends HudsonTestCase {
         }
     }
     
+    @Test
     public void testSearchByProjectName() throws Exception {
         final String projectName = "testSearchByProjectName";
         
-        createFreeStyleProject(projectName);
+        j.createFreeStyleProject(projectName);
         
-        Page result = search(projectName);
+        Page result = j.search(projectName);
         Assert.assertNotNull(result);
-        assertGoodStatus(result);
+        j.assertGoodStatus(result);
         
         // make sure we've fetched the testSearchByDisplayName project page
         String contents = result.getWebResponse().getContentAsString();
         Assert.assertTrue(contents.contains(String.format("<title>%s [Jenkins]</title>", projectName)));
     }
 
+    @Test
     public void testSearchByDisplayName() throws Exception {
         final String displayName = "displayName9999999";
         
-        FreeStyleProject project = createFreeStyleProject("testSearchByDisplayName");
+        FreeStyleProject project = j.createFreeStyleProject("testSearchByDisplayName");
         project.setDisplayName(displayName);
         
-        Page result = search(displayName);
+        Page result = j.search(displayName);
         Assert.assertNotNull(result);
-        assertGoodStatus(result);
+        j.assertGoodStatus(result);
         
         // make sure we've fetched the testSearchByDisplayName project page
         String contents = result.getWebResponse().getContentAsString();
         Assert.assertTrue(contents.contains(String.format("<title>%s [Jenkins]</title>", displayName)));
     }
     
+    @Test
     public void testSearch2ProjectsWithSameDisplayName() throws Exception {
         // create 2 freestyle projects with the same display name
         final String projectName1 = "projectName1";
@@ -113,19 +128,19 @@ public class SearchTest extends HudsonTestCase {
         final String displayName = "displayNameFoo";
         final String otherDisplayName = "otherDisplayName";
         
-        FreeStyleProject project1 = createFreeStyleProject(projectName1);
+        FreeStyleProject project1 = j.createFreeStyleProject(projectName1);
         project1.setDisplayName(displayName);
-        FreeStyleProject project2 = createFreeStyleProject(projectName2);
+        FreeStyleProject project2 = j.createFreeStyleProject(projectName2);
         project2.setDisplayName(displayName);
-        FreeStyleProject project3 = createFreeStyleProject(projectName3);
+        FreeStyleProject project3 = j.createFreeStyleProject(projectName3);
         project3.setDisplayName(otherDisplayName);
 
         // make sure that on search we get back one of the projects, it doesn't
         // matter which one as long as the one that is returned has displayName
         // as the display name
-        Page result = search(displayName);
+        Page result = j.search(displayName);
         Assert.assertNotNull(result);
-        assertGoodStatus(result);
+        j.assertGoodStatus(result);
 
         // make sure we've fetched the testSearchByDisplayName project page
         String contents = result.getWebResponse().getContentAsString();
@@ -133,6 +148,7 @@ public class SearchTest extends HudsonTestCase {
         Assert.assertFalse(contents.contains(otherDisplayName));
     }
     
+    @Test
     public void testProjectNamePrecedesDisplayName() throws Exception {
         final String project1Name = "foo";
         final String project1DisplayName = "project1DisplayName";
@@ -142,21 +158,21 @@ public class SearchTest extends HudsonTestCase {
         final String project3DisplayName = "project3DisplayName";
         
         // create 1 freestyle project with the name foo
-        FreeStyleProject project1 = createFreeStyleProject(project1Name);
+        FreeStyleProject project1 = j.createFreeStyleProject(project1Name);
         project1.setDisplayName(project1DisplayName);
         
         // create another with the display name foo
-        FreeStyleProject project2 = createFreeStyleProject(project2Name);
+        FreeStyleProject project2 = j.createFreeStyleProject(project2Name);
         project2.setDisplayName(project2DisplayName);
 
         // create a third project and make sure it's not picked up by search
-        FreeStyleProject project3 = createFreeStyleProject(project3Name);
+        FreeStyleProject project3 = j.createFreeStyleProject(project3Name);
         project3.setDisplayName(project3DisplayName);
         
         // search for foo
-        Page result = search(project1Name);
+        Page result = j.search(project1Name);
         Assert.assertNotNull(result);
-        assertGoodStatus(result);
+        j.assertGoodStatus(result);
         
         // make sure we get the project with the name foo
         String contents = result.getWebResponse().getContentAsString();
@@ -167,17 +183,18 @@ public class SearchTest extends HudsonTestCase {
         Assert.assertFalse(contents.contains(project3DisplayName));
     }
     
+    @Test
     public void testGetSuggestionsHasBothNamesAndDisplayNames() throws Exception {
         final String projectName = "project name";
         final String displayName = "display name";
 
-        FreeStyleProject project1 = createFreeStyleProject(projectName);
+        FreeStyleProject project1 = j.createFreeStyleProject(projectName);
         project1.setDisplayName(displayName);
         
-        WebClient wc = new WebClient();
+        WebClient wc = j.createWebClient();
         Page result = wc.goTo("search/suggest?query=name", "application/json");
         Assert.assertNotNull(result);
-        assertGoodStatus(result);
+        j.assertGoodStatus(result);
         
         String content = result.getWebResponse().getContentAsString();
         System.out.println(content);
@@ -210,32 +227,34 @@ public class SearchTest extends HudsonTestCase {
      * Disable/enable status shouldn't affect the search
      */
     @Bug(13148)
+    @Test
     public void testDisabledJobShouldBeSearchable() throws Exception {
-        FreeStyleProject j = createFreeStyleProject("foo-bar");
-        assertTrue(suggest(jenkins.getSearchIndex(), "foo").contains(j));
+        FreeStyleProject p = j.createFreeStyleProject("foo-bar");
+        assertTrue(suggest(j.jenkins.getSearchIndex(), "foo").contains(p));
 
-        j.disable();
-        assertTrue(suggest(jenkins.getSearchIndex(), "foo").contains(j));
+        p.disable();
+        assertTrue(suggest(j.jenkins.getSearchIndex(), "foo").contains(p));
     }
 
     /**
      * All top-level jobs should be searchable, not just jobs in the current view.
      */
     @Bug(13148)
+    @Test
     public void testCompletionOutsideView() throws Exception {
-        FreeStyleProject j = createFreeStyleProject("foo-bar");
-        ListView v = new ListView("empty1",jenkins);
-        ListView w = new ListView("empty2",jenkins);
-        jenkins.addView(v);
-        jenkins.addView(w);
-        jenkins.setPrimaryView(w);
+        FreeStyleProject p = j.createFreeStyleProject("foo-bar");
+        ListView v = new ListView("empty1",j.jenkins);
+        ListView w = new ListView("empty2",j.jenkins);
+        j.jenkins.addView(v);
+        j.jenkins.addView(w);
+        j.jenkins.setPrimaryView(w);
 
         // new view should be empty
-        assertFalse(v.contains(j));
-        assertFalse(w.contains(j));
-        assertFalse(jenkins.getPrimaryView().contains(j));
+        assertFalse(v.contains(p));
+        assertFalse(w.contains(p));
+        assertFalse(j.jenkins.getPrimaryView().contains(p));
 
-        assertTrue(suggest(jenkins.getSearchIndex(),"foo").contains(j));
+        assertTrue(suggest(j.jenkins.getSearchIndex(),"foo").contains(p));
     }
 
     private List<SearchItem> suggest(SearchIndex index, String term) {

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockFolder;
 
 import com.gargoylesoftware.htmlunit.AlertHandler;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
@@ -255,6 +256,17 @@ public class SearchTest {
         assertFalse(j.jenkins.getPrimaryView().contains(p));
 
         assertTrue(suggest(j.jenkins.getSearchIndex(),"foo").contains(p));
+    }
+    
+    @Test
+    public void testSearchWithinFolders() throws Exception {
+        MockFolder folder1 = j.createFolder("folder1");
+        FreeStyleProject p1 = folder1.createProject(FreeStyleProject.class, "myjob");
+        MockFolder folder2 = j.createFolder("folder2");
+        FreeStyleProject p2 = folder2.createProject(FreeStyleProject.class, "myjob");
+        List<SearchItem> suggest = suggest(j.jenkins.getSearchIndex(), "myjob");
+        assertTrue(suggest.contains(p1));
+        assertTrue(suggest.contains(p2));
     }
 
     private List<SearchItem> suggest(SearchIndex index, String term) {


### PR DESCRIPTION
The goal of this pull request is to make the following possible when using the Folders plugin.

Given the following structure
- folder1/foo
- folder2/foo

if you search for _foo_ in the search bar, both folder1/foo and folder2/foo will be returned. With previous implementation, no result was returned.
