### PR TITLE
[JENKINS-21613] f:combobox may break form.onsubmit

### DIFF
--- a/war/src/main/webapp/scripts/combobox.js
+++ b/war/src/main/webapp/scripts/combobox.js
@@ -88,6 +88,7 @@ function ComboBox(idOrField, callback, config) {
 		alert("You have specified an invalid id for the field you want to turn into a combo box");
 	this.dropdown = document.createElement("div");
 	this.isDropdownShowing = false;
+	this.oldonsubmit = null;
 	
 	// configure the dropdown div
 	this.dropdown.className = "comboBoxList";
@@ -111,11 +112,11 @@ function ComboBox(idOrField, callback, config) {
 			this.setSelectionRange(length, length);
 		}
 	}
-	this.field.form.oldonsubmit = this.field.form.onsubmit;
 	this.field.onfocus = function() {
+		this.comboBox.oldonsubmit = this.form.onsubmit;
 		this.form.onsubmit = function() {
 			if (self.isDropdownShowing) return false;
-			if (this.oldonsubmit) this.oldonsubmit();
+			if (self.oldonsubmit) self.oldonsubmit.call(this);
 			return true;
 		};
 		// repopulate and display the dropdown
@@ -124,7 +125,7 @@ function ComboBox(idOrField, callback, config) {
 	this.field.onblur = function() {
 		var cb = this.comboBox;
 		this.hideTimeout = setTimeout(function() { cb.hideDropdown(); }, 100);
-                this.form.onsubmit = this.form.oldonsubmit;
+		this.form.onsubmit = cb.oldonsubmit;
 	}
 	
 	// privileged methods


### PR DESCRIPTION
f:combobox prevents form submission when the dropdown is open.
This is done by interrupting form.onsubmit.
It handles form.onsubmit in the following way:
1. ComboBox saves the original onsubmit handler in its initialization.
2. When the combobox is selected, it shows the dropdown and overwrites the onsubmit handler. The ovirridden onsubmit prevents form submission of the dropdown is open.
3. When the dropdown is closed, recovers the saved form.onsubmit.

If the form.onsubmit was overridden between step 1 and 2, it would be overridden in step 3 and lost.

This change saves the original onsubmit handler just before overriding it.
