### PR TITLE
safe() also replaces '%' with '_'

### DIFF
--- a/core/src/main/java/hudson/tasks/test/TestObject.java
+++ b/core/src/main/java/hudson/tasks/test/TestObject.java
@@ -351,7 +351,7 @@ public abstract class TestObject extends hudson.tasks.junit.TestObject {
      */
     public static String safe(String s) {
         // this still seems to be a bit faster than a single replace with regexp
-        return s.replace('/', '_').replace('\\', '_').replace(':', '_').replace('?', '_').replace('#', '_');
+        return s.replace('/', '_').replace('\\', '_').replace(':', '_').replace('?', '_').replace('#', '_').replace('%', '_');
         
         // Note: we probably should some helpers like Commons URIEscapeUtils here to escape all invalid URL chars, but then we
         // still would have to escape /, ? and so on

--- a/core/src/test/java/hudson/tasks/test/TestObjectTest.java
+++ b/core/src/test/java/hudson/tasks/test/TestObjectTest.java
@@ -11,7 +11,7 @@ public class TestObjectTest {
 
     @Test
     public void testSafe() {
-        String name = "Foo#approve! is called by approve_on_foo?xyz/\\:";
+        String name = "Foo#approve! is called by approve_on_foo?xyz/\\: 50%";
         String encoded = TestObject.safe(name);
         
         Assert.assertFalse(encoded.contains("#"));
@@ -19,6 +19,7 @@ public class TestObjectTest {
         Assert.assertFalse(encoded.contains("\\"));
         Assert.assertFalse(encoded.contains("/"));
         Assert.assertFalse(encoded.contains(":"));
+        Assert.assertFalse(encoded.contains("%"));
     }
 
     @Test public void uniquifyName() {


### PR DESCRIPTION
`TestObject#safe` replaces `%` with `_` in addition to the other characters it replaces.

The [Cucumber Test Result Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Cucumber+Test+Result+Plugin) converts Cucumber feature and scenario names into hyperlinks for reviewing test results. Feature and scenario names can have any characters into them, including non-URL-safe ones.

This patch fixes the problem for names containing `%`. 
