### PR TITLE
Fix autocompletion for items in folders

### DIFF
--- a/core/src/main/java/hudson/model/AutoCompletionCandidates.java
+++ b/core/src/main/java/hudson/model/AutoCompletionCandidates.java
@@ -91,7 +91,22 @@ public class AutoCompletionCandidates implements HttpResponse {
     public static <T extends Item> AutoCompletionCandidates ofJobNames(final Class<T> type, final String value, @CheckForNull Item self, ItemGroup container) {
         if (self==container)
             container = self.getParent();
+        return ofJobNames(type, value, container);
+    }
 
+
+    /**
+     * Auto-completes possible job names.
+     *
+     * @param type
+     *      Limit the auto-completion to the subtype of this type.
+     * @param value
+     *      The value the user has typed in. Matched as a prefix.
+     * @param container
+     *      The nearby contextual {@link ItemGroup} to resolve relative job names from.
+     * @since TODO
+     */
+    public static  <T extends Item> AutoCompletionCandidates ofJobNames(final Class<T> type, final String value, ItemGroup container) {
         final AutoCompletionCandidates candidates = new AutoCompletionCandidates();
         class Visitor extends ItemVisitor {
             String prefix;

--- a/core/src/main/java/hudson/model/ViewDescriptor.java
+++ b/core/src/main/java/hudson/model/ViewDescriptor.java
@@ -28,6 +28,7 @@ import hudson.views.ListViewColumnDescriptor;
 import hudson.views.ViewJobFilter;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.AncestorInPath;
 
 import java.util.List;
 
@@ -67,10 +68,8 @@ public abstract class ViewDescriptor extends Descriptor<View> {
     protected ViewDescriptor() {
     }
 
-    /**
-     * Auto-completion for the "copy from" field in the new job page.
-     */
-    public AutoCompletionCandidates doAutoCompleteCopyNewItemFrom(@QueryParameter final String value) {
+    @Deprecated
+    public AutoCompletionCandidates doAutoCompleteCopyNewItemFrom(final String prefix) {
         final AutoCompletionCandidates r = new AutoCompletionCandidates();
 
         new ItemVisitor() {
@@ -78,13 +77,13 @@ public abstract class ViewDescriptor extends Descriptor<View> {
             public void onItemGroup(ItemGroup<?> group) {
                 // only dig deep when the path matches what's typed.
                 // for example, if 'foo/bar' is typed, we want to show 'foo/barcode'
-                if (value.startsWith(group.getFullName()))
+                if (prefix.startsWith(group.getFullName()))
                     super.onItemGroup(group);
             }
 
             @Override
             public void onItem(Item i) {
-                if (i.getFullName().startsWith(value)) {
+                if (i.getFullName().startsWith(prefix)) {
                     r.add((i.getFullName()));
                     super.onItem(i);
                 }
@@ -92,6 +91,13 @@ public abstract class ViewDescriptor extends Descriptor<View> {
         }.onItemGroup(Jenkins.getInstance());
 
         return r;
+    }
+
+    /**
+     * Auto-completion for the "copy from" field in the new job page.
+     */
+    public AutoCompletionCandidates doAutoCompleteCopyNewItemFrom(@QueryParameter final String value, @AncestorInPath ItemGroup container) {
+        return AutoCompletionCandidates.ofJobNames(TopLevelItem.class, value, container);
     }
 
     /**


### PR DESCRIPTION
This provides useful autocompletion when typing `Foldername/jobname` into an _Add Item_ page's _Copy from_ text field. 

The problem in the current implementation is the line `if (value.startsWith(group.getFullName()))` which prevents descending into the folder 'F' once the user typed 'F/'. Deprecated, because someone might use it programmatically.

There's a working implementation already, so reuse it, but allow specifying an `ItemGroup` context. Unused in Folders plugin AFAICT, but might be useful anyway.
