### PR TITLE
Introduce ModifiableViewGroup

### DIFF
--- a/core/src/main/java/hudson/model/ModifiableViewGroup.java
+++ b/core/src/main/java/hudson/model/ModifiableViewGroup.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.model;
+
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+
+/**
+ * {@link ViewGroup} that can be modified.
+ *
+ * @author ogondza
+ * @since TODO
+ */
+public interface ModifiableViewGroup extends ViewGroup {
+
+    /**
+     * Add new {@link View} to this {@link ViewGroup}.
+     */
+    public void addView(@Nonnull View view) throws IOException;
+}

--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -58,7 +58,7 @@ import org.kohsuke.stapler.StaplerResponse;
  *
  * @author Tom Huybrechts
  */
-public class MyViewsProperty extends UserProperty implements ViewGroup, Action, StaplerFallback {
+public class MyViewsProperty extends UserProperty implements ModifiableViewGroup, Action, StaplerFallback {
     private String primaryViewName;
 
     /**
@@ -136,6 +136,7 @@ public class MyViewsProperty extends UserProperty implements ViewGroup, Action, 
         viewGroupMixIn.onViewRenamed(view,oldName,newName);
     }
 
+    @Override
     public void addView(View view) throws IOException {
         viewGroupMixIn.addView(view);
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -56,6 +56,7 @@ import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.ItemGroupMixIn;
 import hudson.model.Items;
+import hudson.model.ModifiableViewGroup;
 import hudson.model.JDK;
 import hudson.model.Job;
 import hudson.model.JobPropertyDescriptor;
@@ -77,7 +78,6 @@ import hudson.model.UnprotectedRootAction;
 import hudson.model.UpdateCenter;
 import hudson.model.User;
 import hudson.model.View;
-import hudson.model.ViewGroup;
 import hudson.model.ViewGroupMixIn;
 import hudson.model.Descriptor.FormException;
 import hudson.model.labels.LabelAtom;
@@ -304,7 +304,7 @@ import javax.annotation.Nullable;
  */
 @ExportedBean
 public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGroup, StaplerProxy, StaplerFallback,
-        ViewGroup, AccessControlled, DescriptorByNameOwner,
+        ModifiableViewGroup, AccessControlled, DescriptorByNameOwner,
         ModelObjectWithContextMenu, ModelObjectWithChildren {
     private transient final Queue queue;
 
@@ -1455,6 +1455,7 @@ public class Jenkins extends AbstractCIBase implements ModifiableTopLevelItemGro
         return viewGroupMixIn.getViews();
     }
 
+    @Override
     public void addView(View v) throws IOException {
         viewGroupMixIn.addView(v);
     }

--- a/test/src/main/java/org/jvnet/hudson/test/MockFolder.java
+++ b/test/src/main/java/org/jvnet/hudson/test/MockFolder.java
@@ -33,11 +33,11 @@ import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.ItemGroupMixIn;
+import hudson.model.ModifiableViewGroup;
 import hudson.model.Job;
 import hudson.model.TopLevelItem;
 import hudson.model.TopLevelItemDescriptor;
 import hudson.model.View;
-import hudson.model.ViewGroup;
 import hudson.model.ViewGroupMixIn;
 import hudson.util.Function1;
 import hudson.views.DefaultViewsTabBar;
@@ -69,7 +69,7 @@ import org.kohsuke.stapler.WebMethod;
  * @since 1.494
  */
 @SuppressWarnings({"unchecked", "rawtypes"}) // the usual API mistakes
-public class MockFolder extends AbstractItem implements ModifiableTopLevelItemGroup, TopLevelItem, ViewGroup, StaplerFallback {
+public class MockFolder extends AbstractItem implements ModifiableTopLevelItemGroup, TopLevelItem, ModifiableViewGroup, StaplerFallback {
 
     private transient Map<String,TopLevelItem> items = new TreeMap<String,TopLevelItem>();
     private final List<View> views = new ArrayList<View>(Collections.singleton(new AllView("All", this)));
@@ -188,7 +188,7 @@ public class MockFolder extends AbstractItem implements ModifiableTopLevelItemGr
         return Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
     }
 
-    public void addView(View view) throws IOException {
+    @Override public void addView(View view) throws IOException {
         vgmixin().addView(view);
     }
 


### PR DESCRIPTION
Most of the `ViewGroup` implementations already provide this method. I intend to convert `hudson.plugins.nested_view.NestedView` and `com.cloudbees.hudson.plugins.folder.Folder` to implement this interface.
