### PR TITLE
[WIP] Changed core icons from <img> to <div> + CSS

### DIFF
--- a/core/src/main/java/hudson/model/BallColor.java
+++ b/core/src/main/java/hudson/model/BallColor.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Simon Wiest
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,7 +37,7 @@ import java.util.Locale;
  *
  * <p>
  * There are four basic colors, plus their animated "bouncy" versions.
- * {@link #ordinal()} is the sort order. 
+ * {@link #ordinal()} is the sort order.
  *
  * <p>
  * Note that multiple {@link BallColor} instances may map to the same
@@ -72,26 +72,44 @@ public enum BallColor implements StatusIcon {
     ;
 
     private final Localizable description;
-    private final String image;
+    private final String iconName;
+    private final String imageFile;
     private final Color baseColor;
 
-    BallColor(String image, Localizable description, Color baseColor) {
+    BallColor(String iconName, Localizable description, Color baseColor) {
+        this.iconName = iconName;
         this.baseColor = baseColor;
         // name() is not usable in the constructor, so I have to repeat the name twice
         // in the constants definition.
-        this.image = image+ (image.endsWith("_anime")?".gif":".png");
+        this.imageFile = iconName + (iconName.endsWith("_anime")?".gif":".png");
         this.description = description;
+    }
+
+    /**
+     * Get the ball/orb icon name.
+     * @return The ball/orb icon name.
+     */
+    public String getIconName() {
+        return iconName;
     }
 
     /**
      * String like "red.png" that represents the file name of the image.
      */
     public String getImage() {
-        return image;
+        return imageFile;
     }
 
     public String getImageOf(String size) {
-        return Stapler.getCurrentRequest().getContextPath()+ Jenkins.RESOURCE_PATH+"/images/"+size+'/'+image;
+        return Stapler.getCurrentRequest().getContextPath()+ Jenkins.RESOURCE_PATH+"/images/"+size+'/'+imageFile;
+    }
+
+    /**
+     * Get the name.
+     * @return The name, as with {@link Enum#name()}.
+     */
+    public String getName() {
+        return name();
     }
 
     /**

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -602,11 +602,16 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     @Exported
-    public String getIcon() {
+    public String getIconName() {
         if(isOffline())
-            return "computer-x.png";
+            return "computer-x";
         else
-            return "computer.png";
+            return "computer";
+    }
+
+    @Exported
+    public String getIcon() {
+        return getIconName() + ".png";
     }
 
     public String getIconAltText() {

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -412,11 +412,20 @@ public final class DirectoryBrowserSupport implements HttpResponse {
             return title;
         }
 
-        public String getIconName() {
+        public String getIconBaseName() {
             if (isReadable)
-                return isFolder?"folder.png":"text.png";
+                return isFolder?"folder":"text";
             else
-                return isFolder?"folder-error.png":"text-error.png";
+                return isFolder?"folder-error":"text-error";
+        }
+
+        public String getIconFileName() {
+            return getIconBaseName() + ".png";
+        }
+
+        @Deprecated()
+        public String getIconName() {
+            return getIconFileName();
         }
 
         public long getSize() {

--- a/core/src/main/java/hudson/model/HealthReport.java
+++ b/core/src/main/java/hudson/model/HealthReport.java
@@ -35,7 +35,6 @@ import org.kohsuke.stapler.export.ExportedBean;
 import java.io.*;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * Represents health of something (typically project).
@@ -47,13 +46,20 @@ import java.util.Locale;
 @ExportedBean(defaultVisibility = 2)
 // this is always exported as a part of Job and never on its own, so start with 2.
 public class HealthReport implements Serializable, Comparable<HealthReport> {
+    private static final String HEALTH_OVER_80 = "health-80plus";
+    private static final String HEALTH_61_TO_80 = "health-60to79";
+    private static final String HEALTH_41_TO_60 = "health-40to59";
+    private static final String HEALTH_21_TO_40 = "health-20to39";
+    private static final String HEALTH_0_TO_20 = "health-00to19";
+    private static final String HEALTH_UNKNOWN = "empty";
+
     // These are now 0-20, 21-40, 41-60, 61-80, 81+ but filenames unchanged for compatibility
-    private static final String HEALTH_OVER_80 = "health-80plus.png";
-    private static final String HEALTH_61_TO_80 = "health-60to79.png";
-    private static final String HEALTH_41_TO_60 = "health-40to59.png";
-    private static final String HEALTH_21_TO_40 = "health-20to39.png";
-    private static final String HEALTH_0_TO_20 = "health-00to19.png";
-    private static final String HEALTH_UNKNOWN = "empty.png";
+    private static final String HEALTH_OVER_80_FILENAME = HEALTH_OVER_80 + ".png";
+    private static final String HEALTH_61_TO_80_FILENAME = HEALTH_61_TO_80 + ".png";
+    private static final String HEALTH_41_TO_60_FILENAME = HEALTH_41_TO_60 + ".png";
+    private static final String HEALTH_21_TO_40_FILENAME = HEALTH_21_TO_40 + ".png";
+    private static final String HEALTH_0_TO_20_FILENAME = HEALTH_0_TO_20 + ".png";
+    private static final String HEALTH_UNKNOWN_FILENAME = HEALTH_UNKNOWN + ".png";
 
     /**
      * The percentage health score (from 0 to 100 inclusive).
@@ -122,15 +128,15 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
         this.score = score;
         if (iconUrl == null) {
             if (score <= 20) {
-                this.iconUrl = HEALTH_0_TO_20;
+                this.iconUrl = HEALTH_0_TO_20_FILENAME;
             } else if (score <= 40) {
-                this.iconUrl = HEALTH_21_TO_40;
+                this.iconUrl = HEALTH_21_TO_40_FILENAME;
             } else if (score <= 60) {
-                this.iconUrl = HEALTH_41_TO_60;
+                this.iconUrl = HEALTH_41_TO_60_FILENAME;
             } else if (score <= 80) {
-                this.iconUrl = HEALTH_61_TO_80;
+                this.iconUrl = HEALTH_61_TO_80_FILENAME;
             } else {
-                this.iconUrl = HEALTH_OVER_80;
+                this.iconUrl = HEALTH_OVER_80_FILENAME;
             }
         } else {
             this.iconUrl = iconUrl;
@@ -166,7 +172,7 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
      * Create a new HealthReport.
      */
     public HealthReport() {
-        this(100, HEALTH_UNKNOWN, Messages._HealthReport_EmptyString());
+        this(100, HEALTH_UNKNOWN_FILENAME, Messages._HealthReport_EmptyString());
     }
 
     /**
@@ -206,12 +212,32 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
      */
     public String getIconUrl(String size) {
         if (iconUrl == null) {
-            return Jenkins.RESOURCE_PATH + "/images/" + size + "/" + HEALTH_UNKNOWN;
+            return Jenkins.RESOURCE_PATH + "/images/" + size + "/" + HEALTH_UNKNOWN_FILENAME;
         }
         if (iconUrl.startsWith("/")) {
             return iconUrl.replace("/32x32/", "/" + size + "/");
         }
         return Jenkins.RESOURCE_PATH + "/images/" + size + "/" + iconUrl;
+    }
+
+    /**
+     * Get the health icon name for this report, given the size.
+     *
+     * @param size The size, e.g. 32x32, 24x24 or 16x16.
+     * @return The icon name/alias.
+     */
+    public String getIconName(String size) {
+        if (score <= 20) {
+            return HEALTH_0_TO_20 + "-" + size;
+        } else if (score <= 40) {
+            return HEALTH_21_TO_40 + "-" + size;
+        } else if (score <= 60) {
+            return HEALTH_41_TO_60 + "-" + size;
+        } else if (score <= 80) {
+            return HEALTH_61_TO_80 + "-" + size;
+        } else {
+            return HEALTH_OVER_80 + "-" + size;
+        }
     }
 
     /**

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -101,7 +101,7 @@ THE SOFTWARE.
                 <td class="center pane" id='unpin-${p.shortName}'>
                   <j:if test="${p.isPinned()}">
                     <input type="button" onclick="unpin(this,'${p.shortName}')" value="${%Unpin}" class="yui-button" />
-                    <a href="${%wiki.url}" target="_blank"><img style="vertical-align:top" src="${imagesURL}/16x16/help.png"/></a>
+                    <a href="${%wiki.url}" target="_blank"><l:icon name="help-16x16" style="vertical-align:top"/></a>
                   </j:if>
                 </td>
                 <td class="center pane">
@@ -121,14 +121,14 @@ THE SOFTWARE.
             <!-- failed ones -->
             <j:forEach var="p" items="${it.pluginManager.failedPlugins}">
               <tr class="hoverback">
-                <td class="pane" />
+                <td class="pane"/>
                 <td class="pane">
                   <h4 class="error">Failed : ${p.name}</h4>
                   <div stlyle="padding-left: 1em">
                     <pre>${p.exceptionString}</pre>
                   </div>
                 </td>
-                <td class="pane" />
+                <td class="pane"/>
               </tr>
             </j:forEach>
           </j:otherwise>
@@ -139,7 +139,7 @@ THE SOFTWARE.
         <form method="post" action="${rootURL}/safeRestart">
           ${%Changes will take effect when you restart Jenkins}
           <j:if test="${app.lifecycle.canRestart()}">
-            <s:submit value="${%Restart Once No Jobs Are Running}" />
+            <s:submit value="${%Restart Once No Jobs Are Running}"/>
           </j:if>
         </form>
       </div>

--- a/core/src/main/resources/hudson/cli/CLIAction/command.jelly
+++ b/core/src/main/resources/hudson/cli/CLIAction/command.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout norefresh="true">
     <st:include page="sidepanel.jelly" it="${app}"/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/terminal.png" alt="" height="48" width="48"/>
+        <l:icon name="terminal-48x48"/>
         Command ${command.name}
       </h1>
       <j:set var="commandArgs" value="${command.name}${command.singleLineSummary}"/>

--- a/core/src/main/resources/hudson/cli/CLIAction/index.jelly
+++ b/core/src/main/resources/hudson/cli/CLIAction/index.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout norefresh="true">
     <st:include page="sidepanel.jelly" it="${app}"/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/terminal.png" alt="" height="48" width="48"/>
+        <l:icon name="terminal-48x48"/>
         ${%Jenkins CLI}
       </h1>
       <p>

--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.jelly
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 	<l:layout title="${%JENKINS_HOME is almost full}" permission="${app.ADMINISTER}">
 		<l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/warning.png" height="48" width="48" />
+        <l:icon name="warning-48x48"/>
         ${%blurb}
       </h1>
 

--- a/core/src/main/resources/hudson/diagnosis/MemoryUsageMonitor/index.jelly
+++ b/core/src/main/resources/hudson/diagnosis/MemoryUsageMonitor/index.jelly
@@ -23,13 +23,13 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout title="${it.displayName} Memory Usage">
     <!-- TODO: where in the tree structure should this really belong? -->
     <!-- TODO: st:include page="sidepanel.jelly" /-->
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/monitor.png" alt="" height="48" width="48"/>
+        <l:icon name="monitor-48x48"/>
         ${%JVM Memory Usage}
       </h1>
       <j:set var="type" value="${request.getParameter('type') ?: 'min'}" />
@@ -43,7 +43,7 @@ THE SOFTWARE.
             ${%Short}
           </j:otherwise>
         </j:choose>
-        <st:nbsp />
+        <st:nbsp/>
         <j:choose>
           <j:when test="${type != 'min'}">
             <a href="?type=min">${%Medium}</a>
@@ -52,7 +52,7 @@ THE SOFTWARE.
             ${%Medium}
           </j:otherwise>
         </j:choose>
-        <st:nbsp />
+        <st:nbsp/>
         <j:choose>
           <j:when test="${type != 'hour'}">
             <a href="?type=hour">${%Long}</a>
@@ -62,7 +62,7 @@ THE SOFTWARE.
           </j:otherwise>
         </j:choose>
       </div>
-      <img src="graph?type=${type}&amp;width=500&amp;height=300" />
+      <img src="graph?type=${type}&amp;width=500&amp;height=300"/>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/index.jelly
+++ b/core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/index.jelly
@@ -23,14 +23,14 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout permission="${app.ADMINISTER}" title="${%Install as Windows Service}">
-    <st:include it="${app}" page="sidepanel.jelly" />
+    <st:include it="${app}" page="sidepanel.jelly"/>
     <l:main-panel>
       <j:choose>
         <j:when test="${!it.installed}">
           <h1>
-            <img src="${imagesURL}/48x48/installer.png" alt="" height="48" width="48"/>
+            <l:icon name="installer-48x48"/>
             ${%Install as Windows Service}
           </h1>
 
@@ -39,10 +39,10 @@ THE SOFTWARE.
           <form action="doInstall" method="post">
             <table>
               <f:entry title="${%Installation Directory}">
-                <f:textbox name="dir" value="${app.rootDir}" /><!-- checkUrl="'/install/checkDir?value='+encodeURIComponent(this.value)" -->
+                <f:textbox name="dir" value="${app.rootDir}"/><!-- checkUrl="'/install/checkDir?value='+encodeURIComponent(this.value)" -->
               </f:entry>
               <f:block>
-                <f:submit value="${%Install}" />
+                <f:submit value="${%Install}"/>
               </f:block>
             </table>
           </form>
@@ -51,14 +51,14 @@ THE SOFTWARE.
         <!-- already installed -->
         <j:otherwise>
           <h1>
-            <img src="${imagesURL}/48x48/blue.png" alt="" height="48" width="48"/>
+            <l:icon name="blue-48x48"/>
             ${%Installation Complete}
           </h1>
 
           <p>${%restartBlurb}</p>
 
           <form action="restart" method="post">
-            <f:submit value="${%Yes}" />
+            <f:submit value="${%Yes}"/>
           </form>
         </j:otherwise>
       </j:choose>

--- a/core/src/main/resources/hudson/logging/LogRecorder/index.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/index.jelly
@@ -26,11 +26,11 @@ THE SOFTWARE.
   Log view
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
 <l:layout title="Log" permission="${app.ADMINISTER}">
-  <st:include page="sidepanel.jelly" />
+  <st:include page="sidepanel.jelly"/>
   <l:main-panel>
-    <h1><img src="${rootURL}/images/48x48/clipboard.png" alt="" height="48" width="48"/>${it.displayName}</h1>
+    <h1><l:icon name="clipboard-48x48"/>${it.displayName}</h1>
     <t:logRecords logRecords="${it.logRecords}"/>
     <j:forEach var="entry" items="${it.slaveLogRecords.entrySet()}">
       <h2><a href="${rootURL}/${entry.key.url}" class="model-link">${entry.key.displayName}</a></h2>
@@ -38,10 +38,10 @@ THE SOFTWARE.
     </j:forEach>
 
     <form method="post" id='clear-logrecorder' action="clear">
-      <f:submit value="${%Clear This Log}" />
+      <f:submit value="${%Clear This Log}"/>
     </form>
 
-    <st:include it="${it.parent}" page="feeds.jelly" />    
+    <st:include it="${it.parent}" page="feeds.jelly"/>
   </l:main-panel>
 </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/logging/LogRecorder/sidepanel.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/sidepanel.jelly
@@ -30,10 +30,10 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href=".." title="${%Back to Loggers}" />
-      <l:task icon="images/24x24/notepad.png" href="." title="${%Log records}" />
-      <l:task icon="images/24x24/setting.png" href="configure" title="${%Configure}" />
-      <l:task icon="images/24x24/edit-delete.png" href="delete" title="${%Delete}" />
+      <l:task icon="up-24x24" href=".." title="${%Back to Loggers}" />
+      <l:task icon="notepad-24x24" href="." title="${%Log records}" />
+      <l:task icon="setting-24x24" href="configure" title="${%Configure}" />
+      <l:task icon="edit-delete-24x24" href="delete" title="${%Delete}" />
     </l:tasks>
   </l:side-panel>
 </j:jelly>

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
@@ -26,14 +26,14 @@ THE SOFTWARE.
   Show all hudson.* logs
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
 <l:layout title="Log">
-  <st:include page="sidepanel.jelly" />
+  <st:include page="sidepanel.jelly"/>
   <l:main-panel>
-    <h1><img src="${rootURL}/images/48x48/clipboard.png" alt="" height="48" width="48"/>${%Jenkins Log}</h1>
+    <h1><l:icon name="clipboard-48x48"/>${%Jenkins Log}</h1>
     <t:logRecords logRecords="${h.logRecords}"/>
 
-    <st:include page="feeds.jelly" />
+    <st:include page="feeds.jelly"/>
   </l:main-panel>
 </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
@@ -26,24 +26,24 @@ THE SOFTWARE.
   Log view
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
 <l:layout title="${%Log}">
-  <st:include page="sidepanel.jelly" />
+  <st:include page="sidepanel.jelly"/>
   <l:main-panel xmlns:local="local">
-    <h1><img src="${imagesURL}/48x48/clipboard.png" alt="" height="48" width="48"/>
+    <h1><l:icon name="clipboard-48x48"/>
       ${%Log Recorders}
-      <t:help href="https://wiki.jenkins-ci.org/display/JENKINS/Logging" />
+      <t:help href="https://wiki.jenkins-ci.org/display/JENKINS/Logging"/>
     </h1>
 
     <d:taglib uri="local">
       <d:tag name="row">
         <tr>
           <td width="32">
-            <img src="${imagesURL}/32x32/clipboard.png" width="32" height="32" alt=""/>
+            <l:icon name="clipboard-32x32"/>
           </td>
           <td style="padding-left:2em"><a href="${href}">${name}</a></td>
           <td width="32">
-            <d:invokeBody />
+            <d:invokeBody/>
           </td>
         </tr>
       </d:tag>
@@ -55,17 +55,17 @@ THE SOFTWARE.
         <th initialSortDir="down">${%Name}</th>
         <th width="32"/>
       </tr>
-      <local:row href="all" name="${%All Jenkins Logs}" />
+      <local:row href="all" name="${%All Jenkins Logs}"/>
       <j:forEach var="lr" items="${it.logRecorders.values()}">
         <local:row name="${lr.name}" href="${lr.searchUrl}/">
           <a href="${lr.searchUrl}/configure">
-            <img src="${imagesURL}/32x32/setting.png" width="32" height="32" alt="[configure]" title="Configure"/>
+            <l:icon name="setting-32x32"/>
           </a>
         </local:row>
       </j:forEach>
     </table>
     <form method="get" action="new">
-      <f:submit value="${%Add new log recorder}" />
+      <f:submit value="${%Add new log recorder}"/>
     </form>
   </l:main-panel>
 </l:layout>

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/sidepanel.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/sidepanel.jelly
@@ -30,12 +30,12 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
-      <l:task icon="images/24x24/setting.png" href="${rootURL}/manage" title="${%Manage Jenkins}" />
-      <l:task icon="images/24x24/clipboard.png" href="." title="${%Logger List}" />
-      <l:task icon="images/24x24/notepad.png" href="all" title="${%All Logs}" />
-      <l:task icon="images/24x24/new-package.png" href="new" title="${%New Log Recorder}" />
-      <l:task icon="images/24x24/gear.png" href="levels" title="${%Log Levels}" />
+      <l:task icon="up-24x24" href="${rootURL}/" title="${%Back to Dashboard}" />
+      <l:task icon="setting-24x24" href="${rootURL}/manage" title="${%Manage Jenkins}" />
+      <l:task icon="clipboard-24x24" href="." title="${%Logger List}" />
+      <l:task icon="notepad-24x24" href="all" title="${%All Logs}" />
+      <l:task icon="new-package-24x24" href="new" title="${%New Log Recorder}" />
+      <l:task icon="gear-24x24" href="levels" title="${%Log Levels}" />
     </l:tasks>
   </l:side-panel>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -48,8 +48,10 @@ THE SOFTWARE.
       </div>
 
       <t:buildCaption>
+        <span class="displayName">
         ${%Build} ${it.displayName}
         (<i:formatDate value="${it.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)
+        </span>
       </t:buildCaption>
 
       <div>
@@ -78,8 +80,8 @@ THE SOFTWARE.
                       <j:choose>
                         <j:when test="${dep.from!=null}">
                           <a href="${rootURL}/${dep.from.url}" class="model-link inside">
-                            <img class="model-link-icon" src="${imagesURL}/16x16/${dep.from.buildStatusUrl}"
-                                 alt="${dep.from.iconColor.description}" height="16" width="16" />${dep.from.displayName}</a>
+                              <l:icon name="${dep.from.iconColor.iconName}-16x16" />${dep.from.displayName}
+                          </a>
                         </j:when>
                         <j:otherwise>
                           ?
@@ -88,9 +90,7 @@ THE SOFTWARE.
 
                       &#x2192; <!-- right arrow -->
 
-                      <a href="${rootURL}/${dep.to.url}" class="model-link inside">
-                        <img class="model-link-icon" src="${imagesURL}/16x16/${dep.to.buildStatusUrl}"
-                             alt="${dep.to.iconColor.description}" height="16" width="16" />${dep.to.displayName}</a>
+                      <a href="${rootURL}/${dep.to.url}" class="model-link inside"><l:icon name="${dep.to.iconColor.iconName}-16x16" />${dep.to.displayName}</a>
 
                       (<a href="${rootURL}/${dep.project.url}changes?from=${dep.fromId}&amp;to=${dep.toId}">${%detail}</a>)
                     </li>
@@ -113,7 +113,9 @@ THE SOFTWARE.
         </j:forEach>
       </table>
 
-      <st:include page="main.jelly" optional="true" />
+      <div class="abstractBuildMain">
+        <st:include page="main.jelly" optional="true" />
+      </div>
 
       <!-- upstream/downstream builds -->
       <j:set var="upstream" value="${it.upstreamBuilds}" />

--- a/core/src/main/resources/hudson/model/AbstractBuild/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/sidepanel.jelly
@@ -36,10 +36,10 @@ THE SOFTWARE.
       <st:include page="actions.jelly" />
       <t:actions actions="${it.transientActions}"/>
       <j:if test="${it.previousBuild!=null}">
-        <l:task icon="images/24x24/previous.png" href="${buildUrl.previousBuildUrl}" title="${%Previous Build}" contextMenu="false"/>
+        <l:task icon="previous-24x24" href="${buildUrl.previousBuildUrl}" title="${%Previous Build}" contextMenu="false"/>
       </j:if>
       <j:if test="${it.nextBuild!=null}">
-        <l:task icon="images/24x24/next.png" href="${buildUrl.nextBuildUrl}" title="${%Next Build}" contextMenu="false"/>
+        <l:task icon="next-24x24" href="${buildUrl.nextBuildUrl}" title="${%Next Build}" contextMenu="false"/>
       </j:if>
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/model/AbstractBuild/tasks.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/tasks.jelly
@@ -27,9 +27,9 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:p="/lib/hudson/project">
-      <l:task icon="images/24x24/up.png" href="${it.upUrl}" title="${%Back to Project}" contextMenu="false"/>
-      <l:task icon="images/24x24/search.png" href="${buildUrl.baseUrl}/" title="${%Status}" contextMenu="false"/>
-      <l:task icon="images/24x24/notepad.png" href="${buildUrl.baseUrl}/changes" title="${%Changes}" />
+      <l:task icon="up-24x24" href="${it.upUrl}" title="${%Back to Project}" contextMenu="false"/>
+      <l:task icon="search-24x24" href="${buildUrl.baseUrl}/" title="${%Status}" contextMenu="false"/>
+      <l:task icon="notepad-24x24" href="${buildUrl.baseUrl}/changes" title="${%Changes}" />
       <p:console-link/>
-      <l:task icon="images/24x24/notepad.png" href="${buildUrl.baseUrl}/configure" title="${h.hasPermission(it,it.UPDATE)?'%Edit Build Information':'%View Build Information'}"/>
+      <l:task icon="notepad-24x24" href="${buildUrl.baseUrl}/configure" title="${h.hasPermission(it,it.UPDATE)?'%Edit Build Information':'%View Build Information'}"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/AbstractItem/noWorkspace.jelly
+++ b/core/src/main/resources/hudson/model/AbstractItem/noWorkspace.jelly
@@ -24,11 +24,11 @@ THE SOFTWARE.
 
 <!-- tell user that there's no workspace yet -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <st:include page="sidepanel.jelly" />
+    <st:include page="sidepanel.jelly"/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="" height="48" width="48"/>${%Error: no workspace}</h1>
+      <h1><l:icon name="error-48x48"/>${%Error: no workspace}</h1>
       <j:choose>
         <j:when test="${it.lastBuild==null}">
           <p>

--- a/core/src/main/resources/hudson/model/AbstractProject/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/sidepanel.jelly
@@ -39,16 +39,16 @@ THE SOFTWARE.
       <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
       <j:choose>
         <j:when test="${it.parent==app}">
-          <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" contextMenu="false" />
+          <l:task icon="up-24x24" href="${rootURL}/" title="${%Back to Dashboard}" contextMenu="false" />
         </j:when>
         <j:otherwise>
-          <l:task icon="images/24x24/up.png" href="${rootURL}/${it.parent.url}" title="${%Up}" contextMenu="false" />
+          <l:task icon="up-24x24" href="${rootURL}/${it.parent.url}" title="${%Up}" contextMenu="false" />
         </j:otherwise>
       </j:choose>
-      <l:task icon="images/24x24/search.png"  href="${url}/" title="${%Status}" contextMenu="false"/>
-      <l:task icon="images/24x24/notepad.png" href="${url}/changes" title="${%Changes}" />
-      <l:task icon="images/24x24/folder.png"  href="${url}/ws/" title="${%Workspace}" permission="${it.WORKSPACE}">
-        <l:task icon="images/24x24/folder-delete.png"  href="${url}/doWipeOutWorkspace" title="${%Wipe Out Workspace}" permission="${h.isWipeOutPermissionEnabled() ? it.WIPEOUT : it.BUILD}" post="true" requiresConfirmation="true" confirmationMessage="${%wipe.out.confirm}"/>
+      <l:task icon="search-24x24"  href="${url}/" title="${%Status}" contextMenu="false"/>
+      <l:task icon="notepad-24x24" href="${url}/changes" title="${%Changes}" />
+      <l:task icon="folder-24x24"  href="${url}/ws/" title="${%Workspace}" permission="${it.WORKSPACE}">
+        <l:task icon="folder-delete-24x24"  href="${url}/doWipeOutWorkspace" title="${%Wipe Out Workspace}" permission="${h.isWipeOutPermissionEnabled() ? it.WIPEOUT : it.BUILD}" post="true" requiresConfirmation="true" confirmationMessage="${%wipe.out.confirm}"/>
       </l:task>
       <j:if test="${it.configurable}">
         <p:configurable/>

--- a/core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspaceBlocked.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspaceBlocked.jelly
@@ -24,11 +24,11 @@ THE SOFTWARE.
 
 <!-- tell user that there's no workspace yet -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <st:include page="sidepanel.jelly" />
+    <st:include page="sidepanel.jelly"/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="" height="48" width="48"/>${%Error: Wipe Out Workspace blocked by SCM}</h1>
+      <h1><l:icon name="error-48x48"/>${%Error: Wipe Out Workspace blocked by SCM}</h1>
       <p>
         ${%The SCM for this project has blocked this attempt to wipe out the project's workspace.}
       </p>

--- a/core/src/main/resources/hudson/model/Computer/builds.jelly
+++ b/core/src/main/resources/hudson/model/Computer/builds.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout title="${it.displayName}">
-    <st:include page="sidepanel.jelly" />
+    <st:include page="sidepanel.jelly"/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/notepad.png" alt="" height="48" width="48"/>
+        <l:icon name="notepad-48x48"/>
         ${%title(it.displayName)}
       </h1>
 

--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -52,7 +52,7 @@ THE SOFTWARE.
       </div>
 
       <h1>
-        <img src="${imagesURL}/48x48/${it.icon}" width="48" height="48" alt=""/>
+        <l:icon name="${it.iconName}-48x48" />
         ${it.caption}
         <j:if test="${!empty(it.node.nodeDescription)}">
           <span style="font-size:smaller">(${it.node.nodeDescription})</span>

--- a/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
@@ -30,13 +30,13 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href=".." title="${%Back to List}" contextMenu="false"/>
-      <l:task icon="images/24x24/search.png" href="${rootURL}/${it.url}" title="${%Status}" contextMenu="false"/>
-      <l:task icon="images/24x24/edit-delete.png" href="delete" title="${%Delete Slave}" permission="${it.DELETE}" />
-      <l:task icon="images/24x24/setting.png" href="configure" title="${%Configure}" permission="${it.CONFIGURE}" />
-      <l:task icon="images/24x24/notepad.png" href="builds" title="${%Build History}" />
-      <l:task icon="images/24x24/monitor.png" href="load-statistics" title="${%Load Statistics}" />
-      <l:task icon="images/24x24/terminal.png" href="script" title="${%Script Console}" permission="${app.RUN_SCRIPTS}" />
+      <l:task icon="up-24x24" href=".." title="${%Back to List}" contextMenu="false"/>
+      <l:task icon="search-24x24" href="${rootURL}/${it.url}" title="${%Status}" contextMenu="false"/>
+      <l:task icon="edit-delete-24x24" href="delete" title="${%Delete Slave}" permission="${it.DELETE}" />
+      <l:task icon="setting-24x24" href="configure" title="${%Configure}" permission="${it.CONFIGURE}" />
+      <l:task icon="notepad-24x24" href="builds" title="${%Build History}" />
+      <l:task icon="monitor-24x24" href="load-statistics" title="${%Load Statistics}" />
+      <l:task icon="terminal-24x24" href="script" title="${%Script Console}" permission="${app.RUN_SCRIPTS}" />
       <st:include page="sidepanel2.jelly" optional="true" /><!-- hook for derived class to add more items -->
       <t:actions />
     </l:tasks>

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -26,9 +26,9 @@ THE SOFTWARE.
   Entrance to the configuration page
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:s="/lib/form" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
 <l:layout title="${%Nodes}">
-  <st:include page="sidepanel.jelly" />
+  <st:include page="sidepanel.jelly"/>
   <l:header>
     <style><!-- create some spaces between cells -->
       #computers td {
@@ -49,13 +49,13 @@ THE SOFTWARE.
             <th align="right" tooltip="${m.descriptor.timestampString}">${m.columnCaption}</th>
           </j:if>
         </j:forEach>
-        <th />
+        <th/>
       </tr>
 
       <j:forEach var="c" items="${it._all}">
         <tr id="node_${c.name}">
           <td width="32" data="${c.icon}">
-            <img src="${imagesURL}/32x32/${c.icon}" width="32" height="32" alt="${c.iconAltText}"/>
+            <l:icon name="${c.iconName}-32x32" />
           </td>
           <td><a href="${rootURL}/${c.url}" class="model-link inside">${c.displayName}</a></td>
           <j:forEach var="m" items="${monitors}">
@@ -68,9 +68,7 @@ THE SOFTWARE.
           <td><!-- config link -->
             <j:if test="${c.hasPermission(c.CONFIGURE)}">
               <a href="${rootURL}/${c.url}configure">
-                <img src="${imagesURL}/32x32/setting.png"
-                     title="${%Configure}" alt="${%Configure}"
-                     height="32" width="32" border="0"/>
+                <l:icon name="setting-32x32" tooltip="${%Configure}"/>
               </a>
             </j:if>
           </td>
@@ -83,7 +81,7 @@ THE SOFTWARE.
       </j:forEach>
 
       <tr class="sortbottom">
-        <th />
+        <th/>
         <th>${%Data obtained}</th>
         <j:forEach var="m" items="${monitors}">
           <j:if test="${m.columnCaption!=null}">
@@ -92,7 +90,7 @@ THE SOFTWARE.
             </th>
           </j:if>
         </j:forEach>
-        <th />
+        <th/>
       </tr>
 
     </table>

--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -32,14 +32,13 @@ THE SOFTWARE.
       <!-- parent path -->
         <div class="parentPath">
           <form action="${backPath}" method="get">
-            <a href="${topPath}"><img src="${imagesURL}/48x48/${icon}" class="rootIcon" alt="" height="48" width="48"/></a>
+            <a href="${topPath}"><l:icon name="${icon}-48x48" style="margin-right: 1em;"/></a>
             <j:forEach var="p" items="${parentPath}">
               <a href="${p.href}">${p.title}</a>
               /
             </j:forEach>
             <input type="text" name="pattern" value="${pattern}" />
-            <img src="${imagesURL}/16x16/go-next.png" style="vertical-align:middle; cursor:pointer" alt="[submit]"
-                onclick="this.parentNode.submit()" height="16" width="16"/>
+            <l:icon name="go-next-16x16" style="cursor:pointer" onclick="this.parentNode.submit()" />
           </form>
         </div>
         <j:choose>
@@ -52,7 +51,7 @@ THE SOFTWARE.
                 <j:set var="x" value="${f.get(f.size()-1)}"/>
                 <tr>
                   <td>
-                    <img src="${imagesURL}/16x16/${x.iconName}" alt="" height="16" width="16"/>
+                    <l:icon name="${x.iconBaseName}-16x16" />
                   </td>
                   <td>
                     <j:forEach var="t" items="${f}" varStatus="st">
@@ -77,7 +76,7 @@ THE SOFTWARE.
                       <j:if test="${x.readable}">
                         <j:if test="${app.fingerprintMap.ready}">
                           <a href="${x.href}/*fingerprint*/">
-                            <img src="${imagesURL}/16x16/fingerprint.png" alt="fingerprint" height="16" width="16" />
+                            <l:icon name="fingerprint-16x16" />
                           </a>
                           <st:nbsp/>
                         </j:if>
@@ -91,7 +90,7 @@ THE SOFTWARE.
                 <td style="text-align:right;" colspan="3">
                   <div style="margin-top: 1em;">
                     <a href="${backPath}${pattern!=''?pattern+'/':''}*zip*/${dir.name}.zip">
-                      <img src="${imagesURL}/16x16/package.png" height="16" width="16"/>
+                      <l:icon name="package-16x16" />
                       (${%all files in zip})
                     </a>
                   </div>

--- a/core/src/main/resources/hudson/model/Executor/causeOfDeath.jelly
+++ b/core/src/main/resources/hudson/model/Executor/causeOfDeath.jelly
@@ -28,20 +28,20 @@ THE SOFTWARE.
     <l:header />
     <l:side-panel>
       <l:tasks>
-        <l:task icon="images/24x24/up.png" href="../.." title="${%Back}" />
+        <l:task icon="up-24x24" href="../.." title="${%Back}" />
       </l:tasks>
     </l:side-panel>
     <l:main-panel>
       <j:choose>
         <j:when test="${it.alive}">
           <h1>
-            <img src="${imagesURL}/48x48/blue.png" width="48" height="48" alt=""/>
+            <l:icon name="blue-48x48" />
             ${%Thread is still alive}
           </h1>
         </j:when>
         <j:otherwise>
           <h1>
-            <img src="${imagesURL}/48x48/red.png" width="48" height="48" alt=""/>
+            <l:icon name="red-48x48" />
             ${%Thread has died}
           </h1>
           <pre>${h.printThrowable(it.causeOfDeath)}</pre>

--- a/core/src/main/resources/hudson/model/Fingerprint/index.jelly
+++ b/core/src/main/resources/hudson/model/Fingerprint/index.jelly
@@ -23,20 +23,20 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout title="${it.fileName}">
     <l:header>
       <!-- RSS? -->
     </l:header>
     <l:side-panel>
       <l:tasks>
-        <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
+        <l:task icon="up-24x24" href="${rootURL}/" title="${%Back to Dashboard}" />
         <t:actions/>
       </l:tasks>
     </l:side-panel>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
+        <l:icon name="fingerprint-48x48"/>
         ${it.fileName}
       </h1>
       <div class="md5sum">
@@ -81,7 +81,7 @@ THE SOFTWARE.
                   </j:choose>
                 </td>
                 <td>
-                  <t:buildRangeLink job="${job}" range="${range}" />
+                  <t:buildRangeLink job="${job}" range="${range}"/>
                 </td>
               </tr>
             </j:forEach>

--- a/core/src/main/resources/hudson/model/Label/index.jelly
+++ b/core/src/main/resources/hudson/model/Label/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/attribute.png" width="48" height="48" alt=""/>
+        <l:icon name="attribute-48x48" />
         ${it.name}
       </h1>
 
@@ -42,7 +42,7 @@ THE SOFTWARE.
           <j:set var="c" value="${app.getComputer(n.nodeName)}"/>
           <j:set var="url" value="${rootURL}/computer/${n.nodeName}"/>
           <nobr>
-            <a href="${url}"><img src="${imagesURL}/16x16/${c.icon}" width="16" height="16" alt=""/></a>
+            <a href="${url}"><l:icon name="${c.iconName}-16x16" /></a>
             <st:nbsp/>
             <a href="${url}" class="model-link inside">${c.displayName}</a>
           </nobr>

--- a/core/src/main/resources/hudson/model/Label/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/Label/sidepanel.jelly
@@ -31,9 +31,9 @@ THE SOFTWARE.
   <l:side-panel>
     <l:tasks>
       <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" contextMenu="false"/>
-      <l:task icon="images/24x24/attribute.png" href="${url}" title="${%Overview}" contextMenu="false"/>
-      <l:task icon="images/24x24/monitor.png" href="${url}/load-statistics" title="${%Load Statistics}" />
+      <l:task icon="up-24x24" href="${rootURL}/" title="${%Back to Dashboard}" contextMenu="false"/>
+      <l:task icon="attribute-24x24" href="${url}" title="${%Overview}" contextMenu="false"/>
+      <l:task icon="monitor-24x24" href="${url}/load-statistics" title="${%Load Statistics}" />
       <st:include page="actions.jelly" />
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/model/LoadStatistics/main.jelly
+++ b/core/src/main/resources/hudson/model/LoadStatistics/main.jelly
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 <!-- renders an HTML fragment that shows trend graph -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <h1>
-    <img src="${imagesURL}/48x48/monitor.png" alt="" height="48" width="48"/>
+    <l:icon name="monitor-48x48"/>
     ${%title(it.displayName)}
   </h1>
   <j:set var="type" value="${request.getParameter('type') ?: 'min'}" />
@@ -40,7 +40,7 @@ THE SOFTWARE.
         ${%Short}
       </j:otherwise>
     </j:choose>
-    <st:nbsp />
+    <st:nbsp/>
     <j:choose>
       <j:when test="${type != 'min'}">
         <a href="?type=min">${%Medium}</a>
@@ -49,7 +49,7 @@ THE SOFTWARE.
         ${%Medium}
       </j:otherwise>
     </j:choose>
-    <st:nbsp />
+    <st:nbsp/>
     <j:choose>
       <j:when test="${type != 'hour'}">
         <a href="?type=hour">${%Long}</a>

--- a/core/src/main/resources/hudson/model/NoFingerprintMatch/index.jelly
+++ b/core/src/main/resources/hudson/model/NoFingerprintMatch/index.jelly
@@ -24,17 +24,17 @@ THE SOFTWARE.
 
 <!-- used when fingerprint had no match -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <l:header title="${%No matching record found}" />
+    <l:header title="${%No matching record found}"/>
     <l:side-panel>
       <l:tasks>
-        <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
+        <l:task icon="up-24x24" href="${rootURL}/" title="${%Back to Dashboard}" />
       </l:tasks>
     </l:side-panel>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
+        <l:icon name="fingerprint-48x48"/>
         ${%No matching record found}
       </h1>
 

--- a/core/src/main/resources/hudson/model/Run/artifacts-index.jelly
+++ b/core/src/main/resources/hudson/model/Run/artifacts-index.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
           <j:forEach var="f" items="${it.artifacts}">
             <tr>
               <td>
-                <img src="${imagesURL}/16x16/text.png" alt="" height="16" width="16"/>
+                <l:icon name="text-16x16" />
               </td>
               <td>
                 <a href="artifact/${f.href}">${f.displayPath}</a>

--- a/core/src/main/resources/hudson/model/Run/delete.jelly
+++ b/core/src/main/resources/hudson/model/Run/delete.jelly
@@ -28,6 +28,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:if test="${!it.building}">
-    <l:task icon="images/24x24/edit-delete.png" href="${buildUrl.baseUrl}/confirmDelete" title="${%Delete this build}" permission="${it.DELETE}" />
+    <l:task icon="edit-delete-24x24" href="${buildUrl.baseUrl}/confirmDelete" title="${%Delete this build}" permission="${it.DELETE}" />
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/TreeView/sidepanel2.jelly
+++ b/core/src/main/resources/hudson/model/TreeView/sidepanel2.jelly
@@ -27,5 +27,5 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-  <l:task icon="images/32x32/folder.png" href="newView" title="${%New View}"  permission="${it.CONFIGURE}" />
+  <l:task icon="folder-32x32" href="newView" title="${%New View}"  permission="${it.CONFIGURE}" />
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Failure/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Failure/status.jelly
@@ -25,7 +25,8 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
-    <img src="${imagesURL}/24x24/red.png" alt="" height="24" width="24"/> ${%Failure}
+    <l:icon name="red-24x24" />
+    ${%Failure}
     -
     <a href="" onclick="var n=findNext(this,function(e){return e.tagName=='PRE'});
                n.style.display='block';this.style.display='none';return false">${%Details}</a>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Installing/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Installing/status.jelly
@@ -25,7 +25,8 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
-    <img src="${imagesURL}/24x24/grey_anime.gif" alt="" height="24" width="24"/> ${%Installing}
+    <l:icon name="grey_anime-24x24" />
+    ${%Installing}
   </div>
   <div style="padding-left: 32px">
     <t:progressBar pos="${it.percentage}" />

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Pending/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Pending/status.jelly
@@ -24,5 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <img src="${imagesURL}/24x24/grey.png" alt="" height="24" width="24"/> ${%Pending}
+  <l:icon name="grey-24x24" />
+  ${%Pending}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Success/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Success/status.jelly
@@ -24,5 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <img src="${imagesURL}/24x24/blue.png" alt="" height="24" width="24"/> ${%Success}
+  <l:icon name="blue-24x24" />
+  ${%Success}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/SuccessButRequiresRestart/status.groovy
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/SuccessButRequiresRestart/status.groovy
@@ -22,6 +22,6 @@
  * THE SOFTWARE.
  */
 
-img(src:"${imagesURL}/24x24/yellow.png",height:24,width:24)
-text(" ");
-text(my.message)
+raw("<div class='jenkins-icon yellow-24x24' icon-name='yellow-24x24'></div>");
+raw("&nbsp;")
+raw("<span class='text-align top'>" + my.message + '</span>')

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Canceled/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Canceled/status.jelly
@@ -24,5 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <img src="${imagesURL}/24x24/red.png" alt="" height="24" width="24"/> ${%Canceled}
+    <l:icon name="red-24x24" />
+    ${%Canceled}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status.jelly
@@ -24,5 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <img src="${imagesURL}/24x24/red.png" alt="" height="24" width="24"/> ${%Failure}
+    <l:icon name="red-24x24" />
+    ${%Failure}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status.jelly
@@ -24,5 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <img src="${imagesURL}/24x24/grey.png" alt="" height="24" width="24"/> ${%Pending}
+  <l:icon name="grey-24x24" />
+  ${%Pending}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Running/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Running/status.jelly
@@ -24,5 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <img src="${imagesURL}/24x24/grey_anime.gif" alt="" height="24" width="24"/> ${%Running}
+    <l:icon name="grey_anime-24x24" />
+    ${%Running}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
@@ -67,6 +67,7 @@ THE SOFTWARE.
                       }
                       var scheduleDiv = document.getElementById('scheduleRestartBlock');
                       scheduleDiv.innerHTML = div.lastChild.innerHTML;
+                      layoutUpdateCallback.call();
                       refresh();
                   }
               });

