### PR TITLE
[FIXED JENKINS-23683] Check whether war's directory is writable

### DIFF
--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -158,7 +158,14 @@ public abstract class Lifecycle implements ExtensionPoint {
     public boolean canRewriteHudsonWar() {
         // if we don't know where jenkins.war is, it's impossible to replace.
         File f = getHudsonWar();
-        return f!=null && f.canWrite();
+        if (f == null || !f.canWrite()) {
+            return false;
+        }
+        File parent = f.getParentFile();
+        if (parent == null || !parent.canWrite()) {
+            return false;
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
As we cannot assume in-place editing of the war file (in fact it's not what happens), be extra careful and check both the file's and its parent dir's write permissions.
