### PR TITLE
Fix windows-slaves-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,11 @@ THE SOFTWARE.
         <artifactId>commons-logging</artifactId>
         <version>1.1.3</version>
       </dependency>
+      <dependency>
+        <groupId>org.samba.jcifs</groupId>
+        <artifactId>jcifs</artifactId>
+        <version>1.3.17-kohsuke-1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
2669e4a86d72f2d8b67417812db8f52aa487f3de extracted windows-slaves code
to a separate plugin.
However in the process, it introduced a dependency conflict.
core -> j-interop -> jcifs (1.2.19)
whereas
windows-slaves-plugin -> ... -> jcifs (1.3.17-kohsuke-1)

This was causing NoSuchMethodError while launching windows slaves.

I'd advise to bump the required core version for windows-slaves-plugin once this change gets into a core release.
