### PR TITLE
[JENKINS-26476] Avoid CNFE on ServletException

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1581,6 +1581,7 @@ public final class FilePath implements Serializable {
         act(new SecureFileCallable<Void>() {
             private static final long serialVersionUID = 1L;
             public Void invoke(File f, VirtualChannel channel) throws IOException {
+                // TODO first check for Java 7+ and use PosixFileAttributeView
                 _chmod(writing(f), mask);
 
                 return null;
@@ -1592,7 +1593,9 @@ public final class FilePath implements Serializable {
      * Run chmod via jnr-posix
      */
     private static void _chmod(File f, int mask) throws IOException {
-        if (Functions.isWindows())  return; // noop
+        // TODO WindowsPosix actually does something here (WindowsLibC._wchmod); should we let it?
+        // Anyway the existing calls already skip this method if on Windows.
+        if (File.pathSeparatorChar==';')  return; // noop
 
         PosixAPI.jnr().chmod(f.getAbsolutePath(),mask);
     }


### PR DESCRIPTION
[JENKINS-26476](https://issues.jenkins-ci.org/browse/JENKINS-26476)

Not intended to be a full fix, just a way to avoid the problem at least for the case of `FilePath.chmod`. (Other less commonly used methods may still hit it.)

The better fix for Java 7+ would be to bypass JNR altogether and just check for native JRE methods to manipulate POSIX file attributes.

@reviewbybees
