### PR TITLE
buildEnvironmentFor job shouldn't override slave's environment

### DIFF
--- a/core/src/main/java/jenkins/model/CoreEnvironmentContributor.java
+++ b/core/src/main/java/jenkins/model/CoreEnvironmentContributor.java
@@ -24,6 +24,11 @@ import java.io.IOException;
 public class CoreEnvironmentContributor extends EnvironmentContributor {
     @Override
     public void buildEnvironmentFor(Run r, EnvVars env, TaskListener listener) throws IOException, InterruptedException {
+        Computer c = Computer.currentComputer();
+        if (c!=null){
+            EnvVars compEnv = c.getEnvironment().overrideAll(env);
+            env.putAll(compEnv);
+        }
         env.put("BUILD_DISPLAY_NAME",r.getDisplayName());
 
         Jenkins j = Jenkins.getInstance();
@@ -35,12 +40,6 @@ public class CoreEnvironmentContributor extends EnvironmentContributor {
 
     @Override
     public void buildEnvironmentFor(Job j, EnvVars env, TaskListener listener) throws IOException, InterruptedException {
-        Computer c = Computer.currentComputer();
-        if (c!=null){
-            EnvVars compEnv = c.getEnvironment().overrideAll(env);
-            env.putAll(compEnv);
-        }
-
         Jenkins jenkins = Jenkins.getInstance();
         String rootUrl = jenkins.getRootUrl();
         if(rootUrl!=null) {

--- a/core/src/test/java/jenkins/model/CoreEnvironmentContributorTest.java
+++ b/core/src/test/java/jenkins/model/CoreEnvironmentContributorTest.java
@@ -1,0 +1,61 @@
+package jenkins.model;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import hudson.EnvVars;
+import hudson.model.Computer;
+import hudson.model.Job;
+import hudson.model.TaskListener;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public class CoreEnvironmentContributorTest {
+    CoreEnvironmentContributor instance;
+    
+    @Mock
+    Job job;
+    
+    @Mock
+    TaskListener listener;
+    
+    @Mock
+    Jenkins jenkins;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        instance = new CoreEnvironmentContributor();
+    }
+
+    @Test
+    @PrepareForTest(fullyQualifiedNames={"hudson.model.Computer", "jenkins.model.Jenkins"})
+    public void buildEnvironmentForJobShouldntUseCurrentComputer() throws IOException, InterruptedException {
+        PowerMockito.mockStatic(Computer.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(jenkins.getRootDir()).thenReturn(new File("."));
+        
+        EnvVars env = new EnvVars();
+        instance.buildEnvironmentFor(job, env, listener);
+        
+        // currentComputer shouldn't be called since it relates to a running build,
+        // which is not the case for calls of this method (e.g. polling) 
+        verifyStatic(times(0));
+        Computer.currentComputer();
+    }
+
+}


### PR DESCRIPTION
Slave environment is set in https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Job.java#L361, and the removed blocked was overriding it with master's environment, leading to incorrect environment provided to polling operations after implementation of [JENKINS-19042](https://issues.jenkins-ci.org/browse/JENKINS-19042)
