### PR TITLE
Display username in logs when a failed attempt is made.

### DIFF
--- a/core/src/main/java/hudson/security/AuthenticationProcessingFilter2.java
+++ b/core/src/main/java/hudson/security/AuthenticationProcessingFilter2.java
@@ -103,6 +103,7 @@ public class AuthenticationProcessingFilter2 extends AuthenticationProcessingFil
         LOGGER.log(Level.FINE, "Login attempt failed", failed);
         Authentication auth = failed.getAuthentication();
         if (auth != null) {
+            LOGGER.log(Level.FINE, "User " + auth.getName() + " failed to login.");
             SecurityListener.fireFailedToLogIn(auth.getName());
         }
     }


### PR DESCRIPTION
When a user fails to login, as long as the authentication is not null it should display the username that was trying to login.
