### PR TITLE
Remove extraneous whitespace below title on Job pg

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractProject/makeDisabled.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/makeDisabled.jelly
@@ -24,25 +24,27 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-  <j:choose>
-    <j:when test="${it.disabled}">
-      <div class="warning">
-        <form method="post" id='enable-project' action="enable">
-          ${%This project is currently disabled}
-          <l:hasPermission permission="${it.CONFIGURE}">
-            <f:submit value="${%Enable}" />
-          </l:hasPermission>
-        </form>
-      </div>
-    </j:when>
-    <j:otherwise>
-      <div align="right">
-        <form method="post" id="disable-project" action="disable">
-          <l:hasPermission permission="${it.CONFIGURE}">
-            <f:submit value="${%Disable Project}" />
-          </l:hasPermission>
-        </form>
-      </div>
-    </j:otherwise>
-  </j:choose>
+  <div class="make-disabled-container">
+      <j:choose>
+        <j:when test="${it.disabled}">
+          <div class="warning">
+            <form method="post" id='enable-project' action="enable">
+              ${%This project is currently disabled}
+              <l:hasPermission permission="${it.CONFIGURE}">
+                <f:submit value="${%Enable}" />
+              </l:hasPermission>
+            </form>
+          </div>
+        </j:when>
+        <j:otherwise>
+          <div align="right">
+            <form method="post" id="disable-project" action="disable">
+              <l:hasPermission permission="${it.CONFIGURE}">
+                <f:submit value="${%Disable Project}" />
+              </l:hasPermission>
+            </form>
+          </div>
+        </j:otherwise>
+      </j:choose>
+  </div>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/AbstractProject/makeDisabled.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/makeDisabled.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-  <div class="make-disabled-container">
+  <div class="disable-project-container">
       <j:choose>
         <j:when test="${it.disabled}">
           <div class="warning">

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1276,7 +1276,7 @@ table#legend-table td {
 	vertical-align: middle;
 }
 
-#description, .make-disabled-container {
+#description, .disable-project-container {
     display: inline-block;
     float: right;
     clear: right;

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1276,6 +1276,12 @@ table#legend-table td {
 	vertical-align: middle;
 }
 
+#description, .make-disabled-container {
+    display: inline-block;
+    float: right;
+    clear: right;
+}
+
 /* ========================= Button styles ================= */
 
 #disable-project {


### PR DESCRIPTION
There's extra whitespace caused by the description/Disable Project fields
floating all the way across the page. This change floats those boxes to the
right, which allows the Workspace/Recent Changes boxes to come up the page and
allows more page content to fit onscreen.

Abbreviated screenshot:

<img src="https://api.monosnap.com/image/download?id=4MWcV5qLxbinay9pVKMiyWCeRuk4XP" />
