### PR TITLE
Change Jenkins to use a single consistent data-binding field.

### DIFF
--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -909,7 +909,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
         if (formData!=null) {
             for (Object o : JSONArray.fromObject(formData)) {
                 JSONObject jo = (JSONObject)o;
-                String kind = jo.getString("kind");
+                String kind = jo.getString("$class");
                 Descriptor<T> d = find(descriptors, kind);
                 if (d != null) {
                     items.add(d.newInstance(req, jo));

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -909,7 +909,11 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
         if (formData!=null) {
             for (Object o : JSONArray.fromObject(formData)) {
                 JSONObject jo = (JSONObject)o;
-                String kind = jo.getString("$class");
+                String kind = jo.optString("$class", null);
+                if (kind == null) {
+                  // Legacy: Remove once plugins have been staged onto $class
+                  kind = jo.getString("kind");
+                }
                 Descriptor<T> d = find(descriptors, kind);
                 if (d != null) {
                     items.add(d.newInstance(req, jo));

--- a/core/src/main/java/jenkins/model/GlobalProjectNamingStrategyConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalProjectNamingStrategyConfiguration.java
@@ -44,7 +44,7 @@ public class GlobalProjectNamingStrategyConfiguration extends GlobalConfiguratio
         final JSONObject optJSONObject = json.optJSONObject("useProjectNamingStrategy");
         if (optJSONObject != null) {
             final JSONObject strategyObject = optJSONObject.getJSONObject("namingStrategy");
-            final String className = strategyObject.getString("stapler-class");
+            final String className = strategyObject.getString("$class");
             try {
                 Class clazz = Class.forName(className, true, Jenkins.getInstance().getPluginManager().uberClassLoader);
                 final ProjectNamingStrategy strategy = (ProjectNamingStrategy) req.bindJSON(clazz, strategyObject);

--- a/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
+++ b/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
@@ -56,13 +56,7 @@ THE SOFTWARE.
         <j:set var="descriptor" value="${d}"/>
         <j:set var="instance"
                value="${it.launcher.descriptor==d ? it.launcher : null}"/>
-        <f:invisibleEntry>
-          <!-- Legacy: Remove once plugins have been staged onto $class -->
-          <input type="hidden" name="stapler-class" value="${d.clazz.name}" />
-        </f:invisibleEntry>
-        <f:invisibleEntry>
-          <input type="hidden" name="$class" value="${d.clazz.name}" />
-        </f:invisibleEntry>
+        <f:class-entry descriptor="${d}" />
         <st:include from="${d}" page="${d.configPage}" optional="true"/>
       </f:dropdownListBlock>
     </j:forEach>
@@ -80,11 +74,7 @@ THE SOFTWARE.
             <j:set var="descriptor" value="${d}"/>
             <j:set var="instance"
                    value="${it.retentionStrategy.descriptor==d ? it.retentionStrategy : null}"/>
-            <tr><td>
-              <!-- Legacy: Remove once plugins have been staged onto $class -->
-              <input type="hidden" name="stapler-class" value="${d.clazz.name}" />
-              <input type="hidden" name="$class" value="${d.clazz.name}" />
-            </td></tr>
+            <f:class-entry descriptor="${d}" />
             <st:include from="${d}" page="${d.configPage}" optional="true"/>
           </f:dropdownListBlock>
         </j:if>

--- a/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
+++ b/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
@@ -57,7 +57,11 @@ THE SOFTWARE.
         <j:set var="instance"
                value="${it.launcher.descriptor==d ? it.launcher : null}"/>
         <f:invisibleEntry>
+          <!-- Legacy: Remove once plugins have been staged onto $class -->
           <input type="hidden" name="stapler-class" value="${d.clazz.name}" />
+        </f:invisibleEntry>
+        <f:invisibleEntry>
+          <input type="hidden" name="$class" value="${d.clazz.name}" />
         </f:invisibleEntry>
         <st:include from="${d}" page="${d.configPage}" optional="true"/>
       </f:dropdownListBlock>
@@ -77,7 +81,9 @@ THE SOFTWARE.
             <j:set var="instance"
                    value="${it.retentionStrategy.descriptor==d ? it.retentionStrategy : null}"/>
             <tr><td>
+              <!-- Legacy: Remove once plugins have been staged onto $class -->
               <input type="hidden" name="stapler-class" value="${d.clazz.name}" />
+              <input type="hidden" name="$class" value="${d.clazz.name}" />
             </td></tr>
             <st:include from="${d}" page="${d.configPage}" optional="true"/>
           </f:dropdownListBlock>

--- a/core/src/main/resources/lib/form/class-entry.jelly
+++ b/core/src/main/resources/lib/form/class-entry.jelly
@@ -1,0 +1,43 @@
+<!--
+The MIT License
+
+Copyright (c) 2014, Google, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation>
+    Invisible &lt;f:entry> type for embedding a descriptor's $class field.
+    <st:attribute name="clazz">
+      The describable class that we are instantiating via structured form submission.
+    </st:attribute>
+    <st:attribute name="descriptor">
+      The descriptor of the describable that we are instantiating via
+      structured form submission.  Mutually exclusive with clazz.
+    </st:attribute>
+  </st:documentation>
+  <j:set var="clazz" value="${attrs.clazz ?: attrs.descriptor.clazz.name}" />
+  <f:invisibleEntry>
+    <!-- Legacy: Remove once plugins have been staged onto $class -->
+    <input type="hidden" name="stapler-class" value="${clazz}" />
+    <input type="hidden" name="$class" value="${clazz}" />
+  </f:invisibleEntry>
+</j:jelly>

--- a/core/src/main/resources/lib/form/class-entry.jelly
+++ b/core/src/main/resources/lib/form/class-entry.jelly
@@ -38,6 +38,10 @@ THE SOFTWARE.
   <f:invisibleEntry>
     <!-- Legacy: Remove once plugins have been staged onto $class -->
     <input type="hidden" name="stapler-class" value="${clazz}" />
+    <!-- Legacy: Remove once plugins have been staged onto $class -->
+    <j:if test="${attrs.descriptor != null}">
+      <input type="hidden" name="kind" value="${attrs.descriptor.id}" />
+    </j:if>
     <input type="hidden" name="$class" value="${clazz}" />
   </f:invisibleEntry>
 </j:jelly>

--- a/core/src/main/resources/lib/form/descriptorRadioList.jelly
+++ b/core/src/main/resources/lib/form/descriptorRadioList.jelly
@@ -54,7 +54,11 @@ THE SOFTWARE.
         <j:set var="descriptor" value="${d}" />
 	      <j:set var="instance" value="${instance.descriptor==d?instance:null}" />
         <f:invisibleEntry>
+          <!-- Legacy: Remove once plugins have been staged onto $class -->
           <input type="hidden" name="stapler-class" value="${descriptor.clazz.name}"/>
+        </f:invisibleEntry>
+        <f:invisibleEntry>
+          <input type="hidden" name="$class" value="${descriptor.clazz.name}"/>
         </f:invisibleEntry>
 	      <st:include from="${d}" page="${d.configPage}" optional="true" />
 	    </f:radioBlock>

--- a/core/src/main/resources/lib/form/descriptorRadioList.jelly
+++ b/core/src/main/resources/lib/form/descriptorRadioList.jelly
@@ -53,13 +53,7 @@ THE SOFTWARE.
         title="${d.displayName}" checked="${instance.descriptor==d}">
         <j:set var="descriptor" value="${d}" />
 	      <j:set var="instance" value="${instance.descriptor==d?instance:null}" />
-        <f:invisibleEntry>
-          <!-- Legacy: Remove once plugins have been staged onto $class -->
-          <input type="hidden" name="stapler-class" value="${descriptor.clazz.name}"/>
-        </f:invisibleEntry>
-        <f:invisibleEntry>
-          <input type="hidden" name="$class" value="${descriptor.clazz.name}"/>
-        </f:invisibleEntry>
+	      <f:class-entry descriptor="${descriptor}" />
 	      <st:include from="${d}" page="${d.configPage}" optional="true" />
 	    </f:radioBlock>
 	  </j:forEach>

--- a/core/src/main/resources/lib/form/dropdownListBlock.jelly
+++ b/core/src/main/resources/lib/form/dropdownListBlock.jelly
@@ -52,7 +52,11 @@ THE SOFTWARE.
       <!-- sandwich them by markers so that we know what to show/hide -->
       <tr class="dropdownList-start rowvg-start">
         <j:if test="${!empty(attrs.staplerClass)}">
-          <td style="display:none"><input type="hidden" name="stapler-class" value="${attrs.staplerClass}"/></td>
+          <td style="display:none">
+            <!-- Legacy: Remove once plugins have been staged onto $class -->
+            <input type="hidden" name="stapler-class" value="${attrs.staplerClass}"/>
+            <input type="hidden" name="$class" value="${attrs.staplerClass}"/>
+          </td>
         </j:if>
       </tr>
       <j:choose>

--- a/core/src/main/resources/lib/form/dropdownListBlock.jelly
+++ b/core/src/main/resources/lib/form/dropdownListBlock.jelly
@@ -50,15 +50,7 @@ THE SOFTWARE.
     </j:when>
     <j:when test="${dropdownListMode=='generateEntries'}">
       <!-- sandwich them by markers so that we know what to show/hide -->
-      <tr class="dropdownList-start rowvg-start">
-        <j:if test="${!empty(attrs.staplerClass)}">
-          <td style="display:none">
-            <!-- Legacy: Remove once plugins have been staged onto $class -->
-            <input type="hidden" name="stapler-class" value="${attrs.staplerClass}"/>
-            <input type="hidden" name="$class" value="${attrs.staplerClass}"/>
-          </td>
-        </j:if>
-      </tr>
+      <tr class="dropdownList-start rowvg-start" />
       <j:choose>
         <j:when test="${attrs.lazy!=null and !attrs.selected}">
           <l:renderOnDemand capture="${attrs.lazy}" tag="tr">
@@ -69,6 +61,9 @@ THE SOFTWARE.
           <d:invokeBody />
         </j:otherwise>
       </j:choose>
+      <j:if test="${!empty(attrs.staplerClass)}">
+        <f:class-entry clazz="${attrs.staplerClass}" />
+      </j:if>
       <tr class="dropdownList-end rowvg-end" />
     </j:when>
   </j:choose>

--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -91,11 +91,9 @@ THE SOFTWARE.
 
         <d:invokeBody/>
 
+        <f:class-entry descriptor="${descriptor}" />
         <f:block>
           <div align="right">
-            <!-- Legacy: Remove once plugins have been staged onto $class -->
-            <input type="hidden" name="stapler-class" value="${descriptor.clazz.name}" />
-            <input type="hidden" name="$class" value="${descriptor.clazz.name}" />
             <f:repeatableDeleteButton value="${attrs.deleteCaption}" />
           </div>
         </f:block>

--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -93,12 +93,13 @@ THE SOFTWARE.
 
         <f:block>
           <div align="right">
+            <!-- Legacy: Remove once plugins have been staged onto $class -->
             <input type="hidden" name="stapler-class" value="${descriptor.clazz.name}" />
+            <input type="hidden" name="$class" value="${descriptor.clazz.name}" />
             <f:repeatableDeleteButton value="${attrs.deleteCaption}" />
           </div>
         </f:block>
       </table>
-      <input type="hidden" name="kind" value="${descriptor.id}" />
     </d:tag>
   </d:taglib>
 

--- a/core/src/main/resources/lib/form/hetero-radio.jelly
+++ b/core/src/main/resources/lib/form/hetero-radio.jelly
@@ -47,14 +47,7 @@ THE SOFTWARE.
         <j:set var="descriptor" value="${d}" />
         <j:set var="instance" value="${currentDescriptor==d?currentInstance:null}" />
         <st:include from="${d}" page="${d.configPage}" optional="true" />
-
-        <f:invisibleEntry>
-          <!-- Legacy: Remove once plugins have been staged onto $class -->
-          <input type="hidden" name="stapler-class" value="${d.clazz.name}" />
-        </f:invisibleEntry>
-        <f:invisibleEntry><!-- this tells Stapler which block is for which class -->
-          <input type="hidden" name="$class" value="${d.clazz.name}" />
-        </f:invisibleEntry>
+        <f:class-entry descriptor="${d}" />
       </f:radioBlock>
     </j:forEach>
   </table>

--- a/core/src/main/resources/lib/form/hetero-radio.jelly
+++ b/core/src/main/resources/lib/form/hetero-radio.jelly
@@ -48,9 +48,12 @@ THE SOFTWARE.
         <j:set var="instance" value="${currentDescriptor==d?currentInstance:null}" />
         <st:include from="${d}" page="${d.configPage}" optional="true" />
 
-        <f:invisibleEntry><!-- this tells Stapler which block is for which class -->
+        <f:invisibleEntry>
+          <!-- Legacy: Remove once plugins have been staged onto $class -->
           <input type="hidden" name="stapler-class" value="${d.clazz.name}" />
-          <input type="hidden" name="kind" value="${descriptor.id}"/>
+        </f:invisibleEntry>
+        <f:invisibleEntry><!-- this tells Stapler which block is for which class -->
+          <input type="hidden" name="$class" value="${d.clazz.name}" />
         </f:invisibleEntry>
       </f:radioBlock>
     </j:forEach>


### PR DESCRIPTION
See also: https://github.com/stapler/stapler/pull/39

This commit includes several changes to accommodate the aforementioned change to Stapler (moving away from 'stapler-class'), as well as to make Jenkins consistently use this same JSON field (moving away from 'kind').

NOTE: Stapler will continue to accept 'stapler-class' for backwards compatibility, and similarly this will continue to pass 'stapler-class' for plugins that have keyed off of it.
