### PR TITLE
[JENKINS-24376] [JENKINS-19977] Switch Run.id format to use milliseconds and UTC

### DIFF
--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -26,8 +26,8 @@ package hudson.model;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -187,8 +187,8 @@ public final class RunMap<R extends Run<?,R>> extends AbstractLazyLoadRunMap<R> 
 
     @Override
     protected FilenameFilter createDirectoryFilter() {
-        final SimpleDateFormat formatter = Run.ID_FORMATTER.get();
-
+        final DateFormat formatter = Run.getIDFormatter();
+        final DateFormat formatterOld = Run.getOldIDFormatter();
         return new FilenameFilter() {
             @Override public boolean accept(File dir, String name) {
                 if (name.startsWith("0000")) {
@@ -199,6 +199,13 @@ public final class RunMap<R extends Run<?,R>> extends AbstractLazyLoadRunMap<R> 
                 }
                 try {
                     if (formatter.format(formatter.parse(name)).equals(name)) {
+                        return true;
+                    }
+                } catch (ParseException e) {
+                    // fall through
+                }
+                try {
+                    if (formatterOld.format(formatterOld.parse(name)).equals(name)) {
                         return true;
                     }
                 } catch (ParseException e) {

--- a/core/src/main/java/jenkins/diagnostics/ooom/Problem.java
+++ b/core/src/main/java/jenkins/diagnostics/ooom/Problem.java
@@ -282,10 +282,15 @@ public final class Problem {
 
         private boolean isID(String s) {
             try {
-                Run.ID_FORMATTER.get().parse(s);
+                Run.getIDFormatter().parse(s);
                 return true;
             } catch (ParseException e) {
-                return false;
+                try {
+                    Run.getOldIDFormatter().parse(s);
+                    return true;
+                } catch (ParseException e2) {
+                    return false;
+                }
             }
         }
 

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -107,7 +107,7 @@ public class RunTest {
          
             Util.createSymlink(tempDir, buildDir.getAbsolutePath(), buildDirSymLink.getName(), l);
             long time = Run.parseTimestampFromBuildDir(buildDirSymLink);
-            assertEquals(buildDateTime, Run.ID_FORMATTER.get().format(new Date(time)));
+            assertEquals(buildDateTime, Run.getOldIDFormatter().format(new Date(time)));
         } finally {
             Util.deleteRecursive(tempDir);
         }


### PR DESCRIPTION
[JENKINS-24376](https://issues.jenkins-ci.org/browse/JENKINS-24376) and [JENKINS-19977](https://issues.jenkins-ci.org/browse/JENKINS-19977).

Probably need to put in forward-looking compatibility fixes into several plugins before this could be safely merged.
