### PR TITLE
[JENKINS-24763] Prevent thread starvation by skipping old data removal onSave/remove if doDiscard is running.

### DIFF
--- a/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
@@ -24,20 +24,37 @@
 
 package hudson.diagnosis;
 
+import hudson.XmlFile;
+import hudson.model.Executor;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.InvisibleAction;
+
+import java.io.File;
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import hudson.model.Saveable;
+import hudson.model.listeners.SaveableListener;
+import jenkins.model.Jenkins;
 import jenkins.model.lazy.BuildReference;
 import static org.junit.Assert.*;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MemoryAssert;
 import org.jvnet.hudson.test.recipes.LocalData;
+import org.kohsuke.stapler.Stapler;
 
 public class OldDataMonitorTest {
 
@@ -82,6 +99,52 @@ public class OldDataMonitorTest {
         WeakReference<?> ref = new WeakReference<Object>(b);
         b = null;
         MemoryAssert.assertGC(ref);
+    }
+
+    /**
+     * Note that this doesn't actually run slowly, it just ensures that
+     * the {@link OldDataMonitor#changeListener's onChange()} can complete
+     * while {@link OldDataMonitor#doDiscard(org.kohsuke.stapler.StaplerRequest, org.kohsuke.stapler.StaplerResponse)}
+     * is still running.
+     *
+     */
+    // Test timeout indicates JENKINS-24763 exists
+    @Issue("JENKINS-24763")
+    @Test public void testSlowDiscard() throws InterruptedException, IOException, ExecutionException {
+        final OldDataMonitor oldDataMonitor = OldDataMonitor.get(r.jenkins);
+        final CountDownLatch ensureEntry= new CountDownLatch(1);
+        final CountDownLatch preventExit = new CountDownLatch(1);
+        Saveable slowSavable = new Saveable() {
+            @Override
+            public void save() throws IOException {
+                try {
+                    ensureEntry.countDown();
+                    preventExit.await();
+                } catch (InterruptedException e) {
+                }
+            }
+        };
+
+        OldDataMonitor.report(slowSavable,(String)null);
+        ExecutorService executors = Executors.newSingleThreadExecutor();
+
+        Future<Void> discardFuture = executors.submit(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                oldDataMonitor.doDiscard(Stapler.getCurrentRequest(), Stapler.getCurrentResponse());
+                return null;
+            }
+        });
+
+        ensureEntry.await();
+        // test will hang here due to JENKINS-24763
+        OldDataMonitor.changeListener
+                .onChange(new Saveable() {public void save() throws IOException {}},
+                        new XmlFile(File.createTempFile("somexmlfile","xml")));
+
+        preventExit.countDown();
+        discardFuture.get();
+
     }
 
     public static final class BadAction extends InvisibleAction {


### PR DESCRIPTION
Previous impl did this check after obtaining the synchronization lock, which is pointless. Also, previous flag was not thread safe.
