### PR TITLE
[FIXED JENKINS-20559 and JENKINS-19454] - hudson.Launcher bugfix and additional wrapper

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -972,6 +972,88 @@ public abstract class Launcher {
             }
         }
     }
+    
+    /**
+     * A launcher which delegates to a provided inner launcher. 
+     * Allows subclasses to only implement methods they want to override.
+     * Originally, this launcher has been implemented in 
+     * <a href="https://wiki.jenkins-ci.org/display/JENKINS/Custom+Tools+Plugin">
+     * Custom Tools Plugin</a>.
+     * 
+     * @author rcampbell
+     * @author Oleg Nenashev, Synopsys Inc.
+     * @since TODO: define version
+     */
+    public static class DecoratedLauncher extends Launcher {
+
+        private Launcher inner = null;
+
+        public DecoratedLauncher(Launcher inner) {
+            super(inner);
+            this.inner = inner;
+        }
+
+        @Override
+        public Proc launch(ProcStarter starter) throws IOException {
+            return inner.launch(starter);
+        }
+
+        @Override
+        public Channel launchChannel(String[] cmd, OutputStream out,
+                FilePath workDir, Map<String, String> envVars) throws IOException,
+                InterruptedException {
+            return inner.launchChannel(cmd, out, workDir, envVars);
+        }
+
+        @Override
+        public void kill(Map<String, String> modelEnvVars) throws IOException,
+                InterruptedException {
+            inner.kill(modelEnvVars);
+        }
+
+        @Override
+        public boolean isUnix() {
+            return inner.isUnix();
+        }
+
+        @Override
+        public Proc launch(String[] cmd, boolean[] mask, String[] env, InputStream in, OutputStream out, FilePath workDir) throws IOException {
+            return inner.launch(cmd, mask, env, in, out, workDir);
+        }
+
+        @Override
+        public Computer getComputer() {
+            return inner.getComputer();
+        }
+
+        @Override
+        public TaskListener getListener() {
+            return inner.getListener();
+        }
+
+        @Override
+        public String toString() {
+            return super.toString() + "; decorates " + inner.toString();
+        }
+
+        @Override
+        public VirtualChannel getChannel() {
+            return inner.getChannel();
+        }
+
+        @Override
+        public Proc launch(String[] cmd, String[] env, InputStream in, OutputStream out, FilePath workDir) throws IOException {
+            return inner.launch(cmd, env, in, out, workDir); 
+        }
+   
+        /**
+         * Gets nested launcher.
+         * @return Inner launcher
+         */
+        public Launcher getInner() {
+            return inner;
+        }    
+    }
 
     public static class IOTriplet implements Serializable {
         InputStream stdout,stderr;

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -300,8 +300,13 @@ public abstract class Launcher {
             return this;
         }
 
+        /**
+         * Gets a list of environment variables to be set.
+         * Returns an empty array if envs field has not been initialized.
+         * @return If initialized, returns a copy of internal envs array. Otherwise - a new empty array.
+         */
         public String[] envs() {
-            return envs.clone();
+            return envs != null ? envs.clone() : new String[0];
         }
 
         /**

--- a/test/src/test/java/hudson/ProcStarterTest.java
+++ b/test/src/test/java/hudson/ProcStarterTest.java
@@ -1,0 +1,129 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson;
+
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.model.Run;
+import hudson.tasks.BuildWrapper;
+import hudson.tasks.BuildWrapperDescriptor;
+import java.io.IOException;
+import org.jvnet.hudson.test.Bug;
+import hudson.Launcher.DecoratedLauncher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Contains tests for {@link ProcStarter} class.
+ * @author Oleg Nenashev <nenashev@synopsys.com>, Synopsys Inc.
+ * @since TODO: define a version
+ */
+public class ProcStarterTest {
+
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
+    
+    @Test
+    @Bug(20559)
+    public void testNonInitializedEnvsNPE() throws Exception {
+        // Create nodes and other test stuff
+        rule.hudson.setNumExecutors(0);
+        rule.createSlave();
+
+        // Create a job with test build wrappers
+        FreeStyleProject project = rule.createFreeStyleProject();
+        project.getBuildWrappersList().add(new DecoratedWrapper());
+        project.getBuildWrappersList().add(new EchoWrapper());
+
+        // Run the build. If NPE occurs, the test will fail
+        rule.buildAndAssertSuccess(project);
+    }
+
+    /**
+     * A stub descriptor for {@link BuildWrapper}s.
+     */
+    public abstract static class TestWrapperDescriptor extends BuildWrapperDescriptor {
+
+        @Override
+        public boolean isApplicable(AbstractProject<?, ?> ap) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "testStub";
+        }
+    }
+
+    /**
+     * A wrapper, which contains a nested launch.
+     */
+    public static class EchoWrapper extends BuildWrapper {
+
+        @Override
+        public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+            Launcher.ProcStarter starter = launcher.launch().cmds("echo", "Hello");
+            starter.start();
+            starter.join();
+            return new Environment() {
+            };
+        }
+        
+        @Extension
+        public static class DescriptorImpl extends TestWrapperDescriptor {
+        }
+    };
+
+    /**
+     * A wrapper, which decorates launchers.
+     */
+    public static class DecoratedWrapper extends BuildWrapper {
+
+        @Override
+        public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
+            final BuildListener l = listener;
+            return new DecoratedLauncher(launcher) {
+                @Override
+                public Proc launch(Launcher.ProcStarter starter) throws IOException {
+                    String[] envs = starter.envs(); // Finally, call envs()
+                    l.getLogger().println("[DecoratedWrapper]: Number of environment variables is "+envs.length); // Fail on null
+                    return super.launch(starter);
+                }
+            };
+        }
+
+        @Override
+        public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+            return new Environment() {
+            };
+        }
+        
+        @Extension
+        public static class DescriptorImpl extends TestWrapperDescriptor {
+        }
+    };
+}


### PR DESCRIPTION
Summary:
- A fix for NPE in hudson.Launcher.ProcSrater::envs() 
- A DecoratedLauncher code, which is being duplicated by many plugins (Custom Tools, etc.)
- A test for JENKINS-20559, which uses a DecoratedLauncher

Noting:
<plaintext>
<li class=bug>
    Uninitialized Process Starter environment may cause NPE in build wrappers
    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20559">issue 20559</a>)
  <li class=rfe>
    New API class: DecoratedLauncher, which delegated all call to nested launcher
    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19454">issue 19454</a>)
</plaintext>
The last bullet is a reason, why these changes have been merged into a single PR
