### PR TITLE
[FIXED JENKINS-21772] Only cache CLI credentials in ~/.hudson if it exists

### DIFF
--- a/core/src/main/java/hudson/cli/ClientAuthenticationCache.java
+++ b/core/src/main/java/hudson/cli/ClientAuthenticationCache.java
@@ -43,7 +43,11 @@ public class ClientAuthenticationCache implements Serializable {
         store = (channel==null ? MasterComputer.localChannel :  channel).call(new Callable<FilePath, IOException>() {
             public FilePath call() throws IOException {
                 File home = new File(System.getProperty("user.home"));
-                return new FilePath(new File(home, ".hudson/cli-credentials"));
+                File hudsonHome = new File(home, ".hudson");
+                if (hudsonHome.exists()) {
+                    return new FilePath(new File(hudsonHome, "cli-credentials"));
+                }
+                return new FilePath(new File(home, ".jenkins/cli-credentials"));
             }
         });
         if (store.exists()) {


### PR DESCRIPTION
Need to check for `~/.hudson` only, to prevent Jenkins from using that as home, but caching CLI credentials in `~/.jenkins` when the first user logs in.
