### PR TITLE
[FIXED JENKINS-22688] Made graph font explicit and configurable

### DIFF
--- a/core/src/main/java/hudson/model/MultiStageTimeSeries.java
+++ b/core/src/main/java/hudson/model/MultiStageTimeSeries.java
@@ -95,6 +95,9 @@ public class MultiStageTimeSeries implements Serializable {
 
     private int counter;
 
+    private static final Font CHART_FONT = Font.getFont(MultiStageTimeSeries.class.getName() + ".chartFont",
+            new Font(Font.SANS_SERIF, Font.PLAIN, 10));
+
     public MultiStageTimeSeries(Localizable title, Color color, float initialValue, float decay) {
         this.title = title;
         this.color = color;
@@ -242,6 +245,7 @@ public class MultiStageTimeSeries implements Serializable {
                     );
 
             chart.setBackgroundPaint(Color.white);
+            chart.getLegend().setItemFont(CHART_FONT);
 
             final CategoryPlot plot = chart.getCategoryPlot();
             configurePlot(plot);
@@ -255,6 +259,8 @@ public class MultiStageTimeSeries implements Serializable {
 
         protected void configureRangeAxis(NumberAxis rangeAxis) {
             rangeAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
+            rangeAxis.setTickLabelFont(CHART_FONT);
+            rangeAxis.setLabelFont(CHART_FONT);
         }
 
         protected void crop(CategoryPlot plot) {
@@ -269,6 +275,8 @@ public class MultiStageTimeSeries implements Serializable {
             domainAxis.setLowerMargin(0.0);
             domainAxis.setUpperMargin(0.0);
             domainAxis.setCategoryMargin(0.0);
+            domainAxis.setLabelFont(CHART_FONT);
+            domainAxis.setTickLabelFont(CHART_FONT);
             return domainAxis;
         }
 


### PR DESCRIPTION
Use of whatever is the default font can make the labels difficult to read. `SansSerif` as explicit default should fix this in most cases, but in case of any weird platform messing up even that, make it configurable. This also allows increasing the font size for better accessibility (especially combined with #1198's large graphs), and matching the font used in the graphs to any custom Jenkins CSS.

![Screenshot](https://cloud.githubusercontent.com/assets/1831569/2749582/e77e19f6-c80e-11e3-9bf8-fbad2cd96692.png)
