### PR TITLE
[FIXED JENKINS-19156] - Call ProcessKiller for whole process tree

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -407,9 +407,10 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     }
 
                     public void killRecursively() throws InterruptedException {
-                        LOGGER.finer("Killing recursively "+getPid());
-                        p.killRecursively();
-                        killByKiller();
+                        LOGGER.fine("Recursively killing pid="+getPid());
+                        for (OSProcess p : getChildren())
+                             p.killRecursively();                        
+                        kill();  
                     }
 
                     public void kill() throws InterruptedException {


### PR DESCRIPTION
Previous fix invokes ProcessKiller only for top-level process.
Built-in killRecursive() of WinProcess has been replaced by manual implementation from UnixProcess

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
