### PR TITLE
[WiP] [JENKINS-6268, JENKINS-5393] - Option to disable timestamp checks when publishing Junit-Reports

### DIFF
--- a/core/src/main/java/hudson/tasks/junit/JUnitParser.java
+++ b/core/src/main/java/hudson/tasks/junit/JUnitParser.java
@@ -55,11 +55,20 @@ public class JUnitParser extends TestResultParser {
      * @param keepLongStdio if true, retain a suite's complete stdout/stderr even if this is huge and the suite passed
      * @since 1.358
      */
+    public JUnitParser(boolean keepLongStdio) {
+        this(keepLongStdio, false);
+    }
+    
+    /**
+     * @param keepLongStdio if true, retain a suite's complete stdout/stderr even if this is huge and the suite passed
+     * @param ignoreResultFileTimestamps if true, ignore timestamps of junit report files.
+     * @since 1.358
+     */
     public JUnitParser(boolean keepLongStdio, boolean ignoreResultFileTimestamps) {
         this.keepLongStdio = keepLongStdio;
         this.ignoreResultFileTimestamps = ignoreResultFileTimestamps;
     }
-
+    
     @Override
     public String getDisplayName() {
         return Messages.JUnitParser_DisplayName();

--- a/core/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
+++ b/core/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java
@@ -78,7 +78,7 @@ public class JUnitResultArchiver extends Recorder {
 
     /**
      * If true, ignore timstamp of junit reports.
-     * @since 1.362
+     * @since 1.566
      */
     private final boolean ignoreResultFileTimestamps;
 

--- a/core/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/core/src/main/java/hudson/tasks/junit/TestResult.java
@@ -105,6 +105,12 @@ public final class TestResult extends MetaTabulatedResult {
     /**
      * @since 1.522
      */
+    public TestResult(boolean keepLongStdio) {
+        this(keepLongStdio, false);
+    }
+    /**
+     * @since 1.522
+     */
     public TestResult(boolean keepLongStdio, boolean ignoreResultFileTimestamps) {
         this.keepLongStdio = keepLongStdio;
         this.ignoreResultFileTimestamps = ignoreResultFileTimestamps;

--- a/core/src/main/java/hudson/tasks/junit/TestResult.java
+++ b/core/src/main/java/hudson/tasks/junit/TestResult.java
@@ -92,24 +92,27 @@ public final class TestResult extends MetaTabulatedResult {
     private transient List<CaseResult> failedTests;
 
     private final boolean keepLongStdio;
+    
+    private final boolean ignoreResultFileTimestamps;
 
     /**
      * Creates an empty result.
      */
     public TestResult() {
-        this(false);
+        this(false, false);
     }
 
     /**
      * @since 1.522
      */
-    public TestResult(boolean keepLongStdio) {
+    public TestResult(boolean keepLongStdio, boolean ignoreResultFileTimestamps) {
         this.keepLongStdio = keepLongStdio;
+        this.ignoreResultFileTimestamps = ignoreResultFileTimestamps;
     }
 
     @Deprecated
     public TestResult(long buildTime, DirectoryScanner results) throws IOException {
-        this(buildTime, results, false);
+        this(buildTime, results, false, false);
     }
 
     /**
@@ -118,8 +121,9 @@ public final class TestResult extends MetaTabulatedResult {
      * @param keepLongStdio if true, retain a suite's complete stdout/stderr even if this is huge and the suite passed
      * @since 1.358
      */
-    public TestResult(long buildTime, DirectoryScanner results, boolean keepLongStdio) throws IOException {
+    public TestResult(long buildTime, DirectoryScanner results, boolean keepLongStdio, boolean ignoreResultFileTimestamps) throws IOException {
         this.keepLongStdio = keepLongStdio;
+        this.ignoreResultFileTimestamps = ignoreResultFileTimestamps;
         parse(buildTime, results);
     }
 

--- a/core/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/core/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -33,6 +33,9 @@ THE SOFTWARE.
 	<f:entry field="keepLongStdio" title="">
 		<f:checkbox name="keepLongStdio" checked="${instance.keepLongStdio}" title="${%Retain long standard output/error}"/>
 	</f:entry>
+	<f:entry field="ignoreResultFileTimestamps" title="">
+		<f:checkbox name="ignoreResultFileTimestamps" checked="${instance.ignoreResultFileTimestamps}" title="${%Ignore Resultfile Timestamps}"/>
+	</f:entry>
 	<j:invokeStatic var="testDataPublisherDescriptors"
 		className="hudson.tasks.junit.TestDataPublisher" method="all" />
 	<j:if test="${testDataPublisherDescriptors.size() > 0}">

--- a/core/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config_de.properties
+++ b/core/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config_de.properties
@@ -20,10 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+Ignore\ Resultfile\ Timestamps=Zeitstempel der JUnit-Reports ignorieren
 Retain\ long\ standard\ output/error=Lange Standard-Out/-Error Ausgaben aufbewahren
 Test\ report\ XMLs=Testberichte in XML-Format
 description=\
-  Es sind regul\u00E4re Ausdr\u00FCcke wie z.B. ''myproject/target/test-reports/*.xml'' erlaubt. \
-  Das genaue Format k\u00F6nnen Sie <a href="{0}"> \
-  der Spezifikation f\u00FCr @includes eines Ant-Filesets</a> entnehmen. \
+  Es sind regul\u00e4re Ausdr\u00fccke wie z.B. ''myproject/target/test-reports/*.xml'' erlaubt. \
+  Das genaue Format k\u00f6nnen Sie <a href="{0}"> \
+  der Spezifikation f\u00fcr @includes eines Ant-Filesets</a> entnehmen. \
   Das Ausgangsverzeichnis ist der <a href="ws/">Arbeitsbereich</a>.

--- a/core/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-ignoreResultFileTimestamps.html
+++ b/core/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-ignoreResultFileTimestamps.html
@@ -1,0 +1,5 @@
+<div>
+    If checked, all junit report files will be used, independent from its timestamp.
+    Otherwise report files that have not change during the build will be ignored.
+    Disabling timestamp checks is usefull for incremental unit tests (i.e. Gradle builds).
+</div>

--- a/core/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-ignoreResultFileTimestamps_de.html
+++ b/core/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/help-ignoreResultFileTimestamps_de.html
@@ -1,0 +1,6 @@
+<div>
+    Fall ausgewählt, werden alle Junit Reports unabhängig von ihrem Zeitstempel analysiert.
+    Anderenfalls werden Reports, die nicht während des aktuellen Builds erzeugt wurden ignoriert.
+    Das Deaktivieren der Zeitstempel-Prüfung ist insbesondere für inkrementelle Junit-Tests nützlich
+    (z.B. Gradle Builds).
+</div>

--- a/test/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
+++ b/test/src/test/java/hudson/tasks/junit/TestResultPublishingTest.java
@@ -284,7 +284,7 @@ public class TestResultPublishingTest extends HudsonTestCase {
     public void testBrokenResultFile() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         p.getBuildersList().add(new TestBuilder());
-        p.getPublishersList().add(new JUnitResultArchiver("TEST-foo.xml", false, null));
+        p.getPublishersList().add(new JUnitResultArchiver("TEST-foo.xml", false, false, null));
         assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
     }
     private static final class TestBuilder extends Builder {

--- a/test/src/test/java/hudson/tasks/test/AggregatedTestResultPublisherTest.java
+++ b/test/src/test/java/hudson/tasks/test/AggregatedTestResultPublisherTest.java
@@ -173,7 +173,7 @@ public class AggregatedTestResultPublisherTest {
     }
 
     private void addJUnitResultArchiver(FreeStyleProject project) {
-        JUnitResultArchiver archiver = new JUnitResultArchiver("*.xml", false, null);
+        JUnitResultArchiver archiver = new JUnitResultArchiver("*.xml", false, false, null);
         project.getPublishersList().add(archiver);
         project.getBuildersList().add(new TouchBuilder());
     }


### PR DESCRIPTION
Disabling Timestamp checks is usefull f.e. Gradle builds, which perform incremental testing.
Ignoring unchanged Junit reports leads to incomplete reports or to failed builds, if not all subbuilds run.
Problems are discussed in several open bug-reports:
JENKINS-19287
JENKINS-6268
