### PR TITLE
DO NOT MERGE - FOR DISCUSSION: [FIXES JENKINS-19622] Introduce jenkins.timer.Timer extension point

### DIFF
--- a/core/src/main/groovy/hudson/util/LoadMonitor.groovy
+++ b/core/src/main/groovy/hudson/util/LoadMonitor.groovy
@@ -24,6 +24,7 @@
 package hudson.util
 
 import hudson.model.Computer
+import jenkins.timer.TimerConfiguration
 import jenkins.model.Jenkins
 import hudson.model.Label
 import hudson.model.Queue.BlockedItem
@@ -31,7 +32,6 @@ import hudson.model.Queue.BuildableItem
 import hudson.model.Queue.WaitingItem
 import hudson.triggers.SafeTimerTask
 import java.text.DateFormat
-import hudson.triggers.Trigger;
 
 /**
  * Spits out the load information.
@@ -51,7 +51,7 @@ public class LoadMonitorImpl extends SafeTimerTask {
         this.dataFile = dataFile;
         labels = Jenkins.getInstance().labels*.name;
         printHeaders();
-        Trigger.timer.scheduleAtFixedRate(this,0,10*1000);
+        TimerConfiguration.getTimer().scheduleAtFixedRate(this,0,10*1000);
     }
 
     private String quote(Object s) { "\"${s}\""; }

--- a/core/src/main/java/hudson/model/AperiodicWork.java
+++ b/core/src/main/java/hudson/model/AperiodicWork.java
@@ -25,12 +25,11 @@ package hudson.model;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import jenkins.timer.TimerConfiguration;
 import hudson.triggers.SafeTimerTask;
-import hudson.triggers.Trigger;
 import jenkins.model.Jenkins;
 
 import java.util.Random;
-import java.util.Timer;
 import java.util.logging.Logger;
 
 
@@ -85,10 +84,7 @@ public abstract class AperiodicWork extends SafeTimerTask implements ExtensionPo
     @Override
     public final void doRun() throws Exception{
     	doAperiodicRun();
-        Timer timer = Trigger.timer;
-        if (timer != null) {
-            timer.schedule(getNewInstance(), getRecurrencePeriod());
-        }
+        TimerConfiguration.getTimer().schedule(getNewInstance(), getRecurrencePeriod());
     }
     
     protected abstract void doAperiodicRun();

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -65,8 +65,8 @@ import hudson.model.queue.CauseOfBlockage.BecauseLabelIsOffline;
 import hudson.model.queue.CauseOfBlockage.BecauseNodeIsBusy;
 import hudson.model.queue.WorkUnitContext;
 import hudson.security.ACL;
+import jenkins.timer.TimerConfiguration;
 import hudson.triggers.SafeTimerTask;
-import hudson.triggers.Trigger;
 import hudson.util.TimeUnit2;
 import hudson.util.XStream2;
 import hudson.util.ConsistentHash;
@@ -91,7 +91,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.Timer;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -1986,10 +1985,7 @@ public class Queue extends ResourceController implements Saveable {
 
         private void periodic() {
             long interval = 5000;
-            Timer timer = Trigger.timer;
-            if (timer != null) {
-                timer.schedule(this, interval, interval);
-            }
+            TimerConfiguration.getTimer().scheduleWithFixedDelay(this, interval, interval);
         }
 
         protected void doRun() {

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -26,10 +26,10 @@ package hudson.node_monitors;
 import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
+import jenkins.timer.TimerConfiguration;
 import jenkins.model.Jenkins;
 import hudson.model.ComputerSet;
 import hudson.model.AdministrativeMonitor;
-import hudson.triggers.Trigger;
 import hudson.triggers.SafeTimerTask;
 import hudson.slaves.OfflineCause;
 
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Timer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -87,14 +86,12 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
     }
 
     private void schedule(long interval) {
-        Timer timer = Trigger.timer;
-        if (timer != null) {
-            timer.scheduleAtFixedRate(new SafeTimerTask() {
+        TimerConfiguration.getTimer()
+            .scheduleAtFixedRate(new SafeTimerTask() {
                 public void doRun() {
                     triggerUpdate();
                 }
             }, interval, interval);
-        }
     }
 
     /**

--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -23,18 +23,14 @@
  */
 package hudson.triggers;
 
