### PR TITLE
[FIXED JENKINS-19753] Add view link to job artifacts list

### DIFF
--- a/core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/core/src/main/resources/lib/hudson/artifactList.jelly
@@ -63,6 +63,8 @@ THE SOFTWARE.
                     <a href="${baseURL}artifact/${f.href}/*fingerprint*/">
                       <img src="${imagesURL}/16x16/fingerprint.png" alt="[fingerprint]" height="16" width="16"/>
                     </a>
+                    <st:nbsp/>
+                    <a href="${baseURL}artifact/${f.href}/*view*/">${%view}</a>
                   </td>
                 </tr>
               </j:forEach>


### PR DESCRIPTION
Add a "view" link to a job's Last Successful Artifacts list, just like
an individual build's Build Artifacts list has.
