### PR TITLE
[FIXES JENKINS-19622] Allow background tasks to run simultaneously, preventing task blockage

### DIFF
--- a/core/src/main/groovy/hudson/util/LoadMonitor.groovy
+++ b/core/src/main/groovy/hudson/util/LoadMonitor.groovy
@@ -24,6 +24,7 @@
 package hudson.util
 
 import hudson.model.Computer
+import jenkins.util.Timer
 import jenkins.model.Jenkins
 import hudson.model.Label
 import hudson.model.Queue.BlockedItem
@@ -31,7 +32,7 @@ import hudson.model.Queue.BuildableItem
 import hudson.model.Queue.WaitingItem
 import hudson.triggers.SafeTimerTask
 import java.text.DateFormat
-import hudson.triggers.Trigger;
+import java.util.concurrent.TimeUnit
 
 /**
  * Spits out the load information.
@@ -51,7 +52,7 @@ public class LoadMonitorImpl extends SafeTimerTask {
         this.dataFile = dataFile;
         labels = Jenkins.getInstance().labels*.name;
         printHeaders();
-        Trigger.timer.scheduleAtFixedRate(this,0,10*1000);
+        Timer.get().scheduleAtFixedRate(this,0,10*1000, TimeUnit.MILLISECONDS);
     }
 
     private String quote(Object s) { "\"${s}\""; }

--- a/core/src/main/java/hudson/model/AperiodicWork.java
+++ b/core/src/main/java/hudson/model/AperiodicWork.java
@@ -25,14 +25,17 @@ package hudson.model;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.init.Initializer;
 import hudson.triggers.SafeTimerTask;
-import hudson.triggers.Trigger;
 import jenkins.model.Jenkins;
+import jenkins.util.Timer;
 
 import java.util.Random;
-import java.util.Timer;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import static hudson.init.InitMilestone.JOB_LOADED;
 
 
 /**
@@ -85,12 +88,17 @@ public abstract class AperiodicWork extends SafeTimerTask implements ExtensionPo
     @Override
     public final void doRun() throws Exception{
     	doAperiodicRun();
-        Timer timer = Trigger.timer;
-        if (timer != null) {
-            timer.schedule(getNewInstance(), getRecurrencePeriod());
+        Timer.get().schedule(getNewInstance(), getRecurrencePeriod(), TimeUnit.MILLISECONDS);
+    }
+
+    @Initializer(after= JOB_LOADED)
+    public static void init() {
+        // start all AperidocWorks
+        for (AperiodicWork p : AperiodicWork.all()) {
+            Timer.get().schedule(p, p.getInitialDelay(), TimeUnit.MILLISECONDS);
         }
     }
-    
+
     protected abstract void doAperiodicRun();
     
     /**

--- a/core/src/main/java/hudson/model/PeriodicWork.java
+++ b/core/src/main/java/hudson/model/PeriodicWork.java
@@ -23,16 +23,20 @@
  */
 package hudson.model;
 
+import hudson.init.Initializer;
 import hudson.triggers.SafeTimerTask;
 import hudson.triggers.Trigger;
 import hudson.ExtensionPoint;
 import hudson.Extension;
 import hudson.ExtensionList;
 import jenkins.model.Jenkins;
+import jenkins.util.Timer;
 
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.Random;
-import java.util.Timer;
+
+import static hudson.init.InitMilestone.JOB_LOADED;
 
 /**
  * Extension point to perform a periodic task in Hudson (through {@link Timer}.)
@@ -87,6 +91,14 @@ public abstract class PeriodicWork extends SafeTimerTask implements ExtensionPoi
      */
     public static ExtensionList<PeriodicWork> all() {
         return Jenkins.getInstance().getExtensionList(PeriodicWork.class);
+    }
+
+    @Initializer(after= JOB_LOADED)
+    public static void init() {
+        // start all PeriodicWorks
+        for (PeriodicWork p : PeriodicWork.all()) {
+            Timer.get().scheduleAtFixedRate(p, p.getInitialDelay(), p.getRecurrencePeriod(), TimeUnit.MILLISECONDS);
+        }
     }
 
     // time constants

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -65,8 +65,8 @@ import hudson.model.queue.CauseOfBlockage.BecauseLabelIsOffline;
 import hudson.model.queue.CauseOfBlockage.BecauseNodeIsBusy;
 import hudson.model.queue.WorkUnitContext;
 import hudson.security.ACL;
