### PR TITLE
[FIXED JENKINS-23724] - makeButton(e,onclick) fix for IE10

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -514,7 +514,7 @@ function makeButton(e,onclick) {
         btn.addListener("click",h);
     var be = btn.get("element");
     Element.addClassName(be,clsName);
-    if(n!=null) // copy the name
+    if(n) // copy the name
         be.setAttribute("name",n);
     return btn;
 }


### PR DESCRIPTION
For some reason IE10 craches when document.getElementsByName is called and there is an element with a name attribute but no value. In this case a button had a name attribute set with an empty string as the value.
