### PR TITLE
[FIXED JENKINS-21612] fixed wrong CSS class for f:combobox.

### DIFF
--- a/core/src/main/resources/lib/form/combobox.jelly
+++ b/core/src/main/resources/lib/form/combobox.jelly
@@ -49,7 +49,7 @@ THE SOFTWARE.
   ${descriptor.calcFillSettings(field,attrs)} <!-- this figures out the 'fillUrl' and 'fillDependsOn' attribute -->
 
   <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary" ATTRIBUTES="${attrs}" EXCEPT="field items clazz"
-         autocomplete="off" class="combobox2 settings-input ${attrs.clazz}${attrs.checkUrl!=null ? ' validated' : ''}"
+         autocomplete="off" class="combobox2 setting-input ${attrs.clazz}${attrs.checkUrl!=null ? ' validated' : ''}"
          name="${attrs.name ?: '_.'+attrs.field}"
          value="${attrs.value ?: instance[attrs.field]}" />
   <!-- TODO consider customizedFields -->


### PR DESCRIPTION
f:combobox is narrow for its CSS class "settings-input" is unavailable. It should be "setting-input".
![editable_combobox](https://f.cloud.github.com/assets/3115961/2059517/640c8d08-8bb6-11e3-83c4-113ff73983a8.png)
