### PR TITLE
Fix issue where restart would not properly display username if user was not loaded.

### DIFF
--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -368,8 +368,7 @@ public abstract class Cause {
 
         @Exported(visibility = 3)
         public String getUserName() {
-            User userName = User.get(userId);
-            return (userName == null) ? "anonymous" : userName.getDisplayName();
+            return userId == null ? "anonymous" : User.get(userId).getDisplayName();
         }
 
         @Override

--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -327,8 +327,7 @@ public abstract class Cause {
 
         @Exported(visibility=3)
         public String getUserName() {
-        	User u = User.get(authenticationName, false);
-            return u != null ? u.getDisplayName() : authenticationName;
+        	return User.get(authenticationName, true).getDisplayName();
         }
 
         @Override
@@ -369,13 +368,7 @@ public abstract class Cause {
 
         @Exported(visibility = 3)
         public String getUserName() {
-            String userName = "anonymous";
-            if (userId != null) {
-                User user = User.get(userId, false);
-                if (user != null)
-                    userName = user.getDisplayName();
-            }
-            return userName;
+            return User.get(userId, true).getDisplayName();
         }
 
         @Override

--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -327,7 +327,7 @@ public abstract class Cause {
 
         @Exported(visibility=3)
         public String getUserName() {
-        	return User.get(authenticationName, true).getDisplayName();
+        	return User.get(authenticationName).getDisplayName();
         }
 
         @Override
@@ -368,7 +368,8 @@ public abstract class Cause {
 
         @Exported(visibility = 3)
         public String getUserName() {
-            return User.get(userId, true).getDisplayName();
+            User userName = User.get(userId);
+            return (userName == null) ? "anonymous" : userName.getDisplayName();
         }
 
         @Override

--- a/core/src/main/resources/hudson/model/Cause/UserIdCause/description.properties
+++ b/core/src/main/resources/hudson/model/Cause/UserIdCause/description.properties
@@ -20,5 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-started_by_user=Started by user <a href="{2}/user/{0}">{0}</a>
+started_by_user=Started by user <a href="{2}/user/{0}">{1}</a>
 started_by_anonymous=Started by anonymous user

--- a/core/src/main/resources/hudson/model/Cause/UserIdCause/description.properties
+++ b/core/src/main/resources/hudson/model/Cause/UserIdCause/description.properties
@@ -20,5 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-started_by_user=Started by user <a href="{2}/user/{0}">{1}</a>
+started_by_user=Started by user <a href="{2}/user/{0}">{0}</a>
 started_by_anonymous=Started by anonymous user


### PR DESCRIPTION
There is a bug where the "Started by user X" would display "Started by user anonymous" if the user was not properly loaded in Jenkins. The link for the user is available and points to the correct user.
