### PR TITLE
Windows::killRecursively() invokes process killers after completion.

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -406,9 +406,10 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                         return null;
                     }
 
-                    public void killRecursively() {
+                    public void killRecursively() throws InterruptedException {
                         LOGGER.finer("Killing recursively "+getPid());
                         p.killRecursively();
+                        killByKiller();
                     }
 
                     public void kill() throws InterruptedException {


### PR DESCRIPTION
Resolves https://issues.jenkins-ci.org/browse/JENKINS-19156

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