--- a/core/src/main/resources/hudson/model/UpdateCenter/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/sidepanel.jelly
@@ -30,10 +30,10 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
+      <l:task icon="up-24x24" href="${rootURL}/" title="${%Back to Dashboard}" />
       <l:isAdmin>
-        <l:task icon="images/24x24/setting.png" href="${rootURL}/manage" title="${%Manage Jenkins}" />
-        <l:task icon="images/32x32/plugin.png" href="${rootURL}/pluginManager/" title="${%Manage Plugins}" />
+        <l:task icon="setting-24x24" href="${rootURL}/manage" title="${%Manage Jenkins}" />
+        <l:task icon="plugin-32x32" href="${rootURL}/pluginManager/" title="${%Manage Plugins}" />
       </l:isAdmin>
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/model/User/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/User/sidepanel.jelly
@@ -31,14 +31,14 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/asynchPeople/" title="${%People}" contextMenu="false"/>
-      <l:task icon="images/24x24/search.png" href="${rootURL}/${it.url}/" title="${%Status}" contextMenu="false"/>
-      <l:task icon="images/24x24/notepad.png" href="${rootURL}/${it.url}/builds" title="${%Builds}" />
-      <l:task icon="images/24x24/setting.png" href="${rootURL}/${it.url}/configure" title="${%Configure}" permission="${app.ADMINISTER}" />
+      <l:task icon="up-24x24" href="${rootURL}/asynchPeople/" title="${%People}" contextMenu="false"/>
+      <l:task icon="search-24x24" href="${rootURL}/${it.url}/" title="${%Status}" contextMenu="false"/>
+      <l:task icon="notepad-24x24" href="${rootURL}/${it.url}/builds" title="${%Builds}" />
+      <l:task icon="setting-24x24" href="${rootURL}/${it.url}/configure" title="${%Configure}" permission="${app.ADMINISTER}" />
       <t:actions actions="${it.propertyActions}"/>
       <t:actions actions="${it.transientActions}"/>
       <j:if test="${it.canDelete()}">
