### PR TITLE
Fix french translation

### DIFF
--- a/core/src/main/resources/hudson/matrix/MatrixProject/ajaxMatrix_fr.properties
+++ b/core/src/main/resources/hudson/matrix/MatrixProject/ajaxMatrix_fr.properties
@@ -20,4 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Not\ configured=Non configuree
+Not\ configured=Non configur\u00E9e

--- a/core/src/main/resources/hudson/model/AbstractItem/configure-common_fr.properties
+++ b/core/src/main/resources/hudson/model/AbstractItem/configure-common_fr.properties
@@ -21,9 +21,7 @@
 # THE SOFTWARE.
 
 Advanced\ Project\ Options=Options avanc\u00E9es du projet
-Restrict\ where\ this\ project\ can\ be\ run=Restreindre o\u00F9 le projet peut \u00EAtre ex\u00E9cuter
 Tie\ this\ project\ to\ a\ node=Associer ce projet \u00E0 un noeud
 Node=Noeud
-Execute\ concurrent\ builds\ if\ necessary\ =Ex\u00E9cuter les builds en parall\u00E8le si n\u00E9cessaire
 JDK\ to\ be\ used\ for\ this\ project=Le JDK \u00E0 utiliser pour ce projet
 default.value=(Valeur par d\u00E9faut)

--- a/core/src/main/resources/hudson/model/AbstractItem/delete_fr.properties
+++ b/core/src/main/resources/hudson/model/AbstractItem/delete_fr.properties
@@ -22,4 +22,4 @@
 
 Are\ you\ sure\ about\ deleting\ the\ job?=Etes-vous sûr de vouloir supprimer ce job?
 Yes=Oui
-blurb=\u00CAtes vous s\u00FBr de vouloir supprimer ce {0} "{1}"?
+blurb=\u00CAtes-vous s\u00FBr de vouloir supprimer ce {0} "{1}"?

--- a/core/src/main/resources/hudson/model/View/sidepanel_fr.properties
+++ b/core/src/main/resources/hudson/model/View/sidepanel_fr.properties
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-NewJob=Nouvelle {0}
-People=Utilsateurs
+NewJob=Nouveau {0}
+People=Utilisateurs
 Build\ History=Historique des constructions
 Edit\ View=\u00C9diter cette vue
 Delete\ View=Supprimer cette vue

--- a/core/src/main/resources/lib/hudson/project/config-assignedLabel_fr.properties
+++ b/core/src/main/resources/lib/hudson/project/config-assignedLabel_fr.properties
@@ -1,6 +1,6 @@
 # The MIT License
 # 
-# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Eric Lefevre-Ardant
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Simon Wiest
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,17 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-HTTP\ Proxy\ Configuration=Configuration du proxy HTTP
-Submit=Soumettre
-Upload\ Plugin=Soumettre un plugin
-File=Fichier
-Update\ Site=Site de mise \u00E0 jour
-Upload=Soumettre
-lastUpdated=Derni\u00E8re mise \u00E0 jour\u00A0: il y a {0}
-Check\ now=V\u00E9rifier maintenant
-uploadtext=Vous pouvez t\u00E9l\u00E9verser un fichier .hpi pour installer un plugin ext\u00E9rieur au d\u00E9p\u00F4t centralis\u00E9 de plugin.
-Proxy\ Needs\ Authorization=Le proxy n\u00E9cessite une authentification
-Server=Serveur
-User\ name=Nom d''utilisateur
-No\ Proxy\ Host=Pas de proxy pour
-Password=Mot de passe
+Restrict\ where\ this\ project\ can\ be\ run=Restreindre o\u00F9 le projet peut \u00EAtre ex\u00E9cut\u00E9
+Label\ Expression=Expression


### PR DESCRIPTION
This a fix for french translation. It reverts some evident errors (mostly typos) in community-contributed localization (see comments from several users for commit https://github.com/jenkinsci/jenkins/commit/9c7f83659dcf506e27ddbfb72e354f1f96e6bce0), and fixes some character encoding
