### PR TITLE
[FIXED JENKINS-25989] Allow breaking label and node lists

### DIFF
--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -94,6 +94,7 @@ THE SOFTWARE.
             <!-- Skip the label for this node -->
             <j:if test="${entry.item!=it.node.selfLabel}">
               <a class="${entry.className} model-link inside" href="${rootURL}/label/${entry.item.name}">${entry.item.name}</a>
+              <wbr/>
             </j:if>
           </j:forEach>
         </div>

--- a/core/src/main/resources/hudson/model/Label/index.jelly
+++ b/core/src/main/resources/hudson/model/Label/index.jelly
@@ -50,6 +50,7 @@ THE SOFTWARE.
             <st:nbsp/>
             <a href="${url}" class="model-link inside">${c.displayName}</a>
           </nobr>
+          <wbr/>
         </j:forEach>
       </div>
 


### PR DESCRIPTION
This allows both the node list on the label index page and the label list on the node index page to break into multiple lines.
