### PR TITLE
Replace table based panes (build queue, build executors, build history) with a div based approach

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -67,6 +67,9 @@ Upcoming changes</a>
   <li class="rfe">
     Added option to increase impact of test failures on the weather report.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24006">issue 24006</a>)
+  <li class="rfe">
+    Modernized sidebar <code>&lt;l:pane&gt;</code>s and making them work better with new layout.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23810">issue 23810</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/ajaxBuildHistory.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/ajaxBuildHistory.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:ajax>
-    <table>
+    <table class="pane">
       <st:include page="entries.jelly" />
     </table>
   </l:ajax>

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -29,17 +29,34 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:set var="link" value="${it.baseUrl}/${build.number}/" />
   <j:set var="transitive" value="${(it.firstTransientBuildKey!=null and (it.adapter.compare(build,it.firstTransientBuildKey) ge 0)) ? 'transitive' : null}" />
-  <tr class="build-row no-wrap ${transitive}">
-    <td>
+  <tr class="build-row ${transitive}">
+    <td class="pane build-name">
       <a class="build-status-link" href="${link}console"><img class="build-status-icon" width="16" height="16" src="${imagesURL}/16x16/${build.buildStatusUrl}" alt="${build.iconColor.description} &gt; ${%Console Output}" tooltip="${build.iconColor.description} &gt; ${%Console Output}" /></a><st:nbsp/>
       ${build.displayName}
     </td>
-    <td style="padding-right:0">
+    <td class="pane build-details">
       <a class="tip model-link inside" href="${link}">
         <i:formatDate value="${build.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>
       </a>
+      <j:if test="${build.building}">
+        <j:set target="${it}" property="nextBuildNumberToFetch" value="${build.number}"/>
+        <t:buildProgressBar build="${build}"/>
+      </j:if>
+      <j:if test="${!empty build.description}">
+        <div class="desc">
+          <j:out value="${app.markupFormatter.translate(build.truncatedDescription)}"/>
+        </div>
+      </j:if>
     </td>
-    <td class="middle-align">
+    <td class="pane build-stop">
+      <j:if test="${build.building}">
+          <!-- Check ABORT permission for Project, Admin permission otherwise -->
+          <j:if test="${empty(it.owner.ABORT) ? h.hasPermission(app.ADMINISTER) : it.owner.hasPermission(it.owner.ABORT)}">
+            <l:stopButton href="${link}stop" alt="[cancel]"/>
+          </j:if>
+      </j:if>
+    </td>
+    <td class="pane middle-align build-badge">
       <j:set var="badges" value="${build.badgeActions}"/>
       <j:if test="${!empty(badges)}">
         <st:nbsp/>
@@ -49,27 +66,4 @@ THE SOFTWARE.
       </j:if>
     </td>
   </tr>
-  <j:if test="${build.building}">
-    <j:set target="${it}" property="nextBuildNumberToFetch" value="${build.number}"/>
-    <tr class="transitive build-progress-bar"><td></td><td colspan="2" style="padding:0">
-      <table class="middle-align">
-        <tr><td>
-          <t:buildProgressBar build="${build}"/>
-        </td><td style="padding:0">
-          <!-- Check ABORT permission for Project, Admin permission otherwise -->
-          <j:if test="${empty(it.owner.ABORT) ? h.hasPermission(app.ADMINISTER) : it.owner.hasPermission(it.owner.ABORT)}">
-            <l:stopButton href="${link}stop" alt="[cancel]"/>
-          </j:if>
-        </td></tr>
-      </table>
-    </td></tr>
-  </j:if>
-  <j:if test="${!empty build.description}">
-    <tr class="${transitive}">
-      <td></td>
-      <td colspan="2" class="desc">
-        <j:out value="${app.markupFormatter.translate(build.truncatedDescription)}"/>
-      </td>
-    </tr>
-  </j:if>
 </j:jelly>

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -31,11 +31,27 @@ THE SOFTWARE.
       <j:arg value="hudson.model.Job"/>
     </j:invoke>
     <j:if test="${jobClass.isAssignableFrom(it.owner.class)}">
-      <div style="float:right">(<a href="${it.baseUrl}/buildTimeTrend">${%trend}</a>)</div>
+      <div style="float:right"><a href="${it.baseUrl}/buildTimeTrend">${%trend}</a></div>
       <t:buildHealth job="${it.owner}" iconSize="16x16" link="${it.baseUrl}/lastBuild"/>
     </j:if>
   </j:parse>
-  <l:pane width="3" title="${h.runScript(paneTitle)}${it.displayName}" id="buildHistory">
+
+  <j:parse var="paneFooter">
+    <!--
+      RSS link
+    -->
+    <span class="build-rss-links">
+        <a class="build-rss-all-icon" href="${it.baseUrl}/rssAll"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+        <st:nbsp/>
+        <a class="build-rss-all-link" href="${it.baseUrl}/rssAll">RSS ${%for all}</a>
+        <st:nbsp/>
+        <a class="build-rss-failed-icon" href="${it.baseUrl}/rssFailed"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+        <st:nbsp/>
+        <a class="build-rss-failed-link" href="${it.baseUrl}/rssFailed">RSS ${%for failures}</a>
+    </span>
+  </j:parse>
+
+  <l:pane width="3" title="${h.runScript(paneTitle)}${it.displayName}" footer="${h.runScript(paneFooter)}" id="buildHistory" class="stripped">
 
     <!-- build history -->
     <st:include page="entries.jelly" />
@@ -83,20 +99,6 @@ THE SOFTWARE.
         </td>
       </tr>
     </j:if>
-    <!--
-      RSS link
-    -->
-    <tr class="build-row build-rss-links">
-      <td colspan="3" align="right">
-        <a class="build-rss-all-icon" href="${it.baseUrl}/rssAll"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
-        <st:nbsp/>
-        <a class="build-rss-all-link" href="${it.baseUrl}/rssAll">RSS ${%for all}</a>
-        <st:nbsp/>
-        <a class="build-rss-failed-icon" href="${it.baseUrl}/rssFailed"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
-        <st:nbsp/>
-        <a class="build-rss-failed-link" href="${it.baseUrl}/rssFailed">RSS ${%for failures}</a>
-      </td>
-    </tr>
   </l:pane>
   <script defer="true">
     updateBuildHistory("${it.baseUrl}/buildHistory/ajax",${it.nextBuildNumberToFetch});

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -33,7 +33,8 @@ THE SOFTWARE.
   </st:documentation>
   <d:taglib uri="local">
     <d:tag name="computerCaption">
-      <a href="${rootURL}/${c.url}" class="model-link inside">${title}</a>
+
+      <a href="${rootURL}/${c.url}" class="model-link inside"><img src="${imagesURL}/16x16/computer${c.offline?'-x':''}.png"/><st:nbsp/>${title}</a>
       <j:if test="${c.offline}"> <st:nbsp/> (${%offline})</j:if>
       <j:if test="${!c.acceptingTasks}"> <st:nbsp/> (${%suspended})</j:if>
     </d:tag>
@@ -52,6 +53,7 @@ THE SOFTWARE.
                   </a>
                 </td>
                 <td class="pane"/>
+                <td class="pane"/>
               </j:when>
               <j:when test="${e.idle}">
                 <td class="pane">
@@ -65,13 +67,14 @@ THE SOFTWARE.
                   </j:choose>
                 </td>
                 <td class="pane"/>
+                <td class="pane"/>
               </j:when>
               <j:otherwise>
                 <!-- not actually optional, but it helps with backward compatibility -->
                 <j:set var="executor" value="${e}" />
                 <st:include it="${e.currentExecutable}" page="executorCell.jelly" optional="true">
                   <td class="pane">
-                    <div style="white-space: normal">${%Building}
+                    <div style="white-space: normal">
                       <j:set var="exe" value="${e.currentExecutable}" />
                       <j:invokeStatic var="exeparent"
                          className="hudson.model.queue.Executables" method="getParentOf">
@@ -79,7 +82,7 @@ THE SOFTWARE.
                       </j:invokeStatic>
                       <j:choose>
                         <j:when test="${h.hasPermission(exeparent,exeparent.READ)}">
-                          <a href="${rootURL}/${exeparent.url}"><l:breakable value="${exeparent.fullDisplayName}"/></a>&#160;<a href="${rootURL}/${exe.url}" class="model-link inside"><l:breakable value="${exe.displayName}"/></a>
+                          <a href="${rootURL}/${exeparent.url}"><l:breakable value="${exeparent.fullDisplayName}"/></a>
                           <t:buildProgressBar build="${exe}" executor="${executor}"/>
                         </j:when>
                         <j:otherwise>
@@ -88,6 +91,11 @@ THE SOFTWARE.
                       </j:choose>
                     </div>
                   </td>
+                <td class="pane">
+                  <j:if test="${h.hasPermission(exeparent,exeparent.READ)}">
+                      <a href="${rootURL}/${exe.url}" class="model-link inside"><l:breakable value="${exe.displayName}"/></a>
+                  </j:if>
+                </td>
                 </st:include>
                 <td class="pane" align="center" valign="middle">
                   <j:if test="${e.hasStopPermission()}">
