### PR TITLE
Predictable cron behavior

### DIFF
--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -194,14 +194,22 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
     public static class Cron extends PeriodicWork {
         private final Calendar cal = new GregorianCalendar();
 
+        public Cron() {
+            cal.set(Calendar.SECOND, 0);
+            cal.set(Calendar.MILLISECOND, 0);
+        }
+
         public long getRecurrencePeriod() {
             return MIN;
         }
 
-        public void doRun() {
-            while(new Date().getTime()-cal.getTimeInMillis()>1000) {
-                LOGGER.log(Level.FINE, "cron checking {0}", cal.getTime());
+        public long getInitialDelay() {
+            return MIN - (Calendar.getInstance().get(Calendar.SECOND) * 1000);
+        }
 
+        public void doRun() {
+            while(new Date().getTime() >= cal.getTimeInMillis()) {
+                LOGGER.log(Level.FINE, "cron checking {0}", cal.getTime());
                 try {
                     checkTriggers(cal);
                 } catch (Throwable e) {


### PR DESCRIPTION
Right now the PeriodicWork that handles firing crons has an internal calendar that is set at instantiation.  The initial delay for the thread is set at a random value between 0-60 seconds.  This can lead to Jobs that have a trigger that uses crons to start up to almost two minutes after the time indicated by the cron.  Consider the case where the trigger is kicked off few seconds before the internal calendar.

cal = 59 seconds
cron 57 seconds

I have a cron that is supposed to go off at noon
12:00:57 - cron goes off at 12:00:57, checks 11:59:59, bumps to 12:00:59
12:01:57, checks 12:59, my noon cron goes off.

This change sets the internal calendar to the start of the minute, and the initial delay on the TimerTask to start at the next minute.

I understand it's not the goal to have Jenkins give the precision that a traditional cron provides, but this change will start jobs within a second of the given cron.  At the very least, the behavior is more predictable.
