### PR TITLE
[JENKINS-25953] Tabs in job view are mis-aligned

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -426,11 +426,10 @@ pre.console {
   display: none;
 }
 .tabBar [type=radio]:checked ~ a {
-  border: solid 1px #f0f0f0;
+  border: none;
   background: #eee;
   color: #000;
   font-weight: bold;
-  border-bottom: 1px solid #eee;
   z-index: 2;
 }
 .tabBarBaseline {


### PR DESCRIPTION
Before: 
![beforefix_jenkins-25953](https://cloud.githubusercontent.com/assets/496507/5893332/d0dd9c40-a494-11e4-9307-6459b205b328.png)

After (Chrome):
![afterfix_jenkins-25953_chrome](https://cloud.githubusercontent.com/assets/496507/5906480/cffc8184-a54c-11e4-8f92-b246be90fca1.png)

After (Firefox):
![afterfix_jenkins-25953_firefox](https://cloud.githubusercontent.com/assets/496507/5906492/dfa10466-a54c-11e4-909e-efadf2b58a63.png)
