### PR TITLE
[FIXED JENKINS-24825] define hudson.model.AbstractItem#movedTo

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -91,6 +91,9 @@ Upcoming changes</a>
   <li class=bug>
     umask setting on Debian did not work.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1397">pull 1397</a>)
+  <li class=bug>
+    handle job move when buildDir is configured to a custom location.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24825">issue 24825</a>)
 </ul>
 </div><!--=END=-->
 <h3><a name=v1.581>What's new in 1.581</a> (2014/09/21)</h3>

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -42,6 +42,7 @@ import hudson.util.AlternativeUiTextProvider;
 import hudson.util.AlternativeUiTextProvider.Message;
 import hudson.util.AtomicFileWriter;
 import hudson.util.IOUtils;
+import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
 import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.types.FileSet;
@@ -306,6 +307,10 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                 ItemListener.fireLocationChange(this, oldFullName);
             }
         }
+    }
+
+    public void movedTo(DirectlyModifiableTopLevelItemGroup destination, AbstractItem newItem, File destDir) throws IOException {
+        newItem.onLoad(destination, name);
     }
 
     /**
@@ -712,4 +717,5 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      * Replaceable pronoun of that points to a job. Defaults to "Job"/"Project" depending on the context.
      */
     public static final Message<AbstractItem> PRONOUN = new Message<AbstractItem>();
+
 }

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -309,6 +309,15 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         }
     }
 
+    /**
+     * Notify this item it's been moved to another location, replaced by newItem (might be the same object, but not guaranteed).
+     * This method is executed <em>after</em> the item root directory has been moved to it's new location.
+     * <p>
+     * Derived classes can override this method to add some specific behavior on move, but have to call parent method
+     * so the item is actually setup within it's new parent.
+     *
+     * @see hudson.model.Items#move(AbstractItem, jenkins.model.DirectlyModifiableTopLevelItemGroup)
+     */
     public void movedTo(DirectlyModifiableTopLevelItemGroup destination, AbstractItem newItem, File destDir) throws IOException {
         newItem.onLoad(destination, name);
     }

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -381,7 +381,7 @@ public class Items {
         FileUtils.moveDirectory(item.getRootDir(), destDir);
         oldParent.remove(item);
         I newItem = destination.add(item, name);
-        newItem.onLoad(destination, name);
+        item.movedTo(destination, newItem, destDir);
         ItemListener.fireLocationChange(newItem, oldFullName);
         return newItem;
     }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -63,6 +63,7 @@ import hudson.widgets.HistoryWidget;
 import hudson.widgets.HistoryWidget.Adapter;
 import hudson.widgets.Widget;
 import jenkins.model.BuildDiscarder;
+import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
 import jenkins.model.ProjectNamingStrategy;
 import jenkins.security.HexStringConfidentialKey;
@@ -70,6 +71,7 @@ import jenkins.util.io.OnMaster;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
+import org.apache.commons.io.FileUtils;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryAxis;
@@ -625,6 +627,18 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             if (!oldBuildDir.renameTo(newBuildDir)) {
                 throw new IOException("failed to rename " + oldBuildDir + " to " + newBuildDir);
             }
+        }
+    }
+
+    @Override
+    public void movedTo(DirectlyModifiableTopLevelItemGroup destination, AbstractItem newItem, File destDir) throws IOException {
+        Job newJob = (Job) newItem; // Missing covariant parameters type here.
+        File oldBuildDir = getBuildDir();
+        super.movedTo(destination, newItem, destDir);
+        File newBuildDir = getBuildDir();
+        if (oldBuildDir.isDirectory() && !newBuildDir.isDirectory()) {
+            FileUtils.forceMkdir(destDir.getParentFile());
+            FileUtils.moveDirectory(oldBuildDir, newBuildDir);
         }
     }
 

--- a/test/src/test/java/hudson/model/ItemsTest.java
+++ b/test/src/test/java/hudson/model/ItemsTest.java
@@ -24,10 +24,14 @@
 
 package hudson.model;
 
+import java.io.File;
 import java.util.Arrays;
+
+import hudson.Util;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockFolder;
 
@@ -54,6 +58,19 @@ public class ItemsTest {
         FreeStyleProject sub2charlie = sub2.createProject(FreeStyleProject.class, "charlie");
         assertEquals(Arrays.asList(dp, sub1p, sub1q, sub2ap, sub2alpha, sub2bp, sub2BRAVO, sub2cp, sub2charlie), Items.getAllItems(d, FreeStyleProject.class));
         assertEquals(Arrays.<Item>asList(sub2a, sub2ap, sub2alpha, sub2b, sub2bp, sub2BRAVO, sub2c, sub2cp, sub2charlie), Items.getAllItems(sub2, Item.class));
+    }
+
+    @Issue("JENKINS-24825")
+    @Test public void moveItem() throws Exception {
+        File tmp = Util.createTempDir();
+        r.jenkins.setRawBuildsDir(tmp.getAbsolutePath()+"/${ITEM_FULL_NAME}");
+        MockFolder foo = r.createFolder("foo");
+        MockFolder bar = r.createFolder("bar");
+        FreeStyleProject test = foo.createProject(FreeStyleProject.class, "test");
+        test.scheduleBuild2(0).get();
+        Items.move(test, bar);
+        assertFalse(new File(tmp, "foo/test/1").exists());
+        assertTrue(new File(tmp, "bar/test/1").exists());
     }
 
 }


### PR DESCRIPTION
movedTo can be overridden for Item-specific stuff, in JENKINS-24825 specific case Job can move the build directory to it's new location.