-import static hudson.init.InitMilestone.JOB_LOADED;
 import hudson.DependencyRunner;
 import hudson.DependencyRunner.ProjectRunnable;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.ExtensionPoint;
-import hudson.init.Initializer;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
-import hudson.model.AperiodicWork;
 import hudson.model.Build;
-import hudson.model.ComputerSet;
 import hudson.model.Describable;
 import hudson.scheduler.Hash;
 import jenkins.model.Jenkins;
@@ -45,7 +41,6 @@ import hudson.model.TopLevelItem;
 import hudson.model.TopLevelItemDescriptor;
 import hudson.scheduler.CronTab;
 import hudson.scheduler.CronTabList;
-import hudson.util.DoubleLaunchChecker;
 
 import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
@@ -56,7 +51,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.Timer;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -279,34 +273,12 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
      * Initialized and cleaned up by {@link jenkins.model.Jenkins}, but value kept here for compatibility.
      *
      * If plugins want to run periodic jobs, they should implement {@link PeriodicWork}.
+     *
+     * @deprecated Use {@link jenkins.timer.TimerConfiguration#getTimer()} instead.
      */
     @SuppressWarnings("MS_SHOULD_BE_FINAL")
-    public static @CheckForNull Timer timer;
-
-    @Initializer(after=JOB_LOADED)
-    public static void init() {
-        new DoubleLaunchChecker().schedule();
-
-        Timer _timer = timer;
-        if (_timer != null) {
-            // start all PeridocWorks
-            for(PeriodicWork p : PeriodicWork.all()) {
-                _timer.scheduleAtFixedRate(p,p.getInitialDelay(),p.getRecurrencePeriod());
-            }
-
-            // start all AperidocWorks
-            for(AperiodicWork p : AperiodicWork.all()) {
-                _timer.schedule(p,p.getInitialDelay());
-            }
-
-            // start monitoring nodes, although there's no hurry.
-            _timer.schedule(new SafeTimerTask() {
-                public void doRun() {
-                    ComputerSet.initialize();
-                }
-            }, 1000*10);
-        }
-    }
+    @Deprecated
+    public static @CheckForNull java.util.Timer timer;
 
     /**
      * Returns all the registered {@link Trigger} descriptors.

--- a/core/src/main/java/hudson/util/DoubleLaunchChecker.java
+++ b/core/src/main/java/hudson/util/DoubleLaunchChecker.java
@@ -23,9 +23,9 @@
  */
 package hudson.util;
 
+import jenkins.timer.TimerConfiguration;
 import jenkins.model.Jenkins;
 import hudson.triggers.SafeTimerTask;
-import hudson.triggers.Trigger;
 import org.apache.commons.io.FileUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -40,7 +40,6 @@ import java.util.logging.Logger;
 import java.util.logging.Level;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
-import java.util.Timer;
 
 /**
  * Makes sure that no other Hudson uses our <tt>JENKINS_HOME</tt> directory,
@@ -146,14 +145,13 @@ public class DoubleLaunchChecker {
     public void schedule() {
         // randomize the scheduling so that multiple Hudson instances will write at the file at different time
         long MINUTE = 1000*60;
-        Timer timer = Trigger.timer;
-        if (timer != null) {
-            timer.schedule(new SafeTimerTask() {
+
+        TimerConfiguration.getTimer()
+            .schedule(new SafeTimerTask() {
                 protected void doRun() {
                     execute();
                 }
-            },(random.nextInt(30)+60)*MINUTE);
-        }
+            }, (random.nextInt(30) + 60) * MINUTE);
     }
 
     /**

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -161,6 +161,7 @@ import hudson.slaves.RetentionStrategy;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
+import jenkins.timer.TimerConfiguration;
 import hudson.triggers.SafeTimerTask;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
@@ -838,15 +839,12 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
             }
             dnsMultiCast = new DNSMultiCast(this);
 
-            Timer timer = Trigger.timer;
-            if (timer != null) {
-                timer.scheduleAtFixedRate(new SafeTimerTask() {
-                    @Override
-                    protected void doRun() throws Exception {
-                        trimLabels();
-                    }
-                }, TimeUnit2.MINUTES.toMillis(5), TimeUnit2.MINUTES.toMillis(5));
-            }
+            TimerConfiguration.getTimer().scheduleAtFixedRate(new SafeTimerTask() {
+                @Override
+                protected void doRun() throws Exception {
+                    trimLabels();
+                }
+            }, TimeUnit2.MINUTES.toMillis(5), TimeUnit2.MINUTES.toMillis(5));
 
             updateComputerList();
 
@@ -2700,12 +2698,8 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
         if(dnsMultiCast!=null)
             dnsMultiCast.close();
         interruptReloadThread();
-        Timer timer = Trigger.timer;
-        if (timer != null) {
-            timer.cancel();
-        }
-        // TODO: how to wait for the completion of the last job?
-        Trigger.timer = null;
+        TimerConfiguration.getTimer().shutdown();
+
         if(tcpSlaveAgentListener!=null)
             tcpSlaveAgentListener.shutdown();
 

--- a/core/src/main/java/jenkins/timer/LegacyTimer.java
+++ b/core/src/main/java/jenkins/timer/LegacyTimer.java
@@ -1,0 +1,51 @@
+package jenkins.timer;
+
+import hudson.Extension;
+import hudson.triggers.Trigger;
+
+import java.util.TimerTask;
+
+/**
+ * A timer which uses the legacy {@link java.util.Timer} {@link Trigger#timer}.
+ *
+ * This implementation suffers from <a href="https://issues.jenkins-ci.org/browse/JENKINS-19622">
+ *     JENKINS-19622</a>. IE, it can be blocked by poorly written plugins.
+ *
+ *  @deprecated Use {@link ScheduledExecutorTimer} instead.
+ */
+@Extension
+@Deprecated
+public class LegacyTimer extends Timer {
+    @Override
+    public void scheduleWithFixedDelay(TimerTask task, long delay, long period) {
+        java.util.Timer timer = Trigger.timer;
+        if (timer != null) {
+            timer.schedule(task, delay, period);
+        }
+    }
+
+    @Override
+    public void schedule(TimerTask task, long delay) {
+        java.util.Timer timer = Trigger.timer;
+        if (timer != null) {
+            timer.schedule(task, delay);
+        }
+    }
+
+    @Override
+    public void scheduleAtFixedRate(TimerTask task, long firstTime, long period) {
+        java.util.Timer timer = Trigger.timer;
+        if (timer != null) {
+            timer.scheduleAtFixedRate(task, firstTime, period);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        java.util.Timer timer = Trigger.timer;
+        if (timer != null) {
+            timer.cancel();
+        }
+        Trigger.timer = null;
+    }
+}

--- a/core/src/main/java/jenkins/timer/ScheduledExecutorTimer.java
+++ b/core/src/main/java/jenkins/timer/ScheduledExecutorTimer.java
@@ -1,0 +1,39 @@
+package jenkins.timer;
+
+import hudson.Extension;
+
+import java.util.TimerTask;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A timer which uses a {@link ScheduledExecutorService} to schedule tasks.
+ *
+ * Additional threads will be created to schedule tasks as they become due.
+ */
+@Extension
+public class ScheduledExecutorTimer extends Timer {
+
+    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+
+    @Override
+    public void scheduleWithFixedDelay(TimerTask task, long delay, long period) {
+        executorService.scheduleWithFixedDelay(task, delay, period, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void schedule(TimerTask task, long delay) {
+        executorService.schedule(task,delay, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void scheduleAtFixedRate(TimerTask task, long delay, long period) {
+        executorService.scheduleAtFixedRate(task, delay, period, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void shutdown() {
+        executorService.shutdownNow();
+    }
+}

--- a/core/src/main/java/jenkins/timer/Timer.java
+++ b/core/src/main/java/jenkins/timer/Timer.java
@@ -1,0 +1,64 @@
+package jenkins.timer;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.init.Initializer;
+import hudson.model.AperiodicWork;
+import hudson.model.ComputerSet;
+import hudson.model.PeriodicWork;
+import hudson.triggers.SafeTimerTask;
+import hudson.util.DoubleLaunchChecker;
+import jenkins.model.Jenkins;
+
+import java.util.TimerTask;
+
+import static hudson.init.InitMilestone.JOB_LOADED;
+
+/**
+ * An abstraction of the low-level Timer service in Jenkins.
+ *
+ * NOTE: Plugins should prefer using {@link PeriodicWork},
+ * {@link AperiodicWork}, {@link hudson.model.AsyncPeriodicWork}
+ * or {@link hudson.model.AsyncAperiodicWork} as they provide higher level
+ * abstractions.
+ */
+public abstract class Timer implements ExtensionPoint {
+
+    public abstract void scheduleWithFixedDelay(TimerTask task, long delay, long period);
+
+    public abstract void schedule(TimerTask task, long delay);
+
+    public abstract void scheduleAtFixedRate(TimerTask task, long delay, long period);
+
+    public abstract void shutdown();
+
+    public static ExtensionList<Timer> all() {
+        return Jenkins.getInstance().getExtensionList(Timer.class);
+    }
+
+    @Initializer(after=JOB_LOADED)
+    public static void init() {
+        new DoubleLaunchChecker().schedule();
+
+        Timer _timer = TimerConfiguration.getTimer();
+        // start all PeridocWorks
+        for(PeriodicWork p : PeriodicWork.all()) {
+            _timer.scheduleAtFixedRate(p,p.getInitialDelay(),p.getRecurrencePeriod());
+        }
+
+        // start all AperidocWorks
+        for(AperiodicWork p : AperiodicWork.all()) {
+            _timer.schedule(p,p.getInitialDelay());
+        }
+
+        // start monitoring nodes, although there's no hurry.
+        _timer.schedule(new SafeTimerTask() {
+            public void doRun() {
+                ComputerSet.initialize();
+            }
+        }, 1000*10);
+
+    }
+
+
+}

--- a/core/src/main/java/jenkins/timer/TimerConfiguration.java
+++ b/core/src/main/java/jenkins/timer/TimerConfiguration.java
@@ -1,0 +1,34 @@
+package jenkins.timer;
+
+import hudson.Extension;
+import hudson.util.VersionNumber;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
+
+/**
+ * Allow users to configure their Timer.
+ */
+@Extension
+public class TimerConfiguration extends GlobalConfiguration {
+
+    private Timer timer = null;
+
+    public TimerConfiguration() {
+        load();
+        if (timer == null) {
+            if (Jenkins.getInstance().isUpgradedFromBefore(new VersionNumber("1.537"))) {
+                timer = Timer.all().get(LegacyTimer.class);
+            } else {
+                timer = Timer.all().get(ScheduledExecutorTimer.class);
+            }
+        }
+    }
+    public static Timer getTimer() {
+        return get().timer;
+    }
+
+    public static TimerConfiguration get() {
+        return Jenkins.getInstance().getInjector().getInstance(TimerConfiguration.class);
+    }
+
+}


### PR DESCRIPTION
 [FIXES JENKINS-19622] Introduce jenkins.timer.Timer extension point to provide plugability of the timer in Jenkins.

This provides a way for users to control migration from the old
java.util.Timer to the new ScheduledExecutorService in order to fix JENKINS-19622.
