### PR TITLE
Upgrade to commons-io 2.4

### DIFF
--- a/core/src/main/java/hudson/util/IOUtils.java
+++ b/core/src/main/java/hudson/util/IOUtils.java
@@ -3,8 +3,11 @@ package hudson.util;
 import hudson.Functions;
 import hudson.os.PosixAPI;
 import hudson.os.PosixException;
+import org.apache.commons.io.LineIterator;
 
 import java.io.*;
+import java.util.Collection;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
@@ -13,30 +16,30 @@ import java.util.regex.Pattern;
  * @author Kohsuke Kawaguchi
  * @since 1.337
  */
-public class IOUtils extends org.apache.commons.io.IOUtils {
+public class IOUtils {
     /**
      * Drains the input stream and closes it.
      */
     public static void drain(InputStream in) throws IOException {
-        copy(in,new NullStream());
+        org.apache.commons.io.IOUtils.copy(in, new NullStream());
         in.close();
     }
 
     public static void copy(File src, OutputStream out) throws IOException {
         FileInputStream in = new FileInputStream(src);
         try {
-            copy(in,out);
+            org.apache.commons.io.IOUtils.copy(in, out);
         } finally {
-            closeQuietly(in);
+            org.apache.commons.io.IOUtils.closeQuietly(in);
         }
     }
 
     public static void copy(InputStream in, File out) throws IOException {
         FileOutputStream fos = new FileOutputStream(out);
         try {
-            copy(in,fos);
+            org.apache.commons.io.IOUtils.copy(in, fos);
         } finally {
-            closeQuietly(fos);
+            org.apache.commons.io.IOUtils.closeQuietly(fos);
         }
     }
 
@@ -96,7 +99,7 @@ public class IOUtils extends org.apache.commons.io.IOUtils {
      * @param base File that represents the parent, may be null if path is absolute
      * @param path Path of the file, may not be null
      * @return new File(name) if name represents an absolute path, new File(base, name) otherwise
-     * @see hudson.FilePath#absolutize() 
+     * @see hudson.FilePath#absolutize()
      */
     public static File absolutize(File base, String path) {
         if (isAbsolute(path))
@@ -140,6 +143,353 @@ public class IOUtils extends org.apache.commons.io.IOUtils {
         } finally {
             reader.close();
         }
+    }
+
+    public static final char DIR_SEPARATOR_UNIX       = org.apache.commons.io.IOUtils.DIR_SEPARATOR_UNIX;
+    public static final char DIR_SEPARATOR_WINDOWS    = org.apache.commons.io.IOUtils.DIR_SEPARATOR_WINDOWS;
+    public static final char DIR_SEPARATOR            = org.apache.commons.io.IOUtils.DIR_SEPARATOR;
+    public static final String LINE_SEPARATOR_UNIX    = org.apache.commons.io.IOUtils.LINE_SEPARATOR_UNIX;
+    public static final String LINE_SEPARATOR_WINDOWS = org.apache.commons.io.IOUtils.LINE_SEPARATOR_WINDOWS;
+    public static final String LINE_SEPARATOR;
+    static {
+        // avoid security issues
+        StringWriter buf = new StringWriter(4);
+        PrintWriter out = new PrintWriter(buf);
+        out.println();
+        LINE_SEPARATOR = buf.toString();
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#closeQuietly(java.io.Reader)}
+     */
+    public static void closeQuietly(Reader input) {
+        org.apache.commons.io.IOUtils.closeQuietly(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#closeQuietly(java.io.Writer)}
+     */
+    public static void closeQuietly(Writer output) {
+        org.apache.commons.io.IOUtils.closeQuietly(output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#closeQuietly(java.io.InputStream)}
+     */
+    public static void closeQuietly(InputStream input) {
+        org.apache.commons.io.IOUtils.closeQuietly(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#closeQuietly(java.io.OutputStream)}
+     */
+    public static void closeQuietly(OutputStream output) {
+        org.apache.commons.io.IOUtils.closeQuietly(output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toByteArray(java.io.InputStream)}
+     */
+    public static byte[] toByteArray(InputStream input) throws IOException {
+        return org.apache.commons.io.IOUtils.toByteArray(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toByteArray(java.io.Reader)}
+     */
+    public static byte[] toByteArray(Reader input) throws IOException {
+        return org.apache.commons.io.IOUtils.toByteArray(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toByteArray(java.io.Reader, String)}
+     */
+    public static byte[] toByteArray(Reader input, String encoding) throws IOException {
+        return org.apache.commons.io.IOUtils.toByteArray(input, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toByteArray(String)}
+     */
+    public static byte[] toByteArray(String input) throws IOException {
+        return org.apache.commons.io.IOUtils.toByteArray(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toCharArray(java.io.InputStream)}
+     */
+    public static char[] toCharArray(InputStream is) throws IOException {
+        return org.apache.commons.io.IOUtils.toCharArray(is);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toCharArray(java.io.InputStream, String)}
+     */
+    public static char[] toCharArray(InputStream is, String encoding) throws IOException {
+        return org.apache.commons.io.IOUtils.toCharArray(is, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toCharArray(java.io.Reader)}
+     */
+    public static char[] toCharArray(Reader input) throws IOException {
+        return org.apache.commons.io.IOUtils.toCharArray(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toString(java.io.InputStream)}
+     */
+    public static String toString(InputStream input) throws IOException {
+        return org.apache.commons.io.IOUtils.toString(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toString(java.io.InputStream, String)}
+     */
+    public static String toString(InputStream input, String encoding) throws IOException {
+        return org.apache.commons.io.IOUtils.toString(input, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toString(java.io.Reader)}
+     */
+    public static String toString(Reader input) throws IOException {
+        return org.apache.commons.io.IOUtils.toString(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toString(byte[])}
+     */
+    public static String toString(byte[] input) throws IOException {
+        return org.apache.commons.io.IOUtils.toString(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toString(byte[], String)}
+     */
+    public static String toString(byte[] input, String encoding) throws IOException {
+        return org.apache.commons.io.IOUtils.toString(input, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#readLines(java.io.InputStream)}
+     */
+    public static List readLines(InputStream input) throws IOException {
+        return org.apache.commons.io.IOUtils.readLines(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#readLines(java.io.InputStream, String)}
+     */
+    public static List readLines(InputStream input, String encoding) throws IOException {
+        return org.apache.commons.io.IOUtils.readLines(input, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#readLines(java.io.Reader)}
+     */
+    public static List readLines(Reader input) throws IOException {
+        return org.apache.commons.io.IOUtils.readLines(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#lineIterator(java.io.Reader)}
+     */
+    public static LineIterator lineIterator(Reader reader) {
+        return org.apache.commons.io.IOUtils.lineIterator(reader);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#lineIterator(java.io.InputStream, String)}
+     */
+    public static LineIterator lineIterator(InputStream input, String encoding) throws IOException {
+        return org.apache.commons.io.IOUtils.lineIterator(input, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toInputStream(String)}
+     */
+    public static InputStream toInputStream(String input) {
+        return org.apache.commons.io.IOUtils.toInputStream(input);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#toInputStream(String, String)}
+     */
+    public static InputStream toInputStream(String input, String encoding) throws IOException {
+        return org.apache.commons.io.IOUtils.toInputStream(input, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(byte[], java.io.OutputStream)}
+     */
+    public static void write(byte[] data, OutputStream output) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(byte[], java.io.Writer)}
+     */
+    public static void write(byte[] data, Writer output) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(byte[], java.io.Writer, String)}
+     */
+    public static void write(byte[] data, Writer output, String encoding) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(char[], java.io.OutputStream)}
+     */
+    public static void write(char[] data, Writer output) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(char[], java.io.OutputStream)}
+     */
+    public static void write(char[] data, OutputStream output) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(char[], java.io.OutputStream, String)}
+     */
+    public static void write(char[] data, OutputStream output, String encoding) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(char[], java.io.Writer)}
+     */
+    public static void write(String data, Writer output) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(String, java.io.OutputStream)}
+     */
+    public static void write(String data, OutputStream output) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(String, java.io.OutputStream, String)}
+     */
+    public static void write(String data, OutputStream output, String encoding) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(StringBuffer, java.io.Writer)}
+     */
+    public static void write(StringBuffer data, Writer output) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(StringBuffer, java.io.OutputStream)}
+     */
+    public static void write(StringBuffer data, OutputStream output) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#write(StringBuffer, java.io.OutputStream, String)}
+     */
+    public static void write(StringBuffer data, OutputStream output, String encoding) throws IOException {
+        org.apache.commons.io.IOUtils.write(data, output, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#writeLines(java.util.Collection, String, java.io.OutputStream)}
+     */
+    public static void writeLines(Collection lines, String lineEnding, OutputStream output) throws IOException {
+        org.apache.commons.io.IOUtils.writeLines(lines, lineEnding, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#writeLines(java.util.Collection, String, java.io.OutputStream, String)}
+     */
+    public static void writeLines(Collection lines, String lineEnding, OutputStream output, String encoding) throws IOException {
+        org.apache.commons.io.IOUtils.writeLines(lines, lineEnding, output, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#writeLines(java.util.Collection, String, java.io.Writer)}
+     */
+    public static void writeLines(Collection lines, String lineEnding, Writer writer) throws IOException {
+        org.apache.commons.io.IOUtils.writeLines(lines, lineEnding, writer);
+    }
+
+    public static int copy(InputStream input, OutputStream output) throws IOException {
+        return org.apache.commons.io.IOUtils.copy(input, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#copyLarge(java.io.InputStream, java.io.OutputStream)}
+     */
+    public static long copyLarge(InputStream input, OutputStream output) throws IOException {
+        return org.apache.commons.io.IOUtils.copyLarge(input, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#copy(java.io.InputStream, java.io.Writer)}
+     */
+    public static void copy(InputStream input, Writer output) throws IOException {
+        org.apache.commons.io.IOUtils.copy(input, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#copy(java.io.InputStream, java.io.Writer, String)}
+     */
+    public static void copy(InputStream input, Writer output, String encoding) throws IOException {
+        org.apache.commons.io.IOUtils.copy(input, output, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#copy(java.io.Reader, java.io.Writer)}
+     */
+    public static int copy(Reader input, Writer output) throws IOException {
+        return org.apache.commons.io.IOUtils.copy(input, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#copyLarge(java.io.Reader, java.io.Writer)}
+     */
+    public static long copyLarge(Reader input, Writer output) throws IOException {
+        return org.apache.commons.io.IOUtils.copyLarge(input, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#copy(java.io.Reader, java.io.OutputStream)}
+     */
+    public static void copy(Reader input, OutputStream output) throws IOException {
+        org.apache.commons.io.IOUtils.copy(input, output);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#copy(java.io.Reader, java.io.OutputStream, String)}
+     */
+    public static void copy(Reader input, OutputStream output, String encoding) throws IOException {
+        org.apache.commons.io.IOUtils.copy(input, output, encoding);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#contentEquals(java.io.InputStream, java.io.InputStream)}
+     */
+    public static boolean contentEquals(InputStream input1, InputStream input2) throws IOException {
+        return org.apache.commons.io.IOUtils.contentEquals(input1, input2);
+    }
+
+    /**
+     * @deprecated Use instead {@link org.apache.commons.io.IOUtils#contentEquals(java.io.Reader, java.io.Reader)}
+     */
+    public static boolean contentEquals(Reader input1, Reader input2) throws IOException {
+        return org.apache.commons.io.IOUtils.contentEquals(input1, input2);
     }
 
     private static final byte[] SKIP_BUFFER = new byte[8192];

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>1.4</version>
+        <version>2.4</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
In order to maintain backwards compatibility we need to keep IOUtils the
same as in commons-io 1.4. This code is backwards compatible, however
most of the methods have been deprecated and should instead use the
org.apache.commons.io.IOUtils version instead.
