### PR TITLE
[IN_PROGRESS] [JENKINS-20683] - Use hetero-lists in build wrappers and triggers to simplify UI

### DIFF
--- a/core/src/main/java/hudson/matrix/MatrixProject.java
+++ b/core/src/main/java/hudson/matrix/MatrixProject.java
@@ -854,7 +854,7 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
         checkAxisNames(newAxes);
         this.axes = new AxisList(newAxes.toList());
 
-        buildWrappers.rebuild(req, json, BuildWrappers.getFor(this));
+        buildWrappers.rebuildHetero(req, json, BuildWrappers.getFor(this), "buildWrapper");
         builders.rebuildHetero(req, json, Builder.all(), "builder");
         publishers.rebuildHetero(req, json, Publisher.all(), "publisher");
 

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -348,6 +348,15 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         }
         return triggers;
     }
+    
+    /**
+     * Gets list of triggers in the project.
+     * This method provides a public interface for triggers as it has been done 
+     * for build actions in ${link Project}.
+     */
+    public DescribableList<Trigger<?>,TriggerDescriptor> getTriggersList() {
+        return triggers();
+    }
 
     @Override
     public EnvVars getEnvironment(Node node, TaskListener listener) throws IOException, InterruptedException {
@@ -2003,7 +2012,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
 
         for (Trigger t : triggers())
             t.stop();
-        triggers.replaceBy(buildDescribable(req, Trigger.for_(this)));
+        triggers().rebuildHetero(req,json, Trigger.for_(this), "trigger");
         for (Trigger t : triggers())
             t.start(this,true);
 

--- a/core/src/main/java/hudson/model/Project.java
+++ b/core/src/main/java/hudson/model/Project.java
@@ -203,7 +203,7 @@ public abstract class Project<P extends Project<P,B>,B extends Build<P,B>>
 
         JSONObject json = req.getSubmittedForm();
 
-        getBuildWrappersList().rebuild(req,json, BuildWrappers.getFor(this));
+        getBuildWrappersList().rebuildHetero(req,json, BuildWrappers.getFor(this), "buildWrapper");
         getBuildersList().rebuildHetero(req,json, Builder.all(), "builder");
         getPublishersList().rebuildHetero(req, json, Publisher.all(), "publisher");
     }

--- a/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/configure-entries.jelly
@@ -93,7 +93,7 @@ THE SOFTWARE.
     </j:choose>
   </f:section>
 
-  <p:config-buildWrappers />
-  <p:config-builders />
+  <p:config-buildWrappers useHeteroList="true"/>
+  <p:config-builders/>
   <p:config-publishers2 />
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Project/configure-entries.jelly
+++ b/core/src/main/resources/hudson/model/Project/configure-entries.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
     <p:config-upstream-pseudo-trigger />
   </p:config-trigger>
 
-  <p:config-buildWrappers />
-  <p:config-builders />
+  <p:config-buildWrappers useHeteroList="true"/>
+  <p:config-builders/>
   <p:config-publishers2 />
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-buildWrappers.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-buildWrappers.jelly
@@ -1,7 +1,8 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2013, Sun Microsystems, Inc., Kohsuke Kawaguchi and contributors
+Copyright (c) 2004-2013, Sun Microsystems, Inc., Kohsuke Kawaguchi, 
+Oleg Nenashev and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -27,18 +28,38 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
+    <st:documentation>
+        The default behavior is not used in core (see JENKINS-20683). 
+        It is recommended update your code to use
+        publishers.rebuildHetero(req, json, Publisher.all(), "buildWrapper");
+        <st:attribute name="useHeteroList">
+            Switches entry to use hetero-list instead of describableList to
+            simplify UI layout (value == "true").
+        </st:attribute>
+    </st:documentation>
     <j:set var="wrappers" value="${h.getBuildWrapperDescriptors(it)}" />
