### PR TITLE
Add getFieldOrder() methods.

### DIFF
--- a/core/src/main/java/hudson/util/jna/Advapi32.java
+++ b/core/src/main/java/hudson/util/jna/Advapi32.java
@@ -22,6 +22,8 @@ import com.sun.jna.Pointer;
 import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.ptr.IntByReference;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  *
@@ -324,6 +326,14 @@ typedef struct _SERVICE_STATUS {
     public int dwServiceSpecificExitCode;
     public int dwCheckPoint;
     public int dwWaitHint;
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList("dwServiceType", "dwCurrentState",
+                "dwControlsAccepted", "dwWin32ExitCode",
+                "dwServiceSpecificExitCode", "dwCheckPoint",
+                "dwWaitHint");
+    }
   }
 
 /*
@@ -335,9 +345,19 @@ typedef struct _SERVICE_TABLE_ENTRY {
   class SERVICE_TABLE_ENTRY extends Structure {
     public String lpServiceName;
     public SERVICE_MAIN_FUNCTION lpServiceProc;
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList(new String[] {"lpServiceName", "lpServiceProc"});
+    }
   }
 
   class ChangeServiceConfig2Info extends Structure {
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList(new String[] {});
+    }
   }
 
 /*

--- a/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
+++ b/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
@@ -25,6 +25,8 @@ package hudson.util.jna;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  *
@@ -73,4 +75,12 @@ public class SHELLEXECUTEINFO extends Structure {
     public static final int SEE_MASK_NOCLOSEPROCESS = 0x40;
     public static final int SW_HIDE = 0;
     public static final int SW_SHOW = 0;
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList("cbSize", "fMask", "hwnd", "lpVerb",
+                "lpFile", "lpParameters", "lpDirectory", "nShow", "hInstApp",
+                "lpIDList", "lpClass", "hkeyClass", "dwHotKey", "hIcon",
+                "hProcess", "SEE_MASK_NOCLOSEPROCESS", "SW_HIDE", "SW_SHOW");
+    }
 }

--- a/core/src/main/java/hudson/util/jna/WINBASE.java
+++ b/core/src/main/java/hudson/util/jna/WINBASE.java
@@ -17,6 +17,8 @@ package hudson.util.jna;
 
 import com.sun.jna.Structure;
 import com.sun.jna.Pointer;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  *
@@ -35,6 +37,12 @@ typedef struct _SECURITY_ATTRIBUTES {
     public int nLength;
     public Pointer lpSecurityDescriptor;
     public boolean bInheritHandle;
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList("nLength", "lpSecurityDescriptor",
+                "bInheritHandle");
+    }
   }
 
 /*
@@ -45,5 +53,10 @@ typedef struct _FILETIME {
   class FILETIME extends Structure {
     public int dwLowDateTime;
     public int dwHighDateTime;
+
+    @Override
+    protected List getFieldOrder() {
+        return Arrays.asList("dwLowDateTime", "dwHighDateTime");
+    }
   }
 }


### PR DESCRIPTION
Add getFieldOrder() methods to classes which extend com.sun.jna.Structure,
for compatibility with newer versions of JNA.  [JENKINS-24521]
