### PR TITLE
Console output update

### DIFF
--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -52,7 +52,7 @@ THE SOFTWARE.
       <j:choose>
         <!-- Do progressive console output -->
         <j:when test="${it.isLogUpdated()}">
-          <pre id="out" class="console-output" />
+          <pre id="out" class="console-output console-output-dark" />
             <div id="spinner">
               <img src="${imagesURL}/spinner.gif" alt="" /> 
             </div>
@@ -60,7 +60,7 @@ THE SOFTWARE.
         </j:when>
         <!-- output is completed now. -->
         <j:otherwise>
-          <pre class="console-output">
+          <pre class="console-output console-output-dark">
             <st:getOutput var="output" />
             <j:whitespace>${it.writeLogTo(offset,output)}</j:whitespace>
           </pre>

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -221,7 +221,7 @@ pre.console {
 
 .console-output {
     background-color: #111;
-    color: #eee;
+    color: #d0d0d0;
     padding: 10px 10px 30px;
     border-radius: 3px;
     font-size: 1.1em;

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -219,7 +219,7 @@ pre.console {
   overflow: auto;
 }
 
-.console-output {
+.console-output-dark {
     background-color: #111;
     color: #d0d0d0;
     padding: 10px 10px 30px;
@@ -228,8 +228,8 @@ pre.console {
     font-family: Consolas, Menlo, monospace;
 }
 
-.console-output a,
-.console-output a:visited {
+.console-output-dark a,
+.console-output-dark a:visited {
     color: #d24939;
 }
 

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -233,6 +233,11 @@ pre.console {
     color: #d24939;
 }
 
+/* For backwards compatibility with the Collapsing Console Section Plugin */
+.collapseHeader {
+    color: #111;
+}
+
 .setting-leftspace {
   width: 2em;
 }

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -46,7 +46,7 @@ dt {
 }
 
 .fixed-width {
-  font-family: Courier, monospace;
+  font-family: Consolas, Menlo, monospace;
 }
 
 .center {
@@ -217,6 +217,19 @@ pre {/* see http://users.tkk.fi/tkarvine/pre-wrap-css3-mozilla-opera-ie.html */
 
 pre.console {
   overflow: auto;
+}
+
+.console-output {
+    background-color: #111;
+    color: #eee;
+    padding: 10px 10px 30px;
+    border-radius: 3px;
+    font-size: 1.1em;
+}
+
+.console-output a,
+.console-output a:visited {
+    color: #ED4A6A;
 }
 
 .setting-leftspace {

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -225,6 +225,7 @@ pre.console {
     padding: 10px 10px 30px;
     border-radius: 3px;
     font-size: 1.1em;
+    font-family: Consolas, Menlo, monospace;
 }
 
 .console-output a,

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -29,7 +29,7 @@ body {
 
 body, table, form, input, td, th, p, textarea, select
 {
-  font-family: Verdana, Helvetica, sans serif;
+  font-family: Verdana, Helvetica, sans-serif;
   font-size: 11px;
 }
 
@@ -46,7 +46,7 @@ dt {
 }
 
 .fixed-width {
-  font-family: Consolas, Menlo, monospace;
+  font-family: Consolas, "Deja Vu Sans Mono", Menlo, monospace;
 }
 
 .center {
@@ -230,7 +230,7 @@ pre.console {
 
 .console-output a,
 .console-output a:visited {
-    color: #ED4A6A;
+    color: #d24939;
 }
 
 .setting-leftspace {
@@ -428,6 +428,11 @@ th.pane {
 
 .disabledJob {
   color: gray;
+}
+
+/* XXX - have console output page use .spinner class */
+#spinner {
+    margin-top: 5px;
 }
 
 .spinner {


### PR DESCRIPTION
Updates Jenkins' console output with several new nice styles:
- Console output background is now black (more terminal-esque feel)
- Font size increased for readability
- Removes Courier New from default fixed-width font list, adds Consolas, Menlo instead.

Before:

<img src="https://api.monosnap.com/image/download?id=LbknPdixnzT0Tz4tJUjLz6rS5Tr4y3" />

After:

<img src="https://api.monosnap.com/image/download?id=WJPBYdJPA0YIa2YWx0L4c9kkd1FHWF" />
