### PR TITLE
[FIX JENKINS-22818] Fix jenkins restart on Linux after plugin update

### DIFF
--- a/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
@@ -80,7 +80,7 @@ public class UnixLifecycle extends Lifecycle {
 
         // exec to self
         String exe = args.get(0);
-        LIBC.execv(exe, new StringArray(args.toArray(new String[args.size()])));
+        LIBC.execvp(exe, new StringArray(args.toArray(new String[args.size()])));
         throw new IOException("Failed to exec '"+exe+"' "+LIBC.strerror(Native.getLastError()));
     }
 

--- a/core/src/main/java/hudson/util/jna/GNUCLibrary.java
+++ b/core/src/main/java/hudson/util/jna/GNUCLibrary.java
@@ -55,7 +55,8 @@ public interface GNUCLibrary extends Library {
     int chdir(String dir);
     int getdtablesize();
 
-    int execv(String file, StringArray args);
+    int execv(String path, StringArray args);
+    int execvp(String file, StringArray args);
     int setenv(String name, String value,int replace);
     int unsetenv(String name);
     void perror(String msg);


### PR DESCRIPTION
This pull request fix jenkins restart on Linux after plugin update if the java executable running Jenkins is started without its full path. The patch uses 'execvp' instead of 'execv' to lookup the java executable filename in the PATH if the specified filename does not contain a slash (/) character.

Regression introduced in 547d4ed8d35de6be4b2788e4816019bb8cc94902

Credits goes to Simon Matter
