### PR TITLE
[JENKINS-20772] Only show error message in dialog

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
@@ -41,6 +41,7 @@ THE SOFTWARE.
       <h1 style="text-align: center">
         <img src="${imagesURL}/rage.png" height="179" width="154"/> <span style="font-size:50px"><st:nbsp/>${%Oops!}</span>
       </h1>
+      <div id="error-description">
       <p>
         ${%problemHappened}
         ${%checkJIRA}
@@ -51,6 +52,7 @@ THE SOFTWARE.
       </p>
       <h2>${%Stack trace}</h2>
       <pre style="margin:2em; clear:both">${h.printThrowable(request.getAttribute('javax.servlet.error.exception'))}</pre>
+      </div>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/lib/form/apply/apply.js
+++ b/core/src/main/resources/lib/form/apply/apply.js
@@ -12,7 +12,7 @@ Behaviour.specify("INPUT.apply-button", 'apply', 0, function (e) {
         });
 
         responseDialog.setHeader("Error");
-        responseDialog.setBody("<div id='"+containerId+"'></iframe>");
+        responseDialog.setBody("<div id='"+containerId+"'></div>");
         responseDialog.render(document.body);
         var target; // iframe
 
@@ -42,7 +42,12 @@ Behaviour.specify("INPUT.apply-button", 'apply', 0, function (e) {
                 } else {
                     // otherwise this is possibly an error from the server, so we need to render the whole content.
                     var doc = target.contentDocument || target.contentWindow.document;
-                    $(containerId).appendChild(doc.getElementsByTagName('body')[0]);
+                    var error = doc.getElementById('error-description');
+                    if (!error) {
+                        // fallback if it's not a regular error dialog from oops.jelly: use the entire body
+                        error = doc.getElementsByTagName('body')[0];
+                    }
+                    $(containerId).appendChild(error);
                     var r = YAHOO.util.Dom.getClientRegion();
                     responseDialog.cfg.setProperty("width",r.width*3/4+"px");
                     responseDialog.cfg.setProperty("height",r.height*3/4+"px");


### PR DESCRIPTION
This change removes the superfluous UI elements around the error
message if possible. Otherwise, fall back to existing behavior
of adding entire page to iframe.

Improves upon 0e8195c.
