### PR TITLE
[FIX JENKINS-22311]: Hide the list of build parameters for pending jobs

### DIFF
--- a/core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
+++ b/core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
@@ -47,6 +47,7 @@ THE SOFTWARE.
               <l:stopButton href="${rootURL}/queue/cancelItem?id=${item.id}" alt="${%cancel this build}"/>
             </j:if>
           </div>
+          <div class="itemsummary" id="${id}">
           <j:set var="cause" value="${item.getCauseOfBlockage()}"/>
           <j:choose>
             <j:when test="${cause!=null}">
@@ -57,6 +58,8 @@ THE SOFTWARE.
             </j:otherwise>
           </j:choose>
           ${item.params}
+          </div>
+          <div class="itemparams" id="${id}">${item.params}</div>
         </td>
       </tr>
     </j:forEach>

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -141,6 +141,11 @@ ${h.initPageVariables(context)}
     <j:forEach var="pd" items="${h.pageDecorators}">
       <st:include it="${pd}" page="header.jelly" optional="true" />
     </j:forEach>
+
+    <!-- itemparams == Pending Job Build Parameters -->
+    <style type="text/css"> div.itemparams { display:none; overflow: hidden; text-overflow: ellipsis; } </style>
+    <script>jQuery(document).ready(function() { jQuery('div.itemsummary').live( "click", function() { jQuery('#'+this.id+'.itemparams').toggle(); }); });</script>
+
   </head>
   <body id="jenkins" class="yui-skin-sam jenkins-${h.version}" data-version="jenkins-${h.version}">
     <!-- for accessibility, skip the entire navigation bar and etc and go straight to the head of the content -->


### PR DESCRIPTION
Large number of build parameters for pending jobs (e.g. gerrit triggered job) can cause unwieldy build history. This patch hides the list of build parameters by default, and shows it when a user clicks on "(pending—Build ...)". Demo: http://jsfiddle.net/jakubczaplicki/WT88W/
