### PR TITLE
Added hover background and click to sidebar nav

### DIFF
--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -126,6 +126,7 @@ THE SOFTWARE.
               </script>
           </j:if>
 
+          <div class="task-link-group">
           <j:choose>
             <j:when test="${requiresConfirmation and not attrs.onClick}">
               <l:confirmationLink href="${href}" post="${post}" message="${confirmationMessage ?: title}">
@@ -166,6 +167,7 @@ THE SOFTWARE.
               </a>
             </j:otherwise>
           </j:choose>
+          </div>
 
           <j:if test="${match}">
             <div class="subtasks">

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -83,6 +83,11 @@ body {
   margin-bottom: 20px;
 }
 
+#tasks .task-link-group:hover {
+  cursor: pointer;
+  background-color: #e0e4dc;
+}
+
 #side-panel-content .pane {
   margin-bottom: 15px;
 }
@@ -381,7 +386,7 @@ pre.console {
 }
 
 #jenkins .task-link:hover {
-    text-decoration: underline;
+    text-decoration: none;
 }
 
 .task {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1212,6 +1212,15 @@ var jenkinsRules = {
         // initial positioning
         Element.observe(window,"load",adjustSticker);
         adjustSticker();
+    },
+
+    "#tasks .task-link-group" : function(task) {
+        var anchors = task.getElementsByTagName("A");
+        if (anchors && anchors.length > 0) {
+            task.onclick = function () {
+                anchors[0].click();
+            }
+        }
     }
 };
 /** @deprecated Use {@link Behaviour.specify} instead. */


### PR DESCRIPTION
This is an extension of #1314.

This PR changes the sidebar nav highlighting from an underline to a background colour change, as well as making the menu item clickable across it's full width (vs just the text/icon boundaries). 

![screenshot 2014-07-12 00 20 57](https://cloud.githubusercontent.com/assets/429311/3560048/46d6cf30-0958-11e4-80a4-2a5b6f8f35b1.png)
