### PR TITLE
[JENKINS-15757] Ignore 'remember me' if disabled in configuration

### DIFF
--- a/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
+++ b/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import jenkins.model.Jenkins;
 import jenkins.security.HMACConfidentialKey;
 import org.acegisecurity.ui.rememberme.TokenBasedRememberMeServices;
 import org.acegisecurity.userdetails.UserDetails;
@@ -68,6 +69,16 @@ public class TokenBasedRememberMeServices2 extends TokenBasedRememberMeServices 
 						getParameter() + "')");
 			}
 
+			return;
+		}
+
+		Jenkins j = Jenkins.getInstance();
+		if (j != null && j.isDisableRememberMe()) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Did not send remember-me cookie because 'Remember Me' is disabled in " +
+						"security configuration (principal did set parameter '" + getParameter() + "')");
+			}
+			// XXX log warning when receiving remember-me request despite the feature being disabled?
 			return;
 		}
 

--- a/test/src/main/java/org/jvnet/hudson/test/recipes/PresetData.java
+++ b/test/src/main/java/org/jvnet/hudson/test/recipes/PresetData.java
@@ -62,6 +62,8 @@ public @interface PresetData {
          * and any logged in user has a full access.
          */
         ANONYMOUS_READONLY,
+
+        SECURED_ACEGI,
     }
 
     class RunnerImpl extends Recipe.Runner<PresetData> {

--- a/test/src/main/preset-data/secured-acegi/config.xml
+++ b/test/src/main/preset-data/secured-acegi/config.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.FullControlOnceLoggedInAuthorizationStrategy"/>
+  <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+    <disableSignup>true</disableSignup>
+    <enableCaptcha>false</enableCaptcha>
+  </securityRealm>
+  <jdks/>
+  <slaves/>
+  <quietPeriod>5</quietPeriod>
+  <slaveAgentPort>0</slaveAgentPort>
+  <secretKey>ed2e66995bec739c0ec71c260bd75be6918ff28b0f1b33d67e205297629a6264</secretKey>
+</hudson>

--- a/test/src/main/preset-data/secured-acegi/readme.txt
+++ b/test/src/main/preset-data/secured-acegi/readme.txt
@@ -1,0 +1,3 @@
+Anonymous users have no permissions, logged in users can do anything.
+
+Uses Jenkins user database, because 'Remember me' functionality requires non-legacy security realm to be enabled.

--- a/test/src/main/preset-data/secured-acegi/users/alice/config.xml
+++ b/test/src/main/preset-data/secured-acegi/users/alice/config.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<user>
+  <fullName>Alice</fullName>
+  <properties>
+    <jenkins.security.ApiTokenProperty>
+      <apiToken>0K7w+E0Bi/rJt1lombWFDYtw0/KLFHwBjJqN8tUd2QO4tzVXKCPuIq2uWlTUdeBd</apiToken>
+    </jenkins.security.ApiTokenProperty>
+    <hudson.model.MyViewsProperty>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson.model.MyViewsProperty" reference="../../.."/>
+          <name>All</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+          <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+      </views>
+    </hudson.model.MyViewsProperty>
+    <hudson.search.UserSearchProperty>
+      <insensitiveSearch>false</insensitiveSearch>
+    </hudson.search.UserSearchProperty>
+    <hudson.security.HudsonPrivateSecurityRealm_-Details>
+      <passwordHash>#jbcrypt:$2a$10$9m4niaJ3tOglIM22Yd.LdOwuU9RcD9FpuXlqlJhQHKt5Qx2mh.2/i</passwordHash>
+    </hudson.security.HudsonPrivateSecurityRealm_-Details>
+    <hudson.tasks.Mailer_-UserProperty plugin="mailer@1.5">
+      <emailAddress>alice@example.org</emailAddress>
+    </hudson.tasks.Mailer_-UserProperty>
+  </properties>
+</user>

--- a/test/src/test/java/hudson/security/LoginTest.java
+++ b/test/src/test/java/hudson/security/LoginTest.java
@@ -1,10 +1,15 @@
 package hudson.security;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlCheckBoxInput;
+
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.recipes.PresetData;
 import org.jvnet.hudson.test.recipes.PresetData.DataSet;
 import org.xml.sax.SAXException;
+
+import static org.acegisecurity.ui.rememberme.TokenBasedRememberMeServices.ACEGI_SECURITY_HASHED_REMEMBER_ME_COOKIE_KEY;
 
 import java.io.IOException;
 import java.net.URL;
@@ -40,5 +45,51 @@ public class LoginTest extends HudsonTestCase {
         wc.assertFails("loginError", SC_UNAUTHORIZED);
         // but not once the user logs in.
         verifyNotError(wc.login("alice"));
+    }
+
+    private HtmlForm prepareLoginFormWithRememberMeChecked(WebClient wc) throws IOException, org.xml.sax.SAXException {
+        wc.getCookieManager().setCookiesEnabled(true);
+        HtmlPage page = wc.goTo("login");
+
+        HtmlForm form = page.getFormByName("login");
+        form.getInputByName("j_username").setValueAttribute("alice");
+        form.getInputByName("j_password").setValueAttribute("alice");
+        ((HtmlCheckBoxInput)form.getInputByName("remember_me")).setChecked(true);
+        return form;
+    }
+
+    /**
+     * Returns the 'remember me' cookie if set, otherwise return null. We don't care about the type, only whether it's null
+     */
+    private Object getRememberMeCookie(WebClient wc) {
+        return wc.getCookieManager().getCookie(ACEGI_SECURITY_HASHED_REMEMBER_ME_COOKIE_KEY);
+    }
+
+    /**
+     * Test 'remember me' cookie
+     */
+    @PresetData(DataSet.SECURED_ACEGI)
+    public void testLoginRememberMe() throws Exception {
+        WebClient wc = createWebClient();
+
+        prepareLoginFormWithRememberMeChecked(wc).submit(null);
+
+        assertNotNull(getRememberMeCookie(wc));
+    }
+
+
+    /**
+     * Test that 'remember me' cookie will not be set if disabled even if requested by user.
+     * This models the case when the feature is disabled between another user loading and submitting the login page.
+     */
+    @PresetData(DataSet.SECURED_ACEGI)
+    public void testLoginDisabledRememberMe() throws Exception {
+        WebClient wc = createWebClient();
+
+        HtmlForm form = prepareLoginFormWithRememberMeChecked(wc);
+        jenkins.setDisableRememberMe(true);
+        form.submit(null);
+
+        assertNull(getRememberMeCookie(wc));
     }
 }


### PR DESCRIPTION
The previous implementation of 'disable remember me' just removes the
checkbox from the UI. Users still can set the parameter using a web
browser extension, or patch the login page using a Greasemonkey script
and keep using the feature. And just after the feature is enabled, users
still might be able to use it if they loaded the login page early.

This change prevents that by checking the current configuration and, if
'remember me' is disabled, ignoring any headers set.
