### PR TITLE
[WiP] [FIXED JENKINS-17825] Configuration page crashes in IE

### DIFF
--- a/core/src/main/resources/lib/form/confirm.js
+++ b/core/src/main/resources/lib/form/confirm.js
@@ -82,6 +82,6 @@
     }
 
     window.onbeforeunload = confirmExit;
-    Event.on(window,'load', initConfirm);
+    $(window).on('load', initConfirm);
 
 })();


### PR DESCRIPTION
When visiting the job configuration page using IE, it crashes without any warnings or errors. This commit reverts part of a6b7f4b.
