### PR TITLE
convert tests from JUnit3 to JUnit4

### DIFF
--- a/core/src/test/java/hudson/BulkChangeTest.java
+++ b/core/src/test/java/hudson/BulkChangeTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,8 +23,10 @@
  */
 package hudson;
 
+import static org.junit.Assert.assertEquals;
+
 import hudson.model.Saveable;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.io.IOException;
 
@@ -33,7 +35,7 @@ import java.io.IOException;
  *
  * @author Kohsuke Kawaguchi
  */
-public class BulkChangeTest extends TestCase {
+public class BulkChangeTest {
 
     private class Point implements Saveable {
         /**
@@ -68,7 +70,8 @@ public class BulkChangeTest extends TestCase {
     /**
      * If there is no BulkChange, we should see two saves.
      */
-    public void testNoBulkChange() throws Exception {
+    @Test
+    public void noBulkChange() throws Exception {
         Point pt = new Point();
         pt.set(0,0);
         assertEquals(2,pt.saveCount);
@@ -77,7 +80,8 @@ public class BulkChangeTest extends TestCase {
     /**
      * With a {@link BulkChange}, this will become just one save.
      */
-    public void testBulkChange() throws Exception {
+    @Test
+    public void bulkChange() throws Exception {
         Point pt = new Point();
         BulkChange bc = new BulkChange(pt);
         try {
@@ -91,7 +95,8 @@ public class BulkChangeTest extends TestCase {
     /**
      * {@link BulkChange}s can be nested.
      */
-    public void testNestedBulkChange() throws Exception {
+    @Test
+    public void nestedBulkChange() throws Exception {
         Point pt = new Point();
         Point _ = new Point();
         BulkChange bc1 = new BulkChange(pt);

--- a/core/src/test/java/hudson/MarkupTextTest.java
+++ b/core/src/test/java/hudson/MarkupTextTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,8 +23,10 @@
  */
 package hudson;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+
 import hudson.MarkupText.SubText;
+import org.junit.Test;
 
 import java.util.List;
 import java.util.regex.Pattern;
@@ -32,7 +34,9 @@ import java.util.regex.Pattern;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class MarkupTextTest extends TestCase {
+public class MarkupTextTest {
+
+    @Test
     public void test1() {
         MarkupText t = new MarkupText("I fixed issue #155. The rest is trick text: xissue #155 issue #123x");
         for (SubText st : t.findTokens(pattern)) {
@@ -43,7 +47,8 @@ public class MarkupTextTest extends TestCase {
         assertEquals("I fixed <155>issue #155<155>. The rest is trick text: xissue #155 issue #123x", t.toString(false));
     }
 
-    public void testBoundary() {
+    @Test
+    public void boundary() {
         MarkupText t = new MarkupText("issue #155---issue #123");
         for (SubText st : t.findTokens(pattern))
             st.surroundWith("<$1>","<$1>");
@@ -51,7 +56,8 @@ public class MarkupTextTest extends TestCase {
         assertEquals("<155>issue #155<155>---<123>issue #123<123>", t.toString(false));
     }
 
-    public void testFindTokensOnSubText() {
+    @Test
+    public void findTokensOnSubText() {
         MarkupText t = new MarkupText("Fixed 2 issues in this commit, fixing issue 155, 145");
         List<SubText> tokens = t.findTokens(Pattern.compile("issue .*"));
         assertEquals("Expected one token", 1, tokens.size());
@@ -62,7 +68,8 @@ public class MarkupTextTest extends TestCase {
         assertEquals("Fixed 2 issues in this commit, fixing issue <155>155<155>, <145>145<145>", t.toString(false));
     }
 
-    public void testLiteralTextSurround() {
+    @Test
+    public void literalTextSurround() {
         MarkupText text = new MarkupText("AAA test AAA");
         for(SubText token : text.findTokens(Pattern.compile("AAA"))) {
             token.surroundWithLiteral("$9","$9");
@@ -73,7 +80,8 @@ public class MarkupTextTest extends TestCase {
     /**
      * Start/end tag nesting should be correct regardless of the order tags are added.
      */
-    public void testAdjacent() {
+    @Test
+    public void adjacent() {
         MarkupText text = new MarkupText("abcdef");
         text.addMarkup(0,3,"$","$");
         text.addMarkup(3,6,"#","#");
@@ -85,7 +93,8 @@ public class MarkupTextTest extends TestCase {
         assertEquals("$abc$#def#",text.toString(false));
     }
 
-    public void testEscape() {
+    @Test
+    public void escape() {
         MarkupText text = new MarkupText("&&&");
         assertEquals("&amp;&amp;&amp;",text.toString(false));
 
@@ -94,7 +103,8 @@ public class MarkupTextTest extends TestCase {
         assertEquals("&amp;<foo>&amp;&nbsp;&amp;",text.toString(false));
     }
 
-    public void testPreEscape() {
+    @Test
+    public void preEscape() {
         MarkupText text = new MarkupText("Line\n2   & 3\n<End>\n");
         assertEquals("Line\n2   &amp; 3\n&lt;End&gt;\n", text.toString(true));
         text.addMarkup(4, "<hr/>");
@@ -102,7 +112,8 @@ public class MarkupTextTest extends TestCase {
     }
 
     /* @Bug(6252) */
-    public void testSubTextSubText() {
+    @Test
+    public void subTextSubText() {
         MarkupText text = new MarkupText("abcdefgh");
         SubText sub = text.subText(2, 7);
         assertEquals("cdefg", sub.getText());

--- a/core/src/test/java/hudson/ProxyConfigurationTest.java
+++ b/core/src/test/java/hudson/ProxyConfigurationTest.java
@@ -23,13 +23,16 @@
  */
 package hudson;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 import java.net.Proxy;
 
-public class ProxyConfigurationTest extends TestCase {
+public class ProxyConfigurationTest {
 
-    public void testNoProxyHost() {
+    @Test
+    public void noProxyHost() {
         String noProxyHost = "*.example.com|192.168.*";
         assertEquals(Proxy.Type.HTTP, ProxyConfiguration.createProxy("test.example.co.jp", "proxy.example.com", 8080, noProxyHost).type());
         assertEquals(Proxy.Type.DIRECT, ProxyConfiguration.createProxy("test.example.com", "proxy.example.com", 8080, noProxyHost).type());

--- a/core/src/test/java/hudson/model/BallColorTest.java
+++ b/core/src/test/java/hudson/model/BallColorTest.java
@@ -1,16 +1,21 @@
 package hudson.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class BallColorTest extends TestCase {
-    public void testHtmlColor() {
+public class BallColorTest {
+
+    @Test
+    public void htmlColor() {
         assertEquals("#EF2929",BallColor.RED.getHtmlBaseColor());
     }
 
-    public void testIconClassName() {
+    @Test
+    public void iconClassName() {
         assertEquals("icon-red",BallColor.RED.getIconClassName());
         assertEquals("icon-aborted-anime",BallColor.ABORTED_ANIME.getIconClassName());
     }

--- a/core/src/test/java/hudson/model/LoadStatisticsTest.java
+++ b/core/src/test/java/hudson/model/LoadStatisticsTest.java
@@ -24,10 +24,10 @@
 package hudson.model;
 
 import hudson.model.MultiStageTimeSeries.TimeScale;
-import junit.framework.TestCase;
 
 import org.apache.commons.io.IOUtils;
 import org.jfree.chart.JFreeChart;
+import org.junit.Test;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -38,8 +38,10 @@ import java.io.IOException;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class LoadStatisticsTest extends TestCase {
-    public void testGraph() throws IOException {
+public class LoadStatisticsTest {
+
+    @Test
+    public void graph() throws IOException {
         LoadStatistics ls = new LoadStatistics(0, 0) {
             public int computeIdleExecutors() {
                 throw new UnsupportedOperationException();

--- a/core/src/test/java/hudson/model/ResourceListTest.java
+++ b/core/src/test/java/hudson/model/ResourceListTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Stephen Connolly
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,14 +23,19 @@
  */
 package hudson.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Stephen Connolly
  */
-public class ResourceListTest extends TestCase {
+public class ResourceListTest {
+
     private Resource a1, a2, a3, a4, a;
     private Resource b1, b2, b3, b4, b;
     private Resource c1, c2, c3, c4, c;
@@ -41,6 +46,7 @@ public class ResourceListTest extends TestCase {
     private ResourceList y;
     private ResourceList z;
 
+    @Before
     public void setUp() {
         entropy = new Random(0);
         a = new Resource("A" + entropy.nextLong());
@@ -67,7 +73,8 @@ public class ResourceListTest extends TestCase {
         z = new ResourceList();
     }
 
-    public void testEmptyLists() throws Exception {
+    @Test
+    public void emptyLists() {
         z.r(a);
         ResourceList w = new ResourceList();
         w.w(a);
@@ -79,7 +86,8 @@ public class ResourceListTest extends TestCase {
         assertFalse("Write vs Empty", w.isCollidingWith(x));
     }
 
-    public void testSimpleR() throws Exception {
+    @Test
+    public void simpleR() {
         x.r(a);
         y.r(b);
         z.r(a);
@@ -92,7 +100,8 @@ public class ResourceListTest extends TestCase {
         assertFalse("Read-Read", y.isCollidingWith(z));
     }
 
-    public void testSimpleRW() throws Exception {
+    @Test
+    public void simpleRW() {
         x.r(a);
         y.r(b);
         z.w(a);
@@ -105,7 +114,8 @@ public class ResourceListTest extends TestCase {
         assertFalse("Read-Write different resources", y.isCollidingWith(z));
     }
 
-    public void testSimpleW() throws Exception {
+    @Test
+    public void simpleW() {
         x.w(a);
         y.w(b);
         z.w(a);
@@ -127,7 +137,8 @@ public class ResourceListTest extends TestCase {
         assertTrue(z.isCollidingWith(w));
     }
 
-    public void testParentChildR() throws Exception {
+    @Test
+    public void parentChildR() {
         x.r(a1);
         x.r(a2);
         y.r(a3);
@@ -141,7 +152,8 @@ public class ResourceListTest extends TestCase {
         assertFalse("Reads should never conflict", y.isCollidingWith(z));
     }
 
-    public void testParentChildW() throws Exception {
+    @Test
+    public void parentChildW() {
         x.w(a1);
         x.w(a2);
         y.w(a3);
@@ -155,7 +167,8 @@ public class ResourceListTest extends TestCase {
         assertTrue("Taking parent resource assumes all children are taken too", y.isCollidingWith(z));
     }
 
-    public void testParentChildR3() throws Exception {
+    @Test
+    public void parentChildR3() {
         x.r(c1);
         x.r(c2);
         y.r(c3);
@@ -169,7 +182,8 @@ public class ResourceListTest extends TestCase {
         assertFalse("Reads should never conflict", y.isCollidingWith(z));
     }
 
-    public void testParentChildW3() throws Exception {
+    @Test
+    public void parentChildW3() {
         x.w(c1);
         x.w(c2);
         y.w(c3);
@@ -199,7 +213,8 @@ public class ResourceListTest extends TestCase {
         assertTrue("Total count = 4, limit is 3", x.isCollidingWith(v));
     }
 
-    public void testMultiWrite1() throws Exception {
+    @Test
+    public void multiWrite1() {
         y.w(e);
         assertFalse(x.isCollidingWith(y));
         assertFalse(y.isCollidingWith(x));
@@ -217,7 +232,8 @@ public class ResourceListTest extends TestCase {
         }
     }
 
-    public void testMultiWriteN() throws Exception {
+    @Test
+    public void multiWriteN() {
         y.w(f);
         for (int i=0; i<f.numConcurrentWrite; i++) {
             assertFalse("Total = W" + i + ", Limit = W" + f.numConcurrentWrite, x.isCollidingWith(y));
@@ -232,7 +248,8 @@ public class ResourceListTest extends TestCase {
         }
     }
 
-    public void testMultiRead1() throws Exception {
+    @Test
+    public void multiRead1() {
         y.r(e);
         for (int i = 0; i < fWriteCount; i++) {
             assertFalse("Total = R" + (i + 1) + ", Limit = W1", x.isCollidingWith(y));
@@ -247,7 +264,8 @@ public class ResourceListTest extends TestCase {
         }
     }
 
-    public void testMultiReadN() throws Exception {
+    @Test
+    public void multiReadN() {
         y.r(f);
         for (int i = 0; i < fWriteCount; i++) {
             assertFalse("Total = R" + (i + 1) + ", Limit = W" + fWriteCount, x.isCollidingWith(y));
@@ -261,5 +279,4 @@ public class ResourceListTest extends TestCase {
             x.r(f);
         }
     }
-
 }

--- a/core/src/test/java/hudson/model/TaskActionTest.java
+++ b/core/src/test/java/hudson/model/TaskActionTest.java
@@ -1,19 +1,19 @@
 package hudson.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 
 import hudson.console.AnnotatedLargeText;
 import hudson.security.ACL;
 import hudson.security.Permission;
-import hudson.security.PermissionGroup;
 import org.acegisecurity.Authentication;
+import org.junit.Test;
 
 /**
  * @author Jerome Lacoste
  */
-public class TaskActionTest extends TestCase {
+public class TaskActionTest {
 
     private static class MyTaskThread extends TaskThread {
         MyTaskThread(TaskAction taskAction) {
@@ -21,22 +21,22 @@ public class TaskActionTest extends TestCase {
         }
         protected void perform(TaskListener listener) throws Exception {
             listener.hyperlink("/localpath", "a link");
-        }            
+        }
     }
-  
+
     private static class MyTaskAction extends TaskAction {
         void start() {
             workerThread = new MyTaskThread(this);
             workerThread.start();
-        }  
-    
+        }
+
         public String getIconFileName() {
             return "Iconfilename";
         }
         public String getDisplayName() {
             return "My Task Thread";
         }
-        
+
         public String getUrlName() {
             return "xyz";
         }
@@ -53,7 +53,8 @@ public class TaskActionTest extends TestCase {
         }
     }
 
-    public void testAnnotatedText() throws Exception {
+    @Test
+    public void annotatedText() throws Exception {
         MyTaskAction action = new MyTaskAction();
         action.start();
         AnnotatedLargeText annotatedText = action.obtainLog();

--- a/core/src/test/java/hudson/model/TimeSeriesTest.java
+++ b/core/src/test/java/hudson/model/TimeSeriesTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,16 +23,21 @@
  */
 package hudson.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class TimeSeriesTest extends TestCase {
+public class TimeSeriesTest {
+
+    @Test
     public void test1() {
         TimeSeries ts = new TimeSeries(0,1-0.1f,100);
-        float last;
-        assertEquals(0f,last=ts.getLatest());
+        float last = ts.getLatest();
+        assertEquals(0f,last, 0f);
         for( int i=0; i<100; i++ ) {
             assertEquals(ts.getHistory().length,i+1);
             ts.update(1);

--- a/core/src/test/java/hudson/search/SearchTest.java
+++ b/core/src/test/java/hudson/search/SearchTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,19 +23,23 @@
  */
 package hudson.search;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import hudson.Util;
-import junit.framework.TestCase;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class SearchTest extends TestCase {
-    public void test1() {
+public class SearchTest {
+
+    @Test
+    public void findAndSuggest() {
         SearchIndex si = new SearchIndexBuilder()
             .add("abc-def-ghi","abc def ghi")
             .add(SearchItems.create("abc","abc",
@@ -53,34 +57,35 @@ public class SearchTest extends TestCase {
         assertEquals("/abc-def-ghi",l.get(0).getUrl());
         assertEquals("/abc/def-ghi",l.get(1).getUrl());
     }
-    
+
     /**
      * This test verifies that if 2 search results are found with the same
      * search name, that the one with the search query in the url is returned
      */
-    public void testFindClosestSuggestedItem() {
+    @Test
+    public void findClosestSuggestedItem() {
         final String query = "foobar 123";
         final String searchName = "sameDisplayName";
-        
-        SearchItem searchItemHit = new SearchItem() {            
+
+        SearchItem searchItemHit = new SearchItem() {
             public SearchIndex getSearchIndex() {
                     return null;
-            }    
+            }
             public String getSearchName() {
                 return searchName;
-            }    
+            }
             public String getSearchUrl() {
                 return "/job/"+Util.rawEncode(query) + "/";
             }
         };
-        
-        SearchItem searchItemNoHit = new SearchItem() {            
+
+        SearchItem searchItemNoHit = new SearchItem() {
             public SearchIndex getSearchIndex() {
                     return null;
-            }    
+            }
             public String getSearchName() {
                 return searchName;
-            }   
+            }
             public String getSearchUrl() {
                 return "/job/someotherJob/";
             }
@@ -91,11 +96,11 @@ public class SearchTest extends TestCase {
         ArrayList<SuggestedItem> list = new ArrayList<SuggestedItem>();
         list.add(suggestedNoHit);
         list.add(suggestedHit); // make sure the hit is the second item
-        
+
         SuggestedItem found = Search.findClosestSuggestedItem(list, query);
-        Assert.assertEquals(searchItemHit, found.item);
-        
+        assertEquals(searchItemHit, found.item);
+
         SuggestedItem found2 = Search.findClosestSuggestedItem(list, "abcd");
-        Assert.assertEquals(searchItemNoHit, found2.item);
+        assertEquals(searchItemNoHit, found2.item);
     }
 }

--- a/core/src/test/java/hudson/slaves/NodeListTest.java
+++ b/core/src/test/java/hudson/slaves/NodeListTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,10 +23,10 @@
  */
 package hudson.slaves;
 
+import static org.junit.Assert.assertEquals;
 
 import hudson.remoting.Callable;
 import jenkins.model.Jenkins;
-import junit.framework.TestCase;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.model.Computer;
@@ -44,11 +44,13 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class NodeListTest extends TestCase {
+public class NodeListTest {
+
     static class DummyNode extends Node {
         String nodeName = Long.toString(new Random().nextLong());
         public String getNodeName() {
@@ -113,13 +115,15 @@ public class NodeListTest extends TestCase {
             throw new UnsupportedOperationException();
 		}
     }
+
     static class EphemeralNode extends DummyNode implements hudson.slaves.EphemeralNode {
         public Node asNode() {
             return this;
         }
     }
 
-    public void testSerialization() throws Exception {
+    @Test
+    public void serialization() throws Exception {
         NodeList nl = new NodeList(new DummyNode(), new EphemeralNode());
 
         File tmp = File.createTempFile("test","test");

--- a/core/src/test/java/hudson/util/ConsistentHashTest.java
+++ b/core/src/test/java/hudson/util/ConsistentHashTest.java
@@ -23,9 +23,10 @@
  */
 package hudson.util;
 
-import com.google.common.collect.Iterables;
+import static org.junit.Assert.*;
+
 import hudson.util.CopyOnWriteMap.Hash;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.util.Random;
 import java.util.Map;
@@ -38,11 +39,12 @@ import java.util.Map.Entry;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class ConsistentHashTest extends TestCase {
+public class ConsistentHashTest {
     /**
      * Just some random tests to ensure that we have no silly NPE or that kind of error.
      */
-    public void testBasic() {
+    @Test
+    public void basic() {
         ConsistentHash<String> hash = new ConsistentHash<String>();
         hash.add("data1");
         hash.add("data2");
@@ -71,7 +73,8 @@ public class ConsistentHashTest extends TestCase {
     /**
      * Uneven distribution should result in uneven mapping.
      */
-    public void testUnevenDisribution() {
+    @Test
+    public void unevenDistribution() {
         ConsistentHash<String> hash = new ConsistentHash<String>();
         hash.add("even",10);
         hash.add("odd",100);
@@ -84,7 +87,7 @@ public class ConsistentHashTest extends TestCase {
             else                    odd++;
         }
 
-        // again, there's a small chance tha this test fails. 
+        // again, there's a small chance tha this test fails.
         System.out.printf("%d/%d\n",even,odd);
         assertTrue(even*8<odd);
     }
@@ -92,7 +95,8 @@ public class ConsistentHashTest extends TestCase {
     /**
      * Removal shouldn't affect existing nodes
      */
-    public void testRemoval() {
+    @Test
+    public void removal() {
         ConsistentHash<Integer> hash = new ConsistentHash<Integer>();
         for( int i=0; i<10; i++ )
             hash.add(i);
@@ -115,7 +119,8 @@ public class ConsistentHashTest extends TestCase {
         }
     }
 
-    public void testEmptyBehavior() {
+    @Test
+    public void emptyBehavior() {
         ConsistentHash<String> hash = new ConsistentHash<String>();
         assertFalse(hash.list(0).iterator().hasNext());
         assertNull(hash.lookup(0));
@@ -125,7 +130,8 @@ public class ConsistentHashTest extends TestCase {
     /**
      * This test doesn't fail but it's written to measure the performance of the consistent hash function with large data set.
      */
-    public void testSpeed() {
+    @Test
+    public void speed() {
         Map<String,Integer> data = new Hash<String, Integer>();
         for (int i = 0; i < 1000; i++)
             data.put("node" + i,100);
@@ -135,7 +141,6 @@ public class ConsistentHashTest extends TestCase {
         for (int j=0; j<10; j++) {
             ConsistentHash<String> b = new ConsistentHash<String>();
             b.addAll(data);
-//            System.out.println(Iterables.toString(b.list("x")));
         }
 
         System.out.println(System.currentTimeMillis()-start);

--- a/core/src/test/java/hudson/util/CopyOnWriteListTest.java
+++ b/core/src/test/java/hudson/util/CopyOnWriteListTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,7 +23,10 @@
  */
 package hudson.util;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +34,8 @@ import java.util.List;
 /**
  * @author Kohsuke Kawaguchi, Alan Harder
  */
-public class CopyOnWriteListTest extends TestCase {
+public class CopyOnWriteListTest {
+
     public static final class TestData {
         CopyOnWriteList list1 = new CopyOnWriteList();
         List list2 = new ArrayList();
@@ -40,7 +44,8 @@ public class CopyOnWriteListTest extends TestCase {
     /**
      * Verify that the serialization form of List and CopyOnWriteList are the same.
      */
-    public void testSerialization() throws Exception {
+    @Test
+    public void serialization() {
         XStream2 xs = new XStream2();
         TestData td = new TestData();
 

--- a/core/src/test/java/hudson/util/CyclicGraphDetectorTest.java
+++ b/core/src/test/java/hudson/util/CyclicGraphDetectorTest.java
@@ -1,7 +1,10 @@
 package hudson.util;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import hudson.util.CyclicGraphDetector.CycleDetectedException;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,7 +14,8 @@ import java.util.Set;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class CyclicGraphDetectorTest extends TestCase {
+public class CyclicGraphDetectorTest {
+
     private class Edge {
         String src,dst;
 
@@ -46,7 +50,7 @@ public class CyclicGraphDetectorTest extends TestCase {
         }
 
         /**
-         * Performs a cycle check. 
+         * Performs a cycle check.
          */
         void check() throws Exception {
             new CyclicGraphDetector<String>() {
@@ -68,16 +72,18 @@ public class CyclicGraphDetectorTest extends TestCase {
         }
     }
 
-    public void testCycle() throws Exception {
+    @Test
+    public void cycle1() throws Exception {
         new Graph().e("A","B").e("B","C").e("C","A").mustContainCycle("A","B","C");
     }
 
-    public void testCycle2() throws Exception {
+    @Test
+    public void cycle2() throws Exception {
         new Graph().e("A","B").e("B","C").e("C","C").mustContainCycle("C");
     }
 
-    public void testCycle3() throws Exception {
+    @Test
+    public void cycle3() throws Exception {
         new Graph().e("A","B").e("B","C").e("C","D").e("B","E").e("E","D").e("E","A").mustContainCycle("A","B","E");
     }
-
 }

--- a/core/src/test/java/hudson/util/IteratorsTest.java
+++ b/core/src/test/java/hudson/util/IteratorsTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,20 +23,23 @@
  */
 package hudson.util;
 
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+
 import hudson.util.Iterators.CountingPredicate;
-import junit.framework.TestCase;
 
 import java.util.Iterator;
 import java.util.List;
 
-import static java.util.Arrays.*;
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class IteratorsTest extends TestCase {
+public class IteratorsTest {
 
-    public void testReverseSequence() {
+    @Test
+    public void reverseSequence() {
         List<Integer> lst = Iterators.reverseSequence(1, 4);
         assertEquals(3,(int)lst.get(0));
         assertEquals(2,(int)lst.get(1));
@@ -44,7 +47,8 @@ public class IteratorsTest extends TestCase {
         assertEquals(3,lst.size());
     }
 
-    public void testSequence() {
+    @Test
+    public void sequence() {
         List<Integer> lst = Iterators.sequence(1,4);
         assertEquals(1,(int)lst.get(0));
         assertEquals(2,(int)lst.get(1));
@@ -52,7 +56,8 @@ public class IteratorsTest extends TestCase {
         assertEquals(3, lst.size());
     }
 
-    public void testWrap() {
+    @Test
+    public void wrap() {
         List<Integer> lst = Iterators.sequence(1,4);
         Iterable<Integer> wrapped = Iterators.wrap(lst);
         assertFalse(wrapped instanceof List);
@@ -66,7 +71,8 @@ public class IteratorsTest extends TestCase {
         assertFalse(iter.hasNext());
     }
 
-    public void testLimit() {
+    @Test
+    public void limit() {
         assertEquals("[0]",com.google.common.collect.Iterators.toString(Iterators.limit(asList(0,1,2,3,4).iterator(), EVEN)));
         assertEquals("[]", com.google.common.collect.Iterators.toString(Iterators.limit(asList(1,2,4,6).iterator(), EVEN)));
     }

--- a/core/src/test/java/hudson/util/LineEndNormalizingWriterTest.java
+++ b/core/src/test/java/hudson/util/LineEndNormalizingWriterTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,7 +23,9 @@
  */
 package hudson.util;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 import java.io.StringWriter;
 import java.io.Writer;
@@ -32,7 +34,9 @@ import java.io.IOException;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class LineEndNormalizingWriterTest extends TestCase {
+public class LineEndNormalizingWriterTest {
+
+    @Test
     public void test1() throws IOException {
         StringWriter sw = new StringWriter();
         Writer w = new LineEndNormalizingWriter(sw);
@@ -43,6 +47,7 @@ public class LineEndNormalizingWriterTest extends TestCase {
         assertEquals(sw.toString(),"abc\r\ndef\r\n");
     }
 
+    @Test
     public void test2() throws IOException {
         StringWriter sw = new StringWriter();
         Writer w = new LineEndNormalizingWriter(sw);
@@ -53,6 +58,7 @@ public class LineEndNormalizingWriterTest extends TestCase {
         assertEquals(sw.toString(),"abc\r\ndef\r\n\r\n");
     }
 
+    @Test
     public void test3() throws IOException {
         StringWriter sw = new StringWriter();
         Writer w = new LineEndNormalizingWriter(sw);

--- a/core/src/test/java/hudson/util/PackedMapTest.java
+++ b/core/src/test/java/hudson/util/PackedMapTest.java
@@ -1,22 +1,26 @@
 package hudson.util;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
+import org.junit.Test;
+
 /**
  * @author Kohsuke Kawaguchi
  */
-public class PackedMapTest extends TestCase {
+public class PackedMapTest {
+
     static class Holder {
         PackedMap pm;
     }
 
     private XStream2 xs = new XStream2();
 
-    public void testBasic() throws Exception {
+    @Test
+    public void basic() {
         Map<String,String> o = new TreeMap<String, String>();
         o.put("a","b");
         o.put("c","d");

--- a/core/src/test/java/hudson/util/QuotedStringTokenizerTest.java
+++ b/core/src/test/java/hudson/util/QuotedStringTokenizerTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,54 +23,63 @@
  */
 package hudson.util;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.util.Arrays;
+
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class QuotedStringTokenizerTest extends TestCase {
-    private void check(String src, String... expected) {
-        String[] r = QuotedStringTokenizer.tokenize(src);
-        System.out.println(Arrays.asList(r));
-        assertTrue(Arrays.equals(r, expected));
-    }
+public class QuotedStringTokenizerTest {
 
+    @Test
     public void test1() {
         check("foo bar",
               "foo","bar");
     }
 
-
+    @Test
     public void test2() {
         check("foo \"bar zot\"",
               "foo","bar zot");
     }
 
+    @Test
     public void test3() {
         check("foo bar=\"quote zot\"",
               "foo","bar=quote zot");
     }
 
+    @Test
     public void test4() {
         check("foo\\\"",
               "foo\"");
     }
 
+    @Test
     public void test5() {
         check("foo\\ bar",
               "foo bar");
     }
 
+    @Test
     public void test6() {
         check("foo\\\\ bar",
               "foo\\","bar");
     }
 
     // see http://www.nabble.com/Error-parsing-%22-in-msbuild-task-to20535754.html
+    @Test
     public void test7() {
         check("foo=\"bar\\zot\"",
               "foo=bar\\zot");
+    }
+
+    private void check(String src, String... expected) {
+        String[] r = QuotedStringTokenizer.tokenize(src);
+        System.out.println(Arrays.asList(r));
+        assertArrayEquals(expected, r);
     }
 }

--- a/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,24 +23,29 @@
  */
 package hudson.util;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConversionException;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.junit.Test;
+
 /**
  * @author Kohsuke Kawaguchi
  */
-public class RobustReflectionConverterTest extends TestCase {
+public class RobustReflectionConverterTest {
 
     static {
         Logger.getLogger(RobustReflectionConverter.class.getName()).setLevel(Level.OFF);
     }
 
-    public void testRobustUnmarshalling() {
+    @Test
+    public void robustUnmarshalling() {
         Point p = read(new XStream2());
         assertEquals(p.x,1);
         assertEquals(p.y,2);
@@ -51,7 +56,8 @@ public class RobustReflectionConverterTest extends TestCase {
         return (Point) xs.fromXML("<" + clsName + "><x>1</x><y>2</y><z>3</z></" + clsName + '>');
     }
 
-    public void testIfWeNeedWorkaround() {
+    @Test
+    public void ifWorkaroundNeeded() {
         try {
             read(new XStream());
             fail();
@@ -61,7 +67,8 @@ public class RobustReflectionConverterTest extends TestCase {
         }
     }
 
-    public void testClassOwnership() throws Exception {
+    @Test
+    public void classOwnership() throws Exception {
         XStream xs = new XStream2(new XStream2.ClassOwnership() {
             @Override public String ownerOf(Class<?> clazz) {
                 Owner o = clazz.getAnnotation(Owner.class);
@@ -96,6 +103,7 @@ public class RobustReflectionConverterTest extends TestCase {
         Moonwalk s = (Moonwalk) xs.fromXML("<" + prefix1 + "Moonwalk plugin='p2'><lover class='" + prefix2 + "Billy' plugin='p3'/></" + prefix1 + "Moonwalk>");
         assertEquals(Billy.class, s.lover.getClass());
     }
+
     @Retention(RetentionPolicy.RUNTIME) @interface Owner {String value();}
     public static class Projekt {
         Bild[] bildz;

--- a/core/src/test/java/hudson/util/RunListTest.java
+++ b/core/src/test/java/hudson/util/RunListTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,12 +23,15 @@
  */
 package hudson.util;
 
-import hudson.model.Run;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
-import junit.framework.TestCase;
+
+import hudson.model.Run;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Bug;
-import static org.mockito.Mockito.when;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -37,7 +40,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  * @author Ignacio Albors
  */
 @RunWith(PowerMockRunner.class)
-public class RunListTest extends TestCase {
+public class RunListTest {
 
 	// RunList for byTimestamp tests
 	private RunList rlist;
@@ -50,46 +53,43 @@ public class RunListTest extends TestCase {
 		when(r1.getNumber()).thenReturn(1);
 		when(r2.getNumber()).thenReturn(2);
 
-		when(r1.getTimeInMillis()).thenReturn(new Long(200));      	
-		when(r2.getTimeInMillis()).thenReturn(new Long(300));
+		when(r1.getTimeInMillis()).thenReturn(200L);
+		when(r2.getTimeInMillis()).thenReturn(300L);
 
 		ArrayList<Run> list = new ArrayList<Run>();
 		list.add(r2);
 		list.add(r1);
 
 		rlist = RunList.fromRuns(list);
-
 	}
 
 	@PrepareForTest({Run.class})
-	public void testbyTimestampAllRuns() {
-
+	@Test
+	public void byTimestampAllRuns() {
 		setUpByTimestampRuns();
 
 		RunList<Run> tested = rlist.byTimestamp(0, 400);
 		assertEquals(2, tested.toArray().length);
-
 	}
 
     @Bug(21159)
 	@PrepareForTest({Run.class})
-	public void testbyTimestampFirstRun() {
+	@Test
+	public void byTimestampFirstRun() {
 		setUpByTimestampRuns();
 		// Only r1
 		RunList<Run> tested = rlist.byTimestamp(150, 250);
 		assertEquals(1, tested.toArray().length);
 		assertEquals(1, tested.getFirstBuild().getNumber());
-
 	}
 
 	@PrepareForTest({Run.class})
-	public void testbyTimestampLastRun() {
-
+	@Test
+	public void byTimestampLastRun() {
 		setUpByTimestampRuns();
 		// Only r2
 		RunList<Run> tested = rlist.byTimestamp(250, 350);
 		assertEquals(1, tested.toArray().length);
 		assertEquals(2, tested.getFirstBuild().getNumber());
 	}
-
 }

--- a/core/src/test/java/hudson/util/SubClassGeneratorTest.java
+++ b/core/src/test/java/hudson/util/SubClassGeneratorTest.java
@@ -23,13 +23,15 @@
  */
 package hudson.util;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 /**
- * 
  * @author Kohsuke Kawaguchi
  */
-public class SubClassGeneratorTest extends TestCase {
+public class SubClassGeneratorTest {
+
     public static class Foo {
         String s;
         double x;
@@ -38,7 +40,9 @@ public class SubClassGeneratorTest extends TestCase {
         public Foo(String s) {this.s=s;}
         public Foo(double x, int y) {this.x=x;this.y=y;}
     }
-    public void testFoo() throws Exception {
+
+    @Test
+    public void foo() throws Exception {
         Class<? extends Foo> c = new SubClassGenerator(getClass().getClassLoader()).generate(Foo.class, "12345");
         assertEquals("12345",c.getName());
 
@@ -48,7 +52,7 @@ public class SubClassGeneratorTest extends TestCase {
         assertEquals("aaa",f.s);
 
         f = c.getConstructor(double.class,int.class).newInstance(1.0,3);
-        assertEquals(1.0,f.x);
+        assertEquals(1.0,f.x,0);
         assertEquals(3,f.y);
     }
 }

--- a/core/src/test/java/hudson/util/XStream2Test.java
+++ b/core/src/test/java/hudson/util/XStream2Test.java
@@ -23,6 +23,8 @@
  */
 package hudson.util;
 
+import static org.junit.Assert.*;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.thoughtworks.xstream.XStreamException;
@@ -35,21 +37,23 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import junit.framework.TestCase;
 import org.apache.commons.io.FileUtils;
+import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.Issue;
 
 /**
  * Tests for XML serialization of java objects.
  * @author Kohsuke Kawaguchi, Mike Dillon, Alan Harder, Richard Mortimer
  */
-public class XStream2Test extends TestCase {
+public class XStream2Test {
 
     public static final class Foo {
         Result r1,r2;
     }
 
-    public void testMarshalValue() {
+    @Test
+    public void marshalValue() {
         Foo f = new Foo();
         f.r1 = f.r2 = Result.FAILURE;
         String xml = Run.XSTREAM.toXML(f);
@@ -64,7 +68,8 @@ public class XStream2Test extends TestCase {
     /**
      * Test ability to read old XML from Hudson 1.105 or older.
      */
-    public void testXStream11Compatibility() {
+    @Test
+    public void xStream11Compatibility() {
         Bar b = (Bar)new XStream2().fromXML(
                 "<hudson.util.XStream2Test-Bar><s>foo</s></hudson.util.XStream2Test-Bar>");
         assertEquals("foo", b.s);
@@ -78,9 +83,10 @@ public class XStream2Test extends TestCase {
 
     /**
      * Test marshal/unmarshal round trip for class/field names with _ and $ characters.
-     * (HUDSON-5768)
      */
-    public void testXmlRoundTrip() {
+    @Issue("HUDSON-5768")
+    @Test
+    public void xmlRoundTrip() {
         XStream2 xs = new XStream2();
         __Foo_Bar$Class b = new __Foo_Bar$Class();
 
@@ -103,11 +109,12 @@ public class XStream2Test extends TestCase {
      * Verify RobustReflectionConverter can handle missing fields in a class extending
      * Throwable/Exception (default ThrowableConverter registered by XStream calls
      * ReflectionConverter directly, rather than our RobustReflectionConverter replacement).
-     * (HUDSON-5769)
      */
-    public void testUnmarshalThrowableMissingField() {
+    @Issue("HUDSON-5769")
+    @Test
+    public void unmarshalThrowableMissingField() {
         Level oldLevel = disableLogging();
-        
+
         Baz baz = new Baz();
         baz.myFailure = new Exception("foo");
 
@@ -125,7 +132,7 @@ public class XStream2Test extends TestCase {
                 + "</myFailure></hudson.util.XStream2Test_-Baz>");
         // Object should load, despite "missingField" in XML above
         assertEquals("hoho", baz.myFailure.getMessage());
-        
+
         enableLogging(oldLevel);
     }
 
@@ -134,7 +141,7 @@ public class XStream2Test extends TestCase {
         Logger.getLogger(RobustReflectionConverter.class.getName()).setLevel(Level.OFF);
         return oldLevel;
     }
-    
+
     private void enableLogging(Level oldLevel) {
         Logger.getLogger(RobustReflectionConverter.class.getName()).setLevel(oldLevel);
     }
@@ -147,7 +154,8 @@ public class XStream2Test extends TestCase {
         Map<?,?> m;
     }
 
-    public void testImmutableMap() {
+    @Test
+    public void immutableMap() {
         XStream2 xs = new XStream2();
 
         roundtripImmutableMap(xs, ImmutableMap.of());
@@ -195,7 +203,8 @@ public class XStream2Test extends TestCase {
         List<?> l;
     }
 
-    public void testImmutableList() {
+    @Test
+    public void immutableList() {
         XStream2 xs = new XStream2();
 
         roundtripImmutableList(xs, ImmutableList.of());
@@ -236,13 +245,15 @@ public class XStream2Test extends TestCase {
     }
 
     @Bug(8006) // Previously a null entry in an array caused NPE
-    public void testEmptyStack() {
+    @Test
+    public void emptyStack() {
         assertEquals("<object-array><null/><null/></object-array>",
                      Run.XSTREAM.toXML(new Object[2]).replaceAll("[ \n\r\t]+", ""));
     }
 
     @Bug(9843)
-    public void testCompatibilityAlias() {
+    @Test
+    public void compatibilityAlias() {
         XStream2 xs = new XStream2();
         xs.addCompatibilityAlias("legacy.Point",Point.class);
         Point pt = (Point)xs.fromXML("<legacy.Point><x>1</x><y>2</y></legacy.Point>");
@@ -265,7 +276,8 @@ public class XStream2Test extends TestCase {
      * Tests that ConcurrentHashMap is serialized into a more compact format,
      * but still can deserialize to older, verbose format.
      */
-    public void testConcurrentHashMapSerialization() throws Exception {
+    @Test
+    public void concurrentHashMapSerialization() throws Exception {
         Foo2 foo = new Foo2();
         foo.m.put("abc","def");
         foo.m.put("ghi","jkl");
@@ -291,7 +303,9 @@ public class XStream2Test extends TestCase {
         assertEquals("def",map.m.get("abc"));
     }
 
-    public void testDynamicProxyBlocked() throws Exception { // SECURITY-105
+    @Issue("SECURITY-105")
+    @Test
+    public void dynamicProxyBlocked() {
         try {
             ((Runnable) new XStream2().fromXML("<dynamic-proxy><interface>java.lang.Runnable</interface><handler class='java.beans.EventHandler'><target class='" + Hacked.class.getName() + "'/><action>oops</action></handler></dynamic-proxy>")).run();
         } catch (XStreamException x) {
@@ -299,6 +313,7 @@ public class XStream2Test extends TestCase {
         }
         assertFalse("should never have run that", Hacked.tripped);
     }
+
     public static final class Hacked {
         static boolean tripped;
         public void oops() {
@@ -306,10 +321,10 @@ public class XStream2Test extends TestCase {
         }
     }
 
-    public void testTrimVersion() throws Exception {
+    @Test
+    public void trimVersion() {
         assertEquals("3.2", XStream2.trimVersion("3.2"));
         assertEquals("3.2.1", XStream2.trimVersion("3.2.1"));
         assertEquals("3.2-SNAPSHOT", XStream2.trimVersion("3.2-SNAPSHOT (private-09/23/2012 12:26-jhacker)"));
     }
-
 }

--- a/core/src/test/java/hudson/util/io/ReopenableRotatingFileOutputStreamTest.java
+++ b/core/src/test/java/hudson/util/io/ReopenableRotatingFileOutputStreamTest.java
@@ -1,7 +1,10 @@
 package hudson.util.io;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import hudson.FilePath;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,8 +13,10 @@ import java.io.PrintWriter;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class ReopenableRotatingFileOutputStreamTest extends TestCase {
-    public void testRotation() throws IOException, InterruptedException {
+public class ReopenableRotatingFileOutputStreamTest {
+
+    @Test
+    public void rotation() throws IOException, InterruptedException {
         File base = File.createTempFile("test", "log");
         ReopenableRotatingFileOutputStream os = new ReopenableRotatingFileOutputStream(base,3);
         PrintWriter w = new PrintWriter(os,true);

--- a/core/src/test/java/hudson/util/io/ZipArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/ZipArchiverTest.java
@@ -1,27 +1,29 @@
 package hudson.util.io;
 
-import junit.framework.TestCase;
-import org.jvnet.hudson.test.Bug;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
-import java.io.OutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-
-import java.util.Enumeration;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.zip.ZipFile;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.test.Bug;
 
-public class ZipArchiverTest extends TestCase {
+public class ZipArchiverTest {
+
     private static final Logger LOGGER = Logger.getLogger(ZipArchiverTest.class.getName());
-    
+
     private File tmpDir;
-    
-    @Override
-    protected void setUp() {
+
+    @Before
+    public void setUp() {
         try {
             // initialize temp directory
             tmpDir = File.createTempFile("temp", ".dir");
@@ -31,20 +33,21 @@ public class ZipArchiverTest extends TestCase {
             fail("unable to create temp directory", e);
         }
     }
-    
-    @Override
-    protected void tearDown() {
+
+    @After
+    public void tearDown() {
         deleteDir(tmpDir);
     }
-    
+
     @Bug(9942)
-    public void testBackwardsSlashesOnWindows()  {
+    @Test
+    public void backwardsSlashesOnWindows()  {
         // create foo/bar/baz/Test.txt
         File tmpFile = null;
         try {
             File baz = new File(new File(new File(tmpDir, "foo"), "bar"), "baz");
             baz.mkdirs();
-            
+
             tmpFile = new File(baz, "Test.txt");
             tmpFile.createNewFile();
         } catch (IOException e) {
@@ -53,14 +56,14 @@ public class ZipArchiverTest extends TestCase {
 
         // a file to store the zip archive in
         File zipFile = null;
-        
+
         // create zip from tmpDir
         ZipArchiver archiver = null;
-        
+
         try {
             zipFile = File.createTempFile("test", ".zip");
             archiver = new ZipArchiver(new FileOutputStream(zipFile));
-            
+
             archiver.visit(tmpFile, "foo\\bar\\baz\\Test.txt");
         } catch (Exception e) {
             fail("exception driving ZipArchiver", e);
@@ -73,15 +76,15 @@ public class ZipArchiverTest extends TestCase {
                 }
             }
         }
-        
+
         // examine zip contents and assert that none of the entry names (paths) have
         // back-slashes ("\")
         String zipEntryName = null;
-        
-        ZipFile zipFileVerify = null; 
+
+        ZipFile zipFileVerify = null;
         try {
-            zipFileVerify = new ZipFile(zipFile); 
-        
+            zipFileVerify = new ZipFile(zipFile);
+
             zipEntryName = ((ZipEntry) zipFileVerify.entries().nextElement()).getName();
         } catch (Exception e) {
             fail("failure enumerating zip entries", e);
@@ -94,21 +97,21 @@ public class ZipArchiverTest extends TestCase {
                 }
             }
         }
-        
+
         assertEquals("foo/bar/baz/Test.txt", zipEntryName);
     }
-    
+
     /**
      * Convenience method for failing with a cause.
-     * 
+     *
      * @param msg the failure description
      * @param cause the root cause of the failure
      */
     private final void fail(final String msg, final Throwable cause) {
         LOGGER.log(Level.SEVERE, msg, cause);
-        fail(msg);
+        Assert.fail(msg);
     }
-    
+
     /**
      * Recursively deletes a directory and all of its children.
      *
@@ -122,7 +125,7 @@ public class ZipArchiverTest extends TestCase {
                 c.delete();
             }
         }
-        
+
         f.delete();
     }
 }

--- a/core/src/test/java/jenkins/util/MarkFindingOutputStreamTest.java
+++ b/core/src/test/java/jenkins/util/MarkFindingOutputStreamTest.java
@@ -1,29 +1,34 @@
 package jenkins.util;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import org.junit.Test;
+
 /**
  * @author Kohsuke Kawaguchi
  */
-public class MarkFindingOutputStreamTest extends TestCase {
+public class MarkFindingOutputStreamTest {
+
     String mark = MarkFindingOutputStream.MARK;
     String markHead = mark.substring(0, 5);
     String markTail = mark.substring(5);
-    
+
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     MarkCountingOutputStream m = new MarkCountingOutputStream(baos);
 
-    public void testFindTwice() throws IOException {
+    @Test
+    public void findTwice() throws IOException {
         write("foo"+mark+"bar"+mark);
         assertCount(2);
         assertOutput("foobar");
     }
-    
-    public void testPartialMatchTurnsOutToBeWrongIn2ndWrite() throws IOException {
+
+    @Test
+    public void partialMatchTurnsOutToBeWrongIn2ndWrite() throws IOException {
         write("bar"+markHead);
         assertOutput("bar"); // at this point we should just see 'bar'
 
@@ -35,14 +40,16 @@ public class MarkFindingOutputStreamTest extends TestCase {
     /**
      * If a stream closes without completing a match, the partial match should be sent to the output.
      */
-    public void testCloseInTheMiddle() throws IOException {
+    @Test
+    public void closeInTheMiddle() throws IOException {
         write("foo"+ markHead);
         m.close();
         assertCount(0);
         assertOutput("foo"+ markHead);
     }
-    
-    public void testOneByOne() throws IOException {
+
+    @Test
+    public void oneByOne() throws IOException {
         m.write('1');
         writeOneByOne(mark);
         m.write('2');
@@ -50,14 +57,14 @@ public class MarkFindingOutputStreamTest extends TestCase {
         assertOutput("12");
     }
 
-    public void testWriteOneHoldOff() throws IOException {
+    @Test
+    public void writeOneHoldOff() throws IOException {
         writeOneByOne(markHead);
         assertOutput("");
         writeOneByOne("x");
         assertOutput(markHead+"x");
         assertCount(0);
     }
-
 
     private void assertOutput(String s) throws IOException {
         assertEquals(s,baos.toString("UTF-8"));
@@ -70,7 +77,7 @@ public class MarkFindingOutputStreamTest extends TestCase {
     private void write(String s) throws IOException {
         m.write(s.getBytes("UTF-8"));
     }
-    
+
     private void writeOneByOne(String s) throws IOException {
         for (int i=0; i< s.length(); i++)
             m.write(s.charAt(i));

--- a/test/src/test/java/hudson/bugs/DateConversionTest.java
+++ b/test/src/test/java/hudson/bugs/DateConversionTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,7 +24,7 @@
 package hudson.bugs;
 
 import com.thoughtworks.xstream.converters.basic.DateConverter;
-import junit.framework.TestCase;
+import org.junit.Test;
 import org.jvnet.hudson.test.Email;
 
 import java.util.ArrayList;
@@ -39,11 +39,12 @@ import java.util.concurrent.Future;
  * @author Kohsuke Kawaguchi
  */
 @Email("http://www.nabble.com/Date-conversion-problem-causes-IOException-reading-fingerprint-file.-td19201137.html")
-public class DateConversionTest extends TestCase {
+public class DateConversionTest {
     /**
      * Put it under a high-concurrency to make sure nothing bad happens.
      */
-    public void test1() throws Exception {
+    @Test
+    public void test() throws Exception {
         final DateConverter dc =new DateConverter();
         ExecutorService es = Executors.newFixedThreadPool(10);
 


### PR DESCRIPTION
- JUnit3 is quite old and should be replaced by JUnit4 (or maybe even spock)
- for now touching all tests that directly inherit from junit.framework.TestCase
- tests with other base classes may follow
