### PR TITLE
Fix SCMTriggerCause javadoc to deprecated constructor

### DIFF
--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -520,7 +520,7 @@ public class SCMTrigger extends Trigger<SCMedItem> {
 
         /**
          * @deprecated
-         *      Use {@link #SCMTriggerCause(String)}.
+         *      Use {@link #SCMTrigger.SCMTriggerCause(String)}.
          */
         public SCMTriggerCause() {
             this("");


### PR DESCRIPTION
http://javadoc.jenkins-ci.org/hudson/triggers/SCMTrigger.SCMTriggerCause.html
includes a deprecated constructor with an @{link } reference to the
preferred constructor.  That link is broken in the current javadoc.
This fixes the broken link.
