### PR TITLE
[FIXED JENKINS-22670] Less aggressive word breaking

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1834,7 +1834,7 @@ public class Functions {
     public static String breakableString(final String plain) {
 
         return plain.replaceAll("([\\p{Punct}&&[^;]]+\\w)", "<wbr>$1")
-                .replaceAll("([^\\p{Punct}\\s-]{10})(?=[^\\p{Punct}\\s-]{3})", "$1<wbr>")
+                .replaceAll("([^\\p{Punct}\\s-]{20})(?=[^\\p{Punct}\\s-]{10})", "$1<wbr>")
         ;
     }
 

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -309,7 +309,9 @@ public class FunctionsTest {
 
         assertBrokenAs("Hello world!", "Hello world!");
         assertBrokenAs("Hello-world!", "Hello", "-world!");
-        assertBrokenAs("ALongStringThatCanNotBeBrokenByDefault", "ALongStrin", "gThatCanNo", "tBeBrokenB", "yDefault");
+        assertBrokenAs("ALongStringThatCanNotBeBrokenByDefaultAndNeedsToUseTheBreakableElement",
+                "ALongStringThatCanNo", "tBeBrokenByDefaultAn", "dNeedsToUseTheBreaka", "bleElement");
+        assertBrokenAs("DontBreakShortStringBefore-Hyphen", "DontBreakShortStringBefore", "-Hyphen");
         assertBrokenAs("jenkins_main_trunk", "jenkins", "_main", "_trunk");
 
         assertBrokenAs("&lt;&lt;&lt;&lt;&lt;", "", "&lt;", "&lt;", "&lt;", "&lt;", "&lt;");
@@ -319,7 +321,7 @@ public class FunctionsTest {
         assertBrokenAs("A;String>Full]Of)Weird}Punctuation", "A;String", ">Full", "]Of", ")Weird", "}Punctuation");
         assertBrokenAs("&lt;&lt;a&lt;bc&lt;def&lt;ghi&lt;", "", "&lt;", "&lt;a", "&lt;bc", "&lt;def", "&lt;ghi", "&lt;");
         assertBrokenAs("H,e.l/l:o=w_o+|d", "H", ",e", ".l", "/l", ":o", "=w", "_o", "+|d");
-        assertBrokenAs("a¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷ", "a¶‱ﻷa¶‱ﻷa¶", "‱ﻷa¶‱ﻷa¶‱ﻷ", "a¶‱ﻷa¶‱ﻷa¶‱ﻷ");
+        assertBrokenAs("a¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷ", "a¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷa¶‱ﻷ", "a¶‱ﻷa¶‱ﻷa¶‱ﻷ");
     }
 
     private void assertBrokenAs(String plain, String... chunks) {


### PR DESCRIPTION
Only break 30+ char words after 20 chars rather than 13+ char words after 10 chars. Goals:
- Much fewer unnecessary work breaks
- Don't break shortly before the word ends

Sample screen shots below.

---

**Old:** Weird unnecessary break.
![c-i-c-old](https://cloud.githubusercontent.com/assets/1831569/2736172/9503fb88-c669-11e3-963a-fd656814f723.png)

**New**: Fixed.
![c-i-c-new](https://cloud.githubusercontent.com/assets/1831569/2736169/8dfb6f10-c669-11e3-9ba4-00ada41008ba.png)

---

**Old**: Weird unnecessary break.
![c-ic-old](https://cloud.githubusercontent.com/assets/1831569/2736180/b2538f1e-c669-11e3-8f2f-057952a48149.png)

**New**: Does not introduce a new line break. Example should also be pretty much the worst case for the fix in the executors list.
![c-ic-new](https://cloud.githubusercontent.com/assets/1831569/2736181/b59a7c78-c669-11e3-8f42-0c7095e0c060.png)

---

**Old**: Necessary break in long unbroken string to preserve the design.
![cic-old](https://cloud.githubusercontent.com/assets/1831569/2736196/de398c78-c669-11e3-856c-f2e0811786f1.png)

**New**: Same necessary break. Still not smarter in the case of nicely breakable CamelCasing.
![cic-new](https://cloud.githubusercontent.com/assets/1831569/2736200/ed1fc554-c669-11e3-9096-bae5fd1acf83.png)

---

**Old**: Breaks words like `JavaVirtualMachines` for no good reason. More even appearance.
![table-old](https://cloud.githubusercontent.com/assets/1831569/2736344/c98534ce-c66b-11e3-8517-bab6cae4f1b0.png)

**New**: Does not break words shorter than 30 chars. More ragged line endings.
![table-new](https://cloud.githubusercontent.com/assets/1831569/2736345/cb5bba2a-c66b-11e3-854e-c60d0f3399ee.png)
