### PR TITLE
[FIXED JENKINS-23339] - Introduce the validated Jenkins::getActiveInstance() method

### DIFF
--- a/core/src/main/java/hudson/model/Hudson.java
+++ b/core/src/main/java/hudson/model/Hudson.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 
 import static hudson.Util.fixEmpty;
+import javax.annotation.CheckForNull;
 
 public class Hudson extends Jenkins {
 
@@ -70,7 +71,7 @@ public class Hudson extends Jenkins {
     /** @deprecated Here only for compatibility. Use {@link Jenkins#getInstance} instead. */
     @Deprecated
     @CLIResolver
-    public static Hudson getInstance() {
+    public static @CheckForNull Hudson getInstance() {
         return (Hudson)Jenkins.getInstance();
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -693,18 +693,35 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Do not use in the production code as the signature may change.
      */
     public interface JenkinsHolder {
-        Jenkins getInstance();
+        @CheckForNull Jenkins getInstance();
     }
 
     static JenkinsHolder HOLDER = new JenkinsHolder() {
-        public Jenkins getInstance() {
+        public @CheckForNull Jenkins getInstance() {
             return theInstance;
         }
     };
 
     /**
-     * Gets the Jenkins singleton.
-     * @return the instance, or null if Jenkins has not been started, or was already shut down
+     * Gets the {@link Jenkins} singleton.
+     * {@link #getInstance()} provides the unchecked versions of the method. 
+     * @return {@link Jenkins} instance
+     * @throws IllegalStateException {@link Jenkins} has not been started, or was already shut down
+     * @since TODO: define the version
+     */
+    public static @Nonnull Jenkins getActiveInstance() throws IllegalStateException {
+        Jenkins instance = HOLDER.getInstance();
+        if (instance == null) {
+            throw new IllegalStateException("Jenkins has not been started, or was already shut down");
+        }
+        return instance;
+    }
+    
+    /**
+     * Gets the {@link Jenkins} singleton.
+     * {@link #getActiveInstance()} provides the checked versions of the method. 
+     * @return The instance. Null if the {@link Jenkins} instance has not been started, 
+     * or was already shut down
      */
     @CLIResolver
     @CheckForNull


### PR DESCRIPTION
Currently, the <code>jenkins.model.Jenkins::getInstance()</code> method is marked as <code>@CheckForNull</code>, but the most of Jenkins code does not actually check the return value. It leads to tons of static analysis errors, hence it is hard to analyze the code.

This change:
- Introduces new <code>@Nonnull jenkins.model.Jenkins::getActiveInstance()</code> method
- Converts all unchecked calls within the core to the new method call

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
