### PR TITLE
Switch font stack to Helvetica, Arial

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -151,7 +151,7 @@ ${h.initPageVariables(context)}
         <td id="top-panel" colspan="2">
           <table cellpadding="0" cellspacing="0" width="100%" border="0">
             <tr><td style="font-weight:bold; font-size: 2em;">
-              <a id="jenkins-home-link" href="${rootURL}/"><img id="jenkins-home-icon" src="${imagesURL}/title.png" alt="title" width="139" height="34" /></a>
+              <h1 id="jenkins-title"><a id="jenkins-home-link" href="${rootURL}/">Jenkins</a></h1>
             </td><td style="vertical-align: middle; text-align: right; padding-right: 1em;">
 
               <!-- search box -->

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -29,8 +29,9 @@ body {
 
 body, table, form, input, td, th, p, textarea, select
 {
-  font-family: Verdana, Helvetica, sans-serif;
-  font-size: 11px;
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  color: #333;
 }
 
 FORM {
@@ -75,6 +76,21 @@ dt {
   height: 34px;
   background: url(../images/topbar.png) repeat-x;
 }
+
+#jenkins-title {
+    margin: 0 5px;
+    font-size: 25px;
+}
+
+#jenkins-home-link,
+#jenkins-home-link:visited {
+    color: #eee;
+}
+
+#jenkins-home-link:hover {
+    color: #fff;
+}
+
 #top-panel a {
   text-decoration: none;
 }
@@ -379,7 +395,7 @@ th.pane {
   padding: 4px 0;
   margin-left: 0;
   border-bottom: 1px solid #090;
-  font: bold 12px Verdana, sans-serif;
+  font: bold 12px Helvetica, Arial, sans-serif;
 }
 
 #foldertab li {
@@ -1203,7 +1219,7 @@ table#legend-table td {
 
   border: 1px solid #cccccc;
   background-color: #e0e0e0;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: Helvetica, Arial, sans-serif;
 
 
   color: #505050;


### PR DESCRIPTION
While Verdana and Georgia are widely available on user machines, they have
become a rare sight in web interfaces today, and are more commonly associated
with old websites. The list of fonts that are on most users computers is small,
and few of those are acceptable to use as a general-purpose web font for
Jenkins. This leaves Helvetica and its close cousin Arial; Helvetica looks
slightly nicer but its cousin is deployed on many more machines, so it provides
a good fallback.

Change the default font color #000 -> #333. This provides a slightly nicer
contrast with pure white, without hurting accessibility.

Change "Jenkins" title to a link, and the font from Georgia to Helvetica. Text
plays better with SEO and reduces the bytes needed to be transferred over the
wire.

Screenshot:

<img src="https://api.monosnap.com/image/download?id=wUTqja9Y1RKQ49wv6gB3MAB8XKYorB" />
