### PR TITLE
Also adapt ownership of /var/cache/jenkins in RPM spec

### DIFF
--- a/rpm/SPECS/jenkins.spec
+++ b/rpm/SPECS/jenkins.spec
@@ -111,6 +111,7 @@ fi
 # Ensure the right ownership on files
 . /etc/sysconfig/jenkins
 chown -R ${JENKINS_USER:-jenkins} /var/log/jenkins
+chown -R ${JENKINS_USER:-jenkins} /var/cache/jenkins
 chown -R ${JENKINS_USER:-jenkins} ${JENKINS_HOME:-%{workdir}}
 
 %preun


### PR DESCRIPTION
I propose the following fix for https://issues.jenkins-ci.org/browse/JENKINS-26460 (reported by myself).
