### PR TITLE
Javadoc: Noting changes in Executor availability check approaches (1.536)

### DIFF
--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -63,7 +63,9 @@ import javax.annotation.CheckForNull;
 
 /**
  * Thread that executes builds.
- *
+ * Since 1.536, {@link Executor}s start threads on-demand. 
+ * The entire logic should use {@link #isActive()} instead of {@link #isAlive()} 
+ * in order to check if the {@link Executor} it ready to take tasks.
  * @author Kohsuke Kawaguchi
  */
 @ExportedBean
@@ -345,6 +347,15 @@ public class Executor extends Thread implements ModelObject {
         return executable!=null;
     }
 
+    /**
+     * Check if executor is ready to accept tasks.
+     * This method becomes the critical one since 1.536, which introduces the
+     * on-demand creation of executor threads. The entire logic should use 
+     * this method instead of {@link #isAlive()}, because it provides wrong
+     * information for non-started threads.
+     * @return True if the executor is available for tasks
+     * @since 1.536
+     */
     public boolean isActive() {
         return !started || isAlive();
     }


### PR DESCRIPTION
This change is a follow-up to <code>Executor::isAlive()</code> issues, which I've experienced in unit tests for #1229.

Since 1.536, <code>Executors</code> start threads on-demand.
The entire logic should use <code>Executor::isActive()</code> instead of Executor::isAlive()</code> in order to check if the <code>Executor</code> it ready to take tasks.

Since the change breaks previous executor availability flows, it is required to document changes somehow.

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
