### PR TITLE
Migrate to asm4

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -552,6 +552,12 @@ THE SOFTWARE.
     </dependency>
 
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>4.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>findbugs</groupId>
       <artifactId>annotations</artifactId>
       <version>1.0.0</version>

--- a/core/src/main/java/hudson/util/SubClassGenerator.java
+++ b/core/src/main/java/hudson/util/SubClassGenerator.java
@@ -25,13 +25,13 @@ package hudson.util;
 
 import hudson.PluginManager.UberClassLoader;
 import jenkins.model.Jenkins;
-import org.kohsuke.asm3.ClassWriter;
-import org.kohsuke.asm3.MethodVisitor;
-import org.kohsuke.asm3.Type;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
 
 import java.lang.reflect.Constructor;
 
-import static org.kohsuke.asm3.Opcodes.*;
+import static org.objectweb.asm.Opcodes.*;
 
 /**
  * Generates a new class that just defines constructors into the super types.


### PR DESCRIPTION
This pull request migrates jenkins-core from renamed asm3 library to asm4. Unlike previous versions, asm4 and future versions should maintain backward compatibility. Two other Jenkins dependencies depend on renamed asm3: stapler and bytecode-compatibility-transformer. I've opened pull requests for them as well.

Thanks
