### PR TITLE
Update version of bundled Mailer plugin to 1.8 to avoid issues with olde...

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -69,6 +69,8 @@ Upcoming changes</a>
   <li class=bug>
     Fix a bug which only showed the first detail part for radio buttons.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22583">issue 22583</a>)
+  <li class=rfe>
+    Update version of bundled Mailer plugin to 1.8 to avoid issues with older versions
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -340,7 +340,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>mailer</artifactId>
-                  <version>1.6</version>
+                  <version>1.8</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
Mailer 1.6 has issues that cause NPE's and so forth. Update the bundled version to avoid these issues.
