### PR TITLE
[JENKINS-23842] <l:icon> tag

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,6 +50,11 @@ THE SOFTWARE.
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>ui-ext-icon-module</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>remoting</artifactId>
       <!-- specified in the parent -->
     </dependency>

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -139,6 +139,7 @@ import org.apache.commons.jelly.XMLOutput;
 import org.apache.commons.jexl.parser.ASTSizeFunction;
 import org.apache.commons.jexl.util.Introspector;
 import org.apache.commons.lang.StringUtils;
+import org.jenkins.ui.icon.IconSet;
 import org.jvnet.tiger_types.Types;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
@@ -225,6 +226,7 @@ public class Functions {
         context.setVariable("imagesURL",rootURL+getResourcePath()+"/images");
 
         context.setVariable("userAgent", currentRequest.getHeader("User-Agent"));
+        IconSet.initPageVariables(context);
     }
 
     /**

--- a/core/src/main/java/hudson/model/Action.java
+++ b/core/src/main/java/hudson/model/Action.java
@@ -56,8 +56,8 @@ import hudson.tasks.test.TestResultProjectAction;
  * Jenkins show the option to wipe out the workspace inside the workspace link:
  *
  * <pre>
- * &lt;l:task icon="images/24x24/folder.gif"  href="${url}/ws/" title="${%Workspace}">
- *   &lt;l:task icon="images/24x24/folder-delete.gif"  href="${url}/wipeOutWorkspace" title="${%Wipe Out Workspace}" />
+ * &lt;l:task icon="icon-folder icon-md"  href="${url}/ws/" title="${%Workspace}">
+ *   &lt;l:task icon="icon-delete icon-md"  href="${url}/wipeOutWorkspace" title="${%Wipe Out Workspace}" />
  * &lt;/l:task>
  * </pre>
  *

--- a/core/src/main/java/hudson/model/BallColor.java
+++ b/core/src/main/java/hudson/model/BallColor.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import hudson.util.ColorPalette;
 import jenkins.model.Jenkins;
+import org.jenkins.ui.icon.Icon;
 import org.jvnet.localizer.LocaleProvider;
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.stapler.Stapler;
@@ -72,15 +73,25 @@ public enum BallColor implements StatusIcon {
     ;
 
     private final Localizable description;
+    private final String iconClassName;
     private final String image;
     private final Color baseColor;
 
     BallColor(String image, Localizable description, Color baseColor) {
+        this.iconClassName = Icon.toNormalizedIconNameClass(image);
         this.baseColor = baseColor;
         // name() is not usable in the constructor, so I have to repeat the name twice
         // in the constants definition.
         this.image = image+ (image.endsWith("_anime")?".gif":".png");
         this.description = description;
+    }
+
+    /**
+     * Get the status ball icon class spec name.
+     * @return The status ball icon class spec name.
+     */
+    public String getIconClassName() {
+        return iconClassName;
     }
 
     /**

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -609,6 +609,14 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             return "computer.png";
     }
 
+    @Exported
+    public String getIconClassName() {
+        if(isOffline())
+            return "icon-computer-x";
+        else
+            return "icon-computer";
+    }
+
     public String getIconAltText() {
         if(isOffline())
             return "[offline]";

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -420,6 +420,13 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                 return isFolder?"folder-error.png":"text-error.png";
         }
 
+        public String getIconClassName() {
+            if (isReadable)
+                return isFolder?"icon-folder":"icon-text";
+            else
+                return isFolder?"icon-folder-error":"icon-text-error";
+        }
+
         public long getSize() {
             return size;
         }

--- a/core/src/main/java/hudson/model/HealthReport.java
+++ b/core/src/main/java/hudson/model/HealthReport.java
@@ -35,7 +35,6 @@ import org.kohsuke.stapler.export.ExportedBean;
 import java.io.*;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * Represents health of something (typically project).
@@ -48,17 +47,28 @@ import java.util.Locale;
 // this is always exported as a part of Job and never on its own, so start with 2.
 public class HealthReport implements Serializable, Comparable<HealthReport> {
     // These are now 0-20, 21-40, 41-60, 61-80, 81+ but filenames unchanged for compatibility
-    private static final String HEALTH_OVER_80 = "health-80plus.png";
-    private static final String HEALTH_61_TO_80 = "health-60to79.png";
-    private static final String HEALTH_41_TO_60 = "health-40to59.png";
-    private static final String HEALTH_21_TO_40 = "health-20to39.png";
-    private static final String HEALTH_0_TO_20 = "health-00to19.png";
-    private static final String HEALTH_UNKNOWN = "empty.png";
+    private static final String HEALTH_OVER_80 = "icon-health-80plus";
+    private static final String HEALTH_61_TO_80 = "icon-health-60to79";
+    private static final String HEALTH_41_TO_60 = "icon-health-40to59";
+    private static final String HEALTH_21_TO_40 = "icon-health-20to39";
+    private static final String HEALTH_0_TO_20 = "icon-health-00to19";
+
+    private static final String HEALTH_OVER_80_IMG = "health-80plus.png";
+    private static final String HEALTH_61_TO_80_IMG = "health-60to79.png";
+    private static final String HEALTH_41_TO_60_IMG = "health-40to59.png";
+    private static final String HEALTH_21_TO_40_IMG = "health-20to39.png";
+    private static final String HEALTH_0_TO_20_IMG = "health-00to19.png";
+    private static final String HEALTH_UNKNOWN_IMG = "empty.png";
 
     /**
      * The percentage health score (from 0 to 100 inclusive).
      */
     private int score;
