### PR TITLE
Custom workspace can specify the (auto-generated) 'WORKSPACE' variable path for modification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ build
 # vim
 *~
 
+# netbeans
+nb-configuration.xml
+
 war/images/16x16
 war/images/24x24
 war/images/32x32
@@ -40,4 +43,3 @@ jenkins_*.changes
 push-build.sh
 war/node_modules/
 .java-version
-/nb-configuration.xml

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ jenkins_*.changes
 push-build.sh
 war/node_modules/
 .java-version
+/nb-configuration.xml

--- a/changelog.html
+++ b/changelog.html
@@ -55,7 +55,9 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
-  <li class=>
+  <li class="rfe">
+  Made it so that a custom workspace can specify the 'WORKSPACE' variable and if that is the case then the custom workspace is treated as a modification of the auto-generated workspace.
+  (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23929">issue 23929</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ THE SOFTWARE.
   <properties>
     <!-- *.html files are in UTF-8, and *.properties are in iso-8859-1, so this configuration is acturally incorrect,
     but this suppresses a warning from Maven, and as long as we don't do filtering we should be OK. -->
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
     <build.type>private</build.type>
 
     <!-- configuration for patch tracker plugin  -->

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ THE SOFTWARE.
   <properties>
     <!-- *.html files are in UTF-8, and *.properties are in iso-8859-1, so this configuration is acturally incorrect,
     but this suppresses a warning from Maven, and as long as we don't do filtering we should be OK. -->
-    <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <build.type>private</build.type>
 
     <!-- configuration for patch tracker plugin  -->


### PR DESCRIPTION
Made it so that a custom workspace can specify the 'WORKSPACE' variable, and if that is the case then the custom workspace is treated as a _modification_ of the auto-generated workspace, i.e. you can append extra detail to the workspace directory name.

For example, this means you can specify ${WORKSPACE}_${Branch} - where Branch is a job parameter. If running concurrent builds then the build separator and concurrent build number are still appended to the end of the workspace path. This is required by the Perforce plug-in, and perhaps others, so this convention is preserved.

My first commit so apologies for any problems! I have tested the changes with normal workspaces, a custom workspace not using the WORKSPACE variable, and modified workspace using the WORKSPACE variable as above. The code works as expected. This change should not break any existing usage scenarios as it would not have been valid to specify the WORKSPACE variable in a custom workspace definition prior to this change.

My original issue has an explanation of the overall problem this solves:
https://issues.jenkins-ci.org/browse/JENKINS-23929

Also added netbeans configs to the .gitignore as these are local config files.

Creating this pull request as functionality seems generally useful and could be beneficial to others.
