### PR TITLE
[JENKINS-18272] Added functionality to expose Maven GAV info through envvars

### DIFF
--- a/maven-plugin/src/main/java/hudson/maven/PomInfo.java
+++ b/maven-plugin/src/main/java/hudson/maven/PomInfo.java
@@ -101,12 +101,12 @@ final class PomInfo implements Serializable {
     /**
      * maven groupId
      */
-    private final String groupId;
+    public final String groupId;
     
     /**
      * maven artifactId
      */    
-    private final String artifactId;
+    public final String artifactId;
 
     public final Notifier mailNotifier;
     


### PR DESCRIPTION
A possible implementation of JENKINS-18272 (https://issues.jenkins-ci.org/browse/JENKINS-18272).

However, I'm a bit uncertain on a few details:
- Are there some ENVVARS naming convention? I prefixed them with POM_, but maybe they should be MVN_?
- Would the GAV info from the submodules be interesting? The same solution as for the subversion-plugin could be implemented (_X-suffix).
- In order to access groupId and artifactId, I had to make them public in PomInfo.java. This is ugly, but by some reason there are no getters in the class and the rest of the variables were already declared public. Is there any reason as to why some variables are declared public and some private?
