### PR TITLE
[FIXED JENKINS-20307] Consider OneOffExecutors in Run.getExecutor()

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -507,6 +507,11 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                 if(e.getCurrentExecutable()==this)
                     return e;
             }
+            for (Executor e : c.getOneOffExecutors()) {
+                if(e.getCurrentExecutable()==this) {
+                    return e;
+                }
+            }
         }
         return null;
     }


### PR DESCRIPTION
This resolves the message…

> Build has been executing for null on master

…as well as possible other issues resulting from the fact that the Javadoc for `Run.getExecutor()`, implying non-`null` result while executing, is not correct for Flyweight tasks.

---

In `AbstractBuild`'s `index.jelly`, `${it.executor}` is null for `Flyweight` tasks if Flyweight support is enabled, as `Run.getExecutor()` does not search `OneOffExecutor`s.

While there is also `Run.getOneOffExecutor()` I doubt this shouldn't be transparent to the API user. So I extended this instead of replacing all `getExecutor()` calls with `getExecutor()/getOneOffExecutor()` combinations. The method `getOneOffExecutor()` was introduced in 17baab5491b846f613c2dafec3d229c40b4104c3 / #258 but it's not clear why this approach was chosen.

What might be a bit weird is that the `OneOffExecutor` is exposed to the build's API this way, but can easily be distinguished from regular executors by having a number of `-1`.
