### PR TITLE
[JENKINS-23330] Spaces in project names are not encoded on <tr> IDs

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -999,6 +999,45 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     /**
+     * https://issues.jenkins-ci.org/browse/JENKINS-23330
+     * @return the job's name where characters not HTML4 compliant are replaced
+     * with _ (see http://www.w3.org/TR/html401/types.html#type-name)
+     */
+    public String getHtml4CompliantName() {
+        String result = getName();
+        if (result != null) {
+            StringBuilder s = new StringBuilder(result);
+            for (int i = 0; i < s.length(); i++) {
+                char c = s.charAt(i);
+                // do not use isLetter() and isDigit()
+                // because the HTML4 norm seems to accept only plain ASCII chars,
+                // not any Unicode characters that are letters or digits
+                if (!(('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+                   || ('0' <= c && c <= '9')
+                   || c == '-' || c == '_' || c == ':' || c == '.')) {
+                    // by default, replace with a _. Maybe that could be parameterized
+                    s.setCharAt(i, '_');
+                }
+            }
+            result = s.toString();
+        }
+        return result;
+    }
+
+    /**
+     * https://issues.jenkins-ci.org/browse/JENKINS-23330
+     * @return the job's name where characters not HTML5 compliant (space) are
+     * replaced with _ (see http://www.w3schools.com/tags/att_global_id.asp)
+     */
+    public String getHtml5CompliantName() {
+        String result = getName();
+        if (result != null) {
+            result = result.replace(' ', '_');
+        }
+        return result;
+    }
+
+    /**
      * Used as the color of the status ball for the project.
      */
     @Exported(visibility = 2, name = "color")

--- a/core/src/main/resources/lib/hudson/projectViewRow.jelly
+++ b/core/src/main/resources/lib/hudson/projectViewRow.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <tr id="job_${job.name}" class="${job.disabled?'disabledJob':null} job-status-${job.iconColor.iconName}">
+  <tr id="job_${job.html4CompliantName}" class="${job.disabled?'disabledJob':null} job-status-${job.iconColor.iconName}">
     <j:forEach var="col" items="${columnExtensions}">
       <st:include page="column.jelly" it="${col}"/>
     </j:forEach>

--- a/core/src/test/java/hudson/model/JobTest.java
+++ b/core/src/test/java/hudson/model/JobTest.java
@@ -28,4 +28,24 @@ public class JobTest {
         // make sure the getDisplayName returns the project name
         Assert.assertEquals(StubJob.DEFAULT_STUB_JOB_NAME, j.getDisplayName());
     }
+    
+    @Test
+    public void testHTML5Name() {
+        Job j = new FreeStyleProject((ItemGroup) null, "stdName");
+        Assert.assertEquals("Job name not HTML5 compliant", "stdName", j.getHtml5CompliantName());
+        j = new FreeStyleProject((ItemGroup) null, "A name with Spaces");
+        Assert.assertEquals("Job name not HTML5 compliant", "A_name_with_Spaces", j.getHtml5CompliantName());
+        j = new FreeStyleProject((ItemGroup) null, "J'aime le français");
+        Assert.assertEquals("Job name not HTML5 compliant", "J'aime_le_français", j.getHtml5CompliantName());
+    }
+
+    @Test
+    public void testHTML4Name() {
+        Job j = new FreeStyleProject((ItemGroup) null, "stdName");
+        Assert.assertEquals("Job name not HTML4 compliant", "stdName", j.getHtml4CompliantName());
+        j = new FreeStyleProject((ItemGroup) null, "A name with Spaces");
+        Assert.assertEquals("Job name not HTML4 compliant", "A_name_with_Spaces", j.getHtml4CompliantName());
+        j = new FreeStyleProject((ItemGroup) null, "J'aime le français 2-_.:{}$%");
+        Assert.assertEquals("Job name not HTML4 compliant", "J_aime_le_fran_ais_2-_.:____", j.getHtml4CompliantName());
+    }
 }


### PR DESCRIPTION
Hello

I was curious to see if I could contribute to the jenkins project, so I started with a bug classified as 'trivial'. Here's my proposition to solve it. I wrote two functions (with unit tests :-) ) but used only one, because I'm unsure if the problem should be addressed for HTML4 or for HTML5.
Looking forward to your feedback!
Regards,

Dominique
