### PR TITLE
[JENKINS-25473] Performance optimization for initial job load

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2602,11 +2602,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 throw new IOException(projectsDir+" is not a directory");
             throw new IOException("Unable to create "+projectsDir+"\nPermission issue? Please create this directory manually.");
         }
-        File[] subdirs = projectsDir.listFiles(new FileFilter() {
-            public boolean accept(File child) {
-                return child.isDirectory() && Items.getConfigFile(child).exists();
-            }
-        });
+        File[] subdirs = projectsDir.listFiles(); 
 
         final Set<String> loadedNames = Collections.synchronizedSet(new HashSet<String>());
 
@@ -2652,6 +2648,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         for (final File subdir : subdirs) {
             g.requires(loadHudson).attains(JOB_LOADED).notFatal().add("Loading job "+subdir.getName(),new Executable() {
                 public void run(Reactor session) throws Exception {
+                    if(!Items.getConfigFile(subdir).exists()) {
+                        //Does not have job config file, so it is not a jenkins job hence skip it
+                        return;
+                    }
                     TopLevelItem item = (TopLevelItem) Items.load(Jenkins.this, subdir);
                     items.put(item.getName(), item);
                     loadedNames.add(item.getName());


### PR DESCRIPTION
This pull request optimizes the loading of jobs. When there are more than 20,000 jobs in jenkins the previous file-filter based check happened in a single thread and was taking in order of minutes to do the check.  This moves the config file check in file filter for listing of jobs (presence of a config file under a directory in jobs) as part of loading job so that it is done in multi-thread fashion than in a single thread. It also does only the config file check  which is sufficient to check job being a directory also (as the job being directory check is redundant and not required). This also reduces the number of file I/O ops by half. 
