### PR TITLE
[bugfix] Do not expose raw type in API

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -759,11 +759,11 @@ public class Functions {
     }
 
     public static List<Descriptor<Builder>> getBuilderDescriptors(AbstractProject<?,?> project) {
-        return BuildStepDescriptor.filter(Builder.all(), project.getClass());
+        return BuildStepDescriptor.filter(Builder.all(), (Class<AbstractProject<?, ?>>)project.getClass());
     }
 
     public static List<Descriptor<Publisher>> getPublisherDescriptors(AbstractProject<?,?> project) {
-        return BuildStepDescriptor.filter(Publisher.all(), project.getClass());
+        return BuildStepDescriptor.filter(Publisher.all(), (Class<AbstractProject<?, ?>>)project.getClass());
     }
 
     public static List<SCMDescriptor<?>> getSCMDescriptors(AbstractProject<?,?> project) {

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -223,7 +223,7 @@ public class ArtifactArchiver extends Recorder {
             return req.bindJSON(ArtifactArchiver.class,formData);
         }
 
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
             return true;
         }
     }

--- a/core/src/main/java/hudson/tasks/BatchFile.java
+++ b/core/src/main/java/hudson/tasks/BatchFile.java
@@ -69,7 +69,7 @@ public class BatchFile extends CommandInterpreter {
             return new BatchFile(data.getString("command"));
         }
 
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
             return true;
         }
     }

--- a/core/src/main/java/hudson/tasks/BuildStepDescriptor.java
+++ b/core/src/main/java/hudson/tasks/BuildStepDescriptor.java
@@ -63,14 +63,14 @@ public abstract class BuildStepDescriptor<T extends BuildStep & Describable<T>> 
      *      true to allow user to configure this post-promotion task for the given project.
      * @see AbstractProjectDescriptor#isApplicable(Descriptor) 
      */
-    public abstract boolean isApplicable(Class<? extends AbstractProject> jobType);
+    public abstract boolean isApplicable(Class<? extends AbstractProject<?, ?>> jobType);
 
 
     /**
      * Filters a descriptor for {@link BuildStep}s by using {@link BuildStepDescriptor#isApplicable(Class)}.
      */
     public static <T extends BuildStep&Describable<T>>
-    List<Descriptor<T>> filter(List<Descriptor<T>> base, Class<? extends AbstractProject> type) {
+    List<Descriptor<T>> filter(List<Descriptor<T>> base, Class<? extends AbstractProject<?, ?>> type) {
         // descriptor of the project
         Descriptor pd = Jenkins.getInstance().getDescriptor((Class) type);
 

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -307,7 +307,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
         }
 
         @Override
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
             return true;
         }
 

--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -282,7 +282,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
             return req.bindJSON(Fingerprinter.class, formData);
         }
 
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(Class<? extends AbstractProject<?, ?>> jobType) {
             return true;
         }
     }

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -392,7 +392,7 @@ public class Maven extends Builder {
             load();
         }
 
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
             return true;
         }
 

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -128,7 +128,7 @@ public class Shell extends CommandInterpreter {
             load();
         }
 
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
             return true;
         }
 

--- a/core/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/core/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -267,7 +267,7 @@ public class JUnitResultArchiver extends Recorder implements MatrixAggregatable 
 			return FilePath.validateFileMask(project.getSomeWorkspace(), value);
 		}
 
-		public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+		public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
 			return true;
 		}
     }

--- a/core/src/main/java/hudson/tasks/test/AggregatedTestResultPublisher.java
+++ b/core/src/main/java/hudson/tasks/test/AggregatedTestResultPublisher.java
@@ -317,7 +317,7 @@ public class AggregatedTestResultPublisher extends Recorder {
 
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
             return true;    // for all types
         }
 

--- a/maven-plugin/src/main/java/hudson/maven/MavenTestDataPublisher.java
+++ b/maven-plugin/src/main/java/hudson/maven/MavenTestDataPublisher.java
@@ -112,7 +112,7 @@ public class MavenTestDataPublisher extends Recorder {
 		}
 
 		@Override
-		public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+		public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
 			return MavenModuleSet.class.isAssignableFrom(jobType) && !TestDataPublisher.all().isEmpty();
 		}
 		

--- a/maven-plugin/src/main/java/hudson/maven/RedeployPublisher.java
+++ b/maven-plugin/src/main/java/hudson/maven/RedeployPublisher.java
@@ -349,7 +349,7 @@ public class RedeployPublisher extends Recorder {
             super(clazz);
         }
 
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
             return jobType==MavenModuleSet.class;
         }
 

--- a/test/src/main/java/org/jvnet/hudson/test/TestBuilder.java
+++ b/test/src/main/java/org/jvnet/hudson/test/TestBuilder.java
@@ -50,7 +50,7 @@ public abstract class TestBuilder extends Builder {
         // throw new UnsupportedOperationException();
         return new BuildStepDescriptor<Builder>() {
             @Override
-            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
                 return true;
             }
 

--- a/test/src/test/java/hudson/tasks/test/TrivialTestResultRecorder.java
+++ b/test/src/test/java/hudson/tasks/test/TrivialTestResultRecorder.java
@@ -70,7 +70,7 @@ public class TrivialTestResultRecorder extends Recorder implements Serializable 
          * @see hudson.model.AbstractProject.AbstractProjectDescriptor#isApplicable(hudson.model.Descriptor)
          */
         @Override
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+        public boolean isApplicable(Class<? extends AbstractProject<?,?>> jobType) {
             return true;
         }
 


### PR DESCRIPTION
Raw types should not be exposed through an API as this makes integration with some non-Java JVM languages impossible, e.g. Scala.

It was previously impossible to implement hudson.tasks.BuildStepDescriptor::isApplicable in Scala due to a raw type.

For background see - http://stackoverflow.com/questions/5279149/implementing-methods-having-raw-types-in-scala/5279343#5279343
