### PR TITLE
[JENKINS-7866] - Fix failed tests displaying as Yellow.

### DIFF
--- a/core/src/main/java/hudson/tasks/junit/History.java
+++ b/core/src/main/java/hudson/tasks/junit/History.java
@@ -228,8 +228,8 @@ public class History {
                 }
             };
             plot.setRenderer(ar);
-            ar.setSeriesPaint(0,ColorPalette.RED); // Failures.
-            ar.setSeriesPaint(1,ColorPalette.YELLOW); // Skips.
+            ar.setSeriesPaint(0,ColorPalette.YELLOW); // Skips.
+            ar.setSeriesPaint(1,ColorPalette.RED); // Failures.
             ar.setSeriesPaint(2,ColorPalette.BLUE); // Total.
 
             // crop extra space around the graph


### PR DESCRIPTION
On the "Test History" page, the counts graph was displaying failed tests as yellow and skipped tests as red.
This patch reverses that behaviour (making it consistent with everywhere else).
