### PR TITLE
[JENKINS-21932] Future#get does not return (or abort) when canceled in queue

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -646,7 +646,7 @@ public class Queue extends ResourceController implements Saveable {
     
     public synchronized boolean cancel(Item item) {
         LOGGER.log(Level.FINE, "Cancelling {0} item#{1}", new Object[] {item.task, item.id});
-        boolean r = item.leave(this);
+        boolean r = item.cancel(this);
 
         LeftItem li = new LeftItem(item);
         li.enter(this);

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -560,7 +560,10 @@ public class QueueTest extends HudsonTestCase {
     
     public void testCancelInQueue() throws Exception
     {
-        DumbSlave slave = createSlave();
+        // parepare an offline slave.
+        DumbSlave slave = createOnlineSlave();
+        assertFalse(slave.toComputer().isOffline());
+        slave.toComputer().disconnect(null).get();
         assertTrue(slave.toComputer().isOffline());
         
         FreeStyleProject p = createFreeStyleProject();


### PR DESCRIPTION
When a build is canceled when it is still in a queue (that is, before placed to a node), `Future#get` does not return nor throw any Exception, and wait forever.
This causes [Parameterised Trigger plugin](https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Trigger+Plugin) hangs when a synchronous downstream job is canceled in a queue.

This is introduced in Jenkins 1.520, 513a45b3091b88d1ad9020099bbd1aec04a8c686 .
