### PR TITLE
Update the link to the Jetty documentation in realm.properties

### DIFF
--- a/war/src/realm.properties
+++ b/war/src/realm.properties
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-for-the-syntax-of-this-file: see-http://jetty.codehaus.org/jetty/jetty-6/apidocs/org/mortbay/jetty/security/HashUserRealm.html
+for-the-syntax-of-this-file: see-http://wiki.eclipse.org/Jetty/Tutorial/Realms#HashLoginService
 guest: guest
 admin: admin,admin
 alice: alice,admin


### PR DESCRIPTION
The link to the Jetty documentation in realm.properties no longer works.
