### PR TITLE
[FIXED JENKINS-25358] Remove extra fields from getFieldOrder()

### DIFF
--- a/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
+++ b/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
@@ -81,6 +81,6 @@ public class SHELLEXECUTEINFO extends Structure {
         return Arrays.asList("cbSize", "fMask", "hwnd", "lpVerb",
                 "lpFile", "lpParameters", "lpDirectory", "nShow", "hInstApp",
                 "lpIDList", "lpClass", "hkeyClass", "dwHotKey", "hIcon",
-                "hProcess", "SEE_MASK_NOCLOSEPROCESS", "SW_HIDE", "SW_SHOW");
+                "hProcess");
     }
 }

--- a/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
+++ b/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
@@ -25,6 +25,7 @@ package hudson.util.jna;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import com.sun.jna.Union;
 import java.util.Arrays;
 import java.util.List;
 
@@ -69,7 +70,7 @@ public class SHELLEXECUTEINFO extends Structure {
     public String lpClass;
     public Pointer hkeyClass;
     public int dwHotKey;
-    public Pointer hIcon;
+    public DUMMYUNIONNAME_union DUMMYUNIONNAME;
     public Pointer hProcess;
 
     public static final int SEE_MASK_NOCLOSEPROCESS = 0x40;
@@ -80,7 +81,29 @@ public class SHELLEXECUTEINFO extends Structure {
     protected List getFieldOrder() {
         return Arrays.asList("cbSize", "fMask", "hwnd", "lpVerb",
                 "lpFile", "lpParameters", "lpDirectory", "nShow", "hInstApp",
-                "lpIDList", "lpClass", "hkeyClass", "dwHotKey", "hIcon",
+                "lpIDList", "lpClass", "hkeyClass", "dwHotKey", "DUMMYUNIONNAME",
                 "hProcess");
     }
+
+    public static class DUMMYUNIONNAME_union extends Union {
+        public Pointer hIcon;
+        public Pointer hMonitor;
+
+        public DUMMYUNIONNAME_union() {
+            super();
+        }
+
+        public DUMMYUNIONNAME_union(Pointer hIcon_or_hMonitor) {
+            super();
+            this.hMonitor = this.hIcon = hIcon_or_hMonitor;
+            setType(Pointer.class);
+        }
+
+        public static class ByReference extends DUMMYUNIONNAME_union implements Structure.ByReference {
+            
+        };
+        public static class ByValue extends DUMMYUNIONNAME_union implements Structure.ByValue {
+            
+        };
+    };
 }


### PR DESCRIPTION
Remove fields which are not part of struct _SHELLEXECUTEINFO.
