### PR TITLE
[JENKINS-23522] - Fix Circular Call

### DIFF
--- a/core/src/main/java/hudson/model/listeners/SCMListener.java
+++ b/core/src/main/java/hudson/model/listeners/SCMListener.java
@@ -109,14 +109,18 @@ public abstract class SCMListener implements ExtensionPoint {
      * @since 1.568
      */
     public void onChangeLogParsed(Run<?,?> build, SCM scm, TaskListener listener, ChangeLogSet<?> changelog) throws Exception {
-        if (build instanceof AbstractBuild && listener instanceof BuildListener && Util.isOverridden(SCMListener.class, getClass(), "onChangeLogParsed", AbstractBuild.class, BuildListener.class, ChangeLogSet.class)) {
+        onChangeLogParsed(Run<?,?> build, SCM scm, TaskListener listener, ChangeLogSet<?> changelog, false);
+    }
+
+    private void onChangeLogParsed(Run<?,?> build, SCM scm, TaskListener listener, ChangeLogSet<?> changelog, boolean blockCircularCall) throws Exception {
+        if (!blockCircularCall && build instanceof AbstractBuild && listener instanceof BuildListener && Util.isOverridden(SCMListener.class, getClass(), "onChangeLogParsed", AbstractBuild.class, BuildListener.class, ChangeLogSet.class)) {
             onChangeLogParsed((AbstractBuild) build, (BuildListener) listener, changelog);
         }
     }
 
     @Deprecated
     public void onChangeLogParsed(AbstractBuild<?,?> build, BuildListener listener, ChangeLogSet<?> changelog) throws Exception {
-        onChangeLogParsed((Run) build, build.getProject().getScm(), listener, changelog);
+        onChangeLogParsed((Run) build, build.getProject().getScm(), listener, changelog, true);
     }
 
     /**

--- a/core/src/main/java/hudson/model/listeners/SCMListener.java
+++ b/core/src/main/java/hudson/model/listeners/SCMListener.java
@@ -109,7 +109,7 @@ public abstract class SCMListener implements ExtensionPoint {
      * @since 1.568
      */
     public void onChangeLogParsed(Run<?,?> build, SCM scm, TaskListener listener, ChangeLogSet<?> changelog) throws Exception {
-        onChangeLogParsed(Run<?,?> build, SCM scm, TaskListener listener, ChangeLogSet<?> changelog, false);
+        onChangeLogParsed(build, scm, listener, changelog, false);
     }
 
     private void onChangeLogParsed(Run<?,?> build, SCM scm, TaskListener listener, ChangeLogSet<?> changelog, boolean blockCircularCall) throws Exception {


### PR DESCRIPTION
Fix Circular call suspected under Youtrack Jenkins Plugin development.

Stack:

```
java.lang.StackOverflowError
    at java.lang.StringCoding$StringEncoder.encode(StringCoding.java:304)
    at java.lang.StringCoding.encode(StringCoding.java:344)
    at java.lang.String.getBytes(String.java:916)
    at java.io.UnixFileSystem.getBooleanAttributes0(Native Method)
    at java.io.UnixFileSystem.getBooleanAttributes(UnixFileSystem.java:242)
    at java.io.File.exists(File.java:813)
    at sun.misc.URLClassPath$FileLoader.getResource(URLClassPath.java:1080)
    at sun.misc.URLClassPath$FileLoader.findResource(URLClassPath.java:1047)
    at sun.misc.URLClassPath.findResource(URLClassPath.java:176)
    at java.net.URLClassLoader$2.run(URLClassLoader.java:551)
    at java.net.URLClassLoader$2.run(URLClassLoader.java:549)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findResource(URLClassLoader.java:548)
    at org.eclipse.jetty.webapp.WebAppClassLoader.getResource(WebAppClassLoader.java:356)
    at java.net.URLClassLoader.getResourceAsStream(URLClassLoader.java:227)
    at javax.xml.parsers.SecuritySupport$4.run(SecuritySupport.java:94)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.xml.parsers.SecuritySupport.getResourceAsStream(SecuritySupport.java:87)
    at javax.xml.parsers.FactoryFinder.findJarServiceProvider(FactoryFinder.java:283)
    at javax.xml.parsers.FactoryFinder.find(FactoryFinder.java:255)
    at javax.xml.parsers.SAXParserFactory.newInstance(SAXParserFactory.java:126)
    at org.jenkinsci.plugins.youtrack.youtrackapi.YouTrackServer.getProjects(YouTrackServer.java:290)
    at org.jenkinsci.plugins.youtrack.YouTrackSCMListener.onChangeLogParsed(YouTrackSCMListener.java:40)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:113)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:119)
    at org.jenkinsci.plugins.youtrack.YouTrackSCMListener.onChangeLogParsed(YouTrackSCMListener.java:84)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:113)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:119)
    at org.jenkinsci.plugins.youtrack.YouTrackSCMListener.onChangeLogParsed(YouTrackSCMListener.java:84)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:113)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:119)
    at org.jenkinsci.plugins.youtrack.YouTrackSCMListener.onChangeLogParsed(YouTrackSCMListener.java:84)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:113)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:119)
    at org.jenkinsci.plugins.youtrack.YouTrackSCMListener.onChangeLogParsed(YouTrackSCMListener.java:84)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:113)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:119)
    at org.jenkinsci.plugins.youtrack.YouTrackSCMListener.onChangeLogParsed(YouTrackSCMListener.java:84)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:113)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:119)
    at org.jenkinsci.plugins.youtrack.YouTrackSCMListener.onChangeLogParsed(YouTrackSCMListener.java:84)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:113)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:119)
    at org.jenkinsci.plugins.youtrack.YouTrackSCMListener.onChangeLogParsed(YouTrackSCMListener.java:84)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:113)
    at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:119)
```
