### PR TITLE
Fix javadoc tag which was not closed, remove ignored @author tag

### DIFF
--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -492,7 +492,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
     }
 
     /**
-     * Akin to {@link #getPropertyType(Object,String) but never returns null.
+     * Akin to {@link #getPropertyType(Object,String)} but never returns null.
      * @throws AssertionError in case the field cannot be found
      * @since 1.492
      */

--- a/core/src/main/java/hudson/tasks/Publisher.java
+++ b/core/src/main/java/hudson/tasks/Publisher.java
@@ -112,7 +112,6 @@ public abstract class Publisher extends BuildStepCompatibilityLayer implements B
      * When {@link Publisher} behaves this way, note that they can no longer
      * change the build status anymore.
      *
-     * @author Kohsuke Kawaguchi
      * @since 1.153
      */
     public boolean needsToRunAfterFinalized() {


### PR DESCRIPTION
Javadoc ignores @author tags on methods, requiring that they be on classes and interfaces.
