### PR TITLE
[JENKINS-19446] - Fix of possible deadlock during simultaneous jobs deletion and renaming

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -614,9 +614,11 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         }
     }
 
-    @Override public synchronized void delete() throws IOException, InterruptedException {
+    @Override public void delete() throws IOException, InterruptedException {
         super.delete();
-        Util.deleteRecursive(getBuildDir());
+        synchronized (this) {
+            Util.deleteRecursive(getBuildDir());
+        }
     }
 
     /**


### PR DESCRIPTION
The fix enforces right locking order (from bigger objects to smaller) during deletion and renaming requests.
Issue URL: https://issues.jenkins-ci.org/browse/JENKINS-19446
