### PR TITLE
Remove unnecessary onblur call

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -456,7 +456,6 @@ function registerValidator(e) {
         e.onchange = function() { checker.call(this); oldOnchange.call(this); }
     } else
         e.onchange = checker;
-    e.onblur = checker;
 
     var v = e.getAttribute("checkDependsOn");
     if (v) {


### PR DESCRIPTION
Right now, checker is being attached to both onblur and onchange.  The result is when the user changes input, and that input loses focus, the checker is being fired twice.  This can cause issues on non-trivial field changes (such as validating a groovy script).  If there is no change, the checker is still called once due to the onblur.

The checker should only be called if the input is changed.
