### PR TITLE
Convert AbstractProject to better utilize structure form submission.

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1789,24 +1789,38 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         super.submit(req,rsp);
         JSONObject json = req.getSubmittedForm();
 
-        makeDisabled(req.getParameter("disable")!=null);
+        // "disable": {}
+        makeDisabled(json.has("disable"));
 
-        jdk = req.getParameter("jdk");
-        if(req.getParameter("hasCustomQuietPeriod")!=null) {
-            quietPeriod = Integer.parseInt(req.getParameter("quiet_period"));
+        jdk = json.optString("jdk", null);
+
+        // "hasCustomQuietPeriod": {"quiet_period": "3"}
+        JSONObject customQuietPeriodJson = json.optJSONObject("hasCustomQuietPeriod");
+        if(customQuietPeriodJson!=null && !customQuietPeriodJson.isNullObject()) {
+            quietPeriod = customQuietPeriodJson.optInt("quiet_period");
         } else {
             quietPeriod = null;
         }
-        if(req.getParameter("hasCustomScmCheckoutRetryCount")!=null) {
-            scmCheckoutRetryCount = Integer.parseInt(req.getParameter("scmCheckoutRetryCount"));
+
+        // "hasCustomScmCheckoutRetryCount": {"scmCheckoutRetryCount": "12"}
+        JSONObject customRetryJson = json.optJSONObject("hasCustomScmCheckoutRetryCount");
+        if(customRetryJson!=null && !customRetryJson.isNullObject()) {
+            scmCheckoutRetryCount = customRetryJson.optInt("scmCheckoutRetryCount");
         } else {
             scmCheckoutRetryCount = null;
         }
-        blockBuildWhenDownstreamBuilding = req.getParameter("blockBuildWhenDownstreamBuilding")!=null;
-        blockBuildWhenUpstreamBuilding = req.getParameter("blockBuildWhenUpstreamBuilding")!=null;
 
-        if(req.hasParameter("customWorkspace")) {
-            customWorkspace = Util.fixEmptyAndTrim(req.getParameter("customWorkspace.directory"));
+        // "blockBuildWhenDownstreamBuilding": {}
+        blockBuildWhenDownstreamBuilding = json.has("blockBuildWhenDownstreamBuilding");
+
+        // "blockBuildWhenUpstreamBuilding": {}
+        blockBuildWhenUpstreamBuilding = json.has("blockBuildWhenUpstreamBuilding");
+
+        // "customWorkspace": {"directory": "aaa"}
+        JSONObject customWorkspaceJson = json.optJSONObject("customWorkspace");
+        if(customWorkspace!=null && !customWorkspaceJson.isNullObject()) {
+            customWorkspace = Util.fixEmptyAndTrim(
+                customWorkspaceJson.optString("directory"));
         } else {
             customWorkspace = null;
         }
@@ -1817,17 +1831,19 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         else
             scmCheckoutStrategy = null;
 
-        
-        if(req.getParameter("hasSlaveAffinity")!=null) {
-            assignedNode = Util.fixEmptyAndTrim(req.getParameter("_.assignedLabelString"));
+
+        JSONObject slaveAffinity = json.getJSONObject("hasSlaveAffinity");
+        if(slaveAffinity!=null && !slaveAffinity.isNullObject()) {
+            assignedNode = Util.fixEmptyAndTrim(
+                slaveAffinity.optString("assignedLabelString"));
         } else {
             assignedNode = null;
         }
         canRoam = assignedNode==null;
 
-        keepDependencies = req.getParameter("keepDependencies") != null;
+        keepDependencies = json.has("keepDependencies");
 
-        concurrentBuild = req.getSubmittedForm().has("concurrentBuild");
+        concurrentBuild = json.has("concurrentBuild");
 
         authToken = BuildAuthorizationToken.create(req);
 

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1789,38 +1789,27 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         super.submit(req,rsp);
         JSONObject json = req.getSubmittedForm();
 
-        // "disable": true
         makeDisabled(json.optBoolean("disable"));
 
         jdk = json.optString("jdk", null);
 
-        // "hasCustomQuietPeriod": {"quiet_period": "3"}
-        JSONObject customQuietPeriodJson = json.optJSONObject("hasCustomQuietPeriod");
-        if(customQuietPeriodJson!=null && !customQuietPeriodJson.isNullObject()) {
-            quietPeriod = customQuietPeriodJson.optInt("quiet_period");
+        if(json.optBoolean("hasCustomQuietPeriod", json.has("quiet_period"))) {
+            quietPeriod = json.optInt("quiet_period");
         } else {
             quietPeriod = null;
         }
 
-        // "hasCustomScmCheckoutRetryCount": {"scmCheckoutRetryCount": "12"}
-        JSONObject customRetryJson = json.optJSONObject("hasCustomScmCheckoutRetryCount");
-        if(customRetryJson!=null && !customRetryJson.isNullObject()) {
-            scmCheckoutRetryCount = customRetryJson.optInt("scmCheckoutRetryCount");
+        if(json.optBoolean("hasCustomScmCheckoutRetryCount", json.has("scmCheckoutRetryCount"))) {
+            scmCheckoutRetryCount = json.optInt("scmCheckoutRetryCount");
         } else {
             scmCheckoutRetryCount = null;
         }
 
-        // "blockBuildWhenDownstreamBuilding": true
         blockBuildWhenDownstreamBuilding = json.optBoolean("blockBuildWhenDownstreamBuilding");
-
-        // "blockBuildWhenUpstreamBuilding": true
         blockBuildWhenUpstreamBuilding = json.optBoolean("blockBuildWhenUpstreamBuilding");
 
-        // "customWorkspace": {"directory": "aaa"}
-        JSONObject customWorkspaceJson = json.optJSONObject("customWorkspace");
-        if(customWorkspace!=null && !customWorkspaceJson.isNullObject()) {
-            customWorkspace = Util.fixEmptyAndTrim(
-                customWorkspaceJson.optString("directory"));
+        if(json.optBoolean("hasCustomWorkspace", json.has("customWorkspace"))) {
+            customWorkspace = Util.fixEmptyAndTrim(json.optString("customWorkspace"));
         } else {
             customWorkspace = null;
         }
@@ -1831,11 +1820,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         else
             scmCheckoutStrategy = null;
 
-
-        JSONObject slaveAffinity = json.getJSONObject("hasSlaveAffinity");
-        if(slaveAffinity!=null && !slaveAffinity.isNullObject()) {
-            assignedNode = Util.fixEmptyAndTrim(
-                slaveAffinity.optString("assignedLabelString"));
+        if(json.optBoolean("hasSlaveAffinity", json.has("label"))) {
+            assignedNode = Util.fixEmptyAndTrim(json.optString("label"));
         } else {
             assignedNode = null;
         }
@@ -2032,8 +2018,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             return true;
         }
 
-        public FormValidation doCheckAssignedLabelString(@AncestorInPath AbstractProject<?,?> project,
-                                                         @QueryParameter String value) {
+        public FormValidation doCheckLabel(@AncestorInPath AbstractProject<?,?> project,
+                                           @QueryParameter String value) {
             if (Util.fixEmpty(value)==null)
                 return FormValidation.ok(); // nothing typed yet
             try {
@@ -2070,7 +2056,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             ));
         }
 
-        public FormValidation doCheckCustomWorkspace(@QueryParameter(value="customWorkspace.directory") String customWorkspace){
+        public FormValidation doCheckCustomWorkspace(@QueryParameter String customWorkspace){
         	if(Util.fixEmptyAndTrim(customWorkspace)==null)
         		return FormValidation.error(Messages.AbstractProject_CustomWorkspaceEmpty());
         	else
@@ -2090,7 +2076,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             return candidates;
         }
 
-        public AutoCompletionCandidates doAutoCompleteAssignedLabelString(@QueryParameter String value) {
+        public AutoCompletionCandidates doAutoCompleteLabel(@QueryParameter String value) {
             AutoCompletionCandidates c = new AutoCompletionCandidates();
             Set<Label> labels = Jenkins.getInstance().getLabels();
             List<String> queries = new AutoCompleteSeeder(value).getSeeds();

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1789,8 +1789,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         super.submit(req,rsp);
         JSONObject json = req.getSubmittedForm();
 
-        // "disable": {}
-        makeDisabled(json.has("disable"));
+        // "disable": true
+        makeDisabled(json.optBoolean("disable"));
 
         jdk = json.optString("jdk", null);
 
@@ -1810,11 +1810,11 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             scmCheckoutRetryCount = null;
         }
 
-        // "blockBuildWhenDownstreamBuilding": {}
-        blockBuildWhenDownstreamBuilding = json.has("blockBuildWhenDownstreamBuilding");
+        // "blockBuildWhenDownstreamBuilding": true
+        blockBuildWhenDownstreamBuilding = json.optBoolean("blockBuildWhenDownstreamBuilding");
 
-        // "blockBuildWhenUpstreamBuilding": {}
-        blockBuildWhenUpstreamBuilding = json.has("blockBuildWhenUpstreamBuilding");
+        // "blockBuildWhenUpstreamBuilding": true
+        blockBuildWhenUpstreamBuilding = json.optBoolean("blockBuildWhenUpstreamBuilding");
 
         // "customWorkspace": {"directory": "aaa"}
         JSONObject customWorkspaceJson = json.optJSONObject("customWorkspace");
@@ -1843,7 +1843,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
 
         keepDependencies = json.has("keepDependencies");
 
-        concurrentBuild = json.has("concurrentBuild");
+        concurrentBuild = json.optBoolean("concurrentBuild");
 
         authToken = BuildAuthorizationToken.create(req);
 

--- a/core/src/main/resources/lib/hudson/project/config-assignedLabel.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-assignedLabel.jelly
@@ -29,9 +29,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!-- master/slave -->
   <j:if test="${app.labels.size() gt 1 || app.clouds.size() gt 0 || (it.assignedLabel!=null and it.assignedLabel!=app.selfLabel)}">
-    <f:optionalBlock name="hasSlaveAffinity" title="${%Restrict where this project can be run}" checked="${it.assignedLabel!=null}" field="slaveAffinity">
-      <f:entry title="${%Label Expression}" field="assignedLabelString">
-        <f:textbox autoCompleteDelimChar=" "/>
+    <f:optionalBlock name="hasSlaveAffinity" title="${%Restrict where this project can be run}" checked="${it.assignedLabel!=null}" field="slaveAffinity" inline="true">
+      <f:entry title="${%Label Expression}" field="label">
+        <f:textbox autoCompleteDelimChar=" " value="${it.assignedLabelString}"/>
       </f:entry>
     </f:optionalBlock>
   </j:if>

--- a/core/src/main/resources/lib/hudson/project/config-blockWhenDownstreamBuilding.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-blockWhenDownstreamBuilding.jelly
@@ -28,5 +28,6 @@ THE SOFTWARE.
   <f:optionalBlock name="blockBuildWhenDownstreamBuilding"
 		   title="${%Block build when downstream project is building}"
 		   help="/help/project-config/block-downstream-building.html"
-		   checked="${it.blockBuildWhenDownstreamBuilding()}" />
+		   checked="${it.blockBuildWhenDownstreamBuilding()}"
+		   inline="true" />
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-blockWhenUpstreamBuilding.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-blockWhenUpstreamBuilding.jelly
@@ -28,5 +28,6 @@ THE SOFTWARE.
   <f:optionalBlock name="blockBuildWhenUpstreamBuilding"
 		   title="${%Block build when upstream project is building}"
 		   help="/help/project-config/block-upstream-building.html"
-		   checked="${it.blockBuildWhenUpstreamBuilding()}" />
+		   checked="${it.blockBuildWhenUpstreamBuilding()}"
+		   inline="true" />
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-concurrentBuild.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-concurrentBuild.jelly
@@ -27,5 +27,5 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:optionalBlock field="concurrentBuild" title="${%title.concurrentbuilds}" />
+  <f:optionalBlock field="concurrentBuild" title="${%title.concurrentbuilds}" inline="true" />
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-customWorkspace.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-customWorkspace.jelly
@@ -25,9 +25,10 @@ THE SOFTWARE.
 <!-- custom workspace -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:optionalBlock name="customWorkspace" title="${%Use custom workspace}" checked="${it.customWorkspace!=null}" help="/help/project-config/custom-workspace.html">
-    <f:entry title="${%Directory}">
-      <f:textbox name="customWorkspace.directory" field="customWorkspace" />
+  <f:optionalBlock name="hasCustomWorkspace" title="${%Use custom workspace}" checked="${it.customWorkspace!=null}"
+                   help="/help/project-config/custom-workspace.html" inline="true">
+    <f:entry title="${%Directory}" field="customWorkspace">
+      <f:textbox />
     </f:entry>
   </f:optionalBlock>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-disableBuild.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-disableBuild.jelly
@@ -28,5 +28,5 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:optionalBlock name="disable" title="${%Disable Build} (${%No new builds will be executed until the project is re-enabled.})" checked="${it.disabled}"
-                   help="/help/project-config/disable.html" />
+                   help="/help/project-config/disable.html" inline="true" />
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-quietPeriod.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-quietPeriod.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:optionalBlock name="hasCustomQuietPeriod" title="${%Quiet period}" checked="${it.hasCustomQuietPeriod}"
-      help="/descriptor/jenkins.model.GlobalQuietPeriodConfiguration/help/quietPeriod">
+      help="/descriptor/jenkins.model.GlobalQuietPeriodConfiguration/help/quietPeriod" inline="true">
     <f:entry title="${%Quiet period}"
       description="${%Number of seconds}">
       <f:number clazz="number" name="quiet_period" value="${it.quietPeriod}" min="0" step="1"/>

--- a/core/src/main/resources/lib/hudson/project/config-retryCount.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-retryCount.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:optionalBlock name="hasCustomScmCheckoutRetryCount" title="${%Retry Count}" checked="${it.hasCustomScmCheckoutRetryCount()}"
-      help="/help/project-config/scmCheckoutRetryCount.html">
+      help="/help/project-config/scmCheckoutRetryCount.html" inline="true">
     <f:entry title="${%SCM checkout retry count}">
       <f:number clazz="number" name="scmCheckoutRetryCount" value="${it.scmCheckoutRetryCount}" min="0" step="1"/>
     </f:entry>

--- a/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
@@ -233,11 +233,11 @@ public class LabelExpressionTest extends HudsonTestCase {
 
                 Label l = jenkins.getLabel("foo");
                 DumbSlave s = createSlave(l);
-                String msg = d.doCheckAssignedLabelString(null, "goo").renderHtml();
+                String msg = d.doCheckLabel(null, "goo").renderHtml();
                 assertTrue(msg.contains("foo"));
                 assertTrue(msg.contains("goo"));
 
-                msg = d.doCheckAssignedLabelString(null, "master && goo").renderHtml();
+                msg = d.doCheckLabel(null, "master && goo").renderHtml();
                 assertTrue(msg.contains("foo"));
                 assertTrue(msg.contains("goo"));
                 return null;


### PR DESCRIPTION
This change configures AbstractProject to more heavily use the structured form data available as a JSONObject via "req.getSubmittedForm()" vs. what it does today, which is to directly retrieve values via "req.getParameter".

This change also makes a handful of adjustments to the structure of the JSON blob that is sent through, including naming in a couple places.

NOTE: I have intentionally staged this as 3 incremental commits, which each affect part of the above transition and individually pass testing (locally).  I am happy to squash these together before merging, if that's preferable.
