### PR TITLE
Show full job names in checkbox tooltips when configuring list views

### DIFF
--- a/core/src/main/resources/hudson/model/ListView/configure-entries.jelly
+++ b/core/src/main/resources/hudson/model/ListView/configure-entries.jelly
@@ -51,7 +51,7 @@ THE SOFTWARE.
           <j:set var="spanStyle" value="${it.recurse?'':'display:none'}"/>
         </j:if>
         <span class="${spanClass}" style="${spanStyle}">
-          <f:checkbox name="${job.getRelativeNameFromGroup(it.ownerItemGroup)}" checked="${it.jobNamesContains(job)}" title="${h.getRelativeDisplayNameFrom(job,it.ownerItemGroup)}" />
+          <f:checkbox name="${job.getRelativeNameFromGroup(it.ownerItemGroup)}" checked="${it.jobNamesContains(job)}" title="${h.getRelativeDisplayNameFrom(job,it.ownerItemGroup)}" tooltip="${job.fullName}" />
           <br/>
         </span>
       </j:forEach>

--- a/core/src/main/resources/lib/form/checkbox.jelly
+++ b/core/src/main/resources/lib/form/checkbox.jelly
@@ -51,15 +51,20 @@ THE SOFTWARE.
       If specified, this human readable text will follow the checkbox, and clicking this text also
       toggles the checkbox.
     </st:attribute>
+    <st:attribute name="tooltip">
+      Used as tooltip of the checkbox, or, if a title is specified, of the title
+    </st:attribute>
   </st:documentation>
   <f:prepareDatabinding />
   <input type="checkbox"
          name="${attrs.name?:'_.'+attrs.field}"
          value="${attrs.value}"
+         title="${attrs.tooltip != null ? attrs.tooltip : null}"
          onclick="${attrs.onclick}" id="${attrs.id}" class="${attrs.negative!=null ? 'negative' : null} ${attrs.checkUrl!=null?'validated':''}"
          checkUrl="${attrs.checkUrl}" json="${attrs.json}"
          checked="${(attrs.checked ?: instance[attrs.field] ?: attrs.default) ? 'true' : null}"/>
   <j:if test="${attrs.title!=null}">
-    <label class="attach-previous">${attrs.title}</label>
+    <label class="attach-previous"
+           title="${attrs.tooltip}">${attrs.title}</label>
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/form/checkbox.jelly
+++ b/core/src/main/resources/lib/form/checkbox.jelly
@@ -52,14 +52,14 @@ THE SOFTWARE.
       toggles the checkbox.
     </st:attribute>
     <st:attribute name="tooltip">
-      Used as tooltip of the checkbox, or, if a title is specified, of the title
+      Used as tooltip of the checkbox, and, if a title is specified, of the title
     </st:attribute>
   </st:documentation>
   <f:prepareDatabinding />
   <input type="checkbox"
          name="${attrs.name?:'_.'+attrs.field}"
          value="${attrs.value}"
-         title="${attrs.tooltip != null ? attrs.tooltip : null}"
+         title="${attrs.tooltip}"
          onclick="${attrs.onclick}" id="${attrs.id}" class="${attrs.negative!=null ? 'negative' : null} ${attrs.checkUrl!=null?'validated':''}"
          checkUrl="${attrs.checkUrl}" json="${attrs.json}"
          checked="${(attrs.checked ?: instance[attrs.field] ?: attrs.default) ? 'true' : null}"/>


### PR DESCRIPTION
This adds a 'tooltip' attribute to /lib/form's checkbox which will be rendered as an HTML 'title' attribute. This new attribute is then used in list views' configuration screens to show the full job name in the tooltip when hovering.

Reason for this PR is explained in [JENKINS-18719](https://issues.jenkins-ci.org/browse/JENKINS-18719). Short version: _Use a regular expression to include jobs into the view_ requires users to be able to determine actual job names.
