### PR TITLE
[FIX JENKINS-22971] Show full project name when in folder.

### DIFF
--- a/core/src/main/resources/hudson/model/Job/index.jelly
+++ b/core/src/main/resources/hudson/model/Job/index.jelly
@@ -28,8 +28,15 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <h1 class="job-index-headline page-headline">${it.pronoun} <l:breakable value="${it.displayName}"/></h1>
-      <j:if test="${(it.name!=it.displayName) and (it.class.name!='hudson.matrix.MatrixConfiguration')}"> <!-- TODO rather check for TopLevelItem (how to do this from Jelly?) -->
-        ${%Project name}: ${it.fullName}
+      <j:if test="${(it.fullName!=it.fullDisplayName) and (it.class.name!='hudson.matrix.MatrixConfiguration')}"> <!-- TODO rather check for TopLevelItem (how to do this from Jelly?) -->
+        <j:choose>
+          <j:when test="${it.parent!=app}">
+            ${%Full project name}: ${it.fullName}
+          </j:when>
+          <j:otherwise>
+            ${%Project name}: ${it.fullName}
+          </j:otherwise>
+        </j:choose>
       </j:if>
       <t:editableDescription permission="${it.CONFIGURE}"/>
 


### PR DESCRIPTION
Jenkins currently shows the full name of a project on its index page when a display name is set.

It should also show the full name when the parent is not `Jenkins.instance`, i.e. the full name not equal to the project name. Projects frequently need to be referenced by their full name (Copy Artifact, Build other projects, ...).

| Full name | Full display name | Full name shown? |
| --- | --- | --- |
| foo | foo | No _(same as project name)_ |
| foo | Foo | Yes |
| bar/baz | bar » baz | Previously no, now **yes** |
| bar/baz | bar » Baz | Yes |
| bar/baz | Bar » baz | Previously no, now **yes** |
| bar/baz | Bar » Baz | Yes |
