### PR TITLE
[FIXED JENKINS-20597 JENKINS-21720] Improved config confirmation.

### DIFF
--- a/core/src/main/resources/hudson/logging/LogRecorder/configure.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/configure.jelly
@@ -71,6 +71,7 @@ THE SOFTWARE.
         <f:submit value="${%Save}" />
       </f:block>
     </f:form>
+    <st:adjunct includes="lib.form.confirm" />
   </l:main-panel>
 </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Computer/configure.jelly
+++ b/core/src/main/resources/hudson/model/Computer/configure.jelly
@@ -46,6 +46,7 @@ THE SOFTWARE.
           <f:submit value="${%Save}"/>
         </f:bottomButtonBar>
       </f:form>
+      <st:adjunct includes="lib.form.confirm" />
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/ComputerSet/_new.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/_new.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
   <l:layout norefresh="true" permission="${it.CREATE}">
     <st:include page="sidepanel.jelly"/>
     <l:main-panel>
-      <f:form method="post" action="doCreateItem">
+      <f:form method="post" action="doCreateItem" name="config">
         <f:entry title="${%Name}" help="/help/system-config/master-slave/name.html">
           <f:textbox name="name" value="${request.getParameter('name')}" clazz="required" checkMessage="${%Name is mandatory}"/>
         </f:entry>
@@ -46,6 +46,7 @@ THE SOFTWARE.
           <f:submit value="${%Save}"/>
         </f:block>
       </f:form>
+      <st:adjunct includes="lib.form.confirm" />
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/ComputerSet/configure.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/configure.jelly
@@ -44,6 +44,7 @@ THE SOFTWARE.
           <f:apply />
         </f:bottomButtonBar>
       </f:form>
+      <st:adjunct includes="lib.form.confirm" />
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -68,7 +68,9 @@ THE SOFTWARE.
           </f:bottomButtonBar>
         </j:if>
       </f:form>
-      <st:adjunct includes="lib.form.confirm" />
+      <j:if test="${h.hasPermission(it,it.CONFIGURE)}">
+        <st:adjunct includes="lib.form.confirm" />
+      </j:if>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Run/configure.jelly
+++ b/core/src/main/resources/hudson/model/Run/configure.jelly
@@ -43,6 +43,7 @@ THE SOFTWARE.
           </f:bottomButtonBar>
         </j:if>
       </f:form>
+      <st:adjunct includes="lib.form.confirm" />
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Run/configure.jelly
+++ b/core/src/main/resources/hudson/model/Run/configure.jelly
@@ -43,7 +43,9 @@ THE SOFTWARE.
           </f:bottomButtonBar>
         </j:if>
       </f:form>
-      <st:adjunct includes="lib.form.confirm" />
+      <j:if test="${h.hasPermission(it,it.UPDATE)}">
+        <st:adjunct includes="lib.form.confirm" />
+      </j:if>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/User/configure.jelly
+++ b/core/src/main/resources/hudson/model/User/configure.jelly
@@ -59,6 +59,7 @@ THE SOFTWARE.
           <f:apply />
         </f:bottomButtonBar>
       </f:form>
+      <st:adjunct includes="lib.form.confirm" />
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/View/configure.jelly
+++ b/core/src/main/resources/hudson/model/View/configure.jelly
@@ -59,6 +59,7 @@ THE SOFTWARE.
           <f:apply />
         </f:bottomButtonBar>
       </f:form>
+      <st:adjunct includes="lib.form.confirm" />
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/labels/LabelAtom/configure.jelly
+++ b/core/src/main/resources/hudson/model/labels/LabelAtom/configure.jelly
@@ -43,6 +43,7 @@ THE SOFTWARE.
           <f:submit value="${%Save}"/>
         </f:block>
       </f:form>
+      <st:adjunct includes="lib.form.confirm" />
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
@@ -56,6 +56,8 @@ l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
                 f.apply()
             }
         }
+
+        st.adjunct(includes: "lib.form.confirm")
     }
 }
 

