### PR TITLE
Fix javadoc warnings in Run.java

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -55,6 +55,7 @@ import hudson.tasks.test.AbstractTestResultAction;
 import hudson.util.FlushProofOutputStream;
 import hudson.util.FormApply;
 import hudson.util.LogTaskListener;
+import hudson.util.ProcessTree;
 import hudson.util.XStream2;
 
 import java.io.BufferedReader;
@@ -1252,7 +1253,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
         /**
          * Gets the artifact file.
-         * @deprecated May not be meaningful with custom artifact managers. Use {@link ArtifactManager#load} with {@link #relativePath} instead.
+         * @deprecated May not be meaningful with custom artifact managers.
          */
         @Deprecated
         public File getFile() {


### PR DESCRIPTION
ProcessTree was referenced without being imported.  Added the import.

ArtifactManager.load() method was referenced but doesn't exist.
