### PR TITLE
[FIXED JENKINS-23966] Master labels disappear when system configuration is updated

### DIFF
--- a/core/src/main/resources/jenkins/model/MasterBuildConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/MasterBuildConfiguration/config.groovy
@@ -5,9 +5,7 @@ def f=namespace(lib.FormTagLib)
 f.entry(title:_("# of executors"), field:"numExecutors") {
     f.number(clazz:"number", min:0, step:1)
 }
-if (!app.slaves.isEmpty() || !app.clouds.isEmpty()) {
-    f.entry(title:_("Labels"),field:"labelString") {
-        f.textbox()
-    }
-    f.slave_mode(name:"master.mode",node:app)
+f.entry(title:_("Labels"),field:"labelString") {
+    f.textbox()
 }
+f.slave_mode(name:"master.mode",node:app)

--- a/test/src/test/java/jenkins/model/MasterBuildConfigurationTest.java
+++ b/test/src/test/java/jenkins/model/MasterBuildConfigurationTest.java
@@ -1,0 +1,34 @@
+package jenkins.model;
+
+import hudson.model.Node.Mode;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class MasterBuildConfigurationTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+    
+    @Test
+    @Issue("JENKINS-23966")
+    public void retainMasterLabelWhenNoSlaveDefined() throws Exception {
+        Jenkins jenkins = j.getInstance();
+        
+        Assert.assertTrue("Test is for master with no slave", jenkins.getComputers().length == 1);
+        
+        // set our own label & mode
+        final String myTestLabel = "TestLabelx0123";
+        jenkins.setLabelString(myTestLabel);
+        jenkins.setMode(Mode.EXCLUSIVE);
+        
+        // call global config page
+        j.configRoundtrip();
+        
+        // make sure settings were not lost
+        Assert.assertTrue("Master's label is lost", myTestLabel.equals(jenkins.getLabelString()));
+        Assert.assertTrue("Master's mode is lost", Mode.EXCLUSIVE.equals(jenkins.getMode()));
+    }
+}


### PR DESCRIPTION
See my observations in https://issues.jenkins-ci.org/browse/JENKINS-23966.
