### PR TITLE
[WIP] [FIXED JENKINS-21819] Add 'tail' functionality for files in WS

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -283,6 +283,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         }
 
         boolean view = rest.equals("*view*");
+        boolean tail = rest.equals("*tail*");
 
         if(rest.equals("*fingerprint*")) {
             rsp.forward(Jenkins.getInstance().getFingerprint(Util.getDigestOf(baseFile.open())), "/", req);
@@ -302,6 +303,13 @@ public final class DirectoryBrowserSupport implements HttpResponse {
 
             // pseudo file name to let the Stapler set text/plain
             rsp.serveFile(req, in, lastModified, -1, length, "plain.txt");
+            return;
+        } else if (tail) {
+            // serve the end of the file -- useful with programs logging to a file in the workspace
+            int tailLength = Integer.getInteger(this.getClass().getName() + ".tailKB", 4).intValue() * 1024;
+            long skip = Math.max(0, length - tailLength);
+            in.skip(skip);
+            rsp.serveFile(req, in, lastModified, -1, length - skip, "tail.txt");
         } else {
             rsp.serveFile(req, in, lastModified, -1, length, baseFile.getName() );
         }

--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -80,6 +80,10 @@ THE SOFTWARE.
                         </a>
                         <st:nbsp/>
                         <a href="${x.href}/*view*/">${%view}</a>
+                        <j:if test="${x.title.endsWith('.log')}">
+                          <st:nbsp/>
+                          <a href="${x.href}/*tail*/">${%tail}</a>
+                        </j:if>
                       </j:if>                      
                     </td>
                   </j:if>


### PR DESCRIPTION
Some tools log so verbosely that the regular build log becomes barely usable. But when redirecting tool output to files in the workspace, they cannot easily be accessed during a build to see the current status, because `view` shows the entire file, and browsers rarely handle these well with >10MB file size.

This change adds a `tail` link next to `view` that only shows the end of the file.

Adds new system property `hudson.model.DirectoryBrowserSupport.tailKB` that will need to be added [to the wiki](https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties) once merged and released.
