### PR TITLE
[FIXED JENKINS-25897] Add range check for H(X-Y) syntax

### DIFF
--- a/core/src/main/grammar/crontab.g
+++ b/core/src/main/grammar/crontab.g
@@ -110,7 +110,7 @@ throws ANTLRException
   }
   | ("H" "(")=> "H" "(" s=token "-" e=token ")" ( "/" d=token )?
   {
-    bits = doHash(s,e,d);
+    bits = doHash(s,e,d,field);
   }
   | "H" ( "/" d=token )?
   {

--- a/core/src/main/java/hudson/scheduler/BaseParser.java
+++ b/core/src/main/java/hudson/scheduler/BaseParser.java
@@ -96,10 +96,12 @@ abstract class BaseParser extends LLkParser {
         int u = UPPER_BOUNDS[field];
         if (field==2) u = 28;   // day of month can vary depending on month, so to make life simpler, just use [1,28] that's always safe
         if (field==4) u = 6;   // Both 0 and 7 of day of week are Sunday. For better distribution, limit upper bound to 6
-        return doHash(LOWER_BOUNDS[field], u, step);
+        return doHash(LOWER_BOUNDS[field], u, step, field);
     }
 
-    protected long doHash(int s, int e, int step) throws ANTLRException {
+    protected long doHash(int s, int e, int step, int field) throws ANTLRException {
+        rangeCheck(s, field);
+        rangeCheck(e, field);
         if (step > e - s + 1) {
             error(Messages.BaseParser_OutOfRange(step, 1, e - s + 1));
             throw new AssertionError();

--- a/core/src/test/java/hudson/scheduler/CronTabTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabTest.java
@@ -280,4 +280,25 @@ public class CronTabTest {
         assertEquals("[35, 56]", times.toString());
     }
 
+    @Test public void rangeBoundsCheckOK() throws Exception {
+        new CronTab("H(0-59) H(0-23) H(1-31) H(1-12) H(0-7)");
+    }
+
+    @Test public void rangeBoundsCheckFailHour() throws Exception {
+        try {
+            new CronTab("H H(12-24) * * *");
+            fail();
+        } catch (ANTLRException e) {
+            // ok
+        }
+    }
+
+    @Test public void rangeBoundsCheckFailMinute() throws Exception {
+        try {
+            new CronTab("H(33-66) * * * *");
+            fail();
+        } catch (ANTLRException e) {
+            // ok
+        }
+    }
 }


### PR DESCRIPTION
Do we need to retain backwards compatibility with this class?

---

New and improved:

![screen shot](https://cloud.githubusercontent.com/assets/1831569/5533276/e625fe72-8a44-11e4-9a26-0d96900a3fd4.png)
