### PR TITLE
Fix for JENKINS-22425, still needs license fix.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -489,7 +489,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>3.3.0-jenkins-3</version>
+      <version>4.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/core/src/main/java/hudson/util/jna/Advapi32.java
+++ b/core/src/main/java/hudson/util/jna/Advapi32.java
@@ -23,6 +23,9 @@ import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.ptr.IntByReference;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  *
  * @author TB
@@ -324,6 +327,12 @@ typedef struct _SERVICE_STATUS {
     public int dwServiceSpecificExitCode;
     public int dwCheckPoint;
     public int dwWaitHint;
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList("dwServiceType", "dwCurrentState", "dwControlsAccepted",
+                "dwWin32ExitCode", "dwServiceSpecificExitCode", "dwCheckPoint", "dwWaitHint");
+    }
   }
 
 /*
@@ -335,9 +344,18 @@ typedef struct _SERVICE_TABLE_ENTRY {
   class SERVICE_TABLE_ENTRY extends Structure {
     public String lpServiceName;
     public SERVICE_MAIN_FUNCTION lpServiceProc;
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList("lpServiceName", "lpServiceProc");
+    }
   }
 
   class ChangeServiceConfig2Info extends Structure {
+      @Override
+      protected List getFieldOrder() {
+          return Arrays.asList();
+      }
   }
 
 /*

--- a/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
+++ b/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
@@ -26,6 +26,9 @@ package hudson.util.jna;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  *
  * <pre>
@@ -69,6 +72,14 @@ public class SHELLEXECUTEINFO extends Structure {
     public int dwHotKey;
     public Pointer hIcon;
     public Pointer hProcess;
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList("cbSize", "fMask", "hwnd",
+                "lpVerb", "lpFile", "lpParameters", "lpDirectory",
+                "nShow", "hInstApp", "lpIDList", "lpClass",
+                "hkeyClass", "dwHotKey", "hIcon", "hProcess");
+    }
 
     public static final int SEE_MASK_NOCLOSEPROCESS = 0x40;
     public static final int SW_HIDE = 0;

--- a/core/src/main/java/hudson/util/jna/WINBASE.java
+++ b/core/src/main/java/hudson/util/jna/WINBASE.java
@@ -18,6 +18,9 @@ package hudson.util.jna;
 import com.sun.jna.Structure;
 import com.sun.jna.Pointer;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  *
  * @author TB
@@ -35,7 +38,12 @@ typedef struct _SECURITY_ATTRIBUTES {
     public int nLength;
     public Pointer lpSecurityDescriptor;
     public boolean bInheritHandle;
-  }
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList("nLength", "lpSecurityDescriptor", "bInheritHandle");
+    }
+}
 
 /*
 typedef struct _FILETIME {
@@ -45,5 +53,10 @@ typedef struct _FILETIME {
   class FILETIME extends Structure {
     public int dwLowDateTime;
     public int dwHighDateTime;
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList("dwLowDateTime", "dwHighDateTime");
+    }
   }
 }

--- a/licenseCompleter.groovy
+++ b/licenseCompleter.groovy
@@ -72,10 +72,6 @@ complete {
         rewriteLicense([],jenkinsLicense)
     }
 
-    match("*:jna") {
-        rewriteLicense([],lgpl)
-    }
-
     match(["org.jvnet.localizer:localizer"]) {
         // see http://java.net/projects/localizer
         // see http://java.net/projects/trilead-putty-extension/


### PR DESCRIPTION
I have a fix ready for: https://issues.jenkins-ci.org/browse/JENKINS-22425
The fix just added a new required method (getFieldOrder()) on Structure sub classes. The fix also upgrades to the latest released version of JNA (4.1.0).

I'm having a problem with cloud bees:maven-license-plugin complaining about an unexpected license after updating to the latest release of JNA (4.1.0 from 3.3.0-jenkins-3):

[INFO] Reactor Summary:
[INFO] 
[INFO] Jenkins main module ............................... SUCCESS [  5.015 s]
[INFO] Jenkins CLI ....................................... SUCCESS [ 12.483 s]
[INFO] Jenkins core ...................................... SUCCESS [02:54 min]
[INFO] Jenkins war ....................................... FAILURE [ 17.299 s]
[INFO] Test harness for Jenkins and plugins .............. SKIPPED
[INFO] Jenkins plugin POM ................................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 03:33 min
[INFO] Finished at: 2014-04-09T22:30:13-05:00
[INFO] Final Memory: 199M/475M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.cloudbees:maven-license-plugin:1.7:process (default) on project jenkins-war: Execution default of goal com.cloudbees:maven-license-plugin:1.7:process failed: java.lang.IllegalStateException: Expecting [] but found [LGPL, version 2.1,ASL, version 2] for dependency net.java.dev.jna:jna:4.1.0 -> [Help 1]

Any suggestions on how I can fix this error?