-        <l:task icon="images/24x24/edit-delete.png" href="${rootURL}/${it.url}/delete" title="${%Delete}" />
+        <l:task icon="edit-delete-24x24" href="${rootURL}/${it.url}/delete" title="${%Delete}" />
       </j:if>
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/model/View/AsynchPeople/index.jelly
+++ b/core/src/main/resources/hudson/model/View/AsynchPeople/index.jelly
@@ -23,13 +23,13 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout title="${%People} - ${it.parent.viewName}">
     <st:include page="sidepanel.jelly" it="${it.parent}" />
     <t:setIconSize/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/user.png" alt="" height="48" width="48"/>
+        <l:icon name="user-48x48"/>
         ${%People}
         <j:set var="viewType" value="${it.parent.class.simpleName}"/>
         <j:set var="isAll" value="${viewType=='Hudson' or viewType=='AllView'}"/>
@@ -100,7 +100,7 @@ THE SOFTWARE.
       <l:progressiveRendering handler="${it}" callback="display"/>
       <table class="sortable pane bigtable" id="people">
         <tr>
-          <th />
+          <th/>
           <th>${%User Id}</th>
           <th>${%Name}</th>
           <th initialSortDir="up">${%Last Active}</th>

--- a/core/src/main/resources/hudson/model/View/builds.jelly
+++ b/core/src/main/resources/hudson/model/View/builds.jelly
@@ -24,12 +24,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout title="${it.displayName}">
-    <st:include page="sidepanel.jelly" />
+    <st:include page="sidepanel.jelly"/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/notepad.png" alt="" height="48" width="48"/>
+        <l:icon name="notepad-48x48"/>
         ${%buildHistory(it.class.name=='hudson.model.AllView' ? app.displayName : it.displayName)}
       </h1>
 

--- a/core/src/main/resources/hudson/model/View/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/View/sidepanel.jelly
@@ -40,28 +40,28 @@ THE SOFTWARE.
 
       <st:include page="tasks-new.jelly" it="${it.owner}" optional="true">
         <!-- made overridable for ViewGroup that doesn't allow modifications -->
-        <l:task icon="images/24x24/new-package.png" href="${rootURL}/${it.viewUrl}newJob" title="${%NewJob(it.newPronoun)}" permission="${it.itemCreatePermission}" it="${app}" />
+        <l:task icon="new-package-24x24" href="${rootURL}/${it.viewUrl}newJob" title="${%NewJob(it.newPronoun)}" permission="${it.itemCreatePermission}" it="${app}" />
       </st:include>
 
       <j:choose>
         <j:when test="${it.class.name=='hudson.model.AllView'}">
-          <l:task icon="images/24x24/user.png" href="${rootURL}/asynchPeople/" title="${%People}" />
+          <l:task icon="user-24x24" href="${rootURL}/asynchPeople/" title="${%People}" />
         </j:when>
         <j:otherwise>
-          <l:task icon="images/24x24/user.png" href="${rootURL}/${it.viewUrl}asynchPeople/" title="${%People}" />
+          <l:task icon="user-24x24" href="${rootURL}/${it.viewUrl}asynchPeople/" title="${%People}" />
         </j:otherwise>
       </j:choose>
-      <l:task icon="images/24x24/notepad.png" href="${rootURL}/${it.viewUrl}builds" title="${%Build History}"/>
+      <l:task icon="notepad-24x24" href="${rootURL}/${it.viewUrl}builds" title="${%Build History}"/>
       <j:if test="${it.isEditable()}">
         <!-- /configure URL on Jenkins object is overloaded with Jenkins's system config, so always use the explicit name. -->
-        <l:task icon="images/24x24/gear.png" href="${rootURL}/${it.viewUrl}configure" title="${%Edit View}" permission="${it.CONFIGURE}" />
+        <l:task icon="gear-24x24" href="${rootURL}/${it.viewUrl}configure" title="${%Edit View}" permission="${it.CONFIGURE}" />
       </j:if>
       <j:if test="${it.owner.canDelete(it)}">
-        <l:task icon="images/24x24/edit-delete.png" href="delete" title="${%Delete View}" permission="${it.DELETE}" />
+        <l:task icon="edit-delete-24x24" href="delete" title="${%Delete View}" permission="${it.DELETE}" />
       </j:if>
       <j:if test="${app.fingerprintMap.ready}">
-        <l:task icon="images/24x24/search.png" href="${rootURL}/projectRelationship" title="${%Project Relationship}" />
-        <l:task icon="images/24x24/fingerprint.png" href="${rootURL}/fingerprintCheck" title="${%Check File Fingerprint}" />
+        <l:task icon="search-24x24" href="${rootURL}/projectRelationship" title="${%Project Relationship}" />
+        <l:task icon="fingerprint-24x24" href="${rootURL}/fingerprintCheck" title="${%Check File Fingerprint}" />
       </j:if>
 
       <!-- subtypes can put more stuff here -->

--- a/core/src/main/resources/hudson/os/solaris/ZFSInstaller/askRootPassword.jelly
+++ b/core/src/main/resources/hudson/os/solaris/ZFSInstaller/askRootPassword.jelly
@@ -23,13 +23,13 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout title="${%Permission Denied}">
-    <l:header />
-    <l:side-panel />
+    <l:header/>
+    <l:side-panel/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/secure.png" width="48" height="48" alt=""/>
+        <l:icon name="secure-48x48"/>
         ${%Permission Denied}
       </h1>
       <div>
