### PR TITLE
Fixed Brazilian Portuguese translation of "Full Log".

### DIFF
--- a/core/src/main/resources/hudson/model/Run/console_pt_BR.properties
+++ b/core/src/main/resources/hudson/model/Run/console_pt_BR.properties
@@ -22,4 +22,4 @@
 
 Console\ Output=Sa\u00edda do Console
 # Skipping {0,number,integer} KB.. <a href="{1}">Full Log</a>
-skipSome= Ignorando {0,number,integer} KB.. <a href="{1}">Log cheio</a>
+skipSome= Ignorando {0,number,integer} KB.. <a href="{1}">Log Completo</a>


### PR DESCRIPTION
The translation was too literal: the log is not full as in a cup of water (this is what "cheio" means), it is full because it is not a partial object.
