### PR TITLE
Add optional version arg to build.sh usage message

### DIFF
--- a/opensuse/build.sh
+++ b/opensuse/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 if [ -z "$1" ]; then
-  echo "Usage: build.sh path/to/jenkins.war"
+  echo "Usage: build.sh path/to/jenkins.war [version]"
   exit 1
 fi
 

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 if [ -z "$1" ]; then
-  echo "Usage: build.sh path/to/jenkins.war"
+  echo "Usage: build.sh path/to/jenkins.war [version]"
   exit 1
 fi
 


### PR DESCRIPTION
Just a small tweak to the build.sh usage message - I just happened to notice it doesn't include the optional version argument that can be passed, so I thought I'd update it.

I'm assuming it's just an oversight that this is missing, rather than by design - but perhaps someone knows better?

Rowan
