### PR TITLE
[JENKINS-22543] Computer getChannel() method returns null in ComputerListeners

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -653,11 +653,11 @@ public class SlaveComputer extends Computer {
         // TODO: race condition between this and the setChannel method.
         Channel c = channel;
         if (c != null) {
-        	for (ComputerListener cl : ComputerListener.all()){
-        		cl.onOffline(this);
-        	}
+            for (ComputerListener cl : ComputerListener.all()){
+                cl.onOffline(this);
+            }
                 
-        	channel = null;
+            channel = null;
             isUnix = null;
             
             try {

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -652,16 +652,19 @@ public class SlaveComputer extends Computer {
     private void closeChannel() {
         // TODO: race condition between this and the setChannel method.
         Channel c = channel;
-        channel = null;
-        isUnix = null;
         if (c != null) {
+        	for (ComputerListener cl : ComputerListener.all()){
+        		cl.onOffline(this);
+        	}
+                
+        	channel = null;
+            isUnix = null;
+            
             try {
                 c.close();
             } catch (IOException e) {
                 logger.log(Level.SEVERE, "Failed to terminate channel to " + getDisplayName(), e);
             }
-            for (ComputerListener cl : ComputerListener.all())
-                cl.onOffline(this);
         }
     }
 


### PR DESCRIPTION
Computer channel can't be used in ComputerListeners because it's closed before the call to listeners done
