### PR TITLE
Javadoc warning fixes for CLICommand, Run, and ViewOptionHandler

### DIFF
--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -249,7 +249,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
     /**
      * Get parser for this command.
      *
-     * Exposed to be overridden by {@link CLIRegisterer}.
+     * Exposed to be overridden by {@link hudson.cli.declarative.CLIRegisterer}.
      * @since TODO
      */
     protected CmdLineParser getCmdLineParser() {

--- a/core/src/main/java/hudson/cli/handlers/ViewOptionHandler.java
+++ b/core/src/main/java/hudson/cli/handlers/ViewOptionHandler.java
@@ -53,7 +53,7 @@ import org.kohsuke.args4j.spi.Setter;
  * Handler traverse the view names from left to right. First one is expected to
  * be a top level view and all but the last one are expected to be instances of
  * {@link ViewGroup}. Handler fails to resolve view provided a view with given
- * name does not exist or a user was not granted {@link View.READ} permission.
+ * name does not exist or a user was not granted {@link View#READ} permission.
  *
  * @author ogondza
  * @since 1.538

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2169,7 +2169,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * processes for this build.
      *
      * <p>
-     * {@link BuildStep}s that invoke external processes should use this.
+     * {@link hudson.tasks.BuildStep}s that invoke external processes should use this.
      * This allows {@link BuildWrapper}s and other project configurations (such as JDK selection)
      * to take effect.
      *


### PR DESCRIPTION
A few javadoc warnings have crept in.  These were easy to resolve.  Others will need further investigation
