### PR TITLE
Fixed min/max operations in ComputerRetentionWork

### DIFF
--- a/core/src/main/java/hudson/slaves/ComputerRetentionWork.java
+++ b/core/src/main/java/hudson/slaves/ComputerRetentionWork.java
@@ -63,7 +63,7 @@ public class ComputerRetentionWork extends PeriodicWork {
             if (!nextCheck.containsKey(c) || startRun > nextCheck.get(c)) {
                 // at the moment I don't trust strategies to wait more than 60 minutes
                 // strategies need to wait at least one minute
-                final long waitInMins = Math.min(1, Math.max(60, c.getRetentionStrategy().check(c)));
+                final long waitInMins = Math.max(1, Math.min(60, c.getRetentionStrategy().check(c)));
                 nextCheck.put(c, startRun + waitInMins*1000*60 /*MINS->MILLIS*/);
             }
         }


### PR DESCRIPTION
I came  across this code while investigating a deadlock. The implementation of the min/max operations meant that the nextCheck would always happen in 1 minute, regardless of what the RetentionStrategy.check() returned.

Based on the comments, I think the min/max should be coded as per this patch.
