### PR TITLE
[FIXED JENKINS-22934] Show poll thread count option when necessary.

### DIFF
--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -45,6 +45,8 @@ import hudson.util.TimeUnit2;
 import hudson.util.SequentialExecutionQueue;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.jelly.XMLOutput;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -258,6 +260,15 @@ public class SCMTrigger extends Trigger<SCMedItem> {
             maximumThreads = n;
 
             resizeThreadPool();
+        }
+
+        @Restricted(NoExternalUse.class)
+        public boolean isPollingThreadCountOptionVisible() {
+            // unless you have a fair number of projects, this option is likely pointless.
+            // so let's hide this option for new users to avoid confusing them
+            // unless it was already changed
+            return Jenkins.getInstance().getAllItems(AbstractProject.class).size() > 10
+                    || getPollingThreadCount() != 0;
         }
 
         /**

--- a/core/src/main/resources/hudson/triggers/SCMTrigger/global.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/global.jelly
@@ -24,11 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <j:if test="${app.items.size()>10}">
-    <!--
-      unless you have a fair number of projects, this option is likely pointless.
-      so let's hide this option for new users to avoid confusing them.
-    -->
+  <j:if test="${descriptor.pollingThreadCountOptionVisible}">
     <f:section title="${%SCM Polling}">
       <f:entry title="${%Max # of concurrent polling}" field="pollingThreadCount">
         <f:number value="${descriptor.pollingThreadCount==0 ? '' : descriptor.pollingThreadCount}"


### PR DESCRIPTION
Old behavior:
- Show the option when `Jenkins` has more than 10 children.

New behavior:
- Only consider `AbstractProject`s
- Also consider grandchildren etc. (i.e. in other `ItemGroup`s)
- Also show the option when the currently configured value is not the default to prevent reset
