### PR TITLE
Fix many of the javadoc unresolved @link warnings

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -487,7 +487,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * If the plugin has {@link #getUpdateInfo() an update},
-     * returns the {@link UpdateSite.Plugin} object.
+     * returns the {@link hudson.model.UpdateSite.Plugin} object.
      *
      * @return
      *      This method may return null &mdash; for example,
@@ -501,7 +501,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     }
     
     /**
-     * returns the {@link UpdateSite.Plugin} object, or null.
+     * returns the {@link hudson.model.UpdateSite.Plugin} object, or null.
      */
     public UpdateSite.Plugin getInfo() {
         UpdateCenter uc = Jenkins.getInstance().getUpdateCenter();

--- a/core/src/main/java/hudson/cli/handlers/package-info.java
+++ b/core/src/main/java/hudson/cli/handlers/package-info.java
@@ -1,5 +1,5 @@
 /**
- * {@link OptionHandler} implementations for Hudson.
+ * {@link org.kohsuke.args4j.spi.OptionHandler} implementations for Hudson.
  */
 package hudson.cli.handlers;
 

--- a/core/src/main/java/hudson/fsp/WorkspaceSnapshotSCM.java
+++ b/core/src/main/java/hudson/fsp/WorkspaceSnapshotSCM.java
@@ -89,7 +89,7 @@ public class WorkspaceSnapshotSCM extends SCM {
     }
     /**
      * Obtains the {@link WorkspaceSnapshot} object that this {@link SCM} points to,
-     * or throws {@link ResolvedFailedException} upon failing.
+     * or throws {@link hudson.fsp.WorkspaceSnapshotSCM.ResolvedFailedException} upon failing.
      *
      * @return never null.
      */

--- a/core/src/main/java/hudson/init/package-info.java
+++ b/core/src/main/java/hudson/init/package-info.java
@@ -27,13 +27,13 @@
  *
  * <p>
  * Hudson's start up is based on the same idea as the modern Unix init mechanism like initng/upstart/SMF.
- * It first builds a set of {@link Task}s that are units of the initialization work, and have them declare
+ * It first builds a set of {@link org.jvnet.hudson.reactor.Task}s that are units of the initialization work, and have them declare
  * dependencies among themselves. For example, jobs are only loaded after all the plugins are initialized,
  * and restoring the build queue requires all the jobs to be loaded.
  *
  * <p>
  * Such micro-scopic dependencies are organized into a bigger directed acyclic graph, which is then executed
- * via {@link Session}. During execution of the reactor, additional tasks can be discovred and added to
+ * via <tt>Session</tt>. During execution of the reactor, additional tasks can be discovred and added to
  * the DAG. We use this additional indirection to:
  *
  * <ol>

--- a/core/src/main/java/hudson/matrix/AxisList.java
+++ b/core/src/main/java/hudson/matrix/AxisList.java
@@ -88,7 +88,7 @@ public class AxisList extends ArrayList<Axis> {
     }
 
     /**
-     * {@link Converter} implementation for XStream.
+     * {@link com.thoughtworks.xstream.converters.Converter} implementation for XStream.
      */
     public static final class ConverterImpl extends RobustCollectionConverter {
         public ConverterImpl(XStream xs) {

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -153,7 +153,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     private volatile Set<String> culprits;
 
     /**
-     * During the build this field remembers {@link BuildWrapper.Environment}s created by
+     * During the build this field remembers {@link hudson.tasks.BuildWrapper.Environment}s created by
      * {@link BuildWrapper}. This design is bit ugly but forced due to compatibility.
      */
     protected transient List<Environment> buildEnvironments;
@@ -360,7 +360,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     }
 
     /**
-     * Normally, a workspace is assigned by {@link RunExecution}, but this lets you set the workspace in case
+     * Normally, a workspace is assigned by {@link hudson.model.Run.RunExecution}, but this lets you set the workspace in case
      * {@link AbstractBuild} is created without a build.
      */
     protected void setWorkspace(FilePath ws) {
@@ -496,7 +496,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
 
     /**
      * @deprecated as of 1.467
-     *      Please use {@link RunExecution}
+     *      Please use {@link hudson.model.Run.RunExecution}
      */
     public abstract class AbstractRunner extends AbstractBuildExecution {
 

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -84,7 +84,7 @@ public class Executor extends Thread implements ModelObject {
      */
     private int number;
     /**
-     * {@link Queue.Executable} being executed right now, or null if the executor is idle.
+     * {@link hudson.model.Queue.Executable} being executed right now, or null if the executor is idle.
      */
     private volatile Queue.Executable executable;
 
@@ -299,7 +299,7 @@ public class Executor extends Thread implements ModelObject {
     }
 
     /**
-     * Returns the current {@link Queue.Task} this executor is running.
+     * Returns the current {@link hudson.model.Queue.Task} this executor is running.
      *
      * @return
      *      null if the executor is idle.

--- a/core/src/main/java/hudson/model/LoadStatistics.java
+++ b/core/src/main/java/hudson/model/LoadStatistics.java
@@ -77,7 +77,7 @@ public abstract class LoadStatistics {
     public final MultiStageTimeSeries totalExecutors;
 
     /**
-     * Number of {@link Queue.BuildableItem}s that can run on any node in this node set but blocked.
+     * Number of {@link hudson.model.Queue.BuildableItem}s that can run on any node in this node set but blocked.
      */
     @Exported
     public final MultiStageTimeSeries queueLength;

--- a/core/src/main/java/hudson/model/ManagementLink.java
+++ b/core/src/main/java/hudson/model/ManagementLink.java
@@ -107,7 +107,7 @@ public abstract class ManagementLink implements ExtensionPoint, Action {
     }
 
     /**
-     * @return permission required for user to access this management link, in addition to {@link Jenkins.ADMINISTER}
+     * @return permission required for user to access this management link, in addition to <tt>ADMINISTER</tt>
      */
     public Permission getRequiredPermission() {
         return null;

--- a/core/src/main/java/hudson/model/ManagementLink.java
+++ b/core/src/main/java/hudson/model/ManagementLink.java
@@ -107,7 +107,7 @@ public abstract class ManagementLink implements ExtensionPoint, Action {
     }
 
     /**
-     * @return permission required for user to access this management link, in addition to <tt>ADMINISTER</tt>
+     * @return permission required for user to access this management link, in addition to {@link Jenkins#ADMINISTER}
      */
     public Permission getRequiredPermission() {
         return null;

--- a/core/src/main/java/hudson/model/OverallLoadStatistics.java
+++ b/core/src/main/java/hudson/model/OverallLoadStatistics.java
@@ -40,7 +40,7 @@ import org.kohsuke.stapler.export.Exported;
  */
 public class OverallLoadStatistics extends LoadStatistics {
     /**
-     * Number of total {@link Queue.BuildableItem}s that represents blocked builds.
+     * Number of total {@link hudson.model.Queue.BuildableItem}s that represents blocked builds.
      *
      * @deprecated as of 1.467
      *      Use {@link #queueLength}. Left as an alias here for backward compatibility.

--- a/core/src/main/java/hudson/model/Resource.java
+++ b/core/src/main/java/hudson/model/Resource.java
@@ -24,11 +24,11 @@
 package hudson.model;
 
 /**
- * Represents things that {@link Queue.Executable} uses while running.
+ * Represents things that {@link hudson.model.Queue.Executable} uses while running.
  *
  * <p>
  * This is used in {@link Queue} to support basic mutual exclusion/locks. If two
- * {@link Queue.Task}s require the same {@link Resource}, they will not
+ * {@link hudson.model.Queue.Task}s require the same {@link Resource}, they will not
  * be run at the same time.
  *
  * <p>

--- a/core/src/main/java/hudson/model/Saveable.java
+++ b/core/src/main/java/hudson/model/Saveable.java
@@ -42,7 +42,7 @@ public interface Saveable {
      * For making a bulk change efficiently, see {@link BulkChange}.
      *
      * <p>
-     * To support listeners monitoring changes to this object, call {@link SaveableListener.fireOnChange}
+     * To support listeners monitoring changes to this object, call {@link SaveableListener#fireOnChange}
      * @throws IOException
      *      if the persistence failed.
      */

--- a/core/src/main/java/hudson/model/listeners/RunListener.java
+++ b/core/src/main/java/hudson/model/listeners/RunListener.java
@@ -94,7 +94,7 @@ public abstract class RunListener<R extends Run> implements ExtensionPoint {
     public void onCompleted(R r, @Nonnull TaskListener listener) {}
 
     /**
-     * Called after a build is moved to the {@link Run.State#COMPLETED} state.
+     * Called after a build is moved to the {@link hudson.model.Run.State#COMPLETED} state.
      *
      * <p>
      * At this point, all the records related to a build is written down to the disk. As such,

--- a/core/src/main/java/hudson/model/queue/AbstractQueueTask.java
+++ b/core/src/main/java/hudson/model/queue/AbstractQueueTask.java
@@ -34,7 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- * Abstract base class for {@link Queue.Task} to protect plugins
+ * Abstract base class for {@link hudson.model.Queue.Task} to protect plugins
  * from new additions to the interface.
  *
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/hudson/model/queue/FoldableAction.java
+++ b/core/src/main/java/hudson/model/queue/FoldableAction.java
@@ -48,7 +48,7 @@ public interface FoldableAction extends Action {
      * is considered as a duplicate.
      *
      * @param item
-     *      The existing {@link Queue.Item} in the queue against which we are judged as a duplicate. Never null.
+     *      The existing {@link hudson.model.Queue.Item} in the queue against which we are judged as a duplicate. Never null.
      * @param owner
      *      The {@link Task} with which this action was submitted to the queue. Never null.
      * @param otherActions

--- a/core/src/main/java/hudson/model/queue/FutureImpl.java
+++ b/core/src/main/java/hudson/model/queue/FutureImpl.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 /**
- * Created when {@link Queue.Item} is created so that the caller can track the progress of the task.
+ * Created when {@link hudson.model.Queue.Item} is created so that the caller can track the progress of the task.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/model/queue/QueueListener.java
+++ b/core/src/main/java/hudson/model/queue/QueueListener.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Executor;
  * {@link Computer#threadPoolForRemoting}.
  *
  * <p>
- * For the state transition of {@link Queue.Item} in {@link Queue}, please refer to the Queue javadoc.
+ * For the state transition of {@link hudson.model.Queue.Item} in {@link Queue}, please refer to the Queue javadoc.
  *
  * @author Kohsuke Kawaguchi
  * @since 1.520

--- a/core/src/main/java/hudson/model/queue/QueueTaskDispatcher.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskDispatcher.java
@@ -102,7 +102,7 @@ public abstract class QueueTaskDispatcher implements ExtensionPoint {
     }
 
     /**
-     * Called whenever {@link Queue} is considering if {@link Queue.Item} is ready to execute immediately
+     * Called whenever {@link Queue} is considering if {@link hudson.model.Queue.Item} is ready to execute immediately
      * (which doesn't necessarily mean that it gets executed right away &mdash; it's still subject to
      * executor availability), or if it should be considered blocked.
      *

--- a/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 import java.util.Collection;
 
 /**
- * Base class for defining filter {@link Queue.Task}.
+ * Base class for defining filter {@link hudson.model.Queue.Task}.
  *
  * @author Kohsuke Kawaguchi
  * @since 1.360

--- a/core/src/main/java/hudson/scm/AbstractScmTagAction.java
+++ b/core/src/main/java/hudson/scm/AbstractScmTagAction.java
@@ -35,7 +35,7 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 
 /**
- * Common part of {@link CVSSCM.TagAction} and {@link SubversionTagAction}.
+ * Common part of <tt>CVSSCM.TagAction</tt> and <tt>SubversionTagAction</tt>.
  *
  * <p>
  * This class implements the action that tags the modules. Derived classes

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -198,7 +198,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
     /**
      * Creates an account and associates that with the given identity. Used in conjunction
-     * with {@link #commenceSignup(FederatedIdentity)}.
+     * with {@link #commenceSignup}.
      */
     public User doCreateAccountWithFederatedIdentity(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         User u = _doCreateAccount(req,rsp,"signupWithFederatedIdentity.jelly");

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -459,7 +459,7 @@ public class Maven extends Builder {
 
         /**
          * @deprecated as of 1.308.
-         *      Use {@link #MavenInstallation(String, String, List)}
+         *      Use {@link #Maven.MavenInstallation(String, String, List)}
          */
         public MavenInstallation(String name, String home) {
             super(name, home);

--- a/core/src/main/java/hudson/util/FormValidation.java
+++ b/core/src/main/java/hudson/util/FormValidation.java
@@ -63,7 +63,7 @@ import java.util.Locale;
  * that you may be able to reuse.
  *
  * <p>
- * Also see {@link CVSSCM.DescriptorImpl#doCheckCvsRoot(String)} as an example.
+ * Also see <tt>doCheckCvsRoot</tt> in <tt>CVSSCM</tt> as an example.
  *
  * <p>
  * This class extends {@link IOException} so that it can be thrown from a method. This allows one to reuse

--- a/core/src/main/java/hudson/util/ProcessKiller.java
+++ b/core/src/main/java/hudson/util/ProcessKiller.java
@@ -40,18 +40,18 @@ import java.io.Serializable;
  * <p>
  * Each implementation of {@link ProcessKiller} is instantiated once on the master.
  * Whenever a process needs to be killed, those implementations are serialized and sent over
- * to the appropriate slave, then the {@link #kill(OSProcess)} method is invoked
+ * to the appropriate slave, then the {@link #kill(ProcessTree.OSProcess)} method is invoked
  * to attempt to kill the process.
  *
  * <p>
  * One of the consequences of this design is that the implementation should be stateless
- * and concurrent-safe. That is, the {@link #kill(OSProcess)} method can be invoked by multiple threads
+ * and concurrent-safe. That is, the {@link #kill(ProcessTree.OSProcess)} method can be invoked by multiple threads
  * concurrently on the single instance.
  *
  * <p>
  * Another consequence of this design is that if your {@link ProcessKiller} requires configuration,
  * it needs to be serializable, and configuration needs to be updated atomically, as another
- * thread may be calling into {@link #kill(OSProcess)} just when you are updating your configuration.
+ * thread may be calling into {@link #kill(ProcessTree.OSProcess)} just when you are updating your configuration.
  *
  * @author jpederzolli
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/jenkins/model/DependencyDeclarer.java
+++ b/core/src/main/java/jenkins/model/DependencyDeclarer.java
@@ -34,7 +34,7 @@ import hudson.tasks.Publisher;
  * in the dependency graph computation process.
  *
  * <p>
- * {@link Publisher}s, {@link Builder}s, and {@link JobProperty}s
+ * {@link Publisher}s, {@link Builder}s, and {@link hudson.model.JobProperty}s
  * can additional implement this method to add additional edges
  * to the dependency graph computation.
  *

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -590,7 +590,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
     /**
      * Load statistics of the free roaming jobs and slaves.
      * 
-     * This includes all executors on {@link Mode#NORMAL} nodes and jobs that do not have any assigned nodes.
+     * This includes all executors on {@link hudson.model.Node.Mode#NORMAL} nodes and jobs that do not have any assigned nodes.
      *
      * @since 1.467
      */

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -95,7 +95,7 @@ import static jenkins.model.lazy.Boundary.*;
  * <p>
  * Object lock of {@code this} is used to make sure mutation occurs sequentially.
  * That is, ensure that only one thread is actually calling {@link #retrieve(File)} and
- * updating {@link Index#byNumber} and {@link Index#byId}.
+ * updating {@link jenkins.model.lazy.AbstractLazyLoadRunMap.Index#byNumber} and {@link jenkins.model.lazy.AbstractLazyLoadRunMap.Index#byId}.
  *
  * @author Kohsuke Kawaguchi
  * @since 1.485

--- a/core/src/main/java/jenkins/security/ExceptionTranslationFilter.java
+++ b/core/src/main/java/jenkins/security/ExceptionTranslationFilter.java
@@ -53,13 +53,13 @@ import java.io.IOException;
  * <p>
  * If an {@link AuthenticationException} is detected, the filter will launch the <code>authenticationEntryPoint</code>.
  * This allows common handling of authentication failures originating from any subclass of
- * {@link org.acegisecurity.intercept.AbstractSecurityInterceptor}.
+ * <tt>AbstractSecurityInterceptor</tt>.
  * </p>
  * <p>
  * If an {@link AccessDeniedException} is detected, the filter will determine whether or not the user is an anonymous
  * user. If they are an anonymous user, the <code>authenticationEntryPoint</code> will be launched. If they are not
- * an anonymous user, the filter will delegate to the {@link org.acegisecurity.ui.AccessDeniedHandler}.
- * By default the filter will use {@link org.acegisecurity.ui.AccessDeniedHandlerImpl}.
+ * an anonymous user, the filter will delegate to the <tt>AccessDeniedHandler</tt>.
+ * By default the filter will use <tt>AccessDeniedHandlerImpl</tt>.
  * </p>
  * <p>
  * To use this filter, it is necessary to specify the following properties:
@@ -74,8 +74,7 @@ import java.io.IOException;
  * </ul>
  * <P>
  * <B>Do not use this class directly.</B> Instead configure
- * <code>web.xml</code> to use the {@link
- * org.acegisecurity.util.FilterToBeanProxy}.
+ * <code>web.xml</code> to use the <tt>FilterToBeanProxy</tt>.
  * </p>
  *
  * @author Ben Alex

--- a/core/src/main/java/jenkins/security/NonSerializableSecurityContext.java
+++ b/core/src/main/java/jenkins/security/NonSerializableSecurityContext.java
@@ -37,7 +37,7 @@ import javax.servlet.http.HttpSession;
  * See <a href="http://jenkins.361315.n4.nabble.com/ActiveDirectory-Plugin-ClassNotFoundException-while-loading-persisted-sessions-tp376451.html">the problem report</a>.
  *
  * @author Kohsuke Kawaguchi
- * @see HttpSessionContextIntegrationFilter2
+ * @see hudson.security.HttpSessionContextIntegrationFilter2
  * @since 1.509
  */
 public class NonSerializableSecurityContext implements SecurityContext {

--- a/core/src/main/java/jenkins/security/QueueItemAuthenticator.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticator.java
@@ -14,7 +14,7 @@ import org.acegisecurity.Authentication;
 import javax.annotation.CheckForNull;
 
 /**
- * Extension point to run {@link Queue.Executable}s under a specific identity for better access control.
+ * Extension point to run {@link hudson.model.Queue.Executable}s under a specific identity for better access control.
  *
  * @author Kohsuke Kawaguchi
  * @since 1.520
@@ -24,11 +24,11 @@ import javax.annotation.CheckForNull;
  */
 public abstract class QueueItemAuthenticator extends AbstractDescribableImpl<QueueItemAuthenticator> implements ExtensionPoint {
     /**
-     * Determines the identity in which the {@link Queue.Executable} will run as.
+     * Determines the identity in which the {@link hudson.model.Queue.Executable} will run as.
      *
      * @param item
      *      The contextual information to assist the authentication.
-     *      The primary interest is likely {@link Queue.Item#task}, which is often {@link AbstractProject}.
+     *      The primary interest is likely {@link hudson.model.Queue.Item#task}, which is often {@link AbstractProject}.
      *      {@link Action}s associated with the item is also likely of interest, such as {@link CauseAction}.
      *
      * @return

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -142,7 +142,7 @@ public class QueueTest extends HudsonTestCase {
     }
 
     /**
-     * {@link Queue.BlockedItem} is not static. Make sure its persistence doesn't end up re-persisting the whole Queue instance.
+     * {@link hudson.model.Queue.BlockedItem} is not static. Make sure its persistence doesn't end up re-persisting the whole Queue instance.
      */
     public void testPersistenceBlockedItem() throws Exception {
         Queue q = jenkins.getQueue();


### PR DESCRIPTION
Several of the links cannot be resolved from within the core classes.  They have been switched to the the "tt" font rather than using an @link tag which will not be converted into a link and which would always generate a warning at javadoc generation.
