### PR TITLE
Make queue item list caching period configurable.

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -211,7 +211,7 @@ public class Queue extends ResourceController implements Saveable {
             long t = System.currentTimeMillis();
             long d = expires.get();
             if (t>d) {// need to refresh the cache
-                long next = t+1000;
+                long next = t+ITEM_CACHE_EXPIRATION;
                 if (expires.compareAndSet(d,next)) {
                     // avoid concurrent cache update via CAS.
                     // if the getItems() lock is contended,
@@ -223,6 +223,8 @@ public class Queue extends ResourceController implements Saveable {
             return itemsView;
         }
     }
+
+    private static int ITEM_CACHE_EXPIRATION = Integer.parseInt(System.getProperty("hudson.model.Queue.itemCacheExpiration", "1000"));
 
     /**
      * Data structure created for each idle {@link Executor}.


### PR DESCRIPTION
With 400+ executors, I am seeing a lot of HTTP threads blocked at:

```
    java.lang.Thread.State: BLOCKED (on object monitor)
        at hudson.model.Queue.getItems(Queue.java:691)
        - waiting to lock <0x000000040768ba18> (a hudson.model.Queue)
        at hudson.model.Queue$CachedItemList.get(Queue.java:218)
        at hudson.model.Queue.getApproximateItemsQuickly(Queue.java:721)
```
