### PR TITLE
[FIXED JENKINS-23330] Removing spaces from jobs html ids

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -786,6 +786,14 @@ public class Functions {
     }
 
     /**
+     * Return s, replacing space characters by '_'. Space are not valid chars in html id (HTML5)
+     * JENKINS-23330
+     */
+    public static String getHTML5CompliantId(String s) {
+        return s == null ? s : s.replace(' ', '_');
+    }
+    
+    /**
      * Infers the hudson installation URL from the given request.
      */
     public static String inferHudsonURL(StaplerRequest req) {

--- a/core/src/main/resources/lib/hudson/projectViewRow.jelly
+++ b/core/src/main/resources/lib/hudson/projectViewRow.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <tr id="job_${job.name}" class="${job.disabled?'disabledJob':null} job-status-${job.iconColor.iconName}">
+  <tr id="job_${h.getHTML5CompliantId(job.name)}" class="${job.disabled?'disabledJob':null} job-status-${job.iconColor.iconName}">
     <j:forEach var="col" items="${columnExtensions}">
       <st:include page="column.jelly" it="${col}"/>
     </j:forEach>

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -29,24 +29,30 @@ import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
 import hudson.model.View;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+
 import jenkins.model.Jenkins;
 import static org.junit.Assert.*;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.Issue;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
+
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -301,6 +307,16 @@ public class FunctionsTest {
         }finally{
             Locale.setDefault(defaultLocale);
         }
+    }
+    
+    @Test
+    @Issue("JENKINS-23330")
+    public void testGetHTML5CompliantId() {
+        // make sure function doesn't blow for null values
+        assertNull(Functions.getHTML5CompliantId(null));
+        // for object not null, result is not predictable but the value is expected to contain only digits
+        assertEquals("A_string_with_space", Functions.getHTML5CompliantId("A string with space"));
+        assertEquals("A_string_with_no_space#$%&é§è!ç%", Functions.getHTML5CompliantId("A_string_with_no_space#$%&é§è!ç%"));
     }
 
     @Bug(17030)


### PR DESCRIPTION
Hello
I followed Daniel's recommendation to add a method in Functions to solve this. So this UI bug is fixed by touching the ui layer (projectViewRow.jelly) and leaving the object model untouched (Job.java etc).
In my opinion the html id should be kept in the code generating the html fragment for each job. Delegating it to the plugin would result in a potential mess if/when another plugin wants to do the same.
Regards,

Dominique
