### PR TITLE
[WiP][FIXED JENKINS-24290] - Added a notification to ComputerListeners when the node changes

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1230,7 +1230,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         // replace the old Node object by the new one
         synchronized (app) {
             List<Node> nodes = new ArrayList<Node>(app.getNodes());
-            Node node = getNode();
+            final @CheckForNull Node node = getNode();
             int i  = (node != null) ? nodes.indexOf(node) : -1;
             if(i<0) {
                 throw new IOException("This slave appears to be removed while you were editing the configuration");
@@ -1240,7 +1240,15 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             app.setNodes(nodes);
             
             for (ComputerListener listener : ComputerListener.all()) {
-                listener.onConfigurationChange(this, node, newNode);
+                try {
+                    if (node != null) {
+                        listener.onConfigurationChange(this, node, newNode);
+                    } else {
+                        listener.onCreated(this, newNode);
+                    }
+                } catch (Throwable t) {
+                    LOGGER.log(Level.SEVERE, "Error in ComputerListener for "+getName(), t);
+                }
             }
         }
     }

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1238,6 +1238,10 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
 
             nodes.set(i, newNode);
             app.setNodes(nodes);
+            
+            for (ComputerListener listener : ComputerListener.all()) {
+                listener.onConfigurationChange(this, node, newNode);
+            }
         }
     }
 

--- a/core/src/main/java/hudson/slaves/ComputerListener.java
+++ b/core/src/main/java/hudson/slaves/ComputerListener.java
@@ -206,16 +206,28 @@ public abstract class ComputerListener implements ExtensionPoint {
     public void onConfigurationChange() {}
 
     /**
+     * Called when a new {@Computer} is being created.
+     * Instead of the {@link #onConfigurationChange()}, this callback operates 
+     * on the per-computer basis.
+     * @param computer Node owner
+     * @param newNode Newly created node
+     * @since TODO: Define a version
+     */
+    public void onCreated(@Nonnull Computer computer, @Nonnull Node newNode) {}
+    
+    /**
      * Called when the configuration of a {@Computer} changes.
      * Instead of the {@link #onConfigurationChange()}, this callback operates 
-     * on the pre-computer basis.
+     * on the per-computer basis. 
+     * For new nodes the {@link #onCreated(hudson.model.Computer, hudson.model.Node)}
+     * handler will be used.
      * @param computer Node owner
-     * @param oldNode Previous node. May be null on the new node creation
+     * @param oldNode Previous node
      * @param newNode Newly created node
      * @since TODO: Define a version
      */
     public void onConfigurationChange(@Nonnull Computer computer, 
-            @CheckForNull Node oldNode, @Nonnull Node newNode) { }
+            @Nonnull Node oldNode, @Nonnull Node newNode) {}
     
     /**
      * Registers this {@link ComputerListener} so that it will start receiving events.

--- a/core/src/main/java/hudson/slaves/ComputerListener.java
+++ b/core/src/main/java/hudson/slaves/ComputerListener.java
@@ -206,6 +206,18 @@ public abstract class ComputerListener implements ExtensionPoint {
     public void onConfigurationChange() {}
 
     /**
+     * Called when the configuration of a {@Computer} changes.
+     * Instead of the {@link #onConfigurationChange()}, this callback operates 
+     * on the pre-computer basis.
+     * @param computer Node owner
+     * @param oldNode Previous node. May be null on the new node creation
+     * @param newNode Newly created node
+     * @since TODO: Define a version
+     */
+    public void onConfigurationChange(@Nonnull Computer computer, 
+            @CheckForNull Node oldNode, @Nonnull Node newNode) { }
+    
+    /**
      * Registers this {@link ComputerListener} so that it will start receiving events.
      *
      * @deprecated as of 1.286


### PR DESCRIPTION
This method is useful to track configuration changes (e.g. for Ownership or Mail-Watcher plugins).

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
