### PR TITLE
Updates to the login/sign up links

### DIFF
--- a/core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
+++ b/core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
@@ -29,5 +29,5 @@ THE SOFTWARE.
     <j:arg value="${if (request.session.attribute('from')!=null) request.session.getAttribute('from');  else if (request.getParameter('from')!=null) request.getParameter('from'); else if (request.requestURI=='/loginError' || request.requestURI=='/login') '/'; else request.requestURI;}"/>
     <j:arg value="UTF-8"/>
   </j:invokeStatic>
-  <a style="color:inherit" href="${rootURL}/${app.securityRealm.loginUrl}?from=${from}"><b>${%login}</b></a>
+  <a href="${rootURL}/${app.securityRealm.loginUrl}?from=${from}"><b>${%login}</b></a>
 </j:jelly>

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -193,6 +193,12 @@ dt {
 
 #header .login a, #header .login a:visited {
   color: white;
+  text-decoration: none;
+}
+
+#header .login a:hover {
+    text-decoration: underline;
+    color: #ccc;
 }
 
 a:link {


### PR DESCRIPTION
- remove the default underline to make them a little less heavy. The use of bold still indicates that these are clickable.
- add hover states - underline + color change.
- remove inline style from login link - is this a security risk, somehow?
