### PR TITLE
Do not attempt to parse blank responses from cancelled XHR POST requests

### DIFF
--- a/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
+++ b/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
@@ -59,10 +59,12 @@ THE SOFTWARE.
                   method:"POST",
                   parameters: {min: i*interval, max:(i+1)*interval},
                   onSuccess: function(t) {
-                    try {
-                      eventSource1.loadJSON(eval('('+t.responseText+')'),'.');
-                    } catch (e) {
-                      alert(e);
+                    if (t.status != 0) {
+                      try {
+                        eventSource1.loadJSON(eval('('+t.responseText+')'),'.');
+                      } catch (e) {
+                        alert(e);
+                      }
                     }
                   }
               });


### PR DESCRIPTION
An XHR POST request may be cancelled by navigating away from the page while the timeline is loading.  This causes alert spam on Chrome and Safari (because trying to eval "()" throws a syntax error for every request that happened to be outstanding).
