### PR TITLE
Fix javadoc link from deprecated DumbSlave constructor

### DIFF
--- a/core/src/main/java/hudson/slaves/DumbSlave.java
+++ b/core/src/main/java/hudson/slaves/DumbSlave.java
@@ -42,7 +42,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public final class DumbSlave extends Slave {
     /**
      * @deprecated as of 1.286.
-     *      Use {@link #DumbSlave(String, String, String, String, Mode, String, ComputerLauncher, RetentionStrategy, List)}
+     *      Use {@link #DumbSlave(String, String, String, String, Node.Mode, String, ComputerLauncher, RetentionStrategy, List)}
      */
     public DumbSlave(String name, String nodeDescription, String remoteFS, String numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy retentionStrategy) throws FormException, IOException {
         this(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, new ArrayList());


### PR DESCRIPTION
The @link javadoc tag did not resolve to any symbol, so the deprecated constructor described at:

http://javadoc.jenkins-ci.org/hudson/slaves/DumbSlave.html 

does not link to the preferred constructor.
