### PR TITLE
[FIXED JENKINS-20928] l:breakable mishandles HTML metacharacters

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1824,8 +1824,8 @@ public class Functions {
      */
     public static String breakableString(final String plain) {
 
-        return plain.replaceAll("(\\p{Punct}+\\w)", "<wbr>$1")
-                .replaceAll("(\\w{10})(?=\\w{3})", "$1<wbr>")
+        return plain.replaceAll("([\\p{Punct}&&[^;]]+\\w)", "<wbr>$1")
+                .replaceAll("([^\\p{Punct}\\s-]{10})(?=[^\\p{Punct}\\s-]{3})", "$1<wbr>")
         ;
     }
 

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -291,9 +291,26 @@ public class FunctionsTest {
     @Test
     public void testBreakableString() {
 
-        assertEquals("Hello world!", Functions.breakableString("Hello world!"));
-        assertEquals("H<wbr>,e<wbr>.l<wbr>/l<wbr>:o<wbr>-w<wbr>_o<wbr>=+|d", Functions.breakableString("H,e.l/l:o-w_o=+|d"));
-        assertEquals("ALongStrin<wbr>gThatCanNo<wbr>tBeBrokenB<wbr>yDefault", Functions.breakableString("ALongStringThatCanNotBeBrokenByDefault"));
+        assertBrokenAs("Hello world!", "Hello world!");
+        assertBrokenAs("Hello-world!", "Hello", "-world!");
+        assertBrokenAs("ALongStringThatCanNotBeBrokenByDefault", "ALongStrin", "gThatCanNo", "tBeBrokenB", "yDefault");
+        assertBrokenAs("jenkins_main_trunk", "jenkins", "_main", "_trunk");
+
+        assertBrokenAs("&lt;&lt;&lt;&lt;&lt;", "", "&lt;", "&lt;", "&lt;", "&lt;", "&lt;");
+        assertBrokenAs("&amp;&amp;&amp;&amp;&amp;", "", "&amp;", "&amp;", "&amp;", "&amp;", "&amp;");
+        assertBrokenAs("&thetasym;&thetasym;&thetasym;", "", "&thetasym;", "&thetasym;", "&thetasym;");
+        assertBrokenAs("Crazy &lt;ha ha&gt;", "Crazy ", "&lt;ha ha", "&gt;");
+        assertBrokenAs("A;String>Full]Of)Weird}Punctuation", "A;String", ">Full", "]Of", ")Weird", "}Punctuation");
+        assertBrokenAs("&lt;&lt;a&lt;bc&lt;def&lt;ghi&lt;", "", "&lt;", "&lt;a", "&lt;bc", "&lt;def", "&lt;ghi", "&lt;");
+        assertBrokenAs("H,e.l/l:o=w_o+|d", "H", ",e", ".l", "/l", ":o", "=w", "_o", "+|d");
+        assertBrokenAs("a¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷ", "a¶‱ﻷa¶‱ﻷa¶", "‱ﻷa¶‱ﻷa¶‱ﻷ", "a¶‱ﻷa¶‱ﻷa¶‱ﻷ");
+    }
+
+    private void assertBrokenAs(String plain, String... chunks) {
+        assertEquals(
+                Util.join(Arrays.asList(chunks), "<wbr>"),
+                Functions.breakableString(plain)
+        );
     }
 
     @Bug(20800)


### PR DESCRIPTION
This prevents breaking inside html entity.

Used regexes are ugly and quite hard to get right. Here is an alternative https://github.com/olivergondza/jenkins/compare/master...breakable. It is a bit wordy but more correct and easier to maintain. @jglick?