@@ -37,11 +37,11 @@ THE SOFTWARE.
 
         <f:form method="post" action="start">
           <f:entry title="${%Username}">
-            <f:textbox name="username" value="root" />
+            <f:textbox name="username" value="root"/>
           </f:entry>
 
           <f:entry title="${%Password}">
-            <f:password name="password" />
+            <f:password name="password"/>
           </f:entry>
 
           <f:block>

--- a/core/src/main/resources/hudson/scm/AbstractScmTagAction/badge.jelly
+++ b/core/src/main/resources/hudson/scm/AbstractScmTagAction/badge.jelly
@@ -23,11 +23,8 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:if test="${it.isTagged()}" xmlns:j="jelly:core">
+<j:if xmlns:j="jelly:core" xmlns:l="/lib/layout" test="${it.isTagged()}">
   <a href="${rootURL}/${it.build.url}tagBuild/">
-    <img width="16" height="16"
-      tooltip="${it.tooltip}"
-      alt="[tagged]"
-      src="${imagesURL}/16x16/save.png"/>
+    <l:icon name="save-16x16" tooltip="${it.tooltip}"/>
   </a>
 </j:if>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
@@ -23,9 +23,9 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout permission="${app.ADMINISTER}" title="${%Users}">
-    <st:include page="sidepanel.jelly" />
+    <st:include page="sidepanel.jelly"/>
     <l:main-panel>
       <h1>${%Users}</h1>
       <p>${%blurb}</p>
@@ -43,9 +43,9 @@ THE SOFTWARE.
             <td><a href="${user.url}/">${user.id}</a></td>
             <td><a href="${user.url}/">${user}</a></td>
             <td>
-              <a href="${user.url}/configure"><img src="${imagesURL}/32x32/setting.png" alt="Setting" height="32" width="32"/></a>
+              <a href="${user.url}/configure"><l:icon name="setting-32x32"/></a>
               <j:if test="${user.canDelete()}">
-                <a href="${user.url}/delete"><img src="${imagesURL}/24x24/edit-delete.png" alt="Delete" height="24" width="24"/></a>
+                <a href="${user.url}/delete"><l:icon name="edit-delete-24x24"/></a>
               </j:if>
             </td>
           </tr>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/sidepanel.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/sidepanel.jelly
@@ -27,9 +27,9 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
-      <l:task icon="images/24x24/setting.png" href="${rootURL}/manage" title="${%Manage Jenkins}" permission="${app.ADMINISTER}" />
-      <l:task icon="images/24x24/new-user.png" href="addUser" title="${%Create User}" permission="${app.ADMINISTER}"/>
+      <l:task icon="up-24x24" href="${rootURL}/" title="${%Back to Dashboard}" />
+      <l:task icon="setting-24x24" href="${rootURL}/manage" title="${%Manage Jenkins}" permission="${app.ADMINISTER}" />
+      <l:task icon="new-user-24x24" href="addUser" title="${%Create User}" permission="${app.ADMINISTER}"/>
     </l:tasks>
   </l:side-panel>
 </j:jelly>

--- a/core/src/main/resources/hudson/slaves/SlaveComputer/sidepanel2.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/sidepanel2.jelly
@@ -24,10 +24,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:task icon="images/24x24/clipboard.png" href="log" title="${%Log}" permission="${it.CONNECT}" />
-  <l:task icon="images/24x24/computer.png" href="systemInfo" title="${%System Information}" permission="${it.CONNECT}"/>
+  <l:task icon="clipboard-24x24" href="log" title="${%Log}" permission="${it.CONNECT}" />
+  <l:task icon="computer-24x24" href="systemInfo" title="${%System Information}" permission="${it.CONNECT}"/>
   <j:if test="${it.channel!=null}">
-    <l:task icon="images/24x24/edit-delete.png" href="disconnect" title="${%Disconnect}" permission="${it.DISCONNECT}"/>
+    <l:task icon="edit-delete-24x24" href="disconnect" title="${%Disconnect}" permission="${it.DISCONNECT}"/>
   </j:if>
 
 </j:jelly>

--- a/core/src/main/resources/hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
+++ b/core/src/main/resources/hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
@@ -28,12 +28,12 @@ THE SOFTWARE.
   This belongs to a build view.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
     <st:include it="${it.build}" page="sidepanel.jelly"/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
+        <l:icon name="fingerprint-48x48"/>
         ${%Recorded Fingerprints}
       </h1>
       <table class="fingerprint-in-build sortable bigtable">
@@ -67,7 +67,7 @@ THE SOFTWARE.
             </td>
             <td>
               <a href="${rootURL}/fingerprint/${f.hashString}/">
-                <img src="${imagesURL}/16x16/fingerprint.png" alt="" height="16" width="16"/> ${%more details}
+                <l:icon name="fingerprint-16x16"/> ${%more details}
               </a>
             </td>
           </tr>

--- a/core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
+++ b/core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <!--  this is loaded on demand in the failed test results summary -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:local="local" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <d:taglib uri="local">
     <d:tag name="item">
       <j:if test="${value!=null and !empty value}">
@@ -35,10 +35,10 @@ THE SOFTWARE.
         <j:set var="close" value="javascript:hideFailureSummary('${id}')"/>
         <h4>
           <a id="${id}-showlink" href="${open}" title="Show ${title}" style="display: ${idisplay}">
-            <img src="${imagesURL}/16x16/document_add.png"/><st:nbsp/>${title}
+            <l:icon name="document_add-16x16"/><st:nbsp/>${title}
           </a>
           <a id="${id}-hidelink" href="${close}" title="Hide ${title}" style="display: ${display}">
-            <img src="${imagesURL}/16x16/document_delete.png"/><st:nbsp/>${title}
+            <l:icon name="document_delete-16x16"/><st:nbsp/>${title}
           </a>
         </h4>
         <pre id="${id}" style="display: ${display}">

--- a/core/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
+++ b/core/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
@@ -33,16 +33,16 @@ THE SOFTWARE.
       <j:set var="buildUrl" value="${h.decompose(request)}" />
       <j:set var="baseUrl" value="${request.findAncestor(it).relativePath}"/>
       <st:include it="${it.owner}" page="tasks.jelly" optional="true"/>
-      <l:task icon="images/24x24/graph.png" href="${baseUrl}/history" title="${%History}"/>
+      <l:task icon="graph-24x24" href="${baseUrl}/history" title="${%History}"/>
       <st:include it="${it.owner}" page="actions.jelly" optional="true" />
 
       <t:actions actions="${it.testActions}" />
 
       <j:if test="${it.owner.previousBuild!=null}">
-        <l:task icon="images/24x24/previous.png" href="${buildUrl.previousBuildUrl}" title="${%Previous Build}" />
+        <l:task icon="previous-24x24" href="${buildUrl.previousBuildUrl}" title="${%Previous Build}" />
       </j:if>
       <j:if test="${it.owner.nextBuild!=null}">
-        <l:task icon="images/24x24/next.png" href="${buildUrl.nextBuildUrl}" title="${%Next Build}" />
+        <l:task icon="next-24x24" href="${buildUrl.nextBuildUrl}" title="${%Next Build}" />
       </j:if>
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/tools/JDKInstaller/DescriptorImpl/enterCredential.jelly
+++ b/core/src/main/resources/hudson/tools/JDKInstaller/DescriptorImpl/enterCredential.jelly
@@ -22,12 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout title="${%Enter Your Oracle Account}">
     <l:main-panel>
 
       <h1>
-        <img src="${imagesURL}/48x48/secure.gif" width="48" height="48" alt=""/>
+        <l:icon name="secure-48x48"/>
         ${%Enter Your Oracle Account}
       </h1>
       <p>

--- a/core/src/main/resources/hudson/triggers/SCMTrigger/BuildAction/index.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/BuildAction/index.jelly
@@ -26,21 +26,21 @@ THE SOFTWARE.
   Displays the polling log output
 -->
 <?jelly escape-by-default='true'?>
-<st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.run.parent.displayName} #${it.run.number} ${%Polling Log}" norefresh="true">
-    <st:include it="${it.run}" page="sidepanel.jelly" />
+<st:compress xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
+  <l:layout norefresh="true" title="${it.run.parent.displayName} #${it.run.number} ${%Polling Log}">
+    <st:include it="${it.run}" page="sidepanel.jelly"/>
     <l:main-panel>
       <h1>${%Polling Log}</h1>
       <l:rightspace>
         <a href="pollingLog">
-          <img src="${imagesURL}/24x24/document.png" alt="" height="24" width="24" />${%View as plain text}
+          <l:icon name="document-24x24"/>${%View as plain text}
         </a>
       </l:rightspace>
 
       <p>${%blurb}</p>
       
       <pre>
-        <st:getOutput var="output" />
+        <st:getOutput var="output"/>
         <j:whitespace>${it.writePollingLogTo(0,output)}</j:whitespace>
       </pre>
     </l:main-panel>

--- a/core/src/main/resources/hudson/util/AWTProblem/index.jelly
+++ b/core/src/main/resources/hudson/util/AWTProblem/index.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <l:header title="Jenkins" />
-    <l:side-panel />
+    <l:header title="Jenkins"/>
+    <l:side-panel/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon name="error-48x48"/><st:nbsp/>${%Error}</h1>
       <p>
         ${%errorMessage}
       </p>

--- a/core/src/main/resources/hudson/util/HudsonFailedToLoad/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonFailedToLoad/index.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <l:header title="Jenkins" />
-    <l:side-panel />
+    <l:header title="Jenkins"/>
+    <l:side-panel/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon name="error-48x48"/><st:nbsp/>${%Error}</h1>
       <pre>${it.stackTraceString}</pre>
     </l:main-panel>
   </l:layout>

--- a/core/src/main/resources/hudson/util/IncompatibleAntVersionDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/IncompatibleAntVersionDetected/index.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <l:header title="Jenkins" />
-    <l:side-panel />
+    <l:header title="Jenkins"/>
+    <l:side-panel/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon name="error-48x48"/><st:nbsp/>${%Error}</h1>
       <p>
         ${%errorMessage(it.whereAntIsLoaded)}
       </p>

--- a/core/src/main/resources/hudson/util/IncompatibleServletVersionDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/IncompatibleServletVersionDetected/index.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <l:header title="Jenkins" />
-    <l:side-panel />
+    <l:header title="Jenkins"/>
+    <l:side-panel/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon name="error-48x48"/><st:nbsp/>${%Error}</h1>
       <p>
         ${%errorMessage(it.whereServletIsLoaded)}
       </p>

--- a/core/src/main/resources/hudson/util/IncompatibleVMDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/IncompatibleVMDetected/index.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <l:header title="Jenkins" />
-    <l:side-panel />
+    <l:header title="Jenkins"/>
+    <l:side-panel/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon name="error-48x48"/><st:nbsp/>${%Error}</h1>
       <p>
         ${%errorMessage}
       </p>

--- a/core/src/main/resources/hudson/util/InsufficientPermissionDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/InsufficientPermissionDetected/index.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <l:header title="Jenkins" />
-    <l:side-panel />
+    <l:header title="Jenkins"/>
+    <l:side-panel/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon name="error-48x48"/><st:nbsp/>${%Error}</h1>
       <p>
          ${%errorMessage.1}
       </p>

--- a/core/src/main/resources/hudson/util/JNADoublyLoaded/index.jelly
+++ b/core/src/main/resources/hudson/util/JNADoublyLoaded/index.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout title="Jenkins">
-    <l:header />
-    <l:side-panel />
+    <l:header/>
+    <l:side-panel/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Failed to load JNA}</h1>
+      <h1><l:icon name="error-48x48"/><st:nbsp/>${%Failed to load JNA}</h1>
       <p>${%blurb}</p>
       <pre>${it.stackTraceString}</pre>
     </l:main-panel>

--- a/core/src/main/resources/hudson/util/NoHomeDir/index.jelly
+++ b/core/src/main/resources/hudson/util/NoHomeDir/index.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <l:header title="Jenkins" />
-    <l:side-panel />
+    <l:header title="Jenkins"/>
+    <l:side-panel/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon name="error-48x48"/><st:nbsp/>${%Error}</h1>
       <p>
         ${%errorMessage.1(it.home)}
       </p>

--- a/core/src/main/resources/hudson/util/NoTempDir/index.jelly
+++ b/core/src/main/resources/hudson/util/NoTempDir/index.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <l:header title="Jenkins" />
-    <l:side-panel />
+    <l:header title="Jenkins"/>
+    <l:side-panel/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon name="error-48x48"/><st:nbsp/>${%Error}</h1>
       <p>${%description(it.tempDir)}</p>
       <pre>${it.stackTraceString}</pre>
     </l:main-panel>

--- a/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
+++ b/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
@@ -38,11 +38,8 @@ THE SOFTWARE.
                           <j:set var="onclick" value="return build_${id}(this)"/>
                       </j:otherwise>
                   </j:choose>
-                  <j:set var="icon" value="${app.queue.contains(job) ? 'clock_anime.gif' : 'clock.png'}"/>
-                  <img src="${imagesURL}/${subIconSize}/${icon}"
-                         title="${title}" alt="${title}"
-                         onclick="${onclick}"
-                         border="0"/>
+                  <j:set var="icon" value="${app.queue.contains(job) ? 'clock_anime' : 'clock'}"/>
+                  <l:icon name="${icon}-${subIconSize}" tooltip="${title}" onclick="${onclick}" />
               </a>
               <script>
                 function build_${id}(img) {

--- a/core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
+++ b/core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
@@ -35,11 +35,9 @@ THE SOFTWARE.
       <j:set var="id" value="${h.generateId()}"/>
       <tr class="build-row transitive" id="${id}">
         <td nowrap="nowrap">
-          <img width="16" height="16" src="${imagesURL}/16x16/grey.png" alt="${%pending}"/>
-          <st:nbsp/>
+          <l:icon name="grey-16x16" />
           <!-- Don't use math unless needed, in case nextBuildNumber is not numeric -->
-          #${queuedItems.size()==1 ? it.owner.nextBuildNumber
-             : it.owner.nextBuildNumber+queuedItems.size()-i-1}
+          #${queuedItems.size()==1 ? it.owner.nextBuildNumber : it.owner.nextBuildNumber+queuedItems.size()-i-1}
         </td>
         <td style="white-space:normal;" colspan="2">
           <div style="float:right">

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -31,8 +31,8 @@ THE SOFTWARE.
   <j:set var="transitive" value="${(it.firstTransientBuildKey!=null and (it.adapter.compare(build,it.firstTransientBuildKey) ge 0)) ? 'transitive' : null}" />
   <tr class="build-row no-wrap ${transitive}">
     <td>
-      <a class="build-status-link" href="${link}console"><img class="build-status-icon" width="16" height="16" src="${imagesURL}/16x16/${build.buildStatusUrl}" alt="${build.iconColor.description} &gt; ${%Console Output}" tooltip="${build.iconColor.description} &gt; ${%Console Output}" /></a><st:nbsp/>
-      ${build.displayName}
+      <a class="build-status-link" href="${link}console"><l:icon name="${build.iconColor.name}-16x16" tooltip="${build.iconColor.description} &gt; ${%Console Output}"/></a><st:nbsp/>
+        ${build.displayName}
     </td>
     <td style="padding-right:0">
       <a class="tip model-link inside" href="${link}">

--- a/core/src/main/resources/jenkins/diagnosis/HsErrPidList/index.jelly
+++ b/core/src/main/resources/jenkins/diagnosis/HsErrPidList/index.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
   <l:layout title="${%Java VM Crash Reports}">
     <st:include page="sidepanel" it="${app}"/>
     <l:main-panel>
@@ -40,14 +40,14 @@ THE SOFTWARE.
         <j:forEach var="f" items="${it.files}" varStatus="idx">
           <tr>
             <td style="padding-right:3em">
-              <img src="${imagesURL}/32x32/clipboard.png" style="margin-right:1em"/>
+              <l:icon name="clipboard-32x32" style="margin-right:1em"/>
               <a href="files/${idx.index}/download/${f.name}">
                 ${f.path}
               </a>
             </td>
             <td data="${f.lastModified}">
               <i:formatDate value="${f.lastModifiedDate}" type="both" dateStyle="medium" timeStyle="medium"/>
-              <st:nbsp />
+              <st:nbsp/>
               (${%ago(f.timeSpanString)})
             </td>
             <td>

--- a/core/src/main/resources/jenkins/model/Jenkins/configureExecutors.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configureExecutors.jelly
@@ -27,12 +27,12 @@ THE SOFTWARE.
   explain what happened.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
 <l:layout title="This page has moved">
-  <st:include page="sidepanel.jelly" />
+  <st:include page="sidepanel.jelly"/>
   <l:main-panel>
     <h1>
-      <img src="${imagesURL}/48x48/error.png" alt="" height="48" width="48"/>
+      <l:icon name="error-48x48"/>
       This page has moved
     </h1>
     <p>

