### PR TITLE
[FIX JENKINS-16827] Don't try to guess the build number

### DIFF
--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -247,11 +247,9 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
                         logger.println(Messages.BuildTrigger_Disabled(ModelHyperlinkNote.encodeTo(p)));
                         continue;
                     }
-                    // this is not completely accurate, as a new build might be triggered
-                    // between these calls
                     boolean scheduled = p.scheduleBuild(p.getQuietPeriod(), new UpstreamCause((Run)build), buildActions.toArray(new Action[buildActions.size()]));
                     if (Jenkins.getInstance().getItemByFullName(p.getFullName()) == p) {
-                        String name = ModelHyperlinkNote.encodeTo(p) + " #" + p.getNextBuildNumber();
+                        String name = ModelHyperlinkNote.encodeTo(p);
                         if (scheduled) {
                             logger.println(Messages.BuildTrigger_Triggering(name));
                         } else {


### PR DESCRIPTION
The confusion resulting from a wrongly guessed build number isn't
worth the minimal use this information provides.