+
+    /**
+     * Icon class.
+     */
+    private String iconClassName;
 
     /**
      * The path to the icon corresponding to this health score or <code>null</code> to use the default icon
@@ -120,17 +130,28 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
      */
     public HealthReport(int score, String iconUrl, Localizable description) {
         this.score = score;
+        if (score <= 20) {
+            this.iconClassName = HEALTH_0_TO_20;
+        } else if (score <= 40) {
+            this.iconClassName = HEALTH_21_TO_40;
+        } else if (score <= 60) {
+            this.iconClassName = HEALTH_41_TO_60;
+        } else if (score <= 80) {
+            this.iconClassName = HEALTH_61_TO_80;
+        } else {
+            this.iconClassName = HEALTH_OVER_80;
+        }
         if (iconUrl == null) {
             if (score <= 20) {
-                this.iconUrl = HEALTH_0_TO_20;
+                this.iconUrl = HEALTH_0_TO_20_IMG;
             } else if (score <= 40) {
-                this.iconUrl = HEALTH_21_TO_40;
+                this.iconUrl = HEALTH_21_TO_40_IMG;
             } else if (score <= 60) {
-                this.iconUrl = HEALTH_41_TO_60;
+                this.iconUrl = HEALTH_41_TO_60_IMG;
             } else if (score <= 80) {
-                this.iconUrl = HEALTH_61_TO_80;
+                this.iconUrl = HEALTH_61_TO_80_IMG;
             } else {
-                this.iconUrl = HEALTH_OVER_80;
+                this.iconUrl = HEALTH_OVER_80_IMG;
             }
         } else {
             this.iconUrl = iconUrl;
@@ -166,7 +187,7 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
      * Create a new HealthReport.
      */
     public HealthReport() {
-        this(100, HEALTH_UNKNOWN, Messages._HealthReport_EmptyString());
+        this(100, HEALTH_UNKNOWN_IMG, Messages._HealthReport_EmptyString());
     }
 
     /**
@@ -188,6 +209,8 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
         this.score = score;
     }
 
+
+
     /**
      * Getter for property 'iconUrl'.
      *
@@ -199,6 +222,16 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
     }
 
     /**
+     * Get health status icon class.
+     *
+     * @return The health status icon class.
+     */
+    @Exported
+    public String getIconClassName() {
+        return iconClassName;
+    }
+
+    /**
      * Get's the iconUrl relative to the hudson root url, for the correct size.
      *
      * @param size The size, e.g. 32x32, 24x24 or 16x16.
@@ -206,7 +239,7 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
      */
     public String getIconUrl(String size) {
         if (iconUrl == null) {
-            return Jenkins.RESOURCE_PATH + "/images/" + size + "/" + HEALTH_UNKNOWN;
+            return Jenkins.RESOURCE_PATH + "/images/" + size + "/" + HEALTH_UNKNOWN_IMG;
         }
         if (iconUrl.startsWith("/")) {
             return iconUrl.replace("/32x32/", "/" + size + "/");

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1234,6 +1234,10 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         return getIconColor().getImage();
     }
 
+    public String getBuildStatusIconClassName() {
+        return getIconColor().getIconClassName();
+    }
+
     public Graph getBuildTimeGraph() {
         return new Graph(getLastBuildTime(),500,400) {
             @Override

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1972,6 +1972,10 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         return getIconColor().getImage();
     }
 
+    public String getBuildStatusIconClassName() {
+        return getIconColor().getIconClassName();
+    }
+
     public static class Summary {
         /**
          * Is this build worse or better, compared to the previous build?

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -101,7 +101,7 @@ THE SOFTWARE.
                 <td class="center pane" id='unpin-${p.shortName}'>
                   <j:if test="${p.isPinned()}">
                     <input type="button" onclick="unpin(this,'${p.shortName}')" value="${%Unpin}" class="yui-button" />
-                    <a href="${%wiki.url}" target="_blank"><img style="vertical-align:top" src="${imagesURL}/16x16/help.png"/></a>
+                    <a href="${%wiki.url}" target="_blank"><l:icon class="icon-help icon-sm" style="vertical-align:top"/></a>
                   </j:if>
                 </td>
                 <td class="center pane">

--- a/core/src/main/resources/hudson/PluginManager/sidepanel.groovy
+++ b/core/src/main/resources/hudson/PluginManager/sidepanel.groovy
@@ -27,10 +27,10 @@ l=namespace(lib.LayoutTagLib)
 l.header()
 l.side_panel {
     l.tasks {
-        l.task(icon:"images/24x24/up.png", href:rootURL+'/', title:_("Back to Dashboard"))
-        l.task(icon:"images/24x24/setting.png", href:"${rootURL}/manage", title:_("Manage Jenkins"), permission:app.ADMINISTER, it:app)
+        l.task(icon:"icon-up icon-md", href:rootURL+'/', title:_("Back to Dashboard"))
+        l.task(icon:"icon-setting icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"), permission:app.ADMINISTER, it:app)
         if (!app.updateCenter.jobs.isEmpty()) {
-            l.task(icon:"images/24x24/plugin.png", href:"${rootURL}/updateCenter/", title:_("Update Center"))
+            l.task(icon:"icon-plugin icon-md", href:"${rootURL}/updateCenter/", title:_("Update Center"))
         }
     }
 }

--- a/core/src/main/resources/hudson/PluginWrapper/uninstall.groovy
+++ b/core/src/main/resources/hudson/PluginWrapper/uninstall.groovy
@@ -8,7 +8,7 @@ l.layout {
     l.header(title:title)
     l.main_panel {
         h1 {
-            img(src:"${imagesURL}/48x48/error.png",alt:"[!]",height:48,width:48)
+            l.icon(class: 'icon-error icon-xlg')
             text(" ")
             text(title)
         }

--- a/core/src/main/resources/hudson/cli/CLIAction/command.jelly
+++ b/core/src/main/resources/hudson/cli/CLIAction/command.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" it="${app}"/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/terminal.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-terminal icon-xlg"/>
         Command ${command.name}
       </h1>
       <j:set var="commandArgs" value="${command.name}${command.singleLineSummary}"/>

--- a/core/src/main/resources/hudson/cli/CLIAction/index.jelly
+++ b/core/src/main/resources/hudson/cli/CLIAction/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" it="${app}"/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/terminal.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-terminal icon-xlg"/>
         ${%Jenkins CLI}
       </h1>
       <p>

--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.jelly
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 	<l:layout title="${%JENKINS_HOME is almost full}" permission="${app.ADMINISTER}">
 		<l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/warning.png" height="48" width="48" />
+        <l:icon class="icon-warning icon-xlg"/>
         ${%blurb}
       </h1>
 

--- a/core/src/main/resources/hudson/diagnosis/MemoryUsageMonitor/index.jelly
+++ b/core/src/main/resources/hudson/diagnosis/MemoryUsageMonitor/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <!-- TODO: st:include page="sidepanel.jelly" /-->
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/monitor.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-monitor icon-xlg"/>
         ${%JVM Memory Usage}
       </h1>
       <j:set var="type" value="${request.getParameter('type') ?: 'min'}" />

--- a/core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/index.jelly
+++ b/core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/index.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
       <j:choose>
         <j:when test="${!it.installed}">
           <h1>
-            <img src="${imagesURL}/48x48/installer.png" alt="" height="48" width="48"/>
+            <l:icon class="icon-installer icon-xlg"/>
             ${%Install as Windows Service}
           </h1>
 
@@ -51,7 +51,7 @@ THE SOFTWARE.
         <!-- already installed -->
         <j:otherwise>
           <h1>
-            <img src="${imagesURL}/48x48/blue.png" alt="" height="48" width="48"/>
+            <l:icon class="icon-blue icon-xlg"/>
             ${%Installation Complete}
           </h1>
 

--- a/core/src/main/resources/hudson/logging/LogRecorder/index.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/index.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
 <l:layout title="Log" permission="${app.ADMINISTER}">
   <st:include page="sidepanel.jelly" />
   <l:main-panel>
-    <h1><img src="${rootURL}/images/48x48/clipboard.png" alt="" height="48" width="48"/>${it.displayName}</h1>
+    <h1><l:icon class="icon-clipboard icon-xlg"/>${it.displayName}</h1>
     <t:logRecords logRecords="${it.logRecords}"/>
     <j:forEach var="entry" items="${it.slaveLogRecords.entrySet()}">
       <h2><a href="${rootURL}/${entry.key.url}" class="model-link">${entry.key.displayName}</a></h2>
@@ -41,7 +41,7 @@ THE SOFTWARE.
       <f:submit value="${%Clear This Log}" />
     </form>
 
-    <st:include it="${it.parent}" page="feeds.jelly" />    
+    <st:include it="${it.parent}" page="feeds.jelly" />
   </l:main-panel>
 </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/logging/LogRecorder/sidepanel.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/sidepanel.jelly
@@ -30,10 +30,10 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href=".." title="${%Back to Loggers}" />
-      <l:task icon="images/24x24/notepad.png" href="." title="${%Log records}" />
-      <l:task icon="images/24x24/setting.png" href="configure" title="${%Configure}" />
-      <l:task icon="images/24x24/edit-delete.png" href="delete" title="${%Delete}" />
+      <l:task href=".." icon="icon-up icon-md" title="${%Back to Loggers}"/>
+      <l:task href="." icon="icon-notepad icon-md" title="${%Log records}"/>
+      <l:task href="configure" icon="icon-setting icon-md" title="${%Configure}"/>
+      <l:task href="delete" icon="icon-edit-delete icon-md" title="${%Delete}"/>
     </l:tasks>
   </l:side-panel>
 </j:jelly>

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
 <l:layout title="Log">
   <st:include page="sidepanel.jelly" />
   <l:main-panel>
-    <h1><img src="${rootURL}/images/48x48/clipboard.png" alt="" height="48" width="48"/>${%Jenkins Log}</h1>
+    <h1><l:icon class="icon-clipboard icon-xlg"/>${%Jenkins Log}</h1>
     <t:logRecords logRecords="${h.logRecords}"/>
 
     <st:include page="feeds.jelly" />

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
 <l:layout title="${%Log}">
   <st:include page="sidepanel.jelly" />
   <l:main-panel xmlns:local="local">
-    <h1><img src="${imagesURL}/48x48/clipboard.png" alt="" height="48" width="48"/>
+    <h1><l:icon class="icon-clipboard icon-xlg"/>
       ${%Log Recorders}
       <t:help href="https://wiki.jenkins-ci.org/display/JENKINS/Logging" />
     </h1>
@@ -39,7 +39,7 @@ THE SOFTWARE.
       <d:tag name="row">
         <tr>
           <td width="32">
-            <img src="${imagesURL}/32x32/clipboard.png" width="32" height="32" alt=""/>
+            <l:icon class="icon-clipboard icon-lg"/>
           </td>
           <td style="padding-left:2em"><a href="${href}">${name}</a></td>
           <td width="32">
@@ -59,7 +59,7 @@ THE SOFTWARE.
       <j:forEach var="lr" items="${it.logRecorders.values()}">
         <local:row name="${lr.name}" href="${lr.searchUrl}/">
           <a href="${lr.searchUrl}/configure">
-            <img src="${imagesURL}/32x32/setting.png" width="32" height="32" alt="[configure]" title="Configure"/>
+            <l:icon class="icon-setting icon-lg" tooltip="Configure"/>
           </a>
         </local:row>
       </j:forEach>

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/sidepanel.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/sidepanel.jelly
@@ -30,12 +30,12 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
-      <l:task icon="images/24x24/setting.png" href="${rootURL}/manage" title="${%Manage Jenkins}" />
-      <l:task icon="images/24x24/clipboard.png" href="." title="${%Logger List}" />
-      <l:task icon="images/24x24/notepad.png" href="all" title="${%All Logs}" />
-      <l:task icon="images/24x24/new-package.png" href="new" title="${%New Log Recorder}" />
-      <l:task icon="images/24x24/gear.png" href="levels" title="${%Log Levels}" />
+      <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
+      <l:task href="${rootURL}/manage" icon="icon-setting icon-md" title="${%Manage Jenkins}"/>
+      <l:task href="." icon="icon-clipboard icon-md" title="${%Logger List}"/>
+      <l:task href="all" icon="icon-notepad icon-md" title="${%All Logs}"/>
+      <l:task href="new" icon="icon-new-package icon-md" title="${%New Log Recorder}"/>
+      <l:task href="levels" icon="icon-gear icon-md" title="${%Log Levels}"/>
     </l:tasks>
   </l:side-panel>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -78,8 +78,7 @@ THE SOFTWARE.
                       <j:choose>
                         <j:when test="${dep.from!=null}">
                           <a href="${rootURL}/${dep.from.url}" class="model-link inside">
-                            <img class="model-link-icon" src="${imagesURL}/16x16/${dep.from.buildStatusUrl}"
-                                 alt="${dep.from.iconColor.description}" height="16" width="16" />${dep.from.displayName}</a>
+                            <l:icon class="${dep.from.buildStatusIconClassName} icon-sm" alt="${dep.from.iconColor.description}"/>${dep.from.displayName}</a>
                         </j:when>
                         <j:otherwise>
                           ?
@@ -89,8 +88,7 @@ THE SOFTWARE.
                       &#x2192; <!-- right arrow -->
 
                       <a href="${rootURL}/${dep.to.url}" class="model-link inside">
-                        <img class="model-link-icon" src="${imagesURL}/16x16/${dep.to.buildStatusUrl}"
-                             alt="${dep.to.iconColor.description}" height="16" width="16" />${dep.to.displayName}</a>
+                        <l:icon class="${dep.to.buildStatusIconClassName} icon-sm" alt="${dep.to.iconColor.description}" />${dep.to.displayName}</a>
 
                       (<a href="${rootURL}/${dep.project.url}changes?from=${dep.fromId}&amp;to=${dep.toId}">${%detail}</a>)
                     </li>

--- a/core/src/main/resources/hudson/model/AbstractBuild/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/sidepanel.jelly
@@ -36,10 +36,10 @@ THE SOFTWARE.
       <st:include page="actions.jelly" />
       <t:actions actions="${it.transientActions}"/>
       <j:if test="${it.previousBuild!=null}">
-        <l:task icon="images/24x24/previous.png" href="${buildUrl.previousBuildUrl}" title="${%Previous Build}" contextMenu="false"/>
+        <l:task contextMenu="false" href="${buildUrl.previousBuildUrl}" icon="icon-previous icon-md" title="${%Previous Build}"/>
       </j:if>
       <j:if test="${it.nextBuild!=null}">
-        <l:task icon="images/24x24/next.png" href="${buildUrl.nextBuildUrl}" title="${%Next Build}" contextMenu="false"/>
+        <l:task contextMenu="false" href="${buildUrl.nextBuildUrl}" icon="icon-next icon-md" title="${%Next Build}"/>
       </j:if>
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/model/AbstractBuild/tasks.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/tasks.jelly
@@ -27,9 +27,9 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:p="/lib/hudson/project">
-      <l:task icon="images/24x24/up.png" href="${it.upUrl}" title="${%Back to Project}" contextMenu="false"/>
-      <l:task icon="images/24x24/search.png" href="${buildUrl.baseUrl}/" title="${%Status}" contextMenu="false"/>
-      <l:task icon="images/24x24/notepad.png" href="${buildUrl.baseUrl}/changes" title="${%Changes}" />
+      <l:task contextMenu="false" href="${it.upUrl}" icon="icon-up icon-md" title="${%Back to Project}"/>
+      <l:task contextMenu="false" href="${buildUrl.baseUrl}/" icon="icon-search icon-md" title="${%Status}"/>
+      <l:task href="${buildUrl.baseUrl}/changes" icon="icon-notepad icon-md" title="${%Changes}"/>
       <p:console-link/>
-      <l:task icon="images/24x24/notepad.png" href="${buildUrl.baseUrl}/configure" title="${h.hasPermission(it,it.UPDATE)?'%Edit Build Information':'%View Build Information'}"/>
+      <l:task href="${buildUrl.baseUrl}/configure" icon="icon-notepad icon-md" title="${h.hasPermission(it,it.UPDATE)?'%Edit Build Information':'%View Build Information'}"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/AbstractItem/noWorkspace.jelly
+++ b/core/src/main/resources/hudson/model/AbstractItem/noWorkspace.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <l:layout>
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="" height="48" width="48"/>${%Error: no workspace}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/>${%Error: no workspace}</h1>
       <j:choose>
         <j:when test="${it.lastBuild==null}">
           <p>

--- a/core/src/main/resources/hudson/model/AbstractProject/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/sidepanel.jelly
@@ -39,16 +39,16 @@ THE SOFTWARE.
       <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
       <j:choose>
         <j:when test="${it.parent==app}">
-          <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" contextMenu="false" />
+          <l:task contextMenu="false" href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
         </j:when>
         <j:otherwise>
-          <l:task icon="images/24x24/up.png" href="${rootURL}/${it.parent.url}" title="${%Up}" contextMenu="false" />
+          <l:task contextMenu="false" href="${rootURL}/${it.parent.url}" icon="icon-up icon-md" title="${%Up}"/>
         </j:otherwise>
       </j:choose>
-      <l:task icon="images/24x24/search.png"  href="${url}/" title="${%Status}" contextMenu="false"/>
-      <l:task icon="images/24x24/notepad.png" href="${url}/changes" title="${%Changes}" />
+      <l:task contextMenu="false" href="${url}/" icon="icon-search icon-md" title="${%Status}"/>
+      <l:task href="${url}/changes" icon="icon-notepad icon-md" title="${%Changes}"/>
       <l:task icon="images/24x24/folder.png"  href="${url}/ws/" title="${%Workspace}" permission="${it.WORKSPACE}">
-        <l:task icon="images/24x24/folder-delete.png"  href="${url}/doWipeOutWorkspace" title="${%Wipe Out Workspace}" permission="${h.isWipeOutPermissionEnabled() ? it.WIPEOUT : it.BUILD}" post="true" requiresConfirmation="true" confirmationMessage="${%wipe.out.confirm}"/>
+        <l:task confirmationMessage="${%wipe.out.confirm}" href="${url}/doWipeOutWorkspace" icon="icon-folder-delete icon-md" permission="${h.isWipeOutPermissionEnabled() ? it.WIPEOUT : it.BUILD}" post="true" requiresConfirmation="true" title="${%Wipe Out Workspace}"/>
       </l:task>
       <j:if test="${it.configurable}">
         <p:configurable/>

--- a/core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspaceBlocked.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspaceBlocked.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <l:layout>
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="" height="48" width="48"/>${%Error: Wipe Out Workspace blocked by SCM}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/>${%Error: Wipe Out Workspace blocked by SCM}</h1>
       <p>
         ${%The SCM for this project has blocked this attempt to wipe out the project's workspace.}
       </p>

--- a/core/src/main/resources/hudson/model/Computer/builds.jelly
+++ b/core/src/main/resources/hudson/model/Computer/builds.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/notepad.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-notepad icon-xlg"/>
         ${%title(it.displayName)}
       </h1>
 

--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -52,7 +52,7 @@ THE SOFTWARE.
       </div>
 
       <h1>
-        <img src="${imagesURL}/48x48/${it.icon}" width="48" height="48" alt=""/>
+        <l:icon class="${it.iconClassName} icon-xlg" />
         ${it.caption}
         <j:if test="${!empty(it.node.nodeDescription)}">
           <span style="font-size:smaller">(${it.node.nodeDescription})</span>

--- a/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
@@ -30,13 +30,13 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href=".." title="${%Back to List}" contextMenu="false"/>
-      <l:task icon="images/24x24/search.png" href="${rootURL}/${it.url}" title="${%Status}" contextMenu="false"/>
-      <l:task icon="images/24x24/edit-delete.png" href="delete" title="${%Delete Slave}" permission="${it.DELETE}" />
-      <l:task icon="images/24x24/setting.png" href="configure" title="${%Configure}" permission="${it.CONFIGURE}" />
-      <l:task icon="images/24x24/notepad.png" href="builds" title="${%Build History}" />
-      <l:task icon="images/24x24/monitor.png" href="load-statistics" title="${%Load Statistics}" />
-      <l:task icon="images/24x24/terminal.png" href="script" title="${%Script Console}" permission="${app.RUN_SCRIPTS}" />
+      <l:task contextMenu="false" href=".." icon="icon-up icon-md" title="${%Back to List}"/>
+      <l:task contextMenu="false" href="${rootURL}/${it.url}" icon="icon-search icon-md" title="${%Status}"/>
+      <l:task href="delete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" title="${%Delete Slave}"/>
+      <l:task href="configure" icon="icon-setting icon-md" permission="${it.CONFIGURE}" title="${%Configure}"/>
+      <l:task href="builds" icon="icon-notepad icon-md" title="${%Build History}"/>
+      <l:task href="load-statistics" icon="icon-monitor icon-md" title="${%Load Statistics}"/>
+      <l:task href="script" icon="icon-terminal icon-md" permission="${app.RUN_SCRIPTS}" title="${%Script Console}"/>
       <st:include page="sidepanel2.jelly" optional="true" /><!-- hook for derived class to add more items -->
       <t:actions />
     </l:tasks>

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -55,7 +55,7 @@ THE SOFTWARE.
       <j:forEach var="c" items="${it._all}">
         <tr id="node_${c.name}">
           <td width="32" data="${c.icon}">
-            <img src="${imagesURL}/32x32/${c.icon}" width="32" height="32" alt="${c.iconAltText}"/>
+            <l:icon class="${c.iconClassName} icon-lg" alt="${c.iconAltText}"/>
           </td>
           <td><a href="${rootURL}/${c.url}" class="model-link inside">${c.displayName}</a></td>
           <j:forEach var="m" items="${monitors}">
@@ -68,9 +68,7 @@ THE SOFTWARE.
           <td><!-- config link -->
             <j:if test="${c.hasPermission(c.CONFIGURE)}">
               <a href="${rootURL}/${c.url}configure">
-                <img src="${imagesURL}/32x32/setting.png"
-                     title="${%Configure}" alt="${%Configure}"
-                     height="32" width="32" border="0"/>
+                <l:icon class="icon-setting icon-lg" tooltip="${%Configure}"/>
               </a>
             </j:if>
           </td>

--- a/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
@@ -31,10 +31,10 @@ THE SOFTWARE.
   <l:side-panel>
     <j:getStatic var="createPermission" className="hudson.model.Computer" field="CREATE"/>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
-      <l:task icon="images/24x24/setting.png" href="${rootURL}/manage" title="${%Manage Jenkins}" permission="${app.ADMINISTER}" />
-      <l:task icon="images/24x24/new-computer.png" href="new" title="${%New Node}" permission="${createPermission}" />
-      <l:task icon="images/24x24/setting.png" href="configure" title="${%Configure}" permission="${app.ADMINISTER}" />
+      <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
+      <l:task href="${rootURL}/manage" icon="icon-setting icon-md" permission="${app.ADMINISTER}" title="${%Manage Jenkins}"/>
+      <l:task href="new" icon="icon-new-computer icon-md" permission="${createPermission}" title="${%New Node}"/>
+      <l:task href="configure" icon="icon-setting icon-md" permission="${app.ADMINISTER}" title="${%Configure}"/>
     </l:tasks>
     <t:queue items="${app.queue.approximateItemsQuickly}" />
     <t:executors />

--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -33,14 +33,13 @@ THE SOFTWARE.
       <!-- parent path -->
         <div class="parentPath">
           <form action="${backPath}" method="get">
-            <a href="${topPath}"><img src="${imagesURL}/48x48/${icon}" class="rootIcon" alt="" height="48" width="48"/></a>
+            <a href="${topPath}"><l:icon class="${icons.toNormalizedIconNameClass(icon)} icon-xlg" /></a>
             <j:forEach var="p" items="${parentPath}">
               <a href="${p.href}">${p.title}</a>
               /
             </j:forEach>
             <input type="text" name="pattern" value="${pattern}" />
-            <img src="${imagesURL}/16x16/go-next.png" style="vertical-align:middle; cursor:pointer" alt="[submit]"
-                onclick="this.parentNode.submit()" height="16" width="16"/>
+            <l:icon class="icon-go-next icon-sm" onclick="this.parentNode.submit()" style="vertical-align:middle; cursor:pointer"/>
           </form>
         </div>
         <j:choose>
@@ -53,7 +52,7 @@ THE SOFTWARE.
                 <j:set var="x" value="${f.get(f.size()-1)}"/>
                 <tr>
                   <td>
-                    <img src="${imagesURL}/16x16/${x.iconName}" alt="" height="16" width="16"/>
+                    <l:icon class="${x.iconClassName} icon-sm"/>
                   </td>
                   <td>
                     <j:forEach var="t" items="${f}" varStatus="st">
@@ -78,7 +77,7 @@ THE SOFTWARE.
                       <j:if test="${x.readable}">
                         <j:if test="${app.fingerprintMap.ready}">
                           <a href="${x.href}/*fingerprint*/">
-                            <img src="${imagesURL}/16x16/fingerprint.png" alt="fingerprint" height="16" width="16" />
+                            <l:icon class="icon-fingerprint icon-sm"/>
                           </a>
                           <st:nbsp/>
                         </j:if>
@@ -92,7 +91,7 @@ THE SOFTWARE.
                 <td style="text-align:right;" colspan="3">
                   <div style="margin-top: 1em;">
                     <a href="${backPath}${pattern!=''?pattern+'/':''}*zip*/${dir.name}.zip">
-                      <img src="${imagesURL}/16x16/package.png" height="16" width="16"/>
+                      <l:icon class="icon-package icon-sm"/>
                       (${%all files in zip})
                     </a>
                   </div>

--- a/core/src/main/resources/hudson/model/Executor/causeOfDeath.jelly
+++ b/core/src/main/resources/hudson/model/Executor/causeOfDeath.jelly
@@ -28,20 +28,20 @@ THE SOFTWARE.
     <l:header />
     <l:side-panel>
       <l:tasks>
-        <l:task icon="images/24x24/up.png" href="../.." title="${%Back}" />
+        <l:task href="../.." icon="icon-up icon-md" title="${%Back}"/>
       </l:tasks>
     </l:side-panel>
     <l:main-panel>
       <j:choose>
         <j:when test="${it.alive}">
           <h1>
-            <img src="${imagesURL}/48x48/blue.png" width="48" height="48" alt=""/>
+            <l:icon class="icon-blue icon-xlg"/>
             ${%Thread is still alive}
           </h1>
         </j:when>
         <j:otherwise>
           <h1>
-            <img src="${imagesURL}/48x48/red.png" width="48" height="48" alt=""/>
+            <l:icon class="icon-red icon-xlg"/>
             ${%Thread has died}
           </h1>
           <pre>${h.printThrowable(it.causeOfDeath)}</pre>

--- a/core/src/main/resources/hudson/model/Fingerprint/index.jelly
+++ b/core/src/main/resources/hudson/model/Fingerprint/index.jelly
@@ -30,13 +30,13 @@ THE SOFTWARE.
     </l:header>
     <l:side-panel>
       <l:tasks>
-        <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
+        <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
         <t:actions/>
       </l:tasks>
     </l:side-panel>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-fingerprint icon-xlg"/>
         ${it.fileName}
       </h1>
       <div class="md5sum">

--- a/core/src/main/resources/hudson/model/Label/index.jelly
+++ b/core/src/main/resources/hudson/model/Label/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/attribute.png" width="48" height="48" alt=""/>
+        <l:icon class="icon-attribute icon-xlg"/>
         ${it.name}
       </h1>
 
@@ -42,7 +42,7 @@ THE SOFTWARE.
           <j:set var="c" value="${app.getComputer(n.nodeName)}"/>
           <j:set var="url" value="${rootURL}/computer/${n.nodeName}"/>
           <nobr>
-            <a href="${url}"><img src="${imagesURL}/16x16/${c.icon}" width="16" height="16" alt=""/></a>
+            <a href="${url}"><l:icon class="${c.iconClassName} icon-sm"/></a>
             <st:nbsp/>
             <a href="${url}" class="model-link inside">${c.displayName}</a>
           </nobr>

--- a/core/src/main/resources/hudson/model/Label/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/Label/sidepanel.jelly
@@ -31,9 +31,9 @@ THE SOFTWARE.
   <l:side-panel>
     <l:tasks>
       <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" contextMenu="false"/>
-      <l:task icon="images/24x24/attribute.png" href="${url}" title="${%Overview}" contextMenu="false"/>
-      <l:task icon="images/24x24/monitor.png" href="${url}/load-statistics" title="${%Load Statistics}" />
+      <l:task contextMenu="false" href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
+      <l:task contextMenu="false" href="${url}" icon="icon-attribute icon-md" title="${%Overview}"/>
+      <l:task href="${url}/load-statistics" icon="icon-monitor icon-md" title="${%Load Statistics}"/>
       <st:include page="actions.jelly" />
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/model/LoadStatistics/main.jelly
+++ b/core/src/main/resources/hudson/model/LoadStatistics/main.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <h1>
-    <img src="${imagesURL}/48x48/monitor.png" alt="" height="48" width="48"/>
+    <l:icon class="icon-monitor icon-xlg"/>
     ${%title(it.displayName)}
   </h1>
   <j:set var="type" value="${request.getParameter('type') ?: 'min'}" />

--- a/core/src/main/resources/hudson/model/NoFingerprintMatch/index.jelly
+++ b/core/src/main/resources/hudson/model/NoFingerprintMatch/index.jelly
@@ -29,12 +29,12 @@ THE SOFTWARE.
     <l:header title="${%No matching record found}" />
     <l:side-panel>
       <l:tasks>
-        <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
+        <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
       </l:tasks>
     </l:side-panel>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-fingerprint icon-xlg"/>
         ${%No matching record found}
       </h1>
 

--- a/core/src/main/resources/hudson/model/Run/KeepLogBuildBadge/badge.jelly
+++ b/core/src/main/resources/hudson/model/Run/KeepLogBuildBadge/badge.jelly
@@ -23,6 +23,4 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<img width="16" height="16"
-  title="${%Keep this build forever}" alt="[saved]"
-  src="${imagesURL}/16x16/lock.png"/>
+<l:icon class="icon-lock icon-sm" tooltip="${%Keep this build forever}" xmlns:l="/lib/layout"/>

--- a/core/src/main/resources/hudson/model/Run/artifacts-index.jelly
+++ b/core/src/main/resources/hudson/model/Run/artifacts-index.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
           <j:forEach var="f" items="${it.artifacts}">
             <tr>
               <td>
-                <img src="${imagesURL}/16x16/text.png" alt="" height="16" width="16"/>
+                <l:icon class="icon-text icon-sm"/>
               </td>
               <td>
                 <a href="artifact/${f.href}">${f.displayPath}</a>

--- a/core/src/main/resources/hudson/model/Run/delete.jelly
+++ b/core/src/main/resources/hudson/model/Run/delete.jelly
@@ -28,6 +28,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:if test="${!it.building}">
-    <l:task icon="images/24x24/edit-delete.png" href="${buildUrl.baseUrl}/confirmDelete" title="${%Delete this build}" permission="${it.DELETE}" />
+    <l:task href="${buildUrl.baseUrl}/confirmDelete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" title="${%Delete this build}"/>
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/TreeView/sidepanel2.jelly
+++ b/core/src/main/resources/hudson/model/TreeView/sidepanel2.jelly
@@ -27,5 +27,5 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-  <l:task icon="images/32x32/folder.png" href="newView" title="${%New View}"  permission="${it.CONFIGURE}" />
+  <l:task href="newView" icon="icon-folder icon-lg" permission="${it.CONFIGURE}" title="${%New View}"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Failure/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Failure/status.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
-    <img src="${imagesURL}/24x24/red.png" alt="" height="24" width="24"/> ${%Failure}
+    <l:icon class="icon-red icon-md"/> ${%Failure}
     -
     <a href="" onclick="var n=findNext(this,function(e){return e.tagName=='PRE'});
                n.style.display='block';this.style.display='none';return false">${%Details}</a>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Installing/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Installing/status.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
-    <img src="${imagesURL}/24x24/grey_anime.gif" alt="" height="24" width="24"/> ${%Installing}
+    <l:icon class="icon-grey-anime icon-md"/> ${%Installing}
   </div>
   <div style="padding-left: 32px">
     <t:progressBar pos="${it.percentage}" />

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Pending/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Pending/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <img src="${imagesURL}/24x24/grey.png" alt="" height="24" width="24"/> ${%Pending}
+  <l:icon class="icon-grey icon-md"/> ${%Pending}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Success/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Success/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <img src="${imagesURL}/24x24/blue.png" alt="" height="24" width="24"/> ${%Success}
+  <l:icon class="icon-blue icon-md"/> ${%Success}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/SuccessButRequiresRestart/status.groovy
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/SuccessButRequiresRestart/status.groovy
@@ -22,6 +22,8 @@
  * THE SOFTWARE.
  */
 
-img(src:"${imagesURL}/24x24/yellow.png",height:24,width:24)
+def l = namespace(lib.LayoutTagLib)
+
+l.icon(class: 'icon-yellow icon-md')
 text(" ");
 text(my.message)

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Canceled/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Canceled/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <img src="${imagesURL}/24x24/red.png" alt="" height="24" width="24"/> ${%Canceled}
+    <l:icon class="icon-red icon-md"/> ${%Canceled}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <img src="${imagesURL}/24x24/red.png" alt="" height="24" width="24"/> ${%Failure}
+    <l:icon class="icon-red icon-md"/> ${%Failure}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <img src="${imagesURL}/24x24/grey.png" alt="" height="24" width="24"/> ${%Pending}
+  <l:icon class="icon-grey icon-md"/> ${%Pending}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Running/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Running/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <img src="${imagesURL}/24x24/grey_anime.gif" alt="" height="24" width="24"/> ${%Running}
+    <l:icon class="icon-grey-anime icon-md"/> ${%Running}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/sidepanel.jelly
@@ -30,10 +30,10 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
+      <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
       <l:isAdmin>
-        <l:task icon="images/24x24/setting.png" href="${rootURL}/manage" title="${%Manage Jenkins}" />
-        <l:task icon="images/32x32/plugin.png" href="${rootURL}/pluginManager/" title="${%Manage Plugins}" />
+        <l:task href="${rootURL}/manage" icon="icon-setting icon-md" title="${%Manage Jenkins}"/>
+        <l:task href="${rootURL}/pluginManager/" icon="icon-plugin icon-lg" title="${%Manage Plugins}"/>
       </l:isAdmin>
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/model/User/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/User/sidepanel.jelly
@@ -31,14 +31,14 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/asynchPeople/" title="${%People}" contextMenu="false"/>
-      <l:task icon="images/24x24/search.png" href="${rootURL}/${it.url}/" title="${%Status}" contextMenu="false"/>
-      <l:task icon="images/24x24/notepad.png" href="${rootURL}/${it.url}/builds" title="${%Builds}" />
-      <l:task icon="images/24x24/setting.png" href="${rootURL}/${it.url}/configure" title="${%Configure}" permission="${app.ADMINISTER}" />
+      <l:task contextMenu="false" href="${rootURL}/asynchPeople/" icon="icon-up icon-md" title="${%People}"/>
+      <l:task contextMenu="false" href="${rootURL}/${it.url}/" icon="icon-search icon-md" title="${%Status}"/>
+      <l:task href="${rootURL}/${it.url}/builds" icon="icon-notepad icon-md" title="${%Builds}"/>
+      <l:task href="${rootURL}/${it.url}/configure" icon="icon-setting icon-md" permission="${app.ADMINISTER}" title="${%Configure}"/>
       <t:actions actions="${it.propertyActions}"/>
       <t:actions actions="${it.transientActions}"/>
       <j:if test="${it.canDelete()}">
-        <l:task icon="images/24x24/edit-delete.png" href="${rootURL}/${it.url}/delete" title="${%Delete}" />
+        <l:task href="${rootURL}/${it.url}/delete" icon="icon-edit-delete icon-md" title="${%Delete}"/>
       </j:if>
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/model/View/AsynchPeople/index.jelly
+++ b/core/src/main/resources/hudson/model/View/AsynchPeople/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <t:setIconSize/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/user.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-user icon-xlg"/>
         ${%People}
         <j:set var="viewType" value="${it.parent.class.simpleName}"/>
         <j:set var="isAll" value="${viewType=='Hudson' or viewType=='AllView'}"/>

--- a/core/src/main/resources/hudson/model/View/builds.jelly
+++ b/core/src/main/resources/hudson/model/View/builds.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/notepad.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-notepad icon-xlg"/>
         ${%buildHistory(it.class.name=='hudson.model.AllView' ? app.displayName : it.displayName)}
       </h1>
 

--- a/core/src/main/resources/hudson/model/View/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/View/sidepanel.jelly
@@ -40,28 +40,28 @@ THE SOFTWARE.
 
       <st:include page="tasks-new.jelly" it="${it.owner}" optional="true">
         <!-- made overridable for ViewGroup that doesn't allow modifications -->
-        <l:task icon="images/24x24/new-package.png" href="${rootURL}/${it.viewUrl}newJob" title="${%NewJob(it.newPronoun)}" permission="${it.itemCreatePermission}" it="${app}" />
+        <l:task href="${rootURL}/${it.viewUrl}newJob" icon="icon-new-package icon-md" it="${app}" permission="${it.itemCreatePermission}" title="${%NewJob(it.newPronoun)}"/>
       </st:include>
 
       <j:choose>
         <j:when test="${it.class.name=='hudson.model.AllView'}">
-          <l:task icon="images/24x24/user.png" href="${rootURL}/asynchPeople/" title="${%People}" />
+          <l:task href="${rootURL}/asynchPeople/" icon="icon-user icon-md" title="${%People}"/>
         </j:when>
         <j:otherwise>
-          <l:task icon="images/24x24/user.png" href="${rootURL}/${it.viewUrl}asynchPeople/" title="${%People}" />
+          <l:task href="${rootURL}/${it.viewUrl}asynchPeople/" icon="icon-user icon-md" title="${%People}"/>
         </j:otherwise>
       </j:choose>
-      <l:task icon="images/24x24/notepad.png" href="${rootURL}/${it.viewUrl}builds" title="${%Build History}"/>
+      <l:task href="${rootURL}/${it.viewUrl}builds" icon="icon-notepad icon-md" title="${%Build History}"/>
       <j:if test="${it.isEditable()}">
         <!-- /configure URL on Jenkins object is overloaded with Jenkins's system config, so always use the explicit name. -->
-        <l:task icon="images/24x24/gear.png" href="${rootURL}/${it.viewUrl}configure" title="${%Edit View}" permission="${it.CONFIGURE}" />
+        <l:task href="${rootURL}/${it.viewUrl}configure" icon="icon-gear icon-md" permission="${it.CONFIGURE}" title="${%Edit View}"/>
       </j:if>
       <j:if test="${it.owner.canDelete(it)}">
-        <l:task icon="images/24x24/edit-delete.png" href="delete" title="${%Delete View}" permission="${it.DELETE}" />
+        <l:task href="delete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" title="${%Delete View}"/>
       </j:if>
       <j:if test="${app.fingerprintMap.ready}">
-        <l:task icon="images/24x24/search.png" href="${rootURL}/projectRelationship" title="${%Project Relationship}" />
-        <l:task icon="images/24x24/fingerprint.png" href="${rootURL}/fingerprintCheck" title="${%Check File Fingerprint}" />
+        <l:task href="${rootURL}/projectRelationship" icon="icon-search icon-md" title="${%Project Relationship}"/>
+        <l:task href="${rootURL}/fingerprintCheck" icon="icon-fingerprint icon-md" title="${%Check File Fingerprint}"/>
       </j:if>
 
       <!-- subtypes can put more stuff here -->

--- a/core/src/main/resources/hudson/os/solaris/ZFSInstaller/askRootPassword.jelly
+++ b/core/src/main/resources/hudson/os/solaris/ZFSInstaller/askRootPassword.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <l:side-panel />
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/secure.png" width="48" height="48" alt=""/>
+        <l:icon class="icon-secure icon-xlg"/>
         ${%Permission Denied}
       </h1>
       <div>

--- a/core/src/main/resources/hudson/scm/AbstractScmTagAction/badge.jelly
+++ b/core/src/main/resources/hudson/scm/AbstractScmTagAction/badge.jelly
@@ -23,11 +23,8 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:if test="${it.isTagged()}" xmlns:j="jelly:core">
+<j:if xmlns:j="jelly:core" xmlns:l="/lib/layout" test="${it.isTagged()}">
   <a href="${rootURL}/${it.build.url}tagBuild/">
-    <img width="16" height="16"
-      tooltip="${it.tooltip}"
-      alt="[tagged]"
-      src="${imagesURL}/16x16/save.png"/>
+    <l:icon class="icon-save icon-sm" tooltip="${it.tooltip}"/>
   </a>
 </j:if>

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
@@ -14,7 +14,7 @@ def st=namespace("jelly:stapler")
 l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
     l.main_panel {
         h1 {
-            img(src:"${imagesURL}/48x48/secure.png", height:48,width:48)
+            l.icon(class: 'icon-secure icon-xlg')
             text(my.displayName)
         }
 

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
@@ -43,9 +43,9 @@ THE SOFTWARE.
             <td><a href="${user.url}/">${user.id}</a></td>
             <td><a href="${user.url}/">${user}</a></td>
             <td>
-              <a href="${user.url}/configure"><img src="${imagesURL}/32x32/setting.png" alt="Setting" height="32" width="32"/></a>
+              <a href="${user.url}/configure"><l:icon class="icon-setting icon-lg"/></a>
               <j:if test="${user.canDelete()}">
-                <a href="${user.url}/delete"><img src="${imagesURL}/24x24/edit-delete.png" alt="Delete" height="24" width="24"/></a>
+                <a href="${user.url}/delete"><l:icon class="icon-edit-delete icon-md"/></a>
               </j:if>
             </td>
           </tr>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/sidepanel.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/sidepanel.jelly
@@ -27,9 +27,9 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
-      <l:task icon="images/24x24/setting.png" href="${rootURL}/manage" title="${%Manage Jenkins}" permission="${app.ADMINISTER}" />
-      <l:task icon="images/24x24/new-user.png" href="addUser" title="${%Create User}" permission="${app.ADMINISTER}"/>
+      <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
+      <l:task href="${rootURL}/manage" icon="icon-setting icon-md" permission="${app.ADMINISTER}" title="${%Manage Jenkins}"/>
+      <l:task href="addUser" icon="icon-new-user icon-md" permission="${app.ADMINISTER}" title="${%Create User}"/>
     </l:tasks>
   </l:side-panel>
 </j:jelly>

--- a/core/src/main/resources/hudson/slaves/SlaveComputer/sidepanel2.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/sidepanel2.jelly
@@ -24,10 +24,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:task icon="images/24x24/clipboard.png" href="log" title="${%Log}" permission="${it.CONNECT}" />
+  <l:task icon="icon-clipboard icon-md" href="log" title="${%Log}" permission="${it.CONNECT}" />
   <j:if test="${it.channel!=null}">
-    <l:task icon="images/24x24/computer.png" href="systemInfo" title="${%System Information}" permission="${it.CONNECT}"/>
-    <l:task icon="images/24x24/edit-delete.png" href="disconnect" title="${%Disconnect}" permission="${it.DISCONNECT}"/>
+    <l:task icon="icon-computer icon-md" href="systemInfo" title="${%System Information}" permission="${it.CONNECT}"/>
+    <l:task icon="icon-edit-delete icon-md" href="disconnect" title="${%Disconnect}" permission="${it.DISCONNECT}"/>
   </j:if>
 
 </j:jelly>

--- a/core/src/main/resources/hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
+++ b/core/src/main/resources/hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
     <st:include it="${it.build}" page="sidepanel.jelly"/>
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-fingerprint icon-xlg"/>
         ${%Recorded Fingerprints}
       </h1>
       <table class="fingerprint-in-build sortable bigtable">
@@ -67,7 +67,7 @@ THE SOFTWARE.
             </td>
             <td>
               <a href="${rootURL}/fingerprint/${f.hashString}/">
-                <img src="${imagesURL}/16x16/fingerprint.png" alt="" height="16" width="16"/> ${%more details}
+                <l:icon class="icon-fingerprint icon-sm"/> ${%more details}
               </a>
             </td>
           </tr>

--- a/core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
+++ b/core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
@@ -35,10 +35,10 @@ THE SOFTWARE.
         <j:set var="close" value="javascript:hideFailureSummary('${id}')"/>
         <h4>
           <a id="${id}-showlink" href="${open}" title="Show ${title}" style="display: ${idisplay}">
-            <img src="${imagesURL}/16x16/document_add.png"/><st:nbsp/>${title}
+            <l:icon class="icon-document-add icon-sm"/><st:nbsp/>${title}
           </a>
           <a id="${id}-hidelink" href="${close}" title="Hide ${title}" style="display: ${display}">
-            <img src="${imagesURL}/16x16/document_delete.png"/><st:nbsp/>${title}
+            <l:icon class="icon-document-delete icon-sm"/><st:nbsp/>${title}
           </a>
         </h4>
         <pre id="${id}" style="display: ${display}">

--- a/core/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
+++ b/core/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
@@ -33,16 +33,16 @@ THE SOFTWARE.
       <j:set var="buildUrl" value="${h.decompose(request)}" />
       <j:set var="baseUrl" value="${request.findAncestor(it).relativePath}"/>
       <st:include it="${it.owner}" page="tasks.jelly" optional="true"/>
-      <l:task icon="images/24x24/graph.png" href="${baseUrl}/history" title="${%History}"/>
+      <l:task href="${baseUrl}/history" icon="icon-graph icon-md" title="${%History}"/>
       <st:include it="${it.owner}" page="actions.jelly" optional="true" />
 
       <t:actions actions="${it.testActions}" />
 
       <j:if test="${it.owner.previousBuild!=null}">
-        <l:task icon="images/24x24/previous.png" href="${buildUrl.previousBuildUrl}" title="${%Previous Build}" />
+        <l:task href="${buildUrl.previousBuildUrl}" icon="icon-previous icon-md" title="${%Previous Build}"/>
       </j:if>
       <j:if test="${it.owner.nextBuild!=null}">
-        <l:task icon="images/24x24/next.png" href="${buildUrl.nextBuildUrl}" title="${%Next Build}" />
+        <l:task href="${buildUrl.nextBuildUrl}" icon="icon-next icon-md" title="${%Next Build}"/>
       </j:if>
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/tools/JDKInstaller/DescriptorImpl/enterCredential.jelly
+++ b/core/src/main/resources/hudson/tools/JDKInstaller/DescriptorImpl/enterCredential.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
     <l:main-panel>
 
       <h1>
-        <img src="${imagesURL}/48x48/secure.gif" width="48" height="48" alt=""/>
+        <l:icon class="icon-secure icon-xlg"/>
         ${%Enter Your Oracle Account}
       </h1>
       <p>

--- a/core/src/main/resources/hudson/triggers/SCMTrigger/BuildAction/index.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/BuildAction/index.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
       <h1>${%Polling Log}</h1>
       <l:rightspace>
         <a href="pollingLog">
-          <img src="${imagesURL}/24x24/document.png" alt="" height="24" width="24" />${%View as plain text}
+          <l:icon class="icon-document icon-md"/>${%View as plain text}
         </a>
       </l:rightspace>
 

--- a/core/src/main/resources/hudson/util/AWTProblem/index.jelly
+++ b/core/src/main/resources/hudson/util/AWTProblem/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
       <p>
         ${%errorMessage}
       </p>

--- a/core/src/main/resources/hudson/util/HudsonFailedToLoad/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonFailedToLoad/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
       <pre>${it.stackTraceString}</pre>
     </l:main-panel>
   </l:layout>

--- a/core/src/main/resources/hudson/util/IncompatibleAntVersionDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/IncompatibleAntVersionDetected/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
       <p>
         ${%errorMessage(it.whereAntIsLoaded)}
       </p>

--- a/core/src/main/resources/hudson/util/IncompatibleServletVersionDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/IncompatibleServletVersionDetected/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
       <p>
         ${%errorMessage(it.whereServletIsLoaded)}
       </p>

--- a/core/src/main/resources/hudson/util/IncompatibleVMDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/IncompatibleVMDetected/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
       <p>
         ${%errorMessage}
       </p>

--- a/core/src/main/resources/hudson/util/InsufficientPermissionDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/InsufficientPermissionDetected/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
       <p>
          ${%errorMessage.1}
       </p>

--- a/core/src/main/resources/hudson/util/JNADoublyLoaded/index.jelly
+++ b/core/src/main/resources/hudson/util/JNADoublyLoaded/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:header />
     <l:side-panel />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Failed to load JNA}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Failed to load JNA}</h1>
       <p>${%blurb}</p>
       <pre>${it.stackTraceString}</pre>
     </l:main-panel>

--- a/core/src/main/resources/hudson/util/JenkinsReloadFailed/index.groovy
+++ b/core/src/main/resources/hudson/util/JenkinsReloadFailed/index.groovy
@@ -6,7 +6,7 @@ l.layout {
     l.header(title:"Jenkins")
     l.main_panel {
         h1 {
-            img(src:"${imagesURL}/48x48/error.png",alt:"[!]",height:48,width:48)
+            l.icon(class: 'icon-error icon-xlg')
             text(" ")
             text(_("Error"))
         }

--- a/core/src/main/resources/hudson/util/NoHomeDir/index.jelly
+++ b/core/src/main/resources/hudson/util/NoHomeDir/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
       <p>
         ${%errorMessage.1(it.home)}
       </p>

--- a/core/src/main/resources/hudson/util/NoTempDir/index.jelly
+++ b/core/src/main/resources/hudson/util/NoTempDir/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/error.png" alt="[!]" height="48" width="48"/><st:nbsp/>${%Error}</h1>
+      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
       <p>${%description(it.tempDir)}</p>
       <pre>${it.stackTraceString}</pre>
     </l:main-panel>

--- a/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
+++ b/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
@@ -38,11 +38,10 @@ THE SOFTWARE.
                           <j:set var="onclick" value="return build_${id}(this)"/>
                       </j:otherwise>
                   </j:choose>
-                  <j:set var="icon" value="${app.queue.contains(job) ? 'clock_anime.gif' : 'clock.png'}"/>
-                  <img src="${imagesURL}/${subIconSize}/${icon}"
+                  <j:set var="icon" value="${app.queue.contains(job) ? 'icon-clock-anime' : 'icon-clock'}"/>
+                  <l:icon class="${icon} ${subIconSizeClass}"
                          title="${title}" alt="${title}"
-                         onclick="${onclick}"
-                         border="0"/>
+                         onclick="${onclick}"/>
               </a>
               <script>
                 function build_${id}(img) {

--- a/core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
+++ b/core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
       <j:set var="id" value="${h.generateId()}"/>
       <tr class="build-row transitive" id="${id}">
         <td nowrap="nowrap">
-          <img width="16" height="16" src="${imagesURL}/16x16/grey.png" alt="${%pending}"/>
+          <l:icon class="icon-grey icon-sm"/>
           <st:nbsp/>
           <!-- Don't use math unless needed, in case nextBuildNumber is not numeric -->
           #${queuedItems.size()==1 ? it.owner.nextBuildNumber

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
   <j:set var="transitive" value="${(it.firstTransientBuildKey!=null and (it.adapter.compare(build,it.firstTransientBuildKey) ge 0)) ? 'transitive' : null}" />
   <tr class="build-row ${transitive}">
     <td class="pane build-name">
-      <a class="build-status-link" href="${link}console"><img class="build-status-icon" width="16" height="16" src="${imagesURL}/16x16/${build.buildStatusUrl}" alt="${build.iconColor.description} &gt; ${%Console Output}" tooltip="${build.iconColor.description} &gt; ${%Console Output}" /></a><st:nbsp/>
+      <a class="build-status-link" href="${link}console"><l:icon alt="${build.iconColor.description} &gt; ${%Console Output}" class="${build.buildStatusIconClassName} icon-sm" tooltip="${build.iconColor.description} &gt; ${%Console Output}"/></a><st:nbsp/>
       ${build.displayName}
     </td>
     <td class="pane build-details">

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
     </j:invoke>
     <j:if test="${jobClass.isAssignableFrom(it.owner.class)}">
       <div style="float:right"><a href="${it.baseUrl}/buildTimeTrend">${%trend}</a></div>
-      <t:buildHealth job="${it.owner}" iconSize="16x16" link="${it.baseUrl}/lastBuild"/>
+      <t:buildHealth job="${it.owner}" iconSizeClass="icon-sm" link="${it.baseUrl}/lastBuild"/>
     </j:if>
   </j:parse>
 

--- a/core/src/main/resources/jenkins/diagnosis/HsErrPidList/index.jelly
+++ b/core/src/main/resources/jenkins/diagnosis/HsErrPidList/index.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
         <j:forEach var="f" items="${it.files}" varStatus="idx">
           <tr>
             <td style="padding-right:3em">
-              <img src="${imagesURL}/32x32/clipboard.png" style="margin-right:1em"/>
+              <l:icon class="icon-clipboard icon-lg" style="margin-right:1em"/>
               <a href="files/${idx.index}/download/${f.name}">
                 ${f.path}
               </a>

--- a/core/src/main/resources/jenkins/model/Jenkins/configureExecutors.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configureExecutors.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
   <st:include page="sidepanel.jelly" />
   <l:main-panel>
     <h1>
-      <img src="${imagesURL}/48x48/error.png" alt="" height="48" width="48"/>
+      <l:icon class="icon-error icon-xlg"/>
       This page has moved
     </h1>
     <p>

--- a/core/src/main/resources/jenkins/model/Jenkins/fingerprintCheck.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/fingerprintCheck.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-fingerprint icon-xlg"/>
         ${%Check File Fingerprint}
       </h1>
       <f:form method="post" action="doFingerprintCheck" enctype="multipart/form-data">

--- a/core/src/main/resources/jenkins/model/Jenkins/legend.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/legend.jelly
@@ -31,55 +31,55 @@ THE SOFTWARE.
     <l:main-panel>
       <table cellpadding="5" id="legend-table">
         <tr><td>
-          <img src="images/48x48/grey.png" alt="" height="48" width="48"/>
+          <l:icon class="icon-grey icon-xlg"/>
           ${%grey}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/grey_anime.gif" alt="" height="48" width="48"/>
+          <l:icon class="icon-grey-anime icon-xlg"/>
           ${%grey_anime}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/blue.png" alt="" height="48" width="48"/>
+          <l:icon class="icon-blue icon-xlg"/>
           ${%blue}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/blue_anime.gif" alt="" height="48" width="48"/>
+          <l:icon class="icon-blue-anime icon-xlg"/>
           ${%blue_anime}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/yellow.png" alt="" height="48" width="48"/>
+          <l:icon class="icon-yellow icon-xlg"/>
           ${%yellow}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/yellow_anime.gif" alt="" height="48" width="48"/>
+          <l:icon class="icon-yellow-anime icon-xlg"/>
           ${%yellow_anime}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/red.png" alt="" height="48" width="48"/>
+          <l:icon class="icon-red icon-xlg"/>
           ${%red}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/red_anime.gif" alt="" height="48" width="48"/>
+          <l:icon class="icon-red-anime icon-xlg"/>
           ${%red_anime}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/health-80plus.png" alt="" height="48" width="48"/>
+          <l:icon class="icon-health-80plus icon-xlg"/>
           ${%health-81plus}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/health-60to79.png" alt="" height="48" width="48"/>
+          <l:icon class="icon-health-60to79 icon-xlg"/>
           ${%health-61to80}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/health-40to59.png" alt="" height="48" width="48"/>
+          <l:icon class="icon-health-40to59 icon-xlg"/>
           ${%health-41to60}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/health-20to39.png" alt="" height="48" width="48"/>
+          <l:icon class="icon-health-20to39 icon-xlg"/>
           ${%health-21to40}
         </td></tr>
         <tr><td>
-          <img src="images/48x48/health-00to19.png" alt="" height="48" width="48"/>
+          <l:icon class="icon-health-00to19 icon-xlg"/>
           ${%health-00to20}
         </td></tr>
       </table>

--- a/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
@@ -31,10 +31,10 @@ THE SOFTWARE.
   <l:layout title="Jenkins" norefresh="true">
     <l:header />
     <l:side-panel>
-      <l:task title="${%Jenkins project}" href="http://jenkins-ci.org/" icon="images/24x24/next.png" />
-      <l:task title="${%Bug tracker}" href="http://issues.jenkins-ci.org/" icon="images/24x24/gear2.png" />
-      <l:task title="${%Mailing Lists}" href="http://jenkins-ci.org/content/mailing-lists" icon="images/24x24/search.png"/>
-      <l:task title="${%Twitter: @jenkinsci}" href="https://twitter.com/jenkinsci" icon="images/24x24/user.png"/>
+      <l:task href="http://jenkins-ci.org/" icon="icon-next icon-md" title="${%Jenkins project}"/>
+      <l:task href="http://issues.jenkins-ci.org/" icon="icon-gear2 icon-md" title="${%Bug tracker}"/>
+      <l:task href="http://jenkins-ci.org/content/mailing-lists" icon="icon-search icon-md" title="${%Mailing Lists}"/>
+      <l:task href="https://twitter.com/jenkinsci" icon="icon-user icon-md" title="${%Twitter: @jenkinsci}"/>
 
     </l:side-panel>
     <l:main-panel>

--- a/core/src/main/resources/jenkins/model/Jenkins/projectRelationship.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/projectRelationship.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
   <l:layout norefresh="true" title="${%Project Relationship}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/search.png" alt="" height="48" width="48"/>${%Project Relationship}</h1>
+      <h1><l:icon class="icon-search icon-xlg"/>${%Project Relationship}</h1>
       <form action="projectRelationship" method="get">
         <table width="100%">
           <tr>
@@ -39,7 +39,7 @@ THE SOFTWARE.
               ${%upstream project}:
               <f:editableComboBox id="lhs" name="lhs" value="${request.getParameter('lhs')}" items="${names}" />
             </td>
-            <td style="width:32px; text-align:center;"><img src="${imagesURL}/24x24/next.png" alt="->" height="24" width="24"/></td>
+            <td style="width:32px; text-align:center;"><l:icon class="icon-next icon-md"/></td>
             <td>
               ${%downstream project}:
               <f:editableComboBox id="rhs" name="rhs" value="${request.getParameter('rhs')}" items="${names}" />
@@ -48,7 +48,7 @@ THE SOFTWARE.
           <tr>
             <td colspan="3" style="text-align:right">
               <f:submit value="${%Compare}" />
-              <a href="projectRelationship-help"><img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/></a>
+              <a href="projectRelationship-help"><l:icon class="icon-help icon-sm"/></a>
             </td>
           </tr>
 

--- a/core/src/main/resources/jenkins/model/Jenkins/threadDump.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/threadDump.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
 
       <j:forEach var="e" items="${tdumps.entrySet()}">
         <j:if test="${e.key != null and e.key.length() > 0}">
-          <a href="#id${e.key.hashCode()}"><img src="${imagesURL}/16x16/computer.png" style="margin-left:10px;" /> ${e.key}</a>
+          <a href="#id${e.key.hashCode()}"><l:icon class="icon-computer icon-sm" style="margin-left:10px;"/> ${e.key}</a>
         </j:if>
       </j:forEach>
 
@@ -46,7 +46,7 @@ THE SOFTWARE.
         </j:if>
         <j:if test="${e.key != null and e.key.length() > 0}">
           <h1 id="id${e.key.hashCode()}">
-            <img src="${imagesURL}/32x32/computer.png"/> <a href="/computer/${e.key}" class="model-link inside">${e.key}</a>
+            <l:icon class="icon-computer icon-lg"/> <a class="model-link inside" href="/computer/${e.key}">${e.key}</a>
           </h1>
         </j:if>
         <j:forEach var="t" items="${e.value.entrySet()}">

--- a/core/src/main/resources/lib/form/advanced.jelly
+++ b/core/src/main/resources/lib/form/advanced.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
 	    <div class="advancedLink" style="${attrs.align!=null?('text-align:'+attrs.align):''}">
               <j:set var="id" value="${h.generateId()}"/>
               <span style="display: none" id="${id}">
-                <img src="${imagesURL}/24x24/notepad.png" style="vertical-align: baseline" alt="${%customizedFields}" tooltip="${%customizedFields}"/>
+                <l:icon class="icon-notepad icon-md" style="vertical-align: baseline" tooltip="${%customizedFields}"/>
               </span>
               <st:nbsp />
 	      <input type="button" value="${attrs.title?:'%Advanced'}..." class="advanced-button advancedButton" /><!-- advancedButton is legacy -->

--- a/core/src/main/resources/lib/form/helpLink.jelly
+++ b/core/src/main/resources/lib/form/helpLink.jelly
@@ -55,7 +55,7 @@ THE SOFTWARE.
     <j:when test="${attrs.url!=null}">
       <j:set var="altText" value="${attrs.featureName != null ? '%Help for feature:' + ' ' + attrs.featureName : '%[Help]'}" />
       <td class="setting-help">
-        <a href="#" class="help-button" helpURL="${rootURL}${attrs.url}"><img src="${imagesURL}/16x16/help.png" alt="${altText}" height="16" width="16"/></a>
+        <a href="#" class="help-button" helpURL="${rootURL}${attrs.url}"><l:icon class="icon-help icon-sm" alt="${altText}"/></a>
       </td>
     </j:when>
     <j:otherwise>

--- a/core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/core/src/main/resources/lib/hudson/artifactList.jelly
@@ -51,7 +51,7 @@ THE SOFTWARE.
               <j:forEach var="f" items="${artifacts}">
                 <tr>
                   <td>
-                    <img src="${imagesURL}/16x16/text.png" alt="" height="16" width="16"/>
+                    <l:icon class="icon-text icon-sm"/>
                   </td>
                   <td>
                     <a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
@@ -62,7 +62,7 @@ THE SOFTWARE.
                   <td>
                     <j:if test="${app.fingerprintMap.ready}">
                       <a href="${baseURL}artifact/${f.href}/*fingerprint*/">
-                        <img src="${imagesURL}/16x16/fingerprint.png" alt="[fingerprint]" height="16" width="16"/>
+                        <l:icon class="icon-fingerprint icon-sm"/>
                       </a>
                       <st:nbsp/>
                     </j:if>

--- a/core/src/main/resources/lib/hudson/ballColorTd.jelly
+++ b/core/src/main/resources/lib/hudson/ballColorTd.jelly
@@ -34,8 +34,8 @@ THE SOFTWARE.
   </st:documentation>
   <td data="${it.ordinal()}">
     <j:if test="${attrs.it!=null}">
-      <img src="${it.getImageOf(iconSize)}" alt="${it.description}"
-           tooltip="${it.description}" style="${attrs.style}" class="icon${iconSize}"/>
+      <l:icon class="${it.iconClassName} ${iconSizeClass}" alt="${it.description}"
+           tooltip="${it.description}" style="${attrs.style}" />
     </j:if>
   </td>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/buildCaption.jelly
+++ b/core/src/main/resources/lib/hudson/buildCaption.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
 	    </div>
 	  </j:if>
 	  
-	  <img class="build-caption-status-icon" src="${imagesURL}/48x48/${it.buildStatusUrl}" width="48" height="48" alt="${it.iconColor.description}" tooltip="${it.iconColor.description}" />
+	  <l:icon alt="${it.iconColor.description}" class="${it.buildStatusIconClassName} icon-xlg" tooltip="${it.iconColor.description}"/>
 	  <d:invokeBody />
 	</h1>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/buildHealth.jelly
+++ b/core/src/main/resources/lib/hudson/buildHealth.jelly
@@ -24,7 +24,8 @@ THE SOFTWARE.
 
 <!--
   <%@ attribute name="job" required="true" type="hudson.model.Job" %>
-  <%@ attribute name="iconSize" required="true" type="java.lang.String" %>
+  <%@ attribute name="iconSizeClass" type="java.lang.String" %>
+  <%@ attribute name="iconSize" type="java.lang.String" %>
   <%@ attribute name="td" required="false" type="java.lang.String" %>
   <%@ attribute name="link" required="false" type="java.lang.String" %>
 -->
@@ -40,18 +41,25 @@ THE SOFTWARE.
         </x:attribute>
         <x:attribute name="onmouseout">this.className='healthReport';return true;</x:attribute>
         <j:if test="${buildHealth!=null}">
+            <j:if test="${iconSizeClass == null}">
+              <j:choose>
+                <j:when  test="${iconSize == null}">
+                  <j:set var="iconSizeClass" value="icon-sm"/>
+                </j:when>
+                <j:otherwise>
+                  <j:set var="iconSizeClass" value="${icons.toNormalizedIconSizeClass(iconSize)}"/>
+                </j:otherwise>
+              </j:choose>
+            </j:if>
             <j:choose>
               <j:when  test="${!empty(healthReports)}">
                 <a class="build-health-link" href="${empty(link)?'#':link}" 
                     style="${attrs.style}">
-                    <img src="${rootURL}${buildHealth.getIconUrl(iconSize)}"
-                         alt="${buildHealth.score}%" 
-                         class="build-health-icon icon${iconSize}"/>
+                    <l:icon class="${buildHealth.iconClassName} ${iconSizeClass}" alt="${buildHealth.score}%"/>
                 </a>
               </j:when>
               <j:otherwise>
-                 <img src="${rootURL}${buildHealth.getIconUrl(iconSize)}"
-                      alt="${buildHealth.score}%" class="build-health-icon icon${iconSize}"/>
+                 <l:icon class="${buildHealth.iconClassName} ${iconSizeClass}" alt="${buildHealth.score}%" />
                </j:otherwise>
              </j:choose>  
         </j:if>
@@ -69,8 +77,7 @@ THE SOFTWARE.
                         <j:forEach var="rpt" items="${job.buildHealthReports}">
                             <tr>
                                 <td align="left">
-                                    <img src="${rootURL}${rpt.getIconUrl('16x16')}" alt=""
-                                         title=""/>
+                                    <l:icon class="${rpt.iconClassName} icon-sm" />
                                 </td>
                                 <td>${rpt.localizableDescription}</td>
                                 <td align="right">${rpt.score}</td>

--- a/core/src/main/resources/lib/hudson/buildLink.jelly
+++ b/core/src/main/resources/lib/hudson/buildLink.jelly
@@ -47,8 +47,7 @@ THE SOFTWARE.
 	      </j:when>
 	      <j:otherwise>
 	        <a href="${attrs.href ?: rootURL+'/'+r.url}" class="model-link">
-	          <img src="${imagesURL}/16x16/${r.buildStatusUrl}"
-                 alt="${r.iconColor.description}" height="16" width="16"/>${jobName_}#<!-- -->${number}</a>
+	          <l:icon alt="${r.iconColor.description}" class="${r.buildStatusIconClassName} icon-sm"/>${jobName_}#<!-- -->${number}</a>
 	      </j:otherwise>
 	    </j:choose>
 	  </j:otherwise>

--- a/core/src/main/resources/lib/hudson/editTypeIcon.jelly
+++ b/core/src/main/resources/lib/hudson/editTypeIcon.jelly
@@ -27,6 +27,4 @@ THE SOFTWARE.
 	<%@ attribute name="type" type="hudson.scm.EditType" required="true" %>
 -->
 <?jelly escape-by-default='true'?>
-<img width="16" height="16"
-  src="${imagesURL}/16x16/document_${type.name}.png"
-  title="${type.description}" alt="${type.description}" />
+<l:icon alt="${type.description}" class="icon-document-${type.name} icon-sm" title="${type.description}" xmlns:l="/lib/layout"/>

--- a/core/src/main/resources/lib/hudson/editableDescription.jelly
+++ b/core/src/main/resources/lib/hudson/editableDescription.jelly
@@ -41,7 +41,7 @@ THE SOFTWARE.
 
     <l:hasPermission permission="${permission}">
       <div align="right"><a id="description-link" href="editDescription" onclick="${h.isAutoRefresh(request) ? null : 'return replaceDescription();'}">
-        <img id="description-image" src="${imagesURL}/16x16/notepad.png" alt="" height="16" width="16" />
+        <l:icon class="icon-notepad icon-sm"/>
         <j:choose>
           <j:when test="${empty(it.description)}">
             ${%add description}

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
   <d:taglib uri="local">
     <d:tag name="computerCaption">
 
-      <a href="${rootURL}/${c.url}" class="model-link inside"><img src="${imagesURL}/16x16/computer${c.offline?'-x':''}.png"/><st:nbsp/>${title}</a>
+      <a href="${rootURL}/${c.url}" class="model-link inside"><l:icon class="icon-computer${c.offline?'-x':''} icon-sm" alt="${altText}"/><st:nbsp/>${title}</a>
       <j:if test="${c.offline}"> <st:nbsp/> (${%offline})</j:if>
       <j:if test="${!c.acceptingTasks}"> <st:nbsp/> (${%suspended})</j:if>
     </d:tag>

--- a/core/src/main/resources/lib/hudson/failed-test.jelly
+++ b/core/src/main/resources/lib/hudson/failed-test.jelly
@@ -85,10 +85,10 @@ THE SOFTWARE.
   <j:set var="open" value="javascript:showFailureSummary('test-${id}','${url}/summary')"/>
   <j:set var="close" value="javascript:hideFailureSummary('test-${id}')"/>
   <a id="test-${id}-showlink" href="${open}" title="${%Show details}">
-    <img src="${imagesURL}/16x16/document_add.png"/>
+    <l:icon class="icon-document-add icon-sm"/>
   </a>
   <a id="test-${id}-hidelink" href="${close}" title="${%Hide details}" style="display:none">
-    <img src="${imagesURL}/16x16/document_delete.png"/>
+    <l:icon class="icon-document-delete icon-sm"/>
   </a>
   <st:nbsp/>
   <a href="${url}" class="model-link inside"><st:out value="${result.fullDisplayName}"/></a>

--- a/core/src/main/resources/lib/hudson/help.jelly
+++ b/core/src/main/resources/lib/hudson/help.jelly
@@ -27,5 +27,5 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <a href="${href}">
-  <img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/>
+  <l:icon class="icon-help icon-sm" xmlns:l="/lib/layout"/>
 </a>

--- a/core/src/main/resources/lib/hudson/jobLink.jelly
+++ b/core/src/main/resources/lib/hudson/jobLink.jelly
@@ -31,6 +31,6 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 
-<img src="${imagesURL}/16x16/${job.buildStatusUrl}" alt="${job.iconColor.description}" height="16" width="16"/>
+<l:icon alt="${job.iconColor.description}" class="${job.buildStatusIconClassName} icon-sm"/>
 <a href="${h.getRelativeLinkTo(job)}" class="model-link"><l:breakable value="${job.fullDisplayName}"/></a>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/configurable.jelly
+++ b/core/src/main/resources/lib/hudson/project/configurable.jelly
@@ -27,8 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
     <j:if test="${it.buildable}">
         <j:set var="id" value="${h.generateId()}"/>
-        <l:task icon="images/24x24/clock.png" href="${url}/build?delay=0sec" title="${it.buildNowText}"
-                  onclick="${it.parameterized?null:'return build_' + id + '(this)'}" post="${!it.parameterized}" permission="${it.BUILD}"/>
+        <l:task href="${url}/build?delay=0sec" icon="icon-clock icon-md" onclick="${it.parameterized?null:'return build_' + id + '(this)'}" permission="${it.BUILD}" post="${!it.parameterized}" title="${it.buildNowText}"/>
         <script>
             function build_${id}(a) {
                 new Ajax.Request(a.href);
@@ -37,13 +36,13 @@ THE SOFTWARE.
             }
         </script>
     </j:if>
-    <l:task icon="images/24x24/edit-delete.png" href="${url}/doDelete" title="${%delete(it.pronoun)}" permission="${it.DELETE}" post="true" requiresConfirmation="true" confirmationMessage="${%delete.confirm(it.pronoun, it.displayName)}"/>
+    <l:task confirmationMessage="${%delete.confirm(it.pronoun, it.displayName)}" href="${url}/doDelete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" post="true" requiresConfirmation="true" title="${%delete(it.pronoun)}"/>
     <j:choose>
         <j:when test="${h.hasPermission(it,it.CONFIGURE)}">
-            <l:task icon="images/24x24/setting.png" href="${url}/configure" title="${%Configure}" />
+            <l:task href="${url}/configure" icon="icon-setting icon-md" title="${%Configure}"/>
         </j:when>
         <j:when test="${h.hasPermission(it,it.EXTENDED_READ)}">
-            <l:task icon="images/24x24/setting.png" href="${url}/configure" title="${%View Configuration}" />
+            <l:task href="${url}/configure" icon="icon-setting icon-md" title="${%View Configuration}"/>
         </j:when>
     </j:choose>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/console-link.jelly
+++ b/core/src/main/resources/lib/hudson/project/console-link.jelly
@@ -28,12 +28,12 @@ THE SOFTWARE.
     <j:choose>
         <j:when test="${it.logFile.length() > 200000}">
             <!-- Show raw link directly so user need not click through live console page, though this is not so bad now as they would just see: Skipping nnn KB.. Full Log. -->
-            <l:task icon="images/24x24/terminal.png" href="${buildUrl.baseUrl}/console" title="${%Console Output}"/>
-            <l:task icon="images/24x24/document.png" href="${buildUrl.baseUrl}/consoleText" title="${%View as plain text}"/>
+            <l:task href="${buildUrl.baseUrl}/console" icon="icon-terminal icon-md" title="${%Console Output}"/>
+            <l:task href="${buildUrl.baseUrl}/consoleText" icon="icon-document icon-md" title="${%View as plain text}"/>
         </j:when>
         <j:otherwise>
             <l:task icon="images/24x24/terminal.png" href="${buildUrl.baseUrl}/console" title="${%Console Output}">
-                <l:task icon="images/24x24/document.png" href="${buildUrl.baseUrl}/consoleText" title="${%View as plain text}"/>
+                <l:task href="${buildUrl.baseUrl}/consoleText" icon="icon-document icon-md" title="${%View as plain text}"/>
             </l:task>
         </j:otherwise>
     </j:choose>

--- a/core/src/main/resources/lib/hudson/project/upstream-downstream.jelly
+++ b/core/src/main/resources/lib/hudson/project/upstream-downstream.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
       <j:if test="${lhs.fingerprintConfigured and rhs.fingerprintConfigured}">
         <st:nbsp/>
         <a href="${rootURL}/projectRelationship?lhs=${lhs.name}&amp;rhs=${rhs.name}">
-          <img src="${imagesURL}/16x16/fingerprint.png" alt="check relationship" height="16" width="16"/>
+          <l:icon class="icon-fingerprint icon-sm"/>
         </a>
       </j:if>
     </d:tag>

--- a/core/src/main/resources/lib/hudson/projectViewNested.jelly
+++ b/core/src/main/resources/lib/hudson/projectViewNested.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
             </a>
           </j:otherwise>
         </j:choose>
-        <img src="${imagesURL}/${iconSize}/folder.png" style="margin-left:4px" alt="" class="icon${iconSize}" />
+        <l:icon class="icon-folder ${iconSizeClass}" style="margin-left:4px" />
       </div>
     </td>
     <td colspan="5" style="${indenter.getCss(job)}">

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -80,7 +80,7 @@ THE SOFTWARE.
                   <j:if test="${stuck}">
                     &#160;
                     <a href="http://wiki.jenkins-ci.org/display/JENKINS/Executor+Starvation">
-                      <img src="${imagesURL}/16x16/hourglass.gif" height="16" width="16"/>
+                      <l:icon class="icon-hourglass icon-sm"/>
                     </a>
                   </j:if>
                 </j:when>

--- a/core/src/main/resources/lib/hudson/setIconSize.jelly
+++ b/core/src/main/resources/lib/hudson/setIconSize.jelly
@@ -28,10 +28,12 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set scope="parent" var="iconSize" value="${h.validateIconSize(h.getCookie(request,'iconSize','32x32'))}" />
+  <j:set scope="parent" var="iconSizeClass" value="${icons.toNormalizedIconSizeClass(iconSize)}" />
   <!--
     balls look smaller than their actual size,
     so we try not to make the secondary icons look bigger than the icon.
     we want the user's eyes to go to balls, not the clock.
   -->
   <j:set scope="parent" var="subIconSize" value="${iconSize=='32x32'?'24x24':iconSize}"/>
+  <j:set scope="parent" var="subIconSizeClass" value="${icons.toNormalizedIconSizeClass(subIconSize)}"/>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/summary.jelly
+++ b/core/src/main/resources/lib/hudson/summary.jelly
@@ -28,8 +28,11 @@ THE SOFTWARE.
     Displays a link with a large icon. Used in the project top page.
 
     <st:attribute name="icon" use="required">
-      link to the icon image. relative paths will be resolved against images/48x48,
-      and absolute paths (that start with '/') will be resolved against the context root of Hudson
+      The icon class name e.g. 'icon-folder'.
+
+      On older versions of Jenkins, this attribute value used to be a link to the raw icon image, where relative
+      paths were resolved against images/48x48 and absolute paths (that start with '/') were resolved against
+      the context root of Hudson.
     </st:attribute>
     <st:attribute name="href">
       where the summary icon links to.
@@ -45,16 +48,44 @@ THE SOFTWARE.
     <j:if test="${attrs.icon!=null}">
       <tr>
         <td>
+          <!--
+            Backward compatibility.  Ugly but needed for now.
+
+            'icon' can be an icon class name (e.g. 'icon-folder'), but can also be an icon file name
+            (without path e.g. 'folder.png'), or can be a full path and name (e.g. to an icon in a
+            plugin - '/plugin/images/48x48/xxxx.png').  So, first we see can we derive an icon
+            from the 'icon' value, which will work if it's just something like 'folder.png'.  Failing
+            that, we try deriving it by URL (assuming it's a full icon path).  If all that fails,
+            we just fall back to the old method by passing a 'src' attribute to the <icon> tag.
+          -->
+          <j:set var="iconMetadata" value="${icons.getIconByClassSpec(icons.toNormalizedIconNameClass(icon) + ' icon-xlg')}"/>
+          <j:if test="${iconMetadata == null}">
+            <j:set var="iconMetadata" value="${icons.getIconByUrl(icon)}"/>
+          </j:if>
+
           <j:choose>
             <j:when test="${attrs.href!=null}">
               <a href="${attrs.href}">
-                <img src="${icon.startsWith('/') ? resURL+icon : imagesURL+'/48x48/'+icon}"
-                     alt="" width="48" height="48" style="margin-right:1em" />
+                <j:choose>
+                  <j:when test="${iconMetadata != null}">
+                    <l:icon class="${iconMetadata.classSpec}"/>
+                  </j:when>
+                  <j:otherwise>
+                    <l:icon width="24" height="24" style="margin: 2px;" alt="" src="${icon}"/>
+                  </j:otherwise>
+                </j:choose>
               </a>
             </j:when>
             <j:otherwise>
-              <img src="${icon.startsWith('/') ? resURL+icon : imagesURL+'/48x48/'+icon}"
-                   alt="" width="48" height="48" style="margin-right:1em" />
+              <j:choose>
+                <j:when test="${iconMetadata != null}">
+                  <l:icon class="${iconMetadata.classSpec}"/>
+                </j:when>
+                <j:otherwise>
+                  <l:icon src="${icon.startsWith('/') ? resURL+icon : imagesURL+'/48x48/'+icon}"
+                          alt="" width="48" height="48" style="margin-right:1em" />
+                </j:otherwise>
+              </j:choose>
             </j:otherwise>
           </j:choose>
         </td>

--- a/core/src/main/resources/lib/layout/icon.jelly
+++ b/core/src/main/resources/lib/layout/icon.jelly
@@ -1,0 +1,68 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <st:documentation>
+    <st:attribute name="class">
+      The icon class specification e.g. 'icon-help icon-sm', 'icon-blue icon-md', 'icon-blue-anime icon-xlg'.
+    </st:attribute>
+
+    <st:attribute name="src">
+      Icon source raw URL. Only relevant if the 'class' attribute is NOT specified.
+    </st:attribute>
+
+    <st:attribute name="onclick">onclick handler.</st:attribute>
+    <st:attribute name="title">title</st:attribute>
+    <st:attribute name="style">style</st:attribute>
+    <st:attribute name="tooltip">tooltip</st:attribute>
+
+    <st:attribute name="alt">alt</st:attribute>
+  </st:documentation>
+
+  <j:set var="imgSrc" value="${attrs.src}"/>
+  <j:set var="imgStyle" value="${attrs.style}"/>
+  <j:if test="${attrs.class != null}">
+  </j:if>
+
+  <j:choose>
+    <j:when test="${attrs.class != null}">
+      <!-- Derive the icon url and style from the class spec -->
+      <j:set var="iconMetadata" value="${icons.getIconByClassSpec(attrs.class)}"/>
+    </j:when>
+    <j:otherwise>
+      <!-- Attempt to work back from the image url (backward compatibility)... -->
+      <j:set var="iconMetadata" value="${icons.getIconByUrl(imgSrc)}"/>
+    </j:otherwise>
+  </j:choose>
+
+  <j:if test="${iconMetadata != null}">
+    <j:set var="imgSrc" value="${iconMetadata.getQualifiedUrl(context)}"/>
+    <j:set var="imgStyle" value="${iconMetadata.style} ${attrs.style}"/>
+  </j:if>
+
+  <img class="${attrs.class}" src="${imgSrc}" style="${imgStyle}" title="${attrs.title}" height="${attrs.height}"
+       alt="${attrs.alt}" width="${attrs.width}" onclick="${attrs.onclick}" tooltip="${attrs.tooltip }"/>
+
+</j:jelly>

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -203,7 +203,7 @@ ${h.initPageVariables(context)}
           <div id="searchform">
             <input name="q" placeholder="${%search}" id="search-box" class="has-default-text" value="${request.getParameter('q')}" />
             <st:nbsp />
-            <a href="${%searchBox.url}"><img src="${imagesURL}/16x16/help.png" alt="help for search" height="16" width="16" /></a>
+            <a href="${%searchBox.url}"><l:icon class="icon-help icon-sm" /></a>
             <div id="search-box-completion" />
             <script>createSearchBox("${searchURL}");</script>
           </div>
@@ -213,7 +213,7 @@ ${h.initPageVariables(context)}
     <div id="breadcrumbBar">
       <l:breadcrumbBar>
         <j:set var="mode" value="breadcrumbs" />
-        <d:invokeBody />
+        <d:invokeBody/>
       </l:breadcrumbBar>
     </div>
 

--- a/core/src/main/resources/lib/layout/pane.jelly
+++ b/core/src/main/resources/lib/layout/pane.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
   <st:documentation>
     Used in the &lt;l:side-panel> to draw a box with a title.
 
@@ -48,15 +48,12 @@ THE SOFTWARE.
       Footer of the box. Can include HTML.
     </st:attribute>
   </st:documentation>
-
   <div class="container-fluid pane-frame" id="${attrs.id}">
     <div class="row">
       <div class="col-xs-24 pane-header">
         <a class="collapse" href="${rootURL}/toggleCollapse?paneId=${attrs.id}"
            title="${h.isCollapsed(attrs.id) ? '%expand' : '%collapse'}">
-          <img src="${imagesURL}/16x16/${h.isCollapsed(attrs.id) ? 'expand' : 'collapse'}.png"
-               class="icon16x16"
-               alt="${h.isCollapsed(attrs.id) ? '%expand' : '%collapse'}"/>
+          <l:icon alt="${h.isCollapsed(attrs.id) ? '%expand' : '%collapse'}" class="${h.isCollapsed(attrs.id) ? 'icon-expand' : 'icon-collapse'} icon-sm"/>
         </a>
         <j:out value="${title}"/>
       </div>

--- a/core/src/main/resources/lib/layout/stopButton.jelly
+++ b/core/src/main/resources/lib/layout/stopButton.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <st:documentation>
         Creates a clickable "Stop" button.
         <st:attribute name="href" use="required">
@@ -35,6 +35,6 @@ THE SOFTWARE.
         </st:attribute>
     </st:documentation>
     <a class="stop-button-link" href="${href}" onclick="new Ajax.Request(this.href); return false">
-        <img class="stop-button-icon" src="${imagesURL}/16x16/stop.png" alt="${alt}" height="16" width="16"/>
+        <l:icon class="icon-stop icon-sm"/>
     </a>
 </j:jelly>

--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -32,11 +32,12 @@ THE SOFTWARE.
       Link target. Relative to the current page.
     </st:attribute>
     <st:attribute name="icon" use="required">
-      URL to the icon, which should be 24x24 in size.
-      It's relative to the context path of Hudson.
+      URL to an icon image, or the icon class specification.  If using an image URL,
+      the image should be 24x24 in size and relative to the context path of Hudson.
 
-      The common values include:
+      Common values include:
 
+      # "icon-folder icon-md" is an example of using a class spec for a medium folder icon
       # "images/24x24/..." then points to the stock icon resources
       # "plugin/foobar/abc/def.png" that points to "src/main/webapp/abc/def.png" in your plugin resources
     </st:attribute>
@@ -91,10 +92,34 @@ THE SOFTWARE.
           <j:set target="${taskMatching.variables}" property="match" value="true"/>
         </j:if>
       </j:when>
+
+      <!--
+      The icon attribute can be an icon class spec, or can be the url of an icon image.
+      Within core Jenkins, we've updated all usages of the task element to use icon class specs,
+      but we need to accommodate plugins etc that still use urls.  So, first we treat the icon
+      attribute value as an icon spec and attempt to use that spec to lookup the icon's metadata.
+      If that lookup fails, we try treat it as a URL and try looking up the icon metadata by URL.
+      If either of these lookups are successful, we create an icon element instance using the
+      icon class spec from the icon metadata, otherwise we create an icon element instance using
+      icon attribute value as an icon "src" (Vs class spec).
+      -->
+      <j:set var="iconMetadata" value="${icons.getIconByClassSpec(attrs.icon)}"/>
+      <j:if test="${iconMetadata == null}">
+        <j:set var="iconMetadata" value="${icons.getIconByUrl(icon)}"/>
+      </j:if>
+
+      <j:set var="icon" value="${rootURL}${icon.startsWith('images/') || icon.startsWith('plugin/') ? h.resourcePath : ''}/${icon}"/>
       <j:when test="${enabled==false}">
         <div class="task disabled">
           <span>
-            <img width="24" height="24" style="margin: 2px;" alt="" src="${rootURL}${icon.startsWith('images/') || icon.startsWith('plugin/') ? h.resourcePath : ''}/${icon}"/>
+            <j:choose>
+              <j:when test="${iconMetadata != null}">
+                <l:icon class="${iconMetadata.classSpec}"/>
+              </j:when>
+              <j:otherwise>
+                <l:icon width="24" height="24" style="margin: 2px;" alt="" src="${icon}"/>
+              </j:otherwise>
+            </j:choose>
           </span>
           <st:nbsp />
 
@@ -112,7 +137,6 @@ THE SOFTWARE.
       </j:when>
       <j:otherwise>
         <div class="task">
-          <j:set var="icon" value="${rootURL}${icon.startsWith('images/') || icon.startsWith('plugin/') ? h.resourcePath : ''}/${icon}"/>
           ${taskTags!=null and attrs.contextMenu!='false' ? taskTags.add(href, icon, title, post == 'true', requiresConfirmation == 'true') : null}
 
           <j:set var="id" value="${h.generateId()}"/>
@@ -129,12 +153,26 @@ THE SOFTWARE.
           <j:choose>
             <j:when test="${requiresConfirmation and not attrs.onClick}">
               <l:confirmationLink href="${href}" post="${post}" message="${confirmationMessage ?: title}">
-                <img class="task-icon" width="24" height="24" style="margin: 2px;" alt="" src="${icon}"/>
+                <j:choose>
+                  <j:when test="${iconMetadata != null}">
+                    <l:icon class="${iconMetadata.classSpec}" style="width: 24px; height: 24px; margin: 2px;" />
+                  </j:when>
+                  <j:otherwise>
+                    <l:icon alt="" src="${icon}" style="width: 24px; height: 24px; margin: 2px;" />
+                  </j:otherwise>
+                </j:choose>
               </l:confirmationLink>
             </j:when>
             <j:otherwise>
               <a href="${href}" class="task-icon-link" onclick="${attrs.onclick ?: (post ? 'postRequest_' + id + '(this)' : null)}">
-                <img class="task-icon" width="24" height="24" style="margin: 2px;" alt="" src="${icon}"/>
+                <j:choose>
+                  <j:when test="${iconMetadata != null}">
+                    <l:icon class="${iconMetadata.classSpec}" style="width: 24px; height: 24px; margin: 2px;" />
+                  </j:when>
+                  <j:otherwise>
+                    <l:icon alt="" src="${icon}" style="width: 24px; height: 24px; margin: 2px;" />
+                  </j:otherwise>
+                </j:choose>
               </a>
             </j:otherwise>
           </j:choose>

--- a/core/src/test/java/hudson/model/BallColorTest.java
+++ b/core/src/test/java/hudson/model/BallColorTest.java
@@ -9,4 +9,9 @@ public class BallColorTest extends TestCase {
     public void testHtmlColor() {
         assertEquals("#EF2929",BallColor.RED.getHtmlBaseColor());
     }
+
+    public void testIconClassName() {
+        assertEquals("icon-red",BallColor.RED.getIconClassName());
+        assertEquals("icon-aborted-anime",BallColor.ABORTED_ANIME.getIconClassName());
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,14 @@ THE SOFTWARE.
   </licenses>
 
   <modules>
+    <module>ui-ext</module>
+    <module>ui-ext/icon/module</module>
     <module>core</module>
     <module>war</module>
     <module>test</module>
     <module>cli</module>
     <module>plugins</module>
+    <module>ui-ext/icon/shim-plugin</module>
   </modules>
 
   <scm>

--- a/ui-ext/icon/module/pom.xml
+++ b/ui-ext/icon/module/pom.xml
@@ -1,0 +1,43 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>ui-ext-pom</artifactId>
+        <version>1.576-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>ui-ext-icon-module</artifactId>
+
+    <name>Jenkins icon ui extension core module</name>
+    <description>
+        Contains Jenkins icon ui extension code relied upon by both Jenkins Core and the icon "shim" plugin.
+    </description>
+
+</project>

--- a/ui-ext/icon/module/src/main/java/org/jenkins/ui/icon/Icon.java
+++ b/ui-ext/icon/module/src/main/java/org/jenkins/ui/icon/Icon.java
@@ -1,0 +1,251 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkins.ui.icon;
+
+import org.apache.commons.jelly.JellyContext;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple icon metadata class.
+ *
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class Icon {
+
+    public static final String ICON_SMALL_STYLE = "width: 16px; height: 16px;";
+    public static final String ICON_MEDIUM_STYLE = "width: 24px; height: 24px;";
+    public static final String ICON_LARGE_STYLE = "width: 32px; height: 32px;";
+    public static final String ICON_XLARGE_STYLE = "width: 48px; height: 48px;";
+
+    private static final Map<String, String> iconDims = new HashMap<String, String>();
+
+    static {
+        iconDims.put("16x16", "icon-sm");
+        iconDims.put("24x24", "icon-md");
+        iconDims.put("32x32", "icon-lg");
+        iconDims.put("48x48", "icon-xlg");
+    }
+
+    private final String classSpec;
+    private final String normalizedSelector;
+    private final String url;
+    private final String style;
+    private IconType iconType;
+
+    /**
+     * Icon instance.
+     * <p/>
+     * Creates a {@link IconType#CORE core} icon.
+     *
+     * @param classSpec The icon class names.
+     * @param url       The icon image url.
+     * @param style     The icon style.
+     */
+    public Icon(String classSpec, String url, String style) {
+        this(classSpec, url, style, IconType.CORE);
+        if (url.startsWith("images/")) {
+            this.iconType = IconType.CORE;
+        } else if (url.startsWith("plugin/")) {
+            this.iconType = IconType.PLUGIN;
+        }
+    }
+
+    /**
+     * Icon instance.
+     *
+     * @param classSpec The icon class specification.
+     * @param url       The icon image url.
+     * @param style     The icon style.
+     * @param iconType  The icon type.
+     */
+    public Icon(String classSpec, String url, String style, IconType iconType) {
+        this.classSpec = classSpec;
+        this.normalizedSelector = toNormalizedCSSSelector(classSpec);
+        this.url = toNormalizedIconUrl(url);
+        this.style = style;
+        this.iconType = iconType;
+    }
+
+    /**
+     * Get the class specification for this Icon.
+     * @return The class specification for this Icon.
+     */
+    public String getClassSpec() {
+        return classSpec;
+    }
+
+    /**
+     * Get the icon's normalized CSS selector.
+     *
+     * @return The icon normalized CSS selector.
+     * @see #toNormalizedCSSSelector(String)
+     */
+    public String getNormalizedSelector() {
+        return normalizedSelector;
+    }
+
+    /**
+     * Get the icon url.
+     *
+     * @return The icon url.
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * Get the qualified icon url.
+     * <p/>
+     * Qualifying the URL involves prefixing it depending on whether the icon is a core or plugin icon.
+     * Core icons are prefixed with the
+     *
+     * @param context The JellyContext.
+     * @return The qualified icon url.
+     */
+    public String getQualifiedUrl(JellyContext context) {
+        return iconType.toQualifiedUrl(url, context);
+    }
+
+    /**
+     * Get the icon style.
+     *
+     * @return The icon style.
+     */
+    public String getStyle() {
+        return style;
+    }
+
+    /**
+     * Normalize the supplied string to an Icon name class e.g. "blue_anime" to "icon-blue-anime".
+     *
+     * @param string The string to be normalized.
+     * @return The normalized icon name class.
+     */
+    public static String toNormalizedIconNameClass(String string) {
+        if (string == null) {
+            return null;
+        }
+        if (string.endsWith(".png") || string.endsWith(".gif")) {
+            string = string.substring(0, string.length() - 4);
+        }
+        return "icon-" + string.replace("_", "-");
+    }
+
+    /**
+     * Normalize the supplied string to an Icon size class e.g. "16x16" to "icon-sm".
+     *
+     * @param string The string to be normalized.
+     * @return The normalized icon size class, or the unmodified {@code string} arg
+     *         if it was an unrecognised icon size.
+     */
+    public static String toNormalizedIconSizeClass(String string) {
+        if (string == null) {
+            return null;
+        }
+        String normalizedSizeClass = iconDims.get(string.trim());
+        return (normalizedSizeClass != null ? normalizedSizeClass : string);
+    }
+
+    /**
+     * Generate a normalized CSS selector from the space separated list of icon class names.
+     * <p/>
+     * The normalized CSS selector is the list of class names, alphabetically sorted and dot separated.
+     * This means that "icon-help icon-xlg" and "icon-xlg icon-help" have the same normalized
+     * selector ".icon-help.icon-xlg".  Spaces are not relevant etc.
+     *
+     * @param classNames The space separated list of icon class names.
+     * @return The normalized CSS selector.
+     */
+    public static String toNormalizedCSSSelector(String classNames) {
+        if (classNames == null) {
+            return null;
+        }
+
+        String[] classNameTokA = classNames.split(" ");
+        List<String> classNameTokL = new ArrayList<String>();
+
+        // Trim all tokens first
+        for (int i = 0; i < classNameTokA.length; i++) {
+            String trimmedToken = classNameTokA[i].trim();
+            if (trimmedToken.length() > 0) {
+                classNameTokL.add(trimmedToken);
+            }
+        }
+
+        // Refill classNameTokA
+        classNameTokA = new String[classNameTokL.size()];
+        classNameTokL.toArray(classNameTokA);
+
+        // Sort classNameTokA
+        Arrays.sort(classNameTokA, new StringComparator());
+
+        // Build the compound name
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < classNameTokA.length; i++) {
+            stringBuilder.append(".").append(classNameTokA[i]);
+        }
+
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Normalize the supplied url.
+     *
+     * @param url The url to be normalized.
+     * @return The normalized url.
+     */
+    public static String toNormalizedIconUrl(String url) {
+        if (url == null) {
+            return null;
+        }
+
+        final String originalUrl = url;
+
+        if (url.startsWith("/")) {
+            url = url.substring(1);
+        }
+        if (url.startsWith("images/")) {
+            return url.substring("images/".length());
+        }
+        if (url.startsWith("plugin/")) {
+            return url.substring("plugin/".length());
+        }
+
+        return originalUrl;
+    }
+
+    private static class StringComparator implements Comparator<String> {
+
+        @Override
+        public int compare(String s1, String s2) {
+            return s1.compareTo(s2);
+        }
+    }
+}

--- a/ui-ext/icon/module/src/main/java/org/jenkins/ui/icon/IconSet.java
+++ b/ui-ext/icon/module/src/main/java/org/jenkins/ui/icon/IconSet.java
@@ -1,0 +1,628 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkins.ui.icon;
+
+import groovy.lang.GString;
+import org.apache.commons.jelly.JellyContext;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An icon set.
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class IconSet {
+
+    public static final IconSet icons = new IconSet();
+
+    private Map<String, Icon> iconsByCSSSelector = new ConcurrentHashMap<String, Icon>();
+    private Map<String, Icon> iconsByUrl  = new ConcurrentHashMap<String, Icon>();
+    private Map<String, Icon> iconsByClassSpec = new ConcurrentHashMap<String, Icon>();
+
+    private static final Icon NO_ICON = new Icon("_", "_", "_");
+
+    private IconSet() {
+    }
+
+    public static void initPageVariables(JellyContext context) {
+        context.setVariable("icons", icons);
+    }
+
+    public IconSet addIcon(Icon icon) {
+        iconsByCSSSelector.put(icon.getNormalizedSelector(), icon);
+        iconsByUrl.put(icon.getUrl(), icon);
+        return this;
+    }
+
+    /**
+     * Get an icon instance from it's {@link  Icon#toNormalizedCSSSelector(String) normalized CSS selector}.
+     * @param cssSelector The icon's normalized CSS selector.
+     * @return The icon instance, or {@code null} if no such icon.
+     */
+    public Icon getIconByNormalizedCSSSelector(GString cssSelector) {
+        if (cssSelector == null) {
+            return null;
+        }
+        return iconsByCSSSelector.get(cssSelector.toString());
+    }
+
+    /**
+     * Get an icon instance from it's {@link  Icon#toNormalizedCSSSelector(String) normalized CSS selector}.
+     * @param cssSelector The icon's normalized CSS selector.
+     * @return The icon instance, or {@code null} if no such icon.
+     */
+    public Icon getIconByNormalizedCSSSelector(String cssSelector) {
+        if (cssSelector == null) {
+            return null;
+        }
+        return iconsByCSSSelector.get(cssSelector);
+    }
+
+    /**
+     * Get an icon instance from a class specification.
+     * @param iconClassSpec The icon's class spec as defined on the &lt;l:icon class&gt; attribute.
+     * @return The icon instance, or {@code null} if no such icon.
+     */
+    public Icon getIconByClassSpec(GString iconClassSpec) {
+        if (iconClassSpec == null) {
+            return null;
+        }
+        return getIconByClassSpec(iconClassSpec.toString());
+    }
+
+    /**
+     * Get an icon instance from a class specification.
+     * @param iconClassSpec The icon's class spec as defined on the &lt;l:icon class&gt; attribute.
+     * @return The icon instance, or {@code null} if no such icon.
+     */
+    public Icon getIconByClassSpec(String iconClassSpec) {
+        if (iconClassSpec == null) {
+            return null;
+        }
+
+        Icon icon = iconsByClassSpec.get(iconClassSpec);
+
+        if (icon == NO_ICON) {
+            return null;
+        }
+
+        if (icon != null) {
+            return icon;
+        }
+
+        String normalizedCSSSelector = Icon.toNormalizedCSSSelector(iconClassSpec);
+
+        icon = getIconByNormalizedCSSSelector(normalizedCSSSelector);
+        if (icon != null) {
+            iconsByClassSpec.put(iconClassSpec, icon);
+            return icon;
+        } else {
+            iconsByClassSpec.put(iconClassSpec, NO_ICON);
+            return null;
+        }
+    }
+
+    /**
+     * Get an icon instance from it's url.
+     * @param url The icon url.
+     * @return The icon instance, or {@code null} if no such icon.
+     */
+    public Icon getIconByUrl(GString url) {
+        if (url == null) {
+            return null;
+        }
+        return getIconByUrl(url.toString());
+    }
+
+    /**
+     * Get an icon instance from it's url.
+     * @param url The icon url.
+     * @return The icon instance, or {@code null} if no such icon.
+     */
+    public Icon getIconByUrl(String url) {
+        if (url == null) {
+            return null;
+        }
+
+        url = Icon.toNormalizedIconUrl(url);
+
+        return iconsByUrl.get(url);
+    }
+
+    /**
+     * Normalize the supplied string to an Icon name class e.g. "blue_anime" to "icon-blue-anime".
+     *
+     * @param string The string to be normalized.
+     * @return The normalized icon name class.
+     */
+    public static String toNormalizedIconNameClass(GString string) {
+        return Icon.toNormalizedIconNameClass(string.toString());
+    }
+
+    /**
+     * Normalize the supplied string to an Icon name class e.g. "blue_anime" to "icon-blue-anime".
+     *
+     * @param string The string to be normalized.
+     * @return The normalized icon name class.
+     */
+    public static String toNormalizedIconNameClass(String string) {
+        return Icon.toNormalizedIconNameClass(string);
+    }
+
+    /**
+     * Normalize the supplied string to an Icon size class e.g. "16x16" to "icon-sm".
+     *
+     * @param string The string to be normalized.
+     * @return The normalized icon size class, or the unmodified {@code string} arg
+     *         if it was an unrecognised icon size.
+     */
+    public static String toNormalizedIconSizeClass(GString string) {
+        return Icon.toNormalizedIconSizeClass(string.toString());
+    }
+
+    /**
+     * Normalize the supplied string to an Icon size class e.g. "16x16" to "icon-sm".
+     *
+     * @param string The string to be normalized.
+     * @return The normalized icon size class, or the unmodified {@code string} arg
+     *         if it was an unrecognised icon size.
+     */
+    public static String toNormalizedIconSizeClass(String string) {
+        return Icon.toNormalizedIconSizeClass(string);
+    }
+
+    /**
+     * Normalize the supplied url.
+     *
+     * @param url The url to be normalized.
+     * @return The normalized url.
+     */
+    public static String toNormalizedIconUrl(GString url) {
+        return Icon.toNormalizedIconUrl(url.toString());
+    }
+
+    /**
+     * Normalize the supplied url.
+     *
+     * @param url The url to be normalized.
+     * @return The normalized url.
+     */
+    public static String toNormalizedIconUrl(String url) {
+        return Icon.toNormalizedIconUrl(url);
+    }
+
+    // Initialize the core Jenkins icons.  We need all this stuff so as to maintain
+    // backward compatibility.
+    static {
+        // Small icons.
+        // .png versions will override .gif versions => only time a gif should be returned by
+        // name is when it's an animated status icon ("-anime-")
+        icons.addIcon(new Icon("icon-aborted icon-sm", "16x16/aborted.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-aborted-anime icon-sm", "16x16/aborted_anime.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-blue icon-sm", "16x16/blue.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-blue-anime icon-sm", "16x16/blue_anime.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-clock icon-sm", "16x16/clock.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-clock-anime icon-sm", "16x16/clock_anime.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-computer-flash icon-sm", "16x16/computer-flash.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-computer-x icon-sm", "16x16/computer-x.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-computer icon-sm", "16x16/computer.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-disabled icon-sm", "16x16/disabled.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-disabled-anime icon-sm", "16x16/disabled_anime.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-document-add icon-sm", "16x16/document_add.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-document-delete icon-sm", "16x16/document_delete.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-document-edit icon-sm", "16x16/document_edit.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-edit-delete icon-sm", "16x16/edit-delete.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-edit-select-all icon-sm", "16x16/edit-select-all.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-empty icon-sm", "16x16/empty.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-error icon-sm", "16x16/error.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-fingerprint icon-sm", "16x16/fingerprint.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-folder-error icon-sm", "16x16/folder-error.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-folder-open icon-sm", "16x16/folder-open.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-folder icon-sm", "16x16/folder.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-gear2 icon-sm", "16x16/gear2.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-go-next icon-sm", "16x16/go-next.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-green icon-sm", "16x16/green.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-green-anime icon-sm", "16x16/green_anime.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-grey icon-sm", "16x16/grey.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-grey-anime icon-sm", "16x16/grey_anime.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-health-00to19 icon-sm", "16x16/health-00to19.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-health-20to39 icon-sm", "16x16/health-20to39.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-health-40to59 icon-sm", "16x16/health-40to59.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-health-60to79 icon-sm", "16x16/health-60to79.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-health-80plus icon-sm", "16x16/health-80plus.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-help icon-sm", "16x16/help.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-hourglass icon-sm", "16x16/hourglass.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-lock icon-sm", "16x16/lock.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt icon-sm", "16x16/nobuilt.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt-anime icon-sm", "16x16/nobuilt_anime.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-notepad icon-sm", "16x16/notepad.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-package icon-sm", "16x16/package.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-person icon-sm", "16x16/person.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-plugin icon-sm", "16x16/plugin.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-red icon-sm", "16x16/red.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-red-anime icon-sm", "16x16/red_anime.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-redo icon-sm", "16x16/redo.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-save icon-sm", "16x16/save.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-search icon-sm", "16x16/search.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-star-gold icon-sm", "16x16/star-gold.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-star icon-sm", "16x16/star.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-stop icon-sm", "16x16/stop.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-terminal icon-sm", "16x16/terminal.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-text-error icon-sm", "16x16/text-error.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-text icon-sm", "16x16/text.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-user icon-sm", "16x16/user.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-warning icon-sm", "16x16/warning.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-yellow icon-sm", "16x16/yellow.gif", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-yellow-anime icon-sm", "16x16/yellow_anime.gif", Icon.ICON_SMALL_STYLE));
+
+        icons.addIcon(new Icon("icon-aborted icon-sm", "16x16/aborted.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-accept icon-sm", "16x16/accept.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-attribute icon-sm", "16x16/attribute.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-blue icon-sm", "16x16/blue.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-clock icon-sm", "16x16/clock.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-collapse icon-sm", "16x16/collapse.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-computer-x icon-sm", "16x16/computer-x.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-computer icon-sm", "16x16/computer.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-disabled icon-sm", "16x16/disabled.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-document-add icon-sm", "16x16/document_add.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-document-delete icon-sm", "16x16/document_delete.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-document-edit icon-sm", "16x16/document_edit.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-edit-delete icon-sm", "16x16/edit-delete.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-edit-select-all icon-sm", "16x16/edit-select-all.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-empty icon-sm", "16x16/empty.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-error icon-sm", "16x16/error.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-expand icon-sm", "16x16/expand.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-fingerprint icon-sm", "16x16/fingerprint.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-folder-error icon-sm", "16x16/folder-error.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-folder-open icon-sm", "16x16/folder-open.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-folder icon-sm", "16x16/folder.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-gear2 icon-sm", "16x16/gear2.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-go-next icon-sm", "16x16/go-next.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-grey icon-sm", "16x16/grey.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-health-00to19 icon-sm", "16x16/health-00to19.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-health-20to39 icon-sm", "16x16/health-20to39.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-health-40to59 icon-sm", "16x16/health-40to59.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-health-60to79 icon-sm", "16x16/health-60to79.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-health-80plus icon-sm", "16x16/health-80plus.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-help icon-sm", "16x16/help.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-hourglass icon-sm", "16x16/hourglass.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-lock icon-sm", "16x16/lock.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt icon-sm", "16x16/nobuilt.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-notepad icon-sm", "16x16/notepad.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-orange-square icon-sm", "16x16/orange-square.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-package icon-sm", "16x16/package.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-person icon-sm", "16x16/person.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-plugin icon-sm", "16x16/plugin.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-red icon-sm", "16x16/red.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-redo icon-sm", "16x16/redo.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-save icon-sm", "16x16/save.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-search icon-sm", "16x16/search.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-secure icon-sm", "16x16/secure.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-setting icon-sm", "16x16/setting.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-star-gold icon-sm", "16x16/star-gold.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-star icon-sm", "16x16/star.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-stop icon-sm", "16x16/stop.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-terminal icon-sm", "16x16/terminal.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-text-error icon-sm", "16x16/text-error.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-text icon-sm", "16x16/text.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-user icon-sm", "16x16/user.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-warning icon-sm", "16x16/warning.png", Icon.ICON_SMALL_STYLE));
+        icons.addIcon(new Icon("icon-yellow icon-sm", "16x16/yellow.png", Icon.ICON_SMALL_STYLE));
+
+        // Medium icons.
+        // .png versions will override .gif versions => only time a gif should be returned by
+        // name is when it's an animated status icon ("-anime-")
+        icons.addIcon(new Icon("icon-aborted icon-md", "24x24/aborted.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-aborted-anime icon-md", "24x24/aborted_anime.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-blue icon-md", "24x24/blue.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-blue-anime icon-md", "24x24/blue_anime.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-clipboard icon-md", "24x24/clipboard.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-clock icon-md", "24x24/clock.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-clock-anime icon-md", "24x24/clock_anime.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-computer-flash icon-md", "24x24/computer-flash.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-computer-x icon-md", "24x24/computer-x.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-computer icon-md", "24x24/computer.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-delete-document icon-md", "24x24/delete-document.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-disabled icon-md", "24x24/disabled.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-disabled-anime icon-md", "24x24/disabled_anime.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-document-properties icon-md", "24x24/document-properties.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-document icon-md", "24x24/document.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-edit-delete icon-md", "24x24/edit-delete.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-empty icon-md", "24x24/empty.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-fingerprint icon-md", "24x24/fingerprint.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-folder-delete icon-md", "24x24/folder-delete.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-folder icon-md", "24x24/folder.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-gear icon-md", "24x24/gear.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-gear2 icon-md", "24x24/gear2.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-graph icon-md", "24x24/graph.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-green icon-md", "24x24/green.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-green-anime icon-md", "24x24/green_anime.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-grey icon-md", "24x24/grey.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-grey-anime icon-md", "24x24/grey_anime.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-health-00to19 icon-md", "24x24/health-00to19.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-health-20to39 icon-md", "24x24/health-20to39.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-health-40to59 icon-md", "24x24/health-40to59.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-health-60to79 icon-md", "24x24/health-60to79.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-health-80plus icon-md", "24x24/health-80plus.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-help icon-md", "24x24/help.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-installer icon-md", "24x24/installer.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-monitor icon-md", "24x24/monitor.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-new-computer icon-md", "24x24/new-computer.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-new-document icon-md", "24x24/new-document.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-new-package icon-md", "24x24/new-package.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-new-user icon-md", "24x24/new-user.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-next icon-md", "24x24/next.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt icon-md", "24x24/nobuilt.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt-anime icon-md", "24x24/nobuilt_anime.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-notepad icon-md", "24x24/notepad.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-orange-square icon-md", "24x24/orange-square.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-package icon-md", "24x24/package.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-previous icon-md", "24x24/previous.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-red icon-md", "24x24/red.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-red-anime icon-md", "24x24/red_anime.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-redo icon-md", "24x24/redo.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-refresh icon-md", "24x24/refresh.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-save icon-md", "24x24/save.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-search icon-md", "24x24/search.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-setting icon-md", "24x24/setting.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-star-gold icon-md", "24x24/star-gold.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-star icon-md", "24x24/star.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-terminal icon-md", "24x24/terminal.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-up icon-md", "24x24/up.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-user icon-md", "24x24/user.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-yellow icon-md", "24x24/yellow.gif", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-yellow-anime icon-md", "24x24/yellow_anime.gif", Icon.ICON_MEDIUM_STYLE));
+
+        icons.addIcon(new Icon("icon-aborted icon-md", "24x24/aborted.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-accept icon-md", "24x24/accept.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-attribute icon-md", "24x24/attribute.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-blue icon-md", "24x24/blue.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-clipboard icon-md", "24x24/clipboard.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-clock icon-md", "24x24/clock.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-computer-x icon-md", "24x24/computer-x.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-computer icon-md", "24x24/computer.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-delete-document icon-md", "24x24/delete-document.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-disabled icon-md", "24x24/disabled.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-document-properties icon-md", "24x24/document-properties.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-document icon-md", "24x24/document.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-edit-delete icon-md", "24x24/edit-delete.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-empty icon-md", "24x24/empty.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-fingerprint icon-md", "24x24/fingerprint.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-folder-delete icon-md", "24x24/folder-delete.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-folder icon-md", "24x24/folder.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-gear icon-md", "24x24/gear.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-gear2 icon-md", "24x24/gear2.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-graph icon-md", "24x24/graph.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-grey icon-md", "24x24/grey.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-health-00to19 icon-md", "24x24/health-00to19.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-health-20to39 icon-md", "24x24/health-20to39.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-health-40to59 icon-md", "24x24/health-40to59.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-health-60to79 icon-md", "24x24/health-60to79.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-health-80plus icon-md", "24x24/health-80plus.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-help icon-md", "24x24/help.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-installer icon-md", "24x24/installer.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-lock icon-md", "24x24/lock.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-monitor icon-md", "24x24/monitor.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-new-computer icon-md", "24x24/new-computer.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-new-document icon-md", "24x24/new-document.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-new-package icon-md", "24x24/new-package.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-new-user icon-md", "24x24/new-user.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-next icon-md", "24x24/next.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt icon-md", "24x24/nobuilt.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-notepad icon-md", "24x24/notepad.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-orange-square icon-md", "24x24/orange-square.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-package icon-md", "24x24/package.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-plugin icon-md", "24x24/plugin.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-previous icon-md", "24x24/previous.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-red icon-md", "24x24/red.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-redo icon-md", "24x24/redo.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-refresh icon-md", "24x24/refresh.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-save icon-md", "24x24/save.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-search icon-md", "24x24/search.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-secure icon-md", "24x24/secure.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-setting icon-md", "24x24/setting.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-star-gold icon-md", "24x24/star-gold.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-star icon-md", "24x24/star.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-terminal icon-md", "24x24/terminal.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-up icon-md", "24x24/up.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-user icon-md", "24x24/user.png", Icon.ICON_MEDIUM_STYLE));
+        icons.addIcon(new Icon("icon-yellow icon-md", "24x24/yellow.png", Icon.ICON_MEDIUM_STYLE));
+
+        // Large icons.
+        // .png versions will override .gif versions => only time a gif should be returned by
+        // name is when it's an animated status icon ("-anime")
+        icons.addIcon(new Icon("icon-aborted icon-lg", "32x32/aborted.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-aborted-anime icon-lg", "32x32/aborted_anime.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-blue icon-lg", "32x32/blue.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-blue-anime icon-lg", "32x32/blue_anime.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-clipboard icon-lg", "32x32/clipboard.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-clock icon-lg", "32x32/clock.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-clock-anime icon-lg", "32x32/clock_anime.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-computer-flash icon-lg", "32x32/computer-flash.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-computer-x icon-lg", "32x32/computer-x.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-computer icon-lg", "32x32/computer.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-disabled icon-lg", "32x32/disabled.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-disabled-anime icon-lg", "32x32/disabled_anime.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-empty icon-lg", "32x32/empty.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-error icon-lg", "32x32/error.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-folder icon-lg", "32x32/folder.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-graph icon-lg", "32x32/graph.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-green icon-lg", "32x32/green.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-green-anime icon-lg", "32x32/green_anime.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-grey icon-lg", "32x32/grey.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-grey-anime icon-lg", "32x32/grey_anime.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-00to19 icon-lg", "32x32/health-00to19.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-20to39 icon-lg", "32x32/health-20to39.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-40to59 icon-lg", "32x32/health-40to59.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-60to79 icon-lg", "32x32/health-60to79.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-80plus icon-lg", "32x32/health-80plus.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt icon-lg", "32x32/nobuilt.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt-anime icon-lg", "32x32/nobuilt_anime.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-plugin icon-lg", "32x32/plugin.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-red icon-lg", "32x32/red.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-red-anime icon-lg", "32x32/red_anime.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-setting icon-lg", "32x32/setting.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-star-gold icon-lg", "32x32/star-gold.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-star icon-lg", "32x32/star.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-user icon-lg", "32x32/user.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-yellow icon-lg", "32x32/yellow.gif", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-yellow-anime icon-lg", "32x32/yellow_anime.gif", Icon.ICON_LARGE_STYLE));
+
+        icons.addIcon(new Icon("icon-aborted icon-lg", "32x32/aborted.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-accept icon-lg", "32x32/accept.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-attribute icon-lg", "32x32/attribute.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-blue icon-lg", "32x32/blue.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-clipboard icon-lg", "32x32/clipboard.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-clock icon-lg", "32x32/clock.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-computer-x icon-lg", "32x32/computer-x.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-computer icon-lg", "32x32/computer.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-disabled icon-lg", "32x32/disabled.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-empty icon-lg", "32x32/empty.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-error icon-lg", "32x32/error.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-folder icon-lg", "32x32/folder.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-gear2 icon-lg", "32x32/gear2.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-graph icon-lg", "32x32/graph.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-grey icon-lg", "32x32/grey.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-00to19 icon-lg", "32x32/health-00to19.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-20to39 icon-lg", "32x32/health-20to39.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-40to59 icon-lg", "32x32/health-40to59.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-60to79 icon-lg", "32x32/health-60to79.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-80plus icon-lg", "32x32/health-80plus.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-lock icon-lg", "32x32/lock.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt icon-lg", "32x32/nobuilt.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-orange-square icon-lg", "32x32/orange-square.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-package icon-lg", "32x32/package.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-plugin icon-lg", "32x32/plugin.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-red icon-lg", "32x32/red.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-secure icon-lg", "32x32/secure.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-setting icon-lg", "32x32/setting.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-star-gold icon-lg", "32x32/star-gold.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-star icon-lg", "32x32/star.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-user icon-lg", "32x32/user.png", Icon.ICON_LARGE_STYLE));
+        icons.addIcon(new Icon("icon-yellow icon-lg", "32x32/yellow.png", Icon.ICON_LARGE_STYLE));
+
+        // X icon-lg icons.
+        // .png versions will override .gif versions => only time a gif should be returned by
+        // name is when it's an animated status icon ("-anime-")
+        icons.addIcon(new Icon("icon-aborted icon-xlg", "48x48/aborted.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-aborted-anime icon-xlg", "48x48/aborted_anime.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-blue icon-xlg", "48x48/blue.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-blue-anime icon-xlg", "48x48/blue_anime.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-clipboard icon-xlg", "48x48/clipboard.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-computer-flash icon-xlg", "48x48/computer-flash.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-computer-x icon-xlg", "48x48/computer-x.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-computer icon-xlg", "48x48/computer.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-disabled icon-xlg", "48x48/disabled.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-disabled-anime icon-xlg", "48x48/disabled_anime.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-document icon-xlg", "48x48/document.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-empty icon-xlg", "48x48/empty.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-error icon-xlg", "48x48/error.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-fingerprint icon-xlg", "48x48/fingerprint.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-folder-delete icon-xlg", "48x48/folder-delete.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-folder icon-xlg", "48x48/folder.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-gear2 icon-xlg", "48x48/gear2.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-graph icon-xlg", "48x48/graph.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-green icon-xlg", "48x48/green.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-green-anime icon-xlg", "48x48/green_anime.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-grey icon-xlg", "48x48/grey.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-grey-anime icon-xlg", "48x48/grey_anime.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-00to19 icon-xlg", "48x48/health-00to19.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-20to39 icon-xlg", "48x48/health-20to39.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-40to59 icon-xlg", "48x48/health-40to59.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-60to79 icon-xlg", "48x48/health-60to79.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-80plus icon-xlg", "48x48/health-80plus.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-help icon-xlg", "48x48/help.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-installer icon-xlg", "48x48/installer.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-monitor icon-xlg", "48x48/monitor.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-network icon-xlg", "48x48/network.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt icon-xlg", "48x48/nobuilt.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt-anime icon-xlg", "48x48/nobuilt_anime.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-notepad icon-xlg", "48x48/notepad.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-orange-square icon-xlg", "48x48/orange-square.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-package icon-xlg", "48x48/package.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-plugin icon-xlg", "48x48/plugin.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-red icon-xlg", "48x48/red.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-red-anime icon-xlg", "48x48/red_anime.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-redo icon-xlg", "48x48/redo.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-refresh icon-xlg", "48x48/refresh.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-search icon-xlg", "48x48/search.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-secure icon-xlg", "48x48/secure.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-setting icon-xlg", "48x48/setting.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-star-gold icon-xlg", "48x48/star-gold.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-star icon-xlg", "48x48/star.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-system-log-out icon-xlg", "48x48/system-log-out.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-terminal icon-xlg", "48x48/terminal.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-user icon-xlg", "48x48/user.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-warning icon-xlg", "48x48/warning.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-yellow icon-xlg", "48x48/yellow.gif", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-yellow-anime icon-xlg", "48x48/yellow_anime.gif", Icon.ICON_XLARGE_STYLE));
+
+        icons.addIcon(new Icon("icon-aborted icon-xlg", "48x48/aborted.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-accept icon-xlg", "48x48/accept.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-attribute icon-xlg", "48x48/attribute.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-blue icon-xlg", "48x48/blue.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-clipboard icon-xlg", "48x48/clipboard.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-computer-x icon-xlg", "48x48/computer-x.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-computer icon-xlg", "48x48/computer.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-disabled icon-xlg", "48x48/disabled.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-document icon-xlg", "48x48/document.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-empty icon-xlg", "48x48/empty.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-error icon-xlg", "48x48/error.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-fingerprint icon-xlg", "48x48/fingerprint.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-folder-delete icon-xlg", "48x48/folder-delete.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-folder icon-xlg", "48x48/folder.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-gear2 icon-xlg", "48x48/gear2.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-graph icon-xlg", "48x48/graph.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-grey icon-xlg", "48x48/grey.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-00to19 icon-xlg", "48x48/health-00to19.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-20to39 icon-xlg", "48x48/health-20to39.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-40to59 icon-xlg", "48x48/health-40to59.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-60to79 icon-xlg", "48x48/health-60to79.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-health-80plus icon-xlg", "48x48/health-80plus.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-help icon-xlg", "48x48/help.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-installer icon-xlg", "48x48/installer.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-lock icon-xlg", "48x48/lock.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-monitor icon-xlg", "48x48/monitor.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-network icon-xlg", "48x48/network.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-nobuilt icon-xlg", "48x48/nobuilt.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-notepad icon-xlg", "48x48/notepad.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-orange-square icon-xlg", "48x48/orange-square.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-package icon-xlg", "48x48/package.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-plugin icon-xlg", "48x48/plugin.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-red icon-xlg", "48x48/red.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-redo icon-xlg", "48x48/redo.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-refresh icon-xlg", "48x48/refresh.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-search icon-xlg", "48x48/search.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-secure icon-xlg", "48x48/secure.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-setting icon-xlg", "48x48/setting.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-star-gold icon-xlg", "48x48/star-gold.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-star icon-xlg", "48x48/star.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-system-log-out icon-xlg", "48x48/system-log-out.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-terminal icon-xlg", "48x48/terminal.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-user icon-xlg", "48x48/user.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-warning icon-xlg", "48x48/warning.png", Icon.ICON_XLARGE_STYLE));
+        icons.addIcon(new Icon("icon-yellow icon-xlg", "48x48/yellow.png", Icon.ICON_XLARGE_STYLE));
+    }
+}

--- a/ui-ext/icon/module/src/main/java/org/jenkins/ui/icon/IconType.java
+++ b/ui-ext/icon/module/src/main/java/org/jenkins/ui/icon/IconType.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkins.ui.icon;
+
+import org.apache.commons.jelly.JellyContext;
+import org.kohsuke.stapler.Stapler;
+
+/**
+ * Icon type.
+ *
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public enum IconType {
+    CORE,
+    PLUGIN,;
+
+    /**
+     * Qualify the supplied icon url.
+     * <p/>
+     * Qualifying the URL involves prefixing it depending on whether the icon is a core or plugin icon.
+     *
+     * @param url The url to be qualified.
+     * @param context The JellyContext.
+     * @return The qualified icon url.
+     */
+    public String toQualifiedUrl(String url, JellyContext context) {
+        String resURL = context.getVariable("resURL").toString();
+
+        switch (this) {
+            case CORE: {
+                return resURL + "/images/" + url;
+            }
+            case PLUGIN: {
+                return resURL + "/plugin/" + url;
+            }
+        }
+
+        return null;
+    }
+}

--- a/ui-ext/icon/module/src/test/java/org/jenkins/ui/icon/IconSetTest.java
+++ b/ui-ext/icon/module/src/test/java/org/jenkins/ui/icon/IconSetTest.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi,
+ * Yahoo! Inc., Stephen Connolly, Tom Huybrechts, Alan Harder, Manufacture
+ * Francaise des Pneumatiques Michelin, Romain Seguy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkins.ui.icon;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class IconSetTest {
+
+    @Test
+    public void test() {
+        test("icon-sm", "16x16", Icon.ICON_SMALL_STYLE);
+        test("icon-md", "24x24", Icon.ICON_MEDIUM_STYLE);
+        test("icon-lg", "32x32", Icon.ICON_LARGE_STYLE);
+        test("icon-xlg", "48x48", Icon.ICON_XLARGE_STYLE);
+    }
+
+    @Test
+    public void test_toNormalizedIconUrl() {
+        Assert.assertEquals(null, IconSet.toNormalizedIconUrl((String)null));
+        Assert.assertEquals("aaaa", IconSet.toNormalizedIconUrl("aaaa"));
+        Assert.assertEquals("aaaa", IconSet.toNormalizedIconUrl("images/aaaa"));
+        Assert.assertEquals("aaaa", IconSet.toNormalizedIconUrl("plugin/aaaa"));
+        Assert.assertEquals("aaaa", IconSet.toNormalizedIconUrl("/images/aaaa"));
+        Assert.assertEquals("aaaa", IconSet.toNormalizedIconUrl("/plugin/aaaa"));
+    }
+
+    private void test(String sizeClass, String sizeDims, String expectedStyle) {
+        Icon icon;
+
+        icon = IconSet.icons.getIconByClassSpec("icon-blue " + sizeClass);
+        Assert.assertEquals(sizeDims + "/blue.png", icon.getUrl());
+        icon = IconSet.icons.getIconByUrl(sizeDims + "/blue.png");
+        Assert.assertEquals(".icon-blue." + sizeClass, icon.getNormalizedSelector());
+        Assert.assertEquals(expectedStyle, icon.getStyle());
+
+        icon = IconSet.icons.getIconByClassSpec("icon-blue-anime " + sizeClass);
+        Assert.assertEquals(sizeDims + "/blue_anime.gif", icon.getUrl());
+        icon = IconSet.icons.getIconByUrl(sizeDims + "/blue_anime.gif");
+        Assert.assertEquals(".icon-blue-anime." + sizeClass, icon.getNormalizedSelector());
+        Assert.assertEquals(expectedStyle, icon.getStyle());
+    }
+}

--- a/ui-ext/icon/module/src/test/java/org/jenkins/ui/icon/IconTest.java
+++ b/ui-ext/icon/module/src/test/java/org/jenkins/ui/icon/IconTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi,
+ * Yahoo! Inc., Stephen Connolly, Tom Huybrechts, Alan Harder, Manufacture
+ * Francaise des Pneumatiques Michelin, Romain Seguy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkins.ui.icon;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class IconTest {
+
+    @Test
+    public void test_toNormalizedCSSSelector() {
+        Assert.assertEquals(".a.b.c", Icon.toNormalizedCSSSelector(" b c   a"));
+    }
+
+    @Test
+    public void test_toNormalizedIconNameClass() {
+        Assert.assertEquals("icon-blue-anime", Icon.toNormalizedIconNameClass("blue_anime"));
+        Assert.assertEquals("icon-blue-anime", Icon.toNormalizedIconNameClass("blue_anime.gif"));
+        Assert.assertEquals("icon-blue", Icon.toNormalizedIconNameClass("blue.png"));
+    }
+
+    @Test
+    public void test_toNormalizedIconSizeClass() {
+        Assert.assertEquals("icon-sm", Icon.toNormalizedIconSizeClass("16x16"));
+        Assert.assertEquals("xxx", Icon.toNormalizedIconSizeClass("xxx"));
+    }
+}

--- a/ui-ext/icon/shim-plugin/pom.xml
+++ b/ui-ext/icon/shim-plugin/pom.xml
@@ -1,0 +1,139 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>1.480</version>
+    </parent>
+
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>ui-ext-icon-shim-plugin</artifactId>
+    <version>1.576-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+
+    <name>Icon Shim Plugin</name>
+    <description>Allows plugins make full use of the &lt;l:icon&gt; layout tag when running on newer versions of Jenkins, while still being compatible with older versions.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>ui-ext-icon-module</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- regular dependencies -->
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.3.1</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-maven</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireMavenVersion>
+                                        <version>(,2.1.0),(2.1.0,2.2.0),(2.2.0,)</version>
+                                        <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.
+                                        </message>
+                                    </requireMavenVersion>
+                                    <requireMavenVersion>
+                                        <version>(,3.0),[3.0.4,)</version>
+                                        <message>Maven 3.0 through 3.0.3 inclusive do not pass correct settings.xml to Maven Release
+                                            Plugin.
+                                        </message>
+                                    </requireMavenVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>2.5.2</version>
+                <configuration>
+                    <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
+                    <failOnError>true</failOnError>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-taglib-interface</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+</project>

--- a/ui-ext/icon/shim-plugin/src/findbugs/excludesFilter.xml
+++ b/ui-ext/icon/shim-plugin/src/findbugs/excludesFilter.xml
@@ -1,0 +1,5 @@
+<FindBugsFilter>
+    <Match>
+        <Class name="~.*\.Messages"/>
+    </Match>
+</FindBugsFilter>

--- a/ui-ext/icon/shim-plugin/src/main/java/org/jenkins/ui/icon/shim/CoreIconTagDetector.java
+++ b/ui-ext/icon/shim-plugin/src/main/java/org/jenkins/ui/icon/shim/CoreIconTagDetector.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkins.ui.icon.shim;
+
+import jenkins.model.Jenkins;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class CoreIconTagDetector {
+
+    public static final boolean TAG_AVAILABLE;
+
+    static {
+        InputStream coreTagFile = Jenkins.class.getResourceAsStream("/lib/layout/icon.jelly");
+        if (coreTagFile != null) {
+            TAG_AVAILABLE = true;
+            try {
+                coreTagFile.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            TAG_AVAILABLE = false;
+        }
+    }
+}

--- a/ui-ext/icon/shim-plugin/src/main/resources/shim/layout/icon/icon.groovy
+++ b/ui-ext/icon/shim-plugin/src/main/resources/shim/layout/icon/icon.groovy
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package shim.layout.icon
+
+import org.jenkins.ui.icon.IconSet
+import org.jenkins.ui.icon.shim.CoreIconTagDetector
+import org.xml.sax.helpers.AttributesImpl
+
+def attrs = context.getVariable('attrs')
+def iconSpec = attrs['class']
+def iconSize = attrs.iconSize
+
+def mapAttribute(def name, def attributes) {
+    def attributeValue = attrs[name];
+    if (attributeValue != null) {
+        attributes.addAttribute("", name, name, "CDATA", attributeValue)
+    }
+}
+
+if (iconSize != null) {
+    iconSpec += ' ' + IconSet.toNormalizedIconSizeClass(iconSize)
+}
+
+if (iconSpec != null) {
+    if (CoreIconTagDetector.TAG_AVAILABLE) {
+        def l = namespace(lib.LayoutTagLib)
+
+        l.icon(class: iconSpec, onclick: attrs.onclick,
+                title: attrs.title, style: attrs.style,
+                tooltip: attrs.tooltip, alt: attrs.alt)
+    } else {
+        def iconDef = IconSet.icons.getIconByClassSpec(iconSpec);
+        if (iconDef != null) {
+            def AttributesImpl attributes = new AttributesImpl()
+            def style = attrs.style
+
+            attributes.addAttribute("", "src", "src", "CDATA", iconDef.getQualifiedUrl(context))
+            if (style == null) {
+                style = iconDef.getStyle()
+            }
+            attributes.addAttribute("", "style", "style", "CDATA", style)
+            mapAttribute("onclick", attributes)
+            mapAttribute("title", attributes)
+            mapAttribute("tooltip", attributes)
+            mapAttribute("alt", attributes)
+
+            output.startElement("img", attributes)
+            output.endElement("img")
+        }
+    }
+}

--- a/ui-ext/icon/shim-plugin/src/main/resources/shim/layout/icon/setIcons.groovy
+++ b/ui-ext/icon/shim-plugin/src/main/resources/shim/layout/icon/setIcons.groovy
@@ -1,0 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package shim.layout.icon
+
+import org.jenkins.ui.icon.IconSet
+
+IconSet.initPageVariables(context)

--- a/ui-ext/icon/shim-plugin/src/main/resources/shim/layout/icon/taglib
+++ b/ui-ext/icon/shim-plugin/src/main/resources/shim/layout/icon/taglib
@@ -1,0 +1,1 @@
+Tag library that defines the shim for the core icon tag in /lib/layout.

--- a/ui-ext/pom.xml
+++ b/ui-ext/pom.xml
@@ -1,0 +1,88 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>pom</artifactId>
+        <version>1.576-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>ui-ext-pom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Jenkins UI Extensions.</name>
+    <description>
+        Contains Jenkins UI extension taglib modules and plugins.
+    </description>
+
+    <properties>
+        <stapler.version>1.227</stapler.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.kohsuke.stapler</groupId>
+            <artifactId>stapler-groovy</artifactId>
+            <version>${stapler.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-jelly</groupId>
+                    <artifactId>commons-jelly</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-jexl</groupId>
+                    <artifactId>commons-jexl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jvnet.hudson</groupId>
+                    <artifactId>commons-jexl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- we bundle groovy-all -->
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
A new `<l:icon>` tag + a "shim" plugin (to allow plugins use the tag but still maintain compatibility with older versions of Jenkins).

Note these changes do not (should not) have any visual effect.  It's foundation for future work with icons (moving them to be CSS based etc).

Once this tag is in place we'll have a lot more control over icons and how they are rendered e.g. allowing us to introduce CSS based icons more easily etc.  See the dev list for more details: https://groups.google.com/forum/?hl=en#!topic/jenkinsci-dev/GOiQdvctBB0

Here's a branch of the Credentials plugin using the shim: https://github.com/jenkinsci/credentials-plugin/compare/icon-tag-shim-test.  A build of that version of the credentials plugin also ran fine on an older version of Jenkins (i.e. the shim cut in and rendered the icon).

At present, the shim plugin is in Jenkins core (ui-ext/icon/shim-plugin):
1. Should it stay there, or must all plugins be in a repo of their own?  
2. If it stays there, how should it be versioned i.e. in line with Jenkins core or independently?
