### PR TITLE
[FIXES JENKINS-24272] jnlp slaves fail to reconnect when master restart

### DIFF
--- a/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
+++ b/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
@@ -69,7 +69,7 @@ public class JnlpSlaveRestarterInstaller extends ComputerListener implements Ser
 
                     e.addListener(new EngineListenerAdapter() {
                         @Override
-                        public void onDisconnect() {
+                        public void onReconnect() {
                             try {
                                 for (SlaveRestarter r : restarters) {
                                     try {


### PR DESCRIPTION
During master restart only attempt to reconnect the slave after the master has
finished restarting.

This uses changes pushed into remoting 2.45.

This is the same as a previous pull request but has been rebased now that the pom references remoting 2.48 via another changeset.
