### PR TITLE
Protect against case where a build could not be scheduled

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -144,6 +144,11 @@ public class BuildCommand extends CLICommand {
         }
 
         QueueTaskFuture<? extends AbstractBuild> f = job.scheduleBuild2(0, new CLICause(Jenkins.getAuthentication().getName()), a);
+
+	if (f == null) {
+            stdout.println("Could not schedule build. A build could already be in Queue.");
+            return -1;
+	}
         
         if (wait || sync || follow) {
             AbstractBuild b = f.waitForStart();    // wait for the start


### PR DESCRIPTION
It is possible that job.scheduleBuild2 can return null if the Queue already has an item for this Task. This protects against a possible NPE.
