### PR TITLE
Adding CLI for updating next build number

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -32,6 +32,7 @@ import hudson.Extension;
 import hudson.ExtensionPoint;
 import hudson.PermalinkList;
 import hudson.Util;
+import hudson.cli.declarative.CLIMethod;
 import hudson.cli.declarative.CLIResolver;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Fingerprint.Range;
@@ -387,7 +388,8 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      * 
      * @since 1.199 (before that, this method was package private.)
      */
-    public synchronized void updateNextBuildNumber(int next) throws IOException {
+    @CLIMethod(name="set-next-build-number")
+    public synchronized void updateNextBuildNumber(@Argument(required=true, metaVar="NEXT_BUILD_NUMBER",usage="Next build number") int next) throws IOException {
         RunT lb = getLastBuild();
         if (lb!=null ?  next>lb.getNumber() : next>0) {
             this.nextBuildNumber = next;

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -98,6 +98,7 @@ CLI.online-node.shortDescription=Resume using a node for performing builds, to c
 CLI.offline-node.shortDescription=Stop using a node for performing builds temporarily, until the next "online-node" command.
 CLI.wait-node-online.shortDescription=Wait for a node to become online
 CLI.wait-node-offline.shortDescription=Wait for a node to become offline
+CLI.set-next-build-number.shortDescription=Set the next build number of a job.
 
 Computer.Caption=Slave {0}
 Computer.NoSuchSlaveExists=No such slave "{0}" exists. Did you mean "{1}"?


### PR DESCRIPTION
This change will enable a new CLI command from core jenkins "set-next-build-number".
This CLI command makes use of hudson.model.Job#updateNextBuildNumber, which already protects against a new build number less than the current build number.

Exposing this operation as a CLI command will enable automation around creating new jobs that start with a build number larger than one. Today the only way to create a new job that starts at a build number greater than one is to first create the job and then to use the Next Build Number plugin (http://goo.gl/zZLbah).

Because of the special nature of the build number inside the Job model, I suspect the CLI command is the best option. I also considered exposing the build number as part of the mutable configuration but decided against it.

I'm open to other options or suggestions on how to improve this. My ultimate goal is to be able to create a new job that begins with a build number that is greater than 1.

Thanks,
Jim
