### PR TITLE
JENKINS-19838 - Enable separate queues per SCM type

### DIFF
--- a/core/src/main/resources/hudson/triggers/SCMTrigger/global.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/global.jelly
@@ -34,6 +34,9 @@ THE SOFTWARE.
         <f:number value="${descriptor.pollingThreadCount==0 ? '' : descriptor.pollingThreadCount}"
            clazz="positive-number" min="1" step="1"/>
       </f:entry>
+      <f:entry title="${%Use separate queues per SCM type}" field="useSeparateQueues">
+        <f:checkbox checked="${descriptor.useSeparateQueues()}"/>
+      </f:entry>
     </f:section>
   </j:if>
 </j:jelly>


### PR DESCRIPTION
Use a map of queues stored after their SCM type. In the default case,
use one map entry of name "default". This is also used in the sync
polling case.
