### PR TITLE
change font to helvetica

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -61,7 +61,7 @@ body {
   top: 6px;
 }
 
-#header div.searchbox, #header div.login {
+#header .searchbox, #header .login {
   float: right;
   padding: 11px;
 }
@@ -91,7 +91,7 @@ body {
   margin-bottom: 3px;
 }
 #side-panel-content .task-link {
-  font-size: 1.3em;
+  font-size: 1.1em;
   vertical-align: middle;
 }
 
@@ -116,8 +116,9 @@ body {
 
 body, table, form, input, td, th, p, textarea, select
 {
-  font-family: Verdana, Helvetica, sans-serif;
-  font-size: 11px;
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  color: #333;
 }
 
 FORM {
@@ -476,7 +477,7 @@ th.pane {
   padding: 4px 0;
   margin-left: 0;
   border-bottom: 1px solid #090;
-  font: bold 12px Verdana, sans-serif;
+  font: bold 12px Helvetica, Arial, sans-serif;
 }
 
 #foldertab li {
@@ -1303,8 +1304,7 @@ table#legend-table td {
 
   border: 1px solid #cccccc;
   background-color: #e0e0e0;
-  font-family: Arial, Helvetica, sans-serif;
-
+  font-family: Helvetica, Arial, sans-serif;
 
   color: #505050;
   font-weight: bold;

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -134,7 +134,7 @@ dt {
 }
 
 .fixed-width {
-  font-family: Courier, monospace;
+  font-family: monospace;
 }
 
 .center {


### PR DESCRIPTION
While Verdana and Georgia are widely available on user machines, they have
become a rare sight in web interfaces today, and are more commonly associated
with old websites. The list of fonts that are on most users computers is small,
and few of those are acceptable to use as a general-purpose web font for
Jenkins. This leaves Helvetica and its close cousin Arial; Helvetica looks
slightly nicer but its cousin is deployed on many more machines, so it provides
a good fallback.

Bumps the default font size by several small points. Each Verdana letter takes up more vertical/horizontal space than the equivalent Helvetica letter, so it's possible to bump readability while keeping things at roughly the same size.

Change the default font color #000 -> #333. This provides a slightly nicer
contrast with pure white, without hurting accessibility.
