### PR TITLE
Add compatibility for SCMTriggerItem-related changes in 1.568

### DIFF
--- a/core/src/main/resources/hudson/triggers/SCMTrigger/DescriptorImpl/index.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/DescriptorImpl/index.jelly
@@ -54,7 +54,7 @@ THE SOFTWARE.
             <j:forEach var="r" items="${it.runners}">
               <tr>
                 <td>
-                  <a href="${rootURL}/${r.target.url}scmPollLog/">${r.target.fullDisplayName}</a>
+                  <a href="${rootURL}/${r.target.asItem().url}scmPollLog/">${r.target.asItem().fullDisplayName}</a>
                 </td>
                 <td>
                   ${r.duration}


### PR DESCRIPTION
Untested, unfortunately. Should affect Maven Projects (or generally anything with `SCM` based on core <1.568 and not a `Project`) though.

Issue report:
https://issues.jenkins-ci.org/browse/JENKINS-5413?focusedCommentId=205518&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-205518

Cause: https://github.com/jenkinsci/jenkins/commit/98ee11a28903e3d3003d912f143150bcf1b37c55#diff-7b17ff0818bb617e18a131fd82f5ff2bL438
