### PR TITLE
Adding a module to allow organizations to track usage of Jenkins within their domain

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -108,6 +108,11 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>domain-discovery</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
       <version>1.4</version>
     </dependency>


### PR DESCRIPTION
There is a privacy concern in having this information reported, but OTOH in a corporate network this seems like a reasonable compromise, and people really often do not have any clues where they are running.
