### PR TITLE
Javadoc fixes in two tests

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/FakeLauncher.java
+++ b/test/src/main/java/org/jvnet/hudson/test/FakeLauncher.java
@@ -12,7 +12,6 @@ import java.io.OutputStream;
  *
  * @author Kohsuke Kawaguchi
  * @see PretendSlave
- * @see MockFakeLauncher
  */
 public interface FakeLauncher {
     /**

--- a/test/src/main/java/org/jvnet/hudson/test/package-info.java
+++ b/test/src/main/java/org/jvnet/hudson/test/package-info.java
@@ -22,6 +22,6 @@
  * THE SOFTWARE.
  */
 /**
- * Test harness for Jenkins and its plugins. Start exploring from {@link JenkinsRule}.
+ * Test harness for Jenkins and its plugins. Start exploring from {@link org.jvnet.hudson.test.JenkinsRule}.
  */
 package org.jvnet.hudson.test;


### PR DESCRIPTION
Fully qualify JenkinsRule reference from package-info source file

Also remove reference to non-existent class
