### PR TITLE
Make CaseResult non-final and it's ctor public

### DIFF
--- a/core/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/core/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Daniel Dyer, Seiji Sogabe, Tom Huybrechts, Yahoo!, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,17 +23,6 @@
  */
 package hudson.tasks.junit;
 
-import hudson.util.TextFile;
-import org.apache.commons.io.FileUtils;
-import org.jvnet.localizer.Localizable;
-
-import hudson.model.AbstractBuild;
-import hudson.model.Run;
-import hudson.tasks.test.TestResult;
-
-import org.dom4j.Element;
-import org.kohsuke.stapler.export.Exported;
-
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
@@ -43,15 +32,27 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.logging.Logger;
 
+import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import hudson.tasks.test.TestResult;
+import hudson.util.TextFile;
+import org.apache.commons.io.FileUtils;
+import org.dom4j.Element;
+import org.jvnet.localizer.Localizable;
+import org.kohsuke.stapler.export.Exported;
+
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 /**
  * One test result.
  *
+ * Non-final class but should not be extended unless absolutely necessary. Might be necessary to
+ * extend if you need to implement {@link hudson.tasks.test.AbstractTestResultAction#getFailedTests()}
+ *
  * @author Kohsuke Kawaguchi
  */
-public final class CaseResult extends TestResult implements Comparable<CaseResult> {
+public class CaseResult extends TestResult implements Comparable<CaseResult> {
     private static final Logger LOGGER = Logger.getLogger(CaseResult.class.getName());
     private final float duration;
     /**
@@ -202,7 +203,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
     /**
      * Used to create a fake failure, when Hudson fails to load data from XML files.
      */
-    CaseResult(SuiteResult parent, String testName, String errorStackTrace) {
+    public CaseResult(SuiteResult parent, String testName, String errorStackTrace) {
         this.className = parent == null ? "unnamed" : parent.getName();
         this.testName = testName;
         this.errorStackTrace = errorStackTrace;
@@ -214,7 +215,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
         this.skipped = false;
         this.skippedMessage = null;
     }
-    
+
     public ClassResult getParent() {
     	return classResult;
     }
@@ -330,11 +331,11 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
         if(idx<0)       return "(root)";
         else            return className.substring(0,idx);
     }
-    
+
     public String getFullName() {
     	return className+'.'+getName();
     }
-    
+
     /**
      * @since 1.515
      */
@@ -373,12 +374,12 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
                 this.failedSince = getOwner().getNumber();
             } else {
                 LOGGER.warning("trouble calculating getFailedSince. We've got prev, but no owner.");
-                // failedSince will be 0, which isn't correct. 
+                // failedSince will be 0, which isn't correct.
             }
         }
         return failedSince;
     }
-    
+
     public Run<?,?> getFailedSinceRun() {
     	return getOwner().getParent().getBuildByNumber(getFailedSince());
     }
@@ -395,7 +396,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
             return getOwner().getNumber()-getFailedSince()+1;
         } else {
             LOGGER.fine("Trying to get age of a CaseResult without an owner");
-            return 0; 
+            return 0;
     }
     }
 
@@ -416,7 +417,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
     public String getStdout() {
         if(stdout!=null)    return stdout;
         SuiteResult sr = getSuiteResult();
-        if (sr==null) return "";         
+        if (sr==null) return "";
         return getSuiteResult().getStdout();
     }
 
@@ -441,7 +442,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
         if(pr==null)    return null;
         return pr.getCase(getName());
     }
-    
+
     /**
      * Case results have no children
      * @return null
@@ -524,7 +525,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
     public boolean isSkipped() {
         return skipped;
     }
-    
+
     /**
      * @return true if the test was not skipped and did not pass, false otherwise.
      * @since 1.520
@@ -546,7 +547,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
     public SuiteResult getSuiteResult() {
         return parent;
     }
-    
+
     @Override
     public AbstractBuild<?,?> getOwner() {
         SuiteResult sr = getSuiteResult();
@@ -555,7 +556,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
         hudson.tasks.junit.TestResult tr = sr.getParent();
         if (tr==null) {
             LOGGER.warning("In getOwner(), suiteResult.getParent() is null."); return null; }
-        return tr.getOwner(); 
+        return tr.getOwner();
     }
 
     public void setParentSuiteResult(SuiteResult parent) {
@@ -598,7 +599,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
     /*package*/ void setClass(ClassResult classResult) {
         this.classResult = classResult;
     }
-    
+
     void replaceParent(SuiteResult parent) {
         this.parent = parent;
     }


### PR DESCRIPTION
See the discussion at https://groups.google.com/forum/#!topic/jenkinsci-dev/CPab12692Qs.

I have been trying to figure out how to get email-ext plugin to support reporting on test failures reported as part of TestNG reports.

The problem stems from the fact that AbstractTestResultAction is supposed to be a generic class but it contains a method:

```
public List<hudson.tasks.junit.CaseResult> getFailedTests() {
    return Collections.emptyList();
}
```

which returns CaseResult objects which are specific to JUnit. Also, CaseResult class is final and hence can't be extended.

TestNG plugin generates test result objects that extend hudson.tasks.test.TestResult but Email-ext and other plugins use the getFailedTests() methods and expect a list of CaseResult and then invoke specific methods on CaseResult object like getStatus, getClassname, getDisplayName etc.

Until Jenkins core developers get around to refactoring this code, I am hacking things to get this working. For other plugins that depend on getFailedTests() method, I'll return a list of objects from a class that extends CaseResult. For this, we need to make CaseResult non-final and it's constructor public.

Testing: Jenkins builds, TestNG and Email-ext plugins execute and generated email contains the correct information about failed tests.

(Didn't intend on changing the imports, IntelliJ was just being intelligent)
