### PR TITLE
[FIXED JENKINS-19332]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -748,25 +748,11 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>findbugs-maven-plugin</artifactId>
+            <version>2.5.2</version>
             <configuration>
               <threshold>High</threshold>
             </configuration>
           </plugin>
-          <!--<plugin>-->
-            <!--<groupId>org.apache.maven.plugins</groupId>-->
-            <!--<artifactId>maven-pmd-plugin</artifactId>-->
-            <!--<version>2.5</version>-->
-            <!--<configuration>-->
-              <!--&lt;!&ndash;rulesets>-->
-                  <!--<ruleset>ruleset.xml</ruleset>-->
-                  <!--</rulesets&ndash;&gt;-->
-            <!--</configuration>-->
-          <!--</plugin>-->
-          <!--<plugin>-->
-            <!--<groupId>org.apache.maven.plugins</groupId>-->
-            <!--<artifactId>maven-checkstyle-plugin</artifactId>-->
-            <!--<version>2.6</version>-->
-          <!--</plugin>-->
         </plugins>
       </reporting>
     </profile>


### PR DESCRIPTION
- set findbugs version to 2.5.2 to avoid:
  [WARNING] 'reporting.plugins.plugin.version' for
  org.codehaus.mojo:findbugs-maven-plugin is missing. ...
- delete maven-pmd-plugin and maven-checkstyle-plugin (commented out
  since more than two years)
