### PR TITLE
Fix changelog generation in ExtractResourceWithChangesSCM

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/ExtractResourceWithChangesSCM.java
+++ b/test/src/main/java/org/jvnet/hudson/test/ExtractResourceWithChangesSCM.java
@@ -122,13 +122,13 @@ public class ExtractResourceWithChangesSCM extends NullSCM {
         stream.println("<extractChanges>");
         stream.println("<entry>");
         stream.println("<zipFile>" + escapeForXml(changeLog.getZipFile()) + "</zipFile>");
-        stream.println("<file>");
 
         for (String fileName : changeLog.getAffectedPaths()) {
+            stream.println("<file>");
             stream.println("<fileName>" + escapeForXml(fileName) + "</fileName>");
+            stream.println("</file>");
         }
 
-        stream.println("</file>");
         stream.println("</entry>");
         stream.println("</extractChanges>");
 


### PR DESCRIPTION
when several files are changed at once
(used in the fix for JENKINS-22622)
