### PR TITLE
Fix jenkins restart on Linux after a JRE system update

### DIFF
--- a/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
@@ -79,7 +79,7 @@ public class UnixLifecycle extends Lifecycle {
         }
 
         // exec to self
-        String exe = Daemon.getCurrentExecutable();
+        String exe = args.get(0);
         LIBC.execv(exe, new StringArray(args.toArray(new String[args.size()])));
         throw new IOException("Failed to exec '"+exe+"' "+LIBC.strerror(Native.getLastError()));
     }


### PR DESCRIPTION
Daemon.getCurrentExecutable() use /proc/PID/exe to retrieve the used JRE. This link is broken when the target changes (ie after a JRE system update) because the kernel appends ' (deleted)' to the symlink. This patch uses the first argument of the command line (in /proc/PID/cmdline) instead.
