### PR TITLE
Fix javadoc for QueueTaskDispatcher and NodeProperty

### DIFF
--- a/core/src/main/java/hudson/model/queue/QueueTaskDispatcher.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskDispatcher.java
@@ -64,7 +64,7 @@ public abstract class QueueTaskDispatcher implements ExtensionPoint {
      * (This relationship is also the same with built-in check logic.)
      *
      * @deprecated since 1.413
-     *      Use {@link #canTake(Node, BuildableItem)}
+     *      Use {@link #canTake(Node, Queue.BuildableItem)}
      */
     public CauseOfBlockage canTake(Node node, Task task) {
         return null;
@@ -85,7 +85,7 @@ public abstract class QueueTaskDispatcher implements ExtensionPoint {
      *
      * <p>
      * This method is primarily designed to fine-tune where the execution should take place. If the execution
-     * shouldn't commence anywhere at all, implementation should use {@link #canRun(Item)} instead so
+     * shouldn't commence anywhere at all, implementation should use {@link #canRun(Queue.Item)} instead so
      * that Jenkins understands the difference between "this node isn't the right place for this work"
      * vs "the time isn't right for this work to execute." This affects the provisioning behaviour
      * with elastic Jenkins deployments.
@@ -107,9 +107,9 @@ public abstract class QueueTaskDispatcher implements ExtensionPoint {
      * executor availability), or if it should be considered blocked.
      *
      * <p>
-     * Compared to {@link #canTake(Node, BuildableItem)}, this version tells Jenkins that the task is
+     * Compared to {@link #canTake(Node, Queue.BuildableItem)}, this version tells Jenkins that the task is
      * simply not ready to execute, even if there's available executor. This is more efficient
-     * than {@link #canTake(Node, BuildableItem)}, and it sends the right signal to Jenkins so that
+     * than {@link #canTake(Node, Queue.BuildableItem)}, and it sends the right signal to Jenkins so that
      * it won't use {@link Cloud} to try to provision new executors.
      *
      * <p>

--- a/core/src/main/java/hudson/slaves/NodeProperty.java
+++ b/core/src/main/java/hudson/slaves/NodeProperty.java
@@ -90,7 +90,7 @@ public abstract class NodeProperty<N extends Node> implements ReconfigurableDesc
      *
      * @since 1.360
      * @deprecated as of 1.413
-     *      Use {@link #canTake(BuildableItem)}
+     *      Use {@link #canTake(Queue.BuildableItem)}
      */
     public CauseOfBlockage canTake(Task task) {
         return null;


### PR DESCRIPTION
There is a BuildableItem interface in hudson.model, but the references
in these files to BuildableItem objects are refering to an inner class
of the Queue object, not to the interface defined in huson.model.  The
javadoc link improvement may help authors see that difference.
