### PR TITLE
[JENKINS-755] make system JDK installation explicit

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,7 +55,9 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
-  <li class=>
+  <li class=bug>
+    Remove confusing black-magic about "Default" JDK
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-755">issue 755</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -328,6 +328,11 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         if(scm==null)
             scm = new NullSCM(); // perhaps it was pointing to a plugin that no longer exists.
 
+        if (jdk == null) {
+            List<JDK> jdks = Jenkins.getInstance().getJDKs();
+            if (jdks.size() == 1) jdk = jdks.get(0).getName();
+        }
+
         if(transientActions==null)
             transientActions = new Vector<Action>();    // happens when loaded from disk
         updateTransientActions();

--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -59,6 +59,8 @@ public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, En
      */
     public static final String DEFAULT_NAME = "(Default)";
 
+    public static final JDK SYSTEM = new JDK(DEFAULT_NAME, null);
+
     /**
      * @deprecated since 2009-02-25
      */

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1618,8 +1618,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     public List<JDK> getJDKs() {
-        if(jdks==null)
+        if(jdks==null) {
             jdks = new ArrayList<JDK>();
+        }
+        if (jdks.isEmpty()) jdks.add(JDK.SYSTEM);
         return jdks;
     }
 
@@ -1627,12 +1629,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Gets the JDK installation of the given name, or returns null.
      */
     public JDK getJDK(String name) {
-        if(name==null) {
-            // if only one JDK is configured, "default JDK" should mean that JDK.
-            List<JDK> jdks = getJDKs();
-            if(jdks.size()==1)  return jdks.get(0);
-            return null;
-        }
         for (JDK j : getJDKs()) {
             if(j.getName().equals(name))
                 return j;

--- a/core/src/main/resources/hudson/model/AbstractProject/configure-common.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/configure-common.jelly
@@ -37,8 +37,6 @@ THE SOFTWARE.
     <f:entry title="JDK"
              description="${%JDK to be used for this project}">
       <select class="setting-input validated" name="jdk" checkUrl="'${rootURL}/defaultJDKCheck?value='+this.value">
-        <j:getStatic var="DEFAULT_NAME" className="hudson.model.JDK" field="DEFAULT_NAME"/>
-        <option>${DEFAULT_NAME}</option>
         <j:forEach var="inst" items="${jdks}">
           <f:option selected="${inst.name==it.JDK.name}" value="${inst.name}">${inst.name}</f:option>
         </j:forEach>


### PR DESCRIPTION
can then be removed by users who don’t want to rely on such a JDK
