### PR TITLE
[FIX JENKINS-16255] Handle environment variables case-sensitive.

### DIFF
--- a/core/src/main/java/hudson/EnvVars.java
+++ b/core/src/main/java/hudson/EnvVars.java
@@ -24,7 +24,9 @@
 package hudson;
 
 import hudson.remoting.Callable;
+import hudson.remoting.LocalChannel;
 import hudson.remoting.VirtualChannel;
+import hudson.slaves.SlaveComputer;
 import hudson.util.CaseInsensitiveComparator;
 
 import java.io.File;
@@ -33,6 +35,10 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.Arrays;
 import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 
 /**
  * Environment variables.
@@ -62,6 +68,8 @@ import java.util.UUID;
  * @author Kohsuke Kawaguchi
  */
 public class EnvVars extends TreeMap<String,String> {
+    private static Logger LOGGER = Logger.getLogger(EnvVars.class.getName());
+    public static final String PROP_CASE_INSENSITIVE = "hudson.EnvVars.caseInsensitive";
     /**
      * If this {@link EnvVars} object represents the whole environment variable set,
      * not just a partial list used for overriding later, then we need to know
@@ -73,8 +81,60 @@ public class EnvVars extends TreeMap<String,String> {
      */
     private Platform platform;
 
+    private boolean caseSensitive;
+
+    /**
+     * Returns whether variables are handled case sensitive.
+     * 
+     * @return Whether variables are handled case sensitive
+     */
+    public boolean isCaseSensitive() {
+        return caseSensitive;
+    }
+
+    public EnvVars(boolean caseSensitive) {
+        super(caseSensitive?null:CaseInsensitiveComparator.INSTANCE);
+        this.platform = Platform.current();
+        this.caseSensitive = caseSensitive;
+    }
+
     public EnvVars() {
-        super(CaseInsensitiveComparator.INSTANCE);
+        this(isShouldCaseSensitive());
+    }
+
+    private static Boolean shouldNotCaseSensitive;
+
+    /**
+     * Return whether configured to handle variables case sensitive.
+     * 
+     * For {@link EnvVars#masterEnvVars} are initialized before Jenkins finishes to startup,
+     * there is a case {@link Jenkins#getInstance()} returns null even on the master node.
+     * 
+     * @return whether configured to handle variables case sensitive
+     */
+    private static boolean isShouldCaseSensitive() {
+        if (shouldNotCaseSensitive != null) {
+            return !shouldNotCaseSensitive;
+        }
+        VirtualChannel channelToMaster = SlaveComputer.getChannelToMaster();
+        if(channelToMaster == null || channelToMaster instanceof LocalChannel) {
+            // Running on master.
+            shouldNotCaseSensitive = Boolean.parseBoolean(System.getProperty(PROP_CASE_INSENSITIVE, "false"));
+        } else {
+            // Running on slave.
+            try {
+                shouldNotCaseSensitive = channelToMaster.call(new Callable<Boolean, Exception>(){
+                    private static final long serialVersionUID = -1077487410050526334L;
+                    @Override
+                    public Boolean call() throws Exception {
+                        return Boolean.parseBoolean(System.getProperty(PROP_CASE_INSENSITIVE, "false"));
+                    }
+                });
+            } catch(Exception e) {
+                LOGGER.log(Level.SEVERE, "Failed to get a system property on the master", e);
+            }
+        }
+        return (shouldNotCaseSensitive != null)?!shouldNotCaseSensitive:true;
     }
 
     public EnvVars(Map<String,String> m) {
@@ -120,7 +180,18 @@ public class EnvVars extends TreeMap<String,String> {
         int idx = key.indexOf('+');
         if(idx>0) {
             String realKey = key.substring(0,idx);
-            String v = get(realKey);
+            String v = null;
+            if (!platform.envCaseSensitive && isCaseSensitive()) {
+                EnvVars incase = new EnvVars(false);
+                incase.putAll(this);
+                if (incase.containsKey(realKey)) {
+                    Map.Entry<String, String> entry = incase.ceilingEntry(realKey);
+                    realKey = entry.getKey();
+                    v = entry.getValue();
+                }
+            } else {
+                v = get(realKey);
+            }
             if(v==null) v=value;
             else {
                 // we might be handling environment variables for a slave that can have different path separator
@@ -242,5 +313,34 @@ public class EnvVars extends TreeMap<String,String> {
             // they'll hang
             vars.remove("MAVEN_OPTS");
         return vars;
+    }
+
+    /**
+     * Return environment variables for launching a native process.
+     * 
+     * In Unix, does nothing.
+     * 
+     * In Windows, removes environment variables with case-different names
+     * except only one value.
+     * It is implementation-dependent which value is used.
+     * 
+     * @return environment variables adjusted for a native process.
+     */
+    public EnvVars forNativeProcess() {
+        if (platform.envCaseSensitive || !isCaseSensitive()) {
+            return this;
+        }
+        EnvVars incase = new EnvVars(false);
+        incase.putAll(this);
+        return incase;
+    }
+
+    /**
+     * @return
+     * @see java.util.AbstractMap#toString()
+     */
+    @Override
+    public String toString() {
+        return isCaseSensitive()?super.toString():String.format("[Case insensitive]%s", super.toString());
     }
 }

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -737,7 +737,7 @@ public abstract class Launcher {
             public Channel launchChannel(String[] cmd, OutputStream out, FilePath workDir, Map<String, String> envVars) throws IOException, InterruptedException {
                 EnvVars e = new EnvVars(env);
                 e.putAll(envVars);
-                return outer.launchChannel(cmd,out,workDir,e);
+                return outer.launchChannel(cmd,out,workDir,e.forNativeProcess());
             }
 
             @Override
@@ -770,7 +770,7 @@ public abstract class Launcher {
             for ( int idx = 0 ; idx < jobCmd.length; idx++ )
             	jobCmd[idx] = jobEnv.expand(ps.commands.get(idx));
 
-            return new LocalProc(jobCmd, Util.mapToEnv(jobEnv),
+            return new LocalProc(jobCmd, Util.mapToEnv(jobEnv.forNativeProcess()),
                     ps.reverseStdin ?LocalProc.SELFPUMP_INPUT:ps.stdin,
                     ps.reverseStdout?LocalProc.SELFPUMP_OUTPUT:ps.stdout,
                     ps.reverseStderr?LocalProc.SELFPUMP_OUTPUT:ps.stderr,

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -1088,10 +1088,8 @@ public abstract class Launcher {
     private static EnvVars inherit(Map<String,String> overrides) {
         EnvVars m = new EnvVars(EnvVars.masterEnvVars);
         // first add all values and then eventually expand them as values can refer other newly added values (see JENKINS-19488)
-        for (Map.Entry<String,String> o : overrides.entrySet()) 
-            m.override(o.getKey(),o.getValue());
-        for (Map.Entry<String,String> o : overrides.entrySet()) 
-            m.override(o.getKey(),m.expand(o.getValue()));
+        m.overrideAll(overrides);
+        m.overrideAll(overrides, m);
         return m;
     }
     

--- a/core/src/main/java/hudson/Platform.java
+++ b/core/src/main/java/hudson/Platform.java
@@ -37,7 +37,7 @@ import java.util.Locale;
  * @author Kohsuke Kawaguchi
  */
 public enum Platform {
-    WINDOWS(';'),UNIX(':');
+    WINDOWS(';', false),UNIX(':', true);
 
     /**
      * The character that separates paths in environment variables like PATH and CLASSPATH. 
@@ -46,9 +46,15 @@ public enum Platform {
      * @see File#pathSeparator
      */
     public final char pathSeparator;
+    /**
+     * Whether names of environment variables are case sensitive on this platform.
+     * On Windows false, and on Unix true.
+     */
+    public final boolean envCaseSensitive;
 
-    private Platform(char pathSeparator) {
+    private Platform(char pathSeparator, boolean envCaseSensitive) {
         this.pathSeparator = pathSeparator;
+        this.envCaseSensitive = envCaseSensitive;
     }
 
     public static Platform current() {

--- a/core/src/main/java/hudson/model/BooleanParameterValue.java
+++ b/core/src/main/java/hudson/model/BooleanParameterValue.java
@@ -29,6 +29,8 @@ import org.kohsuke.stapler.export.Exported;
 
 import java.util.Locale;
 
+import jenkins.model.Jenkins;
+
 import hudson.util.VariableResolver;
 
 /**
@@ -54,7 +56,9 @@ public class BooleanParameterValue extends ParameterValue {
     @Override
     public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
         env.put(name,Boolean.toString(value));
-        env.put(name.toUpperCase(Locale.ENGLISH),Boolean.toString(value)); // backward compatibility pre 1.345
+        if (!env.isCaseSensitive()) {
+            env.put(name.toUpperCase(Locale.ENGLISH),Boolean.toString(value)); // backward compatibility pre 1.345
+        }
     }
 
     @Override

--- a/core/src/main/java/hudson/model/JobParameterValue.java
+++ b/core/src/main/java/hudson/model/JobParameterValue.java
@@ -28,6 +28,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Locale;
 
+import jenkins.model.Jenkins;
+
 public class JobParameterValue extends ParameterValue {
     public final Job job;
 
@@ -44,7 +46,9 @@ public class JobParameterValue extends ParameterValue {
     public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
         // TODO: check with Tom if this is really what he had in mind
         env.put(name,job.toString());
-        env.put(name.toUpperCase(Locale.ENGLISH),job.toString()); // backward compatibility pre 1.345
+        if (!env.isCaseSensitive()) {
+            env.put(name.toUpperCase(Locale.ENGLISH),job.toString()); // backward compatibility pre 1.345
+        }
     }
 
     @Override public String getShortDescription() {

--- a/core/src/main/java/hudson/model/PasswordParameterValue.java
+++ b/core/src/main/java/hudson/model/PasswordParameterValue.java
@@ -30,6 +30,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Locale;
 
+import jenkins.model.Jenkins;
+
 /**
  * @author Kohsuke Kawaguchi
  */
@@ -52,7 +54,9 @@ public class PasswordParameterValue extends ParameterValue {
     public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
         String v = Secret.toString(value);
         env.put(name, v);
-        env.put(name.toUpperCase(Locale.ENGLISH),v); // backward compatibility pre 1.345
+        if (!env.isCaseSensitive()) {
+            env.put(name.toUpperCase(Locale.ENGLISH),v); // backward compatibility pre 1.345
+        }
     }
 
     @Override

--- a/core/src/main/java/hudson/model/RunParameterValue.java
+++ b/core/src/main/java/hudson/model/RunParameterValue.java
@@ -85,7 +85,9 @@ public class RunParameterValue extends ParameterValue {
         String buildResult = (null == run.getResult()) ? "UNKNOWN" : run.getResult().toString();
         env.put(name + "_RESULT",  buildResult);  // since 1.517
 
-        env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
+        if (!env.isCaseSensitive()) {
+            env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
+        }
 
     }
     

--- a/core/src/main/java/hudson/model/StringParameterValue.java
+++ b/core/src/main/java/hudson/model/StringParameterValue.java
@@ -29,6 +29,8 @@ import org.kohsuke.stapler.export.Exported;
 
 import java.util.Locale;
 
+import jenkins.model.Jenkins;
+
 import hudson.util.VariableResolver;
 
 /**
@@ -54,7 +56,9 @@ public class StringParameterValue extends ParameterValue {
     @Override
     public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
         env.put(name,value);
-        env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
+        if (!env.isCaseSensitive()) {
+            env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
+        }
     }
 
     @Override

--- a/core/src/main/java/hudson/slaves/CommandLauncher.java
+++ b/core/src/main/java/hudson/slaves/CommandLauncher.java
@@ -109,7 +109,7 @@ public class CommandLauncher extends ComputerLauncher {
             }
 
             if (env != null) {
-            	pb.environment().putAll(env);
+            	pb.environment().putAll(env.forNativeProcess());
             }
             
             final Process proc = _proc = pb.start();

--- a/core/src/test/java/hudson/EnvVarsTest.java
+++ b/core/src/test/java/hudson/EnvVarsTest.java
@@ -25,18 +25,68 @@ package hudson;
 
 import junit.framework.TestCase;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 public class EnvVarsTest extends TestCase {
+    private void resetEnvVarsCache() throws Exception {
+        Field f = EnvVars.class.getDeclaredField("shouldNotCaseSensitive");
+        f.setAccessible(true);
+        f.set(null, null);
+        f.setAccessible(false);
+    }
+    
+    /**
+     * Makes sure that {@link EnvVars} behave in case-sensitive way.
+     */
+    public void testCaseSensitive() throws Exception {
+        assertNull(System.getProperty(EnvVars.PROP_CASE_INSENSITIVE));
+        resetEnvVarsCache();
+        
+        EnvVars ev = new EnvVars(Collections.singletonMap("Path","A:B:C"));
+        assertFalse(ev.containsKey("PATH"));
+        assertTrue(ev.containsKey("Path"));
+        assertEquals("A:B:C",ev.get("Path"));
+        
+        ev.override("PATH+Test", "D");
+        if (Functions.isWindows()) {
+            // override always acts case-insensitive on Windows.
+            assertFalse(ev.containsKey("PATH"));
+            assertTrue(ev.containsKey("Path"));
+            assertEquals("D;A:B:C", ev.get("Path"));
+        } else {
+            assertTrue(ev.containsKey("PATH"));
+            assertEquals("D", ev.get("PATH"));
+            assertEquals("A:B:C",ev.get("Path"));
+        }
+    }
+    
     /**
      * Makes sure that {@link EnvVars} behave in case-insensitive way.
      */
-    public void test1() {
-        EnvVars ev = new EnvVars(Collections.singletonMap("Path","A:B:C"));
-        assertTrue(ev.containsKey("PATH"));
-        assertEquals("A:B:C",ev.get("PATH"));
-    }
+    public void testCaseInsensitive() throws Exception {
+        assertNull(System.getProperty(EnvVars.PROP_CASE_INSENSITIVE));
+        try {
+            System.setProperty(EnvVars.PROP_CASE_INSENSITIVE, "true");
+            resetEnvVarsCache();
+            
+            EnvVars ev = new EnvVars(Collections.singletonMap("Path","A:B:C"));
+            assertTrue(ev.containsKey("PATH"));
+            assertEquals("A:B:C",ev.get("PATH"));
+            
+            ev.override("PATH+Test", "D");
+            if (Functions.isWindows()) {
+                assertEquals("D;A:B:C", ev.get("Path"));
+                assertEquals("D;A:B:C", ev.get("PATH"));
+            } else {
+                assertEquals("D:A:B:C", ev.get("Path"));
+                assertEquals("D:A:B:C", ev.get("PATH"));
+            }
+        } finally {
+            System.getProperties().remove(EnvVars.PROP_CASE_INSENSITIVE);
+        }
+   }
 }

--- a/test/src/test/java/hudson/EnvVarsTest.java
+++ b/test/src/test/java/hudson/EnvVarsTest.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2013 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson;
+
+import hudson.model.Cause;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersAction;
+import hudson.model.StringParameterValue;
+import hudson.slaves.DumbSlave;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+public class EnvVarsTest extends HudsonTestCase {
+    private void resetEnvVarsCache() throws Exception {
+        Field f = EnvVars.class.getDeclaredField("shouldNotCaseSensitive");
+        f.setAccessible(true);
+        f.set(null, null);
+        f.setAccessible(false);
+    }
+    
+    public void testCaseSensitiveOnMaster() throws Exception {
+        assertNull(System.getProperty(EnvVars.PROP_CASE_INSENSITIVE));
+        resetEnvVarsCache();
+        
+        FreeStyleProject p = createFreeStyleProject();
+        CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
+        p.getBuildersList().add(ceb);
+        assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserCause(), Arrays.asList(
+                new ParametersAction(
+                        new StringParameterValue("var1", "value1"),
+                        new StringParameterValue("Var1", "value2")
+                )
+        )));
+        assertEquals("value1", ceb.getEnvVars().get("var1"));
+        assertEquals("value2", ceb.getEnvVars().get("Var1"));
+        assertNull(ceb.getEnvVars().get("VAR1"));
+    }
+    
+    public void testCaseSensitiveOnSlave() throws Exception {
+        assertNull(System.getProperty(EnvVars.PROP_CASE_INSENSITIVE));
+        resetEnvVarsCache();
+        
+        DumbSlave slave = createOnlineSlave();
+        FreeStyleProject p = createFreeStyleProject();
+        p.setAssignedNode(slave);
+        CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
+        p.getBuildersList().add(ceb);
+        assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserCause(), Arrays.asList(
+                new ParametersAction(
+                        new StringParameterValue("var1", "value1"),
+                        new StringParameterValue("Var1", "value2")
+                )
+        )));
+        assertEquals("value1", ceb.getEnvVars().get("var1"));
+        assertEquals("value2", ceb.getEnvVars().get("Var1"));
+        assertNull(ceb.getEnvVars().get("VAR1"));
+    }
+    
+    public void testCaseInsensitiveOnMaster() throws Exception {
+        assertNull(System.getProperty(EnvVars.PROP_CASE_INSENSITIVE));
+        try {
+            System.setProperty(EnvVars.PROP_CASE_INSENSITIVE, "true");
+            resetEnvVarsCache();
+            
+            FreeStyleProject p = createFreeStyleProject();
+            CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
+            p.getBuildersList().add(ceb);
+            assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserCause(), Arrays.asList(
+                    new ParametersAction(
+                            new StringParameterValue("var1", "value1"),
+                            new StringParameterValue("Var1", "value2")
+                    )
+            )));
+            String expected = ceb.getEnvVars().get("var1");
+            assertEquals(expected, ceb.getEnvVars().get("Var1"));
+            assertEquals(expected, ceb.getEnvVars().get("VAR1"));
+        } finally {
+            System.getProperties().remove(EnvVars.PROP_CASE_INSENSITIVE);
+        }
+    }
+    
+    public void testCaseInsensitiveOnSlave() throws Exception {
+        assertNull(System.getProperty(EnvVars.PROP_CASE_INSENSITIVE));
+        try {
+            System.setProperty(EnvVars.PROP_CASE_INSENSITIVE, "true");
+            resetEnvVarsCache();
+            
+            DumbSlave slave = createOnlineSlave();
+            FreeStyleProject p = createFreeStyleProject();
+            p.setAssignedNode(slave);
+            CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
+            p.getBuildersList().add(ceb);
+            assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserCause(), Arrays.asList(
+                    new ParametersAction(
+                            new StringParameterValue("var1", "value1"),
+                            new StringParameterValue("Var1", "value2")
+                    )
+            )));
+            String expected = ceb.getEnvVars().get("var1");
+            assertEquals(expected, ceb.getEnvVars().get("Var1"));
+            assertEquals(expected, ceb.getEnvVars().get("VAR1"));
+        } finally {
+            System.getProperties().remove(EnvVars.PROP_CASE_INSENSITIVE);
+        }
+    }
+    
+}

--- a/test/src/test/java/hudson/model/ParametersTest.java
+++ b/test/src/test/java/hudson/model/ParametersTest.java
@@ -68,10 +68,10 @@ public class ParametersTest extends HudsonTestCase {
         if (q != null) q.getFuture().get();
         else Thread.sleep(1000);
 
-        assertEquals("newValue", builder.getEnvVars().get("STRING"));
-        assertEquals("true", builder.getEnvVars().get("BOOLEAN"));
-        assertEquals("Choice 1", builder.getEnvVars().get("CHOICE"));
-        assertEquals(jenkins.getRootUrl() + otherProject.getLastBuild().getUrl(), builder.getEnvVars().get("RUN"));
+        assertEquals("newValue", builder.getEnvVars().get("string"));
+        assertEquals("true", builder.getEnvVars().get("boolean"));
+        assertEquals("Choice 1", builder.getEnvVars().get("choice"));
+        assertEquals(jenkins.getRootUrl() + otherProject.getLastBuild().getUrl(), builder.getEnvVars().get("run"));
     }
 
     public void testChoiceWithLTGT() throws Exception {
@@ -102,7 +102,7 @@ public class ParametersTest extends HudsonTestCase {
         else Thread.sleep(1000);
 
         assertNotNull(builder.getEnvVars());
-        assertEquals("Choice <2>", builder.getEnvVars().get("CHOICE"));
+        assertEquals("Choice <2>", builder.getEnvVars().get("choice"));
     }
 
     public void testSensitiveParameters() throws Exception {


### PR DESCRIPTION
This is a fix for [JENKINS-16255](https://issues.jenkins-ci.org/browse/JENKINS-16255).
Jenkins handles names of environment variables in case-insensitive way, and that often causes problems on unix.

Jenkins have handled variables case-insensitively for Windows ([JENKINS-968](https://issues.jenkins-ci.org/browse/JENKINS-968)):
- An exception occurs when launching dot-net programs on windows.
  - I'm not sure how to reproduce this.
- PATH environment variables are split and does not work. 

I resolved these problems in following ways:
- When launching a native process, convert `EnvVars` into case-insensitive on Windows (`EnvVars#forNativeProcess`).
- Handles XYZ+ABC environment variables case-insensitively if that `EnvVars` will be used for Windows.
  - XYZ+ABC is used for adding a new path to the PATH variable. For example, when you use a maven builder, a path to maven binary is added to PATH. 
  - `EnvVars` that is overridden with XYZ+ABC is always instantiated on the node where a process is launched (which is done in `LocalLauncher`).

Users can have Jenkins works as before by launching with -Dhudson.EnvVars.caseInsensitive=true.
Configuring in the system configuration page would be most convenient, but it is not possible for `EnvVars` are used in a very early stage of launching, and the system configuration is not yet loaded.
