### PR TITLE
[JENKINS-21631] - Don't fail with NPE if the PeepholePermalink cache contains a non-numeric value

### DIFF
--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -103,6 +103,9 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
         } catch (InterruptedException e) {
             LOGGER.log(Level.WARNING, "Failed to read permalink cache:" + f, e);
             // if we fail to read the cache, fall back to the re-computation
+        } catch (NumberFormatException e) { 
+            LOGGER.log(Level.WARNING, "Failed to parse the build number in the permalink cache:" + f, e);
+            // if we fail to read the cache, fall back to the re-computation
         } catch (IOException e) {
             // this happens when the symlink doesn't exist
             // (and it cannot be distinguished from the case when the actual I/O error happened


### PR DESCRIPTION
Actually, the change just prevents symptoms. There should be an error somewhere else.

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
