### PR TITLE
[FIXED JENKINS-24340] - Do not disable jobs if supportsMakeDisabled() returns false

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -690,9 +690,13 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
 
     /**
      * Marks the build as disabled.
+     * The method will ignore the disable command if {@link #supportsMakeDisabled()}
+     * returns false. The enable command will be executed in any case.
+     * @param b true - disable, false - enable 
      */
     public void makeDisabled(boolean b) throws IOException {
         if(disabled==b)     return; // noop
+        if (b && !supportsMakeDisabled()) return; // do nothing if the disabling is unsupported
         this.disabled = b;
         if(b)
             Jenkins.getInstance().getQueue().cancel(this);


### PR DESCRIPTION
This changes prevents the improper usage of method without the preliminary <code>supportsMakeDisabled()</code> check. As an example, Subversion plugin behaves in such way (JENKINS-24341)

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
