### PR TITLE
[WiP] Pull up BuildVariable methods from AbstractBuild to Run

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -51,7 +51,6 @@ import hudson.tasks.BuildStep;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.BuildTrigger;
 import hudson.tasks.BuildWrapper;
-import hudson.tasks.Builder;
 import hudson.tasks.Fingerprinter.FingerprintAction;
 import hudson.tasks.Publisher;
 import hudson.util.*;
@@ -988,52 +987,6 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         }
         
         return s;
-    }
-
-    /**
-     * Provides additional variables and their values to {@link Builder}s.
-     *
-     * <p>
-     * This mechanism is used by {@code MatrixConfiguration} to pass
-     * the configuration values to the current build. It is up to
-     * {@link Builder}s to decide whether they want to recognize the values
-     * or how to use them.
-     *
-     * <p>
-     * This also includes build parameters if a build is parameterized.
-     *
-     * @return
-     *      The returned map is mutable so that subtypes can put more values.
-     */
-    public Map<String,String> getBuildVariables() {
-        Map<String,String> r = new HashMap<String, String>();
-
-        ParametersAction parameters = getAction(ParametersAction.class);
-        if (parameters!=null) {
-            // this is a rather round about way of doing this...
-            for (ParameterValue p : parameters) {
-                String v = p.createVariableResolver(this).resolve(p.getName());
-                if (v!=null) r.put(p.getName(),v);
-            }
-        }
-
-        // allow the BuildWrappers to contribute additional build variables
-        if (project instanceof BuildableItemWithBuildWrappers) {
-            for (BuildWrapper bw : ((BuildableItemWithBuildWrappers) project).getBuildWrappersList())
-                bw.makeBuildVariables(this,r);
-        }
-
-        for (BuildVariableContributor bvc : BuildVariableContributor.all())
-            bvc.buildVariablesFor(this,r);
-
-        return r;
-    }
-
-    /**
-     * Creates {@link VariableResolver} backed by {@link #getBuildVariables()}.
-     */
-    public final VariableResolver<String> getBuildVariableResolver() {
-        return new VariableResolver.ByMap<String>(getBuildVariables());
     }
 
     /**

--- a/core/src/main/java/hudson/model/BooleanParameterValue.java
+++ b/core/src/main/java/hudson/model/BooleanParameterValue.java
@@ -63,7 +63,7 @@ public class BooleanParameterValue extends ParameterValue {
     }
 
     @Override
-    public VariableResolver<String> createVariableResolver(AbstractBuild<?, ?> build) {
+    public VariableResolver<String> createVariableResolver(Run<?, ?> build) {
         return new VariableResolver<String>() {
             public String resolve(String name) {
                 return BooleanParameterValue.this.name.equals(name) ? Boolean.toString(value) : null;

--- a/core/src/main/java/hudson/model/BuildVariableContributor.java
+++ b/core/src/main/java/hudson/model/BuildVariableContributor.java
@@ -27,7 +27,6 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
-import jenkins.model.Jenkins;
 
 import java.util.Map;
 
@@ -64,7 +63,7 @@ public abstract class BuildVariableContributor implements ExtensionPoint {
      *      Partially built variable map. Implementation of this method is expected to
      *      add additional variables here. Never null.
      */
-    public abstract void buildVariablesFor(AbstractBuild build, Map<String,String> variables);
+    public abstract void buildVariablesFor(Run build, Map<String,String> variables);
 
     /**
      * Returns all the registered {@link BuildVariableContributor}s.

--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -110,7 +110,7 @@ public class FileParameterValue extends ParameterValue {
     }
 
     @Override
-    public VariableResolver<String> createVariableResolver(AbstractBuild<?, ?> build) {
+    public VariableResolver<String> createVariableResolver(Run<?, ?> build) {
         return new VariableResolver<String>() {
             public String resolve(String name) {
                 return FileParameterValue.this.name.equals(name) ? originalFileName : null;

--- a/core/src/main/java/hudson/model/ParameterValue.java
+++ b/core/src/main/java/hudson/model/ParameterValue.java
@@ -207,7 +207,7 @@ public abstract class ParameterValue implements Serializable {
      *      if the parameter value is not interested in participating to the
      *      variable replacement process, return {@link VariableResolver#NONE}.
      */
