### PR TITLE
Fix a NPE when the 'properties' element is missing from the form's JSON

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1144,7 +1144,12 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
                 logRotator = null;
 
             DescribableList<JobProperty<?>, JobPropertyDescriptor> t = new DescribableList<JobProperty<?>, JobPropertyDescriptor>(NOOP,getAllProperties());
-            t.rebuild(req,json.optJSONObject("properties"),JobPropertyDescriptor.getPropertyDescriptors(Job.this.getClass()));
+            JSONObject jsonProperties = json.optJSONObject("properties");
+            if (jsonProperties != null) {
+              t.rebuild(req,jsonProperties,JobPropertyDescriptor.getPropertyDescriptors(Job.this.getClass()));
+            } else {
+              t.clear();
+            }
             properties.clear();
             for (JobProperty p : t) {
                 p.setOwner(this);


### PR DESCRIPTION
Null check the 'properties' element of the JSON message before attempting to 'rebuild' the 'DescribableList'
