### PR TITLE
fix broken HTML tables

### DIFF
--- a/core/src/main/resources/lib/form/advanced.jelly
+++ b/core/src/main/resources/lib/form/advanced.jelly
@@ -69,5 +69,6 @@ THE SOFTWARE.
               </script>
             </j:if>
 	  </td>
+	  <td/>
 	</tr>
 </j:jelly>

--- a/core/src/main/resources/lib/form/block.jelly
+++ b/core/src/main/resources/lib/form/block.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     Full-width space in the form table that can be filled with arbitrary HTML.
   </st:documentation>
 	<tr>
-	  <td colspan="3">
+	  <td colspan="4">
 	    <d:invokeBody />
 	  </td>
 	</tr>

--- a/core/src/main/resources/lib/form/description.jelly
+++ b/core/src/main/resources/lib/form/description.jelly
@@ -32,5 +32,6 @@ THE SOFTWARE.
     <td class="setting-description">
 	    <d:invokeBody />
 	  </td>
+	  <td />
 	</tr>
 </j:jelly>

--- a/core/src/main/resources/lib/form/dropdownList.jelly
+++ b/core/src/main/resources/lib/form/dropdownList.jelly
@@ -51,13 +51,18 @@ THE SOFTWARE.
                 <d:invokeBody/>
             </select>
         </td>
-        <j:if test="${attrs.help!=null}">
-            <td class="setting-help">
-                <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png"
-                                                                                       alt="Help for feature: ${title}"
-                                                                                       height="16" width="16"/></a>
-            </td>
-        </j:if>
+        <j:choose>
+            <j:when test="${attrs.help!=null}">
+                <td class="setting-help">
+                    <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png"
+                                                                                           alt="Help for feature: ${title}"
+                                                                                           height="16" width="16"/></a>
+                </td>
+            </j:when>
+            <j:otherwise>
+                <td/>
+            </j:otherwise>
+        </j:choose>
     </tr>
 
     <!-- generate the actual form entries -->

--- a/core/src/main/resources/lib/form/dropdownList.jelly
+++ b/core/src/main/resources/lib/form/dropdownList.jelly
@@ -51,18 +51,7 @@ THE SOFTWARE.
                 <d:invokeBody/>
             </select>
         </td>
-        <j:choose>
-            <j:when test="${attrs.help!=null}">
-                <td class="setting-help">
-                    <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png"
-                                                                                           alt="Help for feature: ${title}"
-                                                                                           height="16" width="16"/></a>
-                </td>
-            </j:when>
-            <j:otherwise>
-                <td/>
-            </j:otherwise>
-        </j:choose>
+        <f:helpLink url="${attrs.help}" featureName="${title}"/>
     </tr>
 
     <!-- generate the actual form entries -->

--- a/core/src/main/resources/lib/form/entry.jelly
+++ b/core/src/main/resources/lib/form/entry.jelly
@@ -72,16 +72,7 @@ THE SOFTWARE.
     <td class="setting-main">
       <d:invokeBody />
     </td>
-    <j:choose>
-      <j:when test="${attrs.help!=null}">
-        <td class="setting-help">
-          <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
-        </td>
-      </j:when>
-      <j:otherwise>
-        <td />
-      </j:otherwise>
-    </j:choose>
+    <f:helpLink url="${attrs.help}" featureName="${title}"/>
   </tr>
   <!-- used to display the form validation error -->
   <tr class="validation-error-area"><td colspan="2" /><td /><td /></tr>

--- a/core/src/main/resources/lib/form/entry.jelly
+++ b/core/src/main/resources/lib/form/entry.jelly
@@ -72,14 +72,19 @@ THE SOFTWARE.
     <td class="setting-main">
       <d:invokeBody />
     </td>
-    <j:if test="${attrs.help!=null}">
-      <td class="setting-help">
-        <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
-      </td>
-    </j:if>
+    <j:choose>
+      <j:when test="${attrs.help!=null}">
+        <td class="setting-help">
+          <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
+        </td>
+      </j:when>
+      <j:otherwise>
+        <td />
+      </j:otherwise>
+    </j:choose>
   </tr>
   <!-- used to display the form validation error -->
