### PR TITLE
[FIXED JENKINS-21386] Allow more specific loggers to reduce log level

### DIFF
--- a/core/src/test/java/hudson/logging/LogRecorderTest.java
+++ b/core/src/test/java/hudson/logging/LogRecorderTest.java
@@ -42,10 +42,72 @@ public class LogRecorderTest {
         assertTrue(includes("", "hudson.model.Hudson"));
     }
 
-    private static boolean includes(String target, String logger) {
-        LogRecord r = new LogRecord(Level.INFO, "whatever");
+    @Test public void targetMatches() {
+        assertTrue(matches("hudson", "hudson"));
+        assertFalse(matches("hudson", "hudson", Level.FINE));
+        assertNull(matches("hudson", "hudsone"));
+        assertNull(matches("hudson", "hudso"));
+        assertTrue(matches("hudson", "hudson.model.Hudson"));
+        assertFalse(matches("hudson", "hudson.model.Hudson", Level.FINE));
+        assertNull(matches("hudson", "jenkins.model.Jenkins"));
+        assertTrue(matches("", "hudson.model.Hudson"));
+        assertFalse(matches("", "hudson.model.Hudson", Level.FINE));
+    }
+
+    @Test public void testSpecificExclusion() {
+        LogRecorder lr = new LogRecorder("foo");
+
+        LogRecorder.Target targetLevel0 = new LogRecorder.Target("", Level.FINE);
+        LogRecorder.Target targetLevel1 = new LogRecorder.Target("foo", Level.INFO);
+        LogRecorder.Target targetLevel2 = new LogRecorder.Target("foo.bar", Level.SEVERE);
+
+        lr.targets.add(targetLevel1);
+        lr.targets.add(targetLevel2);
+        lr.targets.add(targetLevel0);
+
+        assertEquals(lr.orderedTargets()[0], targetLevel2);
+        assertEquals(lr.orderedTargets()[1], targetLevel1);
+        assertEquals(lr.orderedTargets()[2], targetLevel0);
+
+        LogRecord r1 = createLogRecord("baz", Level.INFO, "visible");
+        LogRecord r2 = createLogRecord("foo", Level.FINE, "hidden");
+        LogRecord r3 = createLogRecord("foo.bar", Level.INFO, "hidden");
+        LogRecord r4 = createLogRecord("foo.bar.baz", Level.INFO, "hidden");
+        LogRecord r5 = createLogRecord("foo.bar.baz", Level.SEVERE, "visible");
+        LogRecord r6 = createLogRecord("foo", Level.INFO, "visible");
+        lr.handler.publish(r1);
+        lr.handler.publish(r2);
+        lr.handler.publish(r3);
+        lr.handler.publish(r4);
+        lr.handler.publish(r5);
+        lr.handler.publish(r6);
+
+        assertTrue(lr.handler.getView().contains(r1));
+        assertFalse(lr.handler.getView().contains(r2));
+        assertFalse(lr.handler.getView().contains(r3));
+        assertFalse(lr.handler.getView().contains(r4));
+        assertTrue(lr.handler.getView().contains(r5));
+        assertTrue(lr.handler.getView().contains(r6));
+    }
+
+    private static LogRecord createLogRecord(String logger, Level level, String message) {
+        LogRecord r = new LogRecord(level, message);
         r.setLoggerName(logger);
+        return r;
+    }
+
+    private static boolean includes(String target, String logger) {
+        LogRecord r = createLogRecord(logger, Level.INFO, "whatever");
         return new LogRecorder.Target(target, Level.INFO).includes(r);
+    }
+
+    private static Boolean matches(String target, String logger) {
+        return matches(target, logger, Level.INFO);
+    }
+
+    private static Boolean matches(String target, String logger, Level loggerLevel) {
+        LogRecord r = createLogRecord(logger, loggerLevel, "whatever");
+        return new LogRecorder.Target(target, Level.INFO).matches(r);
     }
 
 }

--- a/war/src/main/webapp/help/LogRecorder/logger.html
+++ b/war/src/main/webapp/help/LogRecorder/logger.html
@@ -3,11 +3,11 @@
     this log recorder will collect. For example, if you specify
     <tt>hudson.model.Hudson</tt> and <tt>info</tt>, any logs recorded
     for <tt>hudson.model.Hudson</tt> or its descendants with the log level
-    info or above will show up in this log recorder.
+    info or above will show up in this log recorder, unless a more specific
+    logger with higher log level is also specific.
 
     <p>
-    If you have multiple entries, a log entry that matches any of them
-    will be collected.
+    If you have multiple entries, a log entry will the most specific one will be collected.
 
     <p>
     Also see <a href="http://wiki.jenkins-ci.org/display/JENKINS/Logger+Configuration">


### PR DESCRIPTION
This change uses the most specific log recorder (based on name) to determine whether a log message should be added.

If both `com` (at `INFO`) and `com.example` (at `WARNING`) are defined for a specific log recorder, a log message in logger `com.example.Foo` will only be logged of it's `WARNING` or `SEVERE`, as `com.example` is more specific than `com`.

Might reduce existing log recorders' effective logging output if they have a currently useless configuration of specific loggers having a more relaxed log level than a less specific logger.

This PR is one of two proposed solutions to [JENKINS-21386](https://issues.jenkins-ci.org/browse/JENKINS-21386), the other being #1091.
