### PR TITLE
Allow headless installs again

### DIFF
--- a/debian/debian/control
+++ b/debian/debian/control
@@ -8,7 +8,7 @@ Homepage: https://jenkins-ci.org/
 
 Package: jenkins
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, daemon, adduser, psmisc, java2-runtime
+Depends: ${shlibs:Depends}, ${misc:Depends}, daemon, adduser, psmisc, java2-runtime-headless | java2-runtime
 Conflicts: hudson
 Replaces: hudson
 Description: Continuous integration system written in Java


### PR DESCRIPTION
Servers often want headless java to not install graphical packages
but the current depends force the install of non-headless java.
