### PR TITLE
[FIXED JENKINS-21386] Allow reordering loggers, use first with matching ...

### DIFF
--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -84,14 +84,23 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
 
     public final CopyOnWriteList<Target> targets = new CopyOnWriteList<Target>();
 
-    private transient /*almost final*/ RingBufferLogHandler handler = new RingBufferLogHandler() {
+    @Restricted(NoExternalUse.class)
+    transient /*almost final*/ RingBufferLogHandler handler = new RingBufferLogHandler() {
         @Override
         public void publish(LogRecord record) {
             for (Target t : targets) {
-                if(t.includes(record)) {
-                    super.publish(record);
-                    return;
+                Boolean match = t.matches(record);
+                if (match == null) {
+                    // domain does not match, so continue looking
+                    continue;
                 }
+
+                if (match.booleanValue()) {
+                    // first logger in configured order that matches name
+                    // has sufficient log level
+                    super.publish(record);
+                }
+                return;
             }
         }
     };
@@ -123,6 +132,11 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
             return Level.parse(String.valueOf(level));
         }
 
+        public String getName() {
+            return name;
+        }
+
+        @Deprecated
         public boolean includes(LogRecord r) {
             if(r.getLevel().intValue() < level)
                 return false;   // below the threshold
@@ -134,6 +148,21 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
                 return false;   // not within this logger
             String rest = logName.substring(name.length());
             return rest.startsWith(".") || rest.length()==0;
+        }
+
+        public Boolean matches(LogRecord r) {
+            boolean levelSufficient = r.getLevel().intValue() >= level;
+            if (name.length() == 0) {
+                return Boolean.valueOf(levelSufficient); // include if level matches
+            }
+            String logName = r.getLoggerName();
+            if(logName==null || !logName.startsWith(name))
+                return null; // not in the domain of this logger
+            String rest = logName.substring(name.length());
+            if (rest.startsWith(".") || rest.length()==0) {
+                return Boolean.valueOf(levelSufficient); // include if level matches
+            }
+            return null;
         }
 
         public Logger getLogger() {

--- a/core/src/main/resources/hudson/logging/LogRecorder/configure.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/configure.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
                description="${%List of loggers and the log levels to record}"
                help="/help/LogRecorder/logger.html">
         <j:set var="instance" value="${null}" />
-        <f:repeatable var="instance" items="${it.targets}" name="targets">
+        <f:repeatable var="instance" items="${it.targets}" name="targets" header="Logger">
           <table width="100%">
             <tr>
               <th style="white-space:nowrap;">


### PR DESCRIPTION
...name.

This change uses the top-most matching log recorder (based on name) to determine whether a log message should be added.

If both `com` (at `INFO`) and `com.example` (at `WARNING`) are defined for a specific log recorder, a log message in logger `com.example.Foo` will only be logged if it's `WARNING` or `SEVERE`, or the `com` logger is above the `com.example` logger in the loggers list.

This change will definitely impact existing configurations that start out with fairly restrictive log levels on e.g. `com`, to be more verbose with specific loggers later.

This PR is one of two proposed solutions to [JENKINS-21386](https://issues.jenkins-ci.org/browse/JENKINS-21386), the other being #1090.
