### PR TITLE
Prioritized task API

### DIFF
--- a/core/src/main/java/jenkins/model/queue/PrioritizedTask.java
+++ b/core/src/main/java/jenkins/model/queue/PrioritizedTask.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2014, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model.queue;
+
+import hudson.Extension;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.queue.CauseOfBlockage;
+import hudson.model.queue.QueueTaskDispatcher;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+/**
+ * Marker for tasks which should perhaps “jump ahead” in the queue.
+ * Ensures that this task gets scheduled ahead of regular stuff.
+ * Use judiciously; an appropriate use case is a task which is intended to be the direct continuation of one currently running
+ * or which was running in a previous Jenkins session and is not logically finished.
+ * @since TODO
+ */
+public interface PrioritizedTask extends Queue.Task {
+
+    /**
+     * True if the task should actually be consider prioritized now.
+     */
+    boolean isPrioritized();
+
+    @Restricted(DoNotUse.class) // implementation
+    @Extension class Scheduler extends QueueTaskDispatcher {
+
+        private static boolean isPrioritized(Queue.Task task) {
+            return task instanceof PrioritizedTask && ((PrioritizedTask) task).isPrioritized();
+        }
+
+        @Override public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
+            if (isPrioritized(item.task)) {
+                return null;
+            }
+            for (Queue.BuildableItem other : Queue.getInstance().getBuildableItems()) {
+                if (isPrioritized(other.task)) {
+                    Label label = other.task.getAssignedLabel();
+                    if (label == null || label.matches(node)) { // conservative; might actually go to a different node
+                        return new HoldOnPlease(other.task);
+                    }
+                }
+            }
+            return null;
+        }
+
+        private static final class HoldOnPlease extends CauseOfBlockage {
+
+            private final Queue.Task task;
+
+            HoldOnPlease(Queue.Task task) {
+                this.task = task;
+            }
+
+            @Override public String getShortDescription() {
+                return task.getFullDisplayName() + " should be allowed to run first";
+            }
+
+        }
+
+    }
+
+}

--- a/core/src/main/java/jenkins/model/queue/PrioritizedTask.java
+++ b/core/src/main/java/jenkins/model/queue/PrioritizedTask.java
@@ -78,7 +78,7 @@ public interface PrioritizedTask extends Queue.Task {
             }
 
             @Override public String getShortDescription() {
-                return task.getFullDisplayName() + " should be allowed to run first";
+                return Messages.PrioritizedTask__should_be_allowed_to_run_first(task.getFullDisplayName());
             }
 
         }

--- a/core/src/main/resources/jenkins/model/queue/Messages.properties
+++ b/core/src/main/resources/jenkins/model/queue/Messages.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright 2014 Jesse Glick.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+PrioritizedTask._should_be_allowed_to_run_first={0} should be allowed to run first

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -23,6 +23,7 @@
  */
 package hudson.model;
 
+import jenkins.model.queue.MockTask;
 import com.gargoylesoftware.htmlunit.html.HtmlFileInput;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
@@ -36,12 +37,9 @@ import hudson.matrix.TextAxis;
 import hudson.model.Cause.RemoteCause;
 import hudson.model.Cause.UserIdCause;
 import hudson.model.Queue.BlockedItem;
-import hudson.model.Queue.Executable;
 import hudson.model.Queue.WaitingItem;
-import hudson.model.queue.AbstractQueueTask;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.model.queue.ScheduleResult;
-import hudson.model.queue.SubTask;
 import hudson.security.ACL;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 import hudson.security.SparseACL;
@@ -364,37 +362,15 @@ public class QueueTest extends HudsonTestCase {
         waitUntilNoActivity();
         assertEquals(1, cnt.get());
     }
