### PR TITLE
[FIXED JENKINS-20345] file descriptor leak in zip file download

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -26,6 +26,7 @@ package hudson.model;
 import hudson.FilePath;
 import hudson.Util;
 import jenkins.model.Jenkins;
+import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.HttpResponse;
@@ -351,7 +352,12 @@ public final class DirectoryBrowserSupport implements HttpResponse {
             VirtualFile f = dir.child(n);
             e.setTime(f.lastModified());
             zos.putNextEntry(e);
-            Util.copyStream(f.open(), zos);
+            InputStream in = f.open();
+            try {
+                Util.copyStream(in, zos);
+            } finally {
+                IOUtils.closeQuietly(in);
+            }
             zos.closeEntry();
         }
         zos.close();


### PR DESCRIPTION
When downloading a zip file with all of the artifacts, file descriptors
would be opened and never closed. This resulted in many leaked file
descriptors which would only be cleaned up the next time the garbage
collector was run.

For directories with a large number of files, the zip file would be
corrupted because an exception was thrown during the process of creating
the zip file when the process ran out of file descriptors. Jenkins was
then left in a very brittle state as random threads wouldn't be able to
open files or sockets anymore until the garbage collector was run.
