### PR TITLE
Fix failed to start when removed

### DIFF
--- a/debian/debian/jenkins.init
+++ b/debian/debian/jenkins.init
@@ -28,10 +28,16 @@ DAEMON_ARGS="--name=$NAME --inherit --env=JENKINS_HOME=$JENKINS_HOME --output=$J
 SU=/bin/su
 
 # Exit if the package is not installed
-[ -x "$DAEMON" ] || (echo "daemon package not installed" && exit 0)
+if [ ! -x "$DAEMON" ]; then
+    echo "daemon package not installed" >&2
+    exit 0
+fi
 
 # Exit if not supposed to run standalone
-[ "$RUN_STANDALONE" = "false" ] && echo "Not configured to run standalone" && exit 0
+if [ "$RUN_STANDALONE" = "false" ]; then
+    echo "Not configured to run standalone" >&2
+    exit 0
+fi
 
 # load environments
 if [ -r /etc/default/locale ]; then


### PR DESCRIPTION
When jenkins and daemon are removed and not purged,
failed to start.
Because `(echo && exit 0)` exits sub-shell only.
