### PR TITLE
JENKINS-24272 jnlp slaves fail to reconnect when master is restarted

### DIFF
--- a/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
+++ b/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
@@ -69,7 +69,7 @@ public class JnlpSlaveRestarterInstaller extends ComputerListener implements Ser
 
                     e.addListener(new EngineListenerAdapter() {
                         @Override
-                        public void onDisconnect() {
+                        public void onReconnect() {
                             try {
                                 for (SlaveRestarter r : restarters) {
                                     try {

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>2.44</version>
+        <version>2.45</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
The corresponding remoting changes are already in remoting 2.45
