### PR TITLE
CommandInterpreter enhancement : option in the GUI to mark the build as unstable instead of failed ...

### DIFF
--- a/core/src/main/java/hudson/tasks/BatchFile.java
+++ b/core/src/main/java/hudson/tasks/BatchFile.java
@@ -36,9 +36,13 @@ import org.kohsuke.stapler.StaplerRequest;
  * @author Kohsuke Kawaguchi
  */
 public class BatchFile extends CommandInterpreter {
-    @DataBoundConstructor
     public BatchFile(String command) {
-        super(command);
+        this(command, false);
+    }
+
+    @DataBoundConstructor
+    public BatchFile(String command, boolean markBuildAsUnstable) {
+        super(command, markBuildAsUnstable);
     }
 
     public String[] buildCommandLine(FilePath script) {

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -48,9 +48,13 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 public class Shell extends CommandInterpreter {
-    @DataBoundConstructor
     public Shell(String command) {
-        super(fixCrLf(command));
+        this(command, false);
+    }
+
+    @DataBoundConstructor
+    public Shell(String command, boolean markBuildAsUnstable) {
+        super(fixCrLf(command), markBuildAsUnstable);
     }
 
     /**

--- a/core/src/main/resources/hudson/tasks/BatchFile/config.jelly
+++ b/core/src/main/resources/hudson/tasks/BatchFile/config.jelly
@@ -28,4 +28,8 @@ THE SOFTWARE.
            description="${%description(rootURL)}">
     <f:textarea name="command" value="${instance.command}" class="fixed-width" />
   </f:entry>
+  <f:entry title="">
+    <f:checkbox name="markBuildAsUnstable" checked="${instance.markBuildAsUnstable}"
+            title="${%markAsUnstableTitle}"/>
+  </f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/tasks/BatchFile/config.properties
+++ b/core/src/main/resources/hudson/tasks/BatchFile/config.properties
@@ -21,3 +21,4 @@
 # THE SOFTWARE.
 
 description=See <a href="{0}/env-vars.html" target=_new>the list of available environment variables</a>
+markAsUnstableTitle=If the command fails, mark the build as unstable instead of failed

--- a/core/src/main/resources/hudson/tasks/BatchFile/config_fr.properties
+++ b/core/src/main/resources/hudson/tasks/BatchFile/config_fr.properties
@@ -22,3 +22,4 @@
 
 Command=Commande
 description=Voir <a href="{0}/env-vars.html" target=_new>la liste des variables d''environnement disponibles</a>
+markAsUnstableTitle=Marquer la construction comme instable et non échouée si la commande échoue

--- a/core/src/main/resources/hudson/tasks/Shell/config.groovy
+++ b/core/src/main/resources/hudson/tasks/Shell/config.groovy
@@ -27,3 +27,8 @@ f=namespace(lib.FormTagLib)
 f.entry(title:_("Command"),description:_("description",rootURL)) {
     f.textarea(name:"command",value:instance?.command,class:"fixed-width")
 }
+
+f.entry(title:"") {
+    f.checkbox(name:"markBuildAsUnstable",value:instance?.markBuildAsUnstable,
+            title:_("markAsUnstableTitle"),class:"fixed-width")
+}

--- a/core/src/main/resources/hudson/tasks/Shell/config.properties
+++ b/core/src/main/resources/hudson/tasks/Shell/config.properties
@@ -21,3 +21,4 @@
 # THE SOFTWARE.
 
 description=See <a href="{0}/env-vars.html" target=_new>the list of available environment variables</a>
+markAsUnstableTitle=If the command fails, mark the build as unstable instead of failed

--- a/core/src/main/resources/hudson/tasks/Shell/config_fr.properties
+++ b/core/src/main/resources/hudson/tasks/Shell/config_fr.properties
@@ -22,3 +22,4 @@
 
 Command=Commande
 description=Voir <a href="{0}/env-vars.html" target=_new>la liste des variables d''environnement disponibles</a>
+markAsUnstableTitle=Marquer la construction comme instable et non échouée si la commande échoue

--- a/test/src/test/java/hudson/tasks/ShellTest.java
+++ b/test/src/test/java/hudson/tasks/ShellTest.java
@@ -1,13 +1,18 @@
 package hudson.tasks;
 
+import static org.junit.Assert.*;
 import hudson.Functions;
 import hudson.Launcher.ProcStarter;
 import hudson.Proc;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+
 import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.FakeLauncher;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.PretendSlave;
 
 import java.io.File;
@@ -18,14 +23,17 @@ import java.util.List;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class ShellTest extends HudsonTestCase {
-    public void testBasic() throws Exception {
+public class ShellTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Test public void testBasic() throws Exception {
         // If we're on Windows, don't bother doing this.
         if (Functions.isWindows())
             return;
 
         // TODO: define a FakeLauncher implementation with easymock so that this kind of assertions can be simplified.
-        PretendSlave s = createPretendSlave(new FakeLauncher() {
+        PretendSlave s = j.createPretendSlave(new FakeLauncher() {
             public Proc onLaunch(ProcStarter p) throws IOException {
                 // test the command line argument.
                 List<String> cmds = p.cmds();
@@ -35,19 +43,77 @@ public class ShellTest extends HudsonTestCase {
 
                 // fake the execution
                 PrintStream ps = new PrintStream(p.stdout());
-                ps.println("Hudson was here");
+                ps.println("Jenkins was here");
                 ps.close();
 
                 return new FinishedProc(0);
             }
         });
-        FreeStyleProject p = createFreeStyleProject();
+        FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildersList().add(new Shell("echo abc"));
         p.setAssignedNode(s);
-        
-        FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+
+        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
 
         assertEquals(1,s.numLaunch);
-        assertTrue(FileUtils.readFileToString(b.getLogFile()).contains("Hudson was here"));
+        assertTrue(FileUtils.readFileToString(b.getLogFile()).contains("Jenkins was here"));
+    }
+
+    @Test public void testBuildFailsIfCommandFails() throws Exception {
+        // If we're on Windows, don't bother doing this.
+        if (Functions.isWindows())
+            return;
+
+        // TODO: define a FakeLauncher implementation with easymock so that this kind of assertions can be simplified.
+        PretendSlave s = j.createPretendSlave(new FakeLauncher() {
+            public Proc onLaunch(ProcStarter p) throws IOException {
+                // test the command line argument.
+                List<String> cmds = p.cmds();
+                assertEquals("/bin/sh",cmds.get(0));
+                assertEquals("-xe",cmds.get(1));
+                assertTrue(new File(cmds.get(2)).exists());
+
+                // fake the execution
+                PrintStream ps = new PrintStream(p.stdout());
+                ps.println("Jenkins was here");
+                ps.close();
+
+                return new FinishedProc(1);
+            }
+        });
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new Shell("echo abc"));
+        p.setAssignedNode(s);
+
+        j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+    }
+
+    @Test public void testBuildUnstableIfCommandFailsAndMarkAsUnstableOptionSelected() throws Exception {
+        // If we're on Windows, don't bother doing this.
+        if (Functions.isWindows())
+            return;
+
+        // TODO: define a FakeLauncher implementation with easymock so that this kind of assertions can be simplified.
+        PretendSlave s = j.createPretendSlave(new FakeLauncher() {
+            public Proc onLaunch(ProcStarter p) throws IOException {
+                // test the command line argument.
+                List<String> cmds = p.cmds();
+                assertEquals("/bin/sh",cmds.get(0));
+                assertEquals("-xe",cmds.get(1));
+                assertTrue(new File(cmds.get(2)).exists());
+
+                // fake the execution
+                PrintStream ps = new PrintStream(p.stdout());
+                ps.println("Jenkins was here");
+                ps.close();
+
+                return new FinishedProc(1);
+            }
+        });
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new Shell("echo abc", true));
+        p.setAssignedNode(s);
+
+        j.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
     }
 }


### PR DESCRIPTION
... if the runned command returns anything but 0

Could be a fix for JENKINS-18676 : Allow CommandInterpreters to set
build status based on script result
