### PR TITLE
[FIXED JENKINS-19017] - FileParameter - Handle non-null file parameters as different values

### DIFF
--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -160,7 +160,8 @@ public class FileParameterValue extends ParameterValue {
 	}
 
 	/**
-	 * In practice this will always be false, since location should be unique.
+	 * Compares file parameters (existing files will be considered as different).
+	 * Function has been modified in order to avoid <a href="https://issues.jenkins-ci.org/browse/JENKINS-19017">JENKINS-19017</a> issue (wrong merge of builds in the queue).
 	 */
 	@Override
 	public boolean equals(Object obj) {
@@ -171,12 +172,13 @@ public class FileParameterValue extends ParameterValue {
 		if (getClass() != obj.getClass())
 			return false;
 		FileParameterValue other = (FileParameterValue) obj;
-		if (location == null) {
-			if (other.location != null)
-				return false;
-		} else if (!location.equals(other.location))
-			return false;
-		return true;
+		
+		if (location == null && other.location == null) 
+			return true; // Consider null parameters as equal
+
+		//TODO: check fingerprints or checksums to improve the behavior
+		// Return false even if files are equal
+		return false;
 	}
 
     @Override

--- a/core/src/test/java/hudson/model/FileParameterValueTest.java
+++ b/core/src/test/java/hudson/model/FileParameterValueTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Oleg Nenashev <o.v.nenashev@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model;
+
+import java.io.File;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Test for {@link FileParameterValue}.
+ * @author Oleg Nenashev <o.v.nenashev@gmail.com>
+ */
+public class FileParameterValueTest {
+    
+    @Issue("JENKINS-19017")
+    @Test public void compareParamsWithSameName() {
+        final String paramName = "MY_FILE_PARAM"; // Same paramName (location) reproduces the bug
+        final FileParameterValue param1 = new FileParameterValue(paramName, new File("ws_param1.txt"), "param1.txt");
+        final FileParameterValue param2 = new FileParameterValue(paramName, new File("ws_param2.txt"), "param2.txt");
+        
+        Assert.assertNotEquals("Files with same locations shoud be considered as different", param1, param2);
+        Assert.assertNotEquals("Files with same locations shoud be considered as different", param2, param1);
+    }
+    
+    @Test public void compareNullParams() {
+        final String paramName = "MY_FILE_PARAM";     
+        FileParameterValue nonNullParam = new FileParameterValue(paramName, new File("ws_param1.txt"), "param1.txt");
+        FileParameterValue nullParam1 = new FileParameterValue(null, new File("null_param1.txt"), "null_param1.txt");
+        FileParameterValue nullParam2 = new FileParameterValue(null, new File("null_param2.txt"), "null_param2.txt");
+        
+        // Combine nulls
+        Assert.assertEquals(nullParam1, nullParam1);
+        Assert.assertEquals(nullParam1, nullParam2);
+        Assert.assertEquals(nullParam2, nullParam1);
+        Assert.assertEquals(nullParam2, nullParam2);
+        
+        // Compare with non-null
+        Assert.assertNotEquals(nullParam1, nonNullParam);
+        Assert.assertNotEquals(nonNullParam, nullParam1);
+    }
+}


### PR DESCRIPTION
The change prevents the issue when Jenkins merges builds with different files coming from one source (It may happen!).

This change is a relocated version of #889 (thanks to @daniel-beck for the reminder)

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
