### PR TITLE
Friendlier form styles

### DIFF
--- a/core/src/main/resources/lib/form/section_.css
+++ b/core/src/main/resources/lib/form/section_.css
@@ -1,6 +1,7 @@
 .section-header {
     font-weight: bold;
-    border-bottom: 1px solid black;
+    border-bottom: 1px solid #e0e0e0;
     margin-bottom: 0.2em;
     margin-top: 0.4em;
+    padding-bottom: 3px;
 }

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -29,7 +29,7 @@ body {
 
 body, table, form, input, td, th, p, textarea, select
 {
-  font-family: Verdana, Helvetica, sans serif;
+  font-family: Verdana, Helvetica, sans-serif;
   font-size: 11px;
 }
 
@@ -236,6 +236,10 @@ pre.console {
 
 .setting-input {
   width: 100%;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  padding: 6px;
 }
 
 .setting-description {


### PR DESCRIPTION
- Swap out black borders for gray ones
- Add rounded corners to form areas
- Font sizes stay exactly the same.

Before:

<img src="https://api.monosnap.com/image/download?id=X2jvtdsvkop8l7ZBJXsA3ZrDM6UdSH" />

After:

<img src="https://api.monosnap.com/image/download?id=WAv7k9LkH0MRU30HMoMDfRFzHTvSWx" />
