### PR TITLE
Allow clouds to launch slaves with job-specified parameters

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -87,6 +87,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -836,6 +837,23 @@ public class Queue extends ResourceController implements Saveable {
                 if (null==l || bi.getAssignedLabelFor(st)==l)
                     r++;
         return r;
+    }
+
+    /**
+     * Get the {@link BuildableItem}s that are assigned to the given label
+     */
+    public synchronized Collection<Actionable> getBuildableItemsFor(Label l) {
+        Collection<Actionable> items = new LinkedHashSet<Actionable>();
+
+        for (BuildableItem bi : buildables.values())
+            for (SubTask st : bi.task.getSubTasks())
+                if (null==l || bi.getAssignedLabelFor(st)==l)
+                    items.add(bi);
+        for (BuildableItem bi : pendings.values())
+            for (SubTask st : bi.task.getSubTasks())
+                if (null==l || bi.getAssignedLabelFor(st)==l)
+                    items.add(bi);
+        return items;
     }
 
     /**

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -116,6 +116,21 @@ public abstract class Cloud extends AbstractModelObject implements ExtensionPoin
     }
 
     /**
+     * @deprecated Use {@link #provision(CloudProvisioningRequest)}
+     */
+    public Collection<PlannedNode> provision(Label label, int excessWorkload)
+    {
+        // Non-abstract default impl, so newer clients don't have to implement
+        // a deprecated method.
+        throw new AbstractMethodError("You must override a provision method");
+    }
+
+    /**
+     * Returns true if this cloud is capable of provisioning new nodes for the given label.
+     */
+    public abstract boolean canProvision(Label label);
+
+    /**
      * Provisions new {@link Node}s from this cloud.
      *
      * <p>
@@ -127,18 +142,9 @@ public abstract class Cloud extends AbstractModelObject implements ExtensionPoin
      * The implementation of this method asynchronously starts
      * node provisioning.
      *
-     * @param label
-     *      The label that indicates what kind of nodes are needed now.
-     *      Newly launched node needs to have this label.
-     *      Only those {@link Label}s that this instance returned true
-     *      from the {@link #canProvision(Label)} method will be passed here.
-     *      This parameter is null if Hudson needs to provision a new {@link Node}
-     *      for jobs that don't have any tie to any label.
-     * @param excessWorkload
-     *      Number of total executors needed to meet the current demand.
-     *      Always >= 1. For example, if this is 3, the implementation
-     *      should launch 3 slaves with 1 executor each, or 1 slave with
-     *      3 executors, etc.
+     * @param request
+     *      Information about the node that should be provisioned, such as the label and
+     *      the excess workload.
      * @return
      *      {@link PlannedNode}s that represent asynchronous {@link Node}
      *      provisioning operations. Can be empty but must not be null.
@@ -148,12 +154,9 @@ public abstract class Cloud extends AbstractModelObject implements ExtensionPoin
      *      When the {@link Future} has completed its work, {@link Future#get} will be called to obtain the
      *      provisioned {@link Node} object.
      */
