### PR TITLE
Update UI for forms and buttons

### DIFF
--- a/core/src/main/resources/lib/form/repeatableDeleteButton.jelly
+++ b/core/src/main/resources/lib/form/repeatableDeleteButton.jelly
@@ -32,5 +32,5 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
   <st:adjunct includes="lib.form.repeatable.repeatable"/>
-  <input type="button" value="${attrs.value ?: '%Delete'}" class="repeatable-delete" />
+  <input type="button" value="${attrs.value ?: '%Delete'}" class="danger repeatable-delete" />
 </j:jelly>

--- a/core/src/main/resources/lib/form/section_.css
+++ b/core/src/main/resources/lib/form/section_.css
@@ -1,6 +1,8 @@
 .section-header {
     font-weight: bold;
-    border-bottom: 1px solid black;
+    padding-bottom: 3px;
+    border-bottom: 1px solid #e0e0e0;
     margin-bottom: 0.2em;
-    margin-top: 0.4em;
+    margin-top: 1.0em;
+    font-size: 1.6em;
 }

--- a/core/src/main/resources/lib/form/submit.jelly
+++ b/core/src/main/resources/lib/form/submit.jelly
@@ -37,5 +37,5 @@ THE SOFTWARE.
       The text of the submit button. Something like "submit", "OK", etc.
     </s:attribute>
   </s:documentation>
-  <input type="submit" name="${attrs.name ?: 'Submit'}" value="${attrs.value}" class="submit-button" />
+  <input type="submit" name="${attrs.name ?: 'Submit'}" value="${attrs.value}" class="submit-button primary" />
 </j:jelly>

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -29,7 +29,7 @@ body {
 
 body, table, form, input, td, th, p, textarea, select
 {
-  font-family: Verdana, Helvetica, sans serif;
+  font-family: Verdana, Helvetica, sans-serif;
   font-size: 11px;
 }
 
@@ -235,13 +235,23 @@ pre.console {
 }
 
 .setting-input {
-  width: 100%;
+  /* Setting it to 100% causes overlap with the help buttons. */
+  width: 96%;
+  font-size: 14px;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  padding: 6px;
 }
 
 .setting-description {
   font-size: 0.8em;
   margin-top: 0;
   padding-top: 0;
+}
+
+#disable-project {
+    margin-top: 6px;
 }
 
 /* div that looks like a hyperlink */
@@ -469,8 +479,8 @@ LABEL.attach-previous {
     width:  100%;   /* it needs to occupy the entire width or else the underlying content will see through */
 }
 .bottom-sticker-inner {
-    background:white;
-    padding:1em;
+    background: white;
+    padding: 1em 0;
 }
 .bottom-sticker-edge {
     height:16px;
@@ -903,6 +913,26 @@ DIV.yahooTree td {
   margin-bottom: 1em;
 }
 
+#jenkins .yuimenuitem {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 12px;
+  padding: 3px;
+}
+
+#jenkins .yuimenuitem, 
+#jenkins .yuimenuitemlabel {
+  cursor: pointer;
+}
+
+#jenkins .yuimenu .bd {
+    border: 1px solid #ccc;
+    box-shadow: 0px 3px 10px #bbb;
+}
+
+#jenkins .yui-menu-shadow {
+    display: none;
+}
+
 /* ========================= search box at the top-right of the page ========================= */
 #search-box {
   background: white url(../images/16x16/search.png) no-repeat 2px center;