+import jenkins.util.Timer;
 import hudson.triggers.SafeTimerTask;
-import hudson.triggers.Trigger;
 import hudson.util.TimeUnit2;
 import hudson.util.XStream2;
 import hudson.util.ConsistentHash;
@@ -91,7 +91,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.Timer;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -1986,10 +1985,7 @@ public class Queue extends ResourceController implements Saveable {
 
         private void periodic() {
             long interval = 5000;
-            Timer timer = Trigger.timer;
-            if (timer != null) {
-                timer.schedule(this, interval, interval);
-            }
+            Timer.get().scheduleWithFixedDelay(this, interval, interval, TimeUnit.MILLISECONDS);
         }
 
         protected void doRun() {

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -29,16 +29,16 @@ import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 import hudson.model.ComputerSet;
 import hudson.model.AdministrativeMonitor;
-import hudson.triggers.Trigger;
 import hudson.triggers.SafeTimerTask;
 import hudson.slaves.OfflineCause;
+import jenkins.util.Timer;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Timer;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -87,14 +87,12 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
     }
 
     private void schedule(long interval) {
-        Timer timer = Trigger.timer;
-        if (timer != null) {
-            timer.scheduleAtFixedRate(new SafeTimerTask() {
+        Timer.get()
+            .scheduleAtFixedRate(new SafeTimerTask() {
                 public void doRun() {
                     triggerUpdate();
                 }
-            }, interval, interval);
-        }
+            }, interval, interval, TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -23,18 +23,14 @@
  */
 package hudson.triggers;
 
-import static hudson.init.InitMilestone.JOB_LOADED;
 import hudson.DependencyRunner;
 import hudson.DependencyRunner.ProjectRunnable;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.ExtensionPoint;
-import hudson.init.Initializer;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
-import hudson.model.AperiodicWork;
 import hudson.model.Build;
-import hudson.model.ComputerSet;
 import hudson.model.Describable;
 import hudson.scheduler.Hash;
 import jenkins.model.Jenkins;
@@ -45,7 +41,6 @@ import hudson.model.TopLevelItem;
 import hudson.model.TopLevelItemDescriptor;
 import hudson.scheduler.CronTab;
 import hudson.scheduler.CronTabList;
-import hudson.util.DoubleLaunchChecker;
 
 import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
@@ -56,7 +51,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.Timer;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -279,34 +273,12 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
      * Initialized and cleaned up by {@link jenkins.model.Jenkins}, but value kept here for compatibility.
      *
      * If plugins want to run periodic jobs, they should implement {@link PeriodicWork}.
+     *
+     * @deprecated Use {@link jenkins.util.Timer#get()} instead.
      */
     @SuppressWarnings("MS_SHOULD_BE_FINAL")
-    public static @CheckForNull Timer timer;
-
-    @Initializer(after=JOB_LOADED)
-    public static void init() {
-        new DoubleLaunchChecker().schedule();
-
-        Timer _timer = timer;
-        if (_timer != null) {
-            // start all PeridocWorks
-            for(PeriodicWork p : PeriodicWork.all()) {
-                _timer.scheduleAtFixedRate(p,p.getInitialDelay(),p.getRecurrencePeriod());
-            }
-
-            // start all AperidocWorks
-            for(AperiodicWork p : AperiodicWork.all()) {
-                _timer.schedule(p,p.getInitialDelay());
-            }
-
-            // start monitoring nodes, although there's no hurry.
-            _timer.schedule(new SafeTimerTask() {
-                public void doRun() {
-                    ComputerSet.initialize();
-                }
-            }, 1000*10);
-        }
-    }
+    @Deprecated
+    public static @CheckForNull java.util.Timer timer;
 
     /**
      * Returns all the registered {@link Trigger} descriptors.

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -765,7 +765,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
             // doing this early allows InitStrategy to set environment upfront
             final InitStrategy is = InitStrategy.get(Thread.currentThread().getContextClassLoader());
 
-            Timer.initialize();
+            Trigger.timer = new java.util.Timer("Jenkins cron thread");
             queue = new Queue(LoadBalancer.CONSISTENT_HASH);
 
             try {
@@ -2697,6 +2697,14 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
         if(dnsMultiCast!=null)
             dnsMultiCast.close();
         interruptReloadThread();
+
+        java.util.Timer timer = Trigger.timer;
+        if (timer != null) {
+            timer.cancel();
+        }
+        // TODO: how to wait for the completion of the last job?
+        Trigger.timer = null;
+
         Timer.shutdown();
 
         if(tcpSlaveAgentListener!=null)

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -199,6 +199,7 @@ import jenkins.model.ProjectNamingStrategy.DefaultProjectNamingStrategy;
 import jenkins.security.ConfidentialKey;
 import jenkins.security.ConfidentialStore;
 import jenkins.slaves.WorkspaceLocator;
+import jenkins.util.Timer;
 import jenkins.util.io.FileBoolean;
 import net.sf.json.JSONObject;
 import org.acegisecurity.AccessDeniedException;
@@ -280,7 +281,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
-import java.util.Timer;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -765,7 +765,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
             // doing this early allows InitStrategy to set environment upfront
             final InitStrategy is = InitStrategy.get(Thread.currentThread().getContextClassLoader());
 
-            Trigger.timer = new Timer("Jenkins cron thread");
+            Timer.initialize();
             queue = new Queue(LoadBalancer.CONSISTENT_HASH);
 
             try {
@@ -838,15 +838,12 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
             }
             dnsMultiCast = new DNSMultiCast(this);
 
-            Timer timer = Trigger.timer;
-            if (timer != null) {
-                timer.scheduleAtFixedRate(new SafeTimerTask() {
-                    @Override
-                    protected void doRun() throws Exception {
-                        trimLabels();
-                    }
-                }, TimeUnit2.MINUTES.toMillis(5), TimeUnit2.MINUTES.toMillis(5));
-            }
+            Timer.get().scheduleAtFixedRate(new SafeTimerTask() {
+                @Override
+                protected void doRun() throws Exception {
+                    trimLabels();
+                }
+            }, TimeUnit2.MINUTES.toMillis(5), TimeUnit2.MINUTES.toMillis(5), TimeUnit.MILLISECONDS);
 
             updateComputerList();
 
@@ -2700,12 +2697,8 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
         if(dnsMultiCast!=null)
             dnsMultiCast.close();
         interruptReloadThread();
-        Timer timer = Trigger.timer;
-        if (timer != null) {
-            timer.cancel();
-        }
-        // TODO: how to wait for the completion of the last job?
-        Trigger.timer = null;
+        Timer.shutdown();
+
         if(tcpSlaveAgentListener!=null)
             tcpSlaveAgentListener.shutdown();
 

--- a/core/src/main/java/jenkins/util/Timer.java
+++ b/core/src/main/java/jenkins/util/Timer.java
@@ -62,8 +62,10 @@ public class Timer {
      * Shutdown the timer and throw it away.
      */
     public static synchronized void shutdown() {
-        executorService.shutdownNow();
-        executorService = null;
+        if (executorService != null) {
+            executorService.shutdownNow();
+            executorService = null;
+        }
     }
 
     /**

--- a/core/src/main/java/jenkins/util/Timer.java
+++ b/core/src/main/java/jenkins/util/Timer.java
@@ -1,0 +1,79 @@
+package jenkins.util;
+
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+/**
+ * Holds the {@link ScheduledExecutorService} for running all background tasks in Jenkins.
+ * This ExecutorService will create additional threads to execute due (enabled) tasks.
+ *
+ * Provides a minimal abstraction for locating the ScheduledExecutorService so that we
+ * can modify it's behavior going forward. For instance, to add managability/monitoring.
+ *
+ * This is not an @Extension because it must be available before any extensions are loaded.
+ *
+ * Plugins should probably use one of the following as they provide higher level abstractions:
+ *   {@link hudson.model.AperiodicWork}, {@link hudson.model.PeriodicWork},
+ *   {@link hudson.model.AsyncAperiodicWork}, {@link hudson.model.AsyncPeriodicWork}.
+ *
+ * @author Ryan Campbell
+ * @since 1.538
+ */
+public class Timer {
+
+    /**
+     * The scheduled executor thread pool. This is initialized lazily since it may be created/shutdown many times
+     * when running the test suite.
+     */
+    private static ScheduledExecutorService executorService = null;
+
+    /**
+     * Returns the scheduled executor service used by all timed tasks in Jenkins.
+     *
+     * @return the single {@link ScheduledExecutorService}.
+     */
+    public static ScheduledExecutorService get() {
+        return executorService;
+    }
+
+    /**
+     * Explicitly initialize the Timer.
+     *
+     * We don't initialize lazily because it's not required and
+     * it's simpler than using the requisite DCL/volatile pattern.
+     */
+    public static void initialize() {
+        // corePoolSize is set to 10, but will only be created if needed.
+        // ScheduledThreadPoolExecutor "acts as a fixed-sized pool using corePoolSize threads"
+        executorService = Executors.newScheduledThreadPool(10, new ThreadFactory() {
+
+            private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r);
+                t.setName("Jenkins-cron-thread-" + threadNumber.getAndIncrement());
+                t.setDaemon(true);
+                return t;
+            }
+        });
+    }
+
+    /**
+     * Shutdown the timer and throw it away.
+     */
+    public static void shutdown() {
+        executorService.shutdownNow();
+        executorService = null;
+    }
+
+    /**
+     * Do not create this.
+     */
+    private Timer() {};
+
+}

--- a/core/src/main/java/jenkins/util/Timer.java
+++ b/core/src/main/java/jenkins/util/Timer.java
@@ -30,7 +30,7 @@ public class Timer {
      * The scheduled executor thread pool. This is initialized lazily since it may be created/shutdown many times
      * when running the test suite.
      */
-    private static ScheduledExecutorService executorService = null;
+    private static ScheduledExecutorService executorService;
 
     /**
      * Returns the scheduled executor service used by all timed tasks in Jenkins.

--- a/core/src/test/java/jenkins/util/TimerTest.java
+++ b/core/src/test/java/jenkins/util/TimerTest.java
@@ -16,7 +16,7 @@ public class TimerTest {
      */
     @Test
     @Bug(19622)
-    public void testThatTimersArentBlocked() throws InterruptedException {
+    public void timersArentBlocked() throws InterruptedException {
         final CountDownLatch startLatch = new CountDownLatch(1);
         final CountDownLatch stopLatch = new CountDownLatch(1);
 
@@ -35,7 +35,6 @@ public class TimerTest {
             }
         };
 
-        Timer.initialize();
         Timer.get().schedule(task1, 1, TimeUnit.MILLISECONDS);
         startLatch.await();
         Timer.get().schedule(task2, 2, TimeUnit.MILLISECONDS);

--- a/core/src/test/java/jenkins/util/TimerTest.java
+++ b/core/src/test/java/jenkins/util/TimerTest.java
@@ -1,0 +1,47 @@
+package jenkins.util;
+
+import hudson.triggers.SafeTimerTask;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hudson.test.Bug;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class TimerTest {
+
+    /**
+     * Launch two tasks which can only complete
+     * by running doRun() concurrently.
+     */
+    @Test
+    @Bug(19622)
+    public void testThatTimersArentBlocked() throws InterruptedException {
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch stopLatch = new CountDownLatch(1);
+
+        SafeTimerTask task1 = new SafeTimerTask() {
+            @Override
+            protected void doRun() throws Exception {
+                startLatch.countDown();
+                stopLatch.await();
+            }
+        };
+
+        SafeTimerTask task2 = new SafeTimerTask() {
+            @Override
+            protected void doRun() throws Exception {
+                stopLatch.countDown();
+            }
+        };
+
+        Timer.initialize();
+        Timer.get().schedule(task1, 1, TimeUnit.MILLISECONDS);
+        startLatch.await();
+        Timer.get().schedule(task2, 2, TimeUnit.MILLISECONDS);
+        if (! stopLatch.await(10000, TimeUnit.MILLISECONDS)) {
+            Assert.fail("Failed to run the two tasks simultaneously");
+        }
+
+    }
+}


### PR DESCRIPTION
Deprecate hudson.model.Trigger#timer in favor of jenkins.util.Timer which exposes a ScheduledExecutorService. Up to 10 additional threads will be created to run pending tasks even if running tasks are blocked.

Also, move static initialization of timers to those components which require them.
