### PR TITLE
Remove javadoc reference to now private buildReactorListener

### DIFF
--- a/core/src/main/java/hudson/init/InitReactorListener.java
+++ b/core/src/main/java/hudson/init/InitReactorListener.java
@@ -15,7 +15,6 @@ import org.kohsuke.MetaInfServices;
  * To register, put {@link MetaInfServices} on your implementation.
  *
  * @author Kohsuke Kawaguchi
- * @see jenkins.model.Jenkins#buildReactorListener()
  */
 public interface InitReactorListener extends ReactorListener {
 }


### PR DESCRIPTION
The buildReactorListener method seems to now be private in the implementation, so an @see javadoc reference can't be used to point to its documentation.
