### PR TITLE
[FIXED JENKINS-19926] Add only new env. variables

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -1087,9 +1087,10 @@ public abstract class Launcher {
      */
     private static EnvVars inherit(Map<String,String> overrides) {
         EnvVars m = new EnvVars(EnvVars.masterEnvVars);
-        // first add all values and then eventually expand them as values can refer other newly added values (see JENKINS-19488)
-        for (Map.Entry<String,String> o : overrides.entrySet()) 
-            m.override(o.getKey(),o.getValue());
+        // first add all new values and then eventually expand them as values can refer other newly added values (see JENKINS-19488)
+        for (Map.Entry<String,String> o : overrides.entrySet())
+            if(m.get(o.getKey()) == null)
+                m.put(o.getKey(), o.getValue());
         for (Map.Entry<String,String> o : overrides.entrySet()) 
             m.override(o.getKey(),m.expand(o.getValue()));
         return m;


### PR DESCRIPTION
Previous patch (3eea39648943583a530f47f69f93737266537d9d) broke usescases when evn. variable overwrites already existing one like PATH = $PATH:/my/path
