### PR TITLE
Move invalid body ID to body class and data

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -142,7 +142,7 @@ ${h.initPageVariables(context)}
       <st:include it="${pd}" page="header.jelly" optional="true" />
     </j:forEach>
   </head>
-  <body id="jenkins jenkins-${h.version}" class="yui-skin-sam">
+  <body id="jenkins" class="yui-skin-sam jenkins-${h.version}" data-version="jenkins-${h.version}">
     <!-- for accessibility, skip the entire navigation bar and etc and go straight to the head of the content -->
     <a href="#skip2content" class="skiplink">Skip to content</a>
 


### PR DESCRIPTION
IDs cannot contain spaces. Instead, let's move jenkins-${h.version} to the `class` attribute, which is space delimited. This way it can still be used for styling if needed (using `body.jenkins-x.y`). If this is not used for anything other than knowing which version of Jenkins is running, use `<body id="jenkins" class="yui-skin-sam" data-version="jenkins-${h.version}">` -- IDs and Classes should not be used to store data.
