### PR TITLE
[JENKINS-755] Describe the built-in JDK as '(System)'.

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -351,7 +351,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
                 jdkTool = jdkTool.forNode(node, listener);
             }
             jdkTool.buildEnvVars(env);
-        } else if (jdk != null && !jdk.equals(JDK.DEFAULT_NAME)) {
+        } else if (!JDK.isDefaultName(jdk)) {
             listener.getLogger().println("No JDK named ‘" + jdk + "’ found");
         }
 

--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -45,6 +45,8 @@ import java.util.Collections;
 
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Information about JDK installation.
@@ -58,6 +60,15 @@ public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, En
      * @since 1.577
      */
     public static final String DEFAULT_NAME = "(System)";
+
+    @Restricted(NoExternalUse.class)
+    public static boolean isDefaultName(String name) {
+        if ("(Default)".equals(name)) {
+            // DEFAULT_NAME took this value prior to 1.598.
+            return true;
+        }
+        return DEFAULT_NAME.equals(name);
+    }
 
     /**
      * @deprecated since 2009-02-25

--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -54,10 +54,10 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, EnvironmentSpecific<JDK> {
 
     /**
-     * Name of the “default JDK”, meaning no specific JDK selected.
+     * Name of the “System JDK”, which is just the JDK on Jenkins' $PATH.
      * @since 1.577
      */
-    public static final String DEFAULT_NAME = "(Default)";
+    public static final String DEFAULT_NAME = "(System)";
 
     /**
      * @deprecated since 2009-02-25

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3627,7 +3627,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * If the user chose the default JDK, make sure we got 'java' in PATH.
      */
     public FormValidation doDefaultJDKCheck(StaplerRequest request, @QueryParameter String value) {
-        if(!value.equals(JDK.DEFAULT_NAME))
+        if(!JDK.isDefaultName(value))
             // assume the user configured named ones properly in system config ---
             // or else system config should have reported form field validation errors.
             return FormValidation.ok();

--- a/core/src/test/java/jenkins/model/JDKNameTest.java
+++ b/core/src/test/java/jenkins/model/JDKNameTest.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import hudson.model.JDK;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.Issue;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public class JDKNameTest {
+    @Test
+    public void nullIsNotDefaultName() {
+        assertThat(JDK.isDefaultName(null), is(false));
+    }
+    
+    @Test
+    public void recognizeOldDefaultName() {
+        // DEFAULT_NAME took this value prior to 1.598.
+        assertThat(JDK.isDefaultName("(Default)"), is(true));
+    }
+    
+    @Test
+    public void recognizeDefaultName() {
+        assertThat(JDK.isDefaultName(JDK.DEFAULT_NAME), is(true));
+    }
+    
+    @Test
+    public void othernameNotDefault() {
+        assertThat(JDK.isDefaultName("I'm a customized name"), is(false));
+    }
+    
+}


### PR DESCRIPTION
As suggested in
https://issues.jenkins-ci.org/browse/JENKINS-755?focusedCommentId=206175&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-206175
this avoids confusion where users incorrectly think they're getting a
JDK they've listed in the configuration page.
