### PR TITLE
FIXED JENKINS-10468 - Build Queue does not show the executor a build is waiting for

### DIFF
--- a/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
+++ b/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
@@ -92,7 +92,7 @@ public abstract class CauseOfBlockage {
         }
 
         public String getShortDescription() {
-            return Messages.Queue_NodeOffline(node.getDisplayName());
+            return Messages.Queue_NodeOffline(node.toComputer().getDisplayName());
         }
         
         @Override
@@ -128,7 +128,7 @@ public abstract class CauseOfBlockage {
         }
 
         public String getShortDescription() {
-            return Messages.Queue_WaitingForNextAvailableExecutorOn(node.getNodeName());
+            return Messages.Queue_WaitingForNextAvailableExecutorOn(node.toComputer().getDisplayName());
         }
         
         @Override

--- a/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
+++ b/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
@@ -92,7 +92,8 @@ public abstract class CauseOfBlockage {
         }
 
         public String getShortDescription() {
-            return Messages.Queue_NodeOffline(node.toComputer().getDisplayName());
+            String name = (node.toComputer() != null) ? node.toComputer().getDisplayName() : node.getDisplayName();
+            return Messages.Queue_NodeOffline(name);
         }
         
         @Override
@@ -128,7 +129,8 @@ public abstract class CauseOfBlockage {
         }
 
         public String getShortDescription() {
-            return Messages.Queue_WaitingForNextAvailableExecutorOn(node.toComputer().getDisplayName());
+            String name = (node.toComputer() != null) ? node.toComputer().getDisplayName() : node.getDisplayName();
+            return Messages.Queue_WaitingForNextAvailableExecutorOn(name);
         }
         
         @Override


### PR DESCRIPTION
`node.getNodeName()` on master returns "", `node.getDisplayName()` on master returns "Jenkins", so Kohsuke suggested `node.toComputer().getDisplayName()`
