### PR TITLE
[JENKINS-25734] - Prevent NPE in Executor/causeOfDeath page on "expected thread death"

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -151,6 +151,7 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import hudson.util.RunList;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.CheckForNull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -1372,7 +1373,17 @@ public class Functions {
         return value!=null ? value : defaultValue;
     }
 
-    public static String printThrowable(Throwable t) {
+    /**
+     * Gets info about the specified {@link Throwable}.
+     * @param t Input {@link Throwable}
+     * @return If {@link Throwable} is not null, a summary info with the 
+     *      stacktrace will be returned. Otherwise, the method returns a default
+     *      &quot;No exception details&quot; string.
+     */
+    public static String printThrowable(@CheckForNull Throwable t) {
+        if (t == null) {
+            return Messages.Functions_NoExceptionDetails();
+        }
         StringWriter sw = new StringWriter();
         t.printStackTrace(new PrintWriter(sw));
         return sw.toString();

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -380,7 +380,7 @@ public class Executor extends Thread implements ModelObject {
      * @return null if the death is expected death or the thread is {@link #isAlive() still alive}.
      * @since 1.142
      */
-    public Throwable getCauseOfDeath() {
+    public @CheckForNull Throwable getCauseOfDeath() {
         return causeOfDeath;
     }
 

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -68,3 +68,5 @@ ProxyConfiguration.TestUrlRequired=Test URL is required.
 ProxyConfiguration.FailedToConnectViaProxy=Failed to connect to {0}.
 ProxyConfiguration.FailedToConnect=Failed to connect to {0} (code {1}).
 ProxyConfiguration.Success=Success
+
+Functions.NoExceptionDetails=No Exception details


### PR DESCRIPTION
http://issues.jenkins-ci.org/browse/JENKINS-25734

The change does not fix the issue, but it suppresses NPE at least.

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
