### PR TITLE
ComputerLauncherTest failed with LANG=ja_JP. 

### DIFF
--- a/core/src/test/java/hudson/slaves/ComputerLauncherTest.java
+++ b/core/src/test/java/hudson/slaves/ComputerLauncherTest.java
@@ -38,19 +38,19 @@ import static org.junit.Assert.*;
 public class ComputerLauncherTest {
 
     @Test public void jdk7() throws IOException {
-        assertChecked("java version \"1.7.0_05\"\nJava(TM) SE Runtime Environment (build 1.7.0_05-b05)\nJava HotSpot(TM) Server VM (build 23.1-b03, mixed mode)\n", "1.7");
+        assertChecked("java version \"1.7.0_05\"\nJava(TM) SE Runtime Environment (build 1.7.0_05-b05)\nJava HotSpot(TM) Server VM (build 23.1-b03, mixed mode)\n", "1.7.0");
     }
 
     @Test public void openJDK7() throws IOException {
-        assertChecked("openjdk version \"1.7.0-internal\"\nOpenJDK Runtime Environment (build 1.7.0-internal-pkgsrc_2010_01_03_06_54-b00)\nOpenJDK 64-Bit Server VM (build 17.0-b04, mixed mode)\n", "1.7");
+        assertChecked("openjdk version \"1.7.0-internal\"\nOpenJDK Runtime Environment (build 1.7.0-internal-pkgsrc_2010_01_03_06_54-b00)\nOpenJDK 64-Bit Server VM (build 17.0-b04, mixed mode)\n", "1.7.0");
     }
 
     @Test public void jdk6() throws IOException {
-        assertChecked("java version \"1.6.0_33\"\nJava(TM) SE Runtime Environment (build 1.6.0_33-b03)\nJava HotSpot(TM) Server VM (build 20.8-b03, mixed mode)\n", "1.6");
+        assertChecked("java version \"1.6.0_33\"\nJava(TM) SE Runtime Environment (build 1.6.0_33-b03)\nJava HotSpot(TM) Server VM (build 20.8-b03, mixed mode)\n", "1.6.0");
     }
 
     @Test public void jdk5() throws IOException {
-        assertChecked("java version \"1.5.0_22\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_22-b03)\nJava HotSpot(TM) Server VM (build 1.5.0_22-b03, mixed mode)\n", "1.5");
+        assertChecked("java version \"1.5.0_22\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_22-b03)\nJava HotSpot(TM) Server VM (build 1.5.0_22-b03, mixed mode)\n", "1.5.0");
     }
 
     @Test(expected=IOException.class) public void j2sdk4() throws IOException {
@@ -58,7 +58,7 @@ public class ComputerLauncherTest {
     }
 
     @Test public void jdk10() throws IOException { // predicted
-        assertChecked("java version \"1.10.0_02\"\nJava(TM) SE Runtime Environment (build 1.10.0_02-b01)\nJava HotSpot(TM) Server VM (build 23.1-b03, mixed mode)\n", "1.10");
+        assertChecked("java version \"1.10.0_02\"\nJava(TM) SE Runtime Environment (build 1.10.0_02-b01)\nJava HotSpot(TM) Server VM (build 23.1-b03, mixed mode)\n", "1.10.0");
     }
 
     private static void assertChecked(String text, String spec) throws IOException {


### PR DESCRIPTION
It seems to use invalid expect.

If the output of 'java -version' is 'java version "1.7.0_05" ', then the expect should be 1.7.0 not 1.7.
