### PR TITLE
Include parameter name in exception when value is invalid

### DIFF
--- a/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
@@ -72,7 +72,7 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
 
     private StringParameterValue checkValue(StringParameterValue value) {
         if (!choices.contains(value.value))
-            throw new IllegalArgumentException("Illegal choice: " + value.value);
+            throw new IllegalArgumentException("Illegal choice for parameter " + getName() + ": " + value.value);
         return value;
     }
 


### PR DESCRIPTION
When typing a value into a free-form text field, the system errors out with an error message that isn't helpful for understanding which parameter is wrong.

Include the parameter name along with the value in the exception message.

```
Caused by: java.lang.IllegalArgumentException: Illegal choice: no
    at hudson.model.ChoiceParameterDefinition.checkValue(ChoiceParameterDefinition.java:75)
    at hudson.model.ChoiceParameterDefinition.createValue(ChoiceParameterDefinition.java:83)
    at com.sonyericsson.rebuild.RebuildAction.getParameterValue(RebuildAction.java:329)
    at com.sonyericsson.rebuild.RebuildAction.doConfigSubmit(RebuildAction.java:229)
    at sun.reflect.GeneratedMethodAccessor258.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:298)
    at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:161)
    at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:96)
    at org.kohsuke.stapler.MetaClass$1.doDispatch(MetaClass.java:120)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:728)
    ... 69 more
```
