### PR TITLE
Null check for if build scheduling Refused by extension => not in Queue.

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -89,6 +89,8 @@ public class BuildCommand extends CLICommand {
     @Option(name="-r") @Deprecated
     public int retryCnt = 10;
 
+    protected static final String BUILD_SCHEDULING_REFUSED = "Build scheduling Refused by an extension, hence not in Queue";
+
     protected int run() throws Exception {
         job.checkPermission(Item.BUILD);
 
@@ -142,7 +144,7 @@ public class BuildCommand extends CLICommand {
         
         if (wait || sync || follow) {
             if (f == null) {
-                stderr.println("Build scheduling Refused by an extension, hence not in Queue");
+                stderr.println(BUILD_SCHEDULING_REFUSED);
                 return -1;
             }
             AbstractBuild b = f.waitForStart();    // wait for the start

--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -141,6 +141,10 @@ public class BuildCommand extends CLICommand {
         QueueTaskFuture<? extends AbstractBuild> f = job.scheduleBuild2(0, new CLICause(Jenkins.getAuthentication().getName()), a);
         
         if (wait || sync || follow) {
+            if (f == null) {
+                stderr.println("Build scheduling Refused by an extension, hence not in Queue");
+                return -1;
+            }
             AbstractBuild b = f.waitForStart();    // wait for the start
             stdout.println("Started "+b.getFullDisplayName());
 

--- a/test/src/test/groovy/hudson/cli/BuildCommandTest.groovy
+++ b/test/src/test/groovy/hudson/cli/BuildCommandTest.groovy
@@ -162,7 +162,7 @@ public class BuildCommandTest {
         try {
             def o = new ByteArrayOutputStream()
             cli.execute(["build","-s","-v",p.name],System.in,System.out,new TeeOutputStream(System.err,o))
-            assertTrue(o.toString(), o.toString().contains("Build scheduling Refused by an extension, hence not in Queue"))
+            assertTrue(o.toString(), o.toString().contains(BuildCommand.BUILD_SCHEDULING_REFUSED))
         } finally {
             cli.close()
         }

--- a/test/src/test/groovy/hudson/cli/BuildCommandTest.groovy
+++ b/test/src/test/groovy/hudson/cli/BuildCommandTest.groovy
@@ -23,22 +23,27 @@
  */
 package hudson.cli
 
-import org.jvnet.hudson.test.JenkinsRule
-import org.junit.Rule
-import org.junit.Test
+import org.apache.commons.io.output.TeeOutputStream
 import static org.junit.Assert.*
 import org.junit.Assume
+import org.junit.Rule
+import org.junit.Test
+import org.jvnet.hudson.test.JenkinsRule
+import org.jvnet.hudson.test.TestBuilder
+import org.jvnet.hudson.test.TestExtension
+
+import hudson.Launcher
+import hudson.model.AbstractBuild
+import hudson.model.Action
+import hudson.model.BuildListener
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersAction
+import hudson.model.ParametersDefinitionProperty
+import hudson.model.Queue.QueueDecisionHandler
+import hudson.model.Queue.Task;
+import hudson.model.StringParameterDefinition
 import hudson.tasks.Shell
 import hudson.util.OneShotEvent
-import org.jvnet.hudson.test.TestBuilder
-import hudson.model.AbstractBuild
-import hudson.model.FreeStyleProject;
-import hudson.Launcher
-import hudson.model.BuildListener
-import hudson.model.ParametersDefinitionProperty
-import hudson.model.StringParameterDefinition
-import hudson.model.ParametersAction
-import org.apache.commons.io.output.TeeOutputStream
 
 /**
  * {@link BuildCommand} test.
@@ -72,7 +77,6 @@ public class BuildCommandTest {
         } finally {
             cli.close();
         }
-
     }
 
     /**
@@ -89,7 +93,6 @@ public class BuildCommandTest {
         } finally {
             cli.close();
         }
-
     }
 
     /**
@@ -152,6 +155,26 @@ public class BuildCommandTest {
         }
     }
 
+    @Test void consoleOutputWhenBuildSchedulingRefused() {
+        Assume.assumeFalse("Started test0 #1", "https://jenkins.ci.cloudbees.com/job/core/job/jenkins_main_trunk/".equals(System.getenv("JOB_URL")))
+        def p = j.createFreeStyleProject()
+        def cli = new CLI(j.URL)
+        try {
+            def o = new ByteArrayOutputStream()
+            cli.execute(["build","-s","-v",p.name],System.in,System.out,new TeeOutputStream(System.err,o))
+            assertTrue(o.toString(), o.toString().contains("Build scheduling Refused by an extension, hence not in Queue"))
+        } finally {
+            cli.close()
+        }
+    }
+    // <=>
+    @TestExtension("consoleOutputWhenBuildSchedulingRefused")
+    static class UnschedulingVetoer extends QueueDecisionHandler {
+        public boolean shouldSchedule(Task task, List<Action> actions) {
+            return false;
+        }
+    }
+
     @Test void refuseToBuildDisabledProject() {
 
         def project = j.createFreeStyleProject("the-project");
@@ -180,7 +203,7 @@ public class BuildCommandTest {
 
         def project = j.createFreeStyleProject("the-project");
         project.addProperty(new ParametersDefinitionProperty([
-                new StringParameterDefinition("expr", null)
+            new StringParameterDefinition("expr", null)
         ]));
 
         def invoker = new CLICommandInvoker(j, new BuildCommand());


### PR DESCRIPTION
New test in hudson/cli/BuildCommandTest.groovy, as well as companion
@TestExtension class, thanks to Jesse' suggestion. This is so that we
test this hereby fixed case of a QueueDecisionHandler Refusing a build,
leading to that null value now checked and handled accordingly.

Thx to Scott's preceding pull-req for the initial idea: https://github.com/jenkinsci/jenkins/pull/955
-As agreed with Scott, I did resume the work on it (hereby).

Related issues, which I was unable to reproduce with latest master code:
https://issues.jenkins-ci.org/browse/JENKINS-16692
https://issues.jenkins-ci.org/browse/JENKINS-11347
