### PR TITLE
Revert code changes for Run and change visibility of Computer.getBuilds api call.

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -635,7 +635,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         return (node != null) ? node.getSelfLabel().getTiedJobs() : Collections.EMPTY_LIST;
     }
 
-    @Exported
+    @Exported(visibility=999)
     public RunList getBuilds() {
     	return new RunList(Jenkins.getInstance().getAllItems(Job.class)).node(getNode());
     }

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -420,7 +420,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * returns an intermediate result.
      * @return The status of the build, if it has completed or some build step has set a status; may be null if the build is ongoing.
      */
-    @Exported(visibility=2)
+    @Exported
     public @CheckForNull Result getResult() {
         return result;
     }
@@ -587,7 +587,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      *
      * @see #getStartTimeInMillis()
      */
-    @Exported(visibility=2)
+    @Exported
     public Calendar getTimestamp() {
         GregorianCalendar c = new GregorianCalendar();
         c.setTimeInMillis(timestamp);
@@ -747,11 +747,6 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     @Exported
     public String getFullDisplayName() {
         return project.getFullDisplayName()+' '+getDisplayName();
-    }
-
-    @Exported(visibility = 2)
-    public String getProjectName() {
-        return project.getFullDisplayName();
     }
 
     public String getDisplayName() {


### PR DESCRIPTION
The code changes I made as part of #1154 could cause performance issues if invoking an api call on a computer. This eliminates that by changing the visibility of Computer.getBuild to be invisible by default, and I remove the redundant calls that exist in the run API. Please see #1154 for more information.
