### PR TITLE
[FIXED JENKINS-25144] Http BasicAuth broken in combination with a web Session

### DIFF
--- a/core/src/main/java/jenkins/security/BasicHeaderRealPasswordAuthenticator.java
+++ b/core/src/main/java/jenkins/security/BasicHeaderRealPasswordAuthenticator.java
@@ -50,7 +50,7 @@ public class BasicHeaderRealPasswordAuthenticator extends BasicHeaderAuthenticat
             return null;
 
         if (!authenticationIsRequired(username))
-            return null;
+            return SecurityContextHolder.getContext().getAuthentication();
 
         UsernamePasswordAuthenticationToken authRequest =
                 new UsernamePasswordAuthenticationToken(username, password);

--- a/test/src/test/java/jenkins/security/BasicHeaderProcessorTest.java
+++ b/test/src/test/java/jenkins/security/BasicHeaderProcessorTest.java
@@ -56,9 +56,14 @@ public class BasicHeaderProcessorTest extends Assert {
         // call with incorrect password
         makeRequestAndFail("foo:bar");
 
-        // if the session cookie is valid, then basic header won't be needed
+
         wc.login("bar");
+
+        // if the session cookie is valid, then basic header won't be needed
         makeRequestWithAuthAndVerify(null, "bar");
+
+        // if the session cookie is valid, and basic header is set anyway login should not fail either
+        makeRequestWithAuthAndVerify("bar:bar", "bar");
 
         // but if the password is incorrect, it should fail, instead of silently logging in as the user indicated by session
         makeRequestAndFail("foo:bar");


### PR DESCRIPTION
return authentication object instead of null if authentication is not required - otherwise valid login fails with basic authentication
