### PR TITLE
[JENKINS-20534] Avoid usage of temporary file to write symlink.

### DIFF
--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -167,25 +167,17 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
     static void writeSymlink(File cache, String target) throws IOException, InterruptedException {
         StringWriter w = new StringWriter();
         StreamTaskListener listener = new StreamTaskListener(w);
-        File tmp = new File(cache.getPath()+".tmp");
-        try {
-            Util.createSymlink(tmp.getParentFile(),target,tmp.getName(),listener);
-            // Avoid calling resolveSymlink on a nonexistent file as it will probably throw an IOException:
-            if (!exists(tmp) || Util.resolveSymlink(tmp)==null) {
-                // symlink not supported. use a regular file
-                AtomicFileWriter cw = new AtomicFileWriter(cache);
-                try {
-                    cw.write(target);
-                    cw.commit();
-                } finally {
-                    cw.abort();
-                }
-            } else {
-                cache.delete();
-                tmp.renameTo(cache);
-            }
-        } finally {
-            tmp.delete();
+        Util.createSymlink(cache.getParentFile(),target,cache.getName(),listener);
+        // Avoid calling resolveSymlink on a nonexistent file as it will probably throw an IOException:
+        if (!exists(cache) || Util.resolveSymlink(cache)==null) {
+          // symlink not supported. use a regular file
+          AtomicFileWriter cw = new AtomicFileWriter(cache);
+          try {
+              cw.write(target);
+              cw.commit();
+          } finally {
+              cw.abort();
+          }
         }
     }
 


### PR DESCRIPTION
Creating a symlink is an atomic operation, and additionally
usage of tmp file + rename performs very badly on NTFS file
system because of the way the rename is tracked in the $MFT.

In case symbolic links are not supported, we still fallback to
a regular file.
