### PR TITLE
[FIXED JENKINS-19752] write in the correct outputstream

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -345,7 +345,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
             VirtualFile f = dir.child(n);
             e.setTime(f.lastModified());
             zos.putNextEntry(e);
-            Util.copyStream(f.open(), outputStream);
+            Util.copyStream(f.open(), zos);
             zos.closeEntry();
         }
         zos.close();

--- a/test/src/test/java/hudson/model/UserTest.java
+++ b/test/src/test/java/hudson/model/UserTest.java
@@ -234,13 +234,14 @@ public class UserTest {
         project.setScm(scm);
         Queue.getInstance().schedule(project,0);
         Build build = project.getLastBuild();
-        while(build==null){
+        // should wait until build completion otherwise this test might randomly fail depending on the server load
+        while(build == null || build.isBuilding()){
             Thread.sleep(100);
             build = project.getLastBuild();
         }
         Queue.getInstance().schedule(project2,0);
         Build build2 = project2.getLastBuild();
-        while(build2==null){
+        while(build2 == null || build2.isBuilding()){
             Thread.sleep(100);
             build2 = project2.getLastBuild();
         }


### PR DESCRIPTION
This fixes the isse that appears in 1.532 and that corrupts all the zip generated by DirectoryBrowserSupport (https://issues.jenkins-ci.org/browse/JENKINS-19752)

http://job/zenika/lastSuccessfulBuild/artifact/repository/output/_zip_/output.zip

The process was not writing in the correct output stream. 
This issue is quite annoying as you cannot download anymore the artifacts in a single file (zip)
