### PR TITLE
Fix javadoc for @see reference in MatrixAggregator

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixAggregator.java
+++ b/core/src/main/java/hudson/matrix/MatrixAggregator.java
@@ -74,7 +74,7 @@ public abstract class MatrixAggregator implements ExtensionPoint {
      * @return
      *      true if the build can continue, false if there was an error
      *      and the build needs to be aborted.
-     * @see BuildStep#prebuild(Build,BuildListener)
+     * @see BuildStep#prebuild(AbstractBuild,BuildListener)
      */
     public boolean startBuild() throws InterruptedException, IOException {
         return true;


### PR DESCRIPTION
http://javadoc.jenkins-ci.org/hudson/matrix/MatrixAggregator.html#startBuild()
has an @see reference which should be a link.