--- a/core/src/main/resources/jenkins/model/Jenkins/fingerprintCheck.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/fingerprintCheck.jelly
@@ -26,12 +26,12 @@ THE SOFTWARE.
   New View page
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout norefresh="true" title="${%Check File Fingerprint}">
-    <st:include page="sidepanel.jelly" />
+    <st:include page="sidepanel.jelly"/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
+        <l:icon name="fingerprint-48x48"/>
         ${%Check File Fingerprint}
       </h1>
       <f:form method="post" action="doFingerprintCheck" enctype="multipart/form-data">
@@ -44,7 +44,7 @@ THE SOFTWARE.
           <input type="file" name="name" class="setting-input" />
         </f:entry>
         <f:block>
-          <f:submit value="${%Check}" />
+          <f:submit value="${%Check}"/>
         </f:block>
       </f:form>
     </l:main-panel>

--- a/core/src/main/resources/jenkins/model/Jenkins/legend.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/legend.jelly
@@ -25,61 +25,61 @@ THE SOFTWARE.
 
 <!-- show the icon legend -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:s="/lib/form" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout>
-    <st:include page="sidepanel.jelly" />
+    <st:include page="sidepanel.jelly"/>
     <l:main-panel>
       <table cellpadding="5" id="legend-table">
         <tr><td>
-          <img src="images/48x48/grey.png" alt="" height="48" width="48"/>
+          <l:icon name="grey-48x48"/>
           ${%grey}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/grey_anime.gif" alt="" height="48" width="48"/>
+          <l:icon name="grey_anime-48x48"/>
           ${%grey_anime}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/blue.png" alt="" height="48" width="48"/>
+          <l:icon name="blue-48x48"/>
           ${%blue}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/blue_anime.gif" alt="" height="48" width="48"/>
+          <l:icon name="blue_anime-48x48"/>
           ${%blue_anime}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/yellow.png" alt="" height="48" width="48"/>
+          <l:icon name="yellow-48x48"/>
           ${%yellow}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/yellow_anime.gif" alt="" height="48" width="48"/>
+          <l:icon name="yellow_anime-48x48"/>
           ${%yellow_anime}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/red.png" alt="" height="48" width="48"/>
+          <l:icon name="red-48x48"/>
           ${%red}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/red_anime.gif" alt="" height="48" width="48"/>
+          <l:icon name="red_anime-48x48"/>
           ${%red_anime}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/health-80plus.png" alt="" height="48" width="48"/>
+          <l:icon name="health-80plus-48x48"/>
           ${%health-81plus}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/health-60to79.png" alt="" height="48" width="48"/>
+          <l:icon name="health-60to79-48x48"/>
           ${%health-61to80}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/health-40to59.png" alt="" height="48" width="48"/>
+          <l:icon name="health-40to59-48x48"/>
           ${%health-41to60}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/health-20to39.png" alt="" height="48" width="48"/>
+          <l:icon name="health-20to39-48x48"/>
           ${%health-21to40}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/health-00to19.png" alt="" height="48" width="48"/>
+          <l:icon name="health-00to19-48x48"/>
           ${%health-00to20}
         </td></tr>
       </table>

--- a/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
@@ -31,10 +31,10 @@ THE SOFTWARE.
   <l:layout title="Jenkins" norefresh="true">
     <l:header />
     <l:side-panel>
-      <l:task title="${%Jenkins project}" href="http://jenkins-ci.org/" icon="images/24x24/next.png" />
-      <l:task title="${%Bug tracker}" href="http://issues.jenkins-ci.org/" icon="images/24x24/gear2.png" />
-      <l:task title="${%Mailing Lists}" href="http://jenkins-ci.org/content/mailing-lists" icon="images/24x24/search.png"/>
-      <l:task title="${%Twitter: @jenkinsci}" href="https://twitter.com/jenkinsci" icon="images/24x24/user.png"/>
+      <l:task title="${%Jenkins project}" href="http://jenkins-ci.org/" icon="next-24x24" />
+      <l:task title="${%Bug tracker}" href="http://issues.jenkins-ci.org/" icon="gear2-24x24" />
+      <l:task title="${%Mailing Lists}" href="http://jenkins-ci.org/content/mailing-lists" icon="search-24x24"/>
+      <l:task title="${%Twitter: @jenkinsci}" href="https://twitter.com/jenkinsci" icon="user-24x24"/>
 
     </l:side-panel>
     <l:main-panel>

--- a/core/src/main/resources/jenkins/model/Jenkins/projectRelationship.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/projectRelationship.jelly
@@ -28,9 +28,9 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true" title="${%Project Relationship}">
-    <st:include page="sidepanel.jelly" />
+    <st:include page="sidepanel.jelly"/>
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/search.png" alt="" height="48" width="48"/>${%Project Relationship}</h1>
+      <h1><l:icon name="search-48x48"/>${%Project Relationship}</h1>
       <form action="projectRelationship" method="get">
         <table width="100%">
           <tr>
@@ -39,7 +39,7 @@ THE SOFTWARE.
               ${%upstream project}:
               <f:editableComboBox id="lhs" name="lhs" value="${request.getParameter('lhs')}" items="${names}" />
             </td>
-            <td style="width:32px; text-align:center;"><img src="${imagesURL}/24x24/next.png" alt="->" height="24" width="24"/></td>
+            <td style="width:32px; text-align:center;"><l:icon name="next-24x24"/></td>
             <td>
               ${%downstream project}:
               <f:editableComboBox id="rhs" name="rhs" value="${request.getParameter('rhs')}" items="${names}" />
@@ -47,8 +47,8 @@ THE SOFTWARE.
           </tr>
           <tr>
             <td colspan="3" style="text-align:right">
-              <f:submit value="${%Compare}" />
-              <a href="projectRelationship-help"><img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/></a>
+              <f:submit value="${%Compare}"/>
+              <a href="projectRelationship-help"><l:icon name="help-16x16"/></a>
             </td>
           </tr>
 

--- a/core/src/main/resources/jenkins/model/Jenkins/threadDump.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/threadDump.jelly
@@ -26,9 +26,9 @@ THE SOFTWARE.
   Produces stack dump of all threads by using JMX.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <l:layout permission="${app.ADMINISTER}" title="${%Thread dump}">
-    <st:include page="sidepanel.jelly" />
+    <st:include page="sidepanel.jelly"/>
 
     <l:main-panel>
       <h1>${%Thread Dump}</h1>
@@ -36,7 +36,7 @@ THE SOFTWARE.
 
       <j:forEach var="e" items="${tdumps.entrySet()}">
         <j:if test="${e.key != null and e.key.length() > 0}">
-          <a href="#id${e.key.hashCode()}"><img src="${imagesURL}/16x16/computer.png" style="margin-left:10px;" /> ${e.key}</a>
+          <a href="#id${e.key.hashCode()}"><l:icon name="computer-16x16" style="margin-left:10px;"/> ${e.key}</a>
         </j:if>
       </j:forEach>
 
@@ -46,7 +46,7 @@ THE SOFTWARE.
         </j:if>
         <j:if test="${e.key != null and e.key.length() > 0}">
           <h1 id="id${e.key.hashCode()}">
-            <img src="${imagesURL}/32x32/computer.png"/> <a href="/computer/${e.key}" class="model-link inside">${e.key}</a>
+            <l:icon name="computer-32x32"/> <a class="model-link inside" href="/computer/${e.key}">${e.key}</a>
           </h1>
         </j:if>
         <j:forEach var="t" items="${e.value.entrySet()}">

--- a/core/src/main/resources/lib/form/advanced.jelly
+++ b/core/src/main/resources/lib/form/advanced.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <st:documentation>
     Expandable section that shows "advanced..." button by default.
     Upon clicking it, a section unfolds, and the HTML rendered by the body of this tag
@@ -47,7 +47,7 @@ THE SOFTWARE.
 	    <div class="advancedLink" style="${attrs.align!=null?('text-align:'+attrs.align):''}">
               <j:set var="id" value="${h.generateId()}"/>
               <span style="display: none" id="${id}">
-                <img src="${imagesURL}/16x16/document_edit.png" style="vertical-align: super" alt="${%customizedFields}" tooltip="${%customizedFields}"/>
+                <l:icon name="document_edit-16x16" style="vertical-align: super" tooltip="${%customizedFields}"/>
               </span>
 	      <input type="button" value="${attrs.title?:'%Advanced'}..." class="advanced-button advancedButton" /><!-- advancedButton is legacy -->
 	    </div>

--- a/core/src/main/resources/lib/form/dropdownList.jelly
+++ b/core/src/main/resources/lib/form/dropdownList.jelly
@@ -53,9 +53,7 @@ THE SOFTWARE.
         </td>
         <j:if test="${attrs.help!=null}">
             <td class="setting-help">
-                <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png"
-                                                                                       alt="Help for feature: ${title}"
-                                                                                       height="16" width="16"/></a>
+                <a class="help-button" helpURL="${rootURL}${attrs.help}" href="#"><l:icon name="help-16x16"/></a>
             </td>
         </j:if>
     </tr>

