### PR TITLE
[NO_UNIT_TEST] [FIXED JENKINS-18678] - Update builds location in RunMap after the job's renaming

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1676,6 +1676,13 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         updateTransientActions();
     }
 
+    @Override
+    public void renameTo(String newName) throws IOException {
+        super.renameTo(newName);
+        // Update locations inside builds cache
+        builds.updateBaseDir(getBuildDir(), false);
+    }
+
     protected final synchronized <T extends Describable<T>>
     void removeFromList(Descriptor<T> item, List<T> collection) throws IOException {
         final Iterator<T> iCollection = collection.iterator();
@@ -2119,6 +2126,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         makeDisabled(false);
         return new HttpRedirect(".");
     }
+    
 
     /**
      * RSS feed for changes in this project.

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -211,6 +211,17 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
     }
 
     /**
+     * Updates base directory location after directory changes.
+     * This method should be used on jobs renaming, etc.
+     * @param dir Directory location
+     * @param reloadBuilds Purges cache after the directory update
+     */
+    public final void updateBaseDir(File dir, boolean reloadBuilds) {
+        this.dir = dir;
+        purgeCache();
+    }
+    
+    /**
      * Let go of all the loaded references.
      *
      * This is a bit more sophisticated version of forcing GC.


### PR DESCRIPTION
This change resolves the issue with missing builds after the jobs renaming and further cleanup of cache.
Finally, the cache's directory location will be updated after the each job renaming.
https://issues.jenkins-ci.org/browse/JENKINS-18678
