### PR TITLE
move environment in maven project to same location as in freestyle project

### DIFF
--- a/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
+++ b/maven-plugin/src/main/resources/hudson/maven/MavenModuleSet/configure-entries.jelly
@@ -38,6 +38,8 @@ THE SOFTWARE.
     <p:config-upstream-pseudo-trigger />
   </p:config-trigger>
 
+  <p:config-buildWrappers />
+  
   <f:section title="${%Pre Steps}">
     <f:block>
       <f:hetero-list name="prebuilder" hasHeader="true"
@@ -145,7 +147,5 @@ THE SOFTWARE.
                       instances="${it.reporters.toMap()}" />
   </j:if>
 
-
-  <p:config-buildWrappers />
   <p:config-publishers2 />
 </j:jelly>


### PR DESCRIPTION
The configuration elements in a maven job should have the same logical order as in a freestyle job.
- triggers
- build-wrappers
- builders
- publishers
