### PR TITLE
[FIXED JENKINS-26406] Build history text field wrap fails when containing markup

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -956,7 +956,6 @@ table.parameters > tbody:hover {
   margin-top: 5px;
   white-space: normal;
   opacity: 0.6;
-  font-style: italic;
 }
 
 #buildHistory .build-row-cell {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1681,9 +1681,9 @@ function updateBuildHistory(ajaxUrl,nBuild) {
         resetCellOverflows();
 
         // Insert zero-width spaces so as to allow text to wrap, allowing us to get the true clientWidth.
-        insertZeroWidthSpaces(displayName, 2);
+        insertZeroWidthSpacesInElementText(displayName, 2);
         if (desc) {
-            insertZeroWidthSpaces(desc, 30);
+            insertZeroWidthSpacesInElementText(desc, 30);
             markMultiline();
         }
 
@@ -1701,7 +1701,7 @@ function updateBuildHistory(ajaxUrl,nBuild) {
             // If the name is overflowed, lets remove the zero-width spaces we added above and
             // re-add zero-width spaces with a bigger max word sizes.
             removeZeroWidthSpaces(displayName);
-            insertZeroWidthSpaces(displayName, 20);
+            insertZeroWidthSpacesInElementText(displayName, 20);
         }
 
         function fitToControlsHeight(element) {
@@ -1871,11 +1871,11 @@ function updateBuildHistory(ajaxUrl,nBuild) {
         // Insert zero-width spaces in text that may cause overflow distortions.
         var displayNames = $(bh).getElementsBySelector('.display-name');
         for (var i = 0; i < displayNames.length; i++) {
-            insertZeroWidthSpaces(displayNames[i], 2);
+            insertZeroWidthSpacesInElementText(displayNames[i], 2);
         }
         var descriptions = $(bh).getElementsBySelector('.desc');
         for (var i = 0; i < descriptions.length; i++) {
-            insertZeroWidthSpaces(descriptions[i], 30);
+            insertZeroWidthSpacesInElementText(descriptions[i], 30);
         }
 
         for (var i = 0; i < rows.length; i++) {
@@ -1968,13 +1968,17 @@ function getElementOverflowParams(element) {
 }
 
 var zeroWidthSpace = String.fromCharCode(8203);
-function insertZeroWidthSpaces(element, maxWordSize) {
-    if (Element.hasClassName(element, 'zws-inserted')) {
-        // already done.
+var ELEMENT_NODE = 1;
+var TEXT_NODE = 3;
+function insertZeroWidthSpacesInText(textNode, maxWordSize) {
+    if (textNode.textContent.length < maxWordSize) {
         return;
     }
 
-    var words = element.textContent.split(/\s+/);
+    // capture the original text
+    textNode.preZWSText = textNode.textContent;
+
+    var words = textNode.textContent.split(/\s+/);
     var newTextContent = '';
 
     var splitRegex = new RegExp('.{1,' + maxWordSize + '}', 'g');
@@ -1995,12 +1999,49 @@ function insertZeroWidthSpaces(element, maxWordSize) {
         newTextContent += ' ';
     }
 
-    element.textContent = newTextContent;
+    textNode.textContent = newTextContent;
+}
+function insertZeroWidthSpacesInElementText(element, maxWordSize) {
+    if (Element.hasClassName(element, 'zws-inserted')) {
+        // already done.
+        return;
+    }
+    if (!element.hasChildNodes()) {
+        return;
+    }
+
+    var children = element.childNodes;
+    for (var i = 0; i < children.length; i++) {
+        var child = children[i];
+        if (child.nodeType === TEXT_NODE) {
+            insertZeroWidthSpacesInText(child, maxWordSize);
+        } else if (child.nodeType === ELEMENT_NODE) {
+            insertZeroWidthSpacesInElementText(child, maxWordSize);
+        }
+    }
+
     Element.addClassName(element, 'zws-inserted');
 }
 function removeZeroWidthSpaces(element) {
     if (element) {
-        element.textContent = element.textContent.replace(zeroWidthSpace, '');
+        if (!Element.hasClassName(element, 'zws-inserted')) {
+            // Doesn't have ZWSed text.
+            return;
+        }
+        if (!element.hasChildNodes()) {
+            return;
+        }
+
+        var children = element.childNodes;
+        for (var i = 0; i < children.length; i++) {
+            var child = children[i];
+            if (child.nodeType === TEXT_NODE && child.preZWSText) {
+                child.textContent = child.preZWSText;
+            } else if (child.nodeType === ELEMENT_NODE) {
+                removeZeroWidthSpaces(child);
+            }
+        }
+
         Element.removeClassName(element, 'zws-inserted');
     }
 }


### PR DESCRIPTION
See [JENKINS-26406](https://issues.jenkins-ci.org/browse/JENKINS-26406).

Fix changes how text is wrapped by navigating the DOM element's child elements and only manipulating the TEXT nodes Vs just doing a blanket get and replace on the top element's text.

[jenkins.war](https://jenkins.ci.cloudbees.com/job/core/job/jenkins-core/2055/artifact/war/target/jenkins.war) for testing.
