### PR TITLE
Revert 33db54459a80adb8fe435a96956d3f22dd033414

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2107,9 +2107,6 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             return;
         }
 
-        RunT nb = getNextBuild();
-
-
         try{
             delete();
         }
@@ -2120,7 +2117,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             req.getView(this, "delete-retry.jelly").forward(req, rsp);  
             return;
         }
-        rsp.sendRedirect2(req.getContextPath()+'/' + (nb!=null ? nb.getUrl() : getParent().getUrl()));
+        rsp.sendRedirect2(req.getContextPath()+'/' + getParent().getUrl());
     }
 
     public void setDescription(String description) throws IOException {


### PR DESCRIPTION
33db54459a80adb8fe435a96956d3f22dd033414 aimed to improve usability for users manually bulk deleting build but failed to achieve its goal.

It does not provide a reason for the direction users are redirected. As argued, going from newer to older builds might well be a more useful alternative.

Deleting a build now redirects to _another_ build after confirmation of deletion, confusing users, especially when deleting e.g. the latest failed build from a list view, or from the build history on a project page.

Finally, bulk deleting builds individually from the core UI is horribly inefficient anyway and should not be facilitated. There are numerous alternatives to doing this as shown in the discussion on the linked issue.

This PR reverts the behavior of unexpectedly redirecting to another build.
