### PR TITLE
[FIXED JENKINS-15025] no additional info in console log about failures

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/Maven3Builder.java
+++ b/maven-plugin/src/main/java/hudson/maven/Maven3Builder.java
@@ -129,18 +129,6 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
 
 			// manage of Maven error are moved to ExecutionEventLogger, they are
 			// threaded as in MavenCli
-            if (!mavenExecutionResult.getThrowables().isEmpty() && isDebug()) {
-                logger.println( "mavenExecutionResult exceptions not empty");
-                for(Throwable throwable : mavenExecutionResult.getThrowables()) {
-                    logger.println("message : " + throwable.getMessage());
-                    if (throwable.getCause()!=null) {
-                        logger.println("cause : " + throwable.getCause().getMessage());
-                    }
-                    logger.println("Stack trace : ");
-                    throwable.printStackTrace( logger );
-                }
-                
-            }
 
             if(markAsSuccess) {
                 logger.println(Messages.MavenBuilder_Failed());
@@ -200,7 +188,7 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
             
             // TODO: we should think about reusing the code in org.apache.maven.cli.DefaultMavenExecutionRequestBuilder#logging?
             // E.g. there's also the option to redirect logging to a file which is handled there, but not here.
-            PrintStreamLogger logger = new PrintStreamLogger( maven3Builder.listener.getLogger() );
+            PrintStreamLogger logger = new PrintStreamLogger( /* maven3Builder.listener.getLogger() */ System.out );
             if (maven3Builder.isDebug()) {
                 logger.setThreshold(PrintStreamLogger.LEVEL_DEBUG);
             } else if (maven3Builder.isQuiet()) {

--- a/maven-plugin/src/main/java/hudson/maven/Maven3Builder.java
+++ b/maven-plugin/src/main/java/hudson/maven/Maven3Builder.java
@@ -94,8 +94,9 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
 
             registerSystemProperties();
 
-            listener.getLogger().println(formatArgs(goals));
+            PrintStream logger = listener.getLogger();
 
+            logger.println(formatArgs(goals));
 
             int r = Maven3Main.launch( goals.toArray(new String[goals.size()]));
 
@@ -111,7 +112,6 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
 
             if(profile) {
                 NumberFormat n = NumberFormat.getInstance();
-                PrintStream logger = listener.getLogger();
                 logger.println("Total overhead was "+format(n,mavenExecutionListener.overheadTime)+"ms");
                 Channel ch = Channel.current();
                 logger.println("Class loading "   +format(n,ch.classLoadingTime.get())   +"ms, "+ch.classLoadingCount+" classes");
@@ -120,16 +120,16 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
 
             mavenExecutionResult = Maven3Launcher.getMavenExecutionResult();
             
-            PrintStream logger = listener.getLogger();
-            
             if(r==0 && mavenExecutionResult.getThrowables().isEmpty()) {
                 if(mavenExecutionListener.hasTestFailures()){
                     return Result.UNSTABLE;    
                 }
                 return Result.SUCCESS;
             }
-            
-            if (!mavenExecutionResult.getThrowables().isEmpty()) {
+
+			// manage of Maven error are moved to ExecutionEventLogger, they are
+			// threaded as in MavenCli
+            if (!mavenExecutionResult.getThrowables().isEmpty() && isDebug()) {
                 logger.println( "mavenExecutionResult exceptions not empty");
                 for(Throwable throwable : mavenExecutionResult.getThrowables()) {
                     logger.println("message : " + throwable.getMessage());
@@ -143,7 +143,7 @@ public class Maven3Builder extends AbstractMavenBuilder implements DelegatingCal
             }
 
             if(markAsSuccess) {
-                listener.getLogger().println(Messages.MavenBuilder_Failed());
+                logger.println(Messages.MavenBuilder_Failed());
                 if(mavenExecutionListener.hasTestFailures()){
                     return Result.UNSTABLE;    
                 }

--- a/maven-plugin/src/main/java/hudson/maven/util/ExecutionEventLogger.java
+++ b/maven-plugin/src/main/java/hudson/maven/util/ExecutionEventLogger.java
@@ -23,7 +23,13 @@ import hudson.tasks._maven.Maven3MojoNote;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
+import org.apache.maven.InternalErrorException;
+import org.apache.maven.exception.DefaultExceptionHandler;
+import org.apache.maven.exception.ExceptionHandler;
+import org.apache.maven.exception.ExceptionSummary;
 import org.apache.maven.execution.AbstractExecutionListener;
 import org.apache.maven.execution.BuildFailure;
 import org.apache.maven.execution.BuildSuccess;
@@ -34,6 +40,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Logs execution events to a user-supplied logger.
@@ -139,6 +146,8 @@ public class ExecutionEventLogger
 
             logger.info( chars( '-', LINE_LENGTH ) );
         }
+        
+        logErrors( event.getSession() );
     }
 
     private void logReactorSummary( MavenSession session )
@@ -186,6 +195,72 @@ public class ExecutionEventLogger
             logger.info( buffer.toString() );
         }
     }
+
+    private void logErrors( MavenSession session ) {
+    	MavenExecutionResult result = session.getResult();
+
+        // show all errors and them references as in MavenCli
+        if (!result.getExceptions().isEmpty()) {
+            ExceptionHandler handler = new DefaultExceptionHandler();
+
+            Map<String, String> references = new LinkedHashMap<String, String>();
+
+			for (Throwable exception : result.getExceptions()) {
+				ExceptionSummary summary = handler.handleException(exception);
+
+				logErrorSummary(summary, references, "", logger.isDebugEnabled());
+			}
+
+			if (!references.isEmpty()) {
+				logger.error("For more information about the errors and possible solutions"
+						+ ", please read the following articles:");
+
+				for (Map.Entry<String, String> entry : references.entrySet()) {
+					logger.error(entry.getValue() + " " + entry.getKey());
+				}
+			}
+        }
+    }
+
+	private void logErrorSummary(ExceptionSummary summary, Map<String, String> references, String indent, boolean showErrors) {
+		String referenceKey = "";
+
+		if (StringUtils.isNotEmpty(summary.getReference())) {
+			referenceKey = references.get(summary.getReference());
+			if (referenceKey == null) {
+				referenceKey = "[Help " + (references.size() + 1) + "]";
+				references.put(summary.getReference(), referenceKey);
+			}
+		}
+
+		String msg = summary.getMessage();
+
+		if (StringUtils.isNotEmpty(referenceKey)) {
+			if (msg.indexOf('\n') < 0) {
+				msg += " -> " + referenceKey;
+			} else {
+				msg += "\n-> " + referenceKey;
+			}
+		}
+
+		String[] lines = msg.split("(\r\n)|(\r)|(\n)");
+
+		for (int i = 0; i < lines.length; i++) {
+			String line = indent + lines[i].trim();
+
+			if (i == lines.length - 1 && (showErrors || (summary.getException() instanceof InternalErrorException))) {
+				logger.error(line, summary.getException());
+			} else {
+				logger.error(line);
+			}
+		}
+
+		indent += "  ";
+
+		for (ExceptionSummary child : summary.getChildren()) {
+			logErrorSummary(child, references, indent, showErrors);
+		}
+	}
 
     private void logResult( MavenSession session )
     {

--- a/maven-plugin/src/main/java/hudson/maven/util/ExecutionEventLogger.java
+++ b/maven-plugin/src/main/java/hudson/maven/util/ExecutionEventLogger.java
@@ -146,7 +146,7 @@ public class ExecutionEventLogger
 
             logger.info( chars( '-', LINE_LENGTH ) );
         }
-        
+
         logErrors( event.getSession() );
     }
 
@@ -196,60 +196,71 @@ public class ExecutionEventLogger
         }
     }
 
