### PR TITLE
Use -Djava.awt.headless=true on Debian service

### DIFF
--- a/debian/debian/jenkins.default
+++ b/debian/debian/jenkins.default
@@ -7,6 +7,7 @@ NAME=jenkins
 JAVA=/usr/bin/java
 
 # arguments to pass to java
+JAVA_ARGS="-Djava.awt.headless=true"  # Allow graphs etc. to work even when an X server is present
 #JAVA_ARGS="-Xmx256m"
 #JAVA_ARGS="-Djava.net.preferIPv4Stack=true" # make jenkins listen on IPv4 address
 


### PR DESCRIPTION
I installed the Jenkins Debian package, and later installed an XServer (XVFB).  The graphs of test results etc. were replaced by an image suggesting that I add this flag to the JVM commandline.  I don't see any reason why this shouldn't always be present on Debian systems.
