### PR TITLE
Update login.jelly to avoid autocorrect of username on mobile devices

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
           <table>
             <tr>
               <td>${%User}:</td>
-              <td><input type="text" name="j_username" id="j_username" /></td>
+              <td><input type="text" name="j_username" id="j_username" autocorrect="off" autocapitalize="off" /></td>
             </tr>
             <tr>
               <td>${%Password}:</td>


### PR DESCRIPTION
Added autocorrect off and autocapitalize off to username input. This switches off functionality on mobile devices which attempts to auto correct text entered into the username field, and removes automatic capitalisation of first word entered.
