### PR TITLE
[FIXED JENKINS-23636] Indicate node the job workspace is on

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1886,7 +1886,14 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             req.getView(this,"noWorkspace.jelly").forward(req,rsp);
             return null;
         } else {
-            return new DirectoryBrowserSupport(this, ws, getDisplayName()+" workspace", "folder.png", true);
+            Computer c = ws.toComputer();
+            String title;
+            if (c == null) {
+                title = Messages.AbstractProject_WorkspaceTitle(getDisplayName());
+            } else {
+                title = Messages.AbstractProject_WorkspaceTitleOnComputer(getDisplayName(), c.getDisplayName());
+            }
+            return new DirectoryBrowserSupport(this, ws, title, "folder.png", true);
         }
     }
 

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2063,7 +2063,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         if(Functions.isArtifactsPermissionEnabled()) {
           checkPermission(ARTIFACTS);
         }
-        return new DirectoryBrowserSupport(this, getArtifactManager().root(), project.getDisplayName() + ' ' + getDisplayName(), "package.png", true);
+        return new DirectoryBrowserSupport(this, getArtifactManager().root(), Messages.Run_ArtifactsBrowserTitle(project.getDisplayName(), getDisplayName()), "package.png", true);
     }
 
     /**

--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
   <l:layout title="${it.title} : ${path}">
     <st:include page="sidepanel.jelly" it="${it.owner}"/>
     <l:main-panel>
+      <h1><l:breakable value="${it.title}"/></h1>
       <div class="dirTree">
       <!-- parent path -->
         <div class="parentPath">

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -46,6 +46,8 @@ AbstractProject.ETA=\ (ETA:{0})
 AbstractProject.NoBuilds=No existing build. Scheduling a new one.
 AbstractProject.NoSCM=No SCM
 AbstractProject.NoWorkspace=No workspace is available, so can\u2019t check for updates.
+AbstractProject.WorkspaceTitle=Workspace of {0}
+AbstractProject.WorkspaceTitleOnComputer=Workspace of {0} on {1}
 AbstractProject.PollingABorted=SCM polling aborted
 AbstractProject.ScmAborted=SCM check out aborted
 AbstractProject.WorkspaceOffline=Workspace is offline.
@@ -225,6 +227,7 @@ Run.ArtifactsPermission.Description=\
   builds. If you don\u2019t want an user to access the artifacts, you can do so by \
   revoking this permission.
 Run.InProgressDuration={0} and counting
+Run.ArtifactsBrowserTitle=Artifacts of {0} {1}
 
 Run.Summary.Stable=stable
 Run.Summary.Unstable=unstable


### PR DESCRIPTION
- Modern browsers often don't have a full width title bar anymore, so need to add an `h1` element to the workspace browser
- Enabled localization of the workspace browser and artifacts browser titles
