### PR TITLE
Fixes for unsightly underlined leading/trailing whitespace in hyperlink text

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -88,9 +88,13 @@ THE SOFTWARE.
     -->
     <tr class="build-row">
       <td colspan="3" align="right">
-        <a href="${it.baseUrl}/rssAll"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/> RSS ${%for all}</a>
+        <a href="${it.baseUrl}/rssAll"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
         <st:nbsp/>
-        <a href="${it.baseUrl}/rssFailed"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/> RSS ${%for failures}</a>
+        <a href="${it.baseUrl}/rssAll">RSS ${%for all}</a>
+        <st:nbsp/>
+        <a href="${it.baseUrl}/rssFailed"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+        <st:nbsp/>
+        <a href="${it.baseUrl}/rssFailed">RSS ${%for failures}</a>
       </td>
     </tr>
   </l:pane>

--- a/core/src/main/resources/lib/hudson/rssBar.jelly
+++ b/core/src/main/resources/lib/hudson/rssBar.jelly
@@ -27,13 +27,17 @@ THE SOFTWARE.
   <div align="right" style="margin:1em">
     <a href="${rootURL}/legend">${%Legend}</a>
     <span style="padding-left:1em">
-      <a href="rssAll"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/> RSS ${%for all}</a>
+      <a href="rssAll"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+      <st:nbsp/>
+      <a href="rssAll">RSS ${%for all}</a>
     </span>
     <span style="padding-left:1em">
-      <a href="rssFailed"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/> RSS ${%for failures}</a>
+      <a href="rssFailed"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+      <st:nbsp/>
+      <a href="rssFailed">RSS ${%for failures}</a>
     </span>
     <span style="padding-left:1em">
-      <a href="rssLatest"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/> RSS ${%for just latest builds}</a>
+      <a href="rssLatest"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>&#160;<a href="rssLatest">RSS ${%for just latest builds}</a>
     </span>
   </div>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/rssBar.jelly
+++ b/core/src/main/resources/lib/hudson/rssBar.jelly
@@ -37,7 +37,9 @@ THE SOFTWARE.
       <a href="rssFailed">RSS ${%for failures}</a>
     </span>
     <span style="padding-left:1em">
-      <a href="rssLatest"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>&#160;<a href="rssLatest">RSS ${%for just latest builds}</a>
+      <a href="rssLatest"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+      <st:nbsp/>
+      <a href="rssLatest">RSS ${%for just latest builds}</a>
     </span>
   </div>
 </j:jelly>


### PR DESCRIPTION
Sorry if this is the most trivial pull request you ever receive, but this is something that bugs me every time I look at Jenkins.

This is ugly:

![screen shot 2013-08-27 at 01 01 17](https://f.cloud.github.com/assets/147396/1030140/3adaa4ec-0eac-11e3-9452-ac24e5361898.png)

This is better:

![screen shot 2013-08-27 at 01 01 25](https://f.cloud.github.com/assets/147396/1030139/3a3e8b8e-0eac-11e3-861b-b5089f528c65.png)

In addition to the pictured change, there were also underlined trailing spaces on the job names on the main screen. I've tried to make sense of Jelly's whitespace/new line handling rules and I tried using the `trim=true` attribute but in the end the only thing that worked for me was to eliminate the new line before the closing tag in `core/src/main/resources/lib/layout/breakable.jelly`. Maybe somebody who knows more about Jelly could suggest a better fix, but this works OK for now.
