### PR TITLE
[JENKINS-7776] Show decimals when disk space monitored as less than 1 GB.

### DIFF
--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorDescriptor.java
@@ -98,8 +98,7 @@ public abstract class DiskSpaceMonitorDescriptor extends AbstractAsyncNodeMonito
             long space = size;
             space/=1024L;   // convert to KB
             space/=1024L;   // convert to MB
-            if(triggered) {
-                // less than a GB
+            if(space/1024 < 1) {
                 return Util.wrapToErrorSpan(new BigDecimal(space).scaleByPowerOfTen(-3).toPlainString()+"GB");
             }
 

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorDescriptor.java
@@ -24,6 +24,7 @@
 package hudson.node_monitors;
 
 import hudson.FilePath.FileCallable;
+import hudson.Functions;
 import hudson.remoting.VirtualChannel;
 import hudson.Util;
 import hudson.slaves.OfflineCause;
@@ -95,14 +96,11 @@ public abstract class DiskSpaceMonitorDescriptor extends AbstractAsyncNodeMonito
          * Returns the HTML representation of the space.
          */
         public String toHtml() {
-            long space = size;
-            space/=1024L;   // convert to KB
-            space/=1024L;   // convert to MB
-            if(space/1024 < 1) {
-                return Util.wrapToErrorSpan(new BigDecimal(space).scaleByPowerOfTen(-3).toPlainString()+"GB");
+            String humanReadableSpace = Functions.humanReadableByteSize(size);
+            if(triggered) {
+                return Util.wrapToErrorSpan(humanReadableSpace);
             }
-
-            return space/1024+"GB";
+            return humanReadableSpace;
         }
         
         /**

--- a/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
@@ -25,6 +25,7 @@ package hudson.node_monitors;
 
 import hudson.Util;
 import hudson.Extension;
+import hudson.Functions;
 import hudson.model.Computer;
 import jenkins.model.Jenkins;
 import hudson.remoting.Callable;
@@ -51,14 +52,16 @@ public class SwapSpaceMonitor extends NodeMonitor {
         if(usage.availableSwapSpace==-1)
             return "N/A";
 
+       String humanReadableSpace = Functions.humanReadableByteSize(usage.availableSwapSpace);
+       
         long free = usage.availableSwapSpace;
         free/=1024L;   // convert to KB
         free/=1024L;   // convert to MB
         if(free>256 || usage.totalSwapSpace<usage.availableSwapSpace*5)
-            return free+"MB"; // if we have more than 256MB free or less than 80% filled up, it's OK
+            return humanReadableSpace; // if we have more than 256MB free or less than 80% filled up, it's OK
 
         // Otherwise considered dangerously low.
-        return Util.wrapToErrorSpan(free+"MB");
+        return Util.wrapToErrorSpan(humanReadableSpace);
     }
 
     public long toMB(MemoryUsage usage) {


### PR DESCRIPTION
The logic relied on the monitor being triggered to show more decimals.
The monitor threshold can be set to something other than 1GB.
Therefore check the available space instead of the triggered status.
