### PR TITLE
[JENKINS-20739] Filter descriptors before adding them to hetero-list

### DIFF
--- a/core/src/main/java/hudson/model/DescriptorVisibilityFilter.java
+++ b/core/src/main/java/hudson/model/DescriptorVisibilityFilter.java
@@ -9,6 +9,9 @@ import jenkins.model.Jenkins;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
 /**
  * Hides {@link Descriptor}s from users.
  *
@@ -17,6 +20,8 @@ import java.util.List;
  * @see ExtensionFilter
  */
 public abstract class DescriptorVisibilityFilter implements ExtensionPoint {
+
+    private static final Logger LOGGER = Logger.getLogger(DescriptorVisibilityFilter.class.getName());
 
     /**
      * Decides if the given descriptor should be visible to the user.
@@ -46,9 +51,19 @@ public abstract class DescriptorVisibilityFilter implements ExtensionPoint {
         
         OUTER:
         for (T d : source) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine("Determining visibility of " + d + " in context " + context);
+            }
             for (DescriptorVisibilityFilter f : filters) {
-                if (!f.filter(context,d))
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.finer("Querying " + f + " for visibility of " + d + " in " + context);
+                }
+                if (!f.filter(context,d)) {
+                    if (LOGGER.isLoggable(Level.CONFIG)) {
+                       LOGGER.config("Filter " + f + " hides " + d + " in context " + context);
+                    }
                     continue OUTER; // veto-ed. not shown
+                }
             }
             r.add(d);
         }

--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -126,7 +126,8 @@ THE SOFTWARE.
     <div class="prototypes to-be-removed">
       <!-- render one prototype for each type -->
       <j:set var="instance" value="${null}" />
-      <j:forEach var="descriptor" items="${attrs.descriptors}" varStatus="loop">
+      <j:set var="descriptors" value="${h.filterDescriptors(it,attrs.descriptors)}" />
+      <j:forEach var="descriptor" items="${descriptors}" varStatus="loop">
         <div name="${attrs.name}" title="${descriptor.displayName}" tooltip="${descriptor.tooltip}" descriptorId="${descriptor.id}">
           <j:set var="capture" value="${attrs.capture?:''}" />
           <local:body deleteCaption="${attrs.deleteCaption}">


### PR DESCRIPTION
This allows implementations of `DescriptorVisibilityFilter` to hide items
with descriptors from users to prevent them from being added via the UI
using `hetero-list`.

This is already implemented in `/lib/hudson/newFromList/form.jelly`, as well as `Functions.getSortedDescriptorsForGlobalConfig(Predicate)`, but nowhere else.
