### PR TITLE
[JENKINS-16502] Permission to see an executor/slave (take 2)

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -89,6 +89,9 @@ Upcoming changes</a>
   <li class=bug>
     Job hangs if one of multiple triggered builds was aborted
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21932">issue 21932</a>)
+  <li class=rfe>
+    Add support for hiding build slaves from users.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-16502">issue 16502</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1362,6 +1362,12 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     public static final Permission DISCONNECT = new Permission(PERMISSIONS,"Disconnect", Messages._Computer_DisconnectPermission_Description(), Jenkins.ADMINISTER, PermissionScope.COMPUTER);
     public static final Permission CONNECT = new Permission(PERMISSIONS,"Connect", Messages._Computer_ConnectPermission_Description(), DISCONNECT, PermissionScope.COMPUTER);
     public static final Permission BUILD = new Permission(PERMISSIONS, "Build", Messages._Computer_BuildPermission_Description(),  Permission.WRITE, PermissionScope.COMPUTER);
+    /**
+     * @since 1.560
+     */
+    public static final Permission VIEW = new Permission(PERMISSIONS, "View",
+            Messages._Computer_ViewPermission_Description(), Permission.READ,
+            Boolean.getBoolean("hudson.model.Computer.VIEW.enabled"), new PermissionScope[]{PermissionScope.COMPUTER});
 
     private static final Logger LOGGER = Logger.getLogger(Computer.class.getName());
 }

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -189,7 +189,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
         if(this.matches(h))
             r.add(h);
         for (Node n : h.getNodes()) {
-            if(this.matches(n))
+            if(this.matches(n) && (!Computer.VIEW.getEnabled() || n.hasPermission(Computer.VIEW)))
                 r.add(n);
         }
         return this.nodes = Collections.unmodifiableSet(r);

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1539,7 +1539,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Gets the read-only list of all {@link Computer}s.
      */
     public Computer[] getComputers() {
-        Computer[] r = computers.values().toArray(new Computer[computers.size()]);
+        Collection<Computer> computers = new ArrayList<Computer>(this.computers.size());
+        for (Computer c: this.computers.values()) {
+            if (!Computer.VIEW.getEnabled() || c.hasPermission(Computer.VIEW))
+                computers.add(c);
+        }
+        Computer[] r = computers.toArray(new Computer[computers.size()]);
         Arrays.sort(r,new Comparator<Computer>() {
             final Collator collator = Collator.getInstance();
             public int compare(Computer lhs, Computer rhs) {
@@ -1558,7 +1563,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
         for (Computer c : computers.values()) {
             if(c.getName().equals(name))
-                return c;
+                return !Computer.VIEW.getEnabled() || c.hasPermission(Computer.VIEW) ? c : null;
         }
         return null;
     }

--- a/core/src/main/resources/hudson/model/Computer/builds.jelly
+++ b/core/src/main/resources/hudson/model/Computer/builds.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName}">
+  <l:layout title="${it.displayName}" permission="${it.VIEW.enabled?it.VIEW:null}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <h1>

--- a/core/src/main/resources/hudson/model/Computer/delete.jelly
+++ b/core/src/main/resources/hudson/model/Computer/delete.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout>
+  <l:layout permission="${it.DELETE}">
 		<st:include page="sidepanel.jelly" />
 		<l:main-panel>
 		  <form method="post" action="doDelete">

--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName}">
+  <l:layout title="${it.displayName}" permission="${it.VIEW.enabled?it.VIEW:null}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
 

--- a/core/src/main/resources/hudson/model/Computer/load-statistics.jelly
+++ b/core/src/main/resources/hudson/model/Computer/load-statistics.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName} Load Statistics">
+  <l:layout title="${it.displayName} Load Statistics" permission="${it.VIEW.enabled?it.VIEW:null}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <st:include page="main.jelly" from="${it.loadStatistics}" />

--- a/core/src/main/resources/hudson/model/Computer/markOffline.jelly
+++ b/core/src/main/resources/hudson/model/Computer/markOffline.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${%title(it.displayName)}" norefresh="true">
+  <l:layout title="${%title(it.displayName)}" norefresh="true" permission="${it.VIEW.enabled?it.VIEW:null}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <l:hasPermission permission="${it.DISCONNECT}">

--- a/core/src/main/resources/hudson/model/Computer/setOfflineCause.jelly
+++ b/core/src/main/resources/hudson/model/Computer/setOfflineCause.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${%title(it.displayName)}" norefresh="true">
+  <l:layout title="${%title(it.displayName)}" norefresh="true" permission="${it.VIEW.enabled?it.VIEW:null}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <l:hasPermission permission="${it.DISCONNECT}">

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -112,6 +112,7 @@ Computer.CreatePermission.Description=This permission allows users to create sla
 Computer.ConnectPermission.Description=This permission allows users to connect slaves or mark slaves as online.
 Computer.DisconnectPermission.Description=This permission allows users to disconnect slaves or mark slaves as temporarily offline.
 Computer.BuildPermission.Description=This permission allows users to run jobs as them on slaves.
+Computer.ViewPermission.Description=This permission allows users to see the slaves.
 Computer.BadChannel=Slave node offline or not a remote channel (such as master node).
 
 ComputerSet.NoSuchSlave=No such slave: {0}


### PR DESCRIPTION
- The permission is not enabled by default, so should not cause regressions for existing instances
- Due to node names being exposed as labels, the label autocomplete will still reveal information
  about what slaves exist.
