### PR TITLE
[FIXED JENKINS-22142] Removed obsolete method.

### DIFF
--- a/core/src/main/java/hudson/model/ViewDescriptor.java
+++ b/core/src/main/java/hudson/model/ViewDescriptor.java
@@ -27,6 +27,8 @@ import hudson.views.ListViewColumn;
 import hudson.views.ListViewColumnDescriptor;
 import hudson.views.ViewJobFilter;
 import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.AncestorInPath;
 
@@ -68,35 +70,11 @@ public abstract class ViewDescriptor extends Descriptor<View> {
     protected ViewDescriptor() {
     }
 
-    @Deprecated
-    public AutoCompletionCandidates doAutoCompleteCopyNewItemFrom(final String prefix) {
-        final AutoCompletionCandidates r = new AutoCompletionCandidates();
-
-        new ItemVisitor() {
-            @Override
-            public void onItemGroup(ItemGroup<?> group) {
-                // only dig deep when the path matches what's typed.
-                // for example, if 'foo/bar' is typed, we want to show 'foo/barcode'
-                if (prefix.startsWith(group.getFullName()))
-                    super.onItemGroup(group);
-            }
-
-            @Override
-            public void onItem(Item i) {
-                if (i.getFullName().startsWith(prefix)) {
-                    r.add((i.getFullName()));
-                    super.onItem(i);
-                }
-            }
-        }.onItemGroup(Jenkins.getInstance());
-
-        return r;
-    }
-
     /**
      * Auto-completion for the "copy from" field in the new job page.
      * @since 1.553
      */
+    @Restricted(DoNotUse.class)
     public AutoCompletionCandidates doAutoCompleteCopyNewItemFrom(@QueryParameter final String value, @AncestorInPath ItemGroup container) {
         return AutoCompletionCandidates.ofJobNames(TopLevelItem.class, value, container);
     }


### PR DESCRIPTION
Hoping nobody uses it programmatically. Also, added `@Restricted` to the new one.

---

Fixes an issue introduced in PR #1124: Stapler will happily select action methods that have no chance to execute successfully due to missing parameter annotations. While this behavior might be changed in the future (removing action methods can be dangerous, see e.g. https://github.com/jenkinsci/jenkins/commit/f97b5b33b0754532b945340cdee4b6ea1d2f6ba4#commitcomment-5946853), right now, removing it seems to be the only way to resolve the issue.
