### PR TITLE
Retain permissions when copying files.

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2038,6 +2038,8 @@ public final class FilePath implements Serializable {
                                 File target = new File(dest, relativePath);
                                 mkdirsE(target.getParentFile());
                                 Util.copyFile(f, writing(target));
+				target.setExecutable(f.canExecute());
+				target.setWritable(f.canWrite());
                                 count.incrementAndGet();
                             }
                         }


### PR DESCRIPTION
Fixes JENKINS-14269
https://issues.jenkins-ci.org/browse/JENKINS-14269
