### PR TITLE
[FIXED JENKINS-19173] API to mark an Action to hide from context menu

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -150,6 +150,8 @@ import org.kohsuke.stapler.jelly.InternationalizedStringExpression.RawHtmlArgume
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import hudson.model.Action.ContextMenuVisibility;
+import java.lang.annotation.Annotation;
 import java.util.concurrent.atomic.AtomicLong;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -1847,5 +1849,21 @@ public class Functions {
             rsp.setIntHeader("X-Jenkins-CLI2-Port", tal.getPort());
             rsp.setHeader("X-Jenkins-CLI-Host", TcpSlaveAgentListener.CLI_HOST_NAME);
         }
+    }
+    
+    /**
+     * Checks if an action should be visible in the context menu. If the class
+     * doesn't have the ContextMenuVisibility annotation, we assume it
+     * should be visible.
+     * @param a - the action to check for visibility
+     * @return true if the action should be visible in the context menu, false
+     * otherwise.
+     */
+    public static boolean isContextMenuVisible(Action a) {
+        ContextMenuVisibility v = a.getClass().getAnnotation(ContextMenuVisibility.class);
+        if(v != null) {
+            return v.visible();
+        }
+        return true;
     }
 }

--- a/core/src/main/java/hudson/model/Action.java
+++ b/core/src/main/java/hudson/model/Action.java
@@ -25,6 +25,10 @@ package hudson.model;
 
 import hudson.Functions;
 import hudson.tasks.test.TestResultProjectAction;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Object that contributes additional information, behaviors, and UIs to {@link ModelObject}
@@ -126,4 +130,10 @@ public interface Action extends ModelObject {
      * @see Functions#getActionUrl(String, Action)
      */
     String getUrlName();
+    
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface ContextMenuVisibility {
+        boolean visible() default true;                
+    } 
 }

--- a/core/src/main/resources/lib/hudson/actions.jelly
+++ b/core/src/main/resources/lib/hudson/actions.jelly
@@ -39,7 +39,8 @@ THE SOFTWARE.
     <st:include page="action.jelly" from="${action}" optional="true">
       <j:if test="${action.iconFileName!=null}">
         <l:task icon="${h.getIconFilePath(action)}" title="${action.displayName}"
-                href="${h.getActionUrl(it.url,action)}" />
+                href="${h.getActionUrl(it.url,action)}" 
+                contextMenu="${h.isContextMenuVisible(action)}" />
       </j:if>
     </st:include>
   </j:forEach>

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -24,10 +24,13 @@
 package hudson;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import hudson.model.Action;
+import hudson.model.Action.ContextMenuVisibility;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
@@ -292,5 +295,53 @@ public class FunctionsTest {
         assertEquals("Hello world!", Functions.breakableString("Hello world!"));
         assertEquals("H<wbr>,e<wbr>.l<wbr>/l<wbr>:o<wbr>-w<wbr>_o<wbr>=+|d", Functions.breakableString("H,e.l/l:o-w_o=+|d"));
         assertEquals("ALongStrin<wbr>gThatCanNo<wbr>tBeBrokenB<wbr>yDefault", Functions.breakableString("ALongStringThatCanNotBeBrokenByDefault"));
+    }
+    
+    @Test
+    public void testContextMenuVisibility() {
+        TestActionContextMenuVisible visible = new TestActionContextMenuVisible();
+        assertTrue(Functions.isContextMenuVisible(visible));
+        
+        TestActionContextMenuInvisible invisible = new TestActionContextMenuInvisible();
+        assertFalse(Functions.isContextMenuVisible(invisible));
+    }
+    
+    class TestActionContextMenuVisible implements Action {
+
+        @Override
+        public String getIconFileName() {
+            return "foo.png";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Test Action Context Menu Visible";
+        }
+
+        @Override
+        public String getUrlName() {
+            return "testaction";
+        }       
+    
+    }
+    
+    @ContextMenuVisibility(visible=false)
+    class TestActionContextMenuInvisible implements Action {
+
+        @Override
+        public String getIconFileName() {
+            return "foo.png";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Test Action Context Menu Invisible";
+        }
+
+        @Override
+        public String getUrlName() {
+            return "invisibletestaction";
+        }
+        
     }
 }


### PR DESCRIPTION
[JENKINS-19173](https://issues.jenkins-ci.org/browse/JENKINS-19173) Added `Action.ContextMenuVisibility` annotation and a method to `Functions` to determine if the annotation is present (if it is not, then the `Action` will be visible) and check if the `Action` is marked as not visible. Updated `actions.jelly` to use this method and set the `contextMenu` attribute. Also, added a test to test the annotation.
