### PR TITLE
[FIXED JENKINS-26382] Allow admin signup from /manage as well

### DIFF
--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -697,7 +697,8 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
             HttpServletRequest req = (HttpServletRequest) request;
 
-            if(req.getRequestURI().equals(req.getContextPath()+"/")) {
+            /* allow signup from the Jenkins home page, or /manage, which is where a /configureSecurity form redirects to */
+            if(req.getRequestURI().equals(req.getContextPath()+"/") || req.getRequestURI().equals(req.getContextPath() + "/manage")) {
                 if (needsToCreateFirstUser()) {
                     ((HttpServletResponse)response).sendRedirect("securityRealm/firstUser");
                 } else {// the first user already created. the role of this filter is over.


### PR DESCRIPTION
Currently, it looks like Jenkins locks out users from their instance when they configure security realm (Jenkins user database) and authorization strategy (something restrictive, like matrix-auth) at the same time, especially with disabled user signup. After the form is submitted, a login form is shown, but there are no valid credentials.

While Jenkins protects against this by allowing first user (admin) signup from the home page, that's not where the `/configureSecurity` form redirects to. It redirects to `/manage`, which shows the login form.

Solution: Redirect to the first user signup from `/manage` as well.
