### PR TITLE
AbstractItem accept config.json request

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -599,6 +599,12 @@ THE SOFTWARE.
       <artifactId>jzlib</artifactId>
       <version>1.1.3-kohsuke-1</version>
     </dependency>
+
+    <dependency>
+	  <groupId>org.json</groupId>
+	  <artifactId>json</artifactId>
+	  <version>20140107</version>
+	</dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -45,8 +45,10 @@ import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
 import jenkins.security.NotReallyRoleSensitiveCallable;
 import org.acegisecurity.Authentication;
+import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.types.FileSet;
+import org.json.XML;
 import org.kohsuke.stapler.WebMethod;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -611,6 +613,24 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         if (req.getMethod().equals("POST")) {
             // submission
             updateByXml((Source)new StreamSource(req.getReader()));
+            return;
+        }
+
+        // huh?
+        rsp.sendError(SC_BAD_REQUEST);
+    }
+
+    /**
+     * Accepts <tt>config.json</tt> request.
+     */
+    @WebMethod(name = "config.json")
+    public void doConfigDotJson(StaplerRequest req, StaplerResponse rsp)
+            throws IOException {
+        if (req.getMethod().equals("GET")) {
+            // read
+            checkPermission(EXTENDED_READ);
+            rsp.setContentType("application/json");
+            org.apache.commons.io.IOUtils.write(XML.toJSONObject(FileUtils.readFileToString(getConfigFile().getFile())).toString(),rsp.getOutputStream());
             return;
         }
 


### PR DESCRIPTION
Allow to retrieve the project configuration in JSON format

I've tried to use http://json-lib.sourceforge.net/snippets.html#From_XML_to_JSON without succes, because that I've added org.json as core dependency
