### PR TITLE
[FIXED JENKINS-26081] - Footer overlaps with Save/Apply buttons

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Daniel Dyer, Stephen Connolly
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -123,6 +123,10 @@ body {
 }
 
 #footer-container {
+  position: fixed;
+  bottom: 0px;
+  left: 0px;
+  z-index: 99999;
   width: 100%;
   padding: 10px 0px;
   border-top: 1px solid #d3d7cf;
@@ -341,7 +345,7 @@ pre {/* see http://users.tkk.fi/tkarvine/pre-wrap-css3-mozilla-opera-ie.html */
 }
 
 pre a {
-    word-wrap: break-word;	
+    word-wrap: break-word;
 }
 
 pre.console {
@@ -1318,7 +1322,7 @@ DIV.yahooTree td {
   height: 24px;
   padding-left: 20px;
   width: 15em;
-  position: static; 
+  position: static;
   border: 1px solid #DDD;
   border-radius: 4px;
   box-shadow: 0 0 5px #DDD inset;

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1,19 +1,19 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi,
  * Daniel Dyer, Yahoo! Inc., Alan Harder, InfraDNA, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -561,7 +561,7 @@ function renderOnDemand(e,callback,noBehaviour) {
 }
 
 /**
- * Finds all the script tags 
+ * Finds all the script tags
  */
 function evalInnerHtmlScripts(text,callback) {
     var q = [];
@@ -680,7 +680,7 @@ var jenkinsRules = {
         registerRegexpValidator(e,/^(\d*[1-9]\d*|)$/,"Not a positive integer");
     },
 
-    "INPUT.auto-complete": function(e) {// form field with auto-completion support 
+    "INPUT.auto-complete": function(e) {// form field with auto-completion support
         // insert the auto-completion container
         var div = document.createElement("DIV");
         e.parentNode.insertBefore(div,$(e).next()||null);
@@ -692,7 +692,7 @@ var jenkinsRules = {
             resultsList: "suggestions",
             fields: ["name"]
         };
-        
+
         // Instantiate the AutoComplete
         var ac = new YAHOO.widget.AutoComplete(e, div, ds);
         ac.generateRequest = function(query) {
@@ -748,7 +748,7 @@ var jenkinsRules = {
             var cmdKeyDown = false;
             var mode = e.getAttribute("script-mode") || "text/x-groovy";
             var readOnly = eval(e.getAttribute("script-readOnly")) || false;
-            
+
             var w = CodeMirror.fromTextArea(e,{
               mode: mode,
               lineNumbers: true,
@@ -773,7 +773,7 @@ var jenkinsRules = {
                 function getParentForm(element) {
                     if (element == null) throw 'not found a parent form';
                     if (element instanceof HTMLFormElement) return element;
-                    
+
                     return getParentForm(element.parentNode);
                 }
                 function saveAndSubmit() {
@@ -781,7 +781,7 @@ var jenkinsRules = {
                     getParentForm(e).submit();
                     event.stop();
                 }
-                
+
                 // Mac (Command + Enter)
                 if (navigator.userAgent.indexOf('Mac') > -1) {
                     if (event.type == 'keydown' && isCommandKey()) {
@@ -794,7 +794,7 @@ var jenkinsRules = {
                         saveAndSubmit();
                         return true;
                     }
-                  
+
                 // Windows, Linux (Ctrl + Enter)
                 } else {
                     if (event.ctrlKey && isReturnKeyDown()) {
@@ -1158,6 +1158,7 @@ var jenkinsRules = {
         var DOM = YAHOO.util.Dom;
 
         var shadow = document.createElement("div");
+        var footer = document.getElementById("footer-container");
         sticker.parentNode.insertBefore(shadow,sticker);
 
         var edge = document.createElement("div");
@@ -1173,6 +1174,9 @@ var jenkinsRules = {
             sticker.style.position = "fixed";
 
             var bottomPos = Math.max(0, viewport.bottom - pos.bottom);
+            if(bottomPos < footer.offsetHeight){
+                bottomPos += footer.offsetHeight - bottomPos;
+            }
 
             sticker.style.bottom = bottomPos + "px"
             sticker.style.left = Math.max(0,pos.left-viewport.left) + "px"
@@ -1458,14 +1462,14 @@ function expandTextArea(button,id) {
     button.style.display="none";
     var field = button.parentNode.previousSibling.children[0];
     var value = field.value.replace(/ +/g,'\n');
-    
-    var n = button; 
+
+    var n = button;
     while (n.tagName != "TABLE")
     {
         n = n.parentNode;
     }
 
-    n.parentNode.innerHTML = 
+    n.parentNode.innerHTML =
         "<textarea rows=8 class='setting-input' name='"+field.name+"'>"+value+"</textarea>";
     layoutUpdateCallback.call();
 }
@@ -1496,13 +1500,13 @@ function refreshPart(id,url) {
                     if(isRunAsTest) return;
                     refreshPart(id,url);
                 }
-            });    
+            });
         } else {
             // Reschedule
             if(isRunAsTest) return;
             refreshPart(id,url);
         }
-        
+
     };
     // if run as test, just do it once and do it now to make sure it's working,
     // but don't repeat.
@@ -2010,6 +2014,7 @@ Element.observe(document, 'dom:loaded', function(){
         return;
     }
 
+    var body = $$("body")[0];
     var pageHead = $('page-head');
     var pageBody = $('page-body');
     var sidePanel = $(pageBody).getElementsBySelector('#side-panel')[0];
@@ -2045,6 +2050,8 @@ Element.observe(document, 'dom:loaded', function(){
 
         minPageBodyHeight = Math.max(minPageBodyHeight, sidePanelHeight);
         minPageBodyHeight = Math.max(minPageBodyHeight, mainPanelHeight);
+
+        $(body).setStyle({paddingBottom: footerHeight + 'px'});
 
         $(pageBody).setStyle({minHeight: minPageBodyHeight + 'px'});
         $(sidePanel).setStyle({minHeight: minPageBodyHeight + 'px'});
@@ -2204,7 +2211,7 @@ function createSearchBox(searchURL) {
         sizer.innerHTML = box.value.escapeHTML();
         var w = max(sizer.offsetWidth,minW.offsetWidth);
         box.style.width =
-        comp.style.width = 
+        comp.style.width =
         comp.firstChild.style.width = (w+60)+"px";
 
         var pos = YAHOO.util.Dom.getXY(box);
@@ -2331,7 +2338,7 @@ function buildFormTree(form) {
                 addProperty(findParent(e),e.name,values);
                 continue;
             }
-                
+
             var p;
             var r;
             var type = e.getAttribute("type");
@@ -2461,7 +2468,7 @@ var hoverNotification = (function() {
         document.body.appendChild(div);
         div.innerHTML = "<div id=hoverNotification><div class=bd></div></div>";
         body = $('hoverNotification');
-        
+
         msgBox = new YAHOO.widget.Overlay(body, {
           visible:false,
           width:"10em",


### PR DESCRIPTION
- Footer container is set to fixed to be always at the bottom.
- To avoid [JENKINS-26312] problem updated bottom sticker calculations to include footer height. 
- To be sure that content is not hidden under footer, update body css attribute with padding-bottom: {footer-height}
- Commit includes some unnecessary space removals
