### PR TITLE
Create Executor threads on demand

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -85,11 +85,8 @@ public class BuildCommand extends CLICommand {
     @Option(name="-v",usage="Prints out the console output of the build. Use with -s")
     public boolean consoleOutput = false;
 
-    @Option(name="-r", usage="Number of times to retry reading of the output log if it does not exists on first attempt. Defaults to 0. Use with -v.")
-    public String retryCntStr = "0";
-
-    // hold parsed retryCnt;
-    private int retryCnt = 0;
+    @Option(name="-r") @Deprecated
+    public int retryCnt = 10;
 
     protected int run() throws Exception {
         job.checkPermission(Item.BUILD);
@@ -122,8 +119,6 @@ public class BuildCommand extends CLICommand {
 
             a = new ParametersAction(values);
         }
-
-        retryCnt = Integer.parseInt(retryCntStr);
 
         if (checkSCM) {
             if (job.poll(new StreamTaskListener(stdout, getClientCharset())).change == Change.NONE) {

--- a/core/src/main/java/hudson/init/InitializerFinder.java
+++ b/core/src/main/java/hudson/init/InitializerFinder.java
@@ -23,184 +23,50 @@
  */
 package hudson.init;
 
-import hudson.model.Hudson;
-import jenkins.model.Jenkins;
-import org.jvnet.hudson.annotation_indexer.Index;
 import org.jvnet.hudson.reactor.Milestone;
-import org.jvnet.hudson.reactor.Task;
-import org.jvnet.hudson.reactor.TaskBuilder;
-import org.jvnet.hudson.reactor.MilestoneImpl;
-import org.jvnet.hudson.reactor.Reactor;
-import org.jvnet.localizer.ResourceBundleHolder;
-
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.MissingResourceException;
-import java.util.Set;
-import java.util.logging.Logger;
-
-import static java.util.logging.Level.WARNING;
 
 /**
  * Discovers initialization tasks from {@link Initializer}.
  *
  * @author Kohsuke Kawaguchi
  */
-public class InitializerFinder extends TaskBuilder {
-    private final ClassLoader cl;
-
-    private final Set<Method> discovered = new HashSet<Method>();
+public class InitializerFinder extends TaskMethodFinder<Initializer> {
 
     public InitializerFinder(ClassLoader cl) {
-        this.cl = cl;
+        super(Initializer.class,InitMilestone.class,cl);
     }
 
     public InitializerFinder() {
         this(Thread.currentThread().getContextClassLoader());
     }
 
-    public Collection<Task> discoverTasks(Reactor session) throws IOException {
-        List<Task> result = new ArrayList<Task>();
-        for (Method e : Index.list(Initializer.class,cl,Method.class)) {
-            if (filter(e)) continue;   // already reported once
-
-            if (!Modifier.isStatic(e.getModifiers()))
-                throw new IOException(e+" is not a static method");
-
-            Initializer i = e.getAnnotation(Initializer.class);
-            if (i==null)        continue; // stale index
-
-            result.add(new TaskImpl(i, e));
-        }
-        return result;
+    @Override
+    protected String displayNameOf(Initializer i) {
+        return i.displayName();
     }
 
-    /**
-     * Return true to ignore this method.
-     */
-    protected boolean filter(Method e) {
-        return !discovered.add(e);
+    @Override
+    protected String[] requiresOf(Initializer i) {
+        return i.requires();
     }
 
-    /**
-     * Obtains the display name of the given initialization task
-     */
-    protected String getDisplayNameOf(Method e, Initializer i) {
-        Class<?> c = e.getDeclaringClass();
-        String key = i.displayName();
-        if (key.length()==0)  return c.getSimpleName()+"."+e.getName();
-        try {
-            ResourceBundleHolder rb = ResourceBundleHolder.get(
-                    c.getClassLoader().loadClass(c.getPackage().getName() + ".Messages"));
-            return rb.format(key);
-        } catch (ClassNotFoundException x) {
-            LOGGER.log(WARNING, "Failed to load "+x.getMessage()+" for "+e.toString(),x);
-            return key;
-        } catch (MissingResourceException x) {
-            LOGGER.log(WARNING, "Could not find key '" + key + "' in " + c.getPackage().getName() + ".Messages", x);
-            return key;
-        }
+    @Override
+    protected String[] attainsOf(Initializer i) {
+        return i.attains();
     }
 
-    /**
-     * Invokes the given initialization method.
-     */
-    protected void invoke(Method e) {
-        try {
-            Class<?>[] pt = e.getParameterTypes();
-            Object[] args = new Object[pt.length];
-            for (int i=0; i<args.length; i++)
-                args[i] = lookUp(pt[i]);
-            e.invoke(null,args);
-        } catch (IllegalAccessException x) {
-            throw (Error)new IllegalAccessError().initCause(x);
-        } catch (InvocationTargetException x) {
-            throw new Error(x);
-        }
+    @Override
+    protected Milestone afterOf(Initializer i) {
+        return i.after();
     }
 
-    /**
-     * Determines the parameter injection of the initialization method.
-     */
-    private Object lookUp(Class<?> type) {
-        if (type==Jenkins.class || type==Hudson.class)
-            return Jenkins.getInstance();
-        throw new IllegalArgumentException("Unable to inject "+type);
+    @Override
+    protected Milestone beforeOf(Initializer i) {
+        return i.before();
     }
 
-    /**
-     * Task implementation.
-     */
-    public class TaskImpl implements Task {
-        final Collection<Milestone> requires;
-        final Collection<Milestone> attains;
-        private final Initializer i;
-        private final Method e;
-
-        private TaskImpl(Initializer i, Method e) {
-            this.i = i;
-            this.e = e;
-            requires = toMilestones(i.requires(), i.after());
-            attains = toMilestones(i.attains(), i.before());
-        }
-
-        /**
-         * {@link Initializer} annotaion on the {@linkplain #getMethod() method}
-         */
-        public Initializer getAnnotation() {
-            return i;
-        }
-
-        /**
-         * Static method that runs the initialization, that this task wraps.
-         */
-        public Method getMethod() {
-            return e;
-        }
-
-        public Collection<Milestone> requires() {
-            return requires;
-        }
-
-        public Collection<Milestone> attains() {
-            return attains;
-        }
-
-        public String getDisplayName() {
-            return getDisplayNameOf(e, i);
-        }
-
-        public boolean failureIsFatal() {
-            return i.fatal();
-        }
-
-        public void run(Reactor session) {
-            invoke(e);
-        }
-
-        public String toString() {
-            return e.toString();
-        }
-
-        private Collection<Milestone> toMilestones(String[] tokens, InitMilestone m) {
-            List<Milestone> r = new ArrayList<Milestone>();
-            for (String s : tokens) {
-                try {
-                    r.add(InitMilestone.valueOf(s));
-                } catch (IllegalArgumentException x) {
-                    r.add(new MilestoneImpl(s));
-                }
-            }
-            r.add(m);
-            return r;
-        }
+    @Override
+    protected boolean fatalOf(Initializer i) {
+        return i.fatal();
     }
-
-    private static final Logger LOGGER = Logger.getLogger(InitializerFinder.class.getName());
 }

--- a/core/src/main/java/hudson/init/TaskMethodFinder.java
+++ b/core/src/main/java/hudson/init/TaskMethodFinder.java
@@ -1,0 +1,189 @@
+package hudson.init;
+
+import hudson.model.Hudson;
+import jenkins.model.Jenkins;
+import org.jvnet.hudson.annotation_indexer.Index;
+import org.jvnet.hudson.reactor.Milestone;
+import org.jvnet.hudson.reactor.MilestoneImpl;
+import org.jvnet.hudson.reactor.Reactor;
+import org.jvnet.hudson.reactor.Task;
+import org.jvnet.hudson.reactor.TaskBuilder;
+import org.jvnet.localizer.ResourceBundleHolder;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.MissingResourceException;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.WARNING;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+abstract class TaskMethodFinder<T extends Annotation> extends TaskBuilder {
+    private static final Logger LOGGER = Logger.getLogger(TaskMethodFinder.class.getName());
+    protected final ClassLoader cl;
+    private final Set<Method> discovered = new HashSet<Method>();
+
+    private final Class<T> type;
+    private final Class<? extends Enum> milestoneType;
+
+    public TaskMethodFinder(Class<T> type, Class<? extends Enum> milestoneType, ClassLoader cl) {
+        this.type = type;
+        this.milestoneType = milestoneType;
+        this.cl = cl;
+    }
+
+    // working around the restriction that Java doesn't allow annotation types to extend interfaces
+    protected abstract String displayNameOf(T i);
+    protected abstract String[] requiresOf(T i);
+    protected abstract String[] attainsOf(T i);
+    protected abstract Milestone afterOf(T i);
+    protected abstract Milestone beforeOf(T i);
+    protected abstract boolean fatalOf(T i);
+
+    public Collection<Task> discoverTasks(Reactor session) throws IOException {
+        List<Task> result = new ArrayList<Task>();
+        for (Method e : Index.list(type, cl, Method.class)) {
+            if (filter(e)) continue;   // already reported once
+
+            if (!Modifier.isStatic(e.getModifiers()))
+                throw new IOException(e+" is not a static method");
+
+            T i = e.getAnnotation(type);
+            if (i==null)        continue; // stale index
+
+            result.add(new TaskImpl(i, e));
+        }
+        return result;
+    }
+
+    /**
+     * Return true to ignore this method.
+     */
+    protected boolean filter(Method e) {
+        return !discovered.add(e);
+    }
+
+    /**
+     * Obtains the display name of the given initialization task
+     */
+    protected String getDisplayNameOf(Method e, T i) {
+        Class<?> c = e.getDeclaringClass();
+        String key = displayNameOf(i);
+        if (key.length()==0)  return c.getSimpleName()+"."+e.getName();
+        try {
+            ResourceBundleHolder rb = ResourceBundleHolder.get(
+                    c.getClassLoader().loadClass(c.getPackage().getName() + ".Messages"));
+            return rb.format(key);
+        } catch (ClassNotFoundException x) {
+            LOGGER.log(WARNING, "Failed to load "+x.getMessage()+" for "+e.toString(),x);
+            return key;
+        } catch (MissingResourceException x) {
+            LOGGER.log(WARNING, "Could not find key '" + key + "' in " + c.getPackage().getName() + ".Messages", x);
+            return key;
+        }
+    }
+
+    /**
+     * Invokes the given initialization method.
+     */
+    protected void invoke(Method e) {
+        try {
+            Class<?>[] pt = e.getParameterTypes();
+            Object[] args = new Object[pt.length];
+            for (int i=0; i<args.length; i++)
+                args[i] = lookUp(pt[i]);
+            e.invoke(null,args);
+        } catch (IllegalAccessException x) {
+            throw (Error)new IllegalAccessError().initCause(x);
+        } catch (InvocationTargetException x) {
+            throw new Error(x);
+        }
+    }
+
+    /**
+     * Determines the parameter injection of the initialization method.
+     */
+    private Object lookUp(Class<?> type) {
+        if (type==Jenkins.class || type==Hudson.class)
+            return Jenkins.getInstance();
+        throw new IllegalArgumentException("Unable to inject "+type);
+    }
+
+    /**
+     * Task implementation.
+     */
+    public class TaskImpl implements Task {
+        final Collection<Milestone> requires;
+        final Collection<Milestone> attains;
+        private final T i;
+        private final Method e;
+
+        private TaskImpl(T i, Method e) {
+            this.i = i;
+            this.e = e;
+            requires = toMilestones(requiresOf(i), afterOf(i));
+            attains = toMilestones(attainsOf(i), beforeOf(i));
+        }
+
+        /**
+         * The annotation on the {@linkplain #getMethod() method}
+         */
+        public T getAnnotation() {
+            return i;
+        }
+
+        /**
+         * Static method that runs the initialization, that this task wraps.
+         */
+        public Method getMethod() {
+            return e;
+        }
+
+        public Collection<Milestone> requires() {
+            return requires;
+        }
+
+        public Collection<Milestone> attains() {
+            return attains;
+        }
+
+        public String getDisplayName() {
+            return getDisplayNameOf(e, i);
+        }
+
+        public boolean failureIsFatal() {
+            return fatalOf(i);
+        }
+
+        public void run(Reactor session) {
+            invoke(e);
+        }
+
+        public String toString() {
+            return e.toString();
+        }
+
+        private Collection<Milestone> toMilestones(String[] tokens, Milestone m) {
+            List<Milestone> r = new ArrayList<Milestone>();
+            for (String s : tokens) {
+                try {
+                    r.add((Milestone)Enum.valueOf(milestoneType,s));
+                } catch (IllegalArgumentException x) {
+                    r.add(new MilestoneImpl(s));
+                }
+            }
+            r.add(m);
+            return r;
+        }
+    }
+}

--- a/core/src/main/java/hudson/init/TermMilestone.java
+++ b/core/src/main/java/hudson/init/TermMilestone.java
@@ -1,0 +1,57 @@
+package hudson.init;
+
+import org.jvnet.hudson.reactor.Executable;
+import org.jvnet.hudson.reactor.Milestone;
+import org.jvnet.hudson.reactor.TaskBuilder;
+import org.jvnet.hudson.reactor.TaskGraphBuilder;
+
+/**
+ * Various key milestone in the termination process of Jenkins.
+ *
+ * <p>
+ * Plugins can use these milestones to execute their tear down processing at the right moment
+ * (in addition to defining their own milestones by implementing {@link Milestone}.
+ *
+ * <p>
+ * These milestones are achieve in this order.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public enum TermMilestone implements Milestone {
+    /**
+     * The very first milestone that gets achieved without doing anything.
+     *
+     * This is used in {@link Initializer#after()} since annotations cannot have null as the default value.
+     */
+    STARTED("Started termination"),
+
+    /**
+     * The very last milestone
+     *
+     * This is used in {@link Initializer#before()} since annotations cannot have null as the default value.
+     */
+    COMPLETED("Completed termination");
+
+    private final String message;
+
+    TermMilestone(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Creates a set of dummy tasks to enforce ordering among {@link TermMilestone}s.
+     */
+    public static TaskBuilder ordering() {
+        TaskGraphBuilder b = new TaskGraphBuilder();
+        TermMilestone[] v = values();
+        for (int i=0; i<v.length-1; i++)
+            b.add(null, Executable.NOOP).requires(v[i]).attains(v[i+1]);
+        return b;
+    }
+
+
+    @Override
+    public String toString() {
+        return message;
+    }
+}

--- a/core/src/main/java/hudson/init/Terminator.java
+++ b/core/src/main/java/hudson/init/Terminator.java
@@ -1,0 +1,58 @@
+package hudson.init;
+
+import org.jvnet.hudson.annotation_indexer.Indexed;
+import org.jvnet.hudson.reactor.Task;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static hudson.init.TermMilestone.*;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+@Indexed
+@Documented
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface Terminator {
+    /**
+     * Indicates that the specified milestone is necessary before executing this terminator.
+     *
+     * <p>
+     * This has the identical purpose as {@link #requires()}, but it's separated to allow better type-safety
+     * when using {@link TermMilestone} as a requirement (since enum member definitions need to be constant.)
+     */
+    TermMilestone after() default STARTED;
+
+    /**
+     * Indicates that this terminator is a necessary step before achieving the specified milestone.
+     *
+     * <p>
+     * This has the identical purpose as {@link #attains()}. See {@link #after()} for why there are two things
+     * to achieve the same goal.
+     */
+    TermMilestone before() default COMPLETED;
+
+    /**
+     * Indicates the milestones necessary before executing this terminator.
+     */
+    String[] requires() default {};
+
+    /**
+     * Indicates the milestones that this terminator contributes to.
+     *
+     * A milestone is considered attained if all the terminators that attains the given milestone
+     * completes. So it works as a kind of join.
+     */
+    String[] attains() default {};
+
+    /**
+     * Key in <tt>Messages.properties</tt> that represents what this task is about. Used for rendering the progress.
+     * Defaults to "${short class name}.${method Name}".
+     */
+    String displayName() default "";
+}

--- a/core/src/main/java/hudson/init/TerminatorFinder.java
+++ b/core/src/main/java/hudson/init/TerminatorFinder.java
@@ -1,0 +1,45 @@
+package hudson.init;
+
+import org.jvnet.hudson.reactor.Milestone;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+public class TerminatorFinder extends TaskMethodFinder<Terminator> {
+    public TerminatorFinder(ClassLoader cl) {
+        super(Terminator.class, TermMilestone.class, cl);
+    }
+    
+    @Override
+    protected String displayNameOf(Terminator i) {
+        return i.displayName();
+    }
+
+    @Override
+    protected String[] requiresOf(Terminator i) {
+        return i.requires();
+    }
+
+    @Override
+    protected String[] attainsOf(Terminator i) {
+        return i.attains();
+    }
+
+    @Override
+    protected Milestone afterOf(Terminator i) {
+        return i.after();
+    }
+
+    @Override
+    protected Milestone beforeOf(Terminator i) {
+        return i.before();
+    }
+
+    /**
+     * Termination code is never fatal.
+     */
+    @Override
+    protected boolean fatalOf(Terminator i) {
+        return false;
+    }
+}

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -718,7 +718,6 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
 
         for (Integer number : availableNumbers) {
             Executor e = new Executor(this, number);
-            e.start();
             executors.add(e);
         }
     }
@@ -847,7 +846,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     protected boolean isAlive() {
         for (Executor e : executors)
-            if (e.isAlive())
+            if (e.isActive())
                 return true;
         return false;
     }
@@ -1015,8 +1014,8 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      * Starts executing a fly-weight task.
      */
     /*package*/ final void startFlyWeightTask(WorkUnit p) {
-        OneOffExecutor e = new OneOffExecutor(this, p);
-        e.start();
+        OneOffExecutor e = new OneOffExecutor(this);
+        e.start(p);
         oneOffExecutors.add(e);
     }
 

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -268,7 +268,6 @@ public class Executor extends Thread implements ModelObject {
      */
     public void killHard() {
         induceDeath = true;
-        interrupt();
     }
 
     /**

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -260,6 +260,8 @@ public class Executor extends Thread implements ModelObject {
             if (causeOfDeath==null)
                 // let this thread die and be replaced by a fresh unstarted instance
                 owner.removeExecutor(this);
+
+            queue.scheduleMaintenance();
         }
     }
 

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -144,6 +144,14 @@ public class Executor extends Thread implements ModelObject {
         if (LOGGER.isLoggable(FINE))
             LOGGER.log(FINE, String.format("%s is interrupted(%s): %s", getDisplayName(), result, Util.join(Arrays.asList(causes),",")), new InterruptedException());
 
+        synchronized (this) {
+            if (!started) {
+                // not yet started, so simply dispose this
+                owner.removeExecutor(this);
+                return;
+            }
+        }
+
         interruptStatus = result;
         synchronized (this.causes) {
             for (CauseOfInterruption c : causes) {

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -196,10 +196,6 @@ public class Executor extends Thread implements ModelObject {
         ACL.impersonate(ACL.SYSTEM);
 
         try {
-            // clear the interrupt flag as a precaution.
-            // sometime an interrupt aborts a build but without clearing the flag.
-            // see issue #1583
-            if (Thread.interrupted())   return;
             if (induceDeath)        throw new ThreadDeath();
 
             SubTask task;

--- a/core/src/main/java/hudson/model/OneOffExecutor.java
+++ b/core/src/main/java/hudson/model/OneOffExecutor.java
@@ -24,7 +24,6 @@
 package hudson.model;
 
 import hudson.model.Queue.FlyweightTask;
-import hudson.model.queue.WorkUnit;
 
 /**
  * {@link Executor} that's temporarily added to carry out tasks that doesn't consume
@@ -34,30 +33,8 @@ import hudson.model.queue.WorkUnit;
  * @see FlyweightTask
  */
 public class OneOffExecutor extends Executor {
-    private WorkUnit work;
-
-    public OneOffExecutor(Computer owner, WorkUnit work) {
+    public OneOffExecutor(Computer owner) {
         super(owner,-1);
-        this.work = work;
-    }
-
-    @Override
-    protected boolean shouldRun() {
-        // TODO: consulting super.shouldRun() here means we'll lose the work if it gets scheduled
-        // when super.shouldRun() returns false.
-        return super.shouldRun() && work !=null;
-    }
-
-    public WorkUnit getAssignedWorkUnit() {
-        return work;
-    }
-
-    @Override
-    protected WorkUnit grabJob() throws InterruptedException {
-        WorkUnit r = super.grabJob();
-        assert r==work;
-        work = null;
-        return r;
     }
 
     @Override

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -917,7 +917,7 @@ public class Queue extends ResourceController implements Saveable {
      * <p>
      * This wakes up one {@link Executor} so that it will maintain a queue.
      */
-    public synchronized void scheduleMaintenance() {
+    public void scheduleMaintenance() {
         new MaintainTask(this).once();
     }
 

--- a/core/src/main/java/hudson/node_monitors/NodeMonitorUpdater.java
+++ b/core/src/main/java/hudson/node_monitors/NodeMonitorUpdater.java
@@ -1,6 +1,7 @@
 package hudson.node_monitors;
 
 import hudson.Extension;
+import hudson.init.*;
 import hudson.model.Computer;
 import hudson.model.TaskListener;
 import hudson.slaves.ComputerListener;
@@ -41,5 +42,10 @@ public class NodeMonitorUpdater extends ComputerListener {
                 }
             }
         }, 5, TimeUnit.SECONDS);
+    }
+
+    @Terminator
+    public static void shutdownTimer() {
+        ComputerListener.all().get(NodeMonitorUpdater.class).timer.shutdown();
     }
 }

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -182,7 +182,7 @@ public class NodeProvisioner {
                         cl.onComplete(f,node);
 
                     hudson.addNode(node);
-                    LOGGER.info(f.displayName+" provisioning successfully completed. We have now "+hudson.getComputers().length+" computer(s)");
+                    LOGGER.info(f.displayName+" provisioningE successfully completed. We have now "+hudson.getComputers().length+" computer(s)");
                 } catch (InterruptedException e) {
                     throw new AssertionError(e); // since we confirmed that the future is already done
                 } catch (ExecutionException e) {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2653,6 +2653,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
         Set<Future<?>> pending = new HashSet<Future<?>>();
         terminating = true;
         for( Computer c : computers.values() ) {
+            c.interrupt();
             killComputer(c);
             pending.add(c.disconnect(null));
         }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.Injector;
 import hudson.ExtensionComponent;
 import hudson.ExtensionFinder;
+import hudson.init.*;
 import hudson.model.LoadStatistics;
 import hudson.model.Messages;
 import hudson.model.Node;
@@ -66,7 +67,6 @@ import hudson.model.ManagementLink;
 import hudson.model.NoFingerprintMatch;
 import hudson.model.OverallLoadStatistics;
 import hudson.model.Project;
-import hudson.model.Queue.BuildableItem;
 import hudson.model.Queue.FlyweightTask;
 import hudson.model.RestartListener;
 import hudson.model.RootAction;
@@ -120,8 +120,6 @@ import hudson.cli.CliEntryPoint;
 import hudson.cli.CliManagerImpl;
 import hudson.cli.declarative.CLIMethod;
 import hudson.cli.declarative.CLIResolver;
-import hudson.init.InitMilestone;
-import hudson.init.InitStrategy;
 import hudson.lifecycle.Lifecycle;
 import hudson.logging.LogRecorderManager;
 import hudson.lifecycle.RestartNotSupportedException;
@@ -281,7 +279,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Stack;
 import java.util.StringTokenizer;
 import java.util.Timer;
 import java.util.TreeSet;
@@ -289,6 +286,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -2649,6 +2647,24 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
     public void cleanUp() {
         for (ItemListener l : ItemListener.all())
             l.onBeforeShutdown();
+
+        try {
+            final TerminatorFinder tf = new TerminatorFinder(
+                    pluginManager != null ? pluginManager.uberClassLoader : Thread.currentThread().getContextClassLoader());
+            new Reactor(tf).execute(new Executor() {
+                @Override
+                public void execute(Runnable command) {
+                    command.run();
+                }
+            });
+        } catch (InterruptedException e) {
+            LOGGER.log(SEVERE, "Failed to execute termination",e);
+            e.printStackTrace();
+        } catch (ReactorException e) {
+            LOGGER.log(SEVERE, "Failed to execute termination",e);
+        } catch (IOException e) {
+            LOGGER.log(SEVERE, "Failed to execute termination",e);
+        }
 
         Set<Future<?>> pending = new HashSet<Future<?>>();
         terminating = true;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2653,7 +2653,6 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
         Set<Future<?>> pending = new HashSet<Future<?>>();
         terminating = true;
         for( Computer c : computers.values() ) {
-            c.interrupt();
             killComputer(c);
             pending.add(c.disconnect(null));
         }

--- a/core/src/main/java/jenkins/util/AtmostOneTaskExecutor.java
+++ b/core/src/main/java/jenkins/util/AtmostOneTaskExecutor.java
@@ -1,0 +1,74 @@
+package jenkins.util;
+
+import hudson.remoting.AtmostOneThreadExecutor;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+/**
+ * {@link Executor}-like class that executes a single task repeatedly, in such a way that a single execution
+ * can cover multiple pending queued requests.
+ *
+ * <p>
+ * This is akin to doing laundry &mdash; when you put a dirty cloth into the laundry box, you mentally "schedule"
+ * a laundry task, regardless of whether there already is some cloths in the box or not. When you later actually get around
+ * doing laundry, you wash all the dirty cloths in the box, not just your cloths. And if someone brings
+ * more dirty cloths while a washer and dryer are in operation, the person has to mentally "schedule" the task
+ * and run the machines another time later, as the current batch is already in progress.
+ *
+ * <p>
+ * Since this class collapses multiple submitted tasks into just one run, it only makes sense when everyone
+ * submits the same task. Thus {@link #submit()} method does not take {@link Callable} as a parameter,
+ * instead you pass that in the constructor.
+ *
+ * @author Kohsuke Kawaguchi
+ * @see AtmostOneThreadExecutor
+ */
+public class AtmostOneTaskExecutor<V> {
+    /**
+     * The actual executor that executes {@link #task}
+     */
+    private final ExecutorService base;
+
+    /**
+     * Task to be executed.
+     */
+    private final Callable<V> task;
+
+    /**
+     * If a task is already submitted and pending execution, non-null.
+     * Guarded by "synchronized(this)"
+     */
+    private Future<V> pending;
+
+    public AtmostOneTaskExecutor(ExecutorService base, Callable<V> task) {
+        this.base = base;
+        this.task = task;
+    }
+
+    public AtmostOneTaskExecutor(Callable<V> task) {
+        this(new AtmostOneThreadExecutor(),task);
+    }
+
+    public synchronized Future<V> submit() {
+        if (pending!=null)
+            // if a task is already pending, just join that
+            return pending;
+
+        pending = base.submit(new Callable<V>() {
+            @Override
+            public V call() throws Exception {
+                // before we get going, everyone who submits after this
+                // should form a next batch
+                synchronized (AtmostOneTaskExecutor.this) {
+                    pending = null;
+                }
+
+                return task.call();
+            }
+        });
+        return pending;
+    }
+}

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -45,7 +45,7 @@ THE SOFTWARE.
               ${name}
             </td>
             <j:choose>
-              <j:when test="${!e.alive}">
+              <j:when test="${!e.active}">
                 <td class="pane">
                   <a href="${rootURL}/${c.url}${url}/causeOfDeath">
                     <div class="error">${%Dead} (!)</div>

--- a/test/src/main/java/org/jvnet/hudson/test/MilliSecLogFormatter.java
+++ b/test/src/main/java/org/jvnet/hudson/test/MilliSecLogFormatter.java
@@ -1,0 +1,48 @@
+package org.jvnet.hudson.test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+/**
+ * {@link Formatter} that prints out milliseconds.
+ *
+ * Useful when one needs to understand sub-second timing issues.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public class MilliSecLogFormatter extends Formatter {
+    private final Date dat = new Date();
+
+    public synchronized String format(LogRecord record) {
+        dat.setTime(record.getMillis());
+        String source;
+        if (record.getSourceClassName() != null) {
+            source = record.getSourceClassName();
+            if (record.getSourceMethodName() != null) {
+               source += " " + record.getSourceMethodName();
+            }
+        } else {
+            source = record.getLoggerName();
+        }
+        String message = formatMessage(record);
+        String throwable = "";
+        if (record.getThrown() != null) {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            pw.println();
+            record.getThrown().printStackTrace(pw);
+            pw.close();
+            throwable = sw.toString();
+        }
+        return String.format("%1$tl:%1$tM:%1$tS.%1$tL %1$Tp %2$s%n%4$s: %5$s%6$s%n",
+                             dat,
+                             source,
+                             record.getLoggerName(),
+                             record.getLevel().getLocalizedName(),
+                             message,
+                             throwable);
+    }
+}

--- a/test/src/test/groovy/hudson/matrix/MatrixProjectCustomWorkspaceTest.groovy
+++ b/test/src/test/groovy/hudson/matrix/MatrixProjectCustomWorkspaceTest.groovy
@@ -138,7 +138,7 @@ class MatrixProjectCustomWorkspaceTest extends HudsonTestCase {
     List<MatrixBuild> runTwoConcurrentBuilds(MatrixProject p) {
         def f1 = p.scheduleBuild2(0)
         // get one going
-        Thread.sleep(1000)
+        f1.waitForStart()
         def f2 = p.scheduleBuild2(0)
 
         def bs = [f1, f2]*.get().each { assertBuildStatusSuccess(it) }

--- a/test/src/test/groovy/hudson/matrix/MatrixProjectTest.groovy
+++ b/test/src/test/groovy/hudson/matrix/MatrixProjectTest.groovy
@@ -394,7 +394,7 @@ public class MatrixProjectTest {
         // should have gotten all unique names
         def f1 = p.scheduleBuild2(0)
         // get one going
-        Thread.sleep(1000)
+        f1.waitForStart()
         def f2 = p.scheduleBuild2(0)
         [f1,f2]*.get().each{ j.assertBuildStatusSuccess(it)}
 

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -169,7 +169,7 @@ public class QueueTest extends HudsonTestCase {
         Thread.sleep(1000);
         Queue.Item[] items = q.getItems();
         assertEquals(1,items.length);
-        assertTrue(items[0] instanceof BlockedItem);
+        assertTrue("Got "+items[0], items[0] instanceof BlockedItem);
 
         q.save();
     }

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -172,7 +172,7 @@ public class ArtifactArchiverTest {
         int buildNumber = project.getNextBuildNumber();
         project.scheduleBuild2(0);
         int count = 0;
-        while(project.getBuildByNumber(buildNumber)==null && count<30){
+        while(project.getBuildByNumber(buildNumber)==null && count<50){
             Thread.sleep(100);
             count ++;
         }

--- a/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
+++ b/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
@@ -22,13 +22,10 @@ public class ProcessTreeKillerTest extends HudsonTestCase {
 		project.getBuildersList().add(new Maven("install", "maven"));
 
 		// build the project, wait until tests are running, then cancel.
-		project.scheduleBuild(0);
-		Thread.sleep(2000);
+		project.scheduleBuild2(0).waitForStart();
 
         FreeStyleBuild b = project.getLastBuild();
-        b.doStop(
-				EasyMock.createNiceMock(StaplerRequest.class),
-				EasyMock.createNiceMock(StaplerResponse.class));
+        b.doStop();
 
 		Thread.sleep(1000);
 		


### PR DESCRIPTION
Instead of keeping idle `Executor` threads all the time, create them when there's something to do, and throw them away when they are done with the build.

This saves the system resources on a large system, and it simplifies the queue code, as it needs less synchronization.

The tests do pass, but I noticed that overall test execution time went up from 30 mins to 40 mins, so there's probably still something wrong. While I investigate that bug, I'd appreciate other eyeballs.

**NOT READY TO MERGE UNTIL THE SLOW DOWN IS INVESTIGATED**