@@ -106,15 +114,6 @@ THE SOFTWARE.
         title="&lt;a href='${rootURL}/computer/'>${%Build Executor Status}&lt;/a>"
         collapsedText="${%Computers(computers.size() - 1, app.unlabeledLoad.computeTotalExecutors() - app.unlabeledLoad.computeIdleExecutors(), app.unlabeledLoad.computeTotalExecutors())}">
       <colgroup><col width="30"/><col width="200*"/><col width="24"/></colgroup>
-
-      <tr>
-        <th class="pane">#</th>
-        <th class="pane" colspan="2">
-          <div style="margin-right:19px">
-            ${%Status}
-          </div>
-        </th>
-      </tr>
 
       <j:forEach var="c" items="${computers}">
         <tr>

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -219,7 +219,7 @@ ${h.initPageVariables(context)}
 
     <div id="page-body" class="container-fluid">
       <div class="row">
-        <div id="side-panel" class="col-md-3">
+        <div id="side-panel" class="col-sm-9 col-md-7 col-lg-6 col-xlg-4">
           <div id="side-panel-content">
             <j:set var="mode" value="side-panel" />
             <d:invokeBody />
@@ -237,7 +237,7 @@ ${h.initPageVariables(context)}
           </div>
         </div>
 
-        <div id="main-panel" class="col-md-9">
+        <div id="main-panel" class="col-sm-15 col-md-17 col-lg-18 col-xlg-20">
           <div id="main-panel-content">
             <j:set var="mode" value="main-panel" />
             <d:invokeBody/>

--- a/core/src/main/resources/lib/layout/pane.jelly
+++ b/core/src/main/resources/lib/layout/pane.jelly
@@ -41,30 +41,46 @@ THE SOFTWARE.
     <st:attribute name="id">
       @id of the table, if specified.
     </st:attribute>
+    <st:attribute name="class">
+      Pane table class specification.
+    </st:attribute>
+    <st:attribute name="footer">
+      Footer of the box. Can include HTML.
+    </st:attribute>
   </st:documentation>
-  <table class="pane" id="${attrs.id}">
-    <tr><td class="pane-header" colspan="${width}">
-      <div>
-      <j:out value="${title}"/>
-      <a class="collapse" href="${rootURL}/toggleCollapse?paneId=${attrs.id}" 
-         title="${h.isCollapsed(attrs.id) ? '%expand' : '%collapse'}">
-        <img src="${imagesURL}/16x16/${h.isCollapsed(attrs.id) ? 'expand' : 'collapse'}.png" 
-             class="icon16x16" 
-             alt="${h.isCollapsed(attrs.id) ? '%expand' : '%collapse'}" />
-      </a>
+
+  <div class="container-fluid pane-frame" id="${attrs.id}">
+    <div class="row">
+      <div class="col-xs-24 pane-header">
+        <a class="collapse" href="${rootURL}/toggleCollapse?paneId=${attrs.id}"
+           title="${h.isCollapsed(attrs.id) ? '%expand' : '%collapse'}">
+          <img src="${imagesURL}/16x16/${h.isCollapsed(attrs.id) ? 'expand' : 'collapse'}.png"
+               class="icon16x16"
+               alt="${h.isCollapsed(attrs.id) ? '%expand' : '%collapse'}"/>
+        </a>
+        <j:out value="${title}"/>
       </div>
-    </td></tr>
+    </div>
     <j:choose>
-      <j:when test="${h.isCollapsed(attrs.id)}">
-        <tr>
-          <td class="pane" colspan="${width}">
-            ${attrs.collapsedText}
-          </td>
-        </tr>
-      </j:when>
-      <j:otherwise>
-        <d:invokeBody />
-      </j:otherwise>
+      <div class="row pane-content">
+        <j:when test="${h.isCollapsed(attrs.id)}">
+          <div class="row">
+            <div class="col-xs-24 cell">${attrs.collapsedText}</div>
+          </div>
+        </j:when>
+        <j:otherwise>
+          <table class="pane ${attrs.class}">
+            <d:invokeBody />
+          </table>
+        </j:otherwise>
+      </div>
     </j:choose>
-  </table>
+    <j:if test="${attrs.footer != null}">
+      <div class="row">
+        <div class="col-xs-24 pane-footer">
+          <j:out value="${attrs.footer}"/>
+        </div>
+      </div>
+    </j:if>
+  </div>
 </j:jelly>

