### PR TITLE
[DO NOT MERGE] [JENKINS-6610] Allow clients to request HTTP 401/WWW-Authenticate

### DIFF
--- a/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
+++ b/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
@@ -38,6 +38,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -82,7 +83,13 @@ public class HudsonAuthenticationEntryPoint extends AuthenticationProcessingFilt
             loginForm = MessageFormat.format(loginForm, URLEncoder.encode(uriFrom,"UTF-8"));
             req.setAttribute("loginForm", loginForm);
 
-            rsp.setStatus(SC_FORBIDDEN);
+            if (req.getParameter("basic") != null) {
+                rsp.setStatus(SC_UNAUTHORIZED);
+                rsp.setHeader("WWW-Authenticate", "Basic realm=\"Jenkins\"");
+            } else {
+                rsp.setStatus(SC_FORBIDDEN);
+            }
+
             rsp.setContentType("text/html;charset=UTF-8");
 
             Functions.advertiseHeaders(rsp);


### PR DESCRIPTION
Do not merge, but please share your thoughts on this.

---

Non-browser clients currently have the problem that they don't get a proper basic auth challenge from Jenkins for access to a restricted resource: It's just HTTP 403 Forbidden, and a redirect to the login form.

OTOH if Jenkins sends the HTTP 401 response and WWW-Authenticate header, web browsers will start showing the login popup window for basic authentication.

Would a solution like this one be acceptable? RSS clients would then need to start requesting e.g. `/rssAll?basic` to get a proper challenge, if they don't support preemptive authentication. A simple reconfiguration should do it, and for future users all links to RSS feeds on the UI could be changed.

I considered a few other solutions in a recent comment to [JENKINS-6610](https://issues.jenkins-ci.org/browse/JENKINS-6610), but all of them seem worse than this.
