### PR TITLE
[FIXED JENKINS-19832] Display helps on Configure Global Security page.

### DIFF
--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -30,6 +30,7 @@ import hudson.Functions;
 import hudson.markup.MarkupFormatter;
 import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
+import hudson.model.Describable;
 import hudson.model.ManagementLink;
 import hudson.util.FormApply;
 
@@ -55,7 +56,7 @@ import org.kohsuke.stapler.StaplerResponse;
  * @author Kohsuke Kawaguchi
  */
 @Extension(ordinal = Integer.MAX_VALUE - 210)
-public class GlobalSecurityConfiguration extends ManagementLink {
+public class GlobalSecurityConfiguration extends ManagementLink implements Describable<GlobalSecurityConfiguration> {
     
     private static final Logger LOGGER = Logger.getLogger(GlobalSecurityConfiguration.class.getName());
 
@@ -126,7 +127,7 @@ public class GlobalSecurityConfiguration extends ManagementLink {
 
     @Override
     public String getDisplayName() {
-        return Messages.GlobalSecurityConfiguration_DisplayName();
+        return getDescriptor().getDisplayName();
     }
     
     @Override
@@ -154,4 +155,22 @@ public class GlobalSecurityConfiguration extends ManagementLink {
             return input instanceof GlobalConfigurationCategory.Security;
         }
     };
+
+    /**
+     * @return
+     * @see hudson.model.Describable#getDescriptor()
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public Descriptor<GlobalSecurityConfiguration> getDescriptor() {
+        return Jenkins.getInstance().getDescriptorOrDie(getClass());
+    }
+    
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<GlobalSecurityConfiguration> {
+        @Override
+        public String getDisplayName() {
+            return Messages.GlobalSecurityConfiguration_DisplayName();
+        }
+    }
 }

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
@@ -22,6 +22,7 @@ l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
         div(class:"behavior-loading", _("LOADING"))
         f.form(method:"post",name:"config",action:"configure") {
             set("instance",my);
+            set("descriptor", my.descriptor);
 
             f.optionalBlock( field:"useSecurity", title:_("Enable security"), checked:app.useSecurity) {
                 f.entry (title:_("TCP port for JNLP slave agents"), field:"slaveAgentPort") {


### PR DESCRIPTION
Though there are help files for fields in Configure Global Security page in resources/hudson/security/GlobalSecurityConfiguration, they are not displayed.
This is caused for no existence of a descriptor for `GlobalSecurityConfiguration`.

This patch defines a descriptor for `GlobalSecurityConfiguration` and register it to Jenkins, which displays helps on Configure Global Security page.
