### PR TITLE
Update Guice to 4.0-beta5

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -96,7 +96,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <classifier>no_aop</classifier>
     </dependency>
 
     <dependency> <!-- for compatibility only; all new code should use JNR -->

--- a/pom.xml
+++ b/pom.xml
@@ -185,8 +185,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
-        <version>4.0-beta</version>
-        <classifier>no_aop</classifier>
+        <version>4.0-beta5</version>
       </dependency>
 
       <!-- SLF4J used in maven-plugin and core -->


### PR DESCRIPTION
[Changelog](https://github.com/google/guice/wiki/Guice40#new-features) mentions better Java 8 support (no further details), though it is unclear what the baseline version being compared to is. At any rate it seems sensible to use the newest available version.

This patch also removes the `no_aop` classifier, which Guice documentation says is only really recommended for Android users. Not sure what the motivation was for using it in Jenkins. At any rate, this change makes it possible to get sources for Guice when debugging, which I found helpful while looking into https://github.com/jenkinsci/jenkins/commit/22d433deae5e8e056f83900cc6c9bcc5a3ba60d5.
