### PR TITLE
[FIXED JENKINS-22689] Show load statistics for master node

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -474,7 +474,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
 
     @Exported
     public LoadStatistics getLoadStatistics() {
-        return LabelAtom.get(nodeName != null ? nodeName : "").loadStatistics;
+        return LabelAtom.get(nodeName != null ? nodeName : Jenkins.getInstance().getSelfLabel().toString()).loadStatistics;
     }
 
     public BuildTimelineWidget getTimeline() {


### PR DESCRIPTION
Fixes `/computer/(master)/load-statistics` which is otherwise always empty:

![Screen shot](https://cloud.githubusercontent.com/assets/1831569/2749629/7614038a-c812-11e3-9328-cb79963471a4.png)
