### PR TITLE
JENKINS-25205: "Slaves in label" produces wrong results

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -2110,8 +2110,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
                 }
             }
             return FormValidation.okWithMarkup(Messages.AbstractProject_LabelLink(
-                    j.getRootUrl(), l.getUrl(), l.getNodes().size() + l.getClouds().size()
-            ));
+                    j.getRootUrl(), l.getUrl(), l.getNodes().size(), l.getClouds().size())
+            );
         }
 
         public FormValidation doCheckCustomWorkspace(@QueryParameter String customWorkspace){

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -73,7 +73,7 @@ AbstractProject.AssignedLabelString.InvalidBooleanExpression=\
 AbstractProject.AssignedLabelString.NoMatch=\
   There's no slave/cloud that matches this assignment
 AbstractProject.CustomWorkspaceEmpty=Custom workspace is empty.
-AbstractProject.LabelLink=Slaves in <a href="{0}{1}">label</a>: {2}
+AbstractProject.LabelLink=<a href="{0}{1}">Label</a> is serviced by {2,choice,0#no nodes|1#1 node|1<{2} nodes}{3,choice,0#|1# and 1 cloud|1< and {3} clouds}
 
 Api.MultipleMatch=XPath "{0}" matched {1} nodes. \
     Create XPath that only matches one, or use the "wrapper" query parameter to wrap them all under a root element.

--- a/core/src/main/resources/hudson/model/Messages_pt_BR.properties
+++ b/core/src/main/resources/hudson/model/Messages_pt_BR.properties
@@ -499,8 +499,6 @@ Jenkins.CheckDisplayName.NameNotUniqueWarning=O nome de exibi\u00e7\u00e3o "{0}"
 AbstractProject.CustomWorkspaceEmpty=O workspace customizado est\u00e1 vazio.
 # Wait for a node to become online.
 CLI.wait-node-online.shortDescription=Aguarda por um n\u00f3 que se torne online
-# Slaves in <a href="{0}{1}">label</a>: {2}
-AbstractProject.LabelLink=Slaves em <a href="{0}{1}">label</a>: {2}
 # Artifacts of {0} {1}
 Run.ArtifactsBrowserTitle=Artefatos de {0} {1}
 # Build with Parameters


### PR DESCRIPTION
Changes "Slaves in label: N" to "Label is serviced by N node(s) and M cloud(s)".
Portugese translation reset.
