### PR TITLE
JENKINS-20974 - RunParameter with filtering enabled should not include builds which are not yet completed

### DIFF
--- a/core/src/main/java/hudson/model/RunParameterDefinition.java
+++ b/core/src/main/java/hudson/model/RunParameterDefinition.java
@@ -122,11 +122,11 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
         // use getFilter() method so we dont have to worry about null filter value.
         switch (getFilter()) {
             case COMPLETED:
-                return getProject().getBuilds().overThresholdOnly(Result.ABORTED);
+                return getProject().getBuilds().overThresholdAndCompletedOnly(Result.ABORTED);
             case SUCCESSFUL:
-                return getProject().getBuilds().overThresholdOnly(Result.UNSTABLE);
+                return getProject().getBuilds().overThresholdAndCompletedOnly(Result.UNSTABLE);
             case STABLE	:
-                return getProject().getBuilds().overThresholdOnly(Result.SUCCESS);
+                return getProject().getBuilds().overThresholdAndCompletedOnly(Result.SUCCESS);
             default:
                 return getProject().getBuilds();
         }

--- a/core/src/main/java/hudson/util/RunList.java
+++ b/core/src/main/java/hudson/util/RunList.java
@@ -259,6 +259,19 @@ public class RunList<R extends Run> extends AbstractList<R> {
     }
 
     /**
+     * Filter the list to completed builds above threshold.
+     * <em>Warning:</em> this method mutates the original list and then returns it.
+     * @since 1.545
+     */
+    public RunList<R> overThresholdAndCompletedOnly(final Result threshold) {
+        return filter(new Predicate<R>() {
+            public boolean apply(R r) {
+                return (!r.isBuilding() && r.getResult() != null && r.getResult().isBetterOrEqualTo(threshold));
+            }
+        });
+    }
+
+    /**
      * Filter the list to builds on a single node only
      * <em>Warning:</em> this method mutates the original list and then returns it.
      */


### PR DESCRIPTION
Hi

I had previously added RunList.overThresholdOnly method in Jenkins 1.517
This is not filtering out builds which are still being built.

Not sure if I just change the otherThresholdOnly method or if I should create a new  otherThresholdAndCompletedOnly method which also checks if the build is not building.

Dont know if anyone else is using the existing method so reluctant to change it.
This pull request creates a new method.

thanks
Geoff
