### PR TITLE
Display an explanatory message when Jenkins CLI attempts to build an

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -132,13 +132,13 @@ public class BuildCommand extends CLICommand {
         }
 
         if (!job.isBuildable()) {
-        	String msg = Messages.BuildCommand_CLICause_CannotBuildUnknownReasons(job.getFullDisplayName());
+            String msg = Messages.BuildCommand_CLICause_CannotBuildUnknownReasons(job.getFullDisplayName());
             if (job.isDisabled()) {
-            	msg = Messages.BuildCommand_CLICause_CannotBuildDisabled(job.getFullDisplayName());
+                msg = Messages.BuildCommand_CLICause_CannotBuildDisabled(job.getFullDisplayName());
             } else if (job.isHoldOffBuildUntilSave()){
-            	msg = Messages.BuildCommand_CLICause_CannotBuildConfigNotSaved(job.getFullDisplayName());
+                msg = Messages.BuildCommand_CLICause_CannotBuildConfigNotSaved(job.getFullDisplayName());
             }
-        	stderr.println(msg);
+            stderr.println(msg);
             return -1;
         }
 

--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -132,13 +132,13 @@ public class BuildCommand extends CLICommand {
         }
 
         if (!job.isBuildable()) {
-        	String reason = " for unknown reasons";
+        	String msg = Messages.BuildCommand_CLICause_CannotBuildUnknownReasons(job.getFullDisplayName());
             if (job.isDisabled()) {
-            	reason = "because it is disabled";
+            	msg = Messages.BuildCommand_CLICause_CannotBuildDisabled(job.getFullDisplayName());
             } else if (job.isHoldOffBuildUntilSave()){
-            	reason = "because its configuration has not been saved";
+            	msg = Messages.BuildCommand_CLICause_CannotBuildConfigNotSaved(job.getFullDisplayName());
             }
-        	stderr.println("Cannot build "+job.getFullDisplayName()+" " + reason + ".");
+        	stderr.println(msg);
             return 0;
         }
 

--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -131,8 +131,19 @@ public class BuildCommand extends CLICommand {
             }
         }
 
-        QueueTaskFuture<? extends AbstractBuild> f = job.scheduleBuild2(0, new CLICause(Jenkins.getAuthentication().getName()), a);
+        if (!job.isBuildable()) {
+        	String reason = " for unknown reasons";
+            if (job.isDisabled()) {
+            	reason = "because it is disabled";
+            } else if (job.isHoldOffBuildUntilSave()){
+            	reason = "because its configuration has not been saved";
+            }
+        	stderr.println("Cannot build "+job.getFullDisplayName()+" " + reason + ".");
+            return 0;
+        }
 
+        QueueTaskFuture<? extends AbstractBuild> f = job.scheduleBuild2(0, new CLICause(Jenkins.getAuthentication().getName()), a);
+        
         if (wait || sync) {
             AbstractBuild b = f.waitForStart();    // wait for the start
             stdout.println("Started "+b.getFullDisplayName());

--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -139,7 +139,7 @@ public class BuildCommand extends CLICommand {
             	msg = Messages.BuildCommand_CLICause_CannotBuildConfigNotSaved(job.getFullDisplayName());
             }
         	stderr.println(msg);
-            return 0;
+            return -1;
         }
 
         QueueTaskFuture<? extends AbstractBuild> f = job.scheduleBuild2(0, new CLICause(Jenkins.getAuthentication().getName()), a);

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -254,7 +254,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         return new TextFile(new File(this.getRootDir(), "nextBuildNumber"));
     }
 
-    protected synchronized boolean isHoldOffBuildUntilSave() {
+    public synchronized boolean isHoldOffBuildUntilSave() {
         return holdOffBuildUntilSave;
     }
 

--- a/core/src/main/resources/hudson/cli/Messages.properties
+++ b/core/src/main/resources/hudson/cli/Messages.properties
@@ -57,3 +57,9 @@ UpdateJobCommand.ShortDescription=\
 UpdateNodeCommand.ShortDescription=\
  Updates the node definition XML from stdin. The opposite of the get-node command
 BuildCommand.CLICause.ShortDescription=Started by command line by {0}
+BuildCommand.CLICause.CannotBuildDisabled=\
+Cannot build {0} because it is disabled.
+BuildCommand.CLICause.CannotBuildConfigNotSaved=\
+Cannot build {0} because its configuration has not been saved.
+BuildCommand.CLICause.CannotBuildUnknownReasons=\
+Cannot build {0} for unknown reasons.


### PR DESCRIPTION
[JENKINS-17603] Display an explanatory message when Jenkins CLI attempts to build an unbuildable project.
