### PR TITLE
provide alternate error message for pattern-based naming strategy

### DIFF
--- a/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
+++ b/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
@@ -30,6 +30,7 @@ import hudson.Util;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Failure;
+import jenkins.model.Messages;
 import hudson.util.FormValidation;
 import java.io.IOException;
 
@@ -132,25 +133,39 @@ public abstract class ProjectNamingStrategy implements Describable<ProjectNaming
          */
         private final String namePattern;
 
+        private final String description;
+
         private boolean forceExistingJobs;
 
-        @DataBoundConstructor
+        @Deprecated
         public PatternProjectNamingStrategy(String namePattern, boolean forceExistingJobs) {
+            this(namePattern, null, forceExistingJobs);
+        }
+
+        @DataBoundConstructor
+        public PatternProjectNamingStrategy(String namePattern, String description, boolean forceExistingJobs) {
             this.namePattern = namePattern;
+            this.description = description;
             this.forceExistingJobs = forceExistingJobs;
         }
 
         @Override
-        public void checkName(String name) throws Failure {
+        public void checkName(String name) {
             if (StringUtils.isNotBlank(namePattern) && StringUtils.isNotBlank(name)) {
                 if (!Pattern.matches(namePattern, name)) {
-                    throw new Failure(jenkins.model.Messages._Hudson_JobNameConventionNotApplyed(name, namePattern).toString());
+                    throw new Failure(StringUtils.isEmpty(description) ?
+                        Messages.Hudson_JobNameConventionNotApplyed(name, namePattern) :
+                        description);
                 }
             }
         }
 
         public String getNamePattern() {
             return namePattern;
+        }
+
+        public String getDescription() {
+            return description;
         }
 
         public boolean isForceExistingJobs() {

--- a/core/src/main/resources/jenkins/model/ProjectNamingStrategy/PatternProjectNamingStrategy/config.groovy
+++ b/core/src/main/resources/jenkins/model/ProjectNamingStrategy/PatternProjectNamingStrategy/config.groovy
@@ -6,6 +6,11 @@ def f=namespace(lib.FormTagLib)
 f.entry(title:_("namePattern"), field:"namePattern") {
     f.textbox(value:h.defaulted(instance?.namePattern, descriptor.DEFAULT_PATTERN),class:"fixed-width")
 }
+
+f.entry(title:_("description"), field:"description") {
+    f.textbox()
+}
+
 f.entry(title:_("forceExistingJobs"), field:"forceExistingJobs") {
     f.checkbox(name:"forceExistingJobs")
 }

--- a/core/src/main/resources/jenkins/model/ProjectNamingStrategy/PatternProjectNamingStrategy/config.properties
+++ b/core/src/main/resources/jenkins/model/ProjectNamingStrategy/PatternProjectNamingStrategy/config.properties
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 namePattern = Name Pattern
+description = Description
 forceExistingJobs = force existing
 
 

--- a/core/src/main/resources/jenkins/model/ProjectNamingStrategy/PatternProjectNamingStrategy/help-description.html
+++ b/core/src/main/resources/jenkins/model/ProjectNamingStrategy/PatternProjectNamingStrategy/help-description.html
@@ -1,0 +1,4 @@
+<p>
+    Provide a human-readable description to explain naming constraints.
+    Will be used as error message when job name does not match pattern
+</p>


### PR DESCRIPTION
Let administrator define a custom description for pattern-matching based naming strategy so that user get a human-readable error message, as Regex can quickly become cryptic.
