### PR TITLE
[JENKINS-26331] configurable target directory for WarExploder

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/WarExploder.java
+++ b/test/src/main/java/org/jvnet/hudson/test/WarExploder.java
@@ -88,7 +88,8 @@ final class WarExploder {
         File war = Which.jarFile(Class.forName("executable.Executable"));
 
         // TODO this assumes that the CWD of the Maven process is the plugin ${basedir}, which may not be the case
-        File explodeDir = new File("./target/jenkins-for-test").getAbsoluteFile();
+        File buildDirectory = new File(System.getProperty("buildDirectory", "target"));
+        File explodeDir = new File(buildDirectory, "jenkins-for-test").getAbsoluteFile();
         explodeDir.getParentFile().mkdirs();
         while (new File(explodeDir + ".exploding").isFile()) {
             explodeDir = new File(explodeDir + "x");


### PR DESCRIPTION
See [JENKINS-26331](https://issues.jenkins-ci.org/browse/JENKINS-26331).

This uses the same system property as [JenkinsRule](https://github.com/jenkinsci/jenkins/blob/jenkins-1.596/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java#L647) or [HudsonTestCase](https://github.com/jenkinsci/jenkins/blob/jenkins-1.596/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java#L569).
