### PR TITLE
[JENKINS-20772] Fix scrolling

### DIFF
--- a/core/src/main/resources/lib/form/apply/apply.js
+++ b/core/src/main/resources/lib/form/apply/apply.js
@@ -49,8 +49,18 @@ Behaviour.specify("INPUT.apply-button", 'apply', 0, function (e) {
                     }
                     $(containerId).appendChild(error);
                     var r = YAHOO.util.Dom.getClientRegion();
-                    responseDialog.cfg.setProperty("width",r.width*3/4+"px");
-                    responseDialog.cfg.setProperty("height",r.height*3/4+"px");
+
+                    var contentHeight = r.height*3/4;
+                    var dialogStyleHeight = contentHeight+40;
+                    var contentWidth = r.width*3/4;
+                    var dialogStyleWidth = contentWidth+20;
+
+                    $(containerId).style.height = contentHeight+"px";
+                    $(containerId).style.width = contentWidth+"px";
+                    $(containerId).style.overflow = "scroll";
+
+                    responseDialog.cfg.setProperty("width", dialogStyleWidth+"px");
+                    responseDialog.cfg.setProperty("height", dialogStyleHeight+"px");
                     responseDialog.center();
                     responseDialog.show();
                 }


### PR DESCRIPTION
Define a size for the container div that's slightly smaller than the dialog. This way, its new `overflow:scroll` style will be considered, not some ancestor YUI container's `overflow:hidden`.

Tested in Firefox 26 and Safari 6.1 on OS X 10.8.6.

To facilitate manual visual inspection of element sizes, add e.g. the line `$(containerId).style.backgroundColor = "white";` to make the container div stand out.
