### PR TITLE
[FIXED JENKINS-24110] - Explicitly handle null Executables in hudson.model.Executor

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1185,7 +1185,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         return r;
     }
 
-    public R createExecutable() throws IOException {
+    public @CheckForNull R createExecutable() throws IOException {
         if(isDisabled())    return null;
         return newBuild();
     }

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -220,6 +220,13 @@ public class Executor extends Thread implements ModelObject {
             try {
                 workUnit.context.synchronizeStart();
 
+                // this code handles the behavior of null Executables returned
+                // by tasks. In such case Jenkins starts the workUnit in order 
+                // to report results to console outputs. 
+                if (executable == null) {
+                    throw new Error("The null Executable has been created for "+workUnit+". The task cannot be executed");
+                }
+                
                 if (executable instanceof Actionable) {
                     for (Action action: workUnit.context.actions) {
                         ((Actionable) executable).addAction(action);

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1879,7 +1879,7 @@ public class Queue extends ResourceController implements Saveable {
          * the primary executable (such as {@link AbstractBuild}) that created out of it.
          */
         @Exported
-        public Executable getExecutable() {
+        public @CheckForNull Executable getExecutable() {
             return outcome!=null ? outcome.getPrimaryWorkUnit().getExecutable() : null;
         }
 

--- a/core/src/main/java/hudson/model/ResourceController.java
+++ b/core/src/main/java/hudson/model/ResourceController.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.AbstractCollection;
 import java.util.Iterator;
 import java.util.concurrent.CopyOnWriteArraySet;
+import javax.annotation.Nonnull;
 
 /**
  * Controls mutual exclusion of {@link ResourceList}.
@@ -73,7 +74,7 @@ public class ResourceController {
      * @throws InterruptedException
      *      the thread can be interrupted while waiting for the available resources.
      */
-    public void execute( Runnable task, ResourceActivity activity ) throws InterruptedException {
+    public void execute(@Nonnull Runnable task, ResourceActivity activity ) throws InterruptedException {
         ResourceList resources = activity.getResourceList();
         synchronized(this) {
             while(inUse.isCollidingWith(resources))

--- a/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
@@ -33,6 +33,7 @@ import hudson.model.ResourceList;
 
 import java.io.IOException;
 import java.util.Collection;
+import javax.annotation.CheckForNull;
 
 /**
  * Base class for defining filter {@link hudson.model.Queue.Task}.
@@ -79,7 +80,7 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.getEstimatedDuration();
     }
 
-    public Executable createExecutable() throws IOException {
+    public @CheckForNull Executable createExecutable() throws IOException {
         return base.createExecutable();
     }
 

--- a/core/src/main/java/hudson/model/queue/SubTask.java
+++ b/core/src/main/java/hudson/model/queue/SubTask.java
@@ -23,6 +23,7 @@
  */
 package hudson.model.queue;
 
+import hudson.model.AbstractProject;
 import hudson.model.Executor;
 import hudson.model.Label;
 import hudson.model.Node;
@@ -32,6 +33,7 @@ import hudson.model.ResourceActivity;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 /**
  * A component of {@link Task} that represents a computation carried out by a single {@link Executor}.
@@ -70,8 +72,11 @@ public interface SubTask extends ResourceActivity {
 
     /**
      * Creates {@link Executable}, which performs the actual execution of the task.
+     * @return {@link Executable} to be launched or null if the executable cannot be
+     * created (e.g. {@link AbstractProject} is disabled)
+     * @exception IOException {@link Executable} cannot be created
      */
-    Executable createExecutable() throws IOException;
+    @CheckForNull Executable createExecutable() throws IOException;
 
     /**
      * Gets the {@link Task} that this subtask belongs to.

--- a/core/src/main/java/hudson/model/queue/WorkUnit.java
+++ b/core/src/main/java/hudson/model/queue/WorkUnit.java
@@ -27,6 +27,7 @@ import hudson.model.Executor;
 import hudson.model.Queue;
 import hudson.model.Queue.Executable;
 import hudson.model.Queue.Task;
+import javax.annotation.CheckForNull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -63,11 +64,11 @@ public final class WorkUnit {
      * {@link Executor#getCurrentWorkUnit()} and {@link WorkUnit#getExecutor()}
      * form a bi-directional reachability between them.
      */
-    public Executor getExecutor() {
+    public @CheckForNull Executor getExecutor() {
         return executor;
     }
 
-    public void setExecutor(Executor e) {
+    public void setExecutor(@CheckForNull Executor e) {
         executor = e;
     }
 


### PR DESCRIPTION
This change improves the handling of errors in <code>hudson.model.Executor</code>, which cause issues like JENKINS-18164. It also introduces several annotations in order to prevent further issues.
