### PR TITLE
Switch underline/non underline on sidebar

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -283,6 +283,14 @@ pre.console {
   font-size: 12pt;
 }
 
+#jenkins .task-link {
+    text-decoration: none;
+}
+
+#jenkins .task-link:hover {
+    text-decoration: underline;
+}
+
 .task {
   white-space: nowrap;
 }


### PR DESCRIPTION
The underline adds slightly too much visual weight to the links in question.
This changes the links to not have an underline by default, while still adding
the underline when the link is hovered.

Normally accessibility requirements demand that you add an underline for all
clickable text. However, in this case the positioning of the elements, their
changed color, the presence of an icon next to the links, and the link hover
effect combine to give these elements the appearance of clickability.

New state:

<img src="https://api.monosnap.com/image/download?id=lfNyjZxR9n06oUhJwyebMrku3BK6kD"> 

On hover:

<img src="https://api.monosnap.com/image/download?id=IFY4rjmTFvC561uSO9mENfvW9NqXKt"> 
