### PR TITLE
Force httpclient to use a new protocol socket factory which does not explicitly bind to the client side interface.

### DIFF
--- a/core/src/main/java/hudson/tools/JDKInstaller.java
+++ b/core/src/main/java/hudson/tools/JDKInstaller.java
@@ -48,6 +48,7 @@ import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.auth.AuthScope;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.protocol.Protocol;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpResponse;
@@ -83,6 +84,13 @@ import static hudson.tools.JDKInstaller.Preference.*;
  * @since 1.305
  */
 public class JDKInstaller extends ToolInstaller {
+
+    static {
+        // this socket factory will not attempt to bind to the client interface
+        Protocol.registerProtocol("http", new Protocol("http", new hudson.util.NoClientBindProtocolSocketFactory(), 80));
+        Protocol.registerProtocol("https", new Protocol("https", new hudson.util.NoClientBindSSLProtocolSocketFactory(), 443));
+    }
+
     /**
      * The release ID that Sun assigns to each JDK, such as "jdk-6u13-oth-JPR@CDS-CDS_Developer"
      *

--- a/core/src/main/java/hudson/util/NoClientBindProtocolSocketFactory.java
+++ b/core/src/main/java/hudson/util/NoClientBindProtocolSocketFactory.java
@@ -1,0 +1,128 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2010, Sun Microsystems, Inc., CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.util;
+ 
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import org.apache.commons.httpclient.ConnectTimeoutException;
+import org.apache.commons.httpclient.params.HttpConnectionParams; 
+import org.apache.commons.httpclient.protocol.ControllerThreadSocketFactory;
+import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
+import org.apache.commons.httpclient.protocol.ReflectionSocketFactory;
+
+/**
+ * A SecureProtocolSocketFactory that creates sockets without binding to a specific interface.
+ * Based on org.apache.commons.httpclient.protocol.DefaultProtocolSocketFactory
+ * 
+ */
+public class NoClientBindProtocolSocketFactory implements ProtocolSocketFactory {
+ 
+    public NoClientBindProtocolSocketFactory() {
+    }
+ 
+    public Socket createSocket(String host, 
+                               int port,
+                               InetAddress localAddress,
+                               int localPort) throws IOException, UnknownHostException {
+        // ignore the local address/port for binding
+        return createSocket(host, port);
+    }
+ 
+    /**
+     * Attempts to get a new socket connection to the given host within the given time limit.
+     * <p>
+     * This method employs several techniques to circumvent the limitations of older JREs that 
+     * do not support connect timeout. When running in JRE 1.4 or above reflection is used to 
+     * call Socket#connect(SocketAddress endpoint, int timeout) method. When executing in older 
+     * JREs a controller thread is executed. The controller thread attempts to create a new socket
+     * within the given limit of time. If socket constructor does not return until the timeout 
+     * expires, the controller terminates and throws an {@link ConnectTimeoutException}
+     * </p>
+     *  
+     * @param host the host name/IP
+     * @param port the port on the host
+     * @param localAddress the local host name/IP to bind the socket to, ignored
+     * @param localPort the port on the local machine, ignored
+     * @param params {@link HttpConnectionParams Http connection parameters}
+     * 
+     * @return Socket a new socket
+     * 
+     * @throws IOException if an I/O error occurs while creating the socket
+     * @throws UnknownHostException if the IP address of the host cannot be
+     * determined
+     * @throws ConnectTimeoutException if socket cannot be connected within the
+     *  given time limit
+     * 
+     * @since 3.0
+     */
+    public Socket createSocket(String host, int port, InetAddress localAddress,
+            int localPort, HttpConnectionParams params) throws IOException,
+            UnknownHostException, ConnectTimeoutException {
+        if (params == null) {
+            throw new IllegalArgumentException("Parameters may not be null");
+        }
+        int timeout = params.getConnectionTimeout();
+        if (timeout == 0) {
+            // ignore the local address/port for binding
+            return createSocket(host, port);
+        } else {
+            Socket s=new Socket();
+            s.connect(new InetSocketAddress(host,port),timeout);
+            return s;
+        }
+    }
+    
+    /**
+     * @see ProtocolSocketFactory#createSocket(java.lang.String,int)
+     */
+    public Socket createSocket(String host, int port) throws IOException,
+            UnknownHostException,IOException {
+        Socket socket = null;
+        try {
+            socket = new Socket(host, port);
+        }        
+        catch (IOException e) {
+            throw e;
+        }
+        return socket;
+    }
+    
+    /**
+     * All instances are the same.
+     */
+    public boolean equals(Object obj) {
+        return ((obj != null) && obj.getClass().equals(NoClientBindProtocolSocketFactory.class));
+    }
+
+    /**
+     * All instances have the same hash code.
+     */
+    public int hashCode() {
+        return NoClientBindProtocolSocketFactory.class.hashCode();
+    }
+}

--- a/core/src/main/java/hudson/util/NoClientBindSSLProtocolSocketFactory.java
+++ b/core/src/main/java/hudson/util/NoClientBindSSLProtocolSocketFactory.java
@@ -1,0 +1,171 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2010, Sun Microsystems, Inc., CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.util;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import org.apache.commons.httpclient.ConnectTimeoutException;
+import org.apache.commons.httpclient.params.HttpConnectionParams;
+import org.apache.commons.httpclient.protocol.ControllerThreadSocketFactory;
+import org.apache.commons.httpclient.protocol.ReflectionSocketFactory;
+import org.apache.commons.httpclient.protocol.SecureProtocolSocketFactory;
+import org.apache.commons.httpclient.protocol.SSLProtocolSocketFactory;
+
+
+/**
+ * A SecureProtocolSocketFactory that creates sockets without binding to a specific interface.
+ * Based on org.apache.commons.httpclient.protocol.SSLProtocolSocketFactory
+ * 
+ */
+public class NoClientBindSSLProtocolSocketFactory implements SecureProtocolSocketFactory {
+
+    /**
+     * The factory singleton.
+     */
+    private static final NoClientBindSSLProtocolSocketFactory factory = new NoClientBindSSLProtocolSocketFactory();
+    
+    /**
+     * Gets an singleton instance of the SSLProtocolSocketFactory.
+     * @return a SSLProtocolSocketFactory
+     */
+    static NoClientBindSSLProtocolSocketFactory getSocketFactory() {
+        return factory;
+    }    
+    
+    /**
+     * Constructor for SSLProtocolSocketFactory.
+     */
+    public NoClientBindSSLProtocolSocketFactory() {
+        super();
+    }
+
+    /**
+     * @see SecureProtocolSocketFactory#createSocket(java.lang.String,int,java.net.InetAddress,int)
+     */
+    public Socket createSocket(
+        String host,
+        int port,
+        InetAddress clientHost,
+        int clientPort)
+        throws IOException, UnknownHostException {
+            return createSocket(host,port);
+    }
+
+    /**
+     * Attempts to get a new socket connection to the given host within the given time limit.
+     * <p>
+     * This method employs several techniques to circumvent the limitations of older JREs that 
+     * do not support connect timeout. When running in JRE 1.4 or above reflection is used to 
+     * call Socket#connect(SocketAddress endpoint, int timeout) method. When executing in older 
+     * JREs a controller thread is executed. The controller thread attempts to create a new socket
+     * within the given limit of time. If socket constructor does not return until the timeout 
+     * expires, the controller terminates and throws an {@link ConnectTimeoutException}
+     * </p>
+     *  
+     * @param host the host name/IP
+     * @param port the port on the host
+     * @param localAddress the local host name/IP to bind the socket to, ignored.
+     * @param localPort the port on the local machine, ignored.
+     * @param params {@link HttpConnectionParams Http connection parameters}
+     * 
+     * @return Socket a new socket
+     * 
+     * @throws IOException if an I/O error occurs while creating the socket
+     * @throws UnknownHostException if the IP address of the host cannot be
+     * determined
+     * 
+     * @since 3.0
+     */
+    public Socket createSocket(
+        final String host,
+        final int port,
+        final InetAddress localAddress,
+        final int localPort,
+        final HttpConnectionParams params
+    ) throws IOException, UnknownHostException, ConnectTimeoutException {
+        if (params == null) {
+            throw new IllegalArgumentException("Parameters may not be null");
+        }
+        int timeout = params.getConnectionTimeout();
+        if (timeout == 0) {
+            return createSocket(host, port);
+        } else {
+            // To be eventually deprecated when migrated to Java 1.4 or above
+            Socket socket = ReflectionSocketFactory.createSocket(
+                "javax.net.ssl.SSLSocketFactory", host, port, null, 0, timeout);
+            if (socket == null) {
+                socket = ControllerThreadSocketFactory.createSocket(
+                    this, host, port, null, 0, timeout);
+            }
+            return socket;
+        }
+    }
+
+    /**
+     * @see SecureProtocolSocketFactory#createSocket(java.lang.String,int)
+     */
+    public Socket createSocket(String host, int port)
+        throws IOException, UnknownHostException {
+        return SSLSocketFactory.getDefault().createSocket(
+            host,
+            port
+        );
+    }
+
+    /**
+     * @see SecureProtocolSocketFactory#createSocket(java.net.Socket,java.lang.String,int,boolean)
+     */
+    public Socket createSocket(
+        Socket socket,
+        String host,
+        int port,
+        boolean autoClose)
+        throws IOException, UnknownHostException {
+        return ((SSLSocketFactory) SSLSocketFactory.getDefault()).createSocket(
+            socket,
+            host,
+            port,
+            autoClose
+        );
+    }
+
+    /**
+     * All instances are the same.
+     */
+    public boolean equals(Object obj) {
+        return ((obj != null) && obj.getClass().equals(SSLProtocolSocketFactory.class));
+    }
+
+    /**
+     * All instances have the same hash code.
+     */
+    public int hashCode() {
+        return SSLProtocolSocketFactory.class.hashCode();
+    }       
+}


### PR DESCRIPTION
This functionality is needed when running on OpenShift as the OpenShift runtime environment does not permit binding to arbitrary interfaces (eg 127.0.0.1 and 0.0.0.0) which HttpClient does by default.

This PR is based on the solution proposed in this forum discussion:
https://www.openshift.com/forums/openshift/commons-httpclient-permission-denied
