### PR TITLE
[FIXED JENKINS-25863] Jenkins tries to build jobs on nodes being removed

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -806,6 +806,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     @Exported
     public final boolean isIdle() {
+        // TODO to fix JENKINS-25683 we need to hold the correct lock in this method such that no new jobs will sneak in
         if (!oneOffExecutors.isEmpty())
             return false;
         for (Executor e : executors)

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -85,6 +85,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -802,11 +803,36 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     /**
-     * Returns true if all the executors of this computer are idle.
+     * Returns true if all the executors of this computer are atomically idle. Use {@link #isBusy()} if you
+     * don't need to pay the synchronization cost. Note that when you are calling this method you nearly always
+     * want to have the {@linkplain Queue}'s lock held already, otherwise you can probably use {@link #isBusy()}.
      */
     @Exported
     public final boolean isIdle() {
-        // TODO to fix JENKINS-25683 we need to hold the correct lock in this method such that no new jobs will sneak in
+        try {
+            return Queue.withLock(new Callable<Boolean>() {
+                @Override
+                public Boolean call() {
+                    if (!oneOffExecutors.isEmpty())
+                        return false;
+                    for (Executor e : executors)
+                        if(!e.isIdle())
+                            return false;
+                    return true;
+                }
+            });
+        } catch (Exception e) {
+            throw new IllegalStateException("The Callable we used does not throw an exception", e);
+        }
+    }
+
+    /**
+     * Returns true if any of the executors of this computer are not idle. Note that the converse is not
+     * guaranteed to be true. The check in {@link Computer#isIdle()} needs to acquire a lock on the {@link Queue}
+     * to ensure that none of the executors start building while iterating the list of executors.
+     */
+    @Exported
+    public final boolean isBusy() {
         if (!oneOffExecutors.isEmpty())
             return false;
         for (Executor e : executors)

--- a/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
@@ -52,7 +52,8 @@ public class CloudRetentionStrategy extends RetentionStrategy<AbstractCloudCompu
     @Override
     public synchronized long check(final AbstractCloudComputer c) {
         final AbstractCloudSlave computerNode = c.getNode();
-        if (c.isIdle() && !disabled && computerNode != null) {
+        // check not busy as we only want to use the lock when it is likely that we will disconnect.
+        if (!c.isBusy() && !disabled && computerNode != null) {
             final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
             if (idleMilliseconds > MINUTES.toMillis(idleMinutes)) {
                 Queue.withLock(new Runnable() {

--- a/core/src/main/java/hudson/slaves/RetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/RetentionStrategy.java
@@ -254,7 +254,7 @@ public abstract class RetentionStrategy<T extends Computer> extends AbstractDesc
                             new Object[]{c.getName(), Util.getTimeSpanString(demandMilliseconds)});
                     c.connect(false);
                 }
-            } else if (c.isIdle()) {
+            } else if (!c.isBusy()) { // check not busy as we only want to use the lock when confirming disconnect.
                 final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
                 if (idleMilliseconds > idleDelay * 1000 * 60 /*MINS->MILLIS*/) {
                     Queue.withLock(new Runnable() {

--- a/core/src/main/java/hudson/slaves/SimpleScheduledRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/SimpleScheduledRetentionStrategy.java
@@ -192,13 +192,13 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
             }
         } else if (!shouldBeOnline && c.isOnline()) {
             if (keepUpWhenActive) {
-                if (!c.isIdle() && c.isAcceptingTasks()) {
+                if (c.isBusy() && c.isAcceptingTasks()) {
                     c.setAcceptingTasks(false);
                     LOGGER.log(INFO,
                             "Disabling new jobs for computer {0} as it has finished its scheduled uptime",
                             new Object[]{c.getName()});
                     return 1;
-                } else if (c.isIdle() && c.isAcceptingTasks()) {
+                } else if (!c.isBusy() && c.isAcceptingTasks()) {
                     Queue.withLock(new Runnable() {
                         @Override
                         public void run() {
@@ -212,7 +212,7 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
                             }
                         }
                     });
-                } else if (c.isIdle() && !c.isAcceptingTasks()) {
+                } else if (!c.isBusy() && !c.isAcceptingTasks()) {
                     Queue.withLock(new Runnable() {
                         @Override
                         public void run() {

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -72,31 +72,49 @@ THE SOFTWARE.
               <j:otherwise>
                 <!-- not actually optional, but it helps with backward compatibility -->
                 <j:set var="executor" value="${e}" />
-                <st:include it="${e.currentExecutable}" page="executorCell.jelly" optional="true">
-                  <td class="pane">
-                    <div style="white-space: normal">
-                      <j:set var="exe" value="${e.currentExecutable}" />
-                      <j:invokeStatic var="exeparent"
-                         className="hudson.model.queue.Executables" method="getParentOf">
-                        <j:arg type="hudson.model.Queue$Executable" value="${exe}" />
-                      </j:invokeStatic>
-                      <j:choose>
-                        <j:when test="${h.hasPermission(exeparent,exeparent.READ)}">
-                          <a href="${rootURL}/${exeparent.url}"><l:breakable value="${exeparent.fullDisplayName}"/></a>
-                          <t:buildProgressBar build="${exe}" executor="${executor}"/>
-                        </j:when>
-                        <j:otherwise>
-                          <span>${%Unknown Task}</span>
-                        </j:otherwise>
-                      </j:choose>
-                    </div>
-                  </td>
-                <td class="pane">
-                  <j:if test="${h.hasPermission(exeparent,exeparent.READ)}">
-                      <a href="${rootURL}/${exe.url}" class="model-link inside"><l:breakable value="${exe.displayName}"/></a>
-                  </j:if>
-                </td>
-                </st:include>
+                <j:set var="exe" value="${e.currentExecutable}" />
+                <j:choose>
+                  <j:when test="${exe == null}">
+                    <j:set var="wu" value="${e.currentWorkUnit}" />
+                    <j:set var="wuparent" value="${wu.work}"/>
+                    <j:choose>
+                      <j:when test="${h.hasPermission(wuparent,wuparent.READ)}">
+                        <a href="${rootURL}/${wuparent.url}"><l:breakable value="${wuparent.fullDisplayName}"/></a>
+                        <t:progressBar tooltip="${%Starting...}" pos="-1" />
+                      </j:when>
+                      <j:otherwise>
+                        <span>${%Unknown Task}</span>
+                      </j:otherwise>
+                    </j:choose>
+                    <td class="pane"/>
+                  </j:when>
+                  <j:otherwise>
+                    <st:include it="${exe}" page="executorCell.jelly" optional="true">
+                      <td class="pane">
+                        <div style="white-space: normal">
+                          <j:invokeStatic var="exeparent"
+                             className="hudson.model.queue.Executables" method="getParentOf">
+                            <j:arg type="hudson.model.Queue$Executable" value="${exe}" />
+                          </j:invokeStatic>
+                          <j:choose>
+                            <j:when test="${h.hasPermission(exeparent,exeparent.READ)}">
+                              <a href="${rootURL}/${exeparent.url}"><l:breakable value="${exeparent.fullDisplayName}"/></a>
+                              <t:buildProgressBar build="${exe}" executor="${executor}"/>
+                            </j:when>
+                            <j:otherwise>
+                              <span>${%Unknown Task}</span>
+                            </j:otherwise>
+                          </j:choose>
+                        </div>
+                      </td>
+                      <td class="pane">
+                        <j:if test="${h.hasPermission(exeparent,exeparent.READ)}">
+                            <a href="${rootURL}/${exe.url}" class="model-link inside"><l:breakable value="${exe.displayName}"/></a>
+                        </j:if>
+                      </td>
+                    </st:include>
+                  </j:otherwise>
+                </j:choose>
                 <td class="pane" align="center" valign="middle">
                   <j:if test="${e.hasStopPermission()}">
                     <l:stopButton href="${rootURL}/${c.url}${url}/stop" alt="${%terminate this build}"/>

--- a/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -1,19 +1,19 @@
 /*
  * The MIT License
- * 
- * Copyright (c) 2004-2011, Sun Microsystems, Inc., Kohsuke Kawaguchi, Erik Ramfelt, 
+ *
+ * Copyright (c) 2004-2011, Sun Microsystems, Inc., Kohsuke Kawaguchi, Erik Ramfelt,
  * Yahoo! Inc., Tom Huybrechts, Olivier Lamy
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -321,7 +321,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             throw e;
         }
         jenkins.setNoUsageStatistics(true); // collecting usage stats from tests are pointless.
-        
+
         jenkins.setCrumbIssuer(new TestCrumbIssuer());
 
         jenkins.servletContext.setAttribute("app", jenkins);
@@ -543,10 +543,10 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     protected MavenInstallation configureDefaultMaven() throws Exception {
         return configureDefaultMaven("apache-maven-2.2.1", MavenInstallation.MAVEN_20);
     }
-    
+
     protected MavenInstallation configureMaven3() throws Exception {
         MavenInstallation mvn = configureDefaultMaven("apache-maven-3.0.1", MavenInstallation.MAVEN_30);
-        
+
         MavenInstallation m3 = new MavenInstallation("apache-maven-3.0.1",mvn.getHome(), NO_PROPERTIES);
         jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(m3);
         return m3;
@@ -559,7 +559,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(m3);
         return m3;
     }
-    
+
     /**
      * Locates Maven and configures that as the only Maven in the system.
      */
@@ -573,7 +573,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(mavenInstallation);
             return mavenInstallation;
         }
-        
+
         // Does maven.home point to a Maven installation which satisfies mavenReqVersion?
         String home = System.getProperty("maven.home");
         if(home!=null) {
@@ -788,7 +788,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     public DumbSlave createOnlineSlave() throws Exception {
         return createOnlineSlave(null);
     }
-    
+
     /**
      * Create a new slave on the local host and wait for it to come onilne
      * before returning.
@@ -818,7 +818,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
         return s;
     }
-    
+
     /**
      * Blocks until the ENTER key is hit.
      * This is useful during debugging a test so that one can inspect the state of Jenkins through the web browser.
@@ -908,7 +908,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         submit(createWebClient().goTo(u.getUrl()+"/configure").getFormByName("config"));
         return u;
     }
-        
+
     @SuppressWarnings("unchecked")
     protected <N extends Node> N configRoundtrip(N node) throws Exception {
         submit(createWebClient().goTo("/computer/" + node.getNodeName() + "/configure").getFormByName("config"));
@@ -952,7 +952,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     }
 
     /** Assert that the specified page can be served with a "good" HTTP status,
-     * eg, the page is not missing and can be served without a server error 
+     * eg, the page is not missing and can be served without a server error
      * @param page
      */
     public void assertGoodStatus(Page page) {
@@ -1047,7 +1047,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
         org.w3c.dom.Node n = (org.w3c.dom.Node) node;
         String textString = n.getTextContent();
-        assertTrue("needle found in haystack", textString.contains(needle)); 
+        assertTrue("needle found in haystack", textString.contains(needle));
     }
 
     public void assertXPathResultsContainText(DomNode page, String xpath, String needle) {
@@ -1064,7 +1064,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
                 }
             }
         }
-        assertTrue("needle found in haystack", found); 
+        assertTrue("needle found in haystack", found);
     }
 
     /**
@@ -1251,7 +1251,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         if (lhs==null && rhs==null)     return;
         if (lhs==null)      fail("lhs is null while rhs="+rhs);
         if (rhs==null)      fail("rhs is null while lhs="+lhs);
-        
+
         Constructor<?> lc = findDataBoundConstructor(lhs.getClass());
         Constructor<?> rc = findDataBoundConstructor(rhs.getClass());
         assertEquals("Data bound constructor mismatch. Different type?",lc,rc);
@@ -1299,7 +1299,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      */
     public void assertEqualDataBoundBeans(List<?> lhs, List<?> rhs) throws Exception {
         assertEquals(lhs.size(), rhs.size());
-        for (int i=0; i<lhs.size(); i++) 
+        for (int i=0; i<lhs.size(); i++)
             assertEqualDataBoundBeans(lhs.get(i),rhs.get(i));
     }
 
@@ -1326,7 +1326,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         if (!jenkins.getQueue().isEmpty())
             return true;
         for (Computer n : jenkins.getComputers())
-            if (!n.isIdle())
+            if (n.isBusy())
                 return true;
         return false;
     }
@@ -1422,15 +1422,15 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
         final List<URL> all = Collections.list(jpls);
         all.addAll(Collections.list(hpls));
-        
+
         if(all.isEmpty())    return; // nope
 
         recipes.add(new Runner() {
             @Override
             public void decorateHome(HudsonTestCase testCase, File home) throws Exception {
-            	
+
             	for (URL hpl : all) {
-					
+
                     // make the plugin itself available
                     Manifest m = new Manifest(hpl.openStream());
                     String shortName = m.getMainAttributes().getValue("Short-Name");
@@ -1501,7 +1501,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
                         // found it
                         return Which.jarFile(dependencyPomResource);
                     } else {
-                    	
+
                     	try {
                     		// currently the most of the plugins are still hpi
                             return resolvePluginFile(embedder, artifactId, version, groupId, "hpi");
@@ -1514,7 +1514,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
                                 resolutionError = x;
                     		}
                     	}
-                    	
+
                     }
                 }
 
@@ -1526,7 +1526,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 				final Artifact jpi = embedder.createArtifact(groupId, artifactId, version, "compile"/*doesn't matter*/, type);
 				embedder.resolve(jpi, Arrays.asList(embedder.createRepository("http://maven.glassfish.org/content/groups/public/","repo")),embedder.getLocalRepository());
 				return jpi.getFile();
-				
+
 			}
         });
     }
@@ -1585,7 +1585,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
     /**
      * Sometimes a part of a test case may ends up creeping into the serialization tree of {@link Saveable#save()},
-     * so detect that and flag that as an error. 
+     * so detect that and flag that as an error.
      */
     private Object writeReplace() {
         throw new AssertionError("HudsonTestCase "+getName()+" is not supposed to be serialized");
@@ -1597,7 +1597,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
     public WebClient createWebClient() {
         return new WebClient();
     }
-    
+
     /**
      * Extends {@link com.gargoylesoftware.htmlunit.WebClient} and provide convenience methods
      * for accessing Hudson.
@@ -1843,7 +1843,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             else
                 return null;
         }
-        
+
         /**
          * Verify that the server rejects an attempt to load the given page.
          * @param url a URL path (relative to Jenkins root)
@@ -1865,20 +1865,20 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
         public String getContextPath() throws IOException {
             return getURL().toExternalForm();
         }
-        
+
         /**
          * Adds a security crumb to the quest
          */
         public WebRequestSettings addCrumb(WebRequestSettings req) {
             NameValuePair crumb[] = { new NameValuePair() };
-            
+
             crumb[0].setName(jenkins.getCrumbIssuer().getDescriptor().getCrumbRequestField());
             crumb[0].setValue(jenkins.getCrumbIssuer().getCrumb( null ));
-            
+
             req.setRequestParameters(Arrays.asList( crumb ));
             return req;
         }
-        
+
         /**
          * Creates a URL with crumb parameters relative to {{@link #getContextPath()}
          */
@@ -1886,7 +1886,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             CrumbIssuer issuer = jenkins.getCrumbIssuer();
             String crumbName = issuer.getDescriptor().getCrumbRequestField();
             String crumb = issuer.getCrumb(null);
-            
+
             return new URL(getContextPath()+relativePath+"?"+crumbName+"="+crumb);
         }
 
@@ -1932,7 +1932,7 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
     // needs to keep reference, or it gets GC-ed.
     private static final Logger XML_HTTP_REQUEST_LOGGER = Logger.getLogger(XMLHttpRequest.class.getName());
-    
+
     static {
         // screen scraping relies on locale being fixed.
         Locale.setDefault(Locale.ENGLISH);

--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -354,7 +354,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         jenkins.getActions().add(this);
 
         JenkinsLocationConfiguration.get().setUrl(getURL().toString());
-        
+
         setUpTimeout();
     }
 
@@ -373,7 +373,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         sites.clear();
         sites.add(new UpdateSite("default", updateCenterUrl));
     }
-    
+
     protected void setUpTimeout() {
         if (timeout <= 0) {
             System.out.println("Test timeout disabled.");
@@ -872,7 +872,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
     public DumbSlave createSlave(String nodeName, String labels, EnvVars env) throws Exception {
         synchronized (jenkins) {
             DumbSlave slave = new DumbSlave(nodeName, "dummy",
-    				createTmpDir().getPath(), "1", Node.Mode.NORMAL, labels==null?"":labels, createComputerLauncher(env), RetentionStrategy.NOOP, Collections.EMPTY_LIST);                        
+    				createTmpDir().getPath(), "1", Node.Mode.NORMAL, labels==null?"":labels, createComputerLauncher(env), RetentionStrategy.NOOP, Collections.EMPTY_LIST);
     		jenkins.addNode(slave);
     		return slave;
     	}
@@ -1444,7 +1444,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
         if (!jenkins.getQueue().isEmpty())
             return true;
         for (Computer n : jenkins.getComputers())
-            if (!n.isIdle())
+            if (n.isBusy())
                 return true;
         return false;
     }
@@ -1543,9 +1543,9 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
         final List<URL> all = Collections.list(jpls);
         all.addAll(Collections.list(hpls));
-        
+
         if(all.isEmpty())    return; // nope
-        
+
         recipes.add(new JenkinsRecipe.Runner() {
             private File home;
             private final List<Jpl> jpls = new ArrayList<Jpl>();
@@ -1703,13 +1703,13 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
 
                 throw new Exception("Failed to resolve plugin: "+artifactId+" version "+version,resolutionError);
             }
-            
+
             private @CheckForNull File resolvePluginFile(String artifactId, String version, String groupId, String type) throws Exception {
 				final Artifact jpi = getMavenEmbedder().createArtifact(groupId, artifactId, version, "compile"/*doesn't matter*/, type);
                 getMavenEmbedder().resolve(jpi,
                         Arrays.asList(getMavenEmbedder().createRepository("http://maven.glassfish.org/content/groups/public/", "repo")), embedder.getLocalRepository());
 				return jpi.getFile();
-				
+
 			}
         });
     }


### PR DESCRIPTION
- Any time you have multiple volatiles and you are trying to coordinate state between them, you have failed.
  You either want to have a value object holding the effective state and make that the instance field holding
  that value object volatile, or you probably should just use a lock... because lets face it, the instance field]
  will probably need compare and set semantics any time you want to change the state and your performance
  was shot anyway with the multiple memory barriers for each access of the multiple volatile fields
- In this case we had an "extra" volatile field that could be removed completely, reducing the state that
  requires a lock to just the `workUnit` and `started` fields. We use an internal hidden intrinsic lock
  field in order to reduce the scope of the lock. We also remove the locks on a public object (`Executor`)
  in favour of locking on `stateLock` as those locks were only used to guard access to the (then) volatile
  `started` field (hint: if your field is volatile and you need a lock to access it, you have failed again!)
- In the case of `WorkUnit`, we remove the volatile and replace with the intrinsic lock for all the mutable state
  It might be better to use a lock object, but the scope of this object is such that the intrinsic lock should
  be safe (i.e. we don't want anyone ever locking on a `WorkUnit` explicitly) and we can obtain better
  performance with the intrinsic lock. If the analysis proves incorrect, or if people abuse this and start locking on
  `WorkUnit` we can safely switch to an internal lock object.
