### PR TITLE
[JENKINS 18643] Make tests run on Windows (line break character, query parameters for file schema)

### DIFF
--- a/test/src/test/java/hudson/console/ConsoleAnnotatorTest.java
+++ b/test/src/test/java/hudson/console/ConsoleAnnotatorTest.java
@@ -81,9 +81,10 @@ public class ConsoleAnnotatorTest extends HudsonTestCase {
     };
 
     public static class DemoAnnotator extends ConsoleAnnotator<Object> {
+        private static final String ANNOTATE_TEXT = "ooo" + System.getProperty("line.separator");
         @Override
         public ConsoleAnnotator annotate(Object build, MarkupText text) {
-            if (text.getText().equals("ooo\n")) {
+            if (text.getText().equals(ANNOTATE_TEXT)) {
                 text.addMarkup(0,3,"<b class=demo>","</b>");
                 return null;
             }

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -282,7 +282,8 @@ public class QueueTest extends HudsonTestCase {
 
         // View for build should group duplicates
         WebClient wc = new WebClient();
-        String buildPage = wc.getPage(build, "").asText().replace('\n',' ');
+        String nl = System.getProperty("line.separator");
+        String buildPage = wc.getPage(build, "").asText().replace(nl," ");
         assertTrue("Build page should combine duplicates and show counts: " + buildPage,
                    buildPage.contains("Started by user SYSTEM (2 times) "
                         + "Started by an SCM change (3 times) "


### PR DESCRIPTION
I have troubles in testing resgessions on Windows, for there are tests that always fails on Windows.
These commits do following changes to jenkins-test-harness, which make some of those tests succeed also on Windows. 
- Use environment-dependent line break characters instead of LF (0x0a). 
  - On Windows, CR LF (0x0d0x0a) is used instead of LF.
- Run local HTTP server when testing `UpdateSite` behaviour.
  - On Windows, query parameters with a file schema (file://.....?param=value) does not work.