--- a/core/src/main/resources/lib/form/entry.jelly
+++ b/core/src/main/resources/lib/form/entry.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <st:documentation>
     An entry of the &lt;f:form>, which is one logical row (that consists of
     several &lt;TR> tags.
@@ -67,25 +67,25 @@ THE SOFTWARE.
   <tr>
     <td class="setting-leftspace"><st:nbsp/></td>
     <td class="setting-name">
-      <j:out value="${attrs.title}" />
+      <j:out value="${attrs.title}"/>
     </td>
     <td class="setting-main">
-      <d:invokeBody />
+      <d:invokeBody/>
     </td>
     <j:if test="${attrs.help!=null}">
       <td class="setting-help">
-        <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
+        <a class="help-button" helpURL="${rootURL}${attrs.help}" href="#"><l:icon name="help-16x16"/></a>
       </td>
     </j:if>
   </tr>
   <!-- used to display the form validation error -->
-  <tr class="validation-error-area"><td colspan="2" /><td /></tr>
+  <tr class="validation-error-area"><td colspan="2"/><td/></tr>
   <j:if test="${!empty(attrs.description)}">
     <f:description>
       <j:out value="${description}"/>
     </f:description>
   </j:if>
   <j:if test="${attrs.help!=null}">
-    <f:helpArea />
+    <f:helpArea/>
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:local="local" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <st:documentation>
     Outer most tag for creating a heterogeneous list, where the user can choose arbitrary number of
     arbitrary items from the given list of descriptors, and configure them independently.
@@ -83,13 +83,13 @@ THE SOFTWARE.
             </td>
             <j:if test="${help!=null}">
               <td>
-                <a href="#" class="help-button" helpURL="${rootURL}${help}"><img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/></a>
+                <a class="help-button" helpURL="${rootURL}${help}" href="#"><l:icon name="help-16x16"/></a>
               </td>
             </j:if>
           </tr>
           <!-- TODO: help support is unintuitive; people should be able to see help from drop-down menu -->
           <j:if test="${help!=null}">
-            <f:helpArea />
+            <f:helpArea/>
           </j:if>
         </j:if>
 
@@ -98,7 +98,7 @@ THE SOFTWARE.
         <f:block>
           <div align="right">
             <input type="hidden" name="stapler-class" value="${descriptor.clazz.name}" />
-            <f:repeatableDeleteButton value="${attrs.deleteCaption}" />
+            <f:repeatableDeleteButton value="${attrs.deleteCaption}"/>
           </div>
         </f:block>
       </table>
@@ -121,7 +121,7 @@ THE SOFTWARE.
       </div>
     </j:forEach>
 
-    <div class="repeatable-insertion-point" />
+    <div class="repeatable-insertion-point"/>
 
     <div class="prototypes to-be-removed">
       <!-- render one prototype for each type -->

--- a/core/src/main/resources/lib/form/optionalBlock.jelly
+++ b/core/src/main/resources/lib/form/optionalBlock.jelly
@@ -73,22 +73,22 @@ THE SOFTWARE.
         </td>
         <j:if test="${attrs.help!=null}">
           <td>
-            <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
+            <a class="help-button" helpURL="${rootURL}${attrs.help}" href="#"><l:icon name="help-16x16"/></a>
           </td>
         </j:if>
       </tr>
       <j:if test="${attrs.help!=null}">
-        <f:helpArea />
+        <f:helpArea/>
       </j:if>
-      <tr class="rowvg-start" />
-      <d:invokeBody />
+      <tr class="rowvg-start"/>
+      <d:invokeBody/>
       <!-- end marker -->
-      <tr class="${attrs.inline?'':'row-set-end'} rowvg-end optional-block-end" />
+      <tr class="${attrs.inline?'':'row-set-end'} rowvg-end optional-block-end"/>
     </j:when>
 
     <j:otherwise>
       <f:rowSet name="${attrs.name}">
-        <d:invokeBody />
+        <d:invokeBody/>
       </f:rowSet>
     </j:otherwise>
   </j:choose>

--- a/core/src/main/resources/lib/form/radioBlock.jelly
+++ b/core/src/main/resources/lib/form/radioBlock.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <st:documentation>on
     Radio button with a label that hides additional controls.
     When checked, those additional controls are displayed. This is useful
@@ -64,14 +64,14 @@ THE SOFTWARE.
     </td>
     <j:if test="${attrs.help!=null}">
       <td>
-        <a href="#" class="help-button" helpURL="${rootURL}${help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
+        <a class="help-button" helpURL="${rootURL}${help}" href="#"><l:icon name="help-16x16"/></a>
       </td>
     </j:if>
 	</tr>
   <j:if test="${attrs.help!=null}">
-    <f:helpArea />
+    <f:helpArea/>
   </j:if>
-	<d:invokeBody />
+	<d:invokeBody/>
 	<!-- end marker -->
-	<tr class="${attrs.inline?'':'row-set-end'} radio-block-end" style="display:none" />
+	<tr class="${attrs.inline?'':'row-set-end'} radio-block-end" style="display:none"/>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/actions.jelly
+++ b/core/src/main/resources/lib/hudson/actions.jelly
@@ -38,8 +38,8 @@ THE SOFTWARE.
     -->
     <st:include page="action.jelly" from="${action}" optional="true">
       <j:if test="${action.iconFileName!=null}">
-        <l:task icon="${h.getIconFilePath(action)}" title="${action.displayName}"
-                href="${h.getActionUrl(it.url,action)}" contextMenu="${h.isContextMenuVisible(action)}"/>
+        <l:task icon="${h.getIconName(action)}" title="${action.displayName}"
+              href="${h.getActionUrl(it.url,action)}" contextMenu="${h.isContextMenuVisible(action)}"/>
       </j:if>
     </st:include>
   </j:forEach>

--- a/core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/core/src/main/resources/lib/hudson/artifactList.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <st:documentation>
     Generates a listing of the build artifacts.
     Depending on the size of the artifact, this will either produce a list or a link to the directory view.
@@ -51,7 +51,7 @@ THE SOFTWARE.
               <j:forEach var="f" items="${artifacts}">
                 <tr>
                   <td>
-                    <img src="${imagesURL}/16x16/text.png" alt="" height="16" width="16"/>
+                    <l:icon name="text-16x16"/>
                   </td>
                   <td>
                     <a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
@@ -62,7 +62,7 @@ THE SOFTWARE.
                   <td>
                     <j:if test="${app.fingerprintMap.ready}">
                       <a href="${baseURL}artifact/${f.href}/*fingerprint*/">
-                        <img src="${imagesURL}/16x16/fingerprint.png" alt="[fingerprint]" height="16" width="16"/>
+                        <l:icon name="fingerprint-16x16"/>
                       </a>
                       <st:nbsp/>
                     </j:if>

--- a/core/src/main/resources/lib/hudson/ballColorTd.jelly
+++ b/core/src/main/resources/lib/hudson/ballColorTd.jelly
@@ -34,8 +34,7 @@ THE SOFTWARE.
   </st:documentation>
   <td data="${it.ordinal()}">
     <j:if test="${attrs.it!=null}">
-      <img src="${it.getImageOf(iconSize)}" alt="${it.description}"
-           tooltip="${it.description}" style="${attrs.style}" class="icon${iconSize}"/>
+      <l:icon name="${it.name}-${iconSize}" tooltip="${it.description}" />
     </j:if>
   </td>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/buildCaption.jelly
+++ b/core/src/main/resources/lib/hudson/buildCaption.jelly
@@ -43,8 +43,8 @@ THE SOFTWARE.
 	      </tr></table>
 	    </div>
 	  </j:if>
-	  
-	  <img class="build-caption-status-icon" src="${imagesURL}/48x48/${it.buildStatusUrl}" width="48" height="48" alt="${it.iconColor.description}" tooltip="${it.iconColor.description}" />
+
+      <l:icon name="${it.iconColor.name}-48x48" tooltip="${it.iconColor.description}"/>
 	  <d:invokeBody />
 	</h1>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/buildHealth.jelly
+++ b/core/src/main/resources/lib/hudson/buildHealth.jelly
@@ -44,14 +44,11 @@ THE SOFTWARE.
               <j:when  test="${!empty(healthReports)}">
                 <a class="build-health-link" href="${empty(link)?'#':link}" 
                     style="${attrs.style}">
-                    <img src="${rootURL}${buildHealth.getIconUrl(iconSize)}"
-                         alt="${buildHealth.score}%" 
-                         class="build-health-icon icon${iconSize}"/>
+                    <l:icon name="${buildHealth.getIconName(iconSize)}" />
                 </a>
               </j:when>
               <j:otherwise>
-                 <img src="${rootURL}${buildHealth.getIconUrl(iconSize)}"
-                      alt="${buildHealth.score}%" class="build-health-icon icon${iconSize}"/>
+                 <l:icon name="${buildHealth.getIconName(iconSize)}" />
                </j:otherwise>
              </j:choose>  
         </j:if>
@@ -69,8 +66,7 @@ THE SOFTWARE.
                         <j:forEach var="rpt" items="${job.buildHealthReports}">
                             <tr>
                                 <td align="left">
-                                    <img src="${rootURL}${rpt.getIconUrl('16x16')}" alt=""
-                                         title=""/>
+                                    <l:icon name="${rpt.getIconName('16x16')}" />
                                 </td>
                                 <td>${rpt.localizableDescription}</td>
                                 <td align="right">${rpt.score}</td>

--- a/core/src/main/resources/lib/hudson/buildLink.jelly
+++ b/core/src/main/resources/lib/hudson/buildLink.jelly
@@ -47,8 +47,7 @@ THE SOFTWARE.
 	      </j:when>
 	      <j:otherwise>
 	        <a href="${attrs.href ?: rootURL+'/'+r.url}" class="model-link">
-	          <img src="${imagesURL}/16x16/${r.buildStatusUrl}"
-                 alt="${r.iconColor.description}" height="16" width="16"/>${jobName_}#<!-- -->${number}</a>
+                <l:icon name="${r.iconColor.iconName}-16x16" />${jobName_}#<!-- -->${number}</a>
 	      </j:otherwise>
 	    </j:choose>
 	  </j:otherwise>

--- a/core/src/main/resources/lib/hudson/editableDescription.jelly
+++ b/core/src/main/resources/lib/hudson/editableDescription.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <st:documentation>
     Renders ${it.description} and then allow it to be editable in place,
     if the current user has the specified permission.
@@ -36,12 +36,12 @@ THE SOFTWARE.
 
   <div id="description">
     <div>
-      <j:out value="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}" />
+      <j:out value="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}"/>
     </div>
 
     <l:hasPermission permission="${permission}">
       <div align="right"><a id="description-link" href="editDescription" onclick="${h.isAutoRefresh(request) ? null : 'return replaceDescription();'}">
-        <img id="description-image" src="${imagesURL}/16x16/notepad.png" alt="" height="16" width="16" />
+        <l:icon name="notepad-16x16"/>
         <j:choose>
           <j:when test="${empty(it.description)}">
             ${%add description}

--- a/core/src/main/resources/lib/hudson/failed-test.jelly
+++ b/core/src/main/resources/lib/hudson/failed-test.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <st:documentation>
     Display link to the failed test.
     @since 1.538
@@ -85,10 +85,10 @@ THE SOFTWARE.
   <j:set var="open" value="javascript:showFailureSummary('test-${id}','${url}/summary')"/>
   <j:set var="close" value="javascript:hideFailureSummary('test-${id}')"/>
   <a id="test-${id}-showlink" href="${open}" title="${%Show details}">
-    <img src="${imagesURL}/16x16/document_add.png"/>
+    <l:icon name="document_add-16x16"/>
   </a>
   <a id="test-${id}-hidelink" href="${close}" title="${%Hide details}" style="display:none">
-    <img src="${imagesURL}/16x16/document_delete.png"/>
+    <l:icon name="document_delete-16x16"/>
   </a>
   <st:nbsp/>
   <a href="${url}" class="model-link inside"><st:out value="${result.fullDisplayName}"/></a>

--- a/core/src/main/resources/lib/hudson/help.jelly
+++ b/core/src/main/resources/lib/hudson/help.jelly
@@ -27,5 +27,5 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <a href="${href}">
-  <img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/>
+  <l:icon name="help-16x16" xmlns:l="/lib/layout" />
 </a>

--- a/core/src/main/resources/lib/hudson/jobLink.jelly
+++ b/core/src/main/resources/lib/hudson/jobLink.jelly
@@ -31,6 +31,6 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 
-<img src="${imagesURL}/16x16/${job.buildStatusUrl}" alt="${job.iconColor.description}" height="16" width="16"/>
+<l:icon name="${job.iconColor.iconName}-16x16" />
 <a href="${h.getRelativeLinkTo(job)}" class="model-link"><l:breakable value="${job.fullDisplayName}"/></a>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/configurable.jelly
+++ b/core/src/main/resources/lib/hudson/project/configurable.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
     <j:if test="${it.buildable}">
         <j:set var="id" value="${h.generateId()}"/>
-        <l:task icon="images/24x24/clock.png" href="${url}/build?delay=0sec" title="${it.buildNowText}"
+        <l:task icon="clock-24x24" href="${url}/build?delay=0sec" title="${it.buildNowText}"
                   onclick="${it.parameterized?null:'return build_' + id + '(this)'}" post="${!it.parameterized}" permission="${it.BUILD}"/>
         <script>
             function build_${id}(a) {
@@ -37,13 +37,13 @@ THE SOFTWARE.
             }
         </script>
     </j:if>
-    <l:task icon="images/24x24/edit-delete.png" href="${url}/doDelete" title="${%delete(it.pronoun)}" permission="${it.DELETE}" post="true" requiresConfirmation="true" confirmationMessage="${%delete.confirm(it.pronoun, it.displayName)}"/>
+    <l:task confirmationMessage="${%delete.confirm(it.pronoun, it.displayName)}" href="${url}/doDelete" icon="edit-delete-24x24" permission="${it.DELETE}" post="true" requiresConfirmation="true" title="${%delete(it.pronoun)}"/>
     <j:choose>
         <j:when test="${h.hasPermission(it,it.CONFIGURE)}">
-            <l:task icon="images/24x24/setting.png" href="${url}/configure" title="${%Configure}" />
+            <l:task icon="setting-24x24" href="${url}/configure" title="${%Configure}" />
         </j:when>
         <j:when test="${h.hasPermission(it,it.EXTENDED_READ)}">
-            <l:task icon="images/24x24/setting.png" href="${url}/configure" title="${%View Configuration}" />
+            <l:task icon="setting-24x24" href="${url}/configure" title="${%View Configuration}" />
         </j:when>
     </j:choose>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/console-link.jelly
+++ b/core/src/main/resources/lib/hudson/project/console-link.jelly
@@ -28,12 +28,12 @@ THE SOFTWARE.
     <j:choose>
         <j:when test="${it.logFile.length() > 200000}">
             <!-- Show raw link directly so user need not click through live console page, though this is not so bad now as they would just see: Skipping nnn KB.. Full Log. -->
-            <l:task icon="images/24x24/terminal.png" href="${buildUrl.baseUrl}/console" title="${%Console Output}"/>
-            <l:task icon="images/24x24/document.png" href="${buildUrl.baseUrl}/consoleText" title="${%View as plain text}"/>
+            <l:task icon="terminal-24x24" href="${buildUrl.baseUrl}/console" title="${%Console Output}"/>
+            <l:task icon="document-24x24" href="${buildUrl.baseUrl}/consoleText" title="${%View as plain text}"/>
         </j:when>
         <j:otherwise>
-            <l:task icon="images/24x24/terminal.png" href="${buildUrl.baseUrl}/console" title="${%Console Output}">
-                <l:task icon="images/24x24/document.png" href="${buildUrl.baseUrl}/consoleText" title="${%View as plain text}"/>
+            <l:task icon="terminal-24x24" href="${buildUrl.baseUrl}/console" title="${%Console Output}">
+                <l:task icon="document-24x24" href="${buildUrl.baseUrl}/consoleText" title="${%View as plain text}"/>
             </l:task>
         </j:otherwise>
     </j:choose>

--- a/core/src/main/resources/lib/hudson/project/upstream-downstream.jelly
+++ b/core/src/main/resources/lib/hudson/project/upstream-downstream.jelly
@@ -26,13 +26,13 @@ THE SOFTWARE.
   Display upstream/downstream projects
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:local="local" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <d:taglib uri="local">
     <d:tag name="relationship">
       <j:if test="${lhs.fingerprintConfigured and rhs.fingerprintConfigured}">
         <st:nbsp/>
         <a href="${rootURL}/projectRelationship?lhs=${lhs.name}&amp;rhs=${rhs.name}">
-          <img src="${imagesURL}/16x16/fingerprint.png" alt="check relationship" height="16" width="16"/>
+          <l:icon name="fingerprint-16x16"/>
         </a>
       </j:if>
     </d:tag>

--- a/core/src/main/resources/lib/hudson/projectViewNested.jelly
+++ b/core/src/main/resources/lib/hudson/projectViewNested.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
             </a>
           </j:otherwise>
         </j:choose>
-        <img src="${imagesURL}/${iconSize}/folder.png" style="margin-left:4px" alt="" class="icon${iconSize}" />
+        <l:icon name="folder-${iconSize}" style="margin-left:4px" />
       </div>
     </td>
     <td colspan="5" style="${indenter.getCss(job)}">

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <st:documentation>
     Displays the build queue as &lt;l:pane>
 
@@ -80,7 +80,7 @@ THE SOFTWARE.
                   <j:if test="${stuck}">
                     &#160;
                     <a href="http://wiki.jenkins-ci.org/display/JENKINS/Executor+Starvation">
-                      <img src="${imagesURL}/16x16/hourglass.gif" height="16" width="16"/>
+                      <l:icon name="hourglass-16x16"/>
                     </a>
                   </j:if>
                 </j:when>

--- a/core/src/main/resources/lib/hudson/summary.jelly
+++ b/core/src/main/resources/lib/hudson/summary.jelly
@@ -43,18 +43,17 @@ THE SOFTWARE.
   </st:documentation>
   <j:if test="${h.hasPermission(it,attrs.permission)}">
     <j:if test="${attrs.icon!=null}">
+      <j:set var="resolvedIcon" value="${icon.startsWith('/') ? icon : '/images/48x48/'+icon}"/>
       <tr>
         <td>
           <j:choose>
             <j:when test="${attrs.href!=null}">
               <a href="${attrs.href}">
-                <img src="${icon.startsWith('/') ? resURL+icon : imagesURL+'/48x48/'+icon}"
-                     alt="" width="48" height="48" style="margin-right:1em" />
+                <l:icon name="${h.toIconName(resolvedIcon, '48x48')}" style="margin-right:1em; width: 48px; height: 48px;" />
               </a>
             </j:when>
             <j:otherwise>
-              <img src="${icon.startsWith('/') ? resURL+icon : imagesURL+'/48x48/'+icon}"
-                   alt="" width="48" height="48" style="margin-right:1em" />
+              <l:icon name="${h.toIconName(resolvedIcon, '48x48')}" style="margin-right:1em; width: 48px; height: 48px;" />
             </j:otherwise>
           </j:choose>
         </td>

--- a/core/src/main/resources/lib/layout/icon.jelly
+++ b/core/src/main/resources/lib/layout/icon.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, id:cactusman
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,21 +22,25 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<!--
-  Side panel
--->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-  <l:header />
-  <l:side-panel>
-    <j:getStatic var="createPermission" className="hudson.model.Computer" field="CREATE"/>
-    <l:tasks>
-      <l:task icon="up-24x24" href="${rootURL}/" title="${%Back to Dashboard}" />
-      <l:task icon="setting-24x24" href="${rootURL}/manage" title="${%Manage Jenkins}" permission="${app.ADMINISTER}" />
-      <l:task icon="new-computer-24x24" href="new" title="${%New Node}" permission="${createPermission}" />
-      <l:task icon="setting-24x24" href="configure" title="${%Configure}" permission="${app.ADMINISTER}" />
-    </l:tasks>
-    <t:queue items="${app.queue.approximateItemsQuickly}" />
-    <t:executors />
-  </l:side-panel>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+
+  <st:documentation>
+    <st:attribute name="name" use="required">Icon name.</st:attribute>
+    <st:attribute name="tooltip">Tooltip (optional)</st:attribute>
+    <st:attribute name="style">Inline styles</st:attribute>
+    <st:attribute name="onclick">On-click Javascript.</st:attribute>
+  </st:documentation>
+
+  <j:choose>
+    <j:when test="${!name.contains('/')}">
+        <j:set var="normalizedIconName" value="${attrs.name.toLowerCase()}" />
+        <j:set var="normalizedIconName" value="${normalizedIconName.replace('.gif', '')}" />
+        <j:set var="normalizedIconName" value="${normalizedIconName.replace('.png', '')}" />
+        <div class="jenkins-icon ${normalizedIconName}" icon-name="${normalizedIconName}" tooltip="${attrs.tooltip}" style="${attrs.style}" onclick="${attrs.onclick}"/>
+    </j:when>
+    <j:otherwise>
+        <img src="${rootURL}${name}" style="${attrs.style}" onclick="${attrs.onclick}" alt="" />
+    </j:otherwise>
+  </j:choose>
 </j:jelly>

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:i="jelly:fmt" xmlns:x="jelly:xml">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:x="jelly:xml">
   <st:documentation>
     Outer-most tag for a normal (non-AJAX) HTML rendering.
     This is used with nested &lt;header>, &lt;side-panel>, and &lt;main-panel>
@@ -53,11 +53,11 @@ THE SOFTWARE.
       (The permission will be checked against the "it" object.)
     </st:attribute>
   </st:documentation>
-<st:setHeader name="Expires" value="0" />
-<st:setHeader name="Cache-Control" value="no-cache,must-revalidate" />
-<st:setHeader name="X-Hudson-Theme" value="default" />
-<st:setHeader name="X-Frame-Options" value="sameorigin" />
-<st:contentType value="text/html;charset=UTF-8" />
+<st:setHeader name="Expires" value="0"/>
+<st:setHeader name="Cache-Control" value="no-cache,must-revalidate"/>
+<st:setHeader name="X-Hudson-Theme" value="default"/>
+<st:setHeader name="X-Frame-Options" value="sameorigin"/>
+<st:contentType value="text/html;charset=UTF-8"/>
 
   <j:new var="h" className="hudson.Functions" /><!-- instead of JSP functions -->
 ${h.initPageVariables(context)}
@@ -75,13 +75,14 @@ ${h.initPageVariables(context)}
       <st:include it="${pd}" page="httpHeaders.jelly" optional="true"/>
     </j:forEach>
   </j:if>
-<x:doctype name="html" />
+<x:doctype name="html"/>
 <html>
   <head>
     ${h.checkPermission(it,permission)}
 
     <title>${h.appendIfNotNull(title, ' [Jenkins]', 'Jenkins')}</title>
     <link rel="stylesheet" href="${resURL}/css/style.css" type="text/css" />
+    <link rel="stylesheet" href="${resURL}/css/icons.css" type="text/css" />
     <link rel="stylesheet" href="${resURL}/css/color.css" type="text/css" />
     <j:if test="${attrs.css!=null}">
       <link rel="stylesheet" href="${resURL}${attrs.css}" type="text/css" />
@@ -95,27 +96,26 @@ ${h.initPageVariables(context)}
     <script src="${resURL}/scripts/behavior.js" type="text/javascript"/>
 
     <!-- we include our own prototype.js, so don't let stapler pull in another. -->
-    <st:adjunct assumes="org.kohsuke.stapler.framework.prototype.prototype"
-                includes="org.kohsuke.stapler.bind"/>
+    <st:adjunct assumes="org.kohsuke.stapler.framework.prototype.prototype" includes="org.kohsuke.stapler.bind"/>
 
     <!-- To use the debug version of YUI, set the system property 'debug.YUI' to true -->
-    <j:set var="yuiSuffix" value="${h.yuiSuffix}" />
-    <l:yui module="yahoo" />
-    <l:yui module="dom" />
-    <l:yui module="event" />
+    <j:set value="${h.yuiSuffix}" var="yuiSuffix"/>
+    <l:yui module="yahoo"/>
+    <l:yui module="dom"/>
+    <l:yui module="event"/>
     <j:if test="${h.yuiSuffix=='debug'}">
-      <l:yui module="logger" />
+      <l:yui module="logger"/>
     </j:if>
-    <l:yui module="animation" />
-    <l:yui module="dragdrop" />
-    <l:yui module="container" />
-    <l:yui module="connection" />
-    <l:yui module="datasource" />
-    <l:yui module="autocomplete" />
-    <l:yui module="menu" />
-    <l:yui module="element" />
-    <l:yui module="button" />
-    <l:yui module="storage" />
+    <l:yui module="animation"/>
+    <l:yui module="dragdrop"/>
+    <l:yui module="container"/>
+    <l:yui module="connection"/>
+    <l:yui module="datasource"/>
+    <l:yui module="autocomplete"/>
+    <l:yui module="menu"/>
+    <l:yui module="element"/>
+    <l:yui module="button"/>
+    <l:yui module="storage"/>
     <!--l:yui module="editor" suffix="-beta" /-->
 
     <script src="${resURL}/scripts/hudson-behavior.js" type="text/javascript"></script>
@@ -137,7 +137,7 @@ ${h.initPageVariables(context)}
     </l:hasPermission>
     <meta name="ROBOTS" content="INDEX,NOFOLLOW" />
     <j:set var="mode" value="header" />
-    <d:invokeBody />
+    <d:invokeBody/>
     <j:forEach var="pd" items="${h.pageDecorators}">
       <st:include it="${pd}" page="header.jelly" optional="true" />
     </j:forEach>
@@ -163,9 +163,9 @@ ${h.initPageVariables(context)}
                 <div id="search-box-sizer"/>
                 <div id="searchform">
                   <input name="q" placeholder="${%search}" id="search-box" class="has-default-text" value="${request.getParameter('q')}" />
-                  <st:nbsp />
-                  <a href="${%searchBox.url}"><img src="${imagesURL}/16x16/help.png" alt="help for search" height="16" width="16" /></a>
-                  <div id="search-box-completion" />
+                  <st:nbsp/>
+                  <a href="${%searchBox.url}"><l:icon name="help-16x16"/></a>
+                  <div id="search-box-completion"/>
                   <script>createSearchBox("${searchURL}");</script>
                 </div>
               </form>
@@ -193,7 +193,7 @@ ${h.initPageVariables(context)}
                     </span>
                   </j:when>
                   <j:otherwise>
-                    <st:include it="${app.securityRealm}" page="loginLink.jelly" />
+                    <st:include it="${app.securityRealm}" page="loginLink.jelly"/>
                   </j:otherwise>
                 </j:choose>
               </j:if>
@@ -203,7 +203,7 @@ ${h.initPageVariables(context)}
       </tr>
       <l:breadcrumbBar>
         <j:set var="mode" value="breadcrumbs" />
-        <d:invokeBody />
+        <d:invokeBody/>
       </l:breadcrumbBar>
     </table>
     <table id="main-table" width="100%" height="70%" border="0"
@@ -213,7 +213,7 @@ ${h.initPageVariables(context)}
         <td id="side-panel" width="20%">
           <div id="navigation" style="min-height: 323px; height: auto !important; height: 323px;">
             <j:set var="mode" value="side-panel" />
-            <d:invokeBody />
+            <d:invokeBody/>
 
             <!-- add YUI logger if debugging YUI -->
             <j:if test="${h.yuiSuffix=='debug'}">

--- a/core/src/main/resources/lib/layout/pane.jelly
+++ b/core/src/main/resources/lib/layout/pane.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
   <st:documentation>
     Used in the &lt;l:side-panel> to draw a box with a title.
 
@@ -48,9 +48,7 @@ THE SOFTWARE.
       <j:out value="${title}"/>
       <a class="collapse" href="${rootURL}/toggleCollapse?paneId=${attrs.id}" 
          title="${h.isCollapsed(attrs.id) ? '%expand' : '%collapse'}">
-        <img src="${imagesURL}/16x16/${h.isCollapsed(attrs.id) ? 'expand' : 'collapse'}.png" 
-             class="icon16x16" 
-             alt="${h.isCollapsed(attrs.id) ? '%expand' : '%collapse'}" />
+        <l:icon name="${h.isCollapsed(attrs.id) ? 'expand' : 'collapse'}-16x16" />
       </a>
       </div>
     </td></tr>

--- a/core/src/main/resources/lib/layout/stopButton.jelly
+++ b/core/src/main/resources/lib/layout/stopButton.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:i="jelly:fmt" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
     <st:documentation>
         Creates a clickable "Stop" button.
         <st:attribute name="href" use="required">
@@ -35,6 +35,6 @@ THE SOFTWARE.
         </st:attribute>
     </st:documentation>
     <a class="stop-button-link" href="${href}" onclick="new Ajax.Request(this.href); return false">
-        <img class="stop-button-icon" src="${imagesURL}/16x16/stop.png" alt="${alt}" height="16" width="16"/>
+        <l:icon name="stop-16x16"/>
     </a>
 </j:jelly>

--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -24,156 +24,157 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout">
-  <st:documentation>
-    This tag inside &lt;l:tasks> tag renders the left navigation bar of Hudson.
-    Each &lt;task> tag gets an icon and link.
+    <st:documentation>
+        This tag inside &lt;l:tasks> tag renders the left navigation bar of Hudson.
+        Each &lt;task> tag gets an icon and link.
 
-    <st:attribute name="href" use="required">
-      Link target. Relative to the current page.
-    </st:attribute>
-    <st:attribute name="icon" use="required">
-      URL to the icon, which should be 24x24 in size.
-      It's relative to the context path of Hudson.
+        <st:attribute name="href" use="required">
+            Link target. Relative to the current page.
+        </st:attribute>
+        <st:attribute name="icon" use="required">
+            URL to the icon, which should be 24x24 in size.
+            It's relative to the context path of Hudson.
 
-      The common values include:
+            The common values include:
 
-      # "images/24x24/..." then points to the stock icon resources
-      # "plugin/foobar/abc/def.png" that points to "src/main/webapp/abc/def.png" in your plugin resources
-    </st:attribute>
-    <st:attribute name="title" use="required">
-      Human readable text that follows the icon.
-    </st:attribute>
-    <st:attribute name="enabled">
-      If specified, then this controls whether the task is enabled or not.
-    </st:attribute>
-    <st:attribute name="contextMenu" type="boolean">
-      If "false", remove this item from the context menu.
-    </st:attribute>
-    <st:attribute name="permission">
-      If specified, the link will be only displayed when the current user
-      has the specified permission against the "it" object.
+            # "images/24x24/..." then points to the stock icon resources
+            # "plugin/foobar/abc/def.png" that points to "src/main/webapp/abc/def.png" in your plugin resources
+        </st:attribute>
+        <st:attribute name="title" use="required">
+            Human readable text that follows the icon.
+        </st:attribute>
+        <st:attribute name="enabled">
+            If specified, then this controls whether the task is enabled or not.
+        </st:attribute>
+        <st:attribute name="contextMenu" type="boolean">
+            If "false", remove this item from the context menu.
+        </st:attribute>
+        <st:attribute name="permission">
+            If specified, the link will be only displayed when the current user
+            has the specified permission against the "it" object.
 
-      This is useful for showing links to restricted pages, as showing
-      them to unprivileged users don't make sense.
-    </st:attribute>
-    <st:attribute name="post" type="boolean">
-      If true, send a POST rather than a GET request.
-      (onclick supersedes this except in the context menu.)
-      (since 1.504)
-    </st:attribute>
-    <st:attribute name="requiresConfirmation" type="boolean">
-      If true, require confirmation before clicking.
-      Generally used with post="true".
-      (onclick supersedes this except in the context menu.)
-      (since 1.512)
-    </st:attribute>
-    <st:attribute name="confirmationMessage">
-      Message to use for confirmation, if requested; defaults to title.
-      (since 1.512)
-    </st:attribute>
-  </st:documentation>
+            This is useful for showing links to restricted pages, as showing
+            them to unprivileged users don't make sense.
+        </st:attribute>
+        <st:attribute name="post" type="boolean">
+            If true, send a POST rather than a GET request.
+            (onclick supersedes this except in the context menu.)
+            (since 1.504)
+        </st:attribute>
+        <st:attribute name="requiresConfirmation" type="boolean">
+            If true, require confirmation before clicking.
+            Generally used with post="true".
+            (onclick supersedes this except in the context menu.)
+            (since 1.512)
+        </st:attribute>
+        <st:attribute name="confirmationMessage">
+            Message to use for confirmation, if requested; defaults to title.
+            (since 1.512)
+        </st:attribute>
+    </st:documentation>
 
-  <!--
-    Much of the following horrible code is to implement hierarchy support in <task> tag.
-    The semantics is that when one of the nested <task> matches, the parent is also considered as a match
-    and thus gets a highlight.
-  -->
-  <j:set var="match" value="${h.hyperlinkMatchesCurrentPage(href)}" />
-  <j:scope>
-    <j:set var="taskMatching" value="${context.parent}"/>
-    <d:invokeBody />
-  </j:scope>
+    <!--
+      Much of the following horrible code is to implement hierarchy support in <task> tag.
+      The semantics is that when one of the nested <task> matches, the parent is also considered as a match
+      and thus gets a highlight.
+    -->
+    <j:set var="match" value="${h.hyperlinkMatchesCurrentPage(href)}" />
+    <j:scope>
+        <j:set var="taskMatching" value="${context.parent}"/>
+        <d:invokeBody />
+    </j:scope>
 
-  <j:if test="${attrs.permission==null or h.hasPermission(it,attrs.permission)}">
-    <j:choose>
-      <j:when test="${taskMatching!=null}">
-        <j:if test="${match}">
-          <j:set target="${taskMatching.variables}" property="match" value="true"/>
-        </j:if>
-      </j:when>
-      <j:when test="${enabled==false}">
-        <div class="task disabled">
-          <span>
-            <img width="24" height="24" style="margin: 2px;" alt="" src="${rootURL}${icon.startsWith('images/') || icon.startsWith('plugin/') ? h.resourcePath : ''}/${icon}"/>
-          </span>
-          <st:nbsp />
+    <j:if test="${attrs.permission==null or h.hasPermission(it,attrs.permission)}">
+        <j:choose>
+            <j:when test="${taskMatching!=null}">
+                <j:if test="${match}">
+                    <j:set target="${taskMatching.variables}" property="match" value="true"/>
+                </j:if>
+            </j:when>
+            <j:when test="${enabled==false}">
+                <div class="task disabled">
+                    <span>
+                        <j:set var="icon" value="${icon.startsWith('images/') || icon.startsWith('plugin/') ? h.resourcePath : ''}/${icon}"/>
+                        <l:icon name="${h.toIconName(icon, '24x24')}" style="width: 24px; height: 24px" />
+                    </span>
+                    <st:nbsp />
 
-          <span>
-            <j:choose>
-              <j:when test="${match}">
-                <b>${title}</b>
-              </j:when>
-              <j:otherwise>
-                ${title}
-              </j:otherwise>
-            </j:choose>
-          </span>
-        </div>
-      </j:when>
-      <j:otherwise>
-        <div class="task">
-          <j:set var="icon" value="${rootURL}${icon.startsWith('images/') || icon.startsWith('plugin/') ? h.resourcePath : ''}/${icon}"/>
-          ${taskTags!=null and attrs.contextMenu!='false' ? taskTags.add(href, icon, title, post == 'true', requiresConfirmation == 'true') : null}
-
-          <j:set var="id" value="${h.generateId()}"/>
-          <j:if test="${attrs.onclick == null and post and not requiresConfirmation}">
-              <script>
-                  function postRequest_${id}(a) {
-                      new Ajax.Request(a.href);
-                      hoverNotification('${%Done.}', a.parentNode);
-                      return false;
-                  }
-              </script>
-          </j:if>
-
-          <j:choose>
-            <j:when test="${requiresConfirmation and not attrs.onClick}">
-              <l:confirmationLink href="${href}" post="${post}" message="${confirmationMessage ?: title}">
-                <img class="task-icon" width="24" height="24" style="margin: 2px;" alt="" src="${icon}"/>
-              </l:confirmationLink>
+                    <span>
+                        <j:choose>
+                            <j:when test="${match}">
+                                <b>${title}</b>
+                            </j:when>
+                            <j:otherwise>
+                                ${title}
+                            </j:otherwise>
+                        </j:choose>
+                    </span>
+                </div>
             </j:when>
             <j:otherwise>
-              <a href="${href}" class="task-icon-link" onclick="${attrs.onclick ?: (post ? 'postRequest_' + id + '(this)' : null)}">
-                <img class="task-icon" width="24" height="24" style="margin: 2px;" alt="" src="${icon}"/>
-              </a>
-            </j:otherwise>
-          </j:choose>
-          <st:nbsp />
+                <div class="task">
+                    <j:set var="icon" value="${icon.startsWith('images/') || icon.startsWith('plugin/') ? h.resourcePath : ''}/${icon}"/>
+                    ${taskTags!=null and attrs.contextMenu!='false' ? taskTags.add(href, icon, title, post == 'true', requiresConfirmation == 'true') : null}
 
-          <j:choose>
-            <j:when test="${requiresConfirmation and not attrs.onClick}">
-              <l:confirmationLink class="task-link" href="${href}" post="${post}" message="${confirmationMessage ?: title}">
-                <j:choose>
-                  <j:when test="${match}">
-                    <b>${title}</b>
-                  </j:when>
-                  <j:otherwise>
-                    ${title}
-                  </j:otherwise>
-                </j:choose>
-              </l:confirmationLink>
-            </j:when>
-            <j:otherwise>
-              <a href="${href}" class="task-link" onclick="${attrs.onclick ?: (post ? 'postRequest_' + id + '(this)' : null)}">
-                <j:choose>
-                  <j:when test="${match}">
-                    <b>${title}</b>
-                  </j:when>
-                  <j:otherwise>
-                    ${title}
-                  </j:otherwise>
-                </j:choose>
-              </a>
-            </j:otherwise>
-          </j:choose>
+                    <j:set var="id" value="${h.generateId()}"/>
+                    <j:if test="${attrs.onclick == null and post and not requiresConfirmation}">
+                        <script>
+                            function postRequest_${id}(a) {
+                                new Ajax.Request(a.href);
+                                hoverNotification('${%Done.}', a.parentNode);
+                                return false;
+                            }
+                        </script>
+                    </j:if>
 
-          <j:if test="${match}">
-            <div class="subtasks">
-              <d:invokeBody />
-            </div>
-          </j:if>
-        </div>
-      </j:otherwise>
-    </j:choose>
-  </j:if>
+                    <j:choose>
+                        <j:when test="${requiresConfirmation and not attrs.onClick}">
+                            <l:confirmationLink href="${href}" post="${post}" message="${confirmationMessage ?: title}">
+                                <l:icon name="${h.toIconName(icon, '24x24')}" style="margin: 2px; width: 24px; height: 24px" />
+                            </l:confirmationLink>
+                        </j:when>
+                        <j:otherwise>
+                            <a href="${href}" class="task-icon-link" onclick="${attrs.onclick ?: (post ? 'postRequest_' + id + '(this)' : null)}">
+                                <l:icon name="${h.toIconName(icon, '24x24')}" style="margin: 2px; width: 24px; height: 24px" />
+                            </a>
+                        </j:otherwise>
+                    </j:choose>
+                    <st:nbsp />
+
+                    <j:choose>
+                        <j:when test="${requiresConfirmation and not attrs.onClick}">
+                            <l:confirmationLink class="task-link" href="${href}" post="${post}" message="${confirmationMessage ?: title}">
+                                <j:choose>
+                                    <j:when test="${match}">
+                                        <b>${title}</b>
+                                    </j:when>
+                                    <j:otherwise>
+                                        ${title}
+                                    </j:otherwise>
+                                </j:choose>
+                            </l:confirmationLink>
+                        </j:when>
+                        <j:otherwise>
+                            <a href="${href}" class="task-link" onclick="${attrs.onclick ?: (post ? 'postRequest_' + id + '(this)' : null)}">
+                                <j:choose>
+                                    <j:when test="${match}">
+                                        <b>${title}</b>
+                                    </j:when>
+                                    <j:otherwise>
+                                        ${title}
+                                    </j:otherwise>
+                                </j:choose>
+                            </a>
+                        </j:otherwise>
+                    </j:choose>
+
+                    <j:if test="${match}">
+                        <div class="subtasks">
+                            <d:invokeBody />
+                        </div>
+                    </j:if>
+                </div>
+            </j:otherwise>
+        </j:choose>
+    </j:if>
 </j:jelly>

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -44,6 +44,8 @@ import org.jvnet.hudson.test.Bug;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+
+import static org.junit.Assert.assertEquals;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -339,4 +341,11 @@ public class FunctionsTest {
         assertEquals("Bad input &lt;xml/>\n", Functions.printLogRecordHtml(lr, null)[3]);
     }
 
+    @Test
+    public void testToIconName() {
+        assertEquals("computer-24x24", Functions.toIconName("computer.png"));
+        assertEquals("computer-16x16", Functions.toIconName("computer-16x16"));
+        assertEquals("computer-16x16", Functions.toIconName("images/16x16/computer.png"));
+        assertEquals("blue_anime-16x16", Functions.toIconName("images/16x16/blue_anime.gif"));
+    }
 }

