### PR TITLE
Fixed text alignment about icons on legend page

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/legend.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/legend.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <l:layout>
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <table cellpadding="5">
+      <table cellpadding="5" id="legend-table">
         <tr><td>
           <img src="images/48x48/grey.png" alt="" height="48" width="48"/>
           ${%grey}

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1123,3 +1123,8 @@ td.matrix-cell {
 	border: 1px #BBBBBB solid;
 	text-align: center;
 }
+
+/* ========================= legend.jelly ================== */
+table#legend-table td {
+	vertical-align: middle;
+}


### PR DESCRIPTION
Before:
![2013-11-04 01 37 35](https://f.cloud.github.com/assets/683358/1461131/2a4cab46-4496-11e3-98ff-f7ab4522300d.png)

After:
![2013-11-04 01 39 07](https://f.cloud.github.com/assets/683358/1461132/2fbb26d4-4496-11e3-952a-8ed92acf9a8f.png)

These fixes tested on Ubuntu 13.10 in the following browsers:
- Google Chrome 30
- Opera 12.16
- Firefox 25
