### PR TITLE
Fix wrong directory source of renaming job

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -252,7 +252,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                     if (interrupted)
                         Thread.currentThread().interrupt();
 
-                    if (!renamed) {
+                    if (!renamed && Jenkins.getInstance().getOverwriteDirectories()) {
                         // failed to rename. it must be that some lengthy
                         // process is going on
                         // to prevent a rename operation. So do a copy. Ideally
@@ -265,12 +265,12 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                         cp.setProject(new org.apache.tools.ant.Project());
                         cp.setTodir(newRoot);
                         FileSet src = new FileSet();
-                        src.setDir(getRootDir());
+                        src.setDir(oldRoot);
                         cp.addFileset(src);
                         cp.setOverwrite(true);
                         cp.setPreserveLastModified(true);
                         cp.setFailOnError(false); // keep going even if
-                                                    // there's an error
+                                                // there's an error
                         cp.execute();
 
                         // try to delete as much as possible
@@ -280,6 +280,10 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                             // but ignore the error, since we expect that
                             e.printStackTrace();
                         }
+                    }
+                    else{
+                        throw new IllegalArgumentException("Directory with name " + newRoot.getAbsolutePath()
+                            + " already exists and overwriting is not allowed.");
                     }
 
                     success = true;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -399,6 +399,8 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
      * @see #getBuildDirFor(Job)
      */
     private String buildsDir = "${ITEM_ROOTDIR}/builds";
+    
+    private boolean overwriteDirectories = true;
 
     /**
      * Message displayed in the top page.
@@ -1947,6 +1949,10 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
     public String getRawWorkspaceDir() {
         return workspaceDir;
     }
+    
+    public boolean getOverwriteDirectories(){
+        return overwriteDirectories;
+    }
 
     public String getRawBuildsDir() {
         return buildsDir;
@@ -2728,6 +2734,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
 
             workspaceDir = json.getString("rawWorkspaceDir");
             buildsDir = json.getString("rawBuildsDir");
+            overwriteDirectories = json.getBoolean("overwriteDirectories");
 
             systemMessage = Util.nullify(req.getParameter("system_message"));
 

--- a/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
@@ -46,6 +46,9 @@ THE SOFTWARE.
         <f:entry field="rawBuildsDir" title="${%Build Record Root Directory}">
           <f:textbox/>
         </f:entry>
+        <f:entry field="overwriteDirectories" title="${%Allow overwriting existing directories in renaming process}">
+          <f:checkbox/>
+        </f:entry>
       </f:advanced>
       <f:entry title="${%System Message}" help="/help/system-config/systemMessage.html">
         <f:textarea name="system_message" value="${it.systemMessage}"


### PR DESCRIPTION
Renaming does not work well if directory for new name already exists - it does nothing due to wrong source path and can cause lost of builds or inconsistency between persistent data on disk and data in memory. In advance I think coping into existing directory should be optional - sometime Jenkins fails with loading job and its rewriting does not have to be wanted behaviour.
