### PR TITLE
[FIXED JENKINS-16660]

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -110,9 +110,9 @@ public class Util {
     }
 
     /**
-     * Pattern for capturing variables. Either $xyz or ${xyz}, while ignoring "$$"
+     * Pattern for capturing variables. Either $xyz, ${xyz} or ${a.b} but not $a.b, while ignoring "$$"
       */
-    private static final Pattern VARIABLE = Pattern.compile("\\$([A-Za-z0-9_]+|\\{[A-Za-z0-9_]+\\}|\\$)");
+    private static final Pattern VARIABLE = Pattern.compile("\\$([A-Za-z0-9_]+|\\{[A-Za-z0-9_.]+\\}|\\$)");
 
     /**
      * Replaces the occurrence of '$key' by <tt>properties.get('key')</tt>.

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -50,6 +50,7 @@ public class UtilTest {
     public void testReplaceMacro() {
         Map<String,String> m = new HashMap<String,String>();
         m.put("A","a");
+        m.put("A.B","a-b");
         m.put("AA","aa");
         m.put("B","B");
         m.put("DOLLAR", "$");
@@ -68,6 +69,10 @@ public class UtilTest {
         assertEquals("asd$${AA}dd", Util.replaceMacro("asd$$$${AA}dd",m));
         assertEquals("$", Util.replaceMacro("$$",m));
         assertEquals("$$", Util.replaceMacro("$$$$",m));
+        
+        // dots
+        assertEquals("a.B", Util.replaceMacro("$A.B", m));
+        assertEquals("a-b", Util.replaceMacro("${A.B}", m));
 
     	// test that more complex scenarios work
         assertEquals("/a/B/aa", Util.replaceMacro("/$A/$B/$AA",m));


### PR DESCRIPTION
[FIXED JENKINS-16660]

Allow variable names with dots in bracketed references.

Given these <variable,value> mappings: <A,a> and <A.B,a-b>, $A.B would
evaluate to $a.B, as it currently does, and ${A.B} to a-b instead of the
current ${A.B}.

Existing ${A.B}-like references will break (not evaluate to ${A.B}) if
there actually is an A.B variable defined, which I think is very
unlikely.
