### PR TITLE
Add Java VM name

### DIFF
--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -135,6 +135,7 @@ public class UsageStatistics extends PageDecorator {
             if(c.getNode()==j) {
                 n.put("master",true);
                 n.put("jvm-vendor", System.getProperty("java.vm.vendor"));
+                n.put("jvm-name", System.getProperty("java.vm.name"));
                 n.put("jvm-version", System.getProperty("java.version"));
             }
             n.put("executors",c.getNumExecutors());


### PR DESCRIPTION
Java VM vendor cannot distinguish between various JVMs, e.g. OpenJDK returns Oraclde as a vendor.
Adding this property allows to distinguish between Oracle JVM and OpenJDK JVM.
