### PR TITLE
[FIXED JENKINS-24317] Make user name migration work.

### DIFF
--- a/test/src/test/java/hudson/model/MyViewTest.java
+++ b/test/src/test/java/hudson/model/MyViewTest.java
@@ -69,10 +69,10 @@ public class MyViewTest {
         FreeStyleProject job = rule.createFreeStyleProject("job");
         MyView view = new MyView("My", rule.jenkins);
         rule.jenkins.addView(view);
-        auth.add(Job.READ, "User1");
+        auth.add(Job.READ, "user1");
         SecurityContextHolder.getContext().setAuthentication(user.impersonate());
         assertFalse("View " + view.getDisplayName() + " should not contain job " + job.getDisplayName(), view.contains(job));
-        auth.add(Job.CONFIGURE, "User1");
+        auth.add(Job.CONFIGURE, "user1");
         assertTrue("View " + view.getDisplayName() + " contain job " + job.getDisplayName(), view.contains(job));
     }
     
@@ -96,11 +96,11 @@ public class MyViewTest {
         FreeStyleProject job2 = rule.createFreeStyleProject("job2");
         FreeStyleProject job = rule.createFreeStyleProject("job");
         MyView view = new MyView("My", rule.jenkins);
-        auth.add(Job.READ, "User1");
+        auth.add(Job.READ, "user1");
         SecurityContextHolder.getContext().setAuthentication(user.impersonate());
         assertFalse("View " + view.getDisplayName() + " should not contains job " + job.getDisplayName(), view.getItems().contains(job));
         assertFalse("View " + view.getDisplayName() + " should not contains job " + job2.getDisplayName(), view.getItems().contains(job2));
-        auth.add(Job.CONFIGURE, "User1");
+        auth.add(Job.CONFIGURE, "user1");
         assertTrue("View " + view.getDisplayName() + " should contains job " + job.getDisplayName(), view.getItems().contains(job));
         assertTrue("View " + view.getDisplayName() + " should contains job " + job2.getDisplayName(), view.getItems().contains(job2));
     }

--- a/test/src/test/java/hudson/model/MyViewsPropertyTest.java
+++ b/test/src/test/java/hudson/model/MyViewsPropertyTest.java
@@ -250,7 +250,7 @@ public class MyViewsPropertyTest {
             fail("Property should not throw AccessDeniedException - user should control of himself.");
         }
         SecurityContextHolder.getContext().setAuthentication(user2.impersonate());
-        auth.add(Jenkins.ADMINISTER, "User2");
+        auth.add(Jenkins.ADMINISTER, "user2");
         try{
             property.checkPermission(Permission.CONFIGURE);
         }


### PR DESCRIPTION
[JENKINS-24317](https://issues.jenkins-ci.org/browse/JENKINS-24317)

**Please review this PR and consider it for merge into RC.**

This fixes the migration of user profiles into the folder names expected by the active ID strategy on case-sensitive file systems, tested both on OS X with case sensitive HFS+ and CentOS. And more logging is always good.

I needed to fix a few tests that should have broken a long time ago. This is the result of the change to line 409/412 which is assumed to be an oversight of the previous author: It seems weird to initialize the user with possibly non-canonical ID. Not sure about this, **so please review and confirm**. This PR should work to resolve the issue reported above without this change, if it's considered unsafe to include.
