### PR TITLE
Update center date

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -65,6 +65,8 @@ Upcoming changes</a>
   <li class=rfe>
     Option to download metadata directly from Jenkins rather than going through the browser.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19081">issue 19081</a>)
+  <li class="">
+    Show the release date for the plugin in the update center.
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/changelog.html
+++ b/changelog.html
@@ -65,8 +65,6 @@ Upcoming changes</a>
   <li class=rfe>
     Option to download metadata directly from Jenkins rather than going through the browser.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19081">issue 19081</a>)
-  <li class="">
-    Show the release date for the plugin in the update center.
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -41,8 +41,10 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +63,7 @@ import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.time.DateUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -591,6 +594,12 @@ public class UpdateSite {
         @Exported
         public final Map<String,String> optionalDependencies = new HashMap<String,String>();
 
+        /**
+         * Release date of this plugin.
+         */
+        @Exported
+        public final Date releaseDate;
+
         @DataBoundConstructor
         public Plugin(String sourceId, JSONObject o) {
             super(sourceId, o, UpdateSite.this.url);
@@ -600,6 +609,7 @@ public class UpdateSite {
             this.compatibleSinceVersion = get(o,"compatibleSinceVersion");
             this.requiredCore = get(o,"requiredCore");
             this.categories = o.has("labels") ? (String[])o.getJSONArray("labels").toArray(new String[0]) : null;
+            this.releaseDate = getDate(get(o, "releaseTimestamp"));
             for(Object jo : o.getJSONArray("dependencies")) {
                 JSONObject depObj = (JSONObject) jo;
                 // Make sure there's a name attribute, that that name isn't maven-plugin - we ignore that one -
@@ -615,6 +625,18 @@ public class UpdateSite {
                 
             }
 
+        }
+
+        private Date getDate(String releaseTimestamp) {
+            if (releaseTimestamp != null) {
+                try {
+                    return DateUtils.parseDate(releaseTimestamp, new String[] {"yyyy-MM-dd'T'HH:mm:ss'.00Z'"});
+                } catch (ParseException e) {
+                    LOGGER.log(Level.WARNING, "Unable to parse date " + releaseTimestamp, e);
+                    return null;
+                }
+            }
+            return null;
         }
 
         private String get(JSONObject o, String prop) {

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -596,6 +596,7 @@ public class UpdateSite {
 
         /**
          * Release date of this plugin.
+         * @since TODO
          */
         @Exported
         public final Date releaseDate;

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
      page: page name to be passed to local:tabBar
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%Update Center}" permission="${app.ADMINISTER}" norefresh="true">
     <l:header>
       <script type="text/javascript">
@@ -65,6 +65,7 @@ THE SOFTWARE.
               <th initialSortDir="${isUpdates?'down':null}"
                   onclick="showhideCategories(this,0)">${%Name}</th>
               <th onclick="showhideCategories(this,0)">${%Version}</th>
+              <th onclick="showhideCategories(this,0)">${%Release Date}</th>
               <j:if test="${isUpdates}"><th>${%Installed}</th></j:if>
             </tr>
             <j:choose>
@@ -111,6 +112,7 @@ THE SOFTWARE.
                       </j:if>
                     </td>
                     <td class="pane"><st:out value="${p.version}" /></td>
+                    <td class="pane" data="${p.releaseDate.getTime()}"><i:formatDate value="${p.releaseDate}" type="date" /></td>
                     <j:if test="${isUpdates}">
                       <td class="pane">
                         <j:choose><j:when test="${p.installed.active}">


### PR DESCRIPTION
It is handy to know how old a plugin release is, or looking at all available plugins, to see which are new (or have newer versions). This puts the release date as a column in the update center table.
