### PR TITLE
[FIXED JENKINS-20106] Show different "up" link for jobs in folders

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractProject/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/sidepanel.jelly
@@ -37,7 +37,14 @@ THE SOFTWARE.
   <l:side-panel>
     <l:tasks>
       <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" contextMenu="false" />
+      <j:choose>
+        <j:when test="${it.parent==app}">
+          <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" contextMenu="false" />
+        </j:when>
+        <j:otherwise>
+          <l:task icon="images/24x24/up.png" href="${url}/../../" title="${%Up}" contextMenu="false" />
+        </j:otherwise>
+      </j:choose>
       <l:task icon="images/24x24/search.png"  href="${url}/" title="${%Status}" contextMenu="false"/>
       <l:task icon="images/24x24/notepad.png" href="${url}/changes" title="${%Changes}" />
       <l:task icon="images/24x24/folder.png"  href="${url}/ws/" title="${%Workspace}" permission="${it.WORKSPACE}">


### PR DESCRIPTION
This change determines in the current items parent is the Jenkins
instance. If so, behavior is as before. Otherwise, link to parent
and use the label 'Up' instead of 'Back to Dashboard' similar to
Folders Plugin.
