### PR TITLE
Don't offer install without restart unless it's possible.

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -140,8 +140,10 @@ THE SOFTWARE.
         <j:if test="${!empty(list)}">
           <div id="bottom-sticker" >
             <div class="bottom-sticker-inner">
-              <f:submit value="${%Install without restart}" name="dynamicLoad" />
-              <span style="margin-left:2em;"></span>
+              <j:if test="${!isUpdates}">
+                <f:submit value="${%Install without restart}" name="dynamicLoad" />
+                <span style="margin-left:2em;"></span>
+              </j:if>
               <f:submit value="${%Download now and install after restart}" />
             </div>
           </div>


### PR DESCRIPTION
Jenkins cannot dynamically load updated plugins, so there
is no need to offer it to users.

[JENKINS-20732](https://issues.jenkins-ci.org/browse/JENKINS-20732)
