### PR TITLE
Remove javadoc link references to java.util.concurrent.Future

### DIFF
--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -144,8 +144,8 @@ public abstract class Cloud extends AbstractModelObject implements ExtensionPoin
      *      provisioning operations. Can be empty but must not be null.
      *      {@link NodeProvisioner} will be responsible for adding the resulting {@link Node}s
      *      into Hudson via {@link jenkins.model.Jenkins#addNode(Node)}, so a {@link Cloud} implementation
-     *      just needs to return {@link PlannedNode}s that each contain an object that implements {@link Future}.
-     *      When the {@link Future} has completed its work, {@link Future#get} will be called to obtain the
+     *      just needs to return {@link PlannedNode}s that each contain an object that implements <tt>Future</tt>.
+     *      When the <tt>Future</tt> has completed its work, <tt>Future.get</tt> will be called to obtain the
      *      provisioned {@link Node} object.
      */
     public abstract Collection<PlannedNode> provision(Label label, int excessWorkload);

--- a/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
+++ b/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
@@ -63,7 +63,7 @@ public abstract class CloudProvisioningListener implements ExtensionPoint {
     }
 
     /**
-     * Called when {@link NodeProvisioner.PlannedNode#future#get()} throws an exception.
+     * Called when <tt>PlannedNode.future.get()</tt> throws an exception.
      *
      * @param plannedNode the planned node which failed to launch
      * @param t the exception


### PR DESCRIPTION
Cannot link to external javadoc without additional javadoc flags