-    public abstract Collection<PlannedNode> provision(Label label, int excessWorkload);
-
-    /**
-     * Returns true if this cloud is capable of provisioning new nodes for the given label.
-     */
-    public abstract boolean canProvision(Label label);
+    public Collection<PlannedNode> provision(CloudProvisioningRequest request) {
+        return provision(request.getLabel(), request.getWorkloadToProvision());
+    }
 
     public Descriptor<Cloud> getDescriptor() {
         return Jenkins.getInstance().getDescriptorOrDie(getClass());

--- a/core/src/main/java/hudson/slaves/CloudProvisioningRequest.java
+++ b/core/src/main/java/hudson/slaves/CloudProvisioningRequest.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010, InfraDNA, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.slaves;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import hudson.model.Action;
+import hudson.model.Actionable;
+import hudson.model.Label;
+
+/**
+ * A request for cloud provisioning, including all data for the {@link Cloud} to be able to spin
+ * up an instance with the correct settings.
+ *
+ * @author Nigel Magnay
+ */
+public class CloudProvisioningRequest {
+
+  /**
+   * The label requested.
+   */
+  private final Label label;
+
+  /**
+   * How many slaves are required.
+   */
+  private final int workloadToProvision;
+
+  /**
+   * The queue of actions, if we wish to spin up 'special variety'
+   * slaves (and the cloud has this capability).
+   */
+  private final List<Actionable> queue;
+
+  /**
+   * A request to provision cloud executors.
+   *
+   * @param label
+   *      The label that indicates what kind of nodes are needed now.
+   *      Newly launched node needs to have this label.
+   *      Only those {@link Label}s that this instance returned true
+   *      from the {@link Cloud#canProvision(Label)} method will be passed here.
+   *      This parameter is null if Jenkins needs to provision a new {@link hudson.model.Node}
+   *      for jobs that don't have any tie to any label.
+   * @param workloadToProvision
+   *      Number of total executors needed to meet the current demand.
+   *      Always >= 1. For example, if this is 3, the implementation
+   *      should launch 3 slaves with 1 executor each, or 1 slave with
+   *      3 executors, etc.
+   * @param queue
+   *      Collection of buildable items that are in the queue. Cloud implementations may
+   *      use this information to influence the kinds of nodes that they start up
+   *      (e.g: with specialised requirements based on the build).
+   */
+  CloudProvisioningRequest(Label label, int workloadToProvision,
+                                  Collection<? extends Actionable> queue) {
+    this.label = label;
+    this.workloadToProvision = workloadToProvision;
+    this.queue = new ArrayList<Actionable>(queue);
+  }
+
+  /**
+   * Get the label for this provisioning request.
+   * @return node label
+   */
+  public Label getLabel() {
+    return label;
+  }
+
+  /**
+   * How many slaves are required.
+   * @return number of slaves
+   */
+  public int getWorkloadToProvision() {
+    return workloadToProvision;
+  }
+
+  /**
+   * What items are in the queue?
+   * @return the items that are in the queue.
+   */
+  public Collection<Actionable> getBuildableItems() {
+    return queue;
+  }
+
+
+}

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -579,8 +579,13 @@ public class NodeProvisioner {
                                 }
                             }
 
+                            Label label = state.getLabel();
+                            Collection<Actionable> buildableItems = Jenkins.getInstance().getQueue().getBuildableItemsFor(label);
+
+                            CloudProvisioningRequest cloudProvisioningRequest = new CloudProvisioningRequest(label, workloadToProvision, buildableItems);
+
                             Collection<PlannedNode> additionalCapacities =
-                                    c.provision(state.getLabel(), workloadToProvision);
+                                    c.provision(cloudProvisioningRequest);
 
                             for (CloudProvisioningListener cl : CloudProvisioningListener.all()) {
                                 cl.onStarted(c, state.getLabel(), additionalCapacities);


### PR DESCRIPTION
We would like to be able to add parameters into a build to contain
a setting for various slave parameters - for example, a docker volume
that contains a Jenkins workspace.

This would enable that workspace to be 'passed up' through a build pipeline
to subsequent stages.

However - with the current API, there is no way of the slave launcher
knowing what additional slave startup parameters that it needs. By the
time the slave is constructed, this is too late - such settings can only
be applied at slave construction time.

Thus there is a need for the slave launcher to be aware of (optional)
parameters that it can use in order to control the slave that it is
launching.

So -
- create a new CloudProvisioningRequest object, that contains the existing
  settings (Label, Excess Workload), and a list of 'Actionable' items that
  it is passed. Add a provision option into the Cloud class (default impl
  for backwards compatibility to be the old provision impl).

These Actionable items are, in effect, the builds in the queue. The cloud
subclass can examine this queue and pull off builds. From there it would
look for the ParametersAction, and the Parameters stored within. Cloud
implementations will provide their own ParameterDefinition/Values that
they look for.

Once a slave is launched, we need to make sure the 'right' job is attached
to the 'right' slave. Fortunately, all a cloud implementation needs to do
is add a NodeProperty to the launched slave, which Jenkins will ask
'canTake' to see if a buildable item is appropriate for this slave. All
the slave then needs to do is say it's not appropriate for that node if
the launch parameters don't match the build parameters.

Signed-off-by: Nigel Magnay nigel.magnay@gmail.com
