### PR TITLE
Improvements to API documentation.

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
@@ -27,9 +27,11 @@ THE SOFTWARE.
   <h2>Create Job</h2>
   <p>
     To create a new job, post <tt>config.xml</tt> to <a href="../createItem">this URL</a> with
-    query parameter <tt>name=<i>JOBNAME</i></tt>. You'll get 200 status code if the creation is successful,
+    query parameter <tt>name=<i>JOBNAME</i></tt>. You need to send a <tt>Content-Type: application/xml</tt>
+    header. You'll get 200 status code if the creation is successful,
     or 4xx/5xx code if it fails. <tt>config.xml</tt> is the format Jenkins uses to store the project
-    in the file system, so you can see examples of them in <tt>${app.rootDir}</tt>.
+    in the file system, so you can see examples of them in the Jenkins home directory, or by retrieving
+    the XML configuration of existing jobs from <tt>/job/<i>JOBNAME</i>/config.xml</tt>.
   </p>
 
   <h2>Copy Job</h2>


### PR DESCRIPTION
- Added requirement to send header when POSTing config.xml (thanks jglick)
- Don't tell anyone with Overall/Read where JENKINS_HOME is located
- Add an alternative to viewing config.xml files on the server for non-admins
