### PR TITLE
New -connectViaHttpOnly cli client jar command line option.

### DIFF
--- a/cli/src/main/java/hudson/cli/CLIConnectionFactory.java
+++ b/cli/src/main/java/hudson/cli/CLIConnectionFactory.java
@@ -17,6 +17,7 @@ public class CLIConnectionFactory {
     ExecutorService exec;
     String httpsProxyTunnel;
     String authorization;
+    boolean connectViaHttpOnly;
 
     /**
      * Top URL of the Jenkins to connect to.
@@ -54,6 +55,14 @@ public class CLIConnectionFactory {
      */
     public CLIConnectionFactory authorization(String value) {
         this.authorization = value;
+        return this;
+    }
+
+    /**
+     * Tells CLI to connect via http only, skipping connecting via port.
+     */
+    public CLIConnectionFactory connectViaHttpOnly(boolean value) {
+        this.connectViaHttpOnly = value;
         return this;
     }
 

--- a/cli/src/main/java/hudson/cli/Connection.java
+++ b/cli/src/main/java/hudson/cli/Connection.java
@@ -124,6 +124,7 @@ public class Connection {
     public void writeByteArray(byte[] data) throws IOException {
         dout.writeInt(data.length);
         dout.write(data);
+        dout.flush();
     }
 
     public byte[] readByteArray() throws IOException {

--- a/cli/src/main/resources/hudson/cli/client/Messages.properties
+++ b/cli/src/main/resources/hudson/cli/client/Messages.properties
@@ -5,6 +5,7 @@ CLI.Usage=Jenkins CLI\n\
    -i KEY       : SSH private key file used for authentication\n\
    -p HOST:PORT : HTTP proxy host and port for HTTPS proxy tunneling. See http://jenkins-ci.org/https-proxy-tunnel\n\
    -noCertificateCheck : bypass HTTPS certificate check entirely. Use with caution\n\
+   -connectViaHttpOnly : connect via http, without attempting to connect via port\n\
   \n\
   The available commands depend on the server. Run the 'help' command to\n\
   see the list.


### PR DESCRIPTION
That option connects via http, without attempting to connect via port.
I.e. tells CLI to connect via http only, skipping connecting via port.
This trace shows in cli client jar command stdout when option is used:
Skipping connectViaCliPort => connectViaHttp

Also includes dout.flush internally proposed by CloudBees people, in
Connection.writeByteArray

This can be useful for when connecting via port makes cli hang, as per
issues.jenkins-ci.org/browse/JENKINS-20709
-even though it is still hard to reproduce such hanging as we speak.
