### PR TITLE
[FIXED JENKINS-6153] Add description for label atoms

### DIFF
--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -143,6 +143,13 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     }
 
     /**
+     * Returns true iff this label is an atom.
+     *
+     * @since TODO
+     */
+    public boolean isAtom() { return false; }
+
+    /**
      * Evaluates whether the label expression is true given the specified value assignment.
      * IOW, returns true if the assignment provided by the resolver matches this label expression.
      */

--- a/core/src/main/java/hudson/model/labels/LabelAtom.java
+++ b/core/src/main/java/hudson/model/labels/LabelAtom.java
@@ -33,15 +33,13 @@ import hudson.XmlFile;
 import hudson.model.Action;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Failure;
-import hudson.util.EditDistance;
+import hudson.util.*;
 import jenkins.model.Jenkins;
 import hudson.model.Label;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
-import hudson.util.DescribableList;
-import hudson.util.QuotedStringTokenizer;
-import hudson.util.VariableResolver;
-import hudson.util.XStream2;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
@@ -73,6 +71,11 @@ public class LabelAtom extends Label implements Saveable {
     @CopyOnWrite
     protected transient volatile List<Action> transientActions = new Vector<Action>();
 
+    /**
+     * @since TODO
+     */
+    private String description;
+
     public LabelAtom(String name) {
         super(name);
     }
@@ -84,6 +87,9 @@ public class LabelAtom extends Label implements Saveable {
     public String getExpression() {
         return escape(name);
     }
+
+    @Override
+    public boolean isAtom() { return true; }
 
     /**
      * {@inheritDoc}
@@ -106,31 +112,19 @@ public class LabelAtom extends Label implements Saveable {
     protected void updateTransientActions() {
         Vector<Action> ta = new Vector<Action>();
 
-        // add the config link
-        if (!getApplicablePropertyDescriptors().isEmpty()) {
-            // if there's no property descriptor, there's nothing interesting to configure.
-            ta.add(new Action() {
-                public String getIconFileName() {
-                    if (Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER))
-                        return "setting.png";
-                    else
-                        return null;
-                }
-
-                public String getDisplayName() {
-                    return "Configure";
-                }
-
-                public String getUrlName() {
-                    return "configure";
-                }
-            });
-        }
-
         for (LabelAtomProperty p : properties)
             ta.addAll(p.getActions(this));
 
         transientActions = ta;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) throws IOException {
+        this.description = description;
+        save();
     }
 
     /**
@@ -210,11 +204,25 @@ public class LabelAtom extends Label implements Saveable {
         app.checkPermission(Jenkins.ADMINISTER);
 
         properties.rebuild(req, req.getSubmittedForm(), getApplicablePropertyDescriptors());
+
+        this.description = req.getSubmittedForm().getString("description");
+
         updateTransientActions();
         save();
 
-        // take the user back to the label top page.
-        rsp.sendRedirect2(".");
+        FormApply.success(".").generateResponse(req, rsp, null);
+    }
+
+    /**
+     * Accepts the new description.
+     */
+    @RequirePOST
+    @Restricted(DoNotUse.class)
+    public synchronized void doSubmitDescription( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
+        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+
+        setDescription(req.getParameter("description"));
+        rsp.sendRedirect(".");  // go to the top page
     }
 
     /**

--- a/core/src/main/java/hudson/model/labels/LabelAtom.java
+++ b/core/src/main/java/hudson/model/labels/LabelAtom.java
@@ -71,9 +71,6 @@ public class LabelAtom extends Label implements Saveable {
     @CopyOnWrite
     protected transient volatile List<Action> transientActions = new Vector<Action>();
 
-    /**
-     * @since TODO
-     */
     private String description;
 
     public LabelAtom(String name) {
@@ -118,6 +115,9 @@ public class LabelAtom extends Label implements Saveable {
         transientActions = ta;
     }
 
+    /**
+     * @since TODO
+     */
     public String getDescription() {
         return description;
     }

--- a/core/src/main/resources/hudson/model/AbstractModelObject/descriptionForm.jelly
+++ b/core/src/main/resources/hudson/model/AbstractModelObject/descriptionForm.jelly
@@ -27,8 +27,8 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout">
-  <j:if test="${it.primaryView != null}">
-    <j:set var="it" value="${it.primaryView}"/>
+  <j:if test="${it.getPrimaryView() != null}">
+    <j:set var="it" value="${it.getPrimaryView()}"/>
   </j:if>
   <l:ajax>
     <form action="submitDescription" method="post">

--- a/core/src/main/resources/hudson/model/Label/index.jelly
+++ b/core/src/main/resources/hudson/model/Label/index.jelly
@@ -32,6 +32,10 @@ THE SOFTWARE.
         ${it.name}
       </h1>
 
+      <j:if test="${it.atom}">
+        <t:editableDescription permission="${app.ADMINISTER}"/>
+      </j:if>
+
       <j:forEach var="a" items="${it.actions}">
         <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
       </j:forEach>

--- a/core/src/main/resources/hudson/model/Label/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/Label/sidepanel.jelly
@@ -33,7 +33,9 @@ THE SOFTWARE.
       <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
       <l:task contextMenu="false" href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
       <l:task contextMenu="false" href="${url}" icon="icon-attribute icon-md" title="${%Overview}"/>
-      <l:task href="${url}/configure" icon="icon-setting icon-md" title="${%Configure}" permission="${app.ADMINISTER}" />
+      <j:if test="${it.atom}">
+        <l:task href="${url}/configure" icon="icon-setting icon-md" title="${%Configure}" permission="${app.ADMINISTER}" />
+      </j:if>
       <l:task href="${url}/load-statistics" icon="icon-monitor icon-md" title="${%Load Statistics}"/>
       <st:include page="actions.jelly" />
     </l:tasks>

--- a/core/src/main/resources/hudson/model/Label/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/Label/sidepanel.jelly
@@ -33,6 +33,7 @@ THE SOFTWARE.
       <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>
       <l:task contextMenu="false" href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
       <l:task contextMenu="false" href="${url}" icon="icon-attribute icon-md" title="${%Overview}"/>
+      <l:task href="${url}/configure" icon="icon-setting icon-md" title="${%Configure}" permission="${app.ADMINISTER}" />
       <l:task href="${url}/load-statistics" icon="icon-monitor icon-md" title="${%Load Statistics}"/>
       <st:include page="actions.jelly" />
     </l:tasks>

--- a/core/src/main/resources/hudson/model/labels/LabelAtom/configure.jelly
+++ b/core/src/main/resources/hudson/model/labels/LabelAtom/configure.jelly
@@ -37,10 +37,15 @@ THE SOFTWARE.
           <f:textbox value="${it.name}" readonly="true" />
         </f:entry>
 
+        <f:entry title="${%Description}">
+          <f:textarea name="description" value="${it.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>
+        </f:entry>
+
         <f:descriptorList descriptors="${it.getApplicablePropertyDescriptors()}" instances="${it.properties}" />
 
         <f:block>
           <f:submit value="${%Save}"/>
+          <f:apply />
         </f:block>
       </f:form>
       <st:adjunct includes="lib.form.confirm" />


### PR DESCRIPTION
The change to descriptionForm.jelly is necessary because JEXL
interprets the previous version as a call to the static method
`get(String)` of LabelAtom if `${it}` is of that type.

---

PR remarks:
- _Configure_ is now always shown, as there is always something to configure (the description).
