### PR TITLE
[JENKINS-22691] Trigger "select:filled" event instead of "filled" in /lib/form/select

### DIFF
--- a/core/src/main/resources/lib/form/select/select.js
+++ b/core/src/main/resources/lib/form/select/select.js
@@ -57,7 +57,14 @@ Behaviour.specify("SELECT.select", 'select', 1000, function(e) {
                         }
                     }
 
-                    fireEvent(e,"filled"); // let other interested parties know that the items have changed
+                    // let other interested parties know that the items have changed
+                    $(e).fire("select:filled");
+                    try {
+                      // for backward-compatibility.
+                      fireEvent(e,"filled")
+                    } catch(ex) {
+                      // Firing non-builtin event fails in IE <= 8.
+                    }
 
                     // if the update changed the current selection, others listening to this control needs to be notified.
                     if (e.value!=value) fireEvent(e,"change");


### PR DESCRIPTION
[JENKINS-22691](https://issues.jenkins-ci.org/browse/JENKINS-22691)

/lib/form/select fires `filled` event when it is populated.
This allows plugins watch update of options of select.

But It does not work in IE8 (I tested with IE8 document mode in IE11), as IE8 does not allow to fire non-buildin events using `fireEvent`.
Custom events should be handled using `Event` with prototype.js.

I introduced a new event `select:filled` (custom events must be namespaced in prototype.js).
For backward compatibility, the `filled` event is also fired (Of course, does not fired in IE8).

I'm not sure Jenkins supports IE8 and this should be fixed.
Please let me know if IE8 is no longer supported in Jenkins.
