### PR TITLE
[FIXED JENKINS-24703] Do not set any colors for input elements

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -122,8 +122,11 @@ body, table, form, input, td, th, p, textarea, select
 {
   font-family: Helvetica, Arial, sans-serif;
   font-size: 13px;
+}
+
+body, table, form, td, th, p
+{
   color: #333;
-  background-color: #fff;
 }
 
 FORM {


### PR DESCRIPTION
Merged from https://github.com/quinox/jenkins/commit/78d222c607d31bdcfd5df7c20dbefe3ec937f3de by Ceesjan Luiten (thanks)
