### PR TITLE
Update ChoiceParameterDefinition

### DIFF
--- a/core/src/main/resources/hudson/model/ChoiceParameterDefinition/index.jelly
+++ b/core/src/main/resources/hudson/model/ChoiceParameterDefinition/index.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
 			<input type="hidden" name="name" value="${it.name}" />
             <select name="value">
               <j:forEach var="value" items="${it.choices}">
-                <f:option selected="${it.value==value}">${value}</f:option>
+                <f:option selected="${it.defaultParameterValue.value==value}">${value}</f:option>
               </j:forEach>
             </select>
 		</div>


### PR DESCRIPTION
The "it.value" don't exist, so we need to set the defaultParameterValue. 

It help me display correctly parameter for my multilauncher plugin. 
Note that other ParameterDefinition use the default value to display parameter, so IMO it is safe to do this.
