### PR TITLE
[FIXED JENKINS-20500] filter queue/executors correctly via ajax

### DIFF
--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -134,7 +134,7 @@ THE SOFTWARE.
     <!-- schedule updates only for the full page reload -->
     <j:if test="${ajax==null and !h.isAutoRefresh(request) and h.hasPermission(app.READ)}">
       <script defer="defer">
-        refreshPart('executors',"${rootURL}/${h.hasView(it,'ajaxExecutors')?it.url:''}ajaxExecutors");
+        refreshPart('executors',"${rootURL}/${h.hasView(view,'ajaxExecutors')?view.url:''}ajaxExecutors");
       </script>
     </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -91,7 +91,7 @@ THE SOFTWARE.
   <!-- schedule updates only for the full page reload -->
   <j:if test="${ajax==null and !h.isAutoRefresh(request) and h.hasPermission(app.READ)}">
     <script defer="defer">
-      refreshPart('buildQueue',"${rootURL}/${h.hasView(it,'ajaxBuildQueue')?it.url:''}ajaxBuildQueue");
+      refreshPart('buildQueue',"${rootURL}/${h.hasView(view,'ajaxBuildQueue')?view.url:''}ajaxBuildQueue");
     </script>
   </j:if>
 </j:jelly>


### PR DESCRIPTION
follow the change in 8e6a3f7f03c8cdd93f1fb352088bac9cd2676c49 and fixes
https://issues.jenkins-ci.org/browse/JENKINS-20500
https://issues.jenkins-ci.org/browse/JENKINS-20548
