### PR TITLE
[FIXED JENKINS-23988] Consider CLIAuthenticator for CLIMethods

### DIFF
--- a/core/src/main/java/hudson/cli/declarative/CLIRegisterer.java
+++ b/core/src/main/java/hudson/cli/declarative/CLIRegisterer.java
@@ -149,8 +149,6 @@ public class CLIRegisterer extends ExtensionFinder {
                             while (!chains.isEmpty())
                                 binders.add(new MethodBinder(chains.pop(),this,parser));
 
-                            new ClassParser().parse(Jenkins.getInstance().getSecurityRealm().createCliAuthenticator(this), parser);
-
                             return parser;
                         }
 
@@ -169,6 +167,7 @@ public class CLIRegisterer extends ExtensionFinder {
                                 try {
                                     // authentication
                                     CliAuthenticator authenticator = Jenkins.getInstance().getSecurityRealm().createCliAuthenticator(this);
+                                    new ClassParser().parse(authenticator,parser);
 
                                     // fill up all the binders
                                     parser.parseArgument(args);

--- a/test/src/test/java/hudson/cli/CLIRegistererTest.java
+++ b/test/src/test/java/hudson/cli/CLIRegistererTest.java
@@ -2,17 +2,16 @@ package hudson.cli;
 
 import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
 import static hudson.cli.CLICommandInvoker.Matcher.succeededSilently;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import jenkins.model.Jenkins;
+import hudson.cli.CLICommandInvoker;
 import hudson.cli.CLICommandInvoker.Result;
-import hudson.cli.declarative.CLIMethod;
-import hudson.model.User;
 
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.kohsuke.args4j.Option;
 
 public class CLIRegistererTest {
 
@@ -23,27 +22,15 @@ public class CLIRegistererTest {
     public void testAuthWithSecurityRealmCLIAuthenticator() {
         j.getInstance().setSecurityRealm(j.createDummySecurityRealm());
 
-        CLICommandInvoker command = new CLICommandInvoker(j, "command-for-test");
+        CLICommandInvoker command = new CLICommandInvoker(j, "quiet-down");
 
-        Result invocation = command.invokeWithArgs("--username", "foo", "--password", "foo", "--expected", "foo");
-        assertThat(invocation, succeededSilently());
-
-        invocation = command.invokeWithArgs("--expected", "anonymous");
-        assertThat(invocation, failedWith(1));
-        assertThat(invocation.stderr(), containsString("Not authenticated"));
-
-        invocation = command.invokeWithArgs("--username", "foo", "--password", "invalid", "--expected", "anonymous");
+        Result invocation = command.invokeWithArgs("--username", "foo", "--password", "invalid");
         assertThat(invocation, failedWith(1));
         assertThat(invocation.stderr(), containsString("BadCredentialsException: foo"));
-    }
+        Assert.assertFalse("Unauthorized command was executed", Jenkins.getInstance().isQuietingDown());
 
-    @CLIMethod(name = "command-for-test")
-    public static int commandForTest(@Option(name = "--expected") String expected) {
-        final User user = User.current();
-        if (user == null) throw new RuntimeException("Not authenticated");
-
-        Assert.assertEquals(expected, user.getId());
-
-        return 0;
+        invocation = command.invokeWithArgs("--username", "foo", "--password", "foo");
+        assertThat(invocation, succeededSilently());
+        Assert.assertTrue("Authorized command was not executed", Jenkins.getInstance().isQuietingDown());
     }
 }

--- a/test/src/test/java/hudson/cli/CLIRegistererTest.java
+++ b/test/src/test/java/hudson/cli/CLIRegistererTest.java
@@ -1,0 +1,61 @@
+package hudson.cli;
+
+import hudson.ExtensionComponent;
+import hudson.cli.declarative.CLIRegisterer;
+import hudson.model.Hudson;
+import jenkins.model.Jenkins;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+
+public class CLIRegistererTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testAuthWithSecurityRealmCLIAuthenticator() {
+        j.getInstance().setSecurityRealm(j.createDummySecurityRealm());
+
+        Collection<ExtensionComponent<CLICommand>> extensions = new CLIRegisterer().find(CLICommand.class, (Hudson) j.getInstance());
+
+        CLICommand quietCommand = null;
+        CLICommand cancelCommand = null;
+
+        Assert.assertFalse("Jenkins not in quiet down mode", Jenkins.getInstance().isQuietingDown());
+
+        for (ExtensionComponent<CLICommand> extension : extensions) {
+            CLICommand command = extension.getInstance();
+            if (command.getName().equals("quiet-down")) {
+                quietCommand = command;
+            }
+            if (command.getName().equals("cancel-quiet-down")) {
+                cancelCommand = command;
+            }
+        }
+
+        Assert.assertNotNull(quietCommand);
+        Assert.assertNotNull(cancelCommand);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(baos);
+        ByteArrayInputStream bais = new ByteArrayInputStream(new byte[0]);
+
+        // run the CLI command with valid credentials
+        int quietResult = quietCommand.main(Arrays.asList("--username", "foo", "--password", "foo"), Locale.ENGLISH, bais, out, out);
+        Assert.assertTrue("Jenkins put into quiet down mode", Jenkins.getInstance().isQuietingDown());
+
+        // run the CLI command with invalid credentials
+        int cancelResult = cancelCommand.main(Arrays.asList("--username", "foo", "--password", "invalid"), Locale.ENGLISH, bais, out, out);
+        Assert.assertTrue("Jenkins still in quiet down mode", Jenkins.getInstance().isQuietingDown());
+    }
+}

--- a/test/src/test/resources/hudson/cli/Messages.properties
+++ b/test/src/test/resources/hudson/cli/Messages.properties
@@ -1,1 +1,0 @@
-CLI.command-for-test.shortDescription=command-for-test

--- a/test/src/test/resources/hudson/cli/Messages.properties
+++ b/test/src/test/resources/hudson/cli/Messages.properties
@@ -1,0 +1,1 @@
+CLI.command-for-test.shortDescription=command-for-test


### PR DESCRIPTION
All `@CLIMethod` based CLI commands failed to authenticate with `--username`/`--password` (or whatever the `SecurityRealm`'s `CLIAuthenticator` expected). `CLICommand`s were successful, so any cursory test of this authentication method using e.g. `help` or  `who-am-i` was successful.

Haven't found a good way to test this, so if anyone has suggestions, they'd be welcome.
