### PR TITLE
[JENKINS-16502] Permission to see an executor/slave

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -58,6 +58,9 @@ Upcoming changes</a>
   <li class=rfe>
     Offer alternate error message for pattern-based project naming strategy.
     (<a href="https://github.com/jenkinsci/jenkins/pull/914">pull request 914</a>)
+  <li class=rfe>
+    Add support for hiding build slaves from users.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16502">issue 16502</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1373,6 +1373,10 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     public static final Permission DISCONNECT = new Permission(PERMISSIONS,"Disconnect", Messages._Computer_DisconnectPermission_Description(), Jenkins.ADMINISTER, PermissionScope.COMPUTER);
     public static final Permission CONNECT = new Permission(PERMISSIONS,"Connect", Messages._Computer_ConnectPermission_Description(), DISCONNECT, PermissionScope.COMPUTER);
     public static final Permission BUILD = new Permission(PERMISSIONS, "Build", Messages._Computer_BuildPermission_Description(),  Permission.WRITE, PermissionScope.COMPUTER);
+    /**
+     * @since 1.533
+     */
+    public static final Permission VIEW = new Permission(PERMISSIONS, "View", Messages._Computer_ViewPermission_Description(), Permission.READ, PermissionScope.COMPUTER);
 
     private static final Logger LOGGER = Logger.getLogger(Computer.class.getName());
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1533,7 +1533,12 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
      * Gets the read-only list of all {@link Computer}s.
      */
     public Computer[] getComputers() {
-        Computer[] r = computers.values().toArray(new Computer[computers.size()]);
+        Collection<Computer> computers = new ArrayList<Computer>(this.computers.size());
+        for (Computer c: this.computers.values()) {
+            if (c.hasPermission(Computer.VIEW))
+                computers.add(c);
+        }
+        Computer[] r = computers.toArray(new Computer[computers.size()]);
         Arrays.sort(r,new Comparator<Computer>() {
             final Collator collator = Collator.getInstance();
             public int compare(Computer lhs, Computer rhs) {
@@ -1552,7 +1557,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
 
         for (Computer c : computers.values()) {
             if(c.getName().equals(name))
-                return c;
+                return c.hasPermission(Computer.VIEW) ? c : null;
         }
         return null;
     }

--- a/core/src/main/resources/hudson/model/Computer/builds.jelly
+++ b/core/src/main/resources/hudson/model/Computer/builds.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName}">
+  <l:layout title="${it.displayName}" permission="${it.VIEW}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <h1>

--- a/core/src/main/resources/hudson/model/Computer/delete.jelly
+++ b/core/src/main/resources/hudson/model/Computer/delete.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout>
+  <l:layout permission="${it.DELETE}">
 		<st:include page="sidepanel.jelly" />
 		<l:main-panel>
 		  <form method="post" action="doDelete">

--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName}">
+  <l:layout title="${it.displayName}" permission="${it.VIEW}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
 

--- a/core/src/main/resources/hudson/model/Computer/load-statistics.jelly
+++ b/core/src/main/resources/hudson/model/Computer/load-statistics.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName} Load Statistics">
+  <l:layout title="${it.displayName} Load Statistics" permission="${it.VIEW}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <st:include page="main.jelly" from="${it.loadStatistics}" />

--- a/core/src/main/resources/hudson/model/Computer/markOffline.jelly
+++ b/core/src/main/resources/hudson/model/Computer/markOffline.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${%title(it.displayName)}" norefresh="true">
+  <l:layout title="${%title(it.displayName)}" norefresh="true" permission="${it.VIEW}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <l:hasPermission permission="${it.DISCONNECT}">

--- a/core/src/main/resources/hudson/model/Computer/setOfflineCause.jelly
+++ b/core/src/main/resources/hudson/model/Computer/setOfflineCause.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${%title(it.displayName)}" norefresh="true">
+  <l:layout title="${%title(it.displayName)}" norefresh="true" permission="${it.VIEW}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <l:hasPermission permission="${it.DISCONNECT}">

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -109,6 +109,7 @@ Computer.CreatePermission.Description=This permission allows users to create sla
 Computer.ConnectPermission.Description=This permission allows users to connect slaves or mark slaves as online.
 Computer.DisconnectPermission.Description=This permission allows users to disconnect slaves or mark slaves as temporarily offline.
 Computer.BuildPermission.Description=This permission allows users to run jobs as them on slaves.
+Computer.ViewPermission.Description=This permission allows users to see the slaves.
 Computer.BadChannel=Slave node offline or not a remote channel (such as master node).
 
 ComputerSet.NoSuchSlave=No such slave: {0}


### PR DESCRIPTION
- This is an initial version of the feature.
- The information about slave names is still exposed via label autocomplete
