### PR TITLE
[FIXED JENKINS-19898] test base classes should not be linked to the junit implementation.

### DIFF
--- a/core/src/main/java/hudson/tasks/junit/CaseResult.java
+++ b/core/src/main/java/hudson/tasks/junit/CaseResult.java
@@ -331,6 +331,7 @@ public class CaseResult extends TestResult implements Comparable<CaseResult> {
         else            return className.substring(0,idx);
     }
     
+    @Override
     public String getFullName() {
     	return className+'.'+getName();
     }

--- a/core/src/main/java/hudson/tasks/junit/ClassResult.java
+++ b/core/src/main/java/hudson/tasks/junit/ClassResult.java
@@ -227,6 +227,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
     /**
      * @since 1.515
      */
+    @Override
     public String getFullName() {
     	return getParent().getName() + "." + className;
     }

--- a/core/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
+++ b/core/src/main/java/hudson/tasks/test/AbstractTestResultAction.java
@@ -25,7 +25,6 @@ package hudson.tasks.test;
 
 import hudson.Functions;
 import hudson.model.*;
-import hudson.tasks.junit.CaseResult;
 import hudson.util.*;
 import hudson.util.ChartUtil.NumberOnlyBuildLabel;
 import org.jfree.chart.ChartFactory;
@@ -188,7 +187,7 @@ public abstract class AbstractTestResultAction<T extends AbstractTestResultActio
      * 
      * @return List of failed tests from associated test result.
      */
-    public List<CaseResult> getFailedTests() {
+    public List<? extends TestResult> getFailedTests() {
         return Collections.emptyList();
     }
 

--- a/core/src/main/java/hudson/tasks/test/AggregatedTestResultAction.java
+++ b/core/src/main/java/hudson/tasks/test/AggregatedTestResultAction.java
@@ -24,8 +24,6 @@
 package hudson.tasks.test;
 
 import hudson.model.AbstractBuild;
-import hudson.tasks.junit.CaseResult;
-import hudson.tasks.junit.TestResult;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -104,8 +102,8 @@ public abstract class AggregatedTestResultAction extends AbstractTestResultActio
     }
 
     @Override
-    public List<CaseResult> getFailedTests() {
-        List<CaseResult> failedTests = new ArrayList<CaseResult>(failCount);
+    public List<? extends TestResult> getFailedTests() {
+        List<TestResult> failedTests = new ArrayList<TestResult>(failCount);
         for (ChildReport childReport : getChildReports()) {
             if (childReport.result instanceof TestResult) {
                 failedTests.addAll(((TestResult) childReport.result).getFailedTests());

--- a/core/src/main/java/hudson/tasks/test/TestObject.java
+++ b/core/src/main/java/hudson/tasks/test/TestObject.java
@@ -311,6 +311,20 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
     }
 
     /**
+     * Gets the full name of this object.
+     * @since 1.594
+     */
+    public String getFullName() {
+        StringBuilder sb = new StringBuilder(getName());
+        if (getParent() != null) {
+            sb.insert(0, " : ");
+            sb.insert(0, getParent().getFullName());
+        }
+        return sb.toString();
+    }
+
+
+    /**
      * Gets the version of {@link #getName()} that's URL-safe.
      */
     @Override


### PR DESCRIPTION
Changed the return type to be generic and not the junit specific CaseResult.

TestObject.fullName was used in the baseClasses jelly but this was only defined in the CaseResult so add an implementation to the base class such that people can continue to use the generic jelly in their custom test implementations.

going via review in case there is something I may have missed,
