### PR TITLE
UI: use larger icon for edited advanced area to match the button size

### DIFF
--- a/core/src/main/resources/lib/form/advanced.jelly
+++ b/core/src/main/resources/lib/form/advanced.jelly
@@ -47,8 +47,9 @@ THE SOFTWARE.
 	    <div class="advancedLink" style="${attrs.align!=null?('text-align:'+attrs.align):''}">
               <j:set var="id" value="${h.generateId()}"/>
               <span style="display: none" id="${id}">
-                <img src="${imagesURL}/16x16/document_edit.png" style="vertical-align: super" alt="${%customizedFields}" tooltip="${%customizedFields}"/>
+                <img src="${imagesURL}/24x24/notepad.png" style="vertical-align: baseline" alt="${%customizedFields}" tooltip="${%customizedFields}"/>
               </span>
+              <st:nbsp />
 	      <input type="button" value="${attrs.title?:'%Advanced'}..." class="advanced-button advancedButton" /><!-- advancedButton is legacy -->
 	    </div>
             <j:new var="customizedFields" className="java.util.TreeSet"/>


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/206841/3712293/691dc5c2-150a-11e4-9c38-82a5f89d9d04.png)
After:
![after](https://cloud.githubusercontent.com/assets/206841/3712294/691e17c0-150a-11e4-87ee-f7f418a97038.png)
