### PR TITLE
[FIXED JENKINS-20227] Avoid submitting polling jobs if all suitable executors are offline

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1526,6 +1526,13 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             WorkspaceOfflineReason workspaceOfflineReason = workspaceOffline( b );
             if ( workspaceOfflineReason != null ) {
                 // workspace offline
+                if (workspaceOfflineReason.equals(WorkspaceOfflineReason.all_suitable_nodes_are_offline)) {
+                    // No suitable executor is online
+                    listener.getLogger().print(Messages.AbstractProject_AbortPollingNoExecutor());
+                    listener.getLogger().println(" (" + workspaceOfflineReason.name() + ")");
+                    return NO_CHANGES;
+                }
+
                 for (WorkspaceBrowser browser : Jenkins.getInstance().getExtensionList(WorkspaceBrowser.class)) {
                     ws = browser.getWorkspace(this);
                     if (ws != null) {
@@ -1596,12 +1603,52 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     enum WorkspaceOfflineReason {
         nonexisting_workspace,
         builton_node_gone,
-        builton_node_no_executors
+        builton_node_no_executors,
+        all_suitable_nodes_are_offline
     }
+
+    /**
+     * Returns true if all suitable nodes for the job are offline.
+     *
+     */
+
+    private boolean isAllSuitableNodesOffline(R build) {
+        Label label = getAssignedLabel();
+        List<Node> allNodes = Jenkins.getInstance().getNodes();
+
+        if (allNodes.isEmpty()) {
+            // no master/slave. pointless to talk about nodes
+            label = null;
+        }
+
+        if (label != null) {
+            // Set<Node> nodes = label.getNodes();
+            if (label.isOffline()) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            if (canRoam) {
+                for (Node n : Jenkins.getInstance().getNodes()) {
+                    Computer c = n.toComputer();
+                    if (c != null && (c.isOnline() || c.isConnecting()) && c.isAcceptingTasks())
+                        // Some executor is ready and this job can run anywhere
+                        return false;
+                }
+            }
+         }
+        return true;
+     }
 
     private WorkspaceOfflineReason workspaceOffline(R build) throws IOException, InterruptedException {
         FilePath ws = build.getWorkspace();
-        if (ws==null || !ws.exists()) {
+
+        if (isAllSuitableNodesOffline(build)) {
+            return WorkspaceOfflineReason.all_suitable_nodes_are_offline;
+        }
+
+        if (ws == null || !ws.exists()) {
             return WorkspaceOfflineReason.nonexisting_workspace;
         }
         

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -43,6 +43,7 @@ AbstractProject.DownstreamBuildInProgress=Downstream project {0} is already buil
 AbstractProject.Disabled=Build disabled
 AbstractProject.ETA=\ (ETA:{0})
 AbstractProject.NoBuilds=No existing build. Scheduling a new one.
+AbstractProject.AbortPollingNoExecutor=Abort polling, workspace required but no executors are online
 AbstractProject.NoSCM=No SCM
 AbstractProject.NoWorkspace=No workspace is available, so can\u2019t check for updates.
 AbstractProject.PollingABorted=SCM polling aborted


### PR DESCRIPTION
Added functionality that checks if any the desired slave(s) by label is online, if not NO_CHANGES  is returned, and we will wait until next polling.
If the project is not restricted in terms of where it can run, any slave (executor) that is online is accepted, and the polling job is submitted
