### PR TITLE
[JENKINS-22529] Make sure 'e' doesn't go out of bounds

### DIFF
--- a/core/src/main/java/hudson/model/queue/MappingWorksheet.java
+++ b/core/src/main/java/hudson/model/queue/MappingWorksheet.java
@@ -159,9 +159,12 @@ public class MappingWorksheet {
             assert capacity() >= wc.size();
             int e = 0;
             for (SubTask s : wc) {
-                while (!get(e).isAvailable())
+                while (e < size() && !get(e).isAvailable()) {
                     e++;
-                get(e++).set(wuc.createWorkUnit(s));
+		}
+		if (e < size()) {
+                    get(e++).set(wuc.createWorkUnit(s));
+		}
             }
         }
     }


### PR DESCRIPTION
This fixes a race that would lead to the node being marked as Dead with
the following backtrace (1.509.4):

java.lang.IndexOutOfBoundsException: Index: 62, Size: 62
at java.util.ArrayList.rangeCheck(ArrayList.java:635)
at java.util.ArrayList.get(ArrayList.java:411)
at hudson.model.queue.MappingWorksheet$ReadOnlyList.get(MappingWorksheet.java:102)
at hudson.model.queue.MappingWorksheet$ExecutorChunk.execute(MappingWorksheet.java:150)
at hudson.model.queue.MappingWorksheet$ExecutorChunk.access$000(MappingWorksheet.java:110)
at hudson.model.queue.MappingWorksheet$Mapping.execute(MappingWorksheet.java:298)
at hudson.model.Queue.maintain(Queue.java:1048)
at hudson.model.Queue.pop(Queue.java:866)
at hudson.model.Executor.grabJob(Executor.java:285)
at hudson.model.Executor.run(Executor.java:206)
