### PR TITLE
[FIXED JENKINS-14380] hudson appears in a the webpage title

### DIFF
--- a/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageMonitor.java
@@ -55,6 +55,11 @@ public final class HudsonHomeDiskUsageMonitor extends AdministrativeMonitor {
     public boolean isActivated() {
         return activated;
     }
+    
+    @Override
+    public String getDisplayName() {
+    	return Messages.HudsonHomeDiskUsageMonitor_DisplayName();
+    }
 
     /**
      * Depending on whether the user said "yes" or "no", send him to the right place.

--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index_de.properties
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index_de.properties
@@ -1,5 +1,5 @@
 JENKINS_HOME\ is\ almost\ full=Der Speicherplatz für JENKINS_HOME is fast erschöpft.
-blurb=Der Speicherplatz für H<tt>JENKINS_HOME</tt> is fast erschöpft.
+blurb=Der Speicherplatz für <tt>JENKINS_HOME</tt> is fast erschöpft.
 description.1=Das Verzeichnis <tt>JENKINS_HOME</tt> ({0}) ist fast voll. Ist dieser Speicherplatz \
   vollständig erschöpft, kann Jenkins keine weiteren Daten mehr speichern und wird abstürzen.
 description.2=Um dieses Problem zu vermeiden, sollten Sie jetzt handeln.

--- a/core/src/main/resources/hudson/diagnosis/Messages.properties
+++ b/core/src/main/resources/hudson/diagnosis/Messages.properties
@@ -2,3 +2,4 @@ MemoryUsageMonitor.USED=Used
 MemoryUsageMonitor.TOTAL=Total
 OldDataMonitor.Description=Scrub configuration files to remove remnants from old plugins and earlier versions.
 OldDataMonitor.DisplayName=Manage Old Data
+HudsonHomeDiskUsageMonitor.DisplayName=Disk Usage Monitor

--- a/core/src/main/resources/hudson/diagnosis/Messages_de.properties
+++ b/core/src/main/resources/hudson/diagnosis/Messages_de.properties
@@ -24,3 +24,4 @@ MemoryUsageMonitor.USED=Verwendet
 MemoryUsageMonitor.TOTAL=Total
 OldDataMonitor.DisplayName=Veraltete Daten verwalten
 OldDataMonitor.Description=Konfiguration bereinigen, um \u00DCberbleibsel alter Plugins und fr\u00FCherer Versionen zu entfernen.
+HudsonHomeDiskUsageMonitor.DisplayName=Speicherplatz-Monitor


### PR DESCRIPTION
fixed [JENKINS-14380](https://issues.jenkins-ci.org/browse/JENKINS-14380) by providing localization for `HudsonHomeDiskUsageMonitor.getDisplayName()`.
Without this fix the internal ID _hudsonHomeIsFull_ is displayed in the breadcrumb bar.
