### PR TITLE
[FIXED JENKINS-26365] Animated ball in job's build history widget won't open Console Output

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -58,6 +58,9 @@ Upcoming changes</a>
   <li class=bug>
     Remote <code>FilePath.chmod</code> fails with <code>ClassNotFoundException: javax.servlet.ServletException</code>.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26476">issue 26476</a>)
+  <li class=bug>
+    Animated ball in job's build history widget won't open Console Output.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26365">issue 26365</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1066,7 +1066,7 @@ table.parameters > tbody:hover {
 
 .build-row-cell .pane.build-name .display-name,
 .build-row-cell .indent-multiline {
-  padding-left: 20px !important;  /* Sync changes with func expandControlsTo50Percent in hudson-behavior.js */
+  margin-left: 20px !important;  /* Sync changes with func expandControlsTo50Percent in hudson-behavior.js */
 }
 
 .build-row .build-row-cell {


### PR DESCRIPTION
See [JENKINS-26365](https://issues.jenkins-ci.org/browse/JENKINS-26365).
