### PR TITLE
[FIXED JENKINS-20031] Useful error message when UC not found

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -721,7 +721,9 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     String pluginName = n.substring(0, index);
                     String siteName = n.substring(index + 1);
                     UpdateSite updateSite = Jenkins.getInstance().getUpdateCenter().getById(siteName);
-                    if (siteName != null) {
+                    if (updateSite == null) {
+                        throw new Failure("No such update center: " + siteName);
+                    } else {
                         UpdateSite.Plugin plugin = updateSite.getPlugin(pluginName);
                         if (plugin != null) {
                             if (p != null) {


### PR DESCRIPTION
Previously, it was simply an NPE one line further down.

It seems kind of stupid to use a different ID than the ID the UC is registered with in Jenkins for the plugin manager form — maybe specific to UpdateSites Manager plugin —, but that appears to be a separate issue.
