### PR TITLE
[FIXED JENKINS-22311] Show queue item parameters in tool tip

### DIFF
--- a/core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
+++ b/core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
               <l:icon class="icon-grey icon-sm"/>
             </div>
             <!-- Don't use math unless needed, in case nextBuildNumber is not numeric -->
-            <div class="display-name">
+            <div class="display-name" title="${%Expected build number}">
             #${queuedItems.size()==1 ? it.owner.nextBuildNumber
                : it.owner.nextBuildNumber+queuedItems.size()-i-1}
             </div>
@@ -55,7 +55,11 @@ THE SOFTWARE.
                 (${%pending})
               </j:otherwise>
             </j:choose>
-            ${item.params}
+          <j:if test="${!item.params.isEmpty()}">
+            <div style="float:right;margin-right:10px;">
+              <a href="#" tooltip="Build Parameters:${h.escape(item.params)}"><l:icon class="icon-notepad icon-sm" /></a>
+            </div>
+          </j:if>
           </div>
           <div class="pane build-controls">
             <div class="build-stop">


### PR DESCRIPTION
How build parameters are currently displayed makes them difficult to read:

![screen shot 2014-12-20 at 13 28 22](https://cloud.githubusercontent.com/assets/1831569/5514815/f83ee866-884c-11e4-95b7-fd009d301088.png)

This change replaces them with an icon that, when hovered, shows the parameters in the tool tip:

![screen shot 2014-12-20 at 13 28 40](https://cloud.githubusercontent.com/assets/1831569/5514820/0cef8586-884d-11e4-951b-2af829bf050b.png)

Since no line breaks are necessary to maintain the page layout, slightly longer parameter values don't need to be broken. Every parameter is on its own line.

Only tested on OS X Firefox 34.0.5.

---

Added a tool tip to the projected build number as well. It's not guaranteed to be build `#5` for a number of reasons.