--- a/war/src/main/webapp/css/icons.css
+++ b/war/src/main/webapp/css/icons.css
@@ -1,0 +1,278 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Daniel Dyer, Stephen Connolly
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * 16x16 icons.
+ */
+.jenkins-icon.accept-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/accept.png" );}
+.jenkins-icon.attribute-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/attribute.png" );}
+.jenkins-icon.collapse-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/collapse.png" );}
+.jenkins-icon.computer-x-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/computer-x.png" );}
+.jenkins-icon.computer-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/computer.png" );}
+.jenkins-icon.document_add-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/document_add.png" );}
+.jenkins-icon.document_delete-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/document_delete.png" );}
+.jenkins-icon.document_edit-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/document_edit.png" );}
+.jenkins-icon.edit-delete-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/edit-delete.png" );}
+.jenkins-icon.edit-select-all-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/edit-select-all.png" );}
+.jenkins-icon.empty-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/empty.png" );}
+.jenkins-icon.error-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/error.png" );}
+.jenkins-icon.expand-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/expand.png" );}
+.jenkins-icon.fingerprint-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/fingerprint.png" );}
+.jenkins-icon.folder-error-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/folder-error.png" );}
+.jenkins-icon.folder-open-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/folder-open.png" );}
+.jenkins-icon.folder-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/folder.png" );}
+.jenkins-icon.gear2-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/gear2.png" );}
+.jenkins-icon.go-next-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/go-next.png" );}
+.jenkins-icon.health-00to19-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/health-00to19.png" );}
+.jenkins-icon.health-20to39-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/health-20to39.png" );}
+.jenkins-icon.health-40to59-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/health-40to59.png" );}
+.jenkins-icon.health-60to79-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/health-60to79.png" );}
+.jenkins-icon.health-80plus-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/health-80plus.png" );}
+.jenkins-icon.help-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/help.png" );}
+.jenkins-icon.hourglass-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/hourglass.png" );}
+.jenkins-icon.lock-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/lock.png" );}
+.jenkins-icon.notepad-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/notepad.png" );}
+.jenkins-icon.orange-square-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/orange-square.png" );}
+.jenkins-icon.package-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/package.png" );}
+.jenkins-icon.person-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/person.png" );}
+.jenkins-icon.plugin-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/plugin.png" );}
+.jenkins-icon.redo-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/redo.png" );}
+.jenkins-icon.save-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/save.png" );}
+.jenkins-icon.search-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/search.png" );}
+.jenkins-icon.secure-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/secure.png" );}
+.jenkins-icon.setting-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/setting.png" );}
+.jenkins-icon.star-gold-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/star-gold.png" );}
+.jenkins-icon.star-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/star.png" );}
+.jenkins-icon.stop-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/stop.png" );}
+.jenkins-icon.terminal-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/terminal.png" );}
+.jenkins-icon.text-error-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/text-error.png" );}
+.jenkins-icon.text-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/text.png" );}
+.jenkins-icon.user-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/user.png" );}
+.jenkins-icon.warning-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/warning.png" );}
+
+.jenkins-icon.aborted-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/aborted.gif" );}
+.jenkins-icon.aborted_anime-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/aborted_anime.gif" );}
+.jenkins-icon.blue-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/blue.gif" );}
+.jenkins-icon.blue_anime-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/blue_anime.gif" );}
+.jenkins-icon.clock-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/clock.gif" );}
+.jenkins-icon.clock_anime-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/clock_anime.gif" );}
+.jenkins-icon.disabled-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/disabled.gif" );}
+.jenkins-icon.disabled_anime-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/disabled_anime.gif" );}
+.jenkins-icon.green-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/green.gif" );}
+.jenkins-icon.green_anime-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/green_anime.gif" );}
+.jenkins-icon.grey-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/grey.gif" );}
+.jenkins-icon.grey_anime-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/grey_anime.gif" );}
+.jenkins-icon.nobuilt-16x16, .jenkins-icon.notbuilt-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/nobuilt.gif" );}
+.jenkins-icon.nobuilt_anime-16x16, .jenkins-icon.notbuilt_anime-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/nobuilt_anime.gif" );}
+.jenkins-icon.red-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/red.gif" );}
+.jenkins-icon.red_anime-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/red_anime.gif" );}
+.jenkins-icon.yellow-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/yellow.gif" );}
+.jenkins-icon.yellow_anime-16x16 {width: 16px; height: 16px; background-image: url("../images/16x16/yellow_anime.gif" );}
+
+/*
+ * 24x24 icons.
+ */
+.jenkins-icon.accept-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/accept.png" );}
+.jenkins-icon.attribute-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/attribute.png" );}
+.jenkins-icon.clipboard-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/clipboard.png" );}
+.jenkins-icon.computer-x-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/computer-x.png" );}
+.jenkins-icon.computer-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/computer.png" );}
+.jenkins-icon.delete-document-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/delete-document.png" );}
+.jenkins-icon.document-properties-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/document-properties.png" );}
+.jenkins-icon.document-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/document.png" );}
+.jenkins-icon.edit-delete-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/edit-delete.png" );}
+.jenkins-icon.empty-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/empty.png" );}
+.jenkins-icon.fingerprint-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/fingerprint.png" );}
+.jenkins-icon.folder-delete-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/folder-delete.png" );}
+.jenkins-icon.folder-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/folder.png" );}
+.jenkins-icon.gear-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/gear.png" );}
+.jenkins-icon.gear2-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/gear2.png" );}
+.jenkins-icon.graph-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/graph.png" );}
+.jenkins-icon.health-00to19-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/health-00to19.png" );}
+.jenkins-icon.health-20to39-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/health-20to39.png" );}
+.jenkins-icon.health-40to59-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/health-40to59.png" );}
+.jenkins-icon.health-60to79-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/health-60to79.png" );}
+.jenkins-icon.health-80plus-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/health-80plus.png" );}
+.jenkins-icon.help-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/help.png" );}
+.jenkins-icon.installer-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/installer.png" );}
+.jenkins-icon.lock-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/lock.png" );}
+.jenkins-icon.monitor-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/monitor.png" );}
+.jenkins-icon.new-computer-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/new-computer.png" );}
+.jenkins-icon.new-document-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/new-document.png" );}
+.jenkins-icon.new-package-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/new-package.png" );}
+.jenkins-icon.new-user-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/new-user.png" );}
+.jenkins-icon.next-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/next.png" );}
+.jenkins-icon.notepad-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/notepad.png" );}
+.jenkins-icon.orange-square-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/orange-square.png" );}
+.jenkins-icon.package-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/package.png" );}
+.jenkins-icon.plugin-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/plugin.png" );}
+.jenkins-icon.previous-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/previous.png" );}
+.jenkins-icon.redo-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/redo.png" );}
+.jenkins-icon.refresh-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/refresh.png" );}
+.jenkins-icon.save-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/save.png" );}
+.jenkins-icon.search-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/search.png" );}
+.jenkins-icon.secure-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/secure.png" );}
+.jenkins-icon.setting-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/setting.png" );}
+.jenkins-icon.star-gold-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/star-gold.png" );}
+.jenkins-icon.star-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/star.png" );}
+.jenkins-icon.terminal-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/terminal.png" );}
+.jenkins-icon.up-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/up.png" );}
+.jenkins-icon.user-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/user.png" );}
+
+.jenkins-icon.aborted-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/aborted.gif" );}
+.jenkins-icon.aborted_anime-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/aborted_anime.gif" );}
+.jenkins-icon.blue-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/blue.gif" );}
+.jenkins-icon.blue_anime-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/blue_anime.gif" );}
+.jenkins-icon.clock-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/clock.gif" );}
+.jenkins-icon.clock_anime-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/clock_anime.gif" );}
+.jenkins-icon.disabled-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/disabled.gif" );}
+.jenkins-icon.disabled_anime-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/disabled_anime.gif" );}
+.jenkins-icon.green-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/green.gif" );}
+.jenkins-icon.green_anime-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/green_anime.gif" );}
+.jenkins-icon.grey-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/grey.gif" );}
+.jenkins-icon.grey_anime-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/grey_anime.gif" );}
+.jenkins-icon.nobuilt-24x24, .jenkins-icon.notbuilt-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/nobuilt.gif" );}
+.jenkins-icon.nobuilt_anime-24x24, .jenkins-icon.notbuilt_anime-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/nobuilt_anime.gif" );}
+.jenkins-icon.red-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/red.gif" );}
+.jenkins-icon.red_anime-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/red_anime.gif" );}
+.jenkins-icon.yellow-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/yellow.gif" );}
+.jenkins-icon.yellow_anime-24x24 {width: 24px; height: 24px; background-image: url("../images/24x24/yellow_anime.gif" );}
+
+/*
+ * 32x32 icons.
+ */
+.jenkins-icon.accept-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/accept.png" );}
+.jenkins-icon.attribute-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/attribute.png" );}
+.jenkins-icon.clipboard-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/clipboard.png" );}
+.jenkins-icon.computer-x-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/computer-x.png" );}
+.jenkins-icon.computer-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/computer.png" );}
+.jenkins-icon.empty-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/empty.png" );}
+.jenkins-icon.error-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/error.png" );}
+.jenkins-icon.folder-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/folder.png" );}
+.jenkins-icon.gear2-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/gear2.png" );}
+.jenkins-icon.graph-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/graph.png" );}
+.jenkins-icon.health-00to19-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/health-00to19.png" );}
+.jenkins-icon.health-20to39-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/health-20to39.png" );}
+.jenkins-icon.health-40to59-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/health-40to59.png" );}
+.jenkins-icon.health-60to79-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/health-60to79.png" );}
+.jenkins-icon.health-80plus-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/health-80plus.png" );}
+.jenkins-icon.lock-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/lock.png" );}
+.jenkins-icon.orange-square-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/orange-square.png" );}
+.jenkins-icon.package-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/package.png" );}
+.jenkins-icon.plugin-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/plugin.png" );}
+.jenkins-icon.secure-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/secure.png" );}
+.jenkins-icon.setting-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/setting.png" );}
+.jenkins-icon.star-gold-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/star-gold.png" );}
+.jenkins-icon.star-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/star.png" );}
+.jenkins-icon.user-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/user.png" );}
+
+.jenkins-icon.aborted-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/aborted.gif" );}
+.jenkins-icon.aborted_anime-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/aborted_anime.gif" );}
+.jenkins-icon.blue-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/blue.gif" );}
+.jenkins-icon.blue_anime-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/blue_anime.gif" );}
+.jenkins-icon.clock-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/clock.gif" );}
+.jenkins-icon.clock_anime-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/clock_anime.gif" );}
+.jenkins-icon.disabled-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/disabled.gif" );}
+.jenkins-icon.disabled_anime-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/disabled_anime.gif" );}
+.jenkins-icon.green-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/green.gif" );}
+.jenkins-icon.green_anime-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/green_anime.gif" );}
+.jenkins-icon.grey-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/grey.gif" );}
+.jenkins-icon.grey_anime-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/grey_anime.gif" );}
+.jenkins-icon.nobuilt-32x32, .jenkins-icon.notbuilt-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/nobuilt.gif" );}
+.jenkins-icon.nobuilt_anime-32x32, .jenkins-icon.notbuilt_anime-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/nobuilt_anime.gif" );}
+.jenkins-icon.red-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/red.gif" );}
+.jenkins-icon.red_anime-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/red_anime.gif" );}
+.jenkins-icon.yellow-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/yellow.gif" );}
+.jenkins-icon.yellow_anime-32x32 {width: 32px; height: 32px; background-image: url("../images/32x32/yellow_anime.gif" );}
+
+/*
+ * 48x48 icons.
+ */
+.jenkins-icon.accept-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/accept.png" );}
+.jenkins-icon.attribute-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/attribute.png" );}
+.jenkins-icon.clipboard-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/clipboard.png" );}
+.jenkins-icon.computer-x-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/computer-x.png" );}
+.jenkins-icon.computer-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/computer.png" );}
+.jenkins-icon.document-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/document.png" );}
+.jenkins-icon.empty-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/empty.png" );}
+.jenkins-icon.error-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/error.png" );}
+.jenkins-icon.fingerprint-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/fingerprint.png" );}
+.jenkins-icon.folder-delete-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/folder-delete.png" );}
+.jenkins-icon.folder-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/folder.png" );}
+.jenkins-icon.gear2-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/gear2.png" );}
+.jenkins-icon.graph-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/graph.png" );}
+.jenkins-icon.health-00to19-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/health-00to19.png" );}
+.jenkins-icon.health-20to39-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/health-20to39.png" );}
+.jenkins-icon.health-40to59-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/health-40to59.png" );}
+.jenkins-icon.health-60to79-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/health-60to79.png" );}
+.jenkins-icon.health-80plus-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/health-80plus.png" );}
+.jenkins-icon.help-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/help.png" );}
+.jenkins-icon.installer-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/installer.png" );}
+.jenkins-icon.lock-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/lock.png" );}
+.jenkins-icon.monitor-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/monitor.png" );}
+.jenkins-icon.network-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/network.png" );}
+.jenkins-icon.notepad-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/notepad.png" );}
+.jenkins-icon.orange-square-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/orange-square.png" );}
+.jenkins-icon.package-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/package.png" );}
+.jenkins-icon.plugin-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/plugin.png" );}
+.jenkins-icon.redo-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/redo.png" );}
+.jenkins-icon.refresh-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/refresh.png" );}
+.jenkins-icon.search-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/search.png" );}
+.jenkins-icon.secure-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/secure.png" );}
+.jenkins-icon.setting-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/setting.png" );}
+.jenkins-icon.star-gold-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/star-gold.png" );}
+.jenkins-icon.star-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/star.png" );}
+.jenkins-icon.system-log-out-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/system-log-out.png" );}
+.jenkins-icon.terminal-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/terminal.png" );}
+.jenkins-icon.user-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/user.png" );}
+.jenkins-icon.warning-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/warning.png" );}
+
+.jenkins-icon.aborted-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/aborted.gif" );}
+.jenkins-icon.aborted_anime-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/aborted_anime.gif" );}
+.jenkins-icon.blue-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/blue.gif" );}
+.jenkins-icon.blue_anime-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/blue_anime.gif" );}
+.jenkins-icon.disabled-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/disabled.gif" );}
+.jenkins-icon.disabled_anime-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/disabled_anime.gif" );}
+.jenkins-icon.green-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/green.gif" );}
+.jenkins-icon.green_anime-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/green_anime.gif" );}
+.jenkins-icon.grey-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/grey.gif" );}
+.jenkins-icon.grey_anime-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/grey_anime.gif" );}
+.jenkins-icon.nobuilt-48x48, .jenkins-icon.notbuilt-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/nobuilt.gif" );}
+.jenkins-icon.nobuilt_anime-48x48, .jenkins-icon.notbuilt_anime-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/nobuilt_anime.gif" );}
+.jenkins-icon.red-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/red.gif" );}
+.jenkins-icon.red_anime-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/red_anime.gif" );}
+.jenkins-icon.yellow-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/yellow.gif" );}
+.jenkins-icon.yellow_anime-48x48 {width: 48px; height: 48px; background-image: url("../images/48x48/yellow_anime.gif" );}
+
+/*
+    Unanimated icons.  All colors based on colors from the BallColor class colors.
+ */
+.jenkins-icon.NO_ANIME {
+    border-radius: 50%;
+}
+
+.jenkins-icon {
+    display: inline-block;
+    vertical-align: middle;
+}

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -40,6 +40,9 @@ FORM {
 td {
   vertical-align: top;
 }
+.abstractBuildMain table td.no-wrap a {
+    vertical-align: top;
+}
 
 dt {
   font-weight: bold;
@@ -287,6 +290,10 @@ pre.console {
   white-space: nowrap;
 }
 
+.task-icon-link .jenkins-icon {
+    margin: 2px;
+}
+
 .subtasks {
   padding-left: 1em;
 }
@@ -506,6 +513,15 @@ LABEL.attach-previous {
     padding:0;
 }
 
+.text-align.top {
+    vertical-align: top;
+}
+.text-align.bottom {
+    vertical-align: bottom;
+}
+.text-align.middle {
+    vertical-align: middle;
+}
 
 /* ======================== error/warning message (mainly in the form.) Use them on block elements ======================== */
 .error {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1585,6 +1585,8 @@ function updateBuildHistory(ajaxUrl,nBuild) {
                         pivot.parentNode.insertBefore(newRows[i], pivot.nextSibling);
                     }
 
+                    layoutUpdateCallback.call();
+
                     // next update
                     bh.headers = ["n",rsp.getResponseHeader("n")];
                     window.setTimeout(updateBuilds, 5000);


### PR DESCRIPTION
Just looking for feedback/thoughts on this.  So instead of rendering Jenkins UI icons using a raw &lt;img> tags, we render using a &lt;div> + CSS.  Note we are not proposing to change the actual icons with this change i.e. the user still sees the same icons.

The <div> + CSS approach allows a lot more control over the icons.

So in these changes in core Jenkins, you'll see in the Jelly scripts that instead of rendering the icons like:

```
<img src="${imagesURL}/48x48/blue.png" alt="" height="48" width="48"/>
```

You'd use a new <l:icon> Jelly tag which just names the icon you want placed in that location:

```
<l:icon name="blue-48x48"/>
```

The core icons are all then rendered using CSS: https://github.com/tfennelly/jenkins/blob/icons-via-css/war/src/main/webapp/css/icons.css

If we go this route, we'll provide backward compatibility for plugins that will allow the plugin to continue working on older versions of Jenkins.

Wdyt?
