### PR TITLE
[READY][FIXED JENKINS-21190 and JENKINS-21191]- Views can disable automatic refreshes on their pages

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -374,6 +374,15 @@ public abstract class View extends AbstractModelObject implements AccessControll
     }
     
     /**
+     * Enables or disables automatic refreshes of the view.
+     * By default, automatic refreshes are enabled.
+     * @since TODO: define a version
+     */
+    public boolean isAutomaticRefreshEnabled() {
+        return true;
+    }
+    
+    /**
      * If true, only show relevant executors
      */
     public boolean isFilterExecutors() {

--- a/core/src/main/resources/hudson/model/View/index.jelly
+++ b/core/src/main/resources/hudson/model/View/index.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <l:layout title="${it.class.name=='hudson.model.AllView' ? '%Dashboard' : it.viewName}${not empty it.ownerItemGroup.fullDisplayName?' ['+it.ownerItemGroup.fullDisplayName+']':''}">
+    <l:layout title="${it.class.name=='hudson.model.AllView' ? '%Dashboard' : it.viewName}${not empty it.ownerItemGroup.fullDisplayName?' ['+it.ownerItemGroup.fullDisplayName+']':''}" norefresh="${!it.automaticRefreshEnabled}">
       <j:set var="view" value="${it}"/> <!-- expose view to the scripts we include from owner -->
         <st:include page="sidepanel.jelly" />
         <l:main-panel>

--- a/core/src/main/resources/lib/layout/breadcrumbBar.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumbBar.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
       <div class="top-sticker noedge">
         <div class="top-sticker-inner">
           <div id="right-top-nav">
-            <j:if test="${norefresh==null}">
+            <j:if test="${norefresh==null or norefresh==false}">
               <div id="right-top-nav">
                 <div class="smallfont">
                   <j:choose>

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
       Title of the HTML page. Rendered into &lt;title> tag.
     </st:attribute>
     <st:attribute name="norefresh">
-      If non-null, auto refresh is disabled on this page.
+      If non-null and not "false", auto refresh is disabled on this page.
       This is necessary for pages that include forms.
     </st:attribute>
     <st:attribute name="css" deprecated="true">
@@ -67,8 +67,7 @@ ${h.initPageVariables(context)}
   which I suspect can end up creating sessions for wrong resource types (such as static resources.)
 -->
 <j:set var="_" value="${request.getSession()}"/>
-<j:set var="_" value="${h.configureAutoRefresh(request, response, attrs.norefresh!=null)}"/>
-
+<j:set var="_" value="${h.configureAutoRefresh(request, response, attrs.norefresh!=null and !attrs.norefresh.equals(false))}"/>
   <j:if test="${request.servletPath=='/' || request.servletPath==''}">
     ${h.advertiseHeaders(response)}
     <j:forEach var="pd" items="${h.pageDecorators}">


### PR DESCRIPTION
I've added a new extension method to View, which disables automatic refreshes inside its layout.
Such feature would be very useful for views with static contents.

As example, such feature allows to avoid automatic refreshes inside [Dynamic Search View Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Dynamic+Search+View+Plugin).
