### PR TITLE
[JENKINS-10197] Show keep log reason in tool tip

### DIFF
--- a/core/src/main/resources/hudson/model/Run/KeepLogBuildBadge/badge.jelly
+++ b/core/src/main/resources/hudson/model/Run/KeepLogBuildBadge/badge.jelly
@@ -23,4 +23,4 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<l:icon class="icon-lock icon-sm" tooltip="${%Keep this build forever}" xmlns:l="/lib/layout"/>
+<l:icon class="icon-lock icon-sm" tooltip="${%Keep this build forever}:&lt;br/&gt;${build.whyKeepLog}" xmlns:l="/lib/layout"/>


### PR DESCRIPTION
Currently it's only ever shown on the 'Delete Build' dialog. Especially with automatic build retention in e.g. Matrix projects, it's helpful to be able to quickly determine why a build is kept forever.
