### PR TITLE
Adding ParametersAction#merge(ParametersAction) method with tests.

### DIFF
--- a/core/src/test/java/hudson/model/ParametersActionTest.java
+++ b/core/src/test/java/hudson/model/ParametersActionTest.java
@@ -1,0 +1,79 @@
+package hudson.model;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+public class ParametersActionTest {
+
+    private ParametersAction baseParamsAB;
+    private StringParameterValue baseA;
+
+    @Before
+    public void setUp() {
+        baseA = new StringParameterValue("a", "base-a");
+        StringParameterValue baseB = new StringParameterValue("b", "base-b");
+        baseParamsAB = new ParametersAction(baseA, baseB);
+    }
+
+    @Test
+    public void mergeShouldOverrideParameters() {
+        StringParameterValue overrideB = new StringParameterValue("b", "override-b");
+        ParametersAction extraParams = new ParametersAction(overrideB);
+
+        ParametersAction params = baseParamsAB.merge(extraParams);
+
+        StringParameterValue a = (StringParameterValue) params.getParameter("a");
+        StringParameterValue b = (StringParameterValue) params.getParameter("b");
+        assertEquals(baseA, a);
+        assertEquals(overrideB, b);
+    }
+
+    @Test
+    public void mergeShouldCombineDisparateParameters() {
+        StringParameterValue overrideB = new StringParameterValue("b", "override-b");
+        ParametersAction extraParams = new ParametersAction(overrideB);
+
+        ParametersAction params = baseParamsAB.merge(extraParams);
+
+        StringParameterValue a = (StringParameterValue) params.getParameter("a");
+        StringParameterValue b = (StringParameterValue) params.getParameter("b");
+        assertEquals(baseA, a);
+        assertEquals(overrideB, b);
+    }
+
+    @Test
+    public void mergeShouldHandleEmptyOverrides() {
+        ParametersAction params = baseParamsAB.merge(new ParametersAction());
+
+        StringParameterValue a = (StringParameterValue) params.getParameter("a");
+        assertEquals(baseA, a);
+    }
+
+    @Test
+    public void mergeShouldHandleNullOverrides() {
+        ParametersAction params = baseParamsAB.merge(null);
+
+        StringParameterValue a = (StringParameterValue) params.getParameter("a");
+        assertEquals(baseA, a);
+    }
+
+    @Test
+    public void mergeShouldReturnNewInstanceWithOverride() {
+        StringParameterValue overrideA = new StringParameterValue("a", "override-a");
+        ParametersAction overrideParams = new ParametersAction(overrideA);
+
+        ParametersAction params = baseParamsAB.merge(overrideParams);
+
+        assertNotSame(baseParamsAB, params);
+    }
+
+    @Test
+    public void createUpdatedShouldReturnNewInstanceWithNullOverride() {
+        ParametersAction params = baseParamsAB.createUpdated(null);
+
+        assertNotSame(baseParamsAB, params);
+    }
+}


### PR DESCRIPTION
I propose we build atop the `ParametersAction#createUpdated(Collection<? extends ParameterValue>)` method by creating `ParametersAction#merge(ParametersAction)`.

I'd like to be able to use this functionality in the build-pipeline-plugin, which currently has its own ([tested](https://github.com/jenkinsci/build-pipeline-plugin/blob/62852159b3a8ce8b5a346ed7eaee5ce6897558f3/src/test/java/au/com/centrumsystems/hudson/plugin/util/BuildUtilTest.java#L164-183)) method: [`BuildUtil#mergeParameters(ParametersAction, ParametersAction)`](https://github.com/jenkinsci/build-pipeline-plugin/blob/62852159b3a8ce8b5a346ed7eaee5ce6897558f3/src/main/java/au/com/centrumsystems/hudson/plugin/util/BuildUtil.java#L120-144).

After creating tests that verified:
- overriding parameters replaced original parameters
- a new instance of `ParametersAction` was always returned
- null and empty parameters were handled gracefully

I refactored `ParametersAction#createUpdated(Collection<? extends ParameterValue>)` a bit:
- using a for each loop while iterating both collections
- using `ParametersAction#getName()` instead of `ParametersAction#name`
- initializing the new list of parameters with all overrides, instead of adding them all at the end
