### PR TITLE
[FIXED JENKINS-18884] Access check to jobs in People pages.

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -831,6 +831,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
         }
 
         // for testing purpose
+        @Restricted(NoExternalUse.class)
         /*package*/ Set<User> getModified() {
             return modified;
         }

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -679,15 +679,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
 
         public People(Jenkins parent) {
             this.parent = parent;
-            // for Hudson, really load all users
-            Map<User,UserInfo> users = getUserInfo(parent.getItems());
-            User unknown = User.getUnknown();
-            for (User u : User.getAll()) {
-                if(u==unknown)  continue;   // skip the special 'unknown' user
-                if(!users.containsKey(u))
-                    users.put(u,new UserInfo(u,null,null));
-            }
-            this.users = toList(users);
+            this.users = toList(getUserInfo(parent.getItems()));
         }
 
         public People(View parent) {
@@ -698,7 +690,13 @@ public abstract class View extends AbstractModelObject implements AccessControll
         private Map<User,UserInfo> getUserInfo(Collection<? extends Item> items) {
             Map<User,UserInfo> users = new HashMap<User,UserInfo>();
             for (Item item : items) {
+                if (!item.hasPermission(Item.READ)) {
+                    continue;
+                }
                 for (Job job : item.getAllJobs()) {
+                    if (!job.hasPermission(Item.READ)) {
+                        continue;
+                    }
                     if (job instanceof AbstractProject) {
                         AbstractProject<?,?> p = (AbstractProject) job;
                         for (AbstractBuild<?,?> build : p.getBuilds()) {
@@ -761,7 +759,6 @@ public abstract class View extends AbstractModelObject implements AccessControll
     public static final class AsynchPeople extends ProgressiveRendering { // JENKINS-15206
 
         private final Collection<TopLevelItem> items;
-        private final User unknown;
         private final Map<User,UserInfo> users = new HashMap<User,UserInfo>();
         private final Set<User> modified = new HashSet<User>();
         private final String iconSize;
@@ -771,14 +768,12 @@ public abstract class View extends AbstractModelObject implements AccessControll
         public AsynchPeople(Jenkins parent) {
             this.parent = parent;
             items = parent.getItems();
-            unknown = User.getUnknown();
         }
 
         /** @see View#getAsynchPeople */
         public AsynchPeople(View parent) {
             this.parent = parent;
             items = parent.getItems();
-            unknown = null;
         }
 
         {
@@ -789,7 +784,13 @@ public abstract class View extends AbstractModelObject implements AccessControll
         @Override protected void compute() throws Exception {
             int itemCount = 0;
             for (Item item : items) {
+                if (!item.hasPermission(Item.READ)) {
+                    continue;
+                }
                 for (Job<?,?> job : item.getAllJobs()) {
+                    if (!job.hasPermission(Item.READ)) {
+                        continue;
+                    }
                     if (job instanceof AbstractProject) {
                         AbstractProject<?,?> p = (AbstractProject) job;
                         RunList<? extends AbstractBuild<?,?>> builds = p.getBuilds();
@@ -825,29 +826,13 @@ public abstract class View extends AbstractModelObject implements AccessControll
                     }
                 }
                 itemCount++;
-                progress(1.0 * itemCount / (items.size() + /* handling User.getAll */1));
+                progress(1.0 * itemCount / items.size());
             }
-            if (unknown != null) {
-                if (canceled()) {
-                    return;
-                }
-                for (User u : User.getAll()) { // TODO nice to have a method to iterate these lazily
-                    if (canceled()) {
-                        return;
-                    }
-                    if (u == unknown) {
-                        continue;
-                    }
-                    if (!users.containsKey(u)) {
-                        UserInfo userInfo = new UserInfo(u, null, null);
-                        userInfo.avatar = UserAvatarResolver.resolveOrNull(u, iconSize);
-                        synchronized (this) {
-                            users.put(u, userInfo);
-                            modified.add(u);
-                        }
-                    }
-                }
-            }
+        }
+
+        // for testing purpose
+        /*package*/ Set<User> getModified() {
+            return modified;
         }
 
         @Override protected synchronized JSON data() {

--- a/core/src/main/java/jenkins/util/ProgressiveRendering.java
+++ b/core/src/main/java/jenkins/util/ProgressiveRendering.java
@@ -103,7 +103,14 @@ public abstract class ProgressiveRendering {
             }
         });
     }
-
+    
+    /**
+     * @return whether the computation has finished.
+     */
+    public boolean isFinished() {
+        return (status < 0 || status >= 1);
+    }
+    
     /**
      * Actually do the work.
      * <p>The security context will be that in effect when the web request was made.

--- a/test/src/test/java/hudson/model/AsynchPeopleTest.java
+++ b/test/src/test/java/hudson/model/AsynchPeopleTest.java
@@ -24,15 +24,34 @@
 
 package hudson.model;
 
+import hudson.security.Permission;
+import hudson.security.AuthorizationMatrixProperty;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import jenkins.model.Jenkins;
+
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Sets;
+
 import static org.junit.Assert.*;
+
+import org.acegisecurity.context.SecurityContextHolder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.FakeChangeLogSCM;
 import org.jvnet.hudson.test.For;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 @For(View.AsynchPeople.class)
 public class AsynchPeopleTest {
@@ -42,6 +61,8 @@ public class AsynchPeopleTest {
     @Bug(18641)
     @Test public void display() throws Exception {
         User.get("bob");
+        System.err.println(j.jenkins.getRootUrl());
+        Thread.sleep(60000);
         JenkinsRule.WebClient wc = j.createWebClient();
         HtmlPage page;
         try {
@@ -64,6 +85,114 @@ public class AsynchPeopleTest {
         /* TODO this still fails occasionally, for reasons TBD (I think because User.getAll sometimes is empty):
         assertNotNull(page.getElementById("person-bob"));
         */
+    }
+    
+    @Test
+    @LocalData
+    public void testProjectPermission() throws Exception {
+        User user1 = User.get("user1", false, Collections.emptyMap());
+        User admin = User.get("admin", false, Collections.emptyMap());
+        
+        // p1 can be accessed by user1, admin
+        // p2 can be accessed by admin
+        FreeStyleProject p1 = j.createFreeStyleProject();
+        {
+            Map<Permission, Set<String>> permissions = new HashMap<Permission, Set<String>>();
+            permissions.put(Item.READ, Sets.newHashSet(user1.getId(), admin.getId()));
+            p1.addProperty(new AuthorizationMatrixProperty(permissions));
+        }
+        assertFalse(p1.getACL().hasPermission(Jenkins.ANONYMOUS, Item.READ));
+        assertTrue(p1.getACL().hasPermission(user1.impersonate(), Item.READ));
+        assertTrue(p1.getACL().hasPermission(admin.impersonate(), Item.READ));
+        
+        FreeStyleProject p2 = j.createFreeStyleProject();
+        {
+            Map<Permission, Set<String>> permissions = new HashMap<Permission, Set<String>>();
+            permissions.put(Item.READ, Sets.newHashSet(admin.getId()));
+            p1.addProperty(new AuthorizationMatrixProperty(permissions));
+        }
+        assertFalse(p2.getACL().hasPermission(Jenkins.ANONYMOUS, Item.READ));
+        assertFalse(p2.getACL().hasPermission(user1.impersonate(), Item.READ));
+        assertTrue(p2.getACL().hasPermission(admin.impersonate(), Item.READ));
+        
+        // create fake changelog
+        {
+            FakeChangeLogSCM scm = new FakeChangeLogSCM();
+            scm.addChange().withAuthor("author1");
+            scm.addChange().withAuthor("author2");
+            p1.setScm(scm);
+        }
+        {
+            FakeChangeLogSCM scm = new FakeChangeLogSCM();
+            scm.addChange().withAuthor("author3");
+            scm.addChange().withAuthor("author4");
+            p2.setScm(scm);
+        }
+        
+        j.assertBuildStatusSuccess(p1.scheduleBuild2(0));
+        j.assertBuildStatusSuccess(p2.scheduleBuild2(0));
+        
+        ListView view = new ListView("test", j.jenkins);
+        view.add(p1);
+        view.add(p2);
+        
+        {
+            SecurityContextHolder.getContext().setAuthentication(Jenkins.ANONYMOUS);
+            View.AsynchPeople people = view.getAsynchPeople();
+            people.start();
+            while(!people.isFinished()) {
+                Thread.sleep(100);
+            }
+            Collection<String> authors = Collections2.transform(people.getModified(), new Function<User, String>(){
+                @Override
+                public String apply(User input) {
+                    return input.getId();
+                }
+            });
+            assertFalse(authors.contains("author1"));
+            assertFalse(authors.contains("author2"));
+            assertFalse(authors.contains("author3"));
+            assertFalse(authors.contains("author4"));
+        }
+        
+        {
+            SecurityContextHolder.getContext().setAuthentication(user1.impersonate());
+            View.AsynchPeople people = view.getAsynchPeople();
+            people.start();
+            while(!people.isFinished()) {
+                Thread.sleep(100);
+            }
+            Collection<String> authors = Collections2.transform(people.getModified(), new Function<User, String>(){
+                @Override
+                public String apply(User input) {
+                    return input.getId();
+                }
+            });
+            assertTrue(authors.contains("author1"));
+            assertTrue(authors.contains("author2"));
+            assertFalse(authors.contains("author3"));
+            assertFalse(authors.contains("author4"));
+        }
+        
+        {
+            SecurityContextHolder.getContext().setAuthentication(admin.impersonate());
+            View.AsynchPeople people = view.getAsynchPeople();
+            people.start();
+            while(!people.isFinished()) {
+                Thread.sleep(100);
+            }
+            Collection<String> authors = Collections2.transform(people.getModified(), new Function<User, String>(){
+                @Override
+                public String apply(User input) {
+                    return input.getId();
+                }
+            });
+            assertTrue(authors.contains("author1"));
+            assertTrue(authors.contains("author2"));
+            assertTrue(authors.contains("author3"));
+            assertTrue(authors.contains("author4"));
+        }
+        
     }
 
 }

--- a/test/src/test/java/hudson/model/AsynchPeopleTest.java
+++ b/test/src/test/java/hudson/model/AsynchPeopleTest.java
@@ -61,8 +61,6 @@ public class AsynchPeopleTest {
     @Bug(18641)
     @Test public void display() throws Exception {
         User.get("bob");
-        System.err.println(j.jenkins.getRootUrl());
-        Thread.sleep(60000);
         JenkinsRule.WebClient wc = j.createWebClient();
         HtmlPage page;
         try {

--- a/test/src/test/resources/hudson/model/AsynchPeopleTest/testProjectPermission/config.xml
+++ b/test/src/test/resources/hudson/model/AsynchPeopleTest/testProjectPermission/config.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <version>1.547</version>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.ProjectMatrixAuthorizationStrategy">
+    <permission>hudson.model.Hudson.Administer:admin</permission>
+    <permission>hudson.model.Hudson.Read:admin</permission>
+    <permission>hudson.model.Hudson.Read:anonymous</permission>
+    <permission>hudson.model.Hudson.Read:user1</permission>
+  </authorizationStrategy>
+  <securityRealm class="hudson.security.HudsonPrivateSecurityRealm" />
+</hudson>

--- a/test/src/test/resources/hudson/model/AsynchPeopleTest/testProjectPermission/users/admin/config.xml
+++ b/test/src/test/resources/hudson/model/AsynchPeopleTest/testProjectPermission/users/admin/config.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<user>
+  <fullName>admin</fullName>
+  <properties>
+    <hudson.security.HudsonPrivateSecurityRealm_-Details>
+      <!--password: admin-->
+      <passwordHash>#jbcrypt:$2a$10$eBXjXOF.vPfWeqmYlrsSdeupTlcjh5qAOCeKqoH2JWQGcnE3vfR9K</passwordHash>
+    </hudson.security.HudsonPrivateSecurityRealm_-Details>
+  </properties>
+</user>

--- a/test/src/test/resources/hudson/model/AsynchPeopleTest/testProjectPermission/users/user1/config.xml
+++ b/test/src/test/resources/hudson/model/AsynchPeopleTest/testProjectPermission/users/user1/config.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<user>
+  <fullName>user1</fullName>
+  <properties>
+    <hudson.security.HudsonPrivateSecurityRealm_-Details>
+      <!-- password: user1 -->
+      <passwordHash>#jbcrypt:$2a$10$Xw3Nij/ckiVMAbVPGn24..QtngnfJUDl6KfTz45SVP3tdlkksngZy</passwordHash>
+    </hudson.security.HudsonPrivateSecurityRealm_-Details>
+  </properties>
+</user>


### PR DESCRIPTION
People page displays users extracted from change logs of jobs belonging to that view.
And People page of All view also displays all users registered in Jenkins.

They do no permission check.

This patch does followings:
- Adds permission check to jobs to extract users (now requires Read permission).
- People page of All view no longer display all users registered in Jenkins. It works same as those of other views:
  - There is no reason for People page of All page to work different from those of other views.
  - Displaying all users in Jenkins should be handled by security realms (like [`HudsonPrivateSecurityRealm.ManageUserLinks`](http://javadoc.jenkins-ci.org/hudson/security/HudsonPrivateSecurityRealm.ManageUserLinks.html)). If needed, I would implement a default user listing page for administrators.

This is another approach of #1094 .
First I planned to add a new permission to restrict access to People page in All view, but I get to think that the root problem is the difference of behaviors of People pages between All view and other views.
