### PR TITLE
[FIXED JENKINS-26208] Do not skip polling while quieting down

### DIFF
--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -128,11 +128,6 @@ public class SCMTrigger extends Trigger<Item> {
      * @since 1.375
      */
     public void run(Action[] additionalActions) {
-        if (Jenkins.getInstance().isQuietingDown()) {
-            LOGGER.log(INFO, "Skipping polling for {0} since Jenkins is in quiet mode", job.getFullName());
-            return;
-        }
-
         DescriptorImpl d = getDescriptor();
 
         LOGGER.fine("Scheduling a polling for "+job);


### PR DESCRIPTION
**Feedback welcome**

---

Skipping polling while quieting down results in very annoying delays if one relies on SCM commit notifications.

Subversion plugin, upon receiving a post-commit hook notification, will schedule polling of all projects likely affected by the given commit. This notification is effectively lost if Jenkins is, for whatever reason, quieting down when receiving it.
