### PR TITLE
Handle legacy use of iconSize as a variable

### DIFF
--- a/core/src/main/resources/lib/hudson/ballColorTd.jelly
+++ b/core/src/main/resources/lib/hudson/ballColorTd.jelly
@@ -44,8 +44,15 @@ THE SOFTWARE.
         <j:set var="iconClassName" value="${icons.toNormalizedIconNameClass(it.image)}"/>
       </j:if>
       <!-- convert legacy @iconSize specification to @iconSizeClass -->
-      <j:if test="${iconSizeClass==null and attrs.iconSize!=null}">
-        <j:set var="iconSizeClass" value="${icons.toNormalizedIconSizeClass(attrs.iconSize)}"/>
+      <j:if test="${iconSizeClass==null}">
+        <j:choose>
+          <j:when test="${attrs.iconSize!=null}">
+            <j:set var="iconSizeClass" value="${icons.toNormalizedIconSizeClass(attrs.iconSize)}"/>
+          </j:when>
+          <j:when test="${iconSize!=null}">
+            <j:set var="iconSizeClass" value="${icons.toNormalizedIconSizeClass(iconSize)}" />
+          </j:when>
+        </j:choose>
       </j:if>
 
       <j:choose>


### PR DESCRIPTION
When iconSize was set as a jelly variable, not passed as an attribute,
the value was not being normalized to an IconSizeClass.  Fixes
JENKINS-25220.
