### PR TITLE
[FIXED JENKINS-21716] Set Content-Type header for env-vars.html

### DIFF
--- a/core/src/main/resources/hudson/model/EnvironmentContributor/EnvVarsHtml/index.groovy
+++ b/core/src/main/resources/hudson/model/EnvironmentContributor/EnvVarsHtml/index.groovy
@@ -4,6 +4,8 @@ import hudson.scm.SCM
 
 def st = namespace("jelly:stapler")
 
+st.contentType(value: "text/html;charset=UTF-8")
+
 html {
     head {
         title(_("Available Environmental Variables"))


### PR DESCRIPTION
- Make non-ASCII chars work
- Make the entire page work [behind reverse proxies that add a default `Content-Type` of `text/plain`](https://ci.jenkins-ci.org/env-vars.html/).
