### PR TITLE
Fix NullPointerException which is possible in concurrent builds.

### DIFF
--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -170,17 +170,19 @@ public class ArtifactArchiver extends Recorder {
             AbstractBuild<?,?> b = build.getProject().getLastCompletedBuild();
             Result bestResultSoFar = Result.NOT_BUILT;
             while(b!=null) {
-                if (b.getResult().isBetterThan(bestResultSoFar)) {
-                    bestResultSoFar = b.getResult();
-                } else {
-                    // remove old artifacts
-                    File ad = b.getArtifactsDir();
-                    if(ad.exists()) {
-                        listener.getLogger().println(Messages.ArtifactArchiver_DeletingOld(b.getDisplayName()));
-                        try {
-                            Util.deleteRecursive(ad);
-                        } catch (IOException e) {
-                            e.printStackTrace(listener.error(e.getMessage()));
+                if(b.getResult()!=null){
+                    if (b.getResult().isBetterThan(bestResultSoFar)) {
+                        bestResultSoFar = b.getResult();
+                    } else {
+                        // remove old artifacts
+                        File ad = b.getArtifactsDir();
+                        if(ad.exists()) {
+                            listener.getLogger().println(Messages.ArtifactArchiver_DeletingOld(b.getDisplayName()));
+                            try {
+                                Util.deleteRecursive(ad);
+                            } catch (IOException e) {
+                                e.printStackTrace(listener.error(e.getMessage()));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
If there is enabled concurrent builds and build 1 is in progress and build 2 is finished,  artifact archiver throw NullPointerException for build 3.

I replaced HudsonTestCase with JenkinsRule when I write test for this behaviour.
