### PR TITLE
[JENKINS-26270] Added "lastCompletedBuild" to permalinks.

### DIFF
--- a/core/src/main/java/hudson/model/PermalinkProjectAction.java
+++ b/core/src/main/java/hudson/model/PermalinkProjectAction.java
@@ -178,6 +178,19 @@ public interface PermalinkProjectAction extends Action {
                 return !run.isBuilding() && run.getResult()!=Result.SUCCESS;
             }
         };
+        public static final Permalink LAST_COMPLETED_BUILD = new Permalink() {
+            public String getDisplayName() {
+                return Messages.Permalink_LastCompletedBuild();
+            }
+
+            public String getId() {
+                return "lastCompletedBuild";
+            }
+
+            public Run<?,?> resolve(Job<?,?> job) {
+                return job.getLastCompletedBuild();
+            }
+        };
 
         static {
             BUILTIN.add(LAST_BUILD);
@@ -186,6 +199,7 @@ public interface PermalinkProjectAction extends Action {
             BUILTIN.add(LAST_FAILED_BUILD);
             BUILTIN.add(LAST_UNSTABLE_BUILD);
             BUILTIN.add(LAST_UNSUCCESSFUL_BUILD);
+            BUILTIN.add(LAST_COMPLETED_BUILD);
         }
     }
 }

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -299,6 +299,7 @@ Permalink.LastUnstableBuild=Last unstable build
 Permalink.LastUnsuccessfulBuild=Last unsuccessful build
 Permalink.LastSuccessfulBuild=Last successful build
 Permalink.LastFailedBuild=Last failed build
+Permalink.LastCompletedBuild=Last completed build
 
 ParameterAction.DisplayName=Parameters
 ParametersDefinitionProperty.DisplayName=Parameters

--- a/core/src/main/resources/hudson/model/Messages_ja.properties
+++ b/core/src/main/resources/hudson/model/Messages_ja.properties
@@ -272,6 +272,7 @@ Permalink.LastUnstableBuild=\u6700\u65b0\u306e\u4e0d\u5b89\u5b9a\u30d3\u30eb\u30
 Permalink.LastUnsuccessfulBuild=\u6700\u65b0\u306e\u4e0d\u6210\u529f\u30d3\u30eb\u30c9
 Permalink.LastSuccessfulBuild=\u6700\u65b0\u306e\u6210\u529f\u30d3\u30eb\u30c9
 Permalink.LastFailedBuild=\u6700\u65b0\u306e\u5931\u6557\u30d3\u30eb\u30c9
+Permalink.LastCompletedBuild=\u6700\u65b0\u306e\u5b8c\u4e86\u30d3\u30eb\u30c9
 
 
 ParameterAction.DisplayName=\u30d1\u30e9\u30e1\u30fc\u30bf


### PR DESCRIPTION
[JENKINS-26270](https://issues.jenkins-ci.org/browse/JENKINS-26270)
[JENKINS-16476](https://issues.jenkins-ci.org/browse/JENKINS-16476)

`Job#getLastCompletedBuild` works like the lastBuild permalink but excludes running builds.
It is useful to get the latest result and the latest artifacts.
I want to add "lastCompletedBuild" to permalinks, which provides plugins an easy way to switch a build to use:
- lastSuccessfulBuild: the last build with SUCCESS
- lastFailedBuild: the last build with FAILED
- lastCompletedBuild: the last build ignoring the build status
