### PR TITLE
[FIXED JENKINS-24095] Ensure only numExecutors exist when reducing

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -721,9 +721,16 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             availableNumbers.remove(executor.getNumber());
 
         for (Integer number : availableNumbers) {
-            Executor e = new Executor(this, number);
-            executors.add(e);
+            /* There may be busy executors with higher index, so only
+               fill up until numExecutors is reached.
+               Extra executors will call removeExecutor(...) and that
+               will create any necessary executors from #0 again. */
+            if (executors.size() < numExecutors) {
+                Executor e = new Executor(this, number);
+                executors.add(e);
+            }
         }
+
     }
 
     /**


### PR DESCRIPTION
When reducing the number of executors from M to N, previously it'd
kill all idle executors, and then create executors 0...N-1 unless
they already exist (busy executors).

This can lead to the situation where e.g. executor `#5` is busy and
retained, and when setting the number of executors to 3, 0...2 are
created, resulting temporarily having 4 executors.

This change prevents `#2` from being created in the example. When `#4`
is finished, it'll be killed anyway and a new executor `#2` created,
so after some time the executor indexes are cleaned up matching
expectations.
