### PR TITLE
[JENKINS-22397] Allow a Trigger to be a DependencyDeclarer

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -61,6 +61,9 @@ Upcoming changes</a>
   <li class=bug>
     <code>NoSuchMethodError: hudson.model.BuildAuthorizationToken.checkPermission(…)</code> from Build Token Root plugin since 1.556.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22382">issue 22382</a>)
+  <li class=rfe>
+    Allow a <code>Trigger</code> to be a <code>DependencyDeclarer</code>.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22397">issue 22397</a>)
   <li class=bug>
     Fixed a slow down in resource loading caused by fix to JENKINS-18677.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21579">issue 21579</a>)

--- a/core/src/main/java/hudson/matrix/MatrixProject.java
+++ b/core/src/main/java/hudson/matrix/MatrixProject.java
@@ -802,7 +802,8 @@ public class MatrixProject extends AbstractProject<MatrixProject,MatrixBuild> im
         return false;
     }
 
-    protected void buildDependencyGraph(DependencyGraph graph) {
+    @Override protected void buildDependencyGraph(DependencyGraph graph) {
+        super.buildDependencyGraph(graph);
         publishers.buildDependencyGraph(this,graph);
         builders.buildDependencyGraph(this,graph);
         buildWrappers.buildDependencyGraph(this,graph);

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1712,9 +1712,11 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
 
     /**
      * Builds the dependency graph.
-     * @see DependencyGraph
+     * Since 1.558, not abstract and by default includes dependencies contributed by {@link #triggers()}.
      */
-    protected abstract void buildDependencyGraph(DependencyGraph graph);
+    protected void buildDependencyGraph(DependencyGraph graph) {
+        triggers().buildDependencyGraph(this, graph);
+    }
 
     @Override
     protected SearchIndexBuilder makeSearchIndex() {

--- a/core/src/main/java/hudson/model/Project.java
+++ b/core/src/main/java/hudson/model/Project.java
@@ -175,7 +175,8 @@ public abstract class Project<P extends Project<P,B>,B extends Build<P,B>>
         return null;
     }
 
-    protected void buildDependencyGraph(DependencyGraph graph) {
+    @Override protected void buildDependencyGraph(DependencyGraph graph) {
+        super.buildDependencyGraph(graph);
         getPublishersList().buildDependencyGraph(this,graph);
         getBuildersList().buildDependencyGraph(this,graph);
         getBuildWrappersList().buildDependencyGraph(this,graph);

--- a/core/src/main/java/jenkins/model/DependencyDeclarer.java
+++ b/core/src/main/java/jenkins/model/DependencyDeclarer.java
@@ -25,18 +25,20 @@ package jenkins.model;
 
 import hudson.model.AbstractProject;
 import hudson.model.DependencyGraph;
-import hudson.tasks.BuildStep;
+import hudson.tasks.BuildWrapper;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
+import hudson.triggers.Trigger;
+import hudson.util.DescribableList;
 
 /**
- * Marker interface for those {@link BuildStep}s that can participate
+ * Marker interface for project-associated objects that can participate
  * in the dependency graph computation process.
  *
  * <p>
- * {@link Publisher}s, {@link Builder}s, and {@link hudson.model.JobProperty}s
- * can additional implement this method to add additional edges
- * to the dependency graph computation.
+ * {@link Publisher}s, {@link Builder}s, {@link BuildWrapper}s, and {@link Trigger}s
+ * (or whatever {@link DescribableList#buildDependencyGraph} is called on, by {@link AbstractProject#buildDependencyGraph})
+ * can implement this interface to add additional edges to the dependency graph.
  *
  * @author Nicolas Lalevee
  * @author Martin Ficker


### PR DESCRIPTION
See [JENKINS-22397](https://issues.jenkins-ci.org/browse/JENKINS-22397).
