### PR TITLE
Fix typo for Czech (cs) L10N.

### DIFF
--- a/core/src/main/resources/hudson/model/View/sidepanel_cs.properties
+++ b/core/src/main/resources/hudson/model/View/sidepanel_cs.properties
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 
 Build\ History=Historie sestaven\u00ED
-Check\ File\ Fingerprint=Ov\u011B\u0159it otsk souboru
+Check\ File\ Fingerprint=Ov\u011B\u0159it otisk souboru
 NewJob=Nov\u00E9
 People=Lid\u00E9
 Project\ Relationship=Vazby mezi projekty


### PR DESCRIPTION
Just small typo fix in Czech (cs) translation. "otsk" is wrong (typo), right is "otisk".