-  <tr class="validation-error-area"><td colspan="2" /><td /></tr>
+  <tr class="validation-error-area"><td colspan="2" /><td /><td /></tr>
   <j:if test="${!empty(attrs.description)}">
     <f:description>
       <j:out value="${description}"/>

--- a/core/src/main/resources/lib/form/helpLink.jelly
+++ b/core/src/main/resources/lib/form/helpLink.jelly
@@ -1,0 +1,65 @@
+<!--
+The MIT License
+
+Copyright (c) 2014, Harald Albers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation>
+    Outputs an help link for a &lt;f:form> item if help is available or 
+    a spacer if none is available.
+
+    The help link is rendered as a table cell with an (?) icon.
+    If the user clicks it, the content of the HTML fragment at the given URL 
+    is renderd in the area designated as &lt;f:helpArea> by the caller,
+    usually in a row beneath the item with help.
+    
+    The alternative spacer is just an empty table cell.
+    
+    This tag was introduced to ensure that the space reserved for help items
+    is consistent over the UI whether or not help exists.
+
+    @since XXX
+    <st:attribute name="url">
+      URL to the HTML page. Optional. If not given, no help icon is displayed.
+
+      The URL should return a UTF-8 encoded HTML fragment wrapped in a &lt;div> tag.
+      The URL is interpreted to be rooted at the context path of Jenkins,
+      so it's normally something like "/plugin/foobar/help/abc.html".
+    </st:attribute>
+    <st:attribute name="featureName">
+      Name of the feature described by the help text, used for constructing the 
+      icon's alt attribute. Optional.
+    </st:attribute>
+  </st:documentation>
+  <j:choose>
+    <j:when test="${attrs.url!=null}">
+      <j:set var="altText" value="${attrs.featureName != null ? '%Help for feature:' + ' ' + attrs.featureName : '%[Help]'}" />
+      <td class="setting-help">
+        <a href="#" class="help-button" helpURL="${rootURL}${attrs.url}"><img src="${imagesURL}/16x16/help.png" alt="${altText}" height="16" width="16"/></a>
+      </td>
+    </j:when>
+    <j:otherwise>
+      <td class="setting-no-help" />
+    </j:otherwise>
+  </j:choose>
+</j:jelly>

--- a/core/src/main/resources/lib/form/helpLink_de.properties
+++ b/core/src/main/resources/lib/form/helpLink_de.properties
@@ -1,0 +1,2 @@
+Help\ for\ feature\:=Hilfe f\u00FCr\:
+[Help]=[Hilfe]

--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -81,16 +81,7 @@ THE SOFTWARE.
                 <b>${descriptor.displayName}</b>
               </div>
             </td>
-            <j:choose>
-              <j:when test="${help!=null}">
-                <td>
-                  <a href="#" class="help-button" helpURL="${rootURL}${help}"><img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/></a>
-                </td>
-              </j:when>
-              <j:otherwise>
-                <td />
-              </j:otherwise>
-            </j:choose>
+            <f:helpLink url="${help}"/>
           </tr>
           <!-- TODO: help support is unintuitive; people should be able to see help from drop-down menu -->
           <j:if test="${help!=null}">

--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -81,11 +81,16 @@ THE SOFTWARE.
                 <b>${descriptor.displayName}</b>
               </div>
             </td>
-            <j:if test="${help!=null}">
-              <td>
-                <a href="#" class="help-button" helpURL="${rootURL}${help}"><img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/></a>
-              </td>
-            </j:if>
+            <j:choose>
+              <j:when test="${help!=null}">
+                <td>
+                  <a href="#" class="help-button" helpURL="${rootURL}${help}"><img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/></a>
+                </td>
+              </j:when>
+              <j:otherwise>
+                <td />
+              </j:otherwise>
+            </j:choose>
           </tr>
           <!-- TODO: help support is unintuitive; people should be able to see help from drop-down menu -->
           <j:if test="${help!=null}">

--- a/core/src/main/resources/lib/form/optionalBlock.jelly
+++ b/core/src/main/resources/lib/form/optionalBlock.jelly
@@ -71,16 +71,7 @@ THE SOFTWARE.
           <f:checkbox name="${attrs.name}" onclick="javascript:updateOptionalBlock(this,true)"
                       negative="${attrs.negative}" checked="${attrs.checked}" field="${attrs.field}" title="${title}" />
         </td>
