### PR TITLE
More consistent behavior of Computer.currentComputer

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1313,11 +1313,11 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      * Gets the current {@link Computer} that the build is running.
      * This method only works when called during a build, such as by
      * {@link hudson.tasks.Publisher}, {@link hudson.tasks.BuildWrapper}, etc.
+     * @return the {@link Computer} associated with {@link Executor#currentExecutor}, or null if not on an executor thread
      */
-    public static Computer currentComputer() {
+    public static @Nullable Computer currentComputer() {
         Executor e = Executor.currentExecutor();
-        // If no executor then must be on master node
-        return e != null ? e.getOwner() : Jenkins.getInstance().toComputer();
+        return e != null ? e.getOwner() : null;
     }
 
     /**


### PR DESCRIPTION
Refines fix of [JENKINS-2786](https://issues.jenkins-ci.org/browse/JENKINS-2786) which probably predated null checks in `Run`. If you are not currently on an executor thread, the former behavior would be to return either `MasterComputer` or null, depending on whether master had executors configured. This makes no sense.

Encountered as part of a [Workflow bug](https://trello.com/c/7JhxqeGI/167-broken-environment). The effect was that `Run.getEnvironment` called from a non-executor thread would usually (but not necessarily!) return an environment based on the master, whereas you would expect it in this case to predictably return one ignoring env vars set on the master (since there is no reason to believe the build is running on the master as opposed to a slave in this case).
