### PR TITLE
[JENKINS-26411] Improve error reporting when channel closed during build

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -760,8 +760,10 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 canContinue = mon.perform(bs, AbstractBuild.this, launcher, listener);
             } catch (RequestAbortedException ex) {
                 // Channel is closed, do not continue
-                listener.error("Slave went offline during the build.");
-                final OfflineCause offlineCause = getCurrentNode().toComputer().getOfflineCause();
+                final Node node = getCurrentNode();
+                listener.hyperlink("/" + node.toComputer().getUrl() + "log", "Slave went offline during the build");
+                listener.getLogger().println();
+                final OfflineCause offlineCause = node.toComputer().getOfflineCause();
                 if (offlineCause != null) {
                     listener.error(offlineCause.toString());
                 }

--- a/test/src/test/groovy/hudson/model/AbstractBuildTest.groovy
+++ b/test/src/test/groovy/hudson/model/AbstractBuildTest.groovy
@@ -23,19 +23,23 @@
  */
 package hudson.model
 
+import java.io.IOException;
+
 import com.gargoylesoftware.htmlunit.Page
 
+import hudson.Launcher;
 import hudson.slaves.EnvironmentVariablesNodeProperty
 import hudson.slaves.EnvironmentVariablesNodeProperty.Entry
 
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder
 import org.jvnet.hudson.test.GroovyJenkinsRule
-
 import org.jvnet.hudson.test.FakeChangeLogSCM
 import org.jvnet.hudson.test.FailureBuilder
 import org.jvnet.hudson.test.UnstableBuilder
 
 import static org.junit.Assert.*
+import static org.hamcrest.CoreMatchers.*;
+
 import org.junit.Rule
 import org.junit.Test
 import org.jvnet.hudson.test.Issue
@@ -136,4 +140,20 @@ public class AbstractBuildTest {
         assertEquals(null, b1.getNextBuild());
     }
 
+    @Test void doNotInteruptBuildAbruptlyWhenExceptionThrownFromBuildStep() {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new ThrowBuilder());
+        def build = p.scheduleBuild2(0).get();
+        j.assertBuildStatus(Result.FAILURE, build);
+
+        def log = build.log;
+        assertThat(log, containsString("Finished: FAILURE"));
+        assertThat(log, containsString("Build step 'Bogus' marked build as failure"));
+    }
+
+    private static class ThrowBuilder extends org.jvnet.hudson.test.TestBuilder {
+        @Override public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            throw new NullPointerException();
+        }
+    }
 }

--- a/test/src/test/java/hudson/model/ExecutorTest.java
+++ b/test/src/test/java/hudson/model/ExecutorTest.java
@@ -141,6 +141,8 @@ public class ExecutorTest {
         assertEquals(b.getResult(), Result.FAILURE);
         assertThat(log, containsString("Finished: FAILURE"));
         assertThat(log, containsString("Build step 'Bogus' marked build as failure"));
+        assertThat(log, containsString("Slave went offline during the build"));
+        assertThat(log, containsString("Disconnected by Johnny : Taking offline to break your buil"));
     }
 
     private Future<FreeStyleBuild> startBlockingBuild(FreeStyleProject p) throws Exception {

--- a/test/src/test/java/hudson/model/ExecutorTest.java
+++ b/test/src/test/java/hudson/model/ExecutorTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.*;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import hudson.Launcher;
+import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
 import hudson.util.OneShotEvent;
@@ -166,10 +167,13 @@ public class ExecutorTest {
 
         @Override
         public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            VirtualChannel channel = launcher.getChannel();
+            Node node = build.getBuiltOn();
+
             e.signal(); // we are safe to be interrupted
             for (;;) {
                 // Keep using the channel
-                build.getBuiltOn().getClockDifference();
+                channel.call(node.getClockDifferenceCallable());
                 Thread.sleep(100);
             }
         }


### PR DESCRIPTION
[JENKINS-26411](https://issues.jenkins-ci.org/browse/JENKINS-26411)

There are several partial improvements:
- When there is an exception thrown from BuildStep do not interrupt abruptly. Print exception and report build step failure.
- If such exception indicate the channel is closed print offline cause (if is there any) instead of stacktrace.
  - Do not attach slave log as it not always indicate what happened (user disconnected slave) and leak information otherwise protected by `Computer.CONNECT` (see `log.jelly`).
- Do not try to kill leftover processes if slave is already disconnected. It is doomed to fail cluttering the build log.
