### PR TITLE
[fixed JENKINS-19740] Added postCheckout for SCMs

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -667,6 +667,10 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                             } catch (Exception e) {
                                 throw new IOException2("Failed to parse changelog",e);
                             }
+
+                        // Get a chance to do something after checkout and changelog is done
+                        scm.postCheckout( build, launcher, build.getWorkspace(), listener );
+
                         return;
                     }
                 } catch (AbortException e) {

--- a/core/src/main/java/hudson/scm/SCM.java
+++ b/core/src/main/java/hudson/scm/SCM.java
@@ -421,6 +421,13 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
     public abstract boolean checkout(AbstractBuild<?,?> build, Launcher launcher, FilePath workspace, BuildListener listener, File changelogFile) throws IOException, InterruptedException;
 
     /**
+     * Get a chance to do operations after the workspace i checked out and the changelog is written.
+     */
+    public void postCheckout(AbstractBuild<?,?> build, Launcher launcher, FilePath workspace, BuildListener listener) throws IOException, InterruptedException {
+        /* Default implementation is noop */
+    }
+
+    /**
      * Adds environmental variables for the builds to the given map.
      *
      * <p>


### PR DESCRIPTION
This pull request will first of all add an additional method for the SCM extension point, letting SCM implementations do work after the change log is parsed and written. Secondly it will provide functionality to solve https://issues.jenkins-ci.org/browse/JENKINS-19558. 

JENKINS-19558 describes a scenario where the change log is not written even though there is a change set. This is also the case with the git plugin.
