### PR TITLE
[FIXED JENKINS-25338] Show job name rather than display name in CLI

### DIFF
--- a/core/src/main/java/hudson/cli/ListJobsCommand.java
+++ b/core/src/main/java/hudson/cli/ListJobsCommand.java
@@ -82,7 +82,7 @@ public class ListJobsCommand extends CLICommand {
 
         // Print all jobs.
         for (TopLevelItem item : jobs) {
-            stdout.println(item.getDisplayName());
+            stdout.println(item.getName());
         }
 
         return 0;


### PR DESCRIPTION
This was briefly implemented already (or discussed at least) before #1164 but then reverted. Since that PR stalled, it makes sense to change this one.

While this change may break existing installs, it's hard to imagine anyone actually wanting the currently implemented behavior as it's really mindbogglingly stupid: You get a list of jobs, but cannot act on returned elements, because they don't tell you their name which is the required parameter to pass into other commands (e.g. `get-job`, `disable-job`, …) – instead, you get the display name which cannot really be used for anything.
