### PR TITLE
[JENKINS-25514] Fixed lock case in FutureImpl

### DIFF
--- a/core/src/main/java/hudson/model/queue/FutureImpl.java
+++ b/core/src/main/java/hudson/model/queue/FutureImpl.java
@@ -84,6 +84,14 @@ public final class FutureImpl extends AsyncFutureImpl<Executable> implements Que
         }
     }
 
+    @Override
+    public synchronized void setAsCancelled() {
+        super.setAsCancelled();
+        if (!start.isDone()) {
+            start.setAsCancelled();
+        }
+    }
+
     synchronized void addExecutor(@Nonnull Executor executor) {
         this.executors.add(executor);
     }

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -579,4 +580,33 @@ public class QueueTest extends HudsonTestCase {
         } catch (CancellationException e) {
         }
     }
+
+    public void testWaitForStartAndCancelBeforeStart() throws Exception {
+        final OneShotEvent ev = new OneShotEvent();
+        FreeStyleProject p = createFreeStyleProject();
+
+        QueueTaskFuture<FreeStyleBuild> f = p.scheduleBuild2(10);
+        final Queue.Item item = Queue.getInstance().getItem(p);
+        assertNotNull(item);
+
+        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+        executor.schedule(new Runnable() {
+            @Override
+            public void run() {
+                   try {
+                       Queue.getInstance().doCancelItem(item.id);
+                   } catch (IOException e) {
+                       e.printStackTrace();
+                   } catch (ServletException e) {
+                       e.printStackTrace();
+                   }
+                }
+            }, 2, TimeUnit.SECONDS);
+
+        try {
+            f.waitForStart();
+            fail("Expected an CancellationException to be thrown");
+        } catch (CancellationException e) {}
+    }
+
 }


### PR DESCRIPTION
when some other process is waiting for build in queue.

https://issues.jenkins-ci.org/browse/JENKINS-25514
Test procedute:
1. Start some build using CLI with '-s' option and make sure that this build will stay in queue for some time (offline/busy executor etc)
2. Cancel the build from queue
=>
Expected result: the build is canceled and CLI dropped connection
Result before the fix: the build is canceled and CLI is still waiting without dropping connection.
