### PR TITLE
JENKINS-22755 - RunParameter no longer displays the Full Display Name

### DIFF
--- a/core/src/main/resources/hudson/model/RunParameterDefinition/index.jelly
+++ b/core/src/main/resources/hudson/model/RunParameterDefinition/index.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
 			<input type="hidden" name="name" value="${it.name}" />
             <select name="runId">
               <j:forEach var="run" items="${it.builds}">
-                <option value="${run.externalizableId}">${run}</option>
+                <option value="${run.externalizableId}">${run.fullDisplayName}</option>
               </j:forEach>
             </select>
 		</div>


### PR DESCRIPTION
Run parameter now displays run.fullDisplayName instead of the Run toString()

This is to restore the display format which was changed by the following commit: 
5d92b45f47e630b6d9790a7d91b877c4f0acc449
