### PR TITLE
Expose the computer runs and timestamp to api.

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -635,6 +635,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         return (node != null) ? node.getSelfLabel().getTiedJobs() : Collections.EMPTY_LIST;
     }
 
+    @Exported
     public RunList getBuilds() {
     	return new RunList(Jenkins.getInstance().getAllItems(Job.class)).node(getNode());
     }

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -587,7 +587,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      *
      * @see #getStartTimeInMillis()
      */
-    @Exported
+    @Exported(visibility=2)
     public Calendar getTimestamp() {
         GregorianCalendar c = new GregorianCalendar();
         c.setTimeInMillis(timestamp);

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -420,7 +420,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * returns an intermediate result.
      * @return The status of the build, if it has completed or some build step has set a status; may be null if the build is ongoing.
      */
-    @Exported
+    @Exported(visibility=2)
     public @CheckForNull Result getResult() {
         return result;
     }
@@ -747,6 +747,11 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     @Exported
     public String getFullDisplayName() {
         return project.getFullDisplayName()+' '+getDisplayName();
+    }
+
+    @Exported(visibility = 2)
+    public String getProjectName() {
+        return project.getFullDisplayName();
     }
 
     public String getDisplayName() {


### PR DESCRIPTION
This will allow users to obtain the builds and the timestamp (in milliseconds) for the builds though the api. Output from local test run:

``` xml
<build>
<number>5</number>
<timestamp>1394474068000</timestamp>
<url>http://localhost:8080/job/t/5/</url>
</build>
```
