### PR TITLE
[WIP] JENKINS-23786: Permit the Shell plugin to set a build result as unstable via a return code

### DIFF
--- a/core/src/main/java/hudson/tasks/BatchFile.java
+++ b/core/src/main/java/hudson/tasks/BatchFile.java
@@ -37,9 +37,16 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 public class BatchFile extends CommandInterpreter {
     @DataBoundConstructor
-    public BatchFile(String command) {
+    public BatchFile(String command, Integer unstableReturn) {
         super(command);
+        this.unstableReturn = unstableReturn;
     }
+
+    public BatchFile(String command) {
+        this(command, null);
+    }
+
+    private final Integer unstableReturn;
 
     public String[] buildCommandLine(FilePath script) {
         return new String[] {"cmd","/c","call",script.getRemote()};
@@ -51,6 +58,10 @@ public class BatchFile extends CommandInterpreter {
 
     protected String getFileExtension() {
         return ".bat";
+    }
+
+    public final Integer getUnstableReturn() {
+        return unstableReturn;
     }
 
     @Extension
@@ -66,7 +77,13 @@ public class BatchFile extends CommandInterpreter {
 
         @Override
         public Builder newInstance(StaplerRequest req, JSONObject data) {
-            return new BatchFile(data.getString("command"));
+            final String unstableReturnStr = data.getString("unstableReturn");
+            Integer unstableReturn = null;
+            if (unstableReturnStr != null && ! unstableReturnStr.isEmpty()) {
+                /* Already validated by f.number in the form */
+                unstableReturn = (Integer)Integer.parseInt(unstableReturnStr, 10);
+            }
+            return new BatchFile(data.getString("command"), unstableReturn);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {

--- a/core/src/main/resources/hudson/tasks/BatchFile/config.jelly
+++ b/core/src/main/resources/hudson/tasks/BatchFile/config.jelly
@@ -25,7 +25,13 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Command}"
-           description="${%description(rootURL)}">
+           description="${%command_description(rootURL)}">
     <f:textarea name="command" value="${instance.command}" class="fixed-width" />
   </f:entry>
+  <f:advanced>
+    <f:entry title="errorlevel to set build unstable"
+             description="${%unstableReturn_description(rootURL)}">
+      <f:number clazz="positive-number" name="unstableReturn" value="${instance.unstableReturn}" min="1" max="255" step="1" />
+    </f:entry>
+  </f:advanced>
 </j:jelly>

--- a/core/src/main/resources/hudson/tasks/BatchFile/config.properties
+++ b/core/src/main/resources/hudson/tasks/BatchFile/config.properties
@@ -20,4 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-description=See <a href="{0}/env-vars.html" target=_new>the list of available environment variables</a>
+command_description=See <a href="{0}/env-vars.html" target=_new>the list of available environment variables</a>
+unstableReturn_description=If set, the batch errorlevel result that will be interpreted as an unstable build result.

--- a/core/src/main/resources/hudson/tasks/Shell/config.groovy
+++ b/core/src/main/resources/hudson/tasks/Shell/config.groovy
@@ -28,3 +28,11 @@ f.entry(title:_("Command"),description:_("description",rootURL)) {
     // TODO JENKINS-23151 'codemirror-mode': 'shell' is broken
     f.textarea(name: "command", value: instance?.command, class: "fixed-width")
 }
+
+f.advanced() {
+
+    f.entry(title:_("Return code to set build unstable"), description:_("If set, the script return code that will be interpreted as an unstable build result.")) {
+        f.number(name: "unstableReturn", value: instance?.unstableReturn, min:1, max:255, step:1)
+    }
+
+}

--- a/test/src/test/java/hudson/tasks/BatchFileTest.java
+++ b/test/src/test/java/hudson/tasks/BatchFileTest.java
@@ -1,0 +1,89 @@
+package hudson.tasks;
+
+import static org.junit.Assume.assumeTrue;
+
+import hudson.Functions;
+import hudson.Launcher.ProcStarter;
+import hudson.Proc;
+import hudson.model.Result;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import org.apache.commons.io.FileUtils;
+import org.jvnet.hudson.test.FakeLauncher;
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.PretendSlave;
+import org.jvnet.hudson.test.Issue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+
+public class BatchFileTest extends HudsonTestCase {
+
+    /* A FakeLauncher that just returns the specified error code */
+    private class ReturnCodeFakeLauncher implements FakeLauncher {
+        final int code;
+
+        ReturnCodeFakeLauncher(int code)
+        {
+            super();
+            this.code = code;
+        }
+
+        @Override
+        public Proc onLaunch(ProcStarter p) throws IOException {
+            return new FinishedProc(this.code);
+        }
+    }
+
+    @Issue("JENKINS-23786")
+    public void testUnstableReturn() throws Exception {
+        if(!Functions.isWindows())
+            return;
+
+        PretendSlave returns2 = createPretendSlave(new ReturnCodeFakeLauncher(2));
+        PretendSlave returns1 = createPretendSlave(new ReturnCodeFakeLauncher(1));
+        PretendSlave returns0 = createPretendSlave(new ReturnCodeFakeLauncher(0));
+
+        FreeStyleProject p;
+        FreeStyleBuild b;
+
+        /* Unstable=2, error codes 0/1/2 */
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new BatchFile("", 2));
+        p.setAssignedNode(returns2);
+        b = assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
+
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new BatchFile("", 2));
+        p.setAssignedNode(returns1);
+        b = assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new BatchFile("", 2));
+        p.setAssignedNode(returns0);
+        b = assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
+
+        /* unstable=null, error codes 0/1/2 */
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new BatchFile("", null));
+        p.setAssignedNode(returns2);
+        b = assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new BatchFile("", null));
+        p.setAssignedNode(returns1);
+        b = assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new BatchFile("", null));
+        p.setAssignedNode(returns0);
+        b = assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
+
+        /* Creating unstable=0 produces unstable=null */
+        assertNull( new BatchFile("",0).getUnstableReturn() );
+
+    }
+
+}

