### PR TITLE
[FIXED JENKINS-21394] Avoid irrelevant job queing while node is offline

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1656,19 +1656,9 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         FilePath ws = build.getWorkspace();
         Label label = getAssignedLabel();
 
-        if (isAllSuitableNodesOffline(build)) {
-            //We need to ask jenkins about clouds. Label can be null. 
-            if (!Jenkins.getInstance().clouds.isEmpty()) {
-                // An Ondemand slave can do this, doesnt matter if online now
-                for (  Cloud c : Jenkins.getInstance().clouds) {
-                    if(c.canProvision(label)) {
-                        // OnDemand slave will be provisioned
-                        return WorkspaceOfflineReason.use_ondemand_slave;
-                    }
-                }
-            }
-            
-            return WorkspaceOfflineReason.all_suitable_nodes_are_offline;
+        if (isAllSuitableNodesOffline(build)) {            
+            Collection<Cloud> applicableClouds = label == null ? Jenkins.getInstance().clouds : label.getClouds();
+            return applicableClouds.isEmpty() ? WorkspaceOfflineReason.all_suitable_nodes_are_offline : WorkspaceOfflineReason.use_ondemand_slave;            
         }
 
         if (ws==null || !ws.exists()) {


### PR DESCRIPTION
This Fixes issue 21394.

For a job that:
polls SCM and 
the SCM requires a workspace for polling

When a workspace is not available, Jenkins will submit a build  to create a workspace so the polling can run, and when the submitted build runs, it will return "Nothing To Do" - a grey build, because most of the times there actually was no change in SCM, which means that the build essentially was unnessecary.

The obvious reason for non available workspace is that the workspace does not exist at all, job never ran or workspaces was deleted. The other reason would be that the slave, which has an existing, valid workspace, is offline when polling time occurs. 

My change evaluates if all the slaves or nodes that is allowed to run this job are offline.
If any acceptable node is online but does not have a workspace, the job is submitted, but if no acceptable nodes are online, I will not submit the build, but wait for a suitable node to come online. 
