### PR TITLE
[FIXED JENKINS-17667] - Syncronization of InstallerTranslator::getToolHome() 

### DIFF
--- a/core/src/main/java/hudson/tools/InstallerTranslator.java
+++ b/core/src/main/java/hudson/tools/InstallerTranslator.java
@@ -46,16 +46,22 @@ public class InstallerTranslator extends ToolLocationTranslator {
         if (isp == null) {
             return null;
         }
+
         for (ToolInstaller installer : isp.installers) {
             if (installer.appliesTo(node)) {
-                Map<ToolInstallation, Semaphore> mutexByTool = mutexByNode.get(node);
-                if (mutexByTool == null) {
-                    mutexByNode.put(node, mutexByTool = new WeakHashMap<ToolInstallation, Semaphore>());
+            	Map<ToolInstallation, Semaphore> mutexByTool;
+            	Semaphore semaphore;
+            	
+                synchronized(mutexByNode) {
+                    mutexByTool = mutexByNode.get(node);
+                    if (mutexByTool == null) {
+                        mutexByNode.put(node, mutexByTool = new WeakHashMap<ToolInstallation, Semaphore>());
+                        mutexByTool.put(tool, semaphore = new Semaphore(1));
+                    } else {
+                    	semaphore = mutexByTool.get(tool);
+                    }
                 }
-                Semaphore semaphore = mutexByTool.get(tool);
-                if (semaphore == null) {
-                    mutexByTool.put(tool, semaphore = new Semaphore(1));
-                }
+
                 semaphore.acquire();
                 try {
                     return installer.performInstallation(tool, node, log).getRemote();


### PR DESCRIPTION
There appears to be some unthreadsafe initialization going on here.
Initialize/get inside a synchronized block for threadsaftey.

jira issue: https://issues.jenkins-ci.org/browse/JENKINS-17667
