### PR TITLE
[JENKINS-23595] - Fix makeFlash script bug with ImageMagick v6.7.9+

### DIFF
--- a/war/images/makeFlash.sh
+++ b/war/images/makeFlash.sh
@@ -30,7 +30,7 @@ src=$1
 dst=$2
 for p in 20 40 60 80 100
 do
-  convert $src -fill white -colorize ${p}% -transparent-color white $t.$p.gif
+  convert $src -alpha off -fill white -colorize ${p}% -transparent-color white -alpha on $t.$p.gif
 done
 convert -delay 10 $src $t.20.gif $t.40.gif $t.60.gif $t.80.gif $t.100.gif $t.80.gif $t.60.gif $t.40.gif $t.20.gif -loop 0 $dst
 


### PR DESCRIPTION
prevents colorize from applying fill to alpha channel in makeFlash.sh. alpha is turned back on after colorize operation
