### PR TITLE
UI Improvement - Prevent executor# col expanding

### DIFF
--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -105,7 +105,7 @@ THE SOFTWARE.
     <l:pane width="3" id="executors"
         title="&lt;a href='${rootURL}/computer/'>${%Build Executor Status}&lt;/a>"
         collapsedText="${%Computers(computers.size() - 1, app.unlabeledLoad.computeTotalExecutors() - app.unlabeledLoad.computeIdleExecutors(), app.unlabeledLoad.computeTotalExecutors())}">
-      <colgroup><col width="1*"/><col width="200*"/><col width="24"/></colgroup>
+      <colgroup><col width="30"/><col width="200*"/><col width="24"/></colgroup>
 
       <tr>
         <th class="pane">#</th>


### PR DESCRIPTION
As page expands, the executor number column within the Build Executor Status table expands. By giving a definitive width, column will remain fixed when the page expands. If the executor# is > 99, the column can still expand due to   middle column remaining a flexible width.
