### PR TITLE
[FIXED JENKINS-18813] Add/RemoveTrigger now works

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -122,6 +122,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -1644,15 +1645,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
 
     protected final synchronized <T extends Describable<T>>
     void addToList( T item, List<T> collection ) throws IOException {
-        for( int i=0; i<collection.size(); i++ ) {
-            if(collection.get(i).getDescriptor()==item.getDescriptor()) {
-                // replace
-                collection.set(i,item);
-                save();
-                return;
-            }
-        }
-        // add
+        //No support to replace item in position, remove then add
+        removeFromList(item.getDescriptor(), collection);
         collection.add(item);
         save();
         updateTransientActions();
@@ -1660,10 +1654,12 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
 
     protected final synchronized <T extends Describable<T>>
     void removeFromList(Descriptor<T> item, List<T> collection) throws IOException {
-        for( int i=0; i< collection.size(); i++ ) {
-            if(collection.get(i).getDescriptor()==item) {
+        final Iterator<T> iCollection = collection.iterator();
+        while(iCollection.hasNext()) {
+            final T next = iCollection.next();
+            if(next.getDescriptor()==item) {
                 // found it
-                collection.remove(i);
+                iCollection.remove();
                 save();
                 updateTransientActions();
                 return;

--- a/test/src/test/groovy/hudson/model/AbstractProjectTest.groovy
+++ b/test/src/test/groovy/hudson/model/AbstractProjectTest.groovy
@@ -38,6 +38,8 @@ import hudson.Functions;
 import hudson.Util;
 import hudson.tasks.ArtifactArchiver
 import hudson.triggers.SCMTrigger;
+import hudson.triggers.TimerTrigger
+import hudson.triggers.TriggerDescriptor;
 import hudson.util.StreamTaskListener;
 import hudson.util.OneShotEvent
 import jenkins.model.Jenkins;
@@ -446,5 +448,39 @@ public class AbstractProjectTest extends HudsonTestCase {
         def t = j.triggers()[0]
         assert t.class==SCMTrigger.class;
         assert t.spec=="*/10 * * * *"
+    }
+
+    @Bug(18813)
+    public void testRemoveTrigger() {
+        AbstractProject j = jenkins.createProjectFromXML("foo", getClass().getResourceAsStream("AbstractProjectTest/vectorTriggers.xml"))
+
+        TriggerDescriptor SCM_TRIGGER_DESCRIPTOR = Hudson.instance.getDescriptorOrDie(SCMTrigger.class)
+        j.removeTrigger(SCM_TRIGGER_DESCRIPTOR);
+        assert j.triggers().size()==0
+    }
+
+    @Bug(18813)
+    public void testAddTriggerSameType() {
+        AbstractProject j = jenkins.createProjectFromXML("foo", getClass().getResourceAsStream("AbstractProjectTest/vectorTriggers.xml"))
+
+        def newTrigger = new SCMTrigger("H/5 * * * *")
+        j.addTrigger(newTrigger);
+
+        assert j.triggers().size()==1
+        def t = j.triggers()[0]
+        assert t.class==SCMTrigger.class;
+        assert t.spec=="H/5 * * * *"
+    }
+
+    @Bug(18813)
+    public void testAddTriggerDifferentType() {
+        AbstractProject j = jenkins.createProjectFromXML("foo", getClass().getResourceAsStream("AbstractProjectTest/vectorTriggers.xml"))
+
+        def newTrigger = new TimerTrigger("20 * * * *")
+        j.addTrigger(newTrigger);
+
+        assert j.triggers().size()==2
+        def t = j.triggers()[1]
+        assert t == newTrigger
     }
 }


### PR DESCRIPTION
Ensure the addTrigger and removeTrigger methods only use methods that are
supported by DescribableList. This means no indexed operations are
supported, so use only Iterator#remove and Collection#add

Add Integration Tests to ensure methods work as expected
