### PR TITLE
Don't use target/classes to unpack maven installs.

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -561,7 +561,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     protected MavenInstallation configureDefaultMaven(String mavenVersion, int mavenReqVersion) throws Exception {
         // Does it exists in the buildDirectory - i.e. already extracted from previous test?
         // see maven-junit-plugin systemProperties: buildDirectory -> ${project.build.directory} (so no reason to be null ;-) )
-        String buildDirectory = System.getProperty( "buildDirectory", "./target/classes/" );
+        String buildDirectory = System.getProperty( "buildDirectory", "./target/maven_installs/" );
         File mavenAlreadyInstalled = new File(buildDirectory, mavenVersion);
         if (mavenAlreadyInstalled.exists()) {
             MavenInstallation mavenInstallation = new MavenInstallation("default",mavenAlreadyInstalled.getAbsolutePath(), NO_PROPERTIES);

--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -624,7 +624,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         // first if we are running inside Maven, pick that Maven, if it meets the criteria we require..
         // does it exists in the buildDirectory see maven-junit-plugin systemProperties
         // buildDirectory -> ${project.build.directory} (so no reason to be null ;-) )
-        String buildDirectory = System.getProperty( "buildDirectory", "./target/classes/" );
+        String buildDirectory = System.getProperty( "buildDirectory", "./target/maven_install/" );
         File mavenAlreadyInstalled = new File(buildDirectory, mavenVersion);
         if (mavenAlreadyInstalled.exists()) {
             Maven.MavenInstallation


### PR DESCRIPTION
This causes the jar plugin to see the results of any maven installations used during unit testing and significantly bloats the
resulting jar/hpi/jpi size.

This moves the location of maven installs to a separate folder under target so that it should not conflict with any maven plugins.

The use of "buildDirectory" from a property is questionable - but left as-is incase anyone was relying on this propertyname.

I have not been able to test this as unit test fail in core (before even getting to the test module on windows) - so hoping buildhive has better luck.
