### PR TITLE
Incorrect link to master node on label page

### DIFF
--- a/core/src/main/resources/hudson/model/Label/index.jelly
+++ b/core/src/main/resources/hudson/model/Label/index.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
         <h2>${%Nodes}</h2>
         <j:forEach var="n" items="${it.nodes}">
           <j:set var="c" value="${app.getComputer(n.nodeName)}"/>
-          <j:set var="url" value="${rootURL}/computer/${n.nodeName}"/>
+          <j:set var="url" value="${rootURL}/${c.url}"/>
           <nobr>
             <a href="${url}"><l:icon class="${c.iconClassName} icon-sm"/></a>
             <st:nbsp/>


### PR DESCRIPTION
While working on a plugin for labels, I noticed that the link to the master node on the Label page incorrectly links to the "computer" page instead of the actual page about the master node itself. In fact, "(master)" is missing in the link.
I compared Label\index.jelly and ComputerSet\index.jelly and noticed that Label\index.jelly is trying to calculate the URL of a node by itself, using computer/${n.nodeName}. Node name is empty for the master node, which causes the link issue. ComputerSet\index.jelly instead delegates the computation of the link to the Computer class itself which does it correctly for the master node.
So to solve this I simply put the same approach in Label\index.jelly, using ${c.url} instead of computer/${n.nodeName}.
I didn't find any bug reporting that problem on issues.jenkins-ci.org. Considering it's very simple I supposed it's ok to go directly with a pull request.