-    public VariableResolver<String> createVariableResolver(AbstractBuild<?,?> build) {
+    public VariableResolver<String> createVariableResolver(Run<?,?> build) {
         return VariableResolver.NONE;
     }
 

--- a/core/src/main/java/hudson/model/PasswordParameterValue.java
+++ b/core/src/main/java/hudson/model/PasswordParameterValue.java
@@ -56,7 +56,7 @@ public class PasswordParameterValue extends ParameterValue {
     }
 
     @Override
-    public VariableResolver<String> createVariableResolver(AbstractBuild<?, ?> build) {
+    public VariableResolver<String> createVariableResolver(Run<?, ?> build) {
         return new VariableResolver<String>() {
             public String resolve(String name) {
                 return PasswordParameterValue.this.name.equals(name) ? Secret.toString(value) : null;

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -58,6 +58,7 @@ import hudson.util.FlushProofOutputStream;
 import hudson.util.FormApply;
 import hudson.util.LogTaskListener;
 import hudson.util.ProcessTree;
+import hudson.util.VariableResolver;
 import hudson.util.XStream2;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -348,7 +349,53 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             artifactManager.onLoad(this);
         }
     }
-    
+
+    /**
+     * Creates {@link hudson.util.VariableResolver} backed by {@link #getBuildVariables()}.
+     */
+    public final VariableResolver<String> getBuildVariableResolver() {
+        return new VariableResolver.ByMap<String>(getBuildVariables());
+    }
+
+    /**
+     * Provides additional variables and their values to {@link hudson.tasks.Builder}s.
+     *
+     * <p>
+     * This mechanism is used by {@code MatrixConfiguration} to pass
+     * the configuration values to the current build. It is up to
+     * {@link hudson.tasks.Builder}s to decide whether they want to recognize the values
+     * or how to use them.
+     *
+     * <p>
+     * This also includes build parameters if a build is parameterized.
+     *
+     * @return
+     *      The returned map is mutable so that subtypes can put more values.
+     */
+    public Map<String,String> getBuildVariables() {
+        Map<String,String> r = new HashMap<String, String>();
+
+        ParametersAction parameters = getAction(ParametersAction.class);
+        if (parameters!=null) {
+            // this is a rather round about way of doing this...
+            for (ParameterValue p : parameters) {
+                String v = p.createVariableResolver(this).resolve(p.getName());
+                if (v!=null) r.put(p.getName(),v);
+            }
+        }
+
+        // allow the BuildWrappers to contribute additional build variables
+        if (project instanceof BuildableItemWithBuildWrappers) {
+            for (BuildWrapper bw : ((BuildableItemWithBuildWrappers) project).getBuildWrappersList())
+                bw.makeBuildVariables(this,r);
+        }
+
+        for (BuildVariableContributor bvc : BuildVariableContributor.all())
+            bvc.buildVariablesFor(this,r);
+
+        return r;
+    }
+
     /**
      * Return all transient actions associated with this build.
      * 

--- a/core/src/main/java/hudson/model/StringParameterValue.java
+++ b/core/src/main/java/hudson/model/StringParameterValue.java
@@ -58,7 +58,7 @@ public class StringParameterValue extends ParameterValue {
     }
 
     @Override
-    public VariableResolver<String> createVariableResolver(AbstractBuild<?, ?> build) {
+    public VariableResolver<String> createVariableResolver(Run<?, ?> build) {
         return new VariableResolver<String>() {
             public String resolve(String name) {
                 return StringParameterValue.this.name.equals(name) ? value : null;

--- a/core/src/main/java/hudson/tasks/BuildWrapper.java
+++ b/core/src/main/java/hudson/tasks/BuildWrapper.java
@@ -284,7 +284,7 @@ public abstract class BuildWrapper extends AbstractDescribableImpl<BuildWrapper>
      *      Contains existing build variables. Add additional build variables that you contribute
      *      to this map.
      */
-    public void makeBuildVariables(AbstractBuild build, Map<String,String> variables) {
+    public void makeBuildVariables(Run build, Map<String,String> variables) {
     	// noop
     }
 


### PR DESCRIPTION
This refactoring moves (pulls up) `getBuildVariables()` and `getBuildVariableResolver()` from `AbstractBuild` to `Run`.

Also modifies methods in `ParameterValue` and `BuildVariableContributor` (and overrides) to use `Run` instead of `AbstractBuild`.  I don't think there's a need to create deprecated versions of these methods.

The reason for these refactorings... to help generalise `token-macro-plugin` to use `Run` instead of `AbstractBuild`.  That in turn will help us workflow-enable some plugins that depend on token-macro.

Are these changes safe/dangerous?
