### PR TITLE
use latest version of the ssh-slaves plugin

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -274,7 +274,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>ssh-slaves</artifactId>
-                  <version>1.5</version>
+                  <version>1.6</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
Both release channels for Jenkins ship with v1.5 of the ssh-slaves plugin.  The latest version of ssh-slaves is v1.6, which includes a new optional launch timeout setting.  

Shipping with the lastest version of the ssh-slaves plugin would simplify the groovy script needed to support this new launch timeout setting in the Chef cookbook for Jenkins.  See [opscode/jenkins PR #211](https://github.com/opscode-cookbooks/jenkins/pull/211/files#diff-07b0a2b5973d0ffff6d39365d945fce8R144) for the groovy script that is causing heartburn in the Chef community.
