### PR TITLE
[FIX JENKINS-16255] Handle environment variables case-sensitive.

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -737,7 +737,7 @@ public abstract class Launcher {
             public Channel launchChannel(String[] cmd, OutputStream out, FilePath workDir, Map<String, String> envVars) throws IOException, InterruptedException {
                 EnvVars e = new EnvVars(env);
                 e.putAll(envVars);
-                return outer.launchChannel(cmd,out,workDir,e);
+                return outer.launchChannel(cmd,out,workDir,e.forNativeProcess());
             }
 
             @Override
@@ -770,7 +770,7 @@ public abstract class Launcher {
             for ( int idx = 0 ; idx < jobCmd.length; idx++ )
             	jobCmd[idx] = jobEnv.expand(ps.commands.get(idx));
 
-            return new LocalProc(jobCmd, Util.mapToEnv(jobEnv),
+            return new LocalProc(jobCmd, Util.mapToEnv(jobEnv.forNativeProcess()),
                     ps.reverseStdin ?LocalProc.SELFPUMP_INPUT:ps.stdin,
                     ps.reverseStdout?LocalProc.SELFPUMP_OUTPUT:ps.stdout,
                     ps.reverseStderr?LocalProc.SELFPUMP_OUTPUT:ps.stderr,

--- a/core/src/main/java/hudson/Platform.java
+++ b/core/src/main/java/hudson/Platform.java
@@ -37,7 +37,7 @@ import java.util.Locale;
  * @author Kohsuke Kawaguchi
  */
 public enum Platform {
-    WINDOWS(';'),UNIX(':');
+    WINDOWS(';', false),UNIX(':', true);
 
     /**
      * The character that separates paths in environment variables like PATH and CLASSPATH. 
@@ -46,9 +46,15 @@ public enum Platform {
      * @see File#pathSeparator
      */
     public final char pathSeparator;
+    /**
+     * Whether names of environment variables are case sensitive on this platform.
+     * On Windows false, and on Unix true.
+     */
+    public final boolean envCaseSensitive;
 
-    private Platform(char pathSeparator) {
+    private Platform(char pathSeparator, boolean envCaseSensitive) {
         this.pathSeparator = pathSeparator;
+        this.envCaseSensitive = envCaseSensitive;
     }
 
     public static Platform current() {

--- a/core/src/main/java/hudson/model/BooleanParameterValue.java
+++ b/core/src/main/java/hudson/model/BooleanParameterValue.java
@@ -54,7 +54,9 @@ public class BooleanParameterValue extends ParameterValue {
     @Override
     public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
         env.put(name,Boolean.toString(value));
-        env.put(name.toUpperCase(Locale.ENGLISH),Boolean.toString(value)); // backward compatibility pre 1.345
+        if (!env.isCaseSensitive()) {
+            env.put(name.toUpperCase(Locale.ENGLISH),Boolean.toString(value)); // backward compatibility pre 1.345
+        }
     }
 
     @Override

--- a/core/src/main/java/hudson/model/JobParameterValue.java
+++ b/core/src/main/java/hudson/model/JobParameterValue.java
@@ -44,7 +44,9 @@ public class JobParameterValue extends ParameterValue {
     public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
         // TODO: check with Tom if this is really what he had in mind
         env.put(name,job.toString());
-        env.put(name.toUpperCase(Locale.ENGLISH),job.toString()); // backward compatibility pre 1.345
+        if (!env.isCaseSensitive()) {
+            env.put(name.toUpperCase(Locale.ENGLISH),job.toString()); // backward compatibility pre 1.345
+        }
     }
 
     @Override public String getShortDescription() {

--- a/core/src/main/java/hudson/model/PasswordParameterValue.java
+++ b/core/src/main/java/hudson/model/PasswordParameterValue.java
@@ -52,7 +52,9 @@ public class PasswordParameterValue extends ParameterValue {
     public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
         String v = Secret.toString(value);
         env.put(name, v);
-        env.put(name.toUpperCase(Locale.ENGLISH),v); // backward compatibility pre 1.345
+        if (!env.isCaseSensitive()) {
+            env.put(name.toUpperCase(Locale.ENGLISH),v); // backward compatibility pre 1.345
+        }
     }
 
     @Override

--- a/core/src/main/java/hudson/model/RunParameterValue.java
+++ b/core/src/main/java/hudson/model/RunParameterValue.java
@@ -85,7 +85,9 @@ public class RunParameterValue extends ParameterValue {
         String buildResult = (null == run.getResult()) ? "UNKNOWN" : run.getResult().toString();
         env.put(name + "_RESULT",  buildResult);  // since 1.517
 
-        env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
+        if (!env.isCaseSensitive()) {
+            env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
+        }
 
     }
     

--- a/core/src/main/java/hudson/model/StringParameterValue.java
+++ b/core/src/main/java/hudson/model/StringParameterValue.java
@@ -54,7 +54,9 @@ public class StringParameterValue extends ParameterValue {
     @Override
     public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
         env.put(name,value);
-        env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
+        if (!env.isCaseSensitive()) {
+            env.put(name.toUpperCase(Locale.ENGLISH),value); // backward compatibility pre 1.345
+        }
     }
 
     @Override

--- a/core/src/main/java/hudson/slaves/CommandLauncher.java
+++ b/core/src/main/java/hudson/slaves/CommandLauncher.java
@@ -109,7 +109,7 @@ public class CommandLauncher extends ComputerLauncher {
             }
 
             if (env != null) {
-            	pb.environment().putAll(env);
+            	pb.environment().putAll(env.forNativeProcess());
             }
             
             final Process proc = _proc = pb.start();

--- a/test/src/test/java/hudson/EnvVarsTest.java
+++ b/test/src/test/java/hudson/EnvVarsTest.java
@@ -1,0 +1,143 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2013 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson;
+
+import static org.junit.Assert.*;
+import hudson.model.Cause;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersAction;
+import hudson.model.StringParameterValue;
+import hudson.slaves.DumbSlave;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+
+public class EnvVarsTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    private void resetEnvVarsCache() throws Exception {
+        Field f = EnvVars.class.getDeclaredField("shouldNotCaseSensitive");
+        f.setAccessible(true);
+        f.set(null, null);
+        f.setAccessible(false);
+    }
+    
+    @Test
+    public void testCaseSensitiveOnMaster() throws Exception {
+        assertNull(System.getProperty(EnvVars.PROP_CASE_INSENSITIVE));
+        resetEnvVarsCache();
+        
+        FreeStyleProject p = j.createFreeStyleProject();
+        CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
+        p.getBuildersList().add(ceb);
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserCause(), Arrays.asList(
+                new ParametersAction(
+                        new StringParameterValue("var1", "value1"),
+                        new StringParameterValue("Var1", "value2")
+                )
+        )));
+        assertEquals("value1", ceb.getEnvVars().get("var1"));
+        assertEquals("value2", ceb.getEnvVars().get("Var1"));
+        assertNull(ceb.getEnvVars().get("VAR1"));
+    }
+    
+    @Test
+    public void testCaseSensitiveOnSlave() throws Exception {
+        assertNull(System.getProperty(EnvVars.PROP_CASE_INSENSITIVE));
+        resetEnvVarsCache();
+        
+        DumbSlave slave = j.createOnlineSlave();
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.setAssignedNode(slave);
+        CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
+        p.getBuildersList().add(ceb);
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserCause(), Arrays.asList(
+                new ParametersAction(
+                        new StringParameterValue("var1", "value1"),
+                        new StringParameterValue("Var1", "value2")
+                )
+        )));
+        assertEquals("value1", ceb.getEnvVars().get("var1"));
+        assertEquals("value2", ceb.getEnvVars().get("Var1"));
+        assertNull(ceb.getEnvVars().get("VAR1"));
+    }
+    
+    @Test
+    public void testCaseInsensitiveOnMaster() throws Exception {
+        assertNull(System.getProperty(EnvVars.PROP_CASE_INSENSITIVE));
+        try {
+            System.setProperty(EnvVars.PROP_CASE_INSENSITIVE, "true");
+            resetEnvVarsCache();
+            
+            FreeStyleProject p = j.createFreeStyleProject();
+            CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
+            p.getBuildersList().add(ceb);
+            j.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserCause(), Arrays.asList(
+                    new ParametersAction(
+                            new StringParameterValue("var1", "value1"),
+                            new StringParameterValue("Var1", "value2")
+                    )
+            )));
+            String expected = ceb.getEnvVars().get("var1");
+            assertEquals(expected, ceb.getEnvVars().get("Var1"));
+            assertEquals(expected, ceb.getEnvVars().get("VAR1"));
+        } finally {
+            System.getProperties().remove(EnvVars.PROP_CASE_INSENSITIVE);
+        }
+    }
+    
+    @Test
+    public void testCaseInsensitiveOnSlave() throws Exception {
+        assertNull(System.getProperty(EnvVars.PROP_CASE_INSENSITIVE));
+        try {
+            System.setProperty(EnvVars.PROP_CASE_INSENSITIVE, "true");
+            resetEnvVarsCache();
+            
+            DumbSlave slave = j.createOnlineSlave();
+            FreeStyleProject p = j.createFreeStyleProject();
+            p.setAssignedNode(slave);
+            CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
+            p.getBuildersList().add(ceb);
+            j.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserCause(), Arrays.asList(
+                    new ParametersAction(
+                            new StringParameterValue("var1", "value1"),
+                            new StringParameterValue("Var1", "value2")
+                    )
+            )));
+            String expected = ceb.getEnvVars().get("var1");
+            assertEquals(expected, ceb.getEnvVars().get("Var1"));
+            assertEquals(expected, ceb.getEnvVars().get("VAR1"));
+        } finally {
+            System.getProperties().remove(EnvVars.PROP_CASE_INSENSITIVE);
+        }
+    }
+    
+}

