### PR TITLE
Use copytruncate consistent with .deb packaging

### DIFF
--- a/rpm/SOURCES/jenkins.logrotate
+++ b/rpm/SOURCES/jenkins.logrotate
@@ -7,10 +7,5 @@
     notifempty
     missingok
     create 644
-    postrotate
-      if [ -s /var/run/jenkins.pid ]; then
-        JPID=`cat /var/run/jenkins.pid`
-        test -n "`find /proc/$JPID -maxdepth 0 -user jenkins 2>/dev/null`" && /bin/kill -s ALRM $JPID || :
-      fi
-    endscript
+    copytruncate
 }


### PR DESCRIPTION
also requires no signalling of the process and less risk of (ironically) lost logs which postrotate attempts to address.