--- a/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
@@ -65,6 +65,7 @@ THE SOFTWARE.
         <f:apply />
       </f:bottomButtonBar>
     </f:form>
+    <st:adjunct includes="lib.form.confirm" />
   </l:main-panel>
 </l:layout>
 </j:jelly>

--- a/core/src/main/resources/lib/form/confirm.js
+++ b/core/src/main/resources/lib/form/confirm.js
@@ -6,48 +6,79 @@
       needToConfirm = true;
     }
 
+    function clearConfirm() {
+      needToConfirm = false;
+    }
+
     function confirmExit() {
       if (needToConfirm) {
         return errorMessage;
       }
     }
 
+    function isModifyingButton(btn) {
+      // TODO don't consider hetero list 'add' buttons
+      // needs to handle the yui menus instead
+      // if (btn.classList.contains("hetero-list-add")) {
+      //   return false;
+      // }
+
+      if (btn.parentNode.parentNode.classList.contains("advanced-button")) {
+        // don't consider 'advanced' buttons
+        return false;
+      }
+
+      // default to true
+      return true;
+    }
+
     function initConfirm() {
-      var configForm = document.getElementsByName("config")[0];
+      // Timeout is needed since some events get sent on page load for some reason.
+      // Shouldn't hurt anything for this to only start monitoring events after a few millis;.
+      setTimeout(function() {
+      var configForm = document.getElementsByName("config");
+      if (configForm.length > 0) {
+        configForm = configForm[0]
+      } else {
+        configForm = document.getElementsByName("viewConfig")[0];
+      }
+
+      YAHOO.util.Event.on($(configForm), "submit", clearConfirm, this); 
 
       var buttons = configForm.getElementsByTagName("button");
       var name;
       for ( var i = 0; i < buttons.length; i++) {
         name = buttons[i].parentNode.parentNode.getAttribute('name');
-        if (name == "Submit" || name == "Apply") {
+        if (name == "Submit" || name == "Apply" || name == "OK") {
           $(buttons[i]).on('click', function() {
             needToConfirm = false;
           });
         } else {
-          $(buttons[i]).on('click', confirm);
+          if (isModifyingButton(buttons[i])) {
+            $(buttons[i]).on('click', confirm);
+          }
         }
       }
 
       var inputs = configForm.getElementsByTagName("input");
       for ( var i = 0; i < inputs.length; i++) {
-        $(inputs[i]).on('change', confirm);
         if (inputs[i].type == 'checkbox' || inputs[i].type == 'radio') {
           $(inputs[i]).on('click', confirm);
         } else {
-          $(inputs[i]).on('keydown', confirm);
+          $(inputs[i]).on('input', confirm);
         }
       }
 
       inputs = configForm.getElementsByTagName("select");
       for ( var i = 0; i < inputs.length; i++) {
-        $(inputs[i]).on('keydown', confirm);
-        $(inputs[i]).on('click', confirm);
+        $(inputs[i]).on('change', confirm);
       }
 
       inputs = configForm.getElementsByTagName("textarea");
       for ( var i = 0; i < inputs.length; i++) {
-        $(inputs[i]).on('keydown', confirm);
+        $(inputs[i]).on('input', confirm);
       }
+      }, 100);
     }
 
     window.onbeforeunload = confirmExit;


### PR DESCRIPTION
Ask for confirmation when navigating away from node, global,
security, view and log configuration after changes.

Don't require confirmation when pressing keys without changing
(e.g. pressing Tab for navigation) and when pressing Advanced
buttons.

Don't require confirmation when submitting the form.

---

PR notes:
- This replaces PR #1156
- Timeout is needed to prevent job config page from triggering the 'needs confirmation' state immediately (don't know which element). Even when trying, I haven't been able to get a config change in early enough to not trigger the condition, so it should be safe enough.
- Did not indent script deliberately for cleaner diff
- Tested on OS X Firefox 28 and Safari 7
- PR considered finished despite the added TODO, as implementing that seems to be a lot of effort for very little gain.
