### PR TITLE
Minor changes to computers table status row

### DIFF
--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -188,7 +188,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
             return Messages.AbstractNodeMonitorDescriptor_NoDataYet();
 //        return Messages.AbstractNodeMonitorDescriptor_DataObtainedSometimeAgo(
 //                Util.getTimeSpanString(System.currentTimeMillis()-record.timestamp));
-        return Util.getTimeSpanString(System.currentTimeMillis()-record.timestamp);
+        return Util.getPastTimeString(System.currentTimeMillis()-record.timestamp);
     }
 
     /**

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -52,19 +52,6 @@ THE SOFTWARE.
         <th />
       </tr>
 
-      <tr class="sorttop">
-        <td/>
-        <td height="32">${%Data obtained}</td>
-        <j:forEach var="m" items="${monitors}">
-          <j:if test="${m.columnCaption!=null}">
-            <td align="right">
-              ${m.descriptor.timestampString}
-            </td>
-          </j:if>
-        </j:forEach>
-        <td />
-      </tr>
-
       <j:forEach var="c" items="${it._all}">
         <tr id="node_${c.name}">
           <td width="32" data="${c.icon}">
@@ -94,6 +81,20 @@ THE SOFTWARE.
       <j:forEach var="cloud" items="${app.clouds}">
         <st:include it="${cloud}" page="computerSet.jelly" optional="true" />
       </j:forEach>
+
+      <tr class="sortbottom">
+        <th />
+        <th>${%Data obtained}</th>
+        <j:forEach var="m" items="${monitors}">
+          <j:if test="${m.columnCaption!=null}">
+            <th align="right">
+              ${m.descriptor.timestampString}
+            </th>
+          </j:if>
+        </j:forEach>
+        <th />
+      </tr>
+
     </table>
     <j:if test="${app.hasPermission(app.ADMINISTER)}">
       <div align="right" style="margin-top:0.5em">


### PR DESCRIPTION
- Move update status row to bottom
- make it look similar to title row.
- Use `getPastTimeString` instead of `getTimeSpanString` (which is better for languages using something like '{0} ago' instead of '{0}').

![screen shot](https://f.cloud.github.com/assets/1831569/1950558/e274e17c-814d-11e3-822f-354b636a299b.png)
