### PR TITLE
[FIXED SECURITY-134] Restrict access to admin monitor info page

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.jelly
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-	<l:layout title="${%JENKINS_HOME is almost full}">
+	<l:layout title="${%JENKINS_HOME is almost full}" permission="${app.ADMINISTER}">
 		<l:main-panel>
       <h1>
         <img src="${imagesURL}/48x48/warning.png" height="48" width="48" />


### PR DESCRIPTION
This could contain sensitive information in the list of solutions
provided. It also shows the path to JENKINS_HOME, exposing OS and
configuration information.
