### PR TITLE
Fixes to JDK installer

### DIFF
--- a/core/src/main/java/hudson/tools/JDKInstaller.java
+++ b/core/src/main/java/hudson/tools/JDKInstaller.java
@@ -224,16 +224,28 @@ public class JDKInstaller extends ToolInstaller {
              */
             String logFile = jdkBundle+".install.log";
 
-            ArgumentListBuilder args = new ArgumentListBuilder();
-            args.add(jdkBundle);
-            if (isJava15() || isJava14()) {
-                args.add("/s","/v/qn REBOOT=ReallySuppress INSTALLDIR=\""+ expectedLocation +"\" /L \""+logFile+"\"");
-            } else {
-                // modern version supports arguments in more sane format.
-                args.add("/s","/v","/qn","/L","\""+logFile+"\"","REBOOT=ReallySuppress","INSTALLDIR=\""+ expectedLocation+"\"");
+            expectedLocation = expectedLocation.trim();
+            if (expectedLocation.endsWith("\\")) {
+                // Prevent a trailing slash from escaping quotes
+                expectedLocation = expectedLocation.substring(0, expectedLocation.length() - 1);
             }
-            // according to http://community.acresso.com/showthread.php?t=83301, \" is the trick to quote values with whitespaces.
-            // Oh Windows, oh windows, why do you have to be so difficult?
+            ArgumentListBuilder args = new ArgumentListBuilder();
+            assert (new File(expectedLocation).exists()) : expectedLocation
+                    + " must exist, otherwise /L will cause the installer to fail with error 1622";
+            if (isJava15() || isJava14()) {
+                // Installer uses InstallShield.
+                args.add("CMD.EXE", "/C");
+
+                // CMD.EXE /C must be followed by a single parameter (do not split it!)
+                args.add(jdkBundle + " /s /v\"/qn REBOOT=ReallySuppress INSTALLDIR=\\\""
+                        + expectedLocation + "\\\" /L \\\"" + expectedLocation
+                        + "\\jdk.exe.install.log\\\"\"");
+            } else {
+                // Installed uses Windows Installer (MSI)
+                args.add(jdkBundle, "/s", "REBOOT=ReallySuppress",
+                        "INSTALLDIR=" + expectedLocation,
+                        "/L \\\"" + expectedLocation + "\\jdk.exe.install.log\\\"");
+            }
             int r = launcher.launch().cmds(args).stdout(out)
                     .pwd(new FilePath(launcher.getChannel(), expectedLocation)).join();
             if (r != 0) {

--- a/core/src/main/java/hudson/tools/JDKInstaller.java
+++ b/core/src/main/java/hudson/tools/JDKInstaller.java
@@ -242,8 +242,13 @@ public class JDKInstaller extends ToolInstaller {
                         + "\\jdk.exe.install.log\\\"\"");
             } else {
                 // Installed uses Windows Installer (MSI)
-                args.add(jdkBundle, "/s", "REBOOT=ReallySuppress",
-                        "INSTALLDIR=" + expectedLocation,
+                args.add(jdkBundle, "/s");
+
+                // Create a private JRE by omitting "PublicjreFeature"
+                // @see http://docs.oracle.com/javase/7/docs/webnotes/install/windows/jdk-installation-windows.html#jdk-silent-installation
+                args.add("ADDLOCAL=\"ToolsFeature\"");
+
+                args.add("REBOOT=ReallySuppress", "INSTALLDIR=" + expectedLocation,
                         "/L \\\"" + expectedLocation + "\\jdk.exe.install.log\\\"");
             }
             int r = launcher.launch().cmds(args).stdout(out)


### PR DESCRIPTION
This pull request fixes:
1. The installer hangs when installing into a path with spaces.
2. The installer clobbers the system's public JRE.

I've tested this against JDK 1.5, 1.6 and 1.7.
