### PR TITLE
[FIXED JENKINS-18058]

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -12,7 +12,22 @@
 
   <name>Jenkins CLI</name>
 
+  <properties>
+    <powermock.version>1.5.1</powermock.version>
+  </properties>
   <dependencies>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>

--- a/cli/src/test/java/hudson/cli/ConnectionMockTest.java
+++ b/cli/src/test/java/hudson/cli/ConnectionMockTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.cli;
+
+import static org.powermock.api.mockito.PowerMockito.*;
+
+import hudson.remoting.FastPipedInputStream;
+import hudson.remoting.FastPipedOutputStream;
+
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @author marco.miller@ericsson.com
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Connection.class})
+public class ConnectionMockTest {
+    @Test(expected=EOFException.class)
+    public void shouldGetExceptionUponReadByteArrayStreamEOF() throws IOException {
+        DataInputStream din = mock(DataInputStream.class);
+        when(din.readInt()).thenReturn(-1);
+        Connection c = new Connection(din, new FastPipedOutputStream(new FastPipedInputStream()));
+        c.readByteArray();
+    }
+}


### PR DESCRIPTION
[JENKINS-18058](https://issues.jenkins-ci.org/browse/JENKINS-18058) Waiting 100 millis and retrying just once if premature EOF reached for
stream in port-based cli connection. Throwing exception if unable to
connect still, instead of initializing array with negative size as
before. PowerMock-based unit test introduced to test this specific
case, hence ConnectionMockTest instead of ConnectionTest class usage;
PowerMock requires a dedicated class, indeed.
