### PR TITLE
Add pom.xml.versionsBackup and .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ build
 # vim
 *~
 
+# OS X
+.DS_Store
+
+# mvn versions:set
+pom.xml.versionsBackup
+
 war/images/16x16
 war/images/24x24
 war/images/32x32


### PR DESCRIPTION
I frequently encounter these locally and they're pretty annoying in `git status`. I also cannot imagine anyone wanting them in Git.

So I propose this addition to `.gitignore`.
