### PR TITLE
WorkspaceCleanupThread: the workspace thread is disabled by default

### DIFF
--- a/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
+++ b/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
@@ -57,7 +57,7 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
     }
 
     @Override protected void execute(TaskListener listener) throws InterruptedException, IOException {
-        if (disabled) {
+        if (!enabled) {
             LOGGER.fine("Disabled. Skipping execution");
             return;
         }
@@ -141,7 +141,9 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
     private static final Logger LOGGER = Logger.getLogger(WorkspaceCleanupThread.class.getName());
 
     /**
-     * Can be used to disable workspace clean up.
+     * Do not clean up by default as this can be extremely confusing
+     * when files disappear after a long period of Jenkins running
+     * without a hitch.
      */
-    public static final boolean disabled = Boolean.getBoolean(WorkspaceCleanupThread.class.getName()+".disabled");
+    public static final boolean enabled = Boolean.getBoolean(WorkspaceCleanupThread.class.getName()+".enabled");
 }


### PR DESCRIPTION
The workspace cleanup feature should be off by default. It creates a lot of FUD(fear, uncertainty and doubt) when Jenkins starts falling over for no apparant reason after having worked smoothly for months.

With this change, the bug below can be closed because users who don't want this won't be hurt by this feature.

https://issues.jenkins-ci.org/browse/JENKINS-9436
