### PR TITLE
Ugly hack to fix destroyProcess for Java8

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -549,11 +549,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             try {
                 int pid = getPid();
                 LOGGER.fine("Killing pid="+pid);
-                if (UnixReflection.isJava8()) {
-                    UnixReflection.DESTROY_PROCESS.invoke(null, pid, false);
-                } else {
-                    UnixReflection.DESTROY_PROCESS.invoke(null, pid);
-                }
+                UnixReflection.destroy(pid);
             } catch (IllegalAccessException e) {
                 // this is impossible
                 IllegalAccessError x = new IllegalAccessError();
@@ -628,7 +624,16 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 throw x;
             }
         }
-        public static boolean isJava8() {
+
+        public static void destroy(int pid) throws IllegalAccessException, InvocationTargetException {
+            if (isJava8()) {
+                DESTROY_PROCESS.invoke(null, pid, false);
+            } else {
+                DESTROY_PROCESS.invoke(null, pid);
+            }
+        }
+
+        private static boolean isJava8() {
             return (System.getProperty("java.version").startsWith("1.8"));
         }
 

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -549,7 +549,11 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             try {
                 int pid = getPid();
                 LOGGER.fine("Killing pid="+pid);
-                UnixReflection.DESTROY_PROCESS.invoke(null, pid);
+                if (UnixReflection.isJava8()) {
+                    UnixReflection.DESTROY_PROCESS.invoke(null, pid, false);
+                } else {
+                    UnixReflection.DESTROY_PROCESS.invoke(null, pid);
+                }
             } catch (IllegalAccessException e) {
                 // this is impossible
                 IllegalAccessError x = new IllegalAccessError();
@@ -604,7 +608,11 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 PID_FIELD = clazz.getDeclaredField("pid");
                 PID_FIELD.setAccessible(true);
 
-                DESTROY_PROCESS = clazz.getDeclaredMethod("destroyProcess",int.class);
+                if (isJava8()) {
+                    DESTROY_PROCESS = clazz.getDeclaredMethod("destroyProcess",int.class, boolean.class);
+                }   else {
+                    DESTROY_PROCESS = clazz.getDeclaredMethod("destroyProcess",int.class);
+                }
                 DESTROY_PROCESS.setAccessible(true);
             } catch (ClassNotFoundException e) {
                 LinkageError x = new LinkageError();
@@ -620,6 +628,10 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 throw x;
             }
         }
+        public static boolean isJava8() {
+            return (System.getProperty("java.version").startsWith("1.8"));
+        }
+
     }
 
 

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -428,15 +428,15 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     public synchronized EnvVars getEnvironmentVariables() {
                         if(env !=null)
                           return env;
-                        env = new EnvVars();   
-                        
-                        try 
+                        env = new EnvVars();
+
+                        try
                         {
                            env.putAll(p.getEnvironmentVariables());
                         } catch (WinpException e)
                         {
                            LOGGER.log(FINE, "Failed to get environment variable ", e);
-                        }                          
+                        }
                         return env;
                     }
                 });
@@ -604,10 +604,10 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 PID_FIELD = clazz.getDeclaredField("pid");
                 PID_FIELD.setAccessible(true);
 
-                if (isJava8()) {
-                    DESTROY_PROCESS = clazz.getDeclaredMethod("destroyProcess",int.class, boolean.class);
-                }   else {
+                if (isPreJava8()) {
                     DESTROY_PROCESS = clazz.getDeclaredMethod("destroyProcess",int.class);
+                } else {
+                    DESTROY_PROCESS = clazz.getDeclaredMethod("destroyProcess",int.class, boolean.class);
                 }
                 DESTROY_PROCESS.setAccessible(true);
             } catch (ClassNotFoundException e) {
@@ -626,17 +626,17 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         }
 
         public static void destroy(int pid) throws IllegalAccessException, InvocationTargetException {
-            if (isJava8()) {
-                DESTROY_PROCESS.invoke(null, pid, false);
-            } else {
+            if (isPreJava8()) {
                 DESTROY_PROCESS.invoke(null, pid);
+            } else {
+                DESTROY_PROCESS.invoke(null, pid, false);
             }
         }
 
-        private static boolean isJava8() {
-            return (System.getProperty("java.version").startsWith("1.8"));
+        private static boolean isPreJava8() {
+            int javaVersionAsAnInteger = Integer.parseInt(System.getProperty("java.version").replaceAll("\\.", "").replaceAll("_", "").substring(0, 2));
+            return javaVersionAsAnInteger < 18;
         }
-
     }
 
 


### PR DESCRIPTION
This is a real hack (I would suggest a rewrite of the massive use of reflection in this component but that would be a much larger task) to get Jenkins working properly on Java8.
The issue is described in this issue: https://issues.jenkins-ci.org/browse/JENKINS-21341
