### PR TITLE
Update credentials plugin

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -275,7 +275,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>credentials</artifactId>
-                  <version>1.9.1</version>
+                  <version>1.9.4</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
The credentials plugin 1.9.2 through 1.9.3 generates a JavaScript error on form pages that have the credentials:select/ jelly tag.

1.9.4 [fixes the issue](https://github.com/jenkinsci/credentials-plugin/commit/07978d5c546329ff3301e28a11821897ee461d4a), which only affects Jenkins versions form 1.52x ish onwards
