### PR TITLE
[FIXED JENKINS-18634] Advertise the CLI TCP port when we use HudsonAuthenticationEntryPoint

### DIFF
--- a/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
+++ b/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
@@ -23,6 +23,9 @@
  */
 package hudson.security;
 
+import jenkins.model.Jenkins;
+import hudson.TcpSlaveAgentListener;
+
 import com.google.common.base.Strings;
 import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.InsufficientAuthenticationException;
@@ -80,6 +83,15 @@ public class HudsonAuthenticationEntryPoint extends AuthenticationProcessingFilt
 
             rsp.setStatus(SC_FORBIDDEN);
             rsp.setContentType("text/html;charset=UTF-8");
+
+            // advertise the CLI TCP port
+            TcpSlaveAgentListener tal = Jenkins.getInstance().getTcpSlaveAgentListener();
+            if (tal!=null) {
+                rsp.setIntHeader("X-Hudson-CLI-Port", tal.getPort());
+                rsp.setIntHeader("X-Jenkins-CLI-Port", tal.getPort());
+                rsp.setIntHeader("X-Jenkins-CLI2-Port", tal.getPort());
+                rsp.setHeader("X-Jenkins-CLI-Host", TcpSlaveAgentListener.CLI_HOST_NAME);
+            }
 
             AccessDeniedException2 cause = null;
             // report the diagnosis information if possible


### PR DESCRIPTION
layout.jelly exposes a number of HTTP headers that the cli client uses:

X-Hudson-CLI-Port
X-Jenkins-CLI-Port
X-Jenkins-CLI2-Port
X-Jenkins-CLI-Host

Because HudsonAuthenticationEntryPoint doesn't use that layout when it serves a 403, the necessary HTTP headers are missing. If the redirection is external (as is the case with the openid plugin), it breaks CLI support completely.

Bug is here: https://issues.jenkins-ci.org/browse/JENKINS-18634
