### PR TITLE
Update FindBugs annotation library and maven plugin

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -558,9 +558,9 @@ THE SOFTWARE.
     </dependency>
 
     <dependency>
-      <groupId>findbugs</groupId>
+      <groupId>com.google.code.findbugs</groupId>
       <artifactId>annotations</artifactId>
-      <version>1.0.0</version>
+      <version>3.0.0</version>
       <scope>provided</scope>
     </dependency>
 
@@ -865,7 +865,6 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>findbugs-maven-plugin</artifactId>
-            <version>2.5.2</version>
             <configuration>
               <effort>Max</effort>
               <threshold>High</threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@ THE SOFTWARE.
     <maven-plugin.version>2.7.1</maven-plugin.version>
     <matrix-project.version>1.4.1</matrix-project.version>
     <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>
+    <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
 
     <java.level>7</java.level>
   </properties>
@@ -475,7 +476,6 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>2.5.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -501,7 +501,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.3</version>
           <dependencies>
             <dependency>
               <groupId>org.kohsuke</groupId>
@@ -762,7 +762,6 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>findbugs-maven-plugin</artifactId>
-            <version>2.5.2</version>
             <configuration>
               <threshold>High</threshold>
             </configuration>


### PR DESCRIPTION
I tried follow version 1.0.0 version and found that it replaced with other library. But it fails because of bytecode. Investigating it, will keep it open here.
