### PR TITLE
Switch to java.util.logging on few places

### DIFF
--- a/core/src/test/java/hudson/util/io/ZipArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/ZipArchiverTest.java
@@ -9,14 +9,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 import java.util.Enumeration;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipEntry;
 
-import org.apache.commons.logging.LogFactory;
-import org.apache.commons.logging.Log;
 
 public class ZipArchiverTest extends TestCase {
-    private final Log logger = LogFactory.getLog(getClass());
+    private static final Logger LOGGER = Logger.getLogger(ZipArchiverTest.class.getName());
     
     private File tmpDir;
     
@@ -103,7 +103,7 @@ public class ZipArchiverTest extends TestCase {
      * @param cause the root cause of the failure
      */
     private final void fail(final String msg, final Throwable cause) {
-        logger.error(msg, cause);
+        LOGGER.log(Level.SEVERE, msg, cause);
         fail(msg);
     }
     


### PR DESCRIPTION
As per [JENKINS/Logging](https://wiki.jenkins-ci.org/display/JENKINS/Logging), Jenkins uses java.util.logging for logging. This PR replaces usage of Apache Commons Logging with java.util.logging in 2 places (ExceptionTranslationFilter and ZipArchiverTest). Although current code works just fine, sending log messages through the Commons Logging is superfluous.
