### PR TITLE
[FIXED JENKINS-21999] If a slave node does not exist it will throw a

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -39,6 +39,8 @@ import hudson.util.StreamCopyThread;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.ProcessTree;
 import org.apache.commons.io.input.NullInputStream;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -841,6 +843,7 @@ public abstract class Launcher {
         }
     }
 
+    @Restricted(NoExternalUse.class)
     public static class DummyLauncher extends Launcher {
 
         public DummyLauncher(TaskListener listener) {
@@ -849,14 +852,12 @@ public abstract class Launcher {
 
         @Override
         public Proc launch(ProcStarter starter) throws IOException {
-            listener.error("Can not call launch on a dummy launcher.");
-            return null;
+            throw new IOException("Can not call launch on a dummy launcher.");
         }
 
         @Override
         public Channel launchChannel(String[] cmd, OutputStream out, FilePath workDir, Map<String, String> envVars) throws IOException, InterruptedException {
-            listener.error("Can not call launchChannel on a dummy launcher.");
-            return null;
+            throw new IOException("Can not call launchChannel on a dummy launcher.");
         }
 
         @Override

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -841,6 +841,31 @@ public abstract class Launcher {
         }
     }
 
+    public static class DummyLauncher extends Launcher {
+
+        public DummyLauncher(TaskListener listener) {
+            super(listener, null);
+        }
+
+        @Override
+        public Proc launch(ProcStarter starter) throws IOException {
+            listener.error("Can not call launch on a dummy launcher.");
+            return null;
+        }
+
+        @Override
+        public Channel launchChannel(String[] cmd, OutputStream out, FilePath workDir, Map<String, String> envVars) throws IOException, InterruptedException {
+            listener.error("Can not call launchChannel on a dummy launcher.");
+            return null;
+        }
+
+        @Override
+        public void kill(Map<String, String> modelEnvVars) throws IOException, InterruptedException {
+            // Kill method should do nothing.
+        }
+    }
+
+
     /**
      * Launches processes remotely by using the given channel.
      */

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -343,9 +343,21 @@ public abstract class Slave extends Node implements Serializable {
 
     }
 
+    /**
+     * Creates a launcher for the slave.
+     *
+     * @return
+     *      If there is no computer it will return a {@link hudson.Launcher.DummyLauncher}, otherwise it
+     *      will return a {@link hudson.Launcher.RemoteLauncher} instead.
+     */
     public Launcher createLauncher(TaskListener listener) {
         SlaveComputer c = getComputer();
-        return new RemoteLauncher(listener, c.getChannel(), c.isUnix()).decorateFor(this);
+        if (c == null) {
+            listener.error("Issue with creating launcher for slave " + name + ".");
+            return new Launcher.DummyLauncher(listener);
+        } else {
+            return new RemoteLauncher(listener, c.getChannel(), c.isUnix()).decorateFor(this);
+        }
     }
 
     /**


### PR DESCRIPTION
null pointer exception. Instead we create a dummy launcher and return
that if it is unable to get the slave node.
