### PR TITLE
[FIXED 10539] Preserve backslash in Matrix buildstep properties

### DIFF
--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -55,6 +55,8 @@ import hudson.util.ArgumentListBuilder;
 import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
 import hudson.util.VariableResolver;
+import hudson.util.VariableResolver.ByMap;
+import hudson.util.VariableResolver.Union;
 import hudson.util.FormValidation;
 import hudson.util.XStream2;
 import net.sf.json.JSONObject;
@@ -264,7 +266,6 @@ public class Maven extends Builder {
         String targets = Util.replaceMacro(this.targets,vr);
         targets = env.expand(targets);
         String pom = env.expand(this.pom);
-        String properties = env.expand(this.properties);
 
         int startIndex = 0;
         int endIndex;
@@ -314,7 +315,8 @@ public class Maven extends Builder {
             Set<String> sensitiveVars = build.getSensitiveBuildVariables();
 
             args.addKeyValuePairs("-D",build.getBuildVariables(),sensitiveVars);
-            args.addKeyValuePairsFromPropertyString("-D",properties,vr,sensitiveVars);
+            final VariableResolver<String> resolver = new Union<String>(new ByMap<String>(env), vr);
+            args.addKeyValuePairsFromPropertyString("-D",this.properties,resolver,sensitiveVars);
             if (usesPrivateRepository())
                 args.add("-Dmaven.repo.local=" + build.getWorkspace().child(".repository"));
             args.addTokenized(normalizedTarget);

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -192,16 +192,11 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      *      The persisted form of {@link Properties}. For example, "abc=def\nghi=jkl". Can be null, in which
      *      case this method becomes no-op.
      * @param vr
-     *      {@link VariableResolver} to be performed on the values.
+     *      {@link VariableResolver} to resolve variables in properties string.
      * @since 1.262
      */
-    public ArgumentListBuilder addKeyValuePairsFromPropertyString(String prefix, String properties, VariableResolver vr) throws IOException {
-        if(properties==null)    return this;
-
-        for (Entry<Object,Object> entry : Util.loadProperties(properties).entrySet()) {
-            addKeyValuePair(prefix, (String)entry.getKey(), Util.replaceMacro(entry.getValue().toString(),vr), false);
-        }
-        return this;
+    public ArgumentListBuilder addKeyValuePairsFromPropertyString(String prefix, String properties, VariableResolver<String> vr) throws IOException {
+        return addKeyValuePairsFromPropertyString(prefix, properties, vr, null);
     }
 
     /**
@@ -213,19 +208,45 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      *      The persisted form of {@link Properties}. For example, "abc=def\nghi=jkl". Can be null, in which
      *      case this method becomes no-op.
      * @param vr
-     *      {@link VariableResolver} to be performed on the values.
+     *      {@link VariableResolver} to resolve variables in properties string.
      * @param propsToMask
      *      Set containing key names to mark as masked in the argument list. Key
      *      names that do not exist in the set will be added unmasked.
      * @since 1.378
      */
-    public ArgumentListBuilder addKeyValuePairsFromPropertyString(String prefix, String properties, VariableResolver vr, Set<String> propsToMask) throws IOException {
+    public ArgumentListBuilder addKeyValuePairsFromPropertyString(String prefix, String properties, VariableResolver<String> vr, Set<String> propsToMask) throws IOException {
         if(properties==null)    return this;
 
+        properties = Util.replaceMacro(properties, propetiesGeneratingResolver(vr));
+
         for (Entry<Object,Object> entry : Util.loadProperties(properties).entrySet()) {
-            addKeyValuePair(prefix, (String)entry.getKey(), Util.replaceMacro(entry.getValue().toString(),vr), (propsToMask == null) ? false : propsToMask.contains((String)entry.getKey()));
+            addKeyValuePair(prefix, (String)entry.getKey(), entry.getValue().toString(), (propsToMask == null) ? false : propsToMask.contains(entry.getKey()));
         }
         return this;
+    }
+
+    /**
+     * Creates a resolver generating values to be safely placed in properties string
+     *
+     * Property.load() generally removes single backslashes from input and that
+     * is not desirable for outcomes of macro substitution as the values can
+     * contain them but user has no way to escape them.
+     *
+     * @param original Resolution will be delegated to this resolver. Resolved
+     *                 values will be escaped afterwards.
+     * @see https://issues.jenkins-ci.org/browse/JENKINS-10539
+     */
+    private static VariableResolver<String> propetiesGeneratingResolver(final VariableResolver<String> original) {
+
+        return new VariableResolver<String>() {
+
+            public String resolve(String name) {
+                final String value = original.resolve(name);
+                if (value == null) return null;
+                // Replace single backslashes with double ones
+                return value.replaceAll("(?<=[^\\\\])\\\\(?=[^\\\\])", "\\\\\\\\");
+            }
+        };
     }
 
     public String[] toCommandArray() {

--- a/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
+++ b/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
@@ -23,6 +23,7 @@
  */
 package hudson.util;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -182,5 +183,22 @@ public class ArgumentListBuilderTest extends Assert {
         boolean[] array = builder.toMaskArray();
         assertNotNull("The mask array should not be null", array);
         assertArrayEquals("The mask array was incorrect", new boolean[]{false,false,false}, array);
+    }
+
+    @Test
+    public void addKeyValuePairsFromPropertyString() throws IOException {
+        final Map<String, String> map = new HashMap<String, String>();
+        map.put("PATH", "C:\\Windows");
+        final VariableResolver<String> resolver = new VariableResolver.ByMap<String>(map);
+
+        final String properties = "my.path=$PATH";
+
+        ArgumentListBuilder builder = new ArgumentListBuilder();
+        builder.addKeyValuePairsFromPropertyString("", properties, resolver);
+        assertEquals("my.path=C:\\Windows", builder.toString());
+
+        builder = new ArgumentListBuilder();
+        builder.addKeyValuePairsFromPropertyString("", properties, resolver, null);
+        assertEquals("my.path=C:\\Windows", builder.toString());
     }
 }

--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -23,9 +23,6 @@
  */
 package hudson.tasks;
 
-import hudson.maven.MavenModuleSet;
-import hudson.maven.MavenModuleSetBuild;
-import hudson.maven.PlexusModuleContributor;
 import hudson.model.Build;
 import hudson.model.FreeStyleProject;
 import jenkins.model.Jenkins;
@@ -51,44 +48,45 @@ import hudson.tools.ToolPropertyDescriptor;
 import hudson.tools.InstallSourceProperty;
 import hudson.util.DescribableList;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Collections;
-import java.util.List;
-
-import org.apache.maven.settings.building.FileSettingsSource;
-import org.jvnet.hudson.test.HudsonTestCase;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
+
 import hudson.EnvVars;
 import hudson.model.FreeStyleBuild;
 import hudson.model.PasswordParameterDefinition;
-import org.junit.Assert;
+import static org.junit.Assert.*;
+
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.ExtractResourceSCM;
-import org.jvnet.hudson.test.SingleFileSCM;
-import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.JenkinsRule;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class MavenTest extends HudsonTestCase {
+public class MavenTest {
+
+    @Rule public final JenkinsRule j = new JenkinsRule();
+
     /**
      * Tests the round-tripping of the configuration.
      */
+    @Test
     public void testConfigRoundtrip() throws Exception {
-        jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(); // reset
+        j.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(); // reset
 
-        FreeStyleProject p = createFreeStyleProject();
+        FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildersList().add(new Maven("a", null, "b.pom", "c=d", "-e", true));
 
-        WebClient webClient = new WebClient();
+        JenkinsRule.WebClient webClient = j.createWebClient();
         HtmlPage page = webClient.getPage(p, "configure");
 
         HtmlForm form = page.getFormByName("config");
-        submit(form);
+        j.submit(form);
 
         Maven m = p.getBuildersList().get(Maven.class);
         assertNotNull(m);
@@ -97,54 +95,56 @@ public class MavenTest extends HudsonTestCase {
         assertEquals("b.pom", m.pom);
         assertEquals("c=d", m.properties);
         assertEquals("-e", m.jvmOptions);
-	assertTrue(m.usesPrivateRepository());
+	    assertTrue(m.usesPrivateRepository());
     }
 
+    @Test
     public void testWithNodeProperty() throws Exception {
-        MavenInstallation maven = configureDefaultMaven();
+        MavenInstallation maven = j.configureDefaultMaven();
         String mavenHome = maven.getHome();
         String mavenHomeVar = "${VAR_MAVEN}" + mavenHome.substring(3);
         String mavenVar = mavenHome.substring(0, 3);
-        MavenInstallation varMaven = new MavenInstallation("varMaven", mavenHomeVar, NO_PROPERTIES);
-        jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(maven, varMaven);
+        MavenInstallation varMaven = new MavenInstallation("varMaven", mavenHomeVar, j.NO_PROPERTIES);
+        j.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(maven, varMaven);
 
-        JDK jdk = jenkins.getJDK("default");
+        JDK jdk = j.jenkins.getJDK("default");
         String javaHome = jdk.getHome();
         String javaHomeVar = "${VAR_JAVA}" + javaHome.substring(3);
         String javaVar = javaHome.substring(0, 3);
         JDK varJDK = new JDK("varJDK", javaHomeVar);
-        jenkins.getJDKs().add(varJDK);
+        j.jenkins.getJDKs().add(varJDK);
         Jenkins.getInstance().getNodeProperties().replaceBy(
                 Collections.singleton(new EnvironmentVariablesNodeProperty(
                         new Entry("VAR_MAVEN", mavenVar), new Entry("VAR_JAVA",
                                 javaVar))));
 
-        FreeStyleProject project = createFreeStyleProject();
+        FreeStyleProject project = j.createFreeStyleProject();
         project.getBuildersList().add(new Maven("--help", varMaven.getName()));
         project.setJDK(varJDK);
 
         Build<?, ?> build = project.scheduleBuild2(0).get();
 
-        Assert.assertEquals(Result.SUCCESS, build.getResult());
+        assertEquals(Result.SUCCESS, build.getResult());
 
     }
 
+    @Test
     public void testWithParameter() throws Exception {
-        MavenInstallation maven = configureDefaultMaven();
+        MavenInstallation maven = j.configureDefaultMaven();
         String mavenHome = maven.getHome();
         String mavenHomeVar = "${VAR_MAVEN}" + mavenHome.substring(3);
         String mavenVar = mavenHome.substring(0, 3);
-        MavenInstallation varMaven = new MavenInstallation("varMaven",mavenHomeVar,NO_PROPERTIES);
-        jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(maven, varMaven);
+        MavenInstallation varMaven = new MavenInstallation("varMaven",mavenHomeVar,j.NO_PROPERTIES);
+        j.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(maven, varMaven);
 
-        JDK jdk = jenkins.getJDK("default");
+        JDK jdk = j.jenkins.getJDK("default");
         String javaHome = jdk.getHome();
         String javaHomeVar = "${VAR_JAVA}" + javaHome.substring(3);
         String javaVar = javaHome.substring(0, 3);
         JDK varJDK = new JDK("varJDK", javaHomeVar);
-        jenkins.getJDKs().add(varJDK);
+        j.jenkins.getJDKs().add(varJDK);
 
-        FreeStyleProject project = createFreeStyleProject();
+        FreeStyleProject project = j.createFreeStyleProject();
         project.addProperty(new ParametersDefinitionProperty(
                 new StringParameterDefinition("VAR_MAVEN", "XXX"),
                 new StringParameterDefinition("VAR_JAVA", "XXX")));
@@ -156,34 +156,35 @@ public class MavenTest extends HudsonTestCase {
                         new StringParameterValue("VAR_MAVEN", mavenVar),
                         new StringParameterValue("VAR_JAVA", javaVar))).get();
 
-        assertBuildStatusSuccess(build);
+        j.assertBuildStatusSuccess(build);
 
     }
 
     /**
      * Simulates the addition of the new Maven via UI and makes sure it works.
      */
+    @Test
     public void testGlobalConfigAjax() throws Exception {
-        HtmlPage p = new WebClient().goTo("configure");
+        HtmlPage p = j.createWebClient().goTo("configure");
         HtmlForm f = p.getFormByName("config");
-        HtmlButton b = getButtonByCaption(f, "Add Maven");
+        HtmlButton b = j.getButtonByCaption(f, "Add Maven");
         b.click();
-        findPreviousInputElement(b,"name").setValueAttribute("myMaven");
-        findPreviousInputElement(b,"home").setValueAttribute("/tmp/foo");
-        submit(f);
+        j.findPreviousInputElement(b,"name").setValueAttribute("myMaven");
+        j.findPreviousInputElement(b,"home").setValueAttribute("/tmp/foo");
+        j.submit(f);
         verify();
 
         // another submission and verfify it survives a roundtrip
-        p = new WebClient().goTo("configure");
+        p = j.createWebClient().goTo("configure");
         f = p.getFormByName("config");
-        submit(f);
+        j.submit(f);
         verify();
     }
 
     private void verify() throws Exception {
-        MavenInstallation[] l = get(DescriptorImpl.class).getInstallations();
+        MavenInstallation[] l = j.get(DescriptorImpl.class).getInstallations();
         assertEquals(1,l.length);
-        assertEqualBeans(l[0],new MavenInstallation("myMaven","/tmp/foo",NO_PROPERTIES),"name,home");
+        j.assertEqualBeans(l[0],new MavenInstallation("myMaven","/tmp/foo",j.NO_PROPERTIES),"name,home");
 
         // by default we should get the auto installer
         DescribableList<ToolProperty<?>,ToolPropertyDescriptor> props = l[0].getProperties();
@@ -193,8 +194,9 @@ public class MavenTest extends HudsonTestCase {
         assertNotNull(isp.installers.get(MavenInstaller.class));
     }
 
+    @Test
     public void testSensitiveParameters() throws Exception {
-        FreeStyleProject project = createFreeStyleProject();
+        FreeStyleProject project = j.createFreeStyleProject();
         ParametersDefinitionProperty pdb = new ParametersDefinitionProperty(
                 new StringParameterDefinition("string", "defaultValue", "string description"),
                 new PasswordParameterDefinition("password", "12345", "password description"),
@@ -212,9 +214,10 @@ public class MavenTest extends HudsonTestCase {
         assertFalse(buildLog.contains("-Dpassword=12345"));
     }
     
+    @Test
     public void testDefaultSettingsProvider() throws Exception {
         {
-            FreeStyleProject p = createFreeStyleProject();
+            FreeStyleProject p = j.createFreeStyleProject();
             p.getBuildersList().add(new Maven("a", null, "a.pom", "c=d", "-e", true));
     
             Maven m = p.getBuildersList().get(Maven.class);
@@ -229,7 +232,7 @@ public class MavenTest extends HudsonTestCase {
             globalMavenConfig.setSettingsProvider(new FilePathSettingsProvider("/tmp/settigns.xml"));
             globalMavenConfig.setGlobalSettingsProvider(new FilePathGlobalSettingsProvider("/tmp/global-settigns.xml"));
             
-            FreeStyleProject p = createFreeStyleProject();
+            FreeStyleProject p = j.createFreeStyleProject();
             p.getBuildersList().add(new Maven("b", null, "b.pom", "c=d", "-e", true));
             
             Maven m = p.getBuildersList().get(Maven.class);
@@ -240,7 +243,8 @@ public class MavenTest extends HudsonTestCase {
     }
 
     @Bug(18898)
-    public void testNullHome() throws Exception {
+    @Test
+    public void testNullHome() {
         EnvVars env = new EnvVars();
         new MavenInstallation("_", "", Collections.<ToolProperty<?>>emptyList()).buildEnvVars(env);
         assertEquals("{}", env.toString());


### PR DESCRIPTION
Reworked #841.

The backslashes are preserved in both build parameters and environment variables. Other parts of properties string written directly into job configuration form are left untouched.
