### PR TITLE
[JENKINS-17526] Relocating Jetty/Java tmpdir for Mac OS X.

### DIFF
--- a/osx/Library/Application Support/Jenkins/jenkins-runner.sh
+++ b/osx/Library/Application Support/Jenkins/jenkins-runner.sh
@@ -22,6 +22,8 @@ permGen=`$defaults permGen` && javaArgs="$javaArgs -XX:MaxPermSize=${permGen}"
 minHeapSize=`$defaults minHeapSize` && javaArgs="$javaArgs -Xms${minHeapSize}"
 heapSize=`$defaults heapSize` && javaArgs="$javaArgs -Xmx${heapSize}"
 
+tmpdir=`$defaults tmpdir` && javaArgs="$javaArgs -Djava.io.tmpdir=${tmpdir}"
+
 home=`$defaults JENKINS_HOME` && export JENKINS_HOME="$home"
 
 add_to_args() {

--- a/osx/scripts/postinstall-launchd-jenkins
+++ b/osx/scripts/postinstall-launchd-jenkins
@@ -61,6 +61,12 @@ else
     defaults write $DEFAULTS_PLIST minPermGen 64m    
 fi
 
+# Set tmpdir
+JENKINS_TMPDIR="$JENKINS_HOMEDIR/tmp"
+defaults write $DEFAULTS_PLIST tmpdir $JENKINS_TMPDIR
+mkdir -p $JENKINS_TMPDIR
+chown jenkins:jenkins $JENKINS_TMPDIR
+
 # Create log directory, which can be written by Jenkins daemon
 mkdir -p /var/log/jenkins
 chown jenkins:jenkins /var/log/jenkins


### PR DESCRIPTION
Fix for https://issues.jenkins-ci.org/browse/JENKINS-17526 on Mac OS X:
1. Added new `tmpdir` defaults for setting Jetty tmpdir.
2. Added tmpdir creation to postinstall.
