### PR TITLE
Add logging to PeepholePermalink's RunListener

### DIFF
--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -190,10 +190,11 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
         public void onDeleted(Run run) {
             Job<?, ?> j = run.getParent();
             for (PeepholePermalink pp : Util.filter(j.getPermalinks(), PeepholePermalink.class)) {
-                if (pp.apply(run)) {
-                    if (pp.resolve(j)==run) {
-                        pp.updateCache(j,pp.find(run.getPreviousBuild()));
-                    }
+                if (pp.resolve(j)==run) {
+                    Run<?,?> r = pp.find(run.getPreviousBuild());
+                    if (LOGGER.isLoggable(Level.FINE))
+                        LOGGER.fine("Updating "+pp.getPermalinkFile(j).getName()+" permalink from deleted "+run.getNumber()+" to "+(r == null ? -1 : r.getNumber()));
+                    pp.updateCache(j,r);
                 }
             }
         }
@@ -207,8 +208,11 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
             for (PeepholePermalink pp : Util.filter(j.getPermalinks(), PeepholePermalink.class)) {
                 if (pp.apply(run)) {
                     Run<?, ?> cur = pp.resolve(j);
-                    if (cur==null || cur.getNumber()<run.getNumber())
+                    if (cur==null || cur.getNumber()<run.getNumber()) {
+                        if (LOGGER.isLoggable(Level.FINE))
+                            LOGGER.fine("Updating "+pp.getPermalinkFile(j).getName()+" permalink to completed "+run.getNumber());
                         pp.updateCache(j,run);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Also, I changed the behavior in `onDeleted(Run)`:

It shouldn't matter whether a deleted build qualified for an existing permalink (`apply`) if the permalink points to it. Not sure what the rationale here is, perhaps copy&paste from `onCompleted(Run)`?

---

Text samples:

```
Mai 21, 2014 10:13:10 PM FINE jenkins.model.PeepholePermalink
Updating lastStableBuild permalink updated to completed 6
Mai 21, 2014 10:13:10 PM FINE jenkins.model.PeepholePermalink
Updating lastSuccessfulBuild permalink updated to completed 6
Mai 21, 2014 10:13:21 PM FINE jenkins.model.PeepholePermalink
Updating lastStableBuild permalink from deleted 6 to 3
Mai 21, 2014 10:13:21 PM FINE jenkins.model.PeepholePermalink
Updating lastSuccessfulBuild permalink from deleted 6 to 3
```
