### PR TITLE
Add option to require delete permission for disabling Keep Forever

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2086,7 +2086,11 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     }
 
     public void keepLog(boolean newValue) throws IOException {
-        checkPermission(UPDATE);
+        if (newValue || !getParent().isRequireDeletePermissionToDisableKeepLog()) {
+            checkPermission(UPDATE);
+        } else {
+            checkPermission(DELETE);
+        }
         keepLog = newValue;
         save();
     }

--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -51,6 +51,10 @@ THE SOFTWARE.
             help="/help/project-config/log-rotation.html"
             title="${%Discard Old Builds}" checked="${it.buildDiscarder!=null}" inline="true">
             <f:dropdownDescriptorSelector field="buildDiscarder" title="${%Strategy}"/>
+            <f:entry title="${%Disabling ‚Keep Forever’ requires delete permission}"
+                description="${%By default, users with permission to update builds can disable Keep Forever for builds. This can effectively cause build deletion. Check this option to require permission to delete builds instead.}" field="requireDeletePermissionToDisableKeepLog">
+              <f:checkbox id="requireDeletePermissionToDisableKeepLog" />
+            </f:entry>
           </f:optionalBlock>
         </j:if>
 

--- a/core/src/main/resources/hudson/model/Run/logKeep.jelly
+++ b/core/src/main/resources/hudson/model/Run/logKeep.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:if test="${it.parent.logRotator!=null and it.canToggleLogKeep()}">
     <form method="get" action="toggleLogKeep" style="margin-top:1em">
-      <j:if test="${it.keepLog}">
+      <j:if test="${it.keepLog and (h.hasPermission(it,it.DELETE) or not it.getParent().isRequireDeletePermissionToDisableKeepLog())}">
         <f:submit value="${%Don't keep this build forever}"  />
       </j:if>
       <j:if test="${!it.keepLog}">


### PR DESCRIPTION
With this option checked, users with Run.UPDATE will be able to mark
builds as Keep Forever, but will not be able to remove that status
to prevent these users from effectively deleting builds due to log
rotation.

Basically JENKINS-16417, just not as ambitious.
