### PR TITLE
[FIXED JENKINS-19418] Fix random HTTP 404 when viewing build details

### DIFF
--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -498,6 +498,15 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
             }
             return getById(idOnDisk.get(lo-1));
         case EXACT:
+            if (hi<=0)                 return null;
+            R r = load(idOnDisk.get(hi-1), null);
+            if (r==null) {
+                return null;
+            }
+
+            int found = getNumberOf(r);
+            if (found==n)
+                return r;   // exact match
             return null;
         default:
             throw new AssertionError();

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -500,9 +500,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
         case EXACT:
             if (hi<=0)                 return null;
             R r = load(idOnDisk.get(hi-1), null);
-            if (r==null) {
-                return null;
-            }
+            if (r==null)               return null;
 
             int found = getNumberOf(r);
             if (found==n)

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -62,7 +62,7 @@ public class AbstractLazyLoadRunMapTest extends Assert {
         @Override
         public FakeMap make() {
             assert getDir()!=null;
-            return new FakeMap(getDir()){
+            return new FakeMap(getDir()) {
                 @Override
                 protected BuildReference<Build> createReference(Build r) {
                     return new BuildReference<Build>(getIdOf(r), /* pretend referent expired */ null);

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -57,6 +57,21 @@ public class AbstractLazyLoadRunMapTest extends Assert {
     @Rule
     public FakeMapBuilder localBuilder = new FakeMapBuilder();
 
+    @Rule
+    public FakeMapBuilder localExpiredBuilder = new FakeMapBuilder() {
+        @Override
+        public FakeMap make() {
+            assert getDir()!=null;
+            return new FakeMap(getDir()){
+                @Override
+                protected BuildReference<Build> createReference(Build r) {
+                    return new BuildReference<Build>(getIdOf(r), /* pretend referent expired */ null);
+                }
+            };
+        }
+    };
+ 
+    
     @BeforeClass
     public static void setUpClass() {
         AbstractLazyLoadRunMap.LOGGER.setLevel(Level.OFF);
@@ -132,6 +147,18 @@ public class AbstractLazyLoadRunMapTest extends Assert {
         // searching toward non-existent direction
         assertNull(a.search(99, Direction.ASC));
         assertNull(a.search(-99, Direction.DESC));
+    }
+
+    @Test
+    public void searchExactWhenIndexedButSoftReferenceExpired() throws IOException {
+        final FakeMap m = localExpiredBuilder.add(1, "A").add(2, "B").make();
+
+        // force index creation
+        m.entrySet();
+
+        m.search(1, Direction.EXACT).asserts(1, "A");
+        assertNull(m.search(3, Direction.EXACT));
+        assertNull(m.search(0, Direction.EXACT));
     }
 
     /**

--- a/core/src/test/java/jenkins/model/lazy/FakeMapBuilder.java
+++ b/core/src/test/java/jenkins/model/lazy/FakeMapBuilder.java
@@ -39,6 +39,10 @@ import java.io.IOException;
 public class FakeMapBuilder implements TestRule {
     private File dir;
 
+    protected File getDir() {
+        return dir;
+    }
+
     public FakeMapBuilder() {
     }
 


### PR DESCRIPTION
I found [JENKINS-19418](https://issues.jenkins-ci.org/browse/JENKINS-19418) when I noticed API calls (such as `/job/doStuff/17/api/xml`) failing "randomly" with HTTP 404.  The thing is, you then open a browser to `/job/doStuff` and API calls would start working again.  And it would only happen to some jobs and not others, but not always the same jobs.

Attaching a debugger to the running instance where this happened, I eventually was able to trace the defect to the `search()` method of the `AbstractLazyLoadRunMap` class, where it was able to obtain a "ceiling" entry that had a `BuildReference` with a null `referent`, which then hit all the right conditions for the method to return `null` even though the requested build number indeed existed.  A `SoftReference` helps explain why this would occur "randomly" and then suddenly start working again after visiting the job's page, which would [re-]load all the builds.

I was also able to craft a unit test that reproduces this condition exactly.  See the `searchExactWhenIndexedButSoftReferenceExpired()` method.

From what I can tell, this corner case has been missing since commit cf85b72036769549a2221a4c81789552d953006e

Let me know if there's anything you would like me to change/improve.
