### PR TITLE
Enhance the current user link in the header.

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -173,8 +173,17 @@ ${h.initPageVariables(context)}
                 <st:nbsp/>
                 <j:choose>
                   <j:when test="${!h.isAnonymous()}">
+                    <j:set var="user" value="${app.getUser(app.authentication.name)}"/>
+                    <j:choose>
+                      <j:when test="${user.fullName == null || user.fullName.trim().isEmpty()}">
+                        <j:set var="userName" value="${user.id}"/>
+                      </j:when>
+                      <j:otherwise>
+                        <j:set var="userName" value="${user.fullName}"/>
+                      </j:otherwise>
+                    </j:choose>
                     <span style="white-space:nowrap">
-                      <a href="${rootURL}/user/${app.authentication.name}" class="model-link inside"><b>${app.authentication.name}</b></a>
+                      <a href="${rootURL}/user/${user.id}" class="model-link inside"><b>${userName}</b></a>
                       <j:if test="${app.securityRealm.canLogOut()}">
                         |
                         <a href="${rootURL}/logout"><b>${%logout}</b></a>

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -173,7 +173,7 @@ ${h.initPageVariables(context)}
                 <st:nbsp/>
                 <j:choose>
                   <j:when test="${!h.isAnonymous()}">
-                    <j:set var="user" value="${app.getUser(app.authentication.name)}"/>
+                    <j:invokeStatic var="user" className="hudson.model.User" method="current" />
                     <j:choose>
                       <j:when test="${user.fullName == null || user.fullName.trim().isEmpty()}">
                         <j:set var="userName" value="${user.id}"/>


### PR DESCRIPTION
When configured with SSO (using the [Reverse Proxy Auth Plugin](http://wiki.jenkins-ci.org/display/JENKINS/Reverse+Proxy+Auth+Plugin)) and IIS, Jenkins will create the hyperlink in the top-right corner as `http://example.com/user/DOMAIN/userName` which will give a 404.  The correct hyperlink, in this case, is `http://example.com/user/DOMAIN_userName`.

This pull request fixes the link's target and also will display the user's full name, if it's configured, falling back to the user ID otherwise.
