### PR TITLE
[FIX JENKINS-22685] Jenkins cannot restart Windows service

### DIFF
--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -132,7 +132,8 @@ public class WindowsServiceLifecycle extends Lifecycle {
         else            executable = new File(home, "hudson.exe");
         if (!executable.exists())   executable = new File(home, "jenkins.exe");
 
-        int r = new LocalLauncher(task).launch().cmds(executable, "restart")
+        // use restart! to run hudson/jenkins.exe restart in a separate process, so it doesn't kill itself
+        int r = new LocalLauncher(task).launch().cmds(executable, "restart!")
                 .stdout(task).pwd(home).join();
         if(r!=0)
             throw new IOException(baos.toString());


### PR DESCRIPTION
Use "restart!" instead of "restart" when calling the Windows service wrapper to restart Jenkins. Otherwise, the service wrapper kills itself before completing the stop-wait-start procedure. JENKINS-22685 for issue description, and see Winsw README ("Restarting service from itself") for details about the use and intention of "restart!".
