### PR TITLE
Update jenkins.init.in

### DIFF
--- a/opensuse/SOURCES/jenkins.init.in
+++ b/opensuse/SOURCES/jenkins.init.in
@@ -20,9 +20,9 @@
 #
 ### BEGIN INIT INFO
 # Provides:          jenkins
-# Required-Start:    $local_fs $remote_fs $network $time $named
+# Required-Start:    $local_fs $remote_fs $network $named
 # Should-Start: $time sendmail
-# Required-Stop:     $local_fs $remote_fs $network $time $named
+# Required-Stop:     $local_fs $remote_fs $network $named
 # Should-Stop: $time sendmail
 # Default-Start:     3 5
 # Default-Stop:      0 1 2 6


### PR DESCRIPTION
$time removed from Required-Start and Required-Stop
This prevents properly register the jenkis service and jenkins will not starts at boot.
$time (boot.clock) start just on runlevel B and S, but not at runlevel 3 and 5 as jenkins do.
It was also redundant to Shoul-Start and Should-Stop.
Same modification is applied also on OpenSuseBuildService.