-    <j:if test="${!empty(wrappers)}">
-        <f:section title="${%Build Environment}">     
-            <f:block>
-                <f:hetero-list name="buildWrapper" hasHeader="true"
-                   descriptors="${wrappers}"
-                   items="${it.buildWrappersList}"
-                   oneEach="true"
-                   menuAlign="bl-tl"
-                   honorOrder="true"
-                   addCaption="${%Add build wrapper}"/>
-            </f:block>
-        </f:section>
+    <j:if test="${!empty(wrappers)}">      
+        <j:switch on="${attrs.useHeteroList}">
+            <!--New behavior--> 
+            <j:case value="true">
+                <f:section title="${%Build Environment}">     
+                    <f:block>
+                        <f:hetero-list name="buildWrapper" hasHeader="true"
+                               descriptors="${wrappers}"
+                               items="${it.buildWrappersList}"
+                               oneEach="true"
+                               menuAlign="bl-tl"
+                               honorOrder="true"
+                               addCaption="${%Add build wrapper}"/>
+                    </f:block>
+                </f:section>
+            </j:case>         
+            <!--Legacy behavior--> 
+            <j:default> 
+                <f:descriptorList title="${%Build Environment}"
+                                  descriptors="${wrappers}"
+                                  instances="${it.buildWrappers}" />
+            </j:default>
+        </j:switch>
     </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-buildWrappers.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-buildWrappers.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+Copyright (c) 2004-2013, Sun Microsystems, Inc., Kohsuke Kawaguchi and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -27,10 +27,18 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
-  <j:set var="wrappers" value="${h.getBuildWrapperDescriptors(it)}" />
-  <j:if test="${!empty(wrappers)}">
-    <f:descriptorList title="${%Build Environment}"
-                      descriptors="${wrappers}"
-                      instances="${it.buildWrappers}" />
-  </j:if>
+    <j:set var="wrappers" value="${h.getBuildWrapperDescriptors(it)}" />
+    <j:if test="${!empty(wrappers)}">
+        <f:section title="${%Build Environment}">     
+            <f:block>
+                <f:hetero-list name="buildWrapper" hasHeader="true"
+                   descriptors="${wrappers}"
+                   items="${it.buildWrappersList}"
+                   oneEach="true"
+                   menuAlign="bl-tl"
+                   honorOrder="true"
+                   addCaption="${%Add build wrapper}"/>
+            </f:block>
+        </f:section>
+    </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-buildWrappers.properties
+++ b/core/src/main/resources/lib/hudson/project/config-buildWrappers.properties
@@ -1,0 +1,1 @@
+Build\ Environment=Build Environment Wrappers

--- a/core/src/main/resources/lib/hudson/project/config-trigger.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-trigger.jelly
@@ -39,14 +39,13 @@ THE SOFTWARE.
                                oneEach="true"
                                menuAlign="bl-tl"
                                honorOrder="true"
-                               addCaption="${%Add build trigger}">
-              <d:invokeBody />
-              <!-- pseudo-trigger to configure URL to trigger builds remotely. -->
-              <st:include page="/hudson/model/BuildAuthorizationToken/config.jelly" />
-          </f:hetero-list>
+                               addCaption="${%Add build trigger}"/>                    
+          <d:invokeBody />
+          <!-- pseudo-trigger to configure URL to trigger builds remotely. -->
+          <st:include page="/hudson/model/BuildAuthorizationToken/config.jelly" />           
       </f:block>
   </f:section>
-  <!--
+<!--
   <f:descriptorList title="${%Build Triggers}"
                     descriptors="${triggers}"
                     instances="${it.triggers}">

--- a/core/src/main/resources/lib/hudson/project/config-trigger.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-trigger.jelly
@@ -31,11 +31,26 @@ THE SOFTWARE.
   <j:invokeStatic var="triggers" className="hudson.triggers.Trigger" method="for_">
     <j:arg value="${it}" type="hudson.model.Item" />
   </j:invokeStatic>
+  <f:section title="${%Build Triggers}">     
+      <f:block>
+          <f:hetero-list name="trigger" hasHeader="true"
+                               descriptors="${triggers}"
+                               items="${it.triggersList}"
+                               oneEach="true"
+                               menuAlign="bl-tl"
+                               honorOrder="true"
+                               addCaption="${%Add build trigger}">
+              <d:invokeBody />
+              <!-- pseudo-trigger to configure URL to trigger builds remotely. -->
+              <st:include page="/hudson/model/BuildAuthorizationToken/config.jelly" />
+          </f:hetero-list>
+      </f:block>
+  </f:section>
+  <!--
   <f:descriptorList title="${%Build Triggers}"
                     descriptors="${triggers}"
                     instances="${it.triggers}">
     <d:invokeBody />
-    <!-- pseudo-trigger to configure URL to trigger builds remotely. -->
     <st:include page="/hudson/model/BuildAuthorizationToken/config.jelly" />
-  </f:descriptorList>
+  </f:descriptorList> -->
 </j:jelly>


### PR DESCRIPTION
This change removes a huge number of checkboxes in job configuration pages.
Related to: https://issues.jenkins-ci.org/browse/JENKINS-20683

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
