### PR TITLE
Explicitly set the umask for daemon in Debian init script

### DIFF
--- a/debian/debian/jenkins.init
+++ b/debian/debian/jenkins.init
@@ -23,7 +23,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 
 #DAEMON=$JENKINS_SH
 DAEMON=/usr/bin/daemon
-DAEMON_ARGS="--name=$NAME --inherit --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE" 
+DAEMON_ARGS="--name=$NAME --inherit --umask=$UMASK --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE"
 
 SU=/bin/su
 

--- a/debian/debian/jenkins.init
+++ b/debian/debian/jenkins.init
@@ -23,7 +23,11 @@ SCRIPTNAME=/etc/init.d/$NAME
 
 #DAEMON=$JENKINS_SH
 DAEMON=/usr/bin/daemon
-DAEMON_ARGS="--name=$NAME --inherit --umask=$UMASK --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE"
+DAEMON_ARGS="--name=$NAME --inherit --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE"
+
+if [ -n "$UMASK" ]; then
+    DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
+fi
 
 SU=/bin/su
 

--- a/debian/debian/jenkins.init
+++ b/debian/debian/jenkins.init
@@ -112,10 +112,9 @@ do_start()
         ulimit -n $MAXOPENFILES
     fi
     
-    # honor umask setting
+    # notify of explicit umask
     if [ -n "$UMASK" ]; then
         [ "$VERBOSE" != no ] && echo Setting umask to $UMASK
-        umask $UMASK
     fi
 
     # --user in daemon doesn't prepare environment variables like HOME, USER, LOGNAME or USERNAME,


### PR DESCRIPTION
As discovered by danielbeck in #jenkins, daemon(1) does not inherit the parent
process's umask. The --umask flag is the means to set it explicitly.

Here I assumed $UMASK will always be set in `/etc/default/jenkins` since it is there in the stock version and it seems to be the norm elsewhere.

If this PR is accepted, one could make the argument that the calls to "umask" are no longer needed further down in the init script. I'll leave that up to someone else since I'm not sure if there was another intent for it.
