### PR TITLE
[FIXED JENKINS-20407] /var/run/jenkins may not exist

### DIFF
--- a/debian/debian/jenkins.postinst
+++ b/debian/debian/jenkins.postinst
@@ -52,10 +52,16 @@ case "$1" in
         chmod u+rwx /var/lib/jenkins /var/log/jenkins
 
         # make sure jenkins can delete everything in /var/cache/jenkins to
-        # re-explode war. older installations may use /var/run/jenkins
+        # re-explode war.
+        chown -R $JENKINS_USER:adm /var/cache/jenkins
+        chmod -R 750               /var/cache/jenkins
+
+        # older installations may use /var/run/jenkins
         # so make sure that they can delete too.
-        chown -R $JENKINS_USER:adm /var/cache/jenkins /var/run/jenkins
-        chmod -R 750               /var/cache/jenkins /var/run/jenkins
+        if test -d /var/run/jenkins ; then
+            chown -R $JENKINS_USER:adm /var/run/jenkins
+            chmod -R 750               /var/run/jenkins
+        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Test for the existence of `/var/run/jenkins` before trying to `chown` it in
the Debian post-install script.

This bug was introduced by [971491](https://github.com/jenkinsci/jenkins/commit/9714917685e2b50f59b4feda9bc4e561870a944f).
