### PR TITLE
Explode WAR fails when ./target does not yet exist (e.g., run from IDEA)

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/WarExploder.java
+++ b/test/src/main/java/org/jvnet/hudson/test/WarExploder.java
@@ -89,6 +89,7 @@ final class WarExploder {
 
         // TODO this assumes that the CWD of the Maven process is the plugin ${basedir}, which may not be the case
         File explodeDir = new File("./target/jenkins-for-test").getAbsoluteFile();
+        explodeDir.getParentFile().mkdirs();
         while (new File(explodeDir + ".exploding").isFile()) {
             explodeDir = new File(explodeDir + "x");
         }


### PR DESCRIPTION
Create parent directory before trying to lock dir name using files.

java.lang.Exception: Failed to initialize exploded war
    at org.jvnet.hudson.test.WarExploder.getExplodedDir(WarExploder.java:49)
    at org.jvnet.hudson.test.JenkinsRule.createWebServer(JenkinsRule.java:582)
    at org.jvnet.hudson.test.JenkinsRule.newHudson(JenkinsRule.java:538)
    at org.jvnet.hudson.test.JenkinsRule.before(JenkinsRule.java:332)
    at org.jvnet.hudson.test.JenkinsRule$2.evaluate(JenkinsRule.java:482)
    at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
    at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
    at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:74)
    at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:211)
    at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:67)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)
Caused by: java.io.FileNotFoundException: /Users/integer/Documents/idea/jenkins-ws-git-plugin/./target/jenkins-for-test.exploding (No such file or directory)
    at java.io.FileOutputStream.open(Native Method)
    at java.io.FileOutputStream.<init>(FileOutputStream.java:212)
    at java.io.FileOutputStream.<init>(FileOutputStream.java:104)
    at org.jvnet.hudson.test.WarExploder.explode(WarExploder.java:99)
    at org.jvnet.hudson.test.WarExploder.<clinit>(WarExploder.java:58)
    ... 24 more
