### PR TITLE
[FIXED SECURITY-133] Restrict access to SCMTrigger status page

### DIFF
--- a/core/src/main/resources/hudson/triggers/SCMTrigger/DescriptorImpl/index.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/DescriptorImpl/index.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout title="${%Current SCM Polling Activities}">
+  <l:layout title="${%Current SCM Polling Activities}" permission="${app.ADMINISTER}">
     <st:include it="${app}" page="sidepanel.jelly" />
     <l:main-panel>
       <h1>${%Current SCM Polling Activities}</h1>


### PR DESCRIPTION
The page shows the names and URLs of all jobs currently busy with
polling. This includes jobs users might not regularly be able to
access and might therefore reveal otherwise hidden information.
