### PR TITLE
[FIXED JENKINS-11172] Don't throw exception on /signup when not possible

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3560,7 +3560,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Sign up for the user account.
      */
     public void doSignup( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
-        req.getView(getSecurityRealm(), "signup.jelly").forward(req, rsp);
+        if (getSecurityRealm().allowsSignup()) {
+            req.getView(getSecurityRealm(), "signup.jelly").forward(req, rsp);
+            return;
+        }
+        req.getView(SecurityRealm.class, "signup.jelly").forward(req, rsp);
     }
 
     /**

--- a/core/src/main/resources/hudson/security/SecurityRealm/signup.jelly
+++ b/core/src/main/resources/hudson/security/SecurityRealm/signup.jelly
@@ -1,0 +1,33 @@
+<!--
+The MIT License
+
+Copyright (c) 2014 Daniel Beck
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <st:include page="sidepanel.jelly" from="${app}" it="${app}" />
+    <l:layout title="${%Signup not supported}">
+        <l:main-panel>
+            <h1>${%Sign up}</h1>
+            ${%This is not supported in the current configuration.}
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/core/src/main/resources/hudson/security/SecurityRealm/signup.jelly
+++ b/core/src/main/resources/hudson/security/SecurityRealm/signup.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <st:statusCode value="404" />
     <st:include page="sidepanel.jelly" from="${app}" it="${app}" />
     <l:layout title="${%Signup not supported}">
         <l:main-panel>


### PR DESCRIPTION
Nothing links there, just don't show the page that tells users to report a bug.
