### PR TITLE
[FIXED JENKINS-20965] Run.writeWholeLogTo causes high CPU usage.

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1363,10 +1363,16 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     public void writeWholeLogTo(OutputStream out) throws IOException, InterruptedException {
         long pos = 0;
         AnnotatedLargeText logText;
-        do {
+        logText = getLogText();
+        pos = logText.writeLogTo(pos, out);
+
+        while (!logText.isComplete()) {
+            // Instead of us hitting the log file as many times as possible, instead we get the information once every
+            // second to avoid CPU usage getting very high.
+            Thread.sleep(1000);
             logText = getLogText();
             pos = logText.writeLogTo(pos, out);
-        } while (!logText.isComplete());
+        }
     }
 
     /**


### PR DESCRIPTION
Wait one second before writing to log files. Switched to while loop to
prevent extra one second delay.
