### PR TITLE
adding newsyslog user and group permission for jenkins user

### DIFF
--- a/osx/scripts/postinstall-launchd
+++ b/osx/scripts/postinstall-launchd
@@ -16,7 +16,7 @@ chown daemon:daemon /var/log/jenkins
 cat <<_EOT_ > /etc/newsyslog.d/jenkins.conf
 # logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
 # Rotate jenkins log at midnight, and preserve old logs in 3 days
-/var/log/jenkins/jenkins.log            644  3     *    \$D0   J
+/var/log/jenkins/jenkins.log  jenkins:jenkins          644  3     *    \$D0   J
 _EOT_
 
 # Load and start the launch daemon

--- a/osx/scripts/postinstall-launchd-jenkins
+++ b/osx/scripts/postinstall-launchd-jenkins
@@ -75,7 +75,7 @@ chown jenkins:jenkins /var/log/jenkins
 cat <<_EOT_ > /etc/newsyslog.d/jenkins.conf
 # logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
 # Rotate jenkins log at midnight, and preserve old logs in 3 days
-/var/log/jenkins/jenkins.log            644  3     *    \$D0   J
+/var/log/jenkins/jenkins.log jenkins:jenkins           644  3     *    \$D0   J
 _EOT_
 
 # Load and start the launch daemon


### PR DESCRIPTION
This fix is based on this issue: https://issues.jenkins-ci.org/browse/JENKINS-23543

Essentially, when newsyslog runs it will change the log to have root permissions. This will cause jenkins to silently fail and to not be able to restart on OSX. 

I have tested this change on Yosemite, Mavericks, and Mountain Lion.
