### PR TITLE
[FIXED JENKINS-6610] RSS feeds accept basic authentication

### DIFF
--- a/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
+++ b/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
@@ -38,7 +38,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
-
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -56,7 +56,7 @@ import java.text.MessageFormat;
  *
  * <p>
  * The page that programs see is entirely white, and it auto-redirects,
- * so humans wouldn't notice it. 
+ * so humans wouldn't notice it.
  *
  * @author Kohsuke Kawaguchi
  */
@@ -74,6 +74,9 @@ public class HudsonAuthenticationEntryPoint extends AuthenticationProcessingFilt
             // this is not desirable, so don't redirect AJAX requests to the user.
             // this header value is sent from Prototype.
             rsp.sendError(SC_FORBIDDEN);
+        } else if (req.getPathInfo().equals("/rssAll")) {
+            rsp.setStatus(SC_UNAUTHORIZED);
+            rsp.setHeader("WWW-Authenticate", "Basic realm=\"Jenkins\"");
         } else {
             // give the opportunity to include the target URL
             String uriFrom = req.getRequestURI();


### PR DESCRIPTION
I read several solutions from https://issues.jenkins-ci.org/browse/JENKINS-6610. However, not all the RSS clients report that they don't accept `Accept: text/html`. Vienna for MAC, for example, reports that it accepts `text/html`, so I guess that the solution provided by Jessy cannot be applied here.

Basically, I filter `/rssAll` from the request, so in case security is enabled in the instance, then Jenkins will ask for Basic Authentication to the RSS client. This seems to work perfectly at least in the RSS clients I have been working on: Vienna and FeedDemon Pro 4.5

If you prefer a different solution, please, feel free to explain it and I will be happy to implement it.