-        <j:choose>
-          <j:when test="${attrs.help!=null}">
-            <td>
-              <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
-            </td>
-          </j:when>
-          <j:otherwise>
-            <td />
-          </j:otherwise>
-        </j:choose>
+        <f:helpLink url="${attrs.help}" featureName="${title}"/>
       </tr>
       <j:if test="${attrs.help!=null}">
         <f:helpArea />

--- a/core/src/main/resources/lib/form/optionalBlock.jelly
+++ b/core/src/main/resources/lib/form/optionalBlock.jelly
@@ -71,11 +71,16 @@ THE SOFTWARE.
           <f:checkbox name="${attrs.name}" onclick="javascript:updateOptionalBlock(this,true)"
                       negative="${attrs.negative}" checked="${attrs.checked}" field="${attrs.field}" title="${title}" />
         </td>
-        <j:if test="${attrs.help!=null}">
-          <td>
-            <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
-          </td>
-        </j:if>
+        <j:choose>
+          <j:when test="${attrs.help!=null}">
+            <td>
+              <a href="#" class="help-button" helpURL="${rootURL}${attrs.help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
+            </td>
+          </j:when>
+          <j:otherwise>
+            <td />
+          </j:otherwise>
+        </j:choose>
       </tr>
       <j:if test="${attrs.help!=null}">
         <f:helpArea />

--- a/core/src/main/resources/lib/form/radioBlock.jelly
+++ b/core/src/main/resources/lib/form/radioBlock.jelly
@@ -62,16 +62,7 @@ THE SOFTWARE.
         ${title}
       </label>
     </td>
-    <j:choose>
-      <j:when test="${attrs.help!=null}">
-        <td class="setting-help">
-          <a href="#" class="help-button" helpURL="${rootURL}${help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
-        </td>
-      </j:when>
-      <j:otherwise>
-        <td />
-      </j:otherwise>
-    </j:choose>
+    <f:helpLink url="${help}" featureName="${title}" />
 	</tr>
   <j:if test="${attrs.help!=null}">
     <f:helpArea />

--- a/core/src/main/resources/lib/form/radioBlock.jelly
+++ b/core/src/main/resources/lib/form/radioBlock.jelly
@@ -62,11 +62,16 @@ THE SOFTWARE.
         ${title}
       </label>
     </td>
-    <j:if test="${attrs.help!=null}">
-      <td class="setting-help">
-        <a href="#" class="help-button" helpURL="${rootURL}${help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
-      </td>
-    </j:if>
+    <j:choose>
+      <j:when test="${attrs.help!=null}">
+        <td class="setting-help">
+          <a href="#" class="help-button" helpURL="${rootURL}${help}"><img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${title}" height="16" width="16" /></a>
+        </td>
+      </j:when>
+      <j:otherwise>
+        <td />
+      </j:otherwise>
+    </j:choose>
 	</tr>
   <j:if test="${attrs.help!=null}">
     <f:helpArea />

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -328,6 +328,9 @@ pre.console {
   width: 16px;
   vertical-align: middle;
 }
+.setting-no-help {
+  width: 16px;
+}
 
 .setting-input {
   width: 100%;


### PR DESCRIPTION
Whenever the taglib renders a help icon, it does so by outputting an **additional** `td` element, thus producing a table row that has one cell more than rows without any help items. 
Current browsers are quite forgiving about missing cells and silently 'add' them when rendering the table, but still this is invalid HTML. Correcting this will ease any further transitions to `div` based layouts.

This PR ensures that in cases where a help icon could be rendered but no help is available, an empty `td`element is rendered. It does so by factoring out the rendering of help icons into a new Jelly tag.

The following screenshots illustrate the problem. They were taken with a current Firefox and the _Web Developer_ toolbar for highlighting the table structure.

Before:
![missing-table-cells](https://cloud.githubusercontent.com/assets/2901725/3645435/760aae36-10ea-11e4-8b8c-b0cec37d4e78.png)

After:
![added-table-cells](https://cloud.githubusercontent.com/assets/2901725/3645463/a0195150-10ea-11e4-8469-72edcf7e0bf7.png)

Overlaying both images shows that overall layout is not affected.
It might be affected in plugins, though, if they use hardcoded HTML in order to also correct the layout.
