### PR TITLE
[FIXED JENKINS-18902] Exclude lower bound of range from changes

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -540,6 +540,20 @@ public class Functions {
         return map.subMap(Integer.parseInt(to),Integer.parseInt(from)-1);
     }
 
+    /**
+     * Creates a sub map by using the given range (upper end inclusive).
+     */
+    @Restricted(NoExternalUse.class)
+    public static <V> SortedMap<Integer,V> filterExcludingFrom(SortedMap<Integer,V> map, String from, String to) {
+        if(from==null && to==null)      return map;
+        if(to==null)
+            return map.headMap(Integer.parseInt(from));
+        if(from==null)
+            return map.tailMap(Integer.parseInt(to));
+
+        return map.subMap(Integer.parseInt(to),Integer.parseInt(from));
+    }
+
     private static final SimpleFormatter formatter = new SimpleFormatter();
 
     /**

--- a/core/src/main/resources/hudson/model/AbstractProject/changes.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes.jelly
@@ -36,10 +36,17 @@ THE SOFTWARE.
 
       <h1>
         ${%Changes}
-        <j:if test="${from!=null}">${%from.label(from)}</j:if>
-        <j:if test="${to!=null}">&#160;${%to.label(to)}</j:if>
+        <j:choose>
+          <j:when test="${from!=null and to!=null}">
+            ${%range.label(from, to)}
+          </j:when>
+          <j:otherwise>
+            <j:if test="${from!=null}">${%from.label(from)}</j:if>
+            <j:if test="${to!=null}">${%to.label(to)}</j:if>
+          </j:otherwise>
+        </j:choose>
       </h1>
-      <j:set var="builds" value="${h.filter(it.buildsAsMap,from,to).values()}" />
+      <j:set var="builds" value="${h.filterExcludingFrom(it.buildsAsMap,from,to).values()}" />
       <st:include it="${it.scm}" page="project-changes.jelly" />
     </l:main-panel>
   </l:layout>

--- a/core/src/main/resources/hudson/model/AbstractProject/changes.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes.properties
@@ -21,5 +21,6 @@
 # THE SOFTWARE.
 
 changes.title={0} Changes
-from.label=from #{0}
-to.label=to #{0}
+from.label=since #{0}
+to.label=up to #{0}
+range.label=between #{0} and #{1}

--- a/core/src/main/resources/hudson/model/AbstractProject/changes_da.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes_da.properties
@@ -23,4 +23,5 @@
 Changes=\u00c6ndringer
 from.label=# fra #{0}
 to.label=# til #{0}
+range.label=fra #{0} til #{1}
 changes.title=# {0} \u00c6ndringer

--- a/core/src/main/resources/hudson/model/AbstractProject/changes_de.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes_de.properties
@@ -22,5 +22,6 @@
 
 Changes=Änderungen
 changes.title=Änderungen in {0}
-from.label=von #{0}
+from.label=seit #{0}
 to.label=bis #{0}
+range.label=zwischen #{0} und #{1}

--- a/core/src/main/resources/hudson/model/AbstractProject/changes_es.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes_es.properties
@@ -23,4 +23,5 @@
 changes.title={0} Cambios
 from.label=desde #{0}
 to.label=hasta #{0}
+range.label=desde #{0} hasta #{1}
 Changes=Cambios

--- a/core/src/main/resources/hudson/model/AbstractProject/changes_fr.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes_fr.properties
@@ -24,3 +24,4 @@ changes.title=Changements dans {0}
 Changes=Modifications
 from.label=de #{0}
 to.label=à #{0}
+range.label=de #{0} à #{1}

--- a/core/src/main/resources/hudson/model/AbstractProject/changes_ja.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes_ja.properties
@@ -24,3 +24,4 @@ changes.title={0}\u306e\u5909\u66f4
 Changes=\u5909\u66f4\u5c65\u6b74
 from.label=#{0} \u304b\u3089
 to.label=#{0} \u307e\u3067
+range.label=#{0} \u304b\u3089 #{1} \u307e\u3067

--- a/core/src/main/resources/hudson/model/AbstractProject/changes_lv.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes_lv.properties
@@ -23,3 +23,4 @@
 Changes=Izmai\u0146as
 from.label=no #{0}
 to.label=l\u012Bdz #{0}
+range.label=no #{0} l\u012Bdz #{1}

--- a/core/src/main/resources/hudson/model/AbstractProject/changes_pt_BR.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes_pt_BR.properties
@@ -25,5 +25,6 @@ Changes=Mudan\u00e7as
 from.label=de #{0}
 # to #{0}
 to.label= para #{0}
+range.label=de #{0} para #{1}
 # {0} Changes
 changes.title={0} Mudan\u00e7as

--- a/core/src/main/resources/hudson/model/AbstractProject/changes_ru.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes_ru.properties
@@ -23,3 +23,4 @@
 Changes=\u0418\u0437\u043c\u0435\u043d\u0435\u043d\u0438\u044f
 from.label=\u0441 #{0}
 to.label=\u0434\u043E #{0}
+range.label=\u0441 #{0} \u0434\u043E #{1}

--- a/core/src/main/resources/hudson/model/AbstractProject/changes_tr.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes_tr.properties
@@ -24,3 +24,4 @@ Changes=De\u011fi\u015fiklikler
 changes.title={0} degi\u015fiklik
 from.label=#{0}'dan
 to.label=#{0}'a
+range.label=#{0}'dan #{1}'a

--- a/core/src/main/resources/hudson/model/AbstractProject/changes_zh_TW.properties
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes_zh_TW.properties
@@ -25,3 +25,4 @@ changes.title={0} \u8b8a\u66f4
 Changes=\u8b8a\u66f4
 from.label=\u5f9e #{0}
 to.label=\u5230 #{0}
+range.label=\u5f9e #{0} \u5230 #{1}


### PR DESCRIPTION
This is only linked in core from _Changes in dependency_. With this change, `#16 → #19` will no longer show the changes that led to the creation of `#16` (and happened before the build): Only changes in `#17` to `#19` will be listed.
- `Functions.filter()` is public API and documented to include both ends, so created a new `filterExcludingFrom` that does not include the lower bound.
- Allow independent localization of `from X to Y` rather than just concatenating `from X` and `to Y`. English and German localizations have been adapted to indicate lower bound is no longer shown, others just had their existing localizations concatenated.
