### PR TITLE
[FIXED JENKINS-22674] Use JS to resize graph.

### DIFF
--- a/core/src/main/resources/hudson/model/LoadStatistics/main.jelly
+++ b/core/src/main/resources/hudson/model/LoadStatistics/main.jelly
@@ -58,8 +58,14 @@ THE SOFTWARE.
         ${%Long}
       </j:otherwise>
     </j:choose>
-  </div>  
-  <img src="${prefix?:'loadStatistics'}/graph?type=${type}&amp;width=500&amp;height=300" alt="[${%Load statistics graph}]" />
+  </div>
+  <script type="text/javascript">
+    var w = document.getElementById('main-panel').offsetWidth - 30;
+    document.write('<img src="${prefix?:'loadStatistics'}/graph?type=${type}&amp;width=' + w + '&amp;height=500" alt="[${%Load statistics graph}]" />');
+  </script>
+  <noscript>
+    <img src="${prefix?:'loadStatistics'}/graph?type=${type}&amp;width=500&amp;height=300" alt="[${%Load statistics graph}]" />
+  </noscript>
   <div style="margin-top: 2em;">
     ${%blurb}
   </div>


### PR DESCRIPTION
This will make the load statistics graphs fit the window width if JS is enabled. Also changes the graph height in that case. Requires <700 px useable height to fully show without scrolling.

WXGA window size (accounting for 22px menu bar):
![screen shot 2014-04-18 at 14 03 35](https://cloud.githubusercontent.com/assets/1831569/2741679/85de9824-c6f1-11e3-9afd-5c1e0666d715.png)
