### PR TITLE
Improve test failure summary appearance

### DIFF
--- a/core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
+++ b/core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
@@ -24,19 +24,38 @@ THE SOFTWARE.
 
 <!--  this is loaded on demand in the failed test results summary -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+  <d:taglib uri="local">
+    <d:tag name="item">
+      <j:if test="${value!=null and !empty value}">
+        <j:set var="id" value="${attrs.id}-${attrs.name}"/>
+        <j:set var="display" value="${attrs.opened ? '' : 'none'}"/>
+        <j:set var="idisplay" value="${attrs.opened ? 'none' : ''}"/>
+        <j:set var="open" value="javascript:showFailureSummary('${id}')"/>
+        <j:set var="close" value="javascript:hideFailureSummary('${id}')"/>
+        <h4>
+          <a id="${id}-showlink" href="${open}" title="Show ${title}" style="display: ${idisplay}">
+            <img src="${imagesURL}/16x16/document_add.png"/><st:nbsp/>${title}
+          </a>
+          <a id="${id}-hidelink" href="${close}" title="Hide ${title}" style="display: ${display}">
+            <img src="${imagesURL}/16x16/document_delete.png"/><st:nbsp/>${title}
+          </a>
+        </h4>
+        <pre id="${id}" style="display: ${display}">
+          <st:out value="${value}"/>
+        </pre>
+      </j:if>
+    </d:tag>
+  </d:taglib>
   <st:contentType value="text/plain;charset=UTF-8"/>
-  <j:choose>
-		<j:when test="${it.errorDetails!=null}">
-			<h3>${%Error Details}</h3>
-			<pre><st:out value="${it.errorDetails}"/></pre>
-		</j:when>
-		<j:otherwise>
-			<j:if test="${it.errorStackTrace!=null}">
-				<h3>${%Stack Trace}</h3>
-				<pre><j:out value="${it.annotate(it.errorStackTrace)}"/></pre>
-			</j:if>
-		</j:otherwise>
-  </j:choose>
+
+  <j:new var="h" className="hudson.Functions" />
+  ${h.initPageVariables(context)}
+
+  <j:set var="id" value="${h.generateId()}"/>
+
+  <local:item id="${id}" name="error" title="${%Error Details}" value="${it.errorDetails}" opened="true"/>
+  <local:item id="${id}" name="stacktrace" title="${%Stack Trace}" value="${it.errorStackTrace}"/>
+  <local:item id="${id}" name="stdout" title="${%Standard Output}" value="${it.stdout}"/>
+  <local:item id="${id}" name="stderr" title="${%Standard Error}" value="${it.stderr}"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/tasks/test/MatrixTestResult/index.jelly
+++ b/core/src/main/resources/hudson/tasks/test/MatrixTestResult/index.jelly
@@ -66,44 +66,7 @@ THE SOFTWARE.
         </j:forEach>
       </table>
 
-      <br/>
-      <h2>Failed Tests</h2>
-
-      <j:forEach var="report" items="${it.childReports}">
-        <j:if test="${report.result.failCount!=0}">
-
-          <h3>
-            <a name="${report.child.project.name}"/>
-            <a href="../${report.child.project.shortUrl}testReport" class="model-link inside">${report.child.project.name}</a>
-          </h3>
-
-          <table class="pane sortable">
-            <tr>
-              <td class="pane-header">Test Name</td>
-              <td class="pane-header" style="width:4em">Duration</td>
-              <td class="pane-header" style="width:4em">Age</td>
-            </tr>
-            <j:forEach var="f" items="${report.result.failedTests}" varStatus="i">
-              <tr>
-                <td class="pane">
-                  <a href="../${report.child.project.shortUrl}testReport/${f.getRelativePathFrom(report.result)}" class="model-link inside">
-                    <st:out value="${f.fullName}"/>
-                    <j:forEach var="badge" items="${f.testActions}">
-                      <st:include it="${badge}" page="badge.jelly" optional="true"/>
-                    </j:forEach>
-                  </a>
-                </td>
-                <td class="pane" style="text-align:right;">
-                  ${f.duration}
-                </td>
-                <td class="pane" style="text-align:right;">
-                  ${f.age}
-                </td>
-              </tr>
-            </j:forEach>
-          </table>
-        </j:if>
-      </j:forEach>
+      <t:aggregated-failed-tests/>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/tasks/test/MatrixTestResult/index.jelly
+++ b/core/src/main/resources/hudson/tasks/test/MatrixTestResult/index.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
       <h1>Test Result</h1>
       <test:bar/>
 
