### PR TITLE
[FIXED JENKINS-22698] Add indicator that build queue is filtered.

### DIFF
--- a/core/src/main/resources/hudson/model/View/ajaxBuildQueue.jelly
+++ b/core/src/main/resources/hudson/model/View/ajaxBuildQueue.jelly
@@ -28,6 +28,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:ajax>
-    <t:queue items="${it.approximateQueueItemsQuickly}" />
+    <t:queue items="${it.approximateQueueItemsQuickly}" filtered="${it.isFilterQueue()}" />
   </l:ajax>
 </j:jelly>

--- a/core/src/main/resources/jenkins/widgets/BuildQueueWidget/index.groovy
+++ b/core/src/main/resources/jenkins/widgets/BuildQueueWidget/index.groovy
@@ -2,4 +2,4 @@ package jenkins.widgets.BuildQueueWidget;
 
 def t = namespace(lib.JenkinsTagLib.class)
 
-t.queue(items:view.approximateQueueItemsQuickly, it:view)
+t.queue(items:view.approximateQueueItemsQuickly, it:view, filtered:view.filterQueue)

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -32,9 +32,20 @@ THE SOFTWARE.
       but for example you can specify a sublist after some filtering to narrow down
       the list.
     </st:attribute>
+    <st:attribute name="filtered" use="optional">
+      Indicates that the queue has been filtered, i.e. might not show all items.
+    </st:attribute>
   </st:documentation>
   <t:setIconSize/>
-  <l:pane title="${%Build Queue(items.size())}" width="2" id="buildQueue">
+  <j:choose>
+    <j:when test="${filtered}">
+      <j:set var="title" value="${%Filtered Build Queue(items.size())}" />
+    </j:when>
+    <j:otherwise>
+      <j:set var="title" value="${%Build Queue(items.size())}" />
+    </j:otherwise>
+  </j:choose>
+  <l:pane title="${title}" width="2" id="buildQueue">
     <j:if test="${app.quietingDown}">
       <tr>
         <td class="pane" colspan="2" style="white-space: normal;">

--- a/core/src/main/resources/lib/hudson/queue.properties
+++ b/core/src/main/resources/lib/hudson/queue.properties
@@ -1,2 +1,3 @@
 Build\ Queue=Build Queue{0,choice,0#|0< ({0,number})}
+Filtered\ Build\ Queue=Filtered Build Queue{0,choice,0#|0< ({0,number})}
 WaitingFor=Waiting for {0}


### PR DESCRIPTION
[JENKINS-22698](https://issues.jenkins-ci.org/browse/JENKINS-22698).
