### PR TITLE
Fixed display of long descriptions in the build history pane

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -928,6 +928,8 @@ table.parameters > tbody:hover {
   margin-top: 5px;
   white-space: normal;
   max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #buildHistory .build-rss-links {


### PR DESCRIPTION
Broken display:
![jenkins-build-history-broken](https://cloud.githubusercontent.com/assets/3975044/4032317/031591e8-2c6f-11e4-9954-9df147efc84c.png)

Fixed display:
![jenkins-build-history-fixed](https://cloud.githubusercontent.com/assets/3975044/4032318/03198a00-2c6f-11e4-8076-30c2590d64ac.png)