--- a/test/src/test/java/hudson/model/ParametersTest.java
+++ b/test/src/test/java/hudson/model/ParametersTest.java
@@ -68,10 +68,10 @@ public class ParametersTest extends HudsonTestCase {
         if (q != null) q.getFuture().get();
         else Thread.sleep(1000);
 
-        assertEquals("newValue", builder.getEnvVars().get("STRING"));
-        assertEquals("true", builder.getEnvVars().get("BOOLEAN"));
-        assertEquals("Choice 1", builder.getEnvVars().get("CHOICE"));
-        assertEquals(jenkins.getRootUrl() + otherProject.getLastBuild().getUrl(), builder.getEnvVars().get("RUN"));
+        assertEquals("newValue", builder.getEnvVars().get("string"));
+        assertEquals("true", builder.getEnvVars().get("boolean"));
+        assertEquals("Choice 1", builder.getEnvVars().get("choice"));
+        assertEquals(jenkins.getRootUrl() + otherProject.getLastBuild().getUrl(), builder.getEnvVars().get("run"));
     }
 
     public void testChoiceWithLTGT() throws Exception {
@@ -102,7 +102,7 @@ public class ParametersTest extends HudsonTestCase {
         else Thread.sleep(1000);
 
         assertNotNull(builder.getEnvVars());
-        assertEquals("Choice <2>", builder.getEnvVars().get("CHOICE"));
+        assertEquals("Choice <2>", builder.getEnvVars().get("choice"));
     }
 
     public void testSensitiveParameters() throws Exception {


### PR DESCRIPTION
This is a fix for [JENKINS-16255](https://issues.jenkins-ci.org/browse/JENKINS-16255).
Jenkins handles names of environment variables in case-insensitive way, and that often causes problems on UNIX platforms.

Jenkins have handled variables case-insensitively for Windows platforms ([JENKINS-968](https://issues.jenkins-ci.org/browse/JENKINS-968)):
- An exception occurs when launching dot-net programs on Windows.
  - I'm not sure how to reproduce this.
- PATH environment variables are split (PATH and Path) and does not work. 

I resolved these problems in following ways:
- When launching a native process, convert `EnvVars` into case-insensitive on Windows (`EnvVars#forNativeProcess`).
- Handles XYZ+ABC environment variables case-insensitively if that `EnvVars` will be used for Windows.
  - XYZ+ABC is used for adding a new path to the PATH variable. For example, when you use a maven builder, a path to maven binary is added to PATH. 
  - `EnvVars` that is overridden with XYZ+ABC is always instantiated on the node where a process is launched (which is done in `LocalLauncher`).

Users can have Jenkins works as before by launching with -Dhudson.EnvVars.caseInsensitive=true.
Configuring in the system configuration page would be most convenient, but it is not possible for `EnvVars` are used in a very early stage of launching, and the system configuration is not yet loaded.
