### PR TITLE
[JENKINS-19034] restore missing buildnumber-ID symlink

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -140,6 +140,9 @@ Upcoming changes</a>
   <li class=bug>
     Ensuring <code>/log/all</code> shows only <code>INFO</code> and above messages, even if custom loggers display <code>FINE</code> or below.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18959">issue 18959</a>)
+  <li class=bug>
+    (re)create build number->id symlink if missing when updating permalink.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19034">issue 19034</a>)
   <li class=rfe>
     Added a new monitor that detects and fixse out-of-order builds records.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18289">issue 18289</a>)

--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -134,6 +134,11 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
         cache.getParentFile().mkdirs();
 
         try {
+            String target = String.valueOf(n);
+            if (b != null && !new File(job.getBuildDir(), target).exists()) {
+                // (re)create the build Number->Id symlink
+                Util.createSymlink(job.getBuildDir(),b.getId(),target,TaskListener.NULL);
+            }
             writeSymlink(cache, String.valueOf(n));
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Failed to update "+job+" "+getId()+" permalink for " + b, e);

--- a/test/src/test/groovy/jenkins/model/PeepholePermalinkTest.groovy
+++ b/test/src/test/groovy/jenkins/model/PeepholePermalinkTest.groovy
@@ -72,4 +72,16 @@ class PeepholePermalinkTest extends HudsonTestCase {
             assert new File(p.rootDir,"$n/build.xml").length() == new File(b1.rootDir,"build.xml").length()
         }
     }
+
+    void testRebuildBuildNumberPermalinks() {
+        def p = createFreeStyleProject()
+        def b = assertBuildStatusSuccess(p.scheduleBuild2(0))
+        File f = new File(p.getBuildDir(), "1")
+        // assertTrue(Util.isSymlink(f))
+        f.delete()
+        PeepholePermalink link = p.getPermalinks().find({l -> l instanceof PeepholePermalink})
+        println(link)
+        link.updateCache(p, b)
+        assertTrue("build symlink hasn't been restored", f.exists())
+    }
 }


### PR DESCRIPTION
As permalink is updated, check number->ID symlink exists and (re)create if needed.

This issue has been reported for a jenkins installation migrated from windows (without symlink support) migrated to Unix. permalinks are recreated, but point to missing build number file
