### PR TITLE
JENKINS-21160: update pom.xml to warn about mismatched args4j

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -191,7 +191,7 @@ THE SOFTWARE.
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
     </dependency>
-    <dependency>
+    <dependency><!-- JENKINS-21160: remoting also depends on args4j, please update accordingly -->
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
       <version>2.0.23</version>


### PR DESCRIPTION
in some circumstances, you may use some older args4j (coming from remoting) whereas the jenkins about page shows a different version.
