### PR TITLE
set file.encoding=UTF-8 as default in OS X runner

### DIFF
--- a/osx/Library/Application Support/Jenkins/jenkins-runner.sh
+++ b/osx/Library/Application Support/Jenkins/jenkins-runner.sh
@@ -14,7 +14,7 @@ defaults="defaults read /Library/Preferences/org.jenkins-ci"
 
 war=`$defaults war` || war="/Applications/Jenkins/jenkins.war"
 
-javaArgs=""
+javaArgs="-Dfile.encoding=UTF-8"
 
 minPermGen=`$defaults minPermGen` && javaArgs="$javaArgs -XX:PermSize=${minPermGen}"
 permGen=`$defaults permGen` && javaArgs="$javaArgs -XX:MaxPermSize=${permGen}"


### PR DESCRIPTION
When running Jenkins under OS X in Japanese (or also in other non-eurpoean languages I assume), non-ASCII characters in Jenkins console output becomes question ("?") sign.  To avoid the problem you'll need messy tweaks like [using JAVA_TOOL_OPTIONS](http://blog.lidalia.org.uk/2011/04/setting-default-java-file-encoding-to.html) or [modifying system global launchd.conf file](http://stackoverflow.com/questions/135688/setting-environment-variables-in-os-x/588442#588442).

By applying this patch, Jenkins will always be launched with `-Dfile.encoding=UTF-8`, so console messages are correctly displayed in all languages.

This pull-reqest is related to #1067.
