### PR TITLE
JENKINS-21160: use latest and greatest args4j (curr. 2.0.30)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -194,7 +194,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>2.0.23</version>
+      <version>2.0.30</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
also needs to be in sync with remoting, which bundles args4j
https://github.com/jenkinsci/remoting/pull/26
