### PR TITLE
[FIX JENKINS-23041] Fix systemInfo for offline slaves

### DIFF
--- a/core/src/main/resources/hudson/slaves/SlaveComputer/sidepanel2.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/sidepanel2.jelly
@@ -25,8 +25,8 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:task icon="images/24x24/clipboard.png" href="log" title="${%Log}" permission="${it.CONNECT}" />
-  <l:task icon="images/24x24/computer.png" href="systemInfo" title="${%System Information}" permission="${it.CONNECT}"/>
   <j:if test="${it.channel!=null}">
+    <l:task icon="images/24x24/computer.png" href="systemInfo" title="${%System Information}" permission="${it.CONNECT}"/>
     <l:task icon="images/24x24/edit-delete.png" href="disconnect" title="${%Disconnect}" permission="${it.DISCONNECT}"/>
   </j:if>
 

--- a/core/src/main/resources/hudson/slaves/SlaveComputer/systemInfo.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/systemInfo.jelly
@@ -33,13 +33,29 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
 
     <l:main-panel>
-      <l:hasPermission permission="${it.CONNECT}">
-        <h1>${it.oSDescription} slave, version ${it.slaveVersion}</h1>
 
-        <j:forEach var="instance" items="${it.systemInfoExtensions}">
-          <h1>${instance.displayName}</h1>
-          <st:include page="systemInfo" from="${instance}"/>
-        </j:forEach>
+      <h1>
+        <img src="${imagesURL}/48x48/${it.icon}" width="48" height="48" alt=""/>
+        ${it.caption} ${%System Information}
+        <j:if test="${!empty(it.node.nodeDescription)}">
+          <span style="font-size:smaller">(${it.node.nodeDescription})</span>
+        </j:if>
+      </h1>
+
+      <l:hasPermission permission="${it.CONNECT}">
+        <j:choose>
+          <j:when test="${it.online}">
+            <h2>${it.oSDescription} slave, version ${it.slaveVersion}</h2>
+
+            <j:forEach var="instance" items="${it.systemInfoExtensions}">
+              <h1>${instance.displayName}</h1>
+              <st:include page="systemInfo" from="${instance}"/>
+            </j:forEach>
+          </j:when>
+          <j:otherwise>
+            ${%System Information is unavailable when slave is offline.}
+          </j:otherwise>
+        </j:choose>
       </l:hasPermission>
     </l:main-panel>
   </l:layout>


### PR DESCRIPTION
- Don't show link to `systemInfo` in sidebar when slave is offline
- Make `systemInfo` page more robust when accessed via URL by not trying to show anything

Also, nicer page title: Show icon, name, and description of slave at the top of the page.

---

Are there `SlaveSystemInfo` that show real information while slave is offline? Maybe the robustness actually needs to be moved into the individual `SlaveSystemInfo`?

---

![screen shot 2014-05-15 at 05 11 11](https://cloud.githubusercontent.com/assets/1831569/2980061/25e2f69c-dbdf-11e3-9897-cdd44576053b.png)

---

![screen shot 2014-05-15 at 05 10 57](https://cloud.githubusercontent.com/assets/1831569/2980062/27e0e9ae-dbdf-11e3-8762-c273dd95407c.png)
