### PR TITLE
[JENKINS-20407] Make sure dir exists before chmod

### DIFF
--- a/debian/debian/jenkins.postinst
+++ b/debian/debian/jenkins.postinst
@@ -54,6 +54,7 @@ case "$1" in
         # make sure jenkins can delete everything in /var/cache/jenkins to
         # re-explode war. older installations may use /var/run/jenkins
         # so make sure that they can delete too.
+        mkdir -p /var/run/jenkins
         chown -R $JENKINS_USER:adm /var/cache/jenkins /var/run/jenkins
         chmod -R 750               /var/cache/jenkins /var/run/jenkins
     ;;


### PR DESCRIPTION
Ensures that the directory /var/run/jenkins exists before the installer
script attempts to chmod it. New installs via the .deb package were
failing in Debian and Ubuntu because the directory didn't exist. See
https://issues.jenkins-ci.org/browse/JENKINS-20407.
