### PR TITLE
accept only directories have config.xml file to prevent too many IOExcep...

### DIFF
--- a/core/src/main/java/hudson/model/ItemGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ItemGroupMixIn.java
@@ -93,7 +93,7 @@ public abstract class ItemGroupMixIn {
 
         File[] subdirs = modulesDir.listFiles(new FileFilter() {
             public boolean accept(File child) {
-                return child.isDirectory();
+                return child.isDirectory() && new File(child,"config.xml").exists();
             }
         });
         CopyOnWriteMap.Tree<K,V> configurations = new CopyOnWriteMap.Tree<K,V>();


### PR DESCRIPTION
see https://gist.github.com/olamy/9773108
I have a LOT LOT LOT of IOException which slow a lot Jenkin start
