### PR TITLE
add fileEncoding config option to OS X runner

### DIFF
--- a/osx/Library/Application Support/Jenkins/jenkins-runner.sh
+++ b/osx/Library/Application Support/Jenkins/jenkins-runner.sh
@@ -22,6 +22,8 @@ permGen=`$defaults permGen` && javaArgs="$javaArgs -XX:MaxPermSize=${permGen}"
 minHeapSize=`$defaults minHeapSize` && javaArgs="$javaArgs -Xms${minHeapSize}"
 heapSize=`$defaults heapSize` && javaArgs="$javaArgs -Xmx${heapSize}"
 
+fileEncoding=`$defaults fileEncoding` && javaArgs="$javaArgs -Dfile.encoding=$fileEncoding"
+
 home=`$defaults JENKINS_HOME` && export JENKINS_HOME="$home"
 
 add_to_args() {


### PR DESCRIPTION
When running Jenkins under OS X in Japanese (or also in other non-eurpoean languages I assume), non-ASCII characters in Jenkins console output becomes question ("?") sign.
By applying this patch, users can now easily configure `file.encoding` JVM parameter for Jenkins by running:

```
sudo defaults write /Library/Preferences/org.jenkins-ci fileEncoding UTF-8
```

... instead of doing messy tweaks like [using JAVA_TOOL_OPTIONS](http://blog.lidalia.org.uk/2011/04/setting-default-java-file-encoding-to.html) or [modifying system global launchd.conf file](http://stackoverflow.com/questions/135688/setting-environment-variables-in-os-x/588442#588442), to make console messages correctly displayed.
