### PR TITLE
[JENKINS-18723] Calculate a variable only once.

### DIFF
--- a/core/src/main/resources/lib/hudson/projectView.jelly
+++ b/core/src/main/resources/lib/hudson/projectView.jelly
@@ -79,9 +79,9 @@ THE SOFTWARE.
         <j:forEach var="v" items="${attrs.views}">
           <t:projectViewNested />
         </j:forEach>
-
         <j:forEach var="job" items="${jobs}">
-          <t:projectViewRow jobBaseUrl="${h.getRelativeLinkTo(job).substring(0, h.getRelativeLinkTo(job).length() - job.shortUrl.length())}"/>
+          <j:set var="relativeLinkToJob" value="${h.getRelativeLinkTo(job)}"/>
+          <t:projectViewRow jobBaseUrl="${relativeLinkToJob.substring(0, relativeLinkToJob.length() - job.shortUrl.length())}"/>
         </j:forEach>
       </table>
       <t:iconSize><t:rssBar/></t:iconSize>


### PR DESCRIPTION
Fixes a major performance bottleneck described in [JENKINS-18723](https://issues.jenkins-ci.org/browse/JENKINS-18723). 

_Original scope_:

To be short: instead of calculating a current page url for EVERY job in the view which was triggering the calculation of ACLs for all the jobs in Jenkins for a lot of times (that was _actually_ happening if we debug the code), now we do not calculate the current page link at all - any browser can do this for us. Therefore we just specify a job link and browser will prefix it with current page.

That really boosts performance especially on a large set of jobs and views which we have at work. 

_Reduced scope_:

Avoid doubling calculation.
