### PR TITLE
[FIXED JENKINS-17108] No events fired when user selects enable and disable project button

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -182,9 +182,8 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      */
     public void setDescription(String description) throws IOException {
         this.description = description;
-        ItemListener.fireOnUpdated(this);
         save();
-        
+        ItemListener.fireOnUpdated(this);
     }
 
     /**

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -182,7 +182,9 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      */
     public void setDescription(String description) throws IOException {
         this.description = description;
+        ItemListener.fireOnUpdated(this);
         save();
+        
     }
 
     /**

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -53,6 +53,7 @@ import hudson.model.queue.SubTask;
 import hudson.model.RunMap.Constructor;
 import hudson.model.labels.LabelAtom;
 import hudson.model.labels.LabelExpression;
+import hudson.model.listeners.ItemListener;
 import hudson.model.listeners.SCMPollListener;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.SubTaskContributor;
@@ -702,6 +703,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         this.disabled = b;
         if(b)
             Jenkins.getInstance().getQueue().cancel(this);
+        ItemListener.fireOnUpdated(this);
         save();
     }
 

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -703,8 +703,9 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         this.disabled = b;
         if(b)
             Jenkins.getInstance().getQueue().cancel(this);
-        ItemListener.fireOnUpdated(this);
+        
         save();
+        ItemListener.fireOnUpdated(this);
     }
 
     /**


### PR DESCRIPTION
JENKINS-17108. This solves the problem with ItemListner.onUpdated not being called if the project was disabled/enabled by pushing the button on the project page. Also solved the problem with ItemListener.onUpdated not getting called if the project description was updated using the edit description on the project page.