-      <table class="pane sortable">
+      <table class="pane sortable bigtable">
         <tr>
           <td class="pane-header">Configuration Name</td>
           <td class="pane-header" style="width:4em">Duration</td>

--- a/core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -25,28 +25,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-  <script type="text/javascript">
-		<!-- TODO make sure load doesn't happen every time -->
-		function showStackTrace(id,query) {
-			var element = document.getElementById(id)
-			element.style.display = "";
-			document.getElementById(id + "-showlink").style.display = "none";
-			document.getElementById(id + "-hidelink").style.display = "";
-			
-			var rqo = new XMLHttpRequest();
-			rqo.open('GET', query, true);
-			rqo.onreadystatechange = function() { element.innerHTML = rqo.responseText; }  
-			rqo.send(null);
-		}
-		
-		function hideStackTrace(id) {
-			document.getElementById(id).style.display = "none";
-			document.getElementById(id + "-showlink").style.display = "";
-			document.getElementById(id + "-hidelink").style.display = "none";
-		}
-  </script>
-
   <j:if test="${it.failCount!=0}">
     <h2>${%All Failed Tests}</h2>
     <table class="pane sortable">
@@ -57,21 +35,7 @@ THE SOFTWARE.
       </tr>
       <j:forEach var="f" items="${it.failedTests}" varStatus="i">
         <tr>
-          <td class="pane">
-            <a id="test-${f.fullName}-showlink"
-               href="javascript:showStackTrace('test-${h.jsStringEscape(f.fullName)}','${f.getRelativePathFrom(it)}/summary')">&gt;&gt;&gt;</a>
-            <a id="test-${f.fullName}-hidelink" style="display:none"
-               href="javascript:hideStackTrace('test-${h.jsStringEscape(f.fullName)}')">&lt;&lt;&lt;</a>
-            <st:nbsp/>
-            <a href="${f.getRelativePathFrom(it)}" class="model-link inside"><st:out value="${f.fullDisplayName}"/></a>
-            <j:forEach var="badge" items="${f.testActions}">
-              <st:include it="${badge}" page="badge.jelly" optional="true"/>
-            </j:forEach>
-            <div id="test-${f.fullName}" class="hidden" style="display:none">
-              ${%Loading...}
-            </div>
-          </td>
-          
+          <td class="pane"><t:failed-test result="${f}" url="${f.getRelativePathFrom(it)}"/></td>
           <td class="pane" style="text-align:right;" data="${f.duration}">
             ${f.durationString}
           </td>

--- a/core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${it.failCount!=0}">
     <h2>${%All Failed Tests}</h2>
-    <table class="pane sortable">
+    <table class="pane sortable bigtable">
       <tr>
         <td class="pane-header">${%Test Name}</td>
         <td class="pane-header" style="width:4em">${%Duration}</td>
@@ -49,7 +49,7 @@ THE SOFTWARE.
 
   <j:if test="${it.totalCount!=0}">
     <h2>${%All Tests}</h2>
-    <table class="pane sortable" id="testresult">
+    <table class="pane sortable bigtable" id="testresult">
       <tr>
         <td class="pane-header">${it.childTitle}</td>
         <td class="pane-header" style="width:5em">${%Duration}</td>

--- a/core/src/main/resources/lib/hudson/aggregated-failed-tests.jelly
+++ b/core/src/main/resources/lib/hudson/aggregated-failed-tests.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
           <a href="../${report.child.project.shortUrl}testReport" class="model-link inside">${report.child.project.name}</a>
         </h3>
 
-        <table class="pane sortable">
+        <table class="pane sortable bigtable">
           <tr>
             <td class="pane-header">Test Name</td>
             <td class="pane-header" style="width:4em">Duration</td>