-    private void logErrors( MavenSession session ) {
+    private void logErrors( MavenSession session )
+    {
     	MavenExecutionResult result = session.getResult();
 
         // show all errors and them references as in MavenCli
-        if (!result.getExceptions().isEmpty()) {
+        if ( !result.getExceptions().isEmpty() )
+        {
             ExceptionHandler handler = new DefaultExceptionHandler();
 
             Map<String, String> references = new LinkedHashMap<String, String>();
 
-			for (Throwable exception : result.getExceptions()) {
-				ExceptionSummary summary = handler.handleException(exception);
+			for ( Throwable exception : result.getExceptions() )
+			{
+				ExceptionSummary summary = handler.handleException( exception );
 
-				logErrorSummary(summary, references, "", logger.isDebugEnabled());
+				logErrorSummary( summary, references, "", logger.isDebugEnabled() );
 			}
 
-			if (!references.isEmpty()) {
-				logger.error("For more information about the errors and possible solutions"
+			if ( !references.isEmpty() )
+			{
+				logger.error( "For more information about the errors and possible solutions"
 						+ ", please read the following articles:");
 
-				for (Map.Entry<String, String> entry : references.entrySet()) {
-					logger.error(entry.getValue() + " " + entry.getKey());
+				for ( Map.Entry<String, String> entry : references.entrySet() ) {
+					logger.error( entry.getValue() + " " + entry.getKey() );
 				}
 			}
         }
     }
 
-	private void logErrorSummary(ExceptionSummary summary, Map<String, String> references, String indent, boolean showErrors) {
+	private void logErrorSummary(ExceptionSummary summary, Map<String, String> references, String indent, boolean showErrors)
+	{
 		String referenceKey = "";
 
-		if (StringUtils.isNotEmpty(summary.getReference())) {
-			referenceKey = references.get(summary.getReference());
+		if ( StringUtils.isNotEmpty( summary.getReference() ) )
+		{
+			referenceKey = references.get( summary.getReference() );
 			if (referenceKey == null) {
-				referenceKey = "[Help " + (references.size() + 1) + "]";
-				references.put(summary.getReference(), referenceKey);
+				referenceKey = "[Help " + ( references.size() + 1 ) + "]";
+				references.put( summary.getReference(), referenceKey );
 			}
 		}
 
 		String msg = summary.getMessage();
 
-		if (StringUtils.isNotEmpty(referenceKey)) {
-			if (msg.indexOf('\n') < 0) {
+		if (StringUtils.isNotEmpty( referenceKey ))
+		{
+			if (msg.indexOf('\n') < 0)
+			{
 				msg += " -> " + referenceKey;
-			} else {
+			}
+			else
+			{
 				msg += "\n-> " + referenceKey;
 			}
 		}
 
 		String[] lines = msg.split("(\r\n)|(\r)|(\n)");
 
-		for (int i = 0; i < lines.length; i++) {
+		for ( int i = 0; i < lines.length; i++ )
+		{
 			String line = indent + lines[i].trim();
 
-			if (i == lines.length - 1 && (showErrors || (summary.getException() instanceof InternalErrorException))) {
-				logger.error(line, summary.getException());
+			if ( i == lines.length - 1 && ( showErrors || ( summary.getException() instanceof InternalErrorException ) ) ) {
+				logger.error( line, summary.getException() );
 			} else {
 				logger.error(line);
 			}
@@ -257,8 +268,8 @@ public class ExecutionEventLogger
 
 		indent += "  ";
 
-		for (ExceptionSummary child : summary.getChildren()) {
-			logErrorSummary(child, references, indent, showErrors);
+		for ( ExceptionSummary child : summary.getChildren() ) {
+			logErrorSummary( child, references, indent, showErrors );
 		}
 	}
 


### PR DESCRIPTION
Fix JENKINS-15025 problem in Jenkins jobs of type Maven2/3 where in case of failure there no descriptions, only stacktraces of the Maven3Launcher was shown.

Now exceptions in the MavenExecutionResult are handled as in MavenCli and logged to console (with highlight).
![buildfail](https://f.cloud.github.com/assets/4160180/798714/a1ca4048-ed66-11e2-9470-0a89f8b31bb4.jpg)

Errors are managed into hudson.maven.util.ExecutionEventLogger after log Reactor Summary, using the same log of entire maven process. Remove unusefull printstacktrace block from hudson.maven.Maven3Build

I had try to keep original code format (I hope).
