### PR TITLE
[FIXED JENKINS-22686] Add a few pixels distance between tick labels.

### DIFF
--- a/core/src/main/java/hudson/util/NoOverlapCategoryAxis.java
+++ b/core/src/main/java/hudson/util/NoOverlapCategoryAxis.java
@@ -46,12 +46,6 @@ import java.util.*;
  * @author Kohsuke Kawaguchi
  */
 public class NoOverlapCategoryAxis extends CategoryAxis {
-
-    /**
-     * Minimum distance between labels.
-     */
-    private static final double MIN_DISTANCE = 6.0;
-
     public NoOverlapCategoryAxis(String label) {
         super(label);
     }
@@ -147,10 +141,10 @@ public class NoOverlapCategoryAxis extends CategoryAxis {
                     }
                     r = bounds.getBounds2D();
                     // add margins in all directions
-                    r.add(r.getMaxX() + MIN_DISTANCE, r.getCenterY());
-                    r.add(r.getMinX() - MIN_DISTANCE, r.getCenterY());
-                    r.add(r.getCenterX(), r.getMinY() - MIN_DISTANCE);
-                    r.add(r.getCenterX(), r.getMaxX() + MIN_DISTANCE);
+                    r.add(r.getMaxX() + r.getWidth()/2, r.getCenterY());
+                    r.add(r.getMinX() - r.getWidth()/2, r.getCenterY());
+                    r.add(r.getCenterX(), r.getMinY() - r.getHeight()/2);
+                    r.add(r.getCenterX(), r.getMaxX() + r.getHeight()/2);
                 }
 
                 categoryIndex++;

--- a/core/src/main/java/hudson/util/NoOverlapCategoryAxis.java
+++ b/core/src/main/java/hudson/util/NoOverlapCategoryAxis.java
@@ -46,6 +46,12 @@ import java.util.*;
  * @author Kohsuke Kawaguchi
  */
 public class NoOverlapCategoryAxis extends CategoryAxis {
+
+    /**
+     * Minimum distance between labels.
+     */
+    private static final double MIN_DISTANCE = 6.0;
+
     public NoOverlapCategoryAxis(String label) {
         super(label);
     }
@@ -140,6 +146,11 @@ public class NoOverlapCategoryAxis extends CategoryAxis {
                         }
                     }
                     r = bounds.getBounds2D();
+                    // add margins in all directions
+                    r.add(r.getMaxX() + MIN_DISTANCE, r.getCenterY());
+                    r.add(r.getMinX() - MIN_DISTANCE, r.getCenterY());
+                    r.add(r.getCenterX(), r.getMinY() - MIN_DISTANCE);
+                    r.add(r.getCenterX(), r.getMaxX() + MIN_DISTANCE);
                 }
 
                 categoryIndex++;


### PR DESCRIPTION
Because _this_ isn't that easy to read:

![Screen shot](https://cloud.githubusercontent.com/assets/1831569/2749434/b34540fe-c801-11e3-9f46-121614111385.png)

---
### PR notes

**Update**: Updated PR to determine margin from size of the label instead of hard-coding pixel count.

While for the `MultiStageTimeSeries`, only right margin would be needed, I added all four, as the rest of the code also supports other orientations. The left margin is useless (except for consistency) though, could leave that out if it bothers someone.