--- a/core/src/main/resources/lib/hudson/aggregated-failed-tests.jelly
+++ b/core/src/main/resources/lib/hudson/aggregated-failed-tests.jelly
@@ -1,0 +1,64 @@
+<!--
+The MIT License
+
+Copyright (c) 20013 Red Hat, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation>
+    Display links to failed test from all child reports.
+    @since TODO
+    <st:attribute name="it" type="AggregatedTestResultAction">
+      Aggregated action.
+    </st:attribute>
+  </st:documentation>
+
+  <j:if test="${it.failCount!=0}">
+    <br/>
+    <h2>Failed Tests</h2>
+
+    <j:forEach var="report" items="${it.childReports}">
+      <j:if test="${report.result.failCount!=0}">
+
+        <h3>
+          <a name="${report.child.project.name}"/>
+          <a href="../${report.child.project.shortUrl}testReport" class="model-link inside">${report.child.project.name}</a>
+        </h3>
+
+        <table class="pane sortable">
+          <tr>
+            <td class="pane-header">Test Name</td>
+            <td class="pane-header" style="width:4em">Duration</td>
+            <td class="pane-header" style="width:4em">Age</td>
+          </tr>
+          <j:forEach var="f" items="${report.result.failedTests}" varStatus="i">
+            <tr>
+              <td class="pane"><t:failed-test result="${f}" url="../${report.child.project.shortUrl}testReport/${f.getRelativePathFrom(report.result)}"/></td>
+              <td class="pane" style="text-align:right;">${f.duration}</td>
+              <td class="pane" style="text-align:right;">${f.age}</td>
+            </tr>
+          </j:forEach>
+        </table>
+      </j:if>
+    </j:forEach>
+   </j:if>
+</j:jelly>

--- a/core/src/main/resources/lib/hudson/failed-test.jelly
+++ b/core/src/main/resources/lib/hudson/failed-test.jelly
@@ -1,0 +1,70 @@
+<!--
+The MIT License
+
+Copyright (c) 20013 Red Hat, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation>
+    Display link to the failed test.
+    @since TODO
+    <st:attribute name="url" type="String">
+      Path to the failed test.
+    </st:attribute>
+    <st:attribute name="result" type="TestObject">
+      Failed test object
+    </st:attribute>
+  </st:documentation>
+    <st:once>
+      <script type="text/javascript">
+      <!-- TODO make sure load doesn't happen every time -->
+      function showStackTrace(id,query) {
+        var element = document.getElementById(id)
+        element.style.display = "";
+        document.getElementById(id + "-showlink").style.display = "none";
+        document.getElementById(id + "-hidelink").style.display = "";
+
+        var rqo = new XMLHttpRequest();
+        rqo.open('GET', query, true);
+        rqo.onreadystatechange = function() { element.innerHTML = rqo.responseText; }
+        rqo.send(null);
+      }
+
+      function hideStackTrace(id) {
+        document.getElementById(id).style.display = "none";
+        document.getElementById(id + "-showlink").style.display = "";
+        document.getElementById(id + "-hidelink").style.display = "none";
+      }
+    </script>
+  </st:once>
+  <j:set var="id" value="${h.jsStringEscape(url)}"/>
+  <j:set var="open" value="javascript:showStackTrace('test-${id}','${url}/summary')"/>
+  <j:set var="close" value="javascript:hideStackTrace('test-${id}')"/>
+  <a id="test-${id}-showlink" href="${open}" title="${%Show details}">&gt;&gt;&gt;</a>
+  <a id="test-${id}-hidelink" href="${close}" title="${%Hide details}" style="display:none">&lt;&lt;&lt;</a>
+  <st:nbsp/>
+  <a href="${url}" class="model-link inside"><st:out value="${result.fullDisplayName}"/></a>
+  <j:forEach var="badge" items="${result.testActions}">
+    <st:include it="${badge}" page="badge.jelly" optional="true"/>
+  </j:forEach>
+  <div id="test-${id}" class="hidden" style="display:none">${%Loading...}</div>
+</j:jelly>

--- a/core/src/main/resources/lib/hudson/failed-test.jelly
+++ b/core/src/main/resources/lib/hudson/failed-test.jelly
@@ -59,8 +59,8 @@ THE SOFTWARE.
   <j:set var="id" value="${h.jsStringEscape(url)}"/>
   <j:set var="open" value="javascript:showStackTrace('test-${id}','${url}/summary')"/>
   <j:set var="close" value="javascript:hideStackTrace('test-${id}')"/>
