### PR TITLE
[FIXED JENKINS-23970] CLI authentication with username/password try to read my .ssh/id_rsa and prompts for key password

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -420,7 +420,7 @@ public class CLI {
                 args = args.subList(1,args.size());
                 continue;
             }
-            if (head.equals("-noPKey")) {
+            if (head.equals("-noKeyAuth")) {
             	tryLoadPKey = false;
             	args = args.subList(1,args.size());
             	continue;

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -392,6 +392,8 @@ public class CLI {
 
         if (url==null)
             url = System.getenv("HUDSON_URL");
+        
+        boolean tryLoadPKey = true;
 
         while(!args.isEmpty()) {
             String head = args.get(0);
@@ -417,6 +419,11 @@ public class CLI {
                 });
                 args = args.subList(1,args.size());
                 continue;
+            }
+            if (head.equals("-noPKey")) {
+            	tryLoadPKey = false;
+            	args = args.subList(1,args.size());
+            	continue;
             }
             if(head.equals("-i") && args.size()>=2) {
                 File f = new File(args.get(1));
@@ -447,7 +454,7 @@ public class CLI {
         if(args.isEmpty())
             args = Arrays.asList("help"); // default to help
 
-        if (!provider.hasKeys())
+        if (tryLoadPKey && !provider.hasKeys())
             provider.readFromDefaultLocations();
 
         CLIConnectionFactory factory = new CLIConnectionFactory().url(url).httpsProxyTunnel(httpProxy);

--- a/cli/src/main/resources/hudson/cli/client/Messages.properties
+++ b/cli/src/main/resources/hudson/cli/client/Messages.properties
@@ -5,7 +5,7 @@ CLI.Usage=Jenkins CLI\n\
    -i KEY       : SSH private key file used for authentication\n\
    -p HOST:PORT : HTTP proxy host and port for HTTPS proxy tunneling. See http://jenkins-ci.org/https-proxy-tunnel\n\
    -noCertificateCheck : bypass HTTPS certificate check entirely. Use with caution\n\
-   -noPKey      : don't try to load the SSH authentication private key. Conflicts with -i\n\
+   -noKeyAuth   : don't try to load the SSH authentication private key. Conflicts with -i\n\
   \n\
   The available commands depend on the server. Run the 'help' command to\n\
   see the list.

--- a/cli/src/main/resources/hudson/cli/client/Messages.properties
+++ b/cli/src/main/resources/hudson/cli/client/Messages.properties
@@ -5,6 +5,7 @@ CLI.Usage=Jenkins CLI\n\
    -i KEY       : SSH private key file used for authentication\n\
    -p HOST:PORT : HTTP proxy host and port for HTTPS proxy tunneling. See http://jenkins-ci.org/https-proxy-tunnel\n\
    -noCertificateCheck : bypass HTTPS certificate check entirely. Use with caution\n\
+   -noPKey      : don't try to load the SSH authentication private key. Conflicts with -i\n\
   \n\
   The available commands depend on the server. Run the 'help' command to\n\
   see the list.

--- a/cli/src/main/resources/hudson/cli/client/Messages_pt_BR.properties
+++ b/cli/src/main/resources/hudson/cli/client/Messages_pt_BR.properties
@@ -28,7 +28,7 @@ CLI.Usage=Jenkins CLI\n\
    -i KEY       : arquivo contendo a chave SSH privada usada para autentica\u00e7\u00e3o\n\
    -p HOST:PORT : host e porta do proxy HTTP para tunelamento de proxy HTTPS. Veja http://jenkins-ci.org/https-proxy-tunnel\n\
    -noCertificateCheck : ignora completamente a valida\u00e7\u00e3o dos certificados HTTPS. Use com cautela\n\
-   -noPKey      : n\u00e3o tenta carregar a chave privada para autentica\u00e7\u00e3o SSH. Conflita com -i\n\
+   -noKeyAuth   : n\u00e3o tenta carregar a chave privada para autentica\u00e7\u00e3o SSH. Conflita com -i\n\
   \n\
   Os comandos dispon\u00edveis dependem do servidor. Execute o comando 'help' para\n\
   ver a lista.

--- a/cli/src/main/resources/hudson/cli/client/Messages_pt_BR.properties
+++ b/cli/src/main/resources/hudson/cli/client/Messages_pt_BR.properties
@@ -20,22 +20,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Version mismatch. This CLI cannot work with this Hudson server
 CLI.VersionMismatch=A vers\u00e3o n\u00e3o coincide. Esta CLI n\u00e3o pode funcionar com este servidor Hudson
-# Hudson CLI\n\
-# Usage: java -jar jenkins-cli.jar [-s URL] command [opts...] args...\n\
-# Options:\n\
-# \ -s URL : specify the server URL (defaults to the JENKINS_URL env var)\n\
-# \n\
-# The available commands depend on the server. Run the 'help' command to\n\
-# see the list.
 CLI.Usage=Jenkins CLI\n\
   Uso: java -jar jenkins-cli.jar [-s URL] comando [op\u00e7\u00f5es...] par\u00e2metros...\n\
   Op\u00e7\u00f5es:\n\
-  \ -s URL : a URL do servidor (por padr\u00e3o a vari\u00e1vel de ambiente JENKINS_URL \u00e9 usada)\n\
+   -s URL       : a URL do servidor (por padr\u00e3o a vari\u00e1vel de ambiente JENKINS_URL \u00e9 usada)\n\
+   -i KEY       : arquivo contendo a chave SSH privada usada para autentica\u00e7\u00e3o\n\
+   -p HOST:PORT : host e porta do proxy HTTP para tunelamento de proxy HTTPS. Veja http://jenkins-ci.org/https-proxy-tunnel\n\
+   -noCertificateCheck : ignora completamente a valida\u00e7\u00e3o dos certificados HTTPS. Use com cautela\n\
+   -noPKey      : n\u00e3o tenta carregar a chave privada para autentica\u00e7\u00e3o SSH. Conflita com -i\n\
   \n\
   Os comandos dispon\u00edveis dependem do servidor. Execute o comando 'help' para\n\
   ver a lista.
-
-# Neither -s nor the JENKINS_URL env var is specified.
 CLI.NoURL=N\u00e3o foi especificado nem '-s' e nem a vari\u00e1vel de ambiente JENKINS_URL
+CLI.NoSuchFileExists=O arquivo n\u00e3o existe: {0}


### PR DESCRIPTION
Created a new CLI parameter -noPKey to avoid private key access (similar to ssh -o PubkeyAuthentication=no)