@@ -966,6 +996,11 @@ DIV.textarea-handle {
     border: 1px solid #BABDB6;
     border-top: none;
     cursor: s-resize;
+    /* TODO: Align this with the textarea field. Chrome shows a margin-right
+     * property on this object which doesn't seem to be being set with CSS
+     * anywhere. Setting both setting-input and this field to 100% causes
+     * overlap with the setting-help field. */
+    width: 97%;
 }
 TEXTAREA.rich-editor {
   visibility: hidden;
@@ -1142,4 +1177,126 @@ td.matrix-cell {
 /* ========================= legend.jelly ================== */
 table#legend-table td {
 	vertical-align: middle;
+}
+
+/* ========================= Button styles ================= */
+
+#bottom-sticker .yui-button {
+    margin-right: 20px;
+}
+
+/* This level of nesting is technically unnecessary, but to override the
+ * default Yahoo styles. */
+#jenkins .yui-button {
+  border-width: 0;
+  border-style: none;
+  border-color: transparent;
+  background: none;
+}
+
+#jenkins .yui-button .first-child {
+    border-width: 0;
+    border-style: none;
+    border-color: transparent;
+}
+
+#jenkins .yui-button button {
+  font-size: 12px;
+  padding: 3px 20px;
+  *border: 0;
+  border-radius: 1px;
+
+  border: 1px solid #cccccc;
+  background-color: #e0e0e0;
+  font-family: Arial, Helvetica, sans-serif;
+  
+
+  color: #505050;
+  font-weight: bold;
+}
+
+#jenkins .yui-button .hetero-list-add {
+    padding-right: 35px;
+}
+
+#jenkins .yui-button button:hover,
+#jenkins .yui-button .hover 
+{
+    background-color: #d0d0d0;
+    border: 1px solid #c0c0c0;
+}
+
+#jenkins .yui-button button:active,
+#jenkins .yui-button .active {
+    background-color: #bbb;
+    box-shadow: inset 0px 1px 6px 2px #929292;
+    border: 1px solid #bbb;
+}
+
+#jenkins .yui-button button[disabled],
+#jenkins .yui-button button[disabled]:hover,
+#jenkins .yui-button button[disabled]:active,
+#jenkins .yui-button .disabled {
+    background-color: #e5e5e5;
+    color: #999;
+    border: 1px solid #d2d2d2;
+}
+
+/* Color overrides */
+#jenkins .yui-button.primary button {
+    background-color: #4b758b;
+    color: #eee;
+    border: 1px solid #5788a1;
+}
+
+#jenkins .yui-button.primary button:hover,
+#jenkins .yui-button.primary .hover
+{
+    background-color: #3f6275;
+    border: 1px solid #5788a1;
+}
+
+#jenkins .yui-button.primary button:active,
+#jenkins .yui-button.primary .active
+{
+    background-color: #33505f;
+    border: 1px solid #3f6275;
+    box-shadow: inset 0px 1px 6px 2px #1b2b33;
+}
+
+#jenkins .yui-button.primary button:disabled,
+#jenkins .yui-button.primary .disabled
+{
+    background-color: #adc6d3;
+    color: #fff;
+    border: 1px solid #a2becd;
+}
+
+#jenkins .yui-button.danger button {
+    background-color: #d24939;
+    color: #eee;
+    border: 1px solid #be3a2b;
+}
+
+#jenkins .yui-button.danger button:hover,
+#jenkins .yui-button.danger .hover
+{
+    background-color: #a23225;
+    border: 1px solid #942e22;
+}
+
+#jenkins .yui-button.danger button:active,
+#jenkins .yui-button.danger .active
+{
+    background-color: #942e22;
+    border: 1px solid #6b2118;
+    box-shadow: inset 0px 1px 6px 2px #79251b;
+}
+
+#jenkins .yui-button.danger button:disabled,
+#jenkins .yui-button.danger .disabled
+{
+    background-color: #e5958c;
+    color: #f8f8f8;
+    border: 1px solid #e39280;
 }

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -237,11 +237,15 @@ pre.console {
 .setting-input {
   /* Setting it to 100% causes overlap with the help buttons. */
   width: 96%;
-  font-size: 14px;
+  font-size: 13px;
   border-radius: 3px;
   border: 1px solid #ccc;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   padding: 6px;
+}
+
+textarea.setting-input {
+    font-size: 12px;
 }
 
 .setting-description {


### PR DESCRIPTION
UI updates to the "Manage Jenkins" and job configuration pages, per discussion on [the jenkins-dev mailing list](https://groups.google.com/forum/#!topic/jenkinsci-dev/zDaX4yiWLLw).
### Text inputs have larger size, more padding, and rounded corners.

Before (Jenkins version running on Cloudbees):

<img src="https://api.monosnap.com/image/download?id=G0rhktDm0iXVcFK2R8pbETCX0botbY" />

After:

<img src="https://api.monosnap.com/image/download?id=Z4YgRZvy1qyMPcunys0zq0AnENPFLs" />
### Headings on forms are bigger

Now form sections are clearly delineated with spacing, and the size of the heading font - horizontal lines are given less weight.

Before:

<img src="https://api.monosnap.com/image/download?id=PQdWT9f3ptvo12nAsAIMbPASApKEzM" />

After:

<img src="https://api.monosnap.com/image/download?id=UTCk7RTjT3cUvtGXAKTBp3R6vLB6dZ" />
### Updated buttons

Buttons now come in three different colors (from the Jenkins color palette) and have different states for
hovering, clicked, disabled. Dangerous actions are colored red. Buttons have
more padding and use Helvetica instead of Lucida Grande.

This is easier to see the effects if you check out the branch, but here is a static screenshot of the button states. Add the "primary" class to get blue, "danger" class to get red buttons.

<img src="https://api.monosnap.com/image/download?id=FYkxv5KzmbtNgguCNCds2JT0eJdjIj" />

Before:

<img src="https://api.monosnap.com/image/download?id=zYIJaeC5RD1NXQumPlpN8YdGVHct4Z" />

After:

<img src="https://api.monosnap.com/image/download?id=gr43K5pNaQwIFWElM46Dik6G538Oks" />
### Dropdown menu updates

The dropdown menus are slightly larger and have the mechanical-looking yui-menu-shadow replaced with the blur now available with CSS box-shadow.

Before:

<img src="https://api.monosnap.com/image/download?id=N6jM5QMkmOITIM5bQ9GDDcMs34u0qT" />

After:

<img src="https://api.monosnap.com/image/download?id=E5DGvOwNualwt5GeJSf05Rs81nOmF5" />
