### PR TITLE
[JENKINS-20499] Don't fail horribly with null causes

### DIFF
--- a/core/src/main/java/hudson/model/CauseAction.java
+++ b/core/src/main/java/hudson/model/CauseAction.java
@@ -101,8 +101,10 @@ public class CauseAction implements FoldableAction, RunAction2 {
     public Map<Cause,Integer> getCauseCounts() {
         Map<Cause,Integer> result = new LinkedHashMap<Cause,Integer>();
         for (Cause c : causes) {
-            Integer i = result.get(c);
-            result.put(c, i == null ? 1 : i.intValue() + 1);
+            if (c != null) {
+                Integer i = result.get(c);
+                result.put(c, i == null ? 1 : i.intValue() + 1);
+            }
         }
         return result;
     }
@@ -120,7 +122,8 @@ public class CauseAction implements FoldableAction, RunAction2 {
         if (owner instanceof AbstractBuild) { // cf. onAttached
             AbstractBuild<?,?> b = (AbstractBuild) owner;
             for (Cause c : causes) {
-                c.onLoad(b);
+                if (c != null)
+                    c.onLoad(b);
             }
         }
     }
@@ -132,7 +135,8 @@ public class CauseAction implements FoldableAction, RunAction2 {
         if (owner instanceof AbstractBuild) {// this should be always true but being defensive here
             AbstractBuild b = (AbstractBuild) owner;
             for (Cause c : causes) {
-                c.onAddedTo(b);
+                if (c != null)
+                    c.onAddedTo(b);
             }
         }
     }


### PR DESCRIPTION
Alternatively, don't expose the internal `ArrayList` in `getCauses()` so we don't even allow `null` in. Not sure whether that's too compatibility breaking.