-  <a id="test-${id}-showlink" href="${open}" title="${%Show details}">&gt;&gt;&gt;</a>
-  <a id="test-${id}-hidelink" href="${close}" title="${%Hide details}" style="display:none">&lt;&lt;&lt;</a>
+  <a id="test-${id}-showlink" href="${open}" title="${%Show details}"><img src="${imagesURL}/16x16/document_add.png"/></a>
+  <a id="test-${id}-hidelink" href="${close}" title="${%Hide details}" style="display:none"><img src="${imagesURL}/16x16/document_delete.png"/></a>
   <st:nbsp/>
   <a href="${url}" class="model-link inside"><st:out value="${result.fullDisplayName}"/></a>
   <j:forEach var="badge" items="${result.testActions}">

--- a/core/src/main/resources/lib/hudson/failed-test.jelly
+++ b/core/src/main/resources/lib/hudson/failed-test.jelly
@@ -37,34 +37,65 @@ THE SOFTWARE.
     <st:once>
       <script type="text/javascript">
       <!-- TODO make sure load doesn't happen every time -->
-      function showStackTrace(id,query) {
+      function showFailureSummary(id,query) {
         var element = document.getElementById(id)
         element.style.display = "";
         document.getElementById(id + "-showlink").style.display = "none";
         document.getElementById(id + "-hidelink").style.display = "";
 
-        var rqo = new XMLHttpRequest();
-        rqo.open('GET', query, true);
-        rqo.onreadystatechange = function() { element.innerHTML = rqo.responseText; }
-        rqo.send(null);
+        if (typeof query !== 'undefined') {
+          var rqo = new XMLHttpRequest();
+          rqo.open('GET', query, true);
+          rqo.onreadystatechange = function() { element.innerHTML = rqo.responseText; }
+          rqo.send(null);
+        }
       }
 
-      function hideStackTrace(id) {
+      function hideFailureSummary(id) {
         document.getElementById(id).style.display = "none";
         document.getElementById(id + "-showlink").style.display = "";
         document.getElementById(id + "-hidelink").style.display = "none";
       }
     </script>
+    <style type="text/css">
+      .failure-summary {
+        margin-left: 2em;
+      }
+
+      .failure-summary h4 {
+        margin: 0.5em 0 0.5em 0;
+      }
+
+      .failure-summary h4 a {
+        text-decoration: none;
+        color: inherit;
+      }
+
+      .failure-summary h4 a img {
+        width: 8px;
+        height: 8px;
+      }
+
+      .failure-summary pre {
+        margin-left: 2em;
+      }
+    </style>
   </st:once>
   <j:set var="id" value="${h.jsStringEscape(url)}"/>
-  <j:set var="open" value="javascript:showStackTrace('test-${id}','${url}/summary')"/>
-  <j:set var="close" value="javascript:hideStackTrace('test-${id}')"/>
-  <a id="test-${id}-showlink" href="${open}" title="${%Show details}"><img src="${imagesURL}/16x16/document_add.png"/></a>
-  <a id="test-${id}-hidelink" href="${close}" title="${%Hide details}" style="display:none"><img src="${imagesURL}/16x16/document_delete.png"/></a>
+  <j:set var="open" value="javascript:showFailureSummary('test-${id}','${url}/summary')"/>
+  <j:set var="close" value="javascript:hideFailureSummary('test-${id}')"/>
+  <a id="test-${id}-showlink" href="${open}" title="${%Show details}">
+    <img src="${imagesURL}/16x16/document_add.png"/>
+  </a>
+  <a id="test-${id}-hidelink" href="${close}" title="${%Hide details}" style="display:none">
+    <img src="${imagesURL}/16x16/document_delete.png"/>
+  </a>
   <st:nbsp/>
   <a href="${url}" class="model-link inside"><st:out value="${result.fullDisplayName}"/></a>
   <j:forEach var="badge" items="${result.testActions}">
     <st:include it="${badge}" page="badge.jelly" optional="true"/>
   </j:forEach>
-  <div id="test-${id}" class="hidden" style="display:none">${%Loading...}</div>
+  <div id="test-${id}" class="failure-summary" style="display: none;">
+    ${%Loading...}
+  </div>
 </j:jelly>


### PR DESCRIPTION
[JENKINS-19884](https://issues.jenkins-ci.org/browse/JENKINS-19884): Show more details in the failed test overview.
Before:
![tfs-before](https://f.cloud.github.com/assets/206841/1268859/eae9f43a-2cea-11e3-828d-c3447fd5275c.png)
After:
![tfs-after](https://f.cloud.github.com/assets/206841/1268869/1ecfca86-2ceb-11e3-9b08-8f0206a5de5a.png)
