### PR TITLE
Fix javadoc link in MatrixExecutionStrategy

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixExecutionStrategy.java
+++ b/core/src/main/java/hudson/matrix/MatrixExecutionStrategy.java
@@ -47,7 +47,7 @@ public abstract class MatrixExecutionStrategy extends AbstractDescribableImpl<Ma
 
     /**
      * @deprecated
-     *      Override {@link #run(MatrixBuildExecution)}
+     *      Override {@link #run(MatrixBuild.MatrixBuildExecution)}
      */
     public Result run(MatrixBuild build, List<MatrixAggregator> aggregators, BuildListener listener) throws InterruptedException, IOException {
         throw new UnsupportedOperationException(getClass()+" needs to override run(MatrixBuildExecution)");


### PR DESCRIPTION
Uses the outer class plus the inner class to name the argument, which
satisfies javadoc.
