### PR TITLE
[JENKINS-26249] Fix deadlock in CloudRetentionStrategy

### DIFF
--- a/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
@@ -29,6 +29,7 @@ import hudson.model.Queue;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
 
 import static hudson.util.TimeUnit2.*;
@@ -44,36 +45,43 @@ import static java.util.logging.Level.*;
  */
 public class CloudRetentionStrategy extends RetentionStrategy<AbstractCloudComputer> {
     private int idleMinutes;
+    private ReentrantLock checkLock = new ReentrantLock();
 
     public CloudRetentionStrategy(int idleMinutes) {
         this.idleMinutes = idleMinutes;
     }
 
     @Override
-    public synchronized long check(final AbstractCloudComputer c) {
-        final AbstractCloudSlave computerNode = c.getNode();
-        if (c.isIdle() && !disabled && computerNode != null) {
-            final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
-            if (idleMilliseconds > MINUTES.toMillis(idleMinutes)) {
-                Queue.withLock(new Runnable() {
-                    @Override
-                    public void run() {
-                        // re-check idle now that we are within the Queue lock
-                        if (c.isIdle()) {
-                            final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
-                            if (idleMilliseconds > MINUTES.toMillis(idleMinutes)) {
-                                LOGGER.log(Level.INFO, "Disconnecting {0}", c.getName());
-                                try {
-                                    computerNode.terminate();
-                                } catch (InterruptedException e) {
-                                    LOGGER.log(WARNING, "Failed to terminate " + c.getName(), e);
-                                } catch (IOException e) {
-                                    LOGGER.log(WARNING, "Failed to terminate " + c.getName(), e);
+    public long check(final AbstractCloudComputer c) {
+        if (checkLock.tryLock()) {
+            try {
+                final AbstractCloudSlave computerNode = c.getNode();
+                if (c.isIdle() && !disabled && computerNode != null) {
+                    final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
+                    if (idleMilliseconds > MINUTES.toMillis(idleMinutes)) {
+                        Queue.withLock(new Runnable() {
+                            @Override
+                            public void run() {
+                                // re-check idle now that we are within the Queue lock
+                                if (c.isIdle()) {
+                                    final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
+                                    if (idleMilliseconds > MINUTES.toMillis(idleMinutes)) {
+                                        LOGGER.log(Level.INFO, "Disconnecting {0}", c.getName());
+                                        try {
+                                            computerNode.terminate();
+                                        } catch (InterruptedException e) {
+                                            LOGGER.log(WARNING, "Failed to terminate " + c.getName(), e);
+                                        } catch (IOException e) {
+                                            LOGGER.log(WARNING, "Failed to terminate " + c.getName(), e);
+                                        }
+                                    }
                                 }
                             }
-                        }
+                        });
                     }
-                });
+                }
+            } finally {
+                checkLock.unlock();
             }
         }
         return 1;

--- a/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
@@ -45,10 +45,16 @@ import static java.util.logging.Level.*;
  */
 public class CloudRetentionStrategy extends RetentionStrategy<AbstractCloudComputer> {
     private int idleMinutes;
-    private ReentrantLock checkLock = new ReentrantLock();
+    private transient ReentrantLock checkLock;
 
     public CloudRetentionStrategy(int idleMinutes) {
         this.idleMinutes = idleMinutes;
+        readResolve();
+    }
+
+    protected Object readResolve() {
+        checkLock = new ReentrantLock();
+        return this;
     }
 
     @Override


### PR DESCRIPTION
As described in JENKINS-26249, this change fixes one deadlock scenario when removing a Docker node. It uses a ReentrantLock instead of a synchronized method, a technique I saw used in other RetentionStrategy classes. If the lock cannot be obtained, the check doesn't do anything. From what I understand, this is acceptable as the check() method makes no guarantees about when it will run.

Deadlocks can still happen between the Queue and the Jenkins / Hudson model, I'm testing a fix for JENKINS-26380 now that will fix that.