--- a/war/src/main/webapp/css/responsive-grid.css
+++ b/war/src/main/webapp/css/responsive-grid.css
@@ -8,6 +8,18 @@
  * Only the grid and responsive rules from bootstrap.
  */
 
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+*:before,
+*:after {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
 .container {
   padding-right: 15px;
   padding-left: 15px;
@@ -39,640 +51,1533 @@
   margin-right: -15px;
   margin-left: -15px;
 }
-.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
+.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12, .col-xs-13, .col-sm-13, .col-md-13, .col-lg-13, .col-xs-14, .col-sm-14, .col-md-14, .col-lg-14, .col-xs-15, .col-sm-15, .col-md-15, .col-lg-15, .col-xs-16, .col-sm-16, .col-md-16, .col-lg-16, .col-xs-17, .col-sm-17, .col-md-17, .col-lg-17, .col-xs-18, .col-sm-18, .col-md-18, .col-lg-18, .col-xs-19, .col-sm-19, .col-md-19, .col-lg-19, .col-xs-20, .col-sm-20, .col-md-20, .col-lg-20, .col-xs-21, .col-sm-21, .col-md-21, .col-lg-21, .col-xs-22, .col-sm-22, .col-md-22, .col-lg-22, .col-xs-23, .col-sm-23, .col-md-23, .col-lg-23, .col-xs-24, .col-sm-24, .col-md-24, .col-lg-24 {
+  position: relative;
+  min-height: 1px;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12, .col-xs-13, .col-xs-14, .col-xs-15, .col-xs-16, .col-xs-17, .col-xs-18, .col-xs-19, .col-xs-20, .col-xs-21, .col-xs-22, .col-xs-23, .col-xs-24 {
+  float: left;
+}
+.col-xs-24 {
+  width: 100%;
+}
+.col-xs-23 {
+  width: 95.83333333%;
+}
+.col-xs-22 {
+  width: 91.66666667%;
+}
+.col-xs-21 {
+  width: 87.5%;
+}
+.col-xs-20 {
+  width: 83.33333333%;
+}
+.col-xs-19 {
+  width: 79.16666667%;
+}
+.col-xs-18 {
+  width: 75%;
+}
+.col-xs-17 {
+  width: 70.83333333%;
+}
+.col-xs-16 {
+  width: 66.66666667%;
+}
+.col-xs-15 {
+  width: 62.5%;
+}
+.col-xs-14 {
+  width: 58.33333333%;
+}
+.col-xs-13 {
+  width: 54.16666667%;
+}
+.col-xs-12 {
+  width: 50%;
+}
+.col-xs-11 {
+  width: 45.83333333%;
+}
+.col-xs-10 {
+  width: 41.66666667%;
+}
+.col-xs-9 {
+  width: 37.5%;
+}
+.col-xs-8 {
+  width: 33.33333333%;
+}
+.col-xs-7 {
+  width: 29.16666667%;
+}
+.col-xs-6 {
+  width: 25%;
+}
+.col-xs-5 {
+  width: 20.83333333%;
+}
+.col-xs-4 {
+  width: 16.66666667%;
+}
+.col-xs-3 {
+  width: 12.5%;
+}
+.col-xs-2 {
+  width: 8.33333333%;
+}
+.col-xs-1 {
+  width: 4.16666667%;
+}
+.col-xs-pull-24 {
+  right: 100%;
+}
+.col-xs-pull-23 {
+  right: 95.83333333%;
+}
+.col-xs-pull-22 {
+  right: 91.66666667%;
+}
+.col-xs-pull-21 {
+  right: 87.5%;
+}
+.col-xs-pull-20 {
+  right: 83.33333333%;
+}
+.col-xs-pull-19 {
+  right: 79.16666667%;
+}
+.col-xs-pull-18 {
+  right: 75%;
+}
+.col-xs-pull-17 {
+  right: 70.83333333%;
+}
+.col-xs-pull-16 {
+  right: 66.66666667%;
+}
+.col-xs-pull-15 {
+  right: 62.5%;
+}
+.col-xs-pull-14 {
+  right: 58.33333333%;
+}
+.col-xs-pull-13 {
+  right: 54.16666667%;
+}
+.col-xs-pull-12 {
+  right: 50%;
+}
+.col-xs-pull-11 {
+  right: 45.83333333%;
+}
+.col-xs-pull-10 {
+  right: 41.66666667%;
+}
+.col-xs-pull-9 {
+  right: 37.5%;
+}
+.col-xs-pull-8 {
+  right: 33.33333333%;
+}
+.col-xs-pull-7 {
+  right: 29.16666667%;
+}
+.col-xs-pull-6 {
+  right: 25%;
+}
+.col-xs-pull-5 {
+  right: 20.83333333%;
+}
+.col-xs-pull-4 {
+  right: 16.66666667%;
+}
+.col-xs-pull-3 {
+  right: 12.5%;
+}
+.col-xs-pull-2 {
+  right: 8.33333333%;
+}
+.col-xs-pull-1 {
+  right: 4.16666667%;
+}
+.col-xs-pull-0 {
+  right: auto;
+}
+.col-xs-push-24 {
+  left: 100%;
+}
+.col-xs-push-23 {
+  left: 95.83333333%;
+}
+.col-xs-push-22 {
+  left: 91.66666667%;
+}
+.col-xs-push-21 {
+  left: 87.5%;
+}
+.col-xs-push-20 {
+  left: 83.33333333%;
+}
+.col-xs-push-19 {
+  left: 79.16666667%;
+}
+.col-xs-push-18 {
+  left: 75%;
+}
+.col-xs-push-17 {
+  left: 70.83333333%;
+}
+.col-xs-push-16 {
+  left: 66.66666667%;
+}
+.col-xs-push-15 {
+  left: 62.5%;
+}
+.col-xs-push-14 {
+  left: 58.33333333%;
+}
+.col-xs-push-13 {
+  left: 54.16666667%;
+}
+.col-xs-push-12 {
+  left: 50%;
+}
+.col-xs-push-11 {
+  left: 45.83333333%;
+}
+.col-xs-push-10 {
+  left: 41.66666667%;
+}
+.col-xs-push-9 {
+  left: 37.5%;
+}
+.col-xs-push-8 {
+  left: 33.33333333%;
+}
+.col-xs-push-7 {
+  left: 29.16666667%;
+}
+.col-xs-push-6 {
+  left: 25%;
+}
+.col-xs-push-5 {
+  left: 20.83333333%;
+}
+.col-xs-push-4 {
+  left: 16.66666667%;
+}
+.col-xs-push-3 {
+  left: 12.5%;
+}
+.col-xs-push-2 {
+  left: 8.33333333%;
+}
+.col-xs-push-1 {
+  left: 4.16666667%;
+}
+.col-xs-push-0 {
+  left: auto;
+}
+.col-xs-offset-24 {
+  margin-left: 100%;
+}
+.col-xs-offset-23 {
+  margin-left: 95.83333333%;
+}
+.col-xs-offset-22 {
+  margin-left: 91.66666667%;
+}
+.col-xs-offset-21 {
+  margin-left: 87.5%;
+}
+.col-xs-offset-20 {
+  margin-left: 83.33333333%;
+}
+.col-xs-offset-19 {
+  margin-left: 79.16666667%;
+}
+.col-xs-offset-18 {
+  margin-left: 75%;
+}
+.col-xs-offset-17 {
+  margin-left: 70.83333333%;
+}
+.col-xs-offset-16 {
+  margin-left: 66.66666667%;
+}
+.col-xs-offset-15 {
+  margin-left: 62.5%;
+}
+.col-xs-offset-14 {
+  margin-left: 58.33333333%;
+}
+.col-xs-offset-13 {
+  margin-left: 54.16666667%;
+}
+.col-xs-offset-12 {
+  margin-left: 50%;
+}
+.col-xs-offset-11 {
+  margin-left: 45.83333333%;
+}
+.col-xs-offset-10 {
+  margin-left: 41.66666667%;
+}
+.col-xs-offset-9 {
+  margin-left: 37.5%;
+}
+.col-xs-offset-8 {
+  margin-left: 33.33333333%;
+}
+.col-xs-offset-7 {
+  margin-left: 29.16666667%;
+}
+.col-xs-offset-6 {
+  margin-left: 25%;
+}
+.col-xs-offset-5 {
+  margin-left: 20.83333333%;
+}
+.col-xs-offset-4 {
+  margin-left: 16.66666667%;
+}
+.col-xs-offset-3 {
+  margin-left: 12.5%;
+}
+.col-xs-offset-2 {
+  margin-left: 8.33333333%;
+}
+.col-xs-offset-1 {
+  margin-left: 4.16666667%;
+}
+.col-xs-offset-0 {
+  margin-left: 0%;
+}
+@media (min-width: 768px) {
+  .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12, .col-sm-13, .col-sm-14, .col-sm-15, .col-sm-16, .col-sm-17, .col-sm-18, .col-sm-19, .col-sm-20, .col-sm-21, .col-sm-22, .col-sm-23, .col-sm-24 {
+    float: left;
+  }
+  .col-sm-24 {
+    width: 100%;
+  }
+  .col-sm-23 {
+    width: 95.83333333%;
+  }
+  .col-sm-22 {
+    width: 91.66666667%;
+  }
+  .col-sm-21 {
+    width: 87.5%;
+  }
+  .col-sm-20 {
+    width: 83.33333333%;
+  }
+  .col-sm-19 {
+    width: 79.16666667%;
+  }
+  .col-sm-18 {
+    width: 75%;
+  }
+  .col-sm-17 {
+    width: 70.83333333%;
+  }
+  .col-sm-16 {
+    width: 66.66666667%;
+  }
+  .col-sm-15 {
+    width: 62.5%;
+  }
+  .col-sm-14 {
+    width: 58.33333333%;
+  }
+  .col-sm-13 {
+    width: 54.16666667%;
+  }
+  .col-sm-12 {
+    width: 50%;
+  }
+  .col-sm-11 {
+    width: 45.83333333%;
+  }
+  .col-sm-10 {
+    width: 41.66666667%;
+  }
+  .col-sm-9 {
+    width: 37.5%;
+  }
+  .col-sm-8 {
+    width: 33.33333333%;
+  }
+  .col-sm-7 {
+    width: 29.16666667%;
+  }
+  .col-sm-6 {
+    width: 25%;
+  }
+  .col-sm-5 {
+    width: 20.83333333%;
+  }
+  .col-sm-4 {
+    width: 16.66666667%;
+  }
+  .col-sm-3 {
+    width: 12.5%;
+  }
+  .col-sm-2 {
+    width: 8.33333333%;
+  }
+  .col-sm-1 {
+    width: 4.16666667%;
+  }
+  .col-sm-pull-24 {
+    right: 100%;
+  }
+  .col-sm-pull-23 {
+    right: 95.83333333%;
+  }
+  .col-sm-pull-22 {
+    right: 91.66666667%;
+  }
+  .col-sm-pull-21 {
+    right: 87.5%;
+  }
+  .col-sm-pull-20 {
+    right: 83.33333333%;
+  }
+  .col-sm-pull-19 {
+    right: 79.16666667%;
+  }
+  .col-sm-pull-18 {
+    right: 75%;
+  }
+  .col-sm-pull-17 {
+    right: 70.83333333%;
+  }
+  .col-sm-pull-16 {
+    right: 66.66666667%;
+  }
+  .col-sm-pull-15 {
+    right: 62.5%;
+  }
+  .col-sm-pull-14 {
+    right: 58.33333333%;
+  }
+  .col-sm-pull-13 {
+    right: 54.16666667%;
+  }
+  .col-sm-pull-12 {
+    right: 50%;
+  }
+  .col-sm-pull-11 {
+    right: 45.83333333%;
+  }
+  .col-sm-pull-10 {
+    right: 41.66666667%;
+  }
+  .col-sm-pull-9 {
+    right: 37.5%;
+  }
+  .col-sm-pull-8 {
+    right: 33.33333333%;
+  }
+  .col-sm-pull-7 {
+    right: 29.16666667%;
+  }
+  .col-sm-pull-6 {
+    right: 25%;
+  }
+  .col-sm-pull-5 {
+    right: 20.83333333%;
+  }
+  .col-sm-pull-4 {
+    right: 16.66666667%;
+  }
+  .col-sm-pull-3 {
+    right: 12.5%;
+  }
+  .col-sm-pull-2 {
+    right: 8.33333333%;
+  }
+  .col-sm-pull-1 {
+    right: 4.16666667%;
+  }
+  .col-sm-pull-0 {
+    right: auto;
+  }
+  .col-sm-push-24 {
+    left: 100%;
+  }
+  .col-sm-push-23 {
+    left: 95.83333333%;
+  }
+  .col-sm-push-22 {
+    left: 91.66666667%;
+  }
+  .col-sm-push-21 {
+    left: 87.5%;
+  }
+  .col-sm-push-20 {
+    left: 83.33333333%;
+  }
+  .col-sm-push-19 {
+    left: 79.16666667%;
+  }
+  .col-sm-push-18 {
+    left: 75%;
+  }
+  .col-sm-push-17 {
+    left: 70.83333333%;
+  }
+  .col-sm-push-16 {
+    left: 66.66666667%;
+  }
+  .col-sm-push-15 {
+    left: 62.5%;
+  }
+  .col-sm-push-14 {
+    left: 58.33333333%;
+  }
+  .col-sm-push-13 {
+    left: 54.16666667%;
+  }
+  .col-sm-push-12 {
+    left: 50%;
+  }
+  .col-sm-push-11 {
+    left: 45.83333333%;
+  }
+  .col-sm-push-10 {
+    left: 41.66666667%;
+  }
+  .col-sm-push-9 {
+    left: 37.5%;
+  }
+  .col-sm-push-8 {
+    left: 33.33333333%;
+  }
+  .col-sm-push-7 {
+    left: 29.16666667%;
+  }
+  .col-sm-push-6 {
+    left: 25%;
+  }
+  .col-sm-push-5 {
+    left: 20.83333333%;
+  }
+  .col-sm-push-4 {
+    left: 16.66666667%;
+  }
+  .col-sm-push-3 {
+    left: 12.5%;
+  }
+  .col-sm-push-2 {
+    left: 8.33333333%;
+  }
+  .col-sm-push-1 {
+    left: 4.16666667%;
+  }
+  .col-sm-push-0 {
+    left: auto;
+  }
+  .col-sm-offset-24 {
+    margin-left: 100%;
+  }
+  .col-sm-offset-23 {
+    margin-left: 95.83333333%;
+  }
+  .col-sm-offset-22 {
+    margin-left: 91.66666667%;
+  }
+  .col-sm-offset-21 {
+    margin-left: 87.5%;
+  }
+  .col-sm-offset-20 {
+    margin-left: 83.33333333%;
+  }
+  .col-sm-offset-19 {
+    margin-left: 79.16666667%;
+  }
+  .col-sm-offset-18 {
+    margin-left: 75%;
+  }
+  .col-sm-offset-17 {
+    margin-left: 70.83333333%;
+  }
+  .col-sm-offset-16 {
+    margin-left: 66.66666667%;
+  }
+  .col-sm-offset-15 {
+    margin-left: 62.5%;
+  }
+  .col-sm-offset-14 {
+    margin-left: 58.33333333%;
+  }
+  .col-sm-offset-13 {
+    margin-left: 54.16666667%;
+  }
+  .col-sm-offset-12 {
+    margin-left: 50%;
+  }
+  .col-sm-offset-11 {
+    margin-left: 45.83333333%;
+  }
+  .col-sm-offset-10 {
+    margin-left: 41.66666667%;
+  }
+  .col-sm-offset-9 {
+    margin-left: 37.5%;
+  }
+  .col-sm-offset-8 {
+    margin-left: 33.33333333%;
+  }
+  .col-sm-offset-7 {
+    margin-left: 29.16666667%;
+  }
+  .col-sm-offset-6 {
+    margin-left: 25%;
+  }
+  .col-sm-offset-5 {
+    margin-left: 20.83333333%;
+  }
+  .col-sm-offset-4 {
+    margin-left: 16.66666667%;
+  }
+  .col-sm-offset-3 {
+    margin-left: 12.5%;
+  }
+  .col-sm-offset-2 {
+    margin-left: 8.33333333%;
+  }
+  .col-sm-offset-1 {
+    margin-left: 4.16666667%;
+  }
+  .col-sm-offset-0 {
+    margin-left: 0%;
+  }
+}
+@media (min-width: 992px) {
+  .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12, .col-md-13, .col-md-14, .col-md-15, .col-md-16, .col-md-17, .col-md-18, .col-md-19, .col-md-20, .col-md-21, .col-md-22, .col-md-23, .col-md-24 {
+    float: left;
+  }
+  .col-md-24 {
+    width: 100%;
+  }
+  .col-md-23 {
+    width: 95.83333333%;
+  }
+  .col-md-22 {
+    width: 91.66666667%;
+  }
+  .col-md-21 {
+    width: 87.5%;
+  }
+  .col-md-20 {
+    width: 83.33333333%;
+  }
+  .col-md-19 {
+    width: 79.16666667%;
+  }
+  .col-md-18 {
+    width: 75%;
+  }
+  .col-md-17 {
+    width: 70.83333333%;
+  }
+  .col-md-16 {
+    width: 66.66666667%;
+  }
+  .col-md-15 {
+    width: 62.5%;
+  }
+  .col-md-14 {
+    width: 58.33333333%;
+  }
+  .col-md-13 {
+    width: 54.16666667%;
+  }
+  .col-md-12 {
+    width: 50%;
+  }
+  .col-md-11 {
+    width: 45.83333333%;
+  }
+  .col-md-10 {
+    width: 41.66666667%;
+  }
+  .col-md-9 {
+    width: 37.5%;
+  }
+  .col-md-8 {
+    width: 33.33333333%;
+  }
+  .col-md-7 {
+    width: 29.16666667%;
+  }
+  .col-md-6 {
+    width: 25%;
+  }
+  .col-md-5 {
+    width: 20.83333333%;
+  }
+  .col-md-4 {
+    width: 16.66666667%;
+  }
+  .col-md-3 {
+    width: 12.5%;
+  }
+  .col-md-2 {
+    width: 8.33333333%;
+  }
+  .col-md-1 {
+    width: 4.16666667%;
+  }
+  .col-md-pull-24 {
+    right: 100%;
+  }
+  .col-md-pull-23 {
+    right: 95.83333333%;
+  }
+  .col-md-pull-22 {
+    right: 91.66666667%;
+  }
+  .col-md-pull-21 {
+    right: 87.5%;
+  }
+  .col-md-pull-20 {
+    right: 83.33333333%;
+  }
+  .col-md-pull-19 {
+    right: 79.16666667%;
+  }
+  .col-md-pull-18 {
+    right: 75%;
+  }
+  .col-md-pull-17 {
+    right: 70.83333333%;
+  }
+  .col-md-pull-16 {
+    right: 66.66666667%;
+  }
+  .col-md-pull-15 {
+    right: 62.5%;
+  }
+  .col-md-pull-14 {
+    right: 58.33333333%;
+  }
+  .col-md-pull-13 {
+    right: 54.16666667%;
+  }
+  .col-md-pull-12 {
+    right: 50%;
+  }
+  .col-md-pull-11 {
+    right: 45.83333333%;
+  }
+  .col-md-pull-10 {
+    right: 41.66666667%;
+  }
+  .col-md-pull-9 {
+    right: 37.5%;
+  }
+  .col-md-pull-8 {
+    right: 33.33333333%;
+  }
+  .col-md-pull-7 {
+    right: 29.16666667%;
+  }
+  .col-md-pull-6 {
+    right: 25%;
+  }
+  .col-md-pull-5 {
+    right: 20.83333333%;
+  }
+  .col-md-pull-4 {
+    right: 16.66666667%;
+  }
+  .col-md-pull-3 {
+    right: 12.5%;
+  }
+  .col-md-pull-2 {
+    right: 8.33333333%;
+  }
+  .col-md-pull-1 {
+    right: 4.16666667%;
+  }
+  .col-md-pull-0 {
+    right: auto;
+  }
+  .col-md-push-24 {
+    left: 100%;
+  }
+  .col-md-push-23 {
+    left: 95.83333333%;
+  }
+  .col-md-push-22 {
+    left: 91.66666667%;
+  }
+  .col-md-push-21 {
+    left: 87.5%;
+  }
+  .col-md-push-20 {
+    left: 83.33333333%;
+  }
+  .col-md-push-19 {
+    left: 79.16666667%;
+  }
+  .col-md-push-18 {
+    left: 75%;
+  }
+  .col-md-push-17 {
+    left: 70.83333333%;
+  }
+  .col-md-push-16 {
+    left: 66.66666667%;
+  }
+  .col-md-push-15 {
+    left: 62.5%;
+  }
+  .col-md-push-14 {
+    left: 58.33333333%;
+  }
+  .col-md-push-13 {
+    left: 54.16666667%;
+  }
+  .col-md-push-12 {
+    left: 50%;
+  }
+  .col-md-push-11 {
+    left: 45.83333333%;
+  }
+  .col-md-push-10 {
+    left: 41.66666667%;
+  }
+  .col-md-push-9 {
+    left: 37.5%;
+  }
+  .col-md-push-8 {
+    left: 33.33333333%;
+  }
+  .col-md-push-7 {
+    left: 29.16666667%;
+  }
+  .col-md-push-6 {
+    left: 25%;
+  }
+  .col-md-push-5 {
+    left: 20.83333333%;
+  }
+  .col-md-push-4 {
+    left: 16.66666667%;
+  }
+  .col-md-push-3 {
+    left: 12.5%;
+  }
+  .col-md-push-2 {
+    left: 8.33333333%;
+  }
+  .col-md-push-1 {
+    left: 4.16666667%;
+  }
+  .col-md-push-0 {
+    left: auto;
+  }
+  .col-md-offset-24 {
+    margin-left: 100%;
+  }
+  .col-md-offset-23 {
+    margin-left: 95.83333333%;
+  }
+  .col-md-offset-22 {
+    margin-left: 91.66666667%;
+  }
+  .col-md-offset-21 {
+    margin-left: 87.5%;
+  }
+  .col-md-offset-20 {
+    margin-left: 83.33333333%;
+  }
+  .col-md-offset-19 {
+    margin-left: 79.16666667%;
+  }
+  .col-md-offset-18 {
+    margin-left: 75%;
+  }
+  .col-md-offset-17 {
+    margin-left: 70.83333333%;
+  }
+  .col-md-offset-16 {
+    margin-left: 66.66666667%;
+  }
+  .col-md-offset-15 {
+    margin-left: 62.5%;
+  }
+  .col-md-offset-14 {
+    margin-left: 58.33333333%;
+  }
+  .col-md-offset-13 {
+    margin-left: 54.16666667%;
+  }
+  .col-md-offset-12 {
+    margin-left: 50%;
+  }
+  .col-md-offset-11 {
+    margin-left: 45.83333333%;
+  }
+  .col-md-offset-10 {
+    margin-left: 41.66666667%;
+  }
+  .col-md-offset-9 {
+    margin-left: 37.5%;
+  }
+  .col-md-offset-8 {
+    margin-left: 33.33333333%;
+  }
+  .col-md-offset-7 {
+    margin-left: 29.16666667%;
+  }
+  .col-md-offset-6 {
+    margin-left: 25%;
+  }
+  .col-md-offset-5 {
+    margin-left: 20.83333333%;
+  }
+  .col-md-offset-4 {
+    margin-left: 16.66666667%;
+  }
+  .col-md-offset-3 {
+    margin-left: 12.5%;
+  }
+  .col-md-offset-2 {
+    margin-left: 8.33333333%;
+  }
+  .col-md-offset-1 {
+    margin-left: 4.16666667%;
+  }
+  .col-md-offset-0 {
+    margin-left: 0%;
+  }
+}
+@media (min-width: 1200px) {
+  .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12, .col-lg-13, .col-lg-14, .col-lg-15, .col-lg-16, .col-lg-17, .col-lg-18, .col-lg-19, .col-lg-20, .col-lg-21, .col-lg-22, .col-lg-23, .col-lg-24 {
+    float: left;
+  }
+  .col-lg-24 {
+    width: 100%;
+  }
+  .col-lg-23 {
+    width: 95.83333333%;
+  }
+  .col-lg-22 {
+    width: 91.66666667%;
+  }
+  .col-lg-21 {
+    width: 87.5%;
+  }
+  .col-lg-20 {
+    width: 83.33333333%;
+  }
+  .col-lg-19 {
+    width: 79.16666667%;
+  }
+  .col-lg-18 {
+    width: 75%;
+  }
+  .col-lg-17 {
+    width: 70.83333333%;
+  }
+  .col-lg-16 {
+    width: 66.66666667%;
+  }
+  .col-lg-15 {
+    width: 62.5%;
+  }
+  .col-lg-14 {
+    width: 58.33333333%;
+  }
+  .col-lg-13 {
+    width: 54.16666667%;
+  }
+  .col-lg-12 {
+    width: 50%;
+  }
+  .col-lg-11 {
+    width: 45.83333333%;
+  }
+  .col-lg-10 {
+    width: 41.66666667%;
+  }
+  .col-lg-9 {
+    width: 37.5%;
+  }
+  .col-lg-8 {
+    width: 33.33333333%;
+  }
+  .col-lg-7 {
+    width: 29.16666667%;
+  }
+  .col-lg-6 {
+    width: 25%;
+  }
+  .col-lg-5 {
+    width: 20.83333333%;
+  }
+  .col-lg-4 {
+    width: 16.66666667%;
+  }
+  .col-lg-3 {
+    width: 12.5%;
+  }
+  .col-lg-2 {
+    width: 8.33333333%;
+  }
+  .col-lg-1 {
+    width: 4.16666667%;
+  }
+  .col-lg-pull-24 {
+    right: 100%;
+  }
+  .col-lg-pull-23 {
+    right: 95.83333333%;
+  }
+  .col-lg-pull-22 {
+    right: 91.66666667%;
+  }
+  .col-lg-pull-21 {
+    right: 87.5%;
+  }
+  .col-lg-pull-20 {
+    right: 83.33333333%;
+  }
+  .col-lg-pull-19 {
+    right: 79.16666667%;
+  }
+  .col-lg-pull-18 {
+    right: 75%;
+  }
+  .col-lg-pull-17 {
+    right: 70.83333333%;
+  }
+  .col-lg-pull-16 {
+    right: 66.66666667%;
+  }
+  .col-lg-pull-15 {
+    right: 62.5%;
+  }
+  .col-lg-pull-14 {
+    right: 58.33333333%;
+  }
+  .col-lg-pull-13 {
+    right: 54.16666667%;
+  }
+  .col-lg-pull-12 {
+    right: 50%;
+  }
+  .col-lg-pull-11 {
+    right: 45.83333333%;
+  }
+  .col-lg-pull-10 {
+    right: 41.66666667%;
+  }
+  .col-lg-pull-9 {
+    right: 37.5%;
+  }
+  .col-lg-pull-8 {
+    right: 33.33333333%;
+  }
+  .col-lg-pull-7 {
+    right: 29.16666667%;
+  }
+  .col-lg-pull-6 {
+    right: 25%;
+  }
+  .col-lg-pull-5 {
+    right: 20.83333333%;
+  }
+  .col-lg-pull-4 {
+    right: 16.66666667%;
+  }
+  .col-lg-pull-3 {
+    right: 12.5%;
+  }
+  .col-lg-pull-2 {
+    right: 8.33333333%;
+  }
+  .col-lg-pull-1 {
+    right: 4.16666667%;
+  }
+  .col-lg-pull-0 {
+    right: auto;
+  }
+  .col-lg-push-24 {
+    left: 100%;
+  }
+  .col-lg-push-23 {
+    left: 95.83333333%;
+  }
+  .col-lg-push-22 {
+    left: 91.66666667%;
+  }
+  .col-lg-push-21 {
+    left: 87.5%;
+  }
+  .col-lg-push-20 {
+    left: 83.33333333%;
+  }
+  .col-lg-push-19 {
+    left: 79.16666667%;
+  }
+  .col-lg-push-18 {
+    left: 75%;
+  }
+  .col-lg-push-17 {
+    left: 70.83333333%;
+  }
+  .col-lg-push-16 {
+    left: 66.66666667%;
+  }
+  .col-lg-push-15 {
+    left: 62.5%;
+  }
+  .col-lg-push-14 {
+    left: 58.33333333%;
+  }
+  .col-lg-push-13 {
+    left: 54.16666667%;
+  }
+  .col-lg-push-12 {
+    left: 50%;
+  }
+  .col-lg-push-11 {
+    left: 45.83333333%;
+  }
+  .col-lg-push-10 {
+    left: 41.66666667%;
+  }
+  .col-lg-push-9 {
+    left: 37.5%;
+  }
+  .col-lg-push-8 {
+    left: 33.33333333%;
+  }
+  .col-lg-push-7 {
+    left: 29.16666667%;
+  }
+  .col-lg-push-6 {
+    left: 25%;
+  }
+  .col-lg-push-5 {
+    left: 20.83333333%;
+  }
+  .col-lg-push-4 {
+    left: 16.66666667%;
+  }
+  .col-lg-push-3 {
+    left: 12.5%;
+  }
+  .col-lg-push-2 {
+    left: 8.33333333%;
+  }
+  .col-lg-push-1 {
+    left: 4.16666667%;
+  }
+  .col-lg-push-0 {
+    left: auto;
+  }
+  .col-lg-offset-24 {
+    margin-left: 100%;
+  }
+  .col-lg-offset-23 {
+    margin-left: 95.83333333%;
+  }
+  .col-lg-offset-22 {
+    margin-left: 91.66666667%;
+  }
+  .col-lg-offset-21 {
+    margin-left: 87.5%;
+  }
+  .col-lg-offset-20 {
+    margin-left: 83.33333333%;
+  }
+  .col-lg-offset-19 {
+    margin-left: 79.16666667%;
+  }
+  .col-lg-offset-18 {
+    margin-left: 75%;
+  }
+  .col-lg-offset-17 {
+    margin-left: 70.83333333%;
+  }
+  .col-lg-offset-16 {
+    margin-left: 66.66666667%;
+  }
+  .col-lg-offset-15 {
+    margin-left: 62.5%;
+  }
+  .col-lg-offset-14 {
+    margin-left: 58.33333333%;
+  }
+  .col-lg-offset-13 {
+    margin-left: 54.16666667%;
+  }
+  .col-lg-offset-12 {
+    margin-left: 50%;
+  }
+  .col-lg-offset-11 {
+    margin-left: 45.83333333%;
+  }
+  .col-lg-offset-10 {
+    margin-left: 41.66666667%;
+  }
+  .col-lg-offset-9 {
+    margin-left: 37.5%;
+  }
+  .col-lg-offset-8 {
+    margin-left: 33.33333333%;
+  }
+  .col-lg-offset-7 {
+    margin-left: 29.16666667%;
+  }
+  .col-lg-offset-6 {
+    margin-left: 25%;
+  }
+  .col-lg-offset-5 {
+    margin-left: 20.83333333%;
+  }
+  .col-lg-offset-4 {
+    margin-left: 16.66666667%;
+  }
+  .col-lg-offset-3 {
+    margin-left: 12.5%;
+  }
+  .col-lg-offset-2 {
+    margin-left: 8.33333333%;
+  }
+  .col-lg-offset-1 {
+    margin-left: 4.16666667%;
+  }
+  .col-lg-offset-0 {
+    margin-left: 0%;
+  }
+}
+
+/*
+  X-Large display >= 1800px
+ */
+@media (min-width: 1800px) {
+  .container {
+    width: 1760px;
+  }
+}
+.col-xlg-1, .col-xlg-2, .col-xlg-3, .col-xlg-4, .col-xlg-5, .col-xlg-6, .col-xlg-7, .col-xlg-8, .col-xlg-9, .col-xlg-10, .col-xlg-11, .col-xlg-12, .col-xlg-13, .col-xlg-14, .col-xlg-15, .col-xlg-16, .col-xlg-17, .col-xlg-18, .col-xlg-19, .col-xlg-20, .col-xlg-21, .col-xlg-22, .col-xlg-23, .col-xlg-24 {
   position: relative;
   min-height: 1px;
   padding-right: 15px;
   padding-left: 15px;
 }
-.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
-  float: left;
-}
-.col-xs-12 {
-  width: 100%;
-}
-.col-xs-11 {
-  width: 91.66666667%;
-}
-.col-xs-10 {
-  width: 83.33333333%;
-}
-.col-xs-9 {
-  width: 75%;
-}
-.col-xs-8 {
-  width: 66.66666667%;
-}
-.col-xs-7 {
-  width: 58.33333333%;
-}
-.col-xs-6 {
-  width: 50%;
-}
-.col-xs-5 {
-  width: 41.66666667%;
-}
-.col-xs-4 {
-  width: 33.33333333%;
-}
-.col-xs-3 {
-  width: 25%;
-}
-.col-xs-2 {
-  width: 16.66666667%;
-}
-.col-xs-1 {
-  width: 8.33333333%;
-}
-.col-xs-pull-12 {
-  right: 100%;
-}
-.col-xs-pull-11 {
-  right: 91.66666667%;
-}
-.col-xs-pull-10 {
-  right: 83.33333333%;
-}
-.col-xs-pull-9 {
-  right: 75%;
-}
-.col-xs-pull-8 {
-  right: 66.66666667%;
-}
-.col-xs-pull-7 {
-  right: 58.33333333%;
-}
-.col-xs-pull-6 {
-  right: 50%;
-}
-.col-xs-pull-5 {
-  right: 41.66666667%;
-}
-.col-xs-pull-4 {
-  right: 33.33333333%;
-}
-.col-xs-pull-3 {
-  right: 25%;
-}
-.col-xs-pull-2 {
-  right: 16.66666667%;
-}
-.col-xs-pull-1 {
-  right: 8.33333333%;
-}
-.col-xs-pull-0 {
-  right: 0;
-}
-.col-xs-push-12 {
-  left: 100%;
-}
-.col-xs-push-11 {
-  left: 91.66666667%;
-}
-.col-xs-push-10 {
-  left: 83.33333333%;
-}
-.col-xs-push-9 {
-  left: 75%;
-}
-.col-xs-push-8 {
-  left: 66.66666667%;
-}
-.col-xs-push-7 {
-  left: 58.33333333%;
-}
-.col-xs-push-6 {
-  left: 50%;
-}
-.col-xs-push-5 {
-  left: 41.66666667%;
-}
-.col-xs-push-4 {
-  left: 33.33333333%;
-}
-.col-xs-push-3 {
-  left: 25%;
-}
-.col-xs-push-2 {
-  left: 16.66666667%;
-}
-.col-xs-push-1 {
-  left: 8.33333333%;
-}
-.col-xs-push-0 {
-  left: 0;
-}
-.col-xs-offset-12 {
-  margin-left: 100%;
-}
-.col-xs-offset-11 {
-  margin-left: 91.66666667%;
-}
-.col-xs-offset-10 {
-  margin-left: 83.33333333%;
-}
-.col-xs-offset-9 {
-  margin-left: 75%;
-}
-.col-xs-offset-8 {
-  margin-left: 66.66666667%;
-}
-.col-xs-offset-7 {
-  margin-left: 58.33333333%;
-}
-.col-xs-offset-6 {
-  margin-left: 50%;
-}
-.col-xs-offset-5 {
-  margin-left: 41.66666667%;
-}
-.col-xs-offset-4 {
-  margin-left: 33.33333333%;
-}
-.col-xs-offset-3 {
-  margin-left: 25%;
-}
-.col-xs-offset-2 {
-  margin-left: 16.66666667%;
-}
-.col-xs-offset-1 {
-  margin-left: 8.33333333%;
-}
-.col-xs-offset-0 {
-  margin-left: 0;
-}
-@media (min-width: 768px) {
-  .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
+@media (min-width: 1800px) {
+  .col-xlg-1, .col-xlg-2, .col-xlg-3, .col-xlg-4, .col-xlg-5, .col-xlg-6, .col-xlg-7, .col-xlg-8, .col-xlg-9, .col-xlg-10, .col-xlg-11, .col-xlg-12, .col-xlg-13, .col-xlg-14, .col-xlg-15, .col-xlg-16, .col-xlg-17, .col-xlg-18, .col-xlg-19, .col-xlg-20, .col-xlg-21, .col-xlg-22, .col-xlg-23, .col-xlg-24 {
     float: left;
   }
-  .col-sm-12 {
+  .col-xlg-24 {
     width: 100%;
   }
-  .col-sm-11 {
+  .col-xlg-23 {
+    width: 95.83333333%;
+  }
+  .col-xlg-22 {
     width: 91.66666667%;
   }
-  .col-sm-10 {
+  .col-xlg-21 {
+    width: 87.5%;
+  }
+  .col-xlg-20 {
     width: 83.33333333%;
   }
-  .col-sm-9 {
+  .col-xlg-19 {
+    width: 79.16666667%;
+  }
+  .col-xlg-18 {
     width: 75%;
   }
-  .col-sm-8 {
+  .col-xlg-17 {
+    width: 70.83333333%;
+  }
+  .col-xlg-16 {
     width: 66.66666667%;
   }
-  .col-sm-7 {
+  .col-xlg-15 {
+    width: 62.5%;
+  }
+  .col-xlg-14 {
     width: 58.33333333%;
   }
-  .col-sm-6 {
+  .col-xlg-13 {
+    width: 54.16666667%;
+  }
+  .col-xlg-12 {
     width: 50%;
   }
-  .col-sm-5 {
+  .col-xlg-11 {
+    width: 45.83333333%;
+  }
+  .col-xlg-10 {
     width: 41.66666667%;
   }
-  .col-sm-4 {
+  .col-xlg-9 {
+    width: 37.5%;
+  }
+  .col-xlg-8 {
     width: 33.33333333%;
   }
-  .col-sm-3 {
+  .col-xlg-7 {
+    width: 29.16666667%;
+  }
+  .col-xlg-6 {
     width: 25%;
   }
-  .col-sm-2 {
+  .col-xlg-5 {
+    width: 20.83333333%;
+  }
+  .col-xlg-4 {
     width: 16.66666667%;
   }
-  .col-sm-1 {
+  .col-xlg-3 {
+    width: 12.5%;
+  }
+  .col-xlg-2 {
     width: 8.33333333%;
   }
-  .col-sm-pull-12 {
+  .col-xlg-1 {
+    width: 4.16666667%;
+  }
+  .col-xlg-pull-24 {
     right: 100%;
   }
-  .col-sm-pull-11 {
+  .col-xlg-pull-23 {
+    right: 95.83333333%;
+  }
+  .col-xlg-pull-22 {
     right: 91.66666667%;
   }
-  .col-sm-pull-10 {
+  .col-xlg-pull-21 {
+    right: 87.5%;
+  }
+  .col-xlg-pull-20 {
     right: 83.33333333%;
   }
-  .col-sm-pull-9 {
+  .col-xlg-pull-19 {
+    right: 79.16666667%;
+  }
+  .col-xlg-pull-18 {
     right: 75%;
   }
-  .col-sm-pull-8 {
+  .col-xlg-pull-17 {
+    right: 70.83333333%;
+  }
+  .col-xlg-pull-16 {
     right: 66.66666667%;
   }
-  .col-sm-pull-7 {
+  .col-xlg-pull-15 {
+    right: 62.5%;
+  }
+  .col-xlg-pull-14 {
     right: 58.33333333%;
   }
-  .col-sm-pull-6 {
+  .col-xlg-pull-13 {
+    right: 54.16666667%;
+  }
+  .col-xlg-pull-12 {
     right: 50%;
   }
-  .col-sm-pull-5 {
+  .col-xlg-pull-11 {
+    right: 45.83333333%;
+  }
+  .col-xlg-pull-10 {
     right: 41.66666667%;
   }
-  .col-sm-pull-4 {
+  .col-xlg-pull-9 {
+    right: 37.5%;
+  }
+  .col-xlg-pull-8 {
     right: 33.33333333%;
   }
-  .col-sm-pull-3 {
+  .col-xlg-pull-7 {
+    right: 29.16666667%;
+  }
+  .col-xlg-pull-6 {
     right: 25%;
   }
-  .col-sm-pull-2 {
+  .col-xlg-pull-5 {
+    right: 20.83333333%;
+  }
+  .col-xlg-pull-4 {
     right: 16.66666667%;
   }
-  .col-sm-pull-1 {
+  .col-xlg-pull-3 {
+    right: 12.5%;
+  }
+  .col-xlg-pull-2 {
     right: 8.33333333%;
   }
-  .col-sm-pull-0 {
-    right: 0;
+  .col-xlg-pull-1 {
+    right: 4.16666667%;
   }
-  .col-sm-push-12 {
+  .col-xlg-pull-0 {
+    right: auto;
+  }
+  .col-xlg-push-24 {
     left: 100%;
   }
-  .col-sm-push-11 {
+  .col-xlg-push-23 {
+    left: 95.83333333%;
+  }
+  .col-xlg-push-22 {
     left: 91.66666667%;
   }
-  .col-sm-push-10 {
+  .col-xlg-push-21 {
+    left: 87.5%;
+  }
+  .col-xlg-push-20 {
     left: 83.33333333%;
   }
-  .col-sm-push-9 {
+  .col-xlg-push-19 {
+    left: 79.16666667%;
+  }
+  .col-xlg-push-18 {
     left: 75%;
   }
-  .col-sm-push-8 {
+  .col-xlg-push-17 {
+    left: 70.83333333%;
+  }
+  .col-xlg-push-16 {
     left: 66.66666667%;
   }
-  .col-sm-push-7 {
+  .col-xlg-push-15 {
+    left: 62.5%;
+  }
+  .col-xlg-push-14 {
     left: 58.33333333%;
   }
-  .col-sm-push-6 {
+  .col-xlg-push-13 {
+    left: 54.16666667%;
+  }
+  .col-xlg-push-12 {
     left: 50%;
   }
-  .col-sm-push-5 {
+  .col-xlg-push-11 {
+    left: 45.83333333%;
+  }
+  .col-xlg-push-10 {
     left: 41.66666667%;
   }
-  .col-sm-push-4 {
+  .col-xlg-push-9 {
+    left: 37.5%;
+  }
+  .col-xlg-push-8 {
     left: 33.33333333%;
   }
-  .col-sm-push-3 {
+  .col-xlg-push-7 {
+    left: 29.16666667%;
+  }
+  .col-xlg-push-6 {
     left: 25%;
   }
-  .col-sm-push-2 {
+  .col-xlg-push-5 {
+    left: 20.83333333%;
+  }
+  .col-xlg-push-4 {
     left: 16.66666667%;
   }
-  .col-sm-push-1 {
+  .col-xlg-push-3 {
+    left: 12.5%;
+  }
+  .col-xlg-push-2 {
     left: 8.33333333%;
   }
-  .col-sm-push-0 {
-    left: 0;
+  .col-xlg-push-1 {
+    left: 4.16666667%;
   }
-  .col-sm-offset-12 {
+  .col-xlg-push-0 {
+    left: auto;
+  }
+  .col-xlg-offset-24 {
     margin-left: 100%;
   }
-  .col-sm-offset-11 {
+  .col-xlg-offset-23 {
+    margin-left: 95.83333333%;
+  }
+  .col-xlg-offset-22 {
     margin-left: 91.66666667%;
   }
-  .col-sm-offset-10 {
+  .col-xlg-offset-21 {
+    margin-left: 87.5%;
+  }
+  .col-xlg-offset-20 {
     margin-left: 83.33333333%;
   }
-  .col-sm-offset-9 {
+  .col-xlg-offset-19 {
+    margin-left: 79.16666667%;
+  }
+  .col-xlg-offset-18 {
     margin-left: 75%;
   }
-  .col-sm-offset-8 {
+  .col-xlg-offset-17 {
+    margin-left: 70.83333333%;
+  }
+  .col-xlg-offset-16 {
     margin-left: 66.66666667%;
   }
-  .col-sm-offset-7 {
+  .col-xlg-offset-15 {
+    margin-left: 62.5%;
+  }
+  .col-xlg-offset-14 {
     margin-left: 58.33333333%;
   }
-  .col-sm-offset-6 {
+  .col-xlg-offset-13 {
+    margin-left: 54.16666667%;
+  }
+  .col-xlg-offset-12 {
     margin-left: 50%;
   }
-  .col-sm-offset-5 {
+  .col-xlg-offset-11 {
+    margin-left: 45.83333333%;
+  }
+  .col-xlg-offset-10 {
     margin-left: 41.66666667%;
   }
-  .col-sm-offset-4 {
+  .col-xlg-offset-9 {
+    margin-left: 37.5%;
+  }
+  .col-xlg-offset-8 {
     margin-left: 33.33333333%;
   }
-  .col-sm-offset-3 {
+  .col-xlg-offset-7 {
+    margin-left: 29.16666667%;
+  }
+  .col-xlg-offset-6 {
     margin-left: 25%;
   }
-  .col-sm-offset-2 {
+  .col-xlg-offset-5 {
+    margin-left: 20.83333333%;
+  }
+  .col-xlg-offset-4 {
     margin-left: 16.66666667%;
   }
-  .col-sm-offset-1 {
+  .col-xlg-offset-3 {
+    margin-left: 12.5%;
+  }
+  .col-xlg-offset-2 {
     margin-left: 8.33333333%;
   }
-  .col-sm-offset-0 {
-    margin-left: 0;
-  }
-}
-@media (min-width: 992px) {
-  .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
-    float: left;
-  }
-  .col-md-12 {
-    width: 100%;
-  }
-  .col-md-11 {
-    width: 91.66666667%;
-  }
-  .col-md-10 {
-    width: 83.33333333%;
-  }
-  .col-md-9 {
-    width: 75%;
-  }
-  .col-md-8 {
-    width: 66.66666667%;
-  }
-  .col-md-7 {
-    width: 58.33333333%;
-  }
-  .col-md-6 {
-    width: 50%;
-  }
-  .col-md-5 {
-    width: 41.66666667%;
-  }
-  .col-md-4 {
-    width: 33.33333333%;
-  }
-  .col-md-3 {
-    width: 25%;
-  }
-  .col-md-2 {
-    width: 16.66666667%;
-  }
-  .col-md-1 {
-    width: 8.33333333%;
-  }
-  .col-md-pull-12 {
-    right: 100%;
-  }
-  .col-md-pull-11 {
-    right: 91.66666667%;
-  }
-  .col-md-pull-10 {
-    right: 83.33333333%;
-  }
-  .col-md-pull-9 {
-    right: 75%;
-  }
-  .col-md-pull-8 {
-    right: 66.66666667%;
-  }
-  .col-md-pull-7 {
-    right: 58.33333333%;
-  }
-  .col-md-pull-6 {
-    right: 50%;
-  }
-  .col-md-pull-5 {
-    right: 41.66666667%;
-  }
-  .col-md-pull-4 {
-    right: 33.33333333%;
-  }
-  .col-md-pull-3 {
-    right: 25%;
-  }
-  .col-md-pull-2 {
-    right: 16.66666667%;
-  }
-  .col-md-pull-1 {
-    right: 8.33333333%;
-  }
-  .col-md-pull-0 {
-    right: 0;
-  }
-  .col-md-push-12 {
-    left: 100%;
-  }
-  .col-md-push-11 {
-    left: 91.66666667%;
-  }
-  .col-md-push-10 {
-    left: 83.33333333%;
-  }
-  .col-md-push-9 {
-    left: 75%;
-  }
-  .col-md-push-8 {
-    left: 66.66666667%;
-  }
-  .col-md-push-7 {
-    left: 58.33333333%;
-  }
-  .col-md-push-6 {
-    left: 50%;
-  }
-  .col-md-push-5 {
-    left: 41.66666667%;
-  }
-  .col-md-push-4 {
-    left: 33.33333333%;
-  }
-  .col-md-push-3 {
-    left: 25%;
-  }
-  .col-md-push-2 {
-    left: 16.66666667%;
-  }
-  .col-md-push-1 {
-    left: 8.33333333%;
-  }
-  .col-md-push-0 {
-    left: 0;
-  }
-  .col-md-offset-12 {
-    margin-left: 100%;
-  }
-  .col-md-offset-11 {
-    margin-left: 91.66666667%;
-  }
-  .col-md-offset-10 {
-    margin-left: 83.33333333%;
-  }
-  .col-md-offset-9 {
-    margin-left: 75%;
-  }
-  .col-md-offset-8 {
-    margin-left: 66.66666667%;
-  }
-  .col-md-offset-7 {
-    margin-left: 58.33333333%;
-  }
-  .col-md-offset-6 {
-    margin-left: 50%;
-  }
-  .col-md-offset-5 {
-    margin-left: 41.66666667%;
-  }
-  .col-md-offset-4 {
-    margin-left: 33.33333333%;
-  }
-  .col-md-offset-3 {
-    margin-left: 25%;
-  }
-  .col-md-offset-2 {
-    margin-left: 16.66666667%;
-  }
-  .col-md-offset-1 {
-    margin-left: 8.33333333%;
-  }
-  .col-md-offset-0 {
-    margin-left: 0;
-  }
-}
-@media (min-width: 1200px) {
-  .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12 {
-    float: left;
-  }
-  .col-lg-12 {
-    width: 100%;
-  }
-  .col-lg-11 {
-    width: 91.66666667%;
-  }
-  .col-lg-10 {
-    width: 83.33333333%;
-  }
-  .col-lg-9 {
-    width: 75%;
-  }
-  .col-lg-8 {
-    width: 66.66666667%;
-  }
-  .col-lg-7 {
-    width: 58.33333333%;
-  }
-  .col-lg-6 {
-    width: 50%;
-  }
-  .col-lg-5 {
-    width: 41.66666667%;
-  }
-  .col-lg-4 {
-    width: 33.33333333%;
-  }
-  .col-lg-3 {
-    width: 25%;
-  }
-  .col-lg-2 {
-    width: 16.66666667%;
-  }
-  .col-lg-1 {
-    width: 8.33333333%;
-  }
-  .col-lg-pull-12 {
-    right: 100%;
-  }
-  .col-lg-pull-11 {
-    right: 91.66666667%;
-  }
-  .col-lg-pull-10 {
-    right: 83.33333333%;
-  }
-  .col-lg-pull-9 {
-    right: 75%;
-  }
-  .col-lg-pull-8 {
-    right: 66.66666667%;
-  }
-  .col-lg-pull-7 {
-    right: 58.33333333%;
-  }
-  .col-lg-pull-6 {
-    right: 50%;
-  }
-  .col-lg-pull-5 {
-    right: 41.66666667%;
-  }
-  .col-lg-pull-4 {
-    right: 33.33333333%;
-  }
-  .col-lg-pull-3 {
-    right: 25%;
-  }
-  .col-lg-pull-2 {
-    right: 16.66666667%;
-  }
-  .col-lg-pull-1 {
-    right: 8.33333333%;
-  }
-  .col-lg-pull-0 {
-    right: 0;
-  }
-  .col-lg-push-12 {
-    left: 100%;
-  }
-  .col-lg-push-11 {
-    left: 91.66666667%;
-  }
-  .col-lg-push-10 {
-    left: 83.33333333%;
-  }
-  .col-lg-push-9 {
-    left: 75%;
-  }
-  .col-lg-push-8 {
-    left: 66.66666667%;
-  }
-  .col-lg-push-7 {
-    left: 58.33333333%;
-  }
-  .col-lg-push-6 {
-    left: 50%;
-  }
-  .col-lg-push-5 {
-    left: 41.66666667%;
-  }
-  .col-lg-push-4 {
-    left: 33.33333333%;
-  }
-  .col-lg-push-3 {
-    left: 25%;
-  }
-  .col-lg-push-2 {
-    left: 16.66666667%;
-  }
-  .col-lg-push-1 {
-    left: 8.33333333%;
-  }
-  .col-lg-push-0 {
-    left: 0;
-  }
-  .col-lg-offset-12 {
-    margin-left: 100%;
-  }
-  .col-lg-offset-11 {
-    margin-left: 91.66666667%;
-  }
-  .col-lg-offset-10 {
-    margin-left: 83.33333333%;
-  }
-  .col-lg-offset-9 {
-    margin-left: 75%;
-  }
-  .col-lg-offset-8 {
-    margin-left: 66.66666667%;
-  }
-  .col-lg-offset-7 {
-    margin-left: 58.33333333%;
-  }
-  .col-lg-offset-6 {
-    margin-left: 50%;
-  }
-  .col-lg-offset-5 {
-    margin-left: 41.66666667%;
-  }
-  .col-lg-offset-4 {
-    margin-left: 33.33333333%;
-  }
-  .col-lg-offset-3 {
-    margin-left: 25%;
-  }
-  .col-lg-offset-2 {
-    margin-left: 16.66666667%;
-  }
-  .col-lg-offset-1 {
-    margin-left: 8.33333333%;
-  }
-  .col-lg-offset-0 {
-    margin-left: 0;
+  .col-xlg-offset-1 {
+    margin-left: 4.16666667%;
+  }
+  .col-xlg-offset-0 {
+    margin-left: 0%;
   }
 }
 
@@ -798,4 +1703,52 @@
   .hidden-print {
     display: none !important;
   }
+}
+
+.clearfix:before,
+.clearfix:after,
+.container:before,
+.container:after,
+.container-fluid:before,
+.container-fluid:after,
+.row:before,
+.row:after,
+.form-horizontal .form-group:before,
+.form-horizontal .form-group:after,
+.btn-toolbar:before,
+.btn-toolbar:after,
+.btn-group-vertical > .btn-group:before,
+.btn-group-vertical > .btn-group:after,
+.nav:before,
+.nav:after,
+.navbar:before,
+.navbar:after,
+.navbar-header:before,
+.navbar-header:after,
+.navbar-collapse:before,
+.navbar-collapse:after,
+.pager:before,
+.pager:after,
+.panel-body:before,
+.panel-body:after,
+.modal-footer:before,
+.modal-footer:after {
+  display: table;
+  content: " ";
+}
+.clearfix:after,
+.container:after,
+.container-fluid:after,
+.row:after,
+.form-horizontal .form-group:after,
+.btn-toolbar:after,
+.btn-group-vertical > .btn-group:after,
+.nav:after,
+.navbar:after,
+.navbar-header:after,
+.navbar-collapse:after,
+.pager:after,
+.panel-body:after,
+.modal-footer:after {
+  clear: both;
 }

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -81,7 +81,7 @@ body {
   margin-bottom: 20px;
 }
 
-#side-panel-content .pane {
+#side-panel-content .pane-frame {
   margin-bottom: 15px;
 }
 
@@ -409,56 +409,68 @@ div.dashboard {
   clear:both;
 }
 
-.pane  {
-  margin-top: 4px;
-  white-space: nowrap;
+/* pane */
+
+.pane-header, .pane-footer {
+  padding: 8px 0px;
+  background-color: #eee;
+  border: solid 1px #e0e0e0;
+  color: #3b3b3b;
 }
+.pane-header {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+.pane-footer {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
 .pane td {
   padding: 4px 4px 3px 4px;
+  vertical-align: middle;
 }
 
 table.pane {
   width: 100%;
   border-collapse: collapse;
-  border: 1px #bbb solid;
-}
-table.pane > tbody > tr > td:last-child {
-  border-right: 1px #bbb solid;
 }
 
 td.pane {
-  border: 1px #bbb solid;
   padding: 3px 4px 3px 4px;
   vertical-align: middle;
 }
 
-td.pane-header {
-  border: 1px #bbb solid;
-  border-right: none;
-  border-left: none;
-  background-color: #f0f0f0;
+table.pane.stripped tr:nth-child(even) {
+  background: #f7f7f7;
+}
+
+div.pane-header {
   font-weight: bold;
   padding-right: 24px;
 }
 
-td.pane-header > div {
-  position: relative;
-  padding-right: 24px;
-  width: 100%;
-  height: 100%;
-}
-
-td.pane-header > div > a.collapse {
+div.pane-header .collapse {
 	float: right;
-	position: absolute;
-	right: 4px;
-	top: -1px;
+  margin-left: 3px;
 }
 
 th.pane {
-  border: 1px #bbb solid;
   font-weight: bold;
 }
+
+/* executors */
+
+#executors th.pane {
+  text-align: left;
+  padding: 12px 5px 5px 5px;
+}
+
+#executors th.pane a {
+  text-decoration: none;
+}
+
+/* bigtable */
 
 .bigtable tr {
   border: 1px solid #bbb;
@@ -811,9 +823,19 @@ table.parameters > tbody:hover {
     padding: 0;
 }
 
-#buildHistory td.desc {
-    padding: 0;
-    white-space: normal;
+#buildHistory .desc {
+  padding: 0;
+  margin-top: 5px;
+  white-space: normal;
+  max-width: 200px;
+}
+
+#buildHistory .build-rss-links {
+  float: right;
+}
+
+#buildHistory .build-name {
+  max-width: 120px;
 }
 
 /* ========================= editable combobox style ========================= */

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1568,14 +1568,21 @@ function updateBuildHistory(ajaxUrl,nBuild) {
             if (bh.headers == null) {
                 // Yahoo.log("Missing headers in buildHistory element");
             }
+
+            function getDataTable(buildHistoryDiv) {
+                return $(buildHistoryDiv).getElementsBySelector('table.pane')[0];
+            }
+
             new Ajax.Request(ajaxUrl, {
                 requestHeaders: bh.headers,
                 onSuccess: function(rsp) {
-                    var rows = bh.rows;
+                    var dataTable = getDataTable(bh);
+                    var rows = dataTable.rows;
 
                     //delete rows with transitive data
-                    while (rows.length > 2 && Element.hasClassName(rows[1], "transitive"))
-                        Element.remove(rows[1]);
+                    while (rows.length > 0 && Element.hasClassName(rows[0], "transitive")) {
+                        Element.remove(rows[0]);
+                    }
 
                     // insert new rows
                     var div = document.createElement('div');
@@ -1583,9 +1590,16 @@ function updateBuildHistory(ajaxUrl,nBuild) {
                     Behaviour.applySubtree(div);
 
                     var pivot = rows[0];
-                    var newRows = $(div).firstDescendant().rows;
-                    for (var i = newRows.length - 1; i >= 0; i--) {
-                        pivot.parentNode.insertBefore(newRows[i], pivot.nextSibling);
+                    var newRows = getDataTable(div).rows;
+                    while (newRows.length > 0) {
+                        if (pivot !== undefined) {
+                            // The data table has rows.  Insert before a "pivot" row (first row).
+                            pivot.parentNode.insertBefore(newRows[0], pivot);
+                        } else {
+                            // The data table has no rows.  In this case, we just add all new rows directly to the
+                            // table, one after the other i.e. we don't insert before a "pivot" row (first row).
+                            dataTable.appendChild(newRows[0]);
+                        }
                     }
 
                     // next update


### PR DESCRIPTION
This PR changes how `<l:pane>` renders.

The table (containing the "data") is now wrapped in a `<div>`.  The pane title/header is now done using a `<div>` and the `<l:pane>` tag now also supports a "footer" attribute, which works similar to the "title" attribute (i.e. can receive markup).

`<l:pane>` can now also take a "class" attribute which gets mapped onto the inner data table and can be used to apply styles.
