### PR TITLE
[FIXED JENKINS-19803] breadcrumb bar does not move lower than initial position on page

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1187,6 +1187,7 @@ var jenkinsRules = {
         edge.className = "top-sticker-edge";
         sticker.insertBefore(edge,sticker.firstChild);
 
+        var initialBreadcrumbPosition = DOM.getRegion(shadow);
         function adjustSticker() {
             shadow.style.height = sticker.offsetHeight + "px";
 
@@ -1194,7 +1195,9 @@ var jenkinsRules = {
             var pos = DOM.getRegion(shadow);
 
             sticker.style.position = "fixed";
-            sticker.style.top = Math.max(0, pos.top-viewport.top) + "px"
+            if(pos.top <= initialBreadcrumbPosition.top) {
+                sticker.style.top = Math.max(0, pos.top-viewport.top) + "px"
+            }
             sticker.style.left = Math.max(0,pos.left-viewport.left) + "px"
         }
 


### PR DESCRIPTION
This change compares the initial breadcrumb position before adjusting its `top` position. I thought it was the lowest-risk way to ensure the breadcrumb bar doesn't sink when scrolling up past the top of the page in Chrome/Safari/Opera on OS X. :)
