### PR TITLE
[FIX JENKINS-22028] Allow MarkupFormatter without enabling security

### DIFF
--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -99,13 +99,14 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
             } catch (IOException e) {
                 throw new hudson.model.Descriptor.FormException(e, "slaveAgentPortType");
             }
-            if (security.has("markupFormatter")) {
-                j.setMarkupFormatter(req.bindJSON(MarkupFormatter.class, security.getJSONObject("markupFormatter")));
-            } else {
-                j.setMarkupFormatter(null);
-            }
         } else {
             j.disableSecurity();
+        }
+
+        if (json.has("markupFormatter")) {
+            j.setMarkupFormatter(req.bindJSON(MarkupFormatter.class, json.getJSONObject("markupFormatter")));
+        } else {
+            j.setMarkupFormatter(null);
         }
 
         // persist all the additional security configs

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2081,7 +2081,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         useSecurity = null;
         setSecurityRealm(SecurityRealm.NO_AUTHENTICATION);
         authorizationStrategy = AuthorizationStrategy.UNSECURED;
-        markupFormatter = null;
     }
 
     public void setProjectNamingStrategy(ProjectNamingStrategy ns) {

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
@@ -33,8 +33,6 @@ l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
                     f.checkbox()
                 }
 
-                f.dropdownDescriptorSelector(title:_("Markup Formatter"),descriptors: MarkupFormatterDescriptor.all(), field: 'markupFormatter')
-
                 f.entry(title:_("Access Control")) {
                     table(style:"width:100%") {
                         f.descriptorRadioList(title:_("Security Realm"),varName:"realm",         instance:app.securityRealm,         descriptors:SecurityRealm.all())
@@ -42,6 +40,8 @@ l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
                     }
                 }
             }
+
+            f.dropdownDescriptorSelector(title:_("Markup Formatter"),descriptors: MarkupFormatterDescriptor.all(), field: 'markupFormatter')
 
             Functions.getSortedDescriptorsForGlobalConfig(my.FILTER).each { Descriptor descriptor ->
                 set("descriptor",descriptor)


### PR DESCRIPTION
Given the current default of 'Escaped HTML', it makes no sense
to require users to 'Enable Security' to set up a less secure
alternative. So show it on the global security configuration page
on top level.

---

A solution using a proper descriptor, similar to `GlobalCrumbIssuerConfiguration` to get rid of the special handling of this option, can always be added later.
