### PR TITLE
[FIXED JENKINS-22720] Only call getAllItems in recursive ListView

### DIFF
--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -170,7 +170,13 @@ public class ListView extends View implements Saveable {
         includeItems(parent, parentItems, names);
 
         Boolean statusFilter = this.statusFilter; // capture the value to isolate us from concurrent update
-        for (TopLevelItem item : Items.getAllItems(getOwnerItemGroup(), TopLevelItem.class)) {
+        Iterable<? extends TopLevelItem> candidates;
+        if (recurse) {
+            candidates = Items.getAllItems(parent, TopLevelItem.class);
+        } else {
+            candidates = parent.getItems();
+        }
+        for (TopLevelItem item : candidates) {
             if (!names.contains(item.getRelativeNameFrom(getOwnerItemGroup()))) continue;
             // Add if no status filter or filter matches enabled/disabled status:
             if(statusFilter == null || !(item instanceof AbstractProject)

--- a/test/src/test/java/hudson/model/ListViewTest.java
+++ b/test/src/test/java/hudson/model/ListViewTest.java
@@ -119,6 +119,7 @@ public class ListViewTest {
         FreeStyleProject p2 = sub.createProject(FreeStyleProject.class, "p2");
         FreeStyleProject p3 = top.createProject(FreeStyleProject.class, "p3");
         ListView v = new ListView("v");
+        v.setRecurse(true);
         top.addView(v);
         v.add(p1);
         v.add(p2);


### PR DESCRIPTION
Need to adjust the test to set the recurse flag. `sub/p2` cannot be in the list view through user configuration otherwise.