-    private static final class TestTask extends AbstractQueueTask {
-        private final AtomicInteger cnt;
+    private static final class TestTask extends MockTask {
         TestTask(AtomicInteger cnt) {
-            this.cnt = cnt;
+            super(cnt);
         }
         @Override public boolean equals(Object o) {
             return o instanceof TestTask && cnt == ((TestTask) o).cnt;
         }
         @Override public int hashCode() {
             return cnt.hashCode();
-        }
-        @Override public boolean isBuildBlocked() {return false;}
-        @Override public String getWhyBlocked() {return null;}
-        @Override public String getName() {return "test";}
-        @Override public String getFullDisplayName() {return "Test";}
-        @Override public void checkAbortPermission() {}
-        @Override public boolean hasAbortPermission() {return true;}
-        @Override public String getUrl() {return "test/";}
-        @Override public String getDisplayName() {return "Test";}
-        @Override public Label getAssignedLabel() {return null;}
-        @Override public Node getLastBuiltOn() {return null;}
-        @Override public long getEstimatedDuration() {return -1;}
-        @Override public ResourceList getResourceList() {return new ResourceList();}
-        @Override public Executable createExecutable() throws IOException {
-            return new Executable() {
-                @Override public SubTask getParent() {return TestTask.this;}
-                @Override public long getEstimatedDuration() {return -1;}
-                @Override public void run() {
-                    cnt.incrementAndGet();
-                }
-            };
         }
     }
 

--- a/test/src/test/java/jenkins/model/queue/MockTask.java
+++ b/test/src/test/java/jenkins/model/queue/MockTask.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model.queue;
+
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.ResourceList;
+import hudson.model.queue.AbstractQueueTask;
+import hudson.model.queue.SubTask;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Sample queue task.
+ */
+public class MockTask extends AbstractQueueTask {
+
+    public final AtomicInteger cnt;
+
+    public MockTask(AtomicInteger cnt) {
+        this.cnt = cnt;
+    }
+    
+    @Override public boolean isBuildBlocked() {
+        return false;
+    }
+    
+    @Override public String getWhyBlocked() {
+        return null;
+    }
+    
+    @Override public String getName() {
+        return "mock";
+    }
+    
+    @Override public String getFullDisplayName() {
+        return "Mock";
+    }
+    
+    @Override public void checkAbortPermission() {}
+    
+    @Override public boolean hasAbortPermission() {
+        return true;
+    }
+    
+    @Override public String getUrl() {
+        return "mock/";
+    }
+    
+    @Override public String getDisplayName() {
+        return "Mock";
+    }
+    
+    @Override public Label getAssignedLabel() {
+        return null;
+    }
+    
+    @Override public Node getLastBuiltOn() {
+        return null;
+    }
+    
+    @Override public long getEstimatedDuration() {
+        return -1;
+    }
+    
+    @Override public ResourceList getResourceList() {
+        return new ResourceList();
+    }
+    
+    @Override public Queue.Executable createExecutable() throws IOException {
+        return new Queue.Executable() {
+            @Override public SubTask getParent() {
+                return MockTask.this;
+            }
+            @Override public long getEstimatedDuration() {
+                return -1;
+            }
+            @Override public void run() {
+                cnt.incrementAndGet();
+            }
+        };
+    }
+
+}

--- a/test/src/test/java/jenkins/model/queue/PrioritizedTaskTest.java
+++ b/test/src/test/java/jenkins/model/queue/PrioritizedTaskTest.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model.queue;
+
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Label;
+import hudson.model.queue.QueueTaskFuture;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+
+public class PrioritizedTaskTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void basics() throws Exception {
+        FreeStyleProject p = r.createFreeStyleProject();
+        Label label = Label.get("test");
+        p.setAssignedLabel(label);
+        final AtomicInteger cntA = new AtomicInteger();
+        final AtomicInteger cntB = new AtomicInteger();
+        p.getBuildersList().add(new TestBuilder() {
+            @Override public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                assertEquals(0, cntA.get());
+                assertEquals(1, cntB.get());
+                return true;
+            }
+        });
+        QueueTaskFuture<FreeStyleBuild> b1 = p.scheduleBuild2(0);
+        r.jenkins.getQueue().schedule(new TestTask(cntA, false), 0);
+        r.jenkins.getQueue().schedule(new TestTask(cntB, true), 1);
+        // cntB task ought to run first, then b1, then the cntA task
+        r.createSlave(label);
+        r.assertBuildStatusSuccess(b1);
+        r.waitUntilNoActivity();
+        assertEquals(1, cntA.get());
+        assertEquals(1, cntB.get());
+    }
+
+    private static final class TestTask extends MockTask implements PrioritizedTask {
+        private final boolean prioritized;
+        TestTask(AtomicInteger cnt, boolean prioritized) {
+            super(cnt);
+            this.prioritized = prioritized;
+        }
+        @Override public boolean isPrioritized() {
+            return prioritized;
+        }
+        @Override public Label getAssignedLabel() {
+            return Label.get("test");
+        }
+    }
+
+}


### PR DESCRIPTION
Proposed API for marking queue tasks that should be bumped up to the front.

Needed for Workflow and also useful for [other plugins](https://rm.cloudbees.com/issues/2324), but must be defined in a common layer since there should be a single dispatcher. Considered putting this in a plugin, since it need not be in core, but could not think of anything else that would logically go in the same plugin.

Original idea thanks to @stephenc.
