### PR TITLE
Jenkins CLI now connect to existing SSH agent for authentication

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -36,7 +36,24 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>trilead-ssh2</artifactId>
-      <version>build214-jenkins-1</version>
+      <version>build217-jenkins-1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.svnkit-trilead-ssh2</artifactId>
+      <version>0.0.6</version>
+      <exclusions>
+        <exclusion>
+          <!-- we use our own forked version -->
+          <groupId>com.trilead</groupId>
+          <artifactId>trilead-ssh2</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch.agentproxy.connector-factory</artifactId>
+      <version>0.0.6</version>
     </dependency>
   </dependencies>
 

--- a/cli/src/main/java/hudson/cli/Connection.java
+++ b/cli/src/main/java/hudson/cli/Connection.java
@@ -23,6 +23,8 @@
  */
 package hudson.cli;
 
+import com.trilead.ssh2.auth.AgentIdentity;
+import hudson.cli.agent.AgentIdentityUtils;
 import hudson.remoting.SocketInputStream;
 import hudson.remoting.SocketOutputStream;
 import org.apache.commons.codec.binary.Base64;
@@ -35,7 +37,6 @@ import javax.crypto.SecretKey;
 import javax.crypto.interfaces.DHPublicKey;
 import javax.crypto.spec.DHParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -232,6 +233,17 @@ public class Connection {
         sig.update(key.getPublic().getEncoded());
         sig.update(sharedSecret);
         writeObject(sig.sign());
+    }
+
+    public void proveIdentity(final byte[] sharedSecret, final AgentIdentity identity)
+            throws IOException, GeneralSecurityException {
+        final PublicKey publicKey = AgentIdentityUtils.getPublicKey(identity);
+        final String algorithm = detectKeyAlgorithm(publicKey);
+
+        writeUTF(algorithm);
+        writeKey(publicKey);
+
+        writeObject(identity.sign(sharedSecret));
     }
 
     /**

--- a/cli/src/main/java/hudson/cli/agent/AgentIdentityUtils.java
+++ b/cli/src/main/java/hudson/cli/agent/AgentIdentityUtils.java
@@ -1,0 +1,51 @@
+package hudson.cli.agent;
+
+import com.jcraft.jsch.agentproxy.Buffer;
+import com.trilead.ssh2.auth.AgentIdentity;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.DSAPublicKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+
+/**
+ * @author reynald
+ */
+public class AgentIdentityUtils {
+
+    /**
+     * Retrieve the public key from the specified agent identity.
+     * <p/>
+     * Copied from http://svn.apache.org/repos/asf/mina/sshd/tags/sshd-0.8.0/sshd-core/src/main/java/org/apache/sshd/common/util/Buffer.java#getRawPublicKey()
+     *
+     * @param identity Agent identity
+     * @return Public Key
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     */
+    public static PublicKey getPublicKey(final AgentIdentity identity)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+
+        final Buffer buffer = new Buffer(identity.getPublicKeyBlob());
+
+        final String algorithm = new String(buffer.getString());
+
+        if (algorithm.equals("ssh-rsa")) {
+            final BigInteger e = new BigInteger(buffer.getMPInt());
+            final BigInteger n = new BigInteger(buffer.getMPInt());
+            return KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(n, e));
+
+        } else if (algorithm.equals("ssh-dsa")) {
+            final BigInteger p = new BigInteger(buffer.getMPInt());
+            final BigInteger q = new BigInteger(buffer.getMPInt());
+            final BigInteger g = new BigInteger(buffer.getMPInt());
+            final BigInteger y = new BigInteger(buffer.getMPInt());
+            return KeyFactory.getInstance("DSA").generatePublic(new DSAPublicKeySpec(y, p, q, g));
+        }
+
+        throw new IllegalArgumentException("Unsupported agent algorithm " + algorithm);
+    }
+}

--- a/cli/src/main/java/hudson/cli/agent/AgentProxyFactory.java
+++ b/cli/src/main/java/hudson/cli/agent/AgentProxyFactory.java
@@ -1,0 +1,38 @@
+package hudson.cli.agent;
+
+import com.jcraft.jsch.agentproxy.AgentProxyException;
+import com.jcraft.jsch.agentproxy.Connector;
+import com.jcraft.jsch.agentproxy.ConnectorFactory;
+import com.jcraft.jsch.agentproxy.TrileadAgentProxy;
+
+import java.util.logging.Logger;
+
+/**
+ * @author reynald
+ */
+public class AgentProxyFactory {
+
+    private enum AgentProxy {
+        INSTANCE;
+
+        private TrileadAgentProxy agentProxy;
+
+        private AgentProxy() {
+            try {
+                final Connector con = ConnectorFactory.getDefault().createConnector();
+
+                agentProxy = new TrileadAgentProxy(con);
+
+                LOGGER.fine("Connected to SSH agent '" + con.getName() + "'");
+            } catch (AgentProxyException e) {
+                agentProxy = null;
+            }
+        }
+    }
+
+    public static final TrileadAgentProxy getAgentProxy() {
+        return AgentProxy.INSTANCE.agentProxy;
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(AgentProxyFactory.class.getName());
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -111,7 +111,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>trilead-ssh2</artifactId>
-      <version>build214-jenkins-3</version>
+      <version>build217-jenkins-1</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
If an existing SSH agent is detected, the CLI will try to use its known identities to authenticate towards Jenkins. This allow the CLI to not ask the SSH key passphrase at each command.

Agent communication is done through project jsch-agent-proxy (https://github.com/ymnk/jsch-agent-proxy), this new dependency increase the jar size from 2.5 to 3.9 mb.

This has been successfully tested both on OSX (with the OpenSSH agent) and on Windows 8 with Pageant.
