### PR TITLE
Fix `mvn -Plight-test install` on Ubuntu 13.04 with OpenJDK

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -49,7 +49,6 @@ import hudson.util.FormValidation;
 import hudson.util.IOUtils;
 
 import static hudson.Util.*;
-import static hudson.util.jna.GNUCLibrary.LIBC;
 import static hudson.FilePath.TarCompression.GZIP;
 import hudson.org.apache.tools.tar.TarInputStream;
 import hudson.util.io.Archiver;

--- a/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -57,6 +57,7 @@ import hudson.model.*;
 import hudson.model.Executor;
 import hudson.model.Node.Mode;
 import hudson.model.Queue.Executable;
+import hudson.os.PosixAPI;
 import hudson.remoting.Which;
 import hudson.security.ACL;
 import hudson.security.AbstractPasswordBasedSecurityRealm;
@@ -82,7 +83,6 @@ import hudson.tools.ToolProperty;
 import hudson.util.PersistedList;
 import hudson.util.ReflectionUtils;
 import hudson.util.StreamTaskListener;
-import hudson.util.jna.GNUCLibrary;
 
 import java.beans.PropertyDescriptor;
 import java.io.BufferedReader;
@@ -587,8 +587,9 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         mvn.copyFrom(HudsonTestCase.class.getClassLoader().getResource(mavenVersion + "-bin.zip"));
         mvn.unzip(new FilePath(buildDirectory));
         // TODO: switch to tar that preserves file permissions more easily
-        if(!Functions.isWindows())
-            GNUCLibrary.LIBC.chmod(new File(mvnHome, "bin/mvn").getPath(),0755);
+        if(!Functions.isWindows()) {
+            PosixAPI.jnr().chmod(new File(mvnHome, "bin/mvn").getPath(), 0755);
+        }
 
         MavenInstallation mavenInstallation = new MavenInstallation("default",
                 mvnHome.getAbsolutePath(), NO_PROPERTIES);
@@ -611,8 +612,9 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             File antHome = createTmpDir();
             ant.unzip(new FilePath(antHome));
             // TODO: switch to tar that preserves file permissions more easily
-            if(!Functions.isWindows())
-                GNUCLibrary.LIBC.chmod(new File(antHome,"apache-ant-1.8.1/bin/ant").getPath(),0755);
+            if(!Functions.isWindows()) {
+                PosixAPI.jnr().chmod(new File(antHome,"apache-ant-1.8.1/bin/ant").getPath(),0755);
+            }
 
             antInstallation = new AntInstallation("default", new File(antHome,"apache-ant-1.8.1").getAbsolutePath(),NO_PROPERTIES);
         }
@@ -1976,8 +1978,8 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
         if (!Functions.isWindows()) {
             try {
-                GNUCLibrary.LIBC.unsetenv("MAVEN_OPTS");
-                GNUCLibrary.LIBC.unsetenv("MAVEN_DEBUG_OPTS");
+                PosixAPI.jnr().unsetenv("MAVEN_OPTS");
+                PosixAPI.jnr().unsetenv("MAVEN_DEBUG_OPTS");
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING,"Failed to cancel out MAVEN_OPTS",e);
             }


### PR DESCRIPTION
- FilePathTest#testCopyToWithPermission would fail because it would fall back to using Ant chmod as the `GNUCLibrary.LIBC` could not be linked. Migrating calls form `GNUCLibrary.LIBC` to jnr-posix resolved many of the linking issues.
- FilePathTest#testErrorMessageInRemoteCopyRecursive was exceptionally slow as it would create thousands of files to test an error that could be demonstrated with one.

Potential enhancements:
- Currently there are usages of both `GNUCLibrary.LIBC` and jnr-posix it would be awesome to migrate to just jnr-posix.
- Prior to many of the chmod calls, a check is made to see if the current platform is not windows. We should test to see what jnr-posix does with those calls to see if we can remove all the platform checks.
