### PR TITLE
[FIXED JENKINS-21729] Fix IE8 NPE with respect to sortability

### DIFF
--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -55,7 +55,7 @@ var Sortable = (function() {
 
         // We have a first row: assume it's the header, and make its contents clickable links
         firstRow.each(function (cell){
-            cell.innerHTML = '<a href="#" class="sortheader">'+this.getInnerText(cell)+'<span class="sortarrow" /></a>';
+            cell.innerHTML = '<a href="#" class="sortheader">'+this.getInnerText(cell)+'<span class="sortarrow"></span></a>';
             this.arrows.push(cell.firstChild.lastChild);
 
             var self = this;


### PR DESCRIPTION
IE8 (and I assume other browsers that use a doctype pre-html5) interpret the span outside of the link, as in HTML4.01 you need the closing tag.
http://www.w3.org/TR/REC-html40/struct/global.html#h-7.5.4

The code was causing a NPE in IE8 and users could not sort the columns.