--- a/test/src/test/java/hudson/tasks/ShellTest.java
+++ b/test/src/test/java/hudson/tasks/ShellTest.java
@@ -1,14 +1,18 @@
 package hudson.tasks;
 
+import static org.junit.Assume.assumeTrue;
+
 import hudson.Functions;
 import hudson.Launcher.ProcStarter;
 import hudson.Proc;
+import hudson.model.Result;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import org.apache.commons.io.FileUtils;
 import org.jvnet.hudson.test.FakeLauncher;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.PretendSlave;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,9 +23,10 @@ import java.util.List;
  * @author Kohsuke Kawaguchi
  */
 public class ShellTest extends HudsonTestCase {
+
     public void testBasic() throws Exception {
         // If we're on Windows, don't bother doing this.
-        if (Functions.isWindows())
+        if(Functions.isWindows())
             return;
 
         // TODO: define a FakeLauncher implementation with easymock so that this kind of assertions can be simplified.
@@ -50,4 +55,71 @@ public class ShellTest extends HudsonTestCase {
         assertEquals(1,s.numLaunch);
         assertTrue(FileUtils.readFileToString(b.getLogFile()).contains("Hudson was here"));
     }
+
+    /* A FakeLauncher that just returns the specified error code */
+    private class ReturnCodeFakeLauncher implements FakeLauncher {
+        final int code;
+
+        ReturnCodeFakeLauncher(int code)
+        {
+            super();
+            this.code = code;
+        }
+
+        @Override
+        public Proc onLaunch(ProcStarter p) throws IOException {
+            return new FinishedProc(this.code);
+        }
+    }
+
+    @Issue("JENKINS-23786")
+    public void testUnstableReturn() throws Exception {
+        if(Functions.isWindows())
+            return;
+
+        PretendSlave returns2 = createPretendSlave(new ReturnCodeFakeLauncher(2));
+        PretendSlave returns1 = createPretendSlave(new ReturnCodeFakeLauncher(1));
+        PretendSlave returns0 = createPretendSlave(new ReturnCodeFakeLauncher(0));
+
+        FreeStyleProject p;
+        FreeStyleBuild b;
+
+        /* Unstable=2, error codes 0/1/2 */
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new Shell("", 2));
+        p.setAssignedNode(returns2);
+        b = assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
+
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new Shell("", 2));
+        p.setAssignedNode(returns1);
+        b = assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new Shell("", 2));
+        p.setAssignedNode(returns0);
+        b = assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
+
+        /* unstable=null, error codes 0/1/2 */
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new Shell("", null));
+        p.setAssignedNode(returns2);
+        b = assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new Shell("", null));
+        p.setAssignedNode(returns1);
+        b = assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+
+        p = createFreeStyleProject();
+        p.getBuildersList().add(new Shell("", null));
+        p.setAssignedNode(returns0);
+        b = assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
+
+        /* Creating unstable=0 produces unstable=null */
+        assertNull( new Shell("",0).getUnstableReturn() );
+
+    }
+
+
 }


### PR DESCRIPTION
Per JENKINS-23786, currently a shell job has to make a HTTP call back to Jenkins to set its build result as unstable. This is slow, requires the slave to have access to the master's HTTP interface, and is fiddly. The alternative, the TextFinder plugin, is no better.

Instead, allow a job to set the build result to unstable with a return value.

Adds the Advanced parameter "unstable_return" which, if non-zero, is the code the script must return to set the build as unstable.

(Depends on JENKINS-23896)
