### PR TITLE
[FIXED JENKINS-23294] Deal with X-Forwarded-Port

### DIFF
--- a/core/src/test/java/jenkins/model/JenkinsGetRootUrlTest.java
+++ b/core/src/test/java/jenkins/model/JenkinsGetRootUrlTest.java
@@ -37,7 +37,10 @@ import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Bug;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+import static org.mockito.Matchers.anyString;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -107,19 +110,34 @@ public class JenkinsGetRootUrlTest {
     @Test
     public void useForwardedProtoWhenPresent() {
         configured("https://ci/jenkins/");
-        
+
         // Without a forwarded protocol, it should use the request protocol
         accessing("http://ci/jenkins/");
         rootUrlFromRequestIs("http://ci/jenkins/");
-        
+
+        accessing("http://ci:8080/jenkins/");
+        rootUrlFromRequestIs("http://ci:8080/jenkins/");
+
         // With a forwarded protocol, it should use the forwarded protocol
-        accessing("http://ci/jenkins/");
+        accessing("https://ci/jenkins/");
         withHeader("X-Forwarded-Proto", "https");
         rootUrlFromRequestIs("https://ci/jenkins/");
-        
-        accessing("https://ci/jenkins/");
+
+        accessing("http://ci/jenkins/");
         withHeader("X-Forwarded-Proto", "http");
         rootUrlFromRequestIs("http://ci/jenkins/");
+
+        // ServletRequest.getServerPort is not always meaningful.
+        // http://tomcat.apache.org/tomcat-5.5-doc/config/http.html#Proxy_Support or
+        // http://wiki.eclipse.org/Jetty/Howto/Configure_mod_proxy#Configuring_mod_proxy_as_a_Reverse_Proxy.5D
+        // can be used to ensure that it is hardcoded or that X-Forwarded-Port is interpreted.
+        // But this is not something that can be configured purely from the reverse proxy; the container must be modified too.
+        // And the standard bundled Jetty in Jenkins does not work that way;
+        // it will return 80 even when Jenkins is fronted by Apache with SSL.
+        accessing("http://ci/jenkins/"); // as if the container is not aware of the forwarded port
+        withHeader("X-Forwarded-Port", "443"); // but we tell it
+        withHeader("X-Forwarded-Proto", "https");
+        rootUrlFromRequestIs("https://ci/jenkins/");
     }
     
     private void rootUrlFromRequestIs(final String expectedRootUrl) {
@@ -137,7 +155,7 @@ public class JenkinsGetRootUrlTest {
         when(config.getUrl()).thenReturn(configuredHost);
     }
     
-    private void withHeader(String name, String value) {
+    private void withHeader(String name, final String value) {
         final StaplerRequest req = Stapler.getCurrentRequest();
         when(req.getHeader(name)).thenReturn(value);
     }
@@ -149,8 +167,15 @@ public class JenkinsGetRootUrlTest {
         final StaplerRequest req = mock(StaplerRequest.class);
         when(req.getScheme()).thenReturn(url.getProtocol());
         when(req.getServerName()).thenReturn(url.getHost());
-        when(req.getServerPort()).thenReturn(url.getPort() == -1 ? 80 : url.getPort());
+        when(req.getServerPort()).thenReturn(url.getPort() == -1 ? ("https".equals(url.getProtocol()) ? 443 : 80) : url.getPort());
         when(req.getContextPath()).thenReturn(url.getPath().replaceAll("/$", ""));
+        when(req.getIntHeader(anyString())).thenAnswer(new Answer<Integer>() {
+            @Override public Integer answer(InvocationOnMock invocation) throws Throwable {
+                String name = (String) invocation.getArguments()[0];
+                String value = ((StaplerRequest) invocation.getMock()).getHeader(name);
+                return value != null ? Integer.parseInt(value) : -1;
+            }
+        });
 
         when(Stapler.getCurrentRequest()).thenReturn(req);
     }

--- a/test/src/test/java/hudson/diagnosis/ReverseProxySetupMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/ReverseProxySetupMonitorTest.java
@@ -24,6 +24,8 @@
 
 package hudson.diagnosis;
 
+import com.gargoylesoftware.htmlunit.WebRequestSettings;
+import java.net.URL;
 import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -33,7 +35,9 @@ public class ReverseProxySetupMonitorTest {
     @Rule public JenkinsRule r = new JenkinsRule();
 
     @Test public void normal() throws Exception {
-        r.createWebClient().goTo(r.jenkins.getAdministrativeMonitor(ReverseProxySetupMonitor.class.getName()).getUrl() + "/test", null);
+        WebRequestSettings wrs = new WebRequestSettings(new URL(r.getURL(), r.jenkins.getAdministrativeMonitor(ReverseProxySetupMonitor.class.getName()).getUrl() + "/test"));
+        wrs.setAdditionalHeader("Referer", r.getURL() + "manage");
+        r.createWebClient().getPage(wrs);
     }
 
 }


### PR DESCRIPTION
See [JENKINS-23294](https://issues.jenkins-ci.org/browse/JENKINS-23294) for background. I have tried to test this using [jglick/jenkins-demo-reverse-proxy](https://index.docker.io/u/jglick/jenkins-demo-reverse-proxy/), purposely breaking the proxy configuration in various ways, and it seems to work as expected. But there may be subtleties I am missing.
