### PR TITLE
[FIXED JENKINS-19497] - JobProperty::prebuild() throws AbortException

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -825,15 +825,15 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             }
         }
 
-        protected final boolean preBuild(BuildListener listener,Map<?,? extends BuildStep> steps) {
+        protected final boolean preBuild(BuildListener listener,Map<?,? extends BuildStep> steps) throws AbortException {
             return preBuild(listener,steps.values());
         }
 
-        protected final boolean preBuild(BuildListener listener,Collection<? extends BuildStep> steps) {
+        protected final boolean preBuild(BuildListener listener,Collection<? extends BuildStep> steps) throws AbortException {
             return preBuild(listener,(Iterable<? extends BuildStep>)steps);
         }
 
-        protected final boolean preBuild(BuildListener listener,Iterable<? extends BuildStep> steps) {
+        protected final boolean preBuild(BuildListener listener,Iterable<? extends BuildStep> steps) throws AbortException {
             for (BuildStep bs : steps)
                 if (!bs.prebuild(AbstractBuild.this,listener)) {
                     LOGGER.fine(MessageFormat.format("{0} : {1} failed", AbstractBuild.this.toString(), bs));

--- a/core/src/main/java/hudson/tasks/BuildStep.java
+++ b/core/src/main/java/hudson/tasks/BuildStep.java
@@ -81,8 +81,9 @@ public interface BuildStep {
      *      Using the return value to indicate success/failure should
      *      be considered deprecated, and implementations are encouraged
      *      to throw {@link AbortException} to indicate a failure.
+     * @throws AbortException Indicates failure of the pre-build actions
      */
-    boolean prebuild( AbstractBuild<?,?> build, BuildListener listener );
+    boolean prebuild( AbstractBuild<?,?> build, BuildListener listener ) throws AbortException;
 
     /**
      * Runs the step over the given build and reports the progress to the listener.


### PR DESCRIPTION
JobProperty::prebuild() throws AbortException according to Javadoc description from @kohsuke.
Related issue: https://issues.jenkins-ci.org/browse/JENKINS-19497

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
