### PR TITLE
[WIP] Default for JDK name is unclear. Instead it should say system default as...

### DIFF
--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -57,7 +57,7 @@ public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, En
      * Name of the “default JDK”, meaning no specific JDK selected.
      * @since 1.577
      */
-    public static final String DEFAULT_NAME = "(Default)";
+    public static final String DEFAULT_NAME = "(System Default)";
 
     /**
      * @deprecated since 2009-02-25


### PR DESCRIPTION
... this will pick up the java version defined in the path variable on the system.

Credit for actual default name goes to @daniel-beck.
