### PR TITLE
[FIX JENKINS-17114] Distinguish 'nodes offline' from 'no nodes'

### DIFF
--- a/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
+++ b/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
@@ -114,7 +114,11 @@ public abstract class CauseOfBlockage {
         }
 
         public String getShortDescription() {
-            return Messages.Queue_AllNodesOffline(label.getName());
+            if (label.isEmpty()) {
+                return Messages.Queue_LabelHasNoNodes(label.getName());
+            } else {
+                return Messages.Queue_AllNodesOffline(label.getName());
+            }
         }
     }
 

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -189,6 +189,7 @@ Label.ProvisionedFrom=Provisioned from {0}
 ManageJenkinsAction.DisplayName=Manage Jenkins
 MultiStageTimeSeries.EMPTY_STRING=
 Queue.AllNodesOffline=All nodes of label \u2018{0}\u2019 are offline
+Queue.LabelHasNoNodes=There are no nodes with the label \u2018{0}\u2019
 Queue.BlockedBy=Blocked by {0}
 Queue.HudsonIsAboutToShutDown=Jenkins is about to shut down
 Queue.InProgress=A build is already in progress

--- a/core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseLabelIsOffline/summary.jelly
+++ b/core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseLabelIsOffline/summary.jelly
@@ -24,9 +24,20 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <st:structuredMessageFormat key="description">
-    <st:structuredMessageArgument>
-      <a href="${rootURL}/label/${it.label.name}" class="model-link">${it.label.name}</a>
-    </st:structuredMessageArgument>
-  </st:structuredMessageFormat>
+  <j:choose>
+    <j:when test="${it.label.isEmpty()}">
+      <st:structuredMessageFormat key="description_no_nodes">
+        <st:structuredMessageArgument>
+          <a href="${rootURL}/label/${it.label.name}" class="model-link">${it.label.name}</a>
+        </st:structuredMessageArgument>
+      </st:structuredMessageFormat>
+    </j:when>
+    <j:otherwise>
+      <st:structuredMessageFormat key="description">
+        <st:structuredMessageArgument>
+          <a href="${rootURL}/label/${it.label.name}" class="model-link">${it.label.name}</a>
+        </st:structuredMessageArgument>
+      </st:structuredMessageFormat>
+    </j:otherwise>
+  </j:choose>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseLabelIsOffline/summary.properties
+++ b/core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseLabelIsOffline/summary.properties
@@ -22,3 +22,4 @@
 
 # note for translators: this message is referenced from st:structuredMessageFormat
 description=All nodes of label \u2018{0}\u2019 are offline
+description_no_nodes=There are no nodes with the label \u2018{0}\u2019


### PR DESCRIPTION
Jenkins currently does not distinguish between 'All nodes for a
label are offline' and 'There are no nodes for a label'. This is
exacerbated by the current wording:

```
All nodes of label 'foo' are offline
```

Instead of just changing the wording to something not seeming to
imply existence of such nodes, add a second wording that clearly
states that there are no such nodes.
