### PR TITLE
Better build hist wrapping

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -29,14 +29,14 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:set var="link" value="${it.baseUrl}/${build.number}/" />
   <j:set var="transitive" value="${(it.firstTransientBuildKey!=null and (it.adapter.compare(build,it.firstTransientBuildKey) ge 0)) ? 'transitive' : null}" />
-  <tr class="build-row ${transitive}">
+  <tr class="build-row ${transitive}" buildTimeMillis="${build.timestamp.time.time}">
     <td class="pane build-name">
       <a class="build-status-link" href="${link}console"><l:icon alt="${build.iconColor.description} &gt; ${%Console Output}" class="${build.buildStatusIconClassName} icon-sm" tooltip="${build.iconColor.description} &gt; ${%Console Output}"/></a><st:nbsp/>
       ${build.displayName}
     </td>
     <td class="pane build-details">
       <a class="tip model-link inside" href="${link}">
-        <i:formatDate value="${build.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>
+        <i:formatDate value="${build.timestamp.time}" type="time" pattern="HH:mm" />
       </a>
       <j:if test="${build.building}">
         <j:set target="${it}" property="nextBuildNumberToFetch" value="${build.number}"/>

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
   <tr class="build-row ${transitive}" buildTimeMillis="${build.timestamp.time.time}">
     <td class="pane build-name">
       <a class="build-status-link" href="${link}console"><l:icon alt="${build.iconColor.description} &gt; ${%Console Output}" class="${build.buildStatusIconClassName} icon-sm" tooltip="${build.iconColor.description} &gt; ${%Console Output}"/></a><st:nbsp/>
-      ${build.displayName}
+      <span class="break-words" breakAfter="3">${build.displayName}</span>
     </td>
     <td class="pane build-details">
       <a class="tip model-link inside" href="${link}">
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <t:buildProgressBar build="${build}"/>
       </j:if>
       <j:if test="${!empty build.description}">
-        <div class="desc">
+        <div class="desc break-words" breakAfter="15">
           <j:out value="${app.markupFormatter.translate(build.truncatedDescription)}"/>
         </div>
       </j:if>

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -961,13 +961,13 @@ table.parameters > tbody:hover {
 }
 
 #buildHistory .build-name {
-  width: 30%;
+  width: 25%;
 }
 #buildHistory .build-details {
-  width: 50%;
+  width: 45%;
 }
 #buildHistory .build-stop, #buildHistory .build-badge {
-  width: 10%;
+  width: 15%;
 }
 
 /* ========================= editable combobox style ========================= */

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -441,6 +441,23 @@ pre.console {
   width: 480px;
 }
 
+.build-date-separator {
+  font-weight: bold;
+}
+
+.build-date-separator .build-date-today {
+  font-weight: normal;
+  color: #ababab;
+  margin-left: 10px;
+}
+
+.build-date-separator div {
+  padding: 5px 0px;
+  border: 1px dashed #cacaca;
+  border-left: none;
+  border-right: none;
+}
+
 .build-row {
   padding: 3px 4px 3px 4px;
 }
@@ -937,7 +954,6 @@ table.parameters > tbody:hover {
   padding: 0;
   margin-top: 5px;
   white-space: normal;
-  max-width: 200px;
 }
 
 #buildHistory .build-rss-links {
@@ -945,7 +961,13 @@ table.parameters > tbody:hover {
 }
 
 #buildHistory .build-name {
-  max-width: 120px;
+  width: 30%;
+}
+#buildHistory .build-details {
+  width: 50%;
+}
+#buildHistory .build-stop, #buildHistory .build-badge {
+  width: 10%;
 }
 
 /* ========================= editable combobox style ========================= */

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1552,6 +1552,40 @@ Form.findMatchingInput = function(base, name) {
     return null;        // not found
 }
 
+function breakWords(container) {
+    container.getElementsBySelector(".break-words").each(function(element) {
+        if (Element.hasClassName(element, 'words-broken')) {
+            // already done.
+            return;
+        }
+
+        var maxWordSize = element.getAttribute('breakAfter');
+        var words = element.textContent.split(/\s+/);
+        var newTextContent = '';
+
+        var splitRegex = new RegExp('.{1,' + maxWordSize + '}', 'g');
+        for (var i = 0; i < words.length; i++) {
+            var word = words[i];
+            var wordTokens = word.match(splitRegex);
+            if (wordTokens) {
+                for (var ii = 0; ii < wordTokens.length; ii++) {
+                    if (newTextContent.length === 0) {
+                        newTextContent += wordTokens[ii];
+                    } else {
+                        newTextContent += String.fromCharCode(8203) + wordTokens[ii];
+                    }
+                }
+            } else {
+                newTextContent += word;
+            }
+            newTextContent += ' ';
+        }
+
+        element.textContent = newTextContent;
+        Element.addClassName(element, 'words-broken');
+    });
+}
+
 function updateBuildHistory(ajaxUrl,nBuild) {
     if(isRunAsTest) return;
 
@@ -1654,7 +1688,7 @@ function updateBuildHistory(ajaxUrl,nBuild) {
     }
 
     insertDateSeparatorRows();
-
+    breakWords($(bh));
 
     function updateBuilds() {
         if(isPageVisible()){
@@ -1697,6 +1731,7 @@ function updateBuildHistory(ajaxUrl,nBuild) {
                     removeDateSeparatorRows();
                     updateBuildRows();
                     insertDateSeparatorRows();
+                    breakWords($(bh));
                 }
             });
         } else {


### PR DESCRIPTION
2 commits that try make text wrapping in the build history widget a bit nicer:
1. Change the dates to just the time of day and then introduce date separators in the history, so builds from a given day are grouped together. (related to [JENKINS-25381](https://issues.jenkins-ci.org/browse/JENKINS-25381) )
2. Introduce zero-width spaces in long words in the build name and description, allowing them to wrap more cleanly.

![screenshot 2014-11-19 13 49 31](https://cloud.githubusercontent.com/assets/429311/5088294/d32da238-6f29-11e4-9bb0-dbf1447b7404.png)
