### PR TITLE
[FIXED JENKINS-25174] Show run display name on parameters page

### DIFF
--- a/core/src/main/resources/hudson/model/RunParameterValue/value.jelly
+++ b/core/src/main/resources/hudson/model/RunParameterValue/value.jelly
@@ -27,6 +27,6 @@ THE SOFTWARE.
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
 	<f:entry title="${it.name}" description="${it.description}">
-		<a href="${rootURL}/${it.run.url}" class="model-link inside">${it.run}</a>
+		<a href="${rootURL}/${it.run.url}" class="model-link inside">${it.run.fullDisplayName}</a>
 	</f:entry>
 </j:jelly>


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/commit/5d92b45f47e630b6d9790a7d91b877c4f0acc449 switched `Run.toString()` to showing basic build numbers. Queue item parameters and _Build With Parameters_ already showed the `fullDisplayName`, but the parameters page did not.
