### PR TITLE
Aggregate multiple FormValidations into one

### DIFF
--- a/core/src/test/java/hudson/util/FormValidationTest.java
+++ b/core/src/test/java/hudson/util/FormValidationTest.java
@@ -25,6 +25,8 @@ package hudson.util;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+
 import org.junit.Test;
 
 /**
@@ -56,5 +58,51 @@ public class FormValidationTest {
     @Test
     public void testMessage() {
         assertEquals("test msg", FormValidation.errorWithMarkup("test msg").getMessage());
+    }
+
+    @Test
+    public void aggregateZeroValidations() {
+        assertEquals(FormValidation.ok(), aggregate());
+    }
+
+    @Test
+    public void aggregateSingleValidations() {
+        FormValidation ok = FormValidation.ok();
+        FormValidation warning = FormValidation.warning("");
+        FormValidation error = FormValidation.error("");
+
+        assertEquals(ok, aggregate(ok));
+        assertEquals(warning, aggregate(warning));
+        assertEquals(error, aggregate(error));
+    }
+
+    @Test
+    public void aggregateSeveralValidations() {
+        FormValidation ok = FormValidation.ok("ok_message");
+        FormValidation warning = FormValidation.warning("warning_message");
+        FormValidation error = FormValidation.error("error_message");
+
+        final FormValidation ok_ok = aggregate(ok, ok);
+        assertEquals(FormValidation.Kind.OK, ok_ok.kind);
+        assertTrue(ok_ok.renderHtml().contains(ok.getMessage()));
+
+        final FormValidation ok_warning = aggregate(ok, warning);
+        assertEquals(FormValidation.Kind.WARNING, ok_warning.kind);
+        assertTrue(ok_warning.renderHtml().contains(ok.getMessage()));
+        assertTrue(ok_warning.renderHtml().contains(warning.getMessage()));
+
+        final FormValidation ok_error = aggregate(ok, error);
+        assertEquals(FormValidation.Kind.ERROR, ok_error.kind);
+        assertTrue(ok_error.renderHtml().contains(ok.getMessage()));
+        assertTrue(ok_error.renderHtml().contains(error.getMessage()));
+
+        final FormValidation warninig_error = aggregate(warning, error);
+        assertEquals(FormValidation.Kind.ERROR, warninig_error.kind);
+        assertTrue(warninig_error.renderHtml().contains(error.getMessage()));
+        assertTrue(warninig_error.renderHtml().contains(warning.getMessage()));
+    }
+
+    private FormValidation aggregate(FormValidation... fvs) {
+        return FormValidation.aggregate(Arrays.asList(fvs));
     }
 }

--- a/core/src/test/java/hudson/util/FormValidationTest.java
+++ b/core/src/test/java/hudson/util/FormValidationTest.java
@@ -23,24 +23,29 @@
  */
 package hudson.util;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
 
 /**
  * @author sogabe
  */
-public class FormValidationTest extends TestCase {
+public class FormValidationTest {
 
+    @Test
     public void testValidateRequired_OK() {
         FormValidation actual = FormValidation.validateRequired("Name");
         assertEquals(FormValidation.ok(), actual);
     }
 
+    @Test
     public void testValidateRequired_Null() {
         FormValidation actual = FormValidation.validateRequired(null);
         assertNotNull(actual);
         assertEquals(FormValidation.Kind.ERROR, actual.kind);
     }
 
+    @Test
     public void testValidateRequired_Empty() {
         FormValidation actual = FormValidation.validateRequired("  ");
         assertNotNull(actual);
@@ -48,6 +53,7 @@ public class FormValidationTest extends TestCase {
     }
 
     // @Bug(7438)
+    @Test
     public void testMessage() {
         assertEquals("test msg", FormValidation.errorWithMarkup("test msg").getMessage());
     }


### PR DESCRIPTION
With this change `doCheckXxx` methods can return several indications of different `Kind`s.

Use case: https://github.com/jenkinsci/matrix-project-plugin/pull/10

![aggregated_validations](https://cloud.githubusercontent.com/assets/206841/4950314/837f1736-6659-11e4-96f7-17fbc5a39a80.png)
