### PR TITLE
JENKINS-26604 Ensures GlobalSettingsProvider does not swallow fatal exceptions

### DIFF
--- a/core/src/main/java/jenkins/mvn/GlobalSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/GlobalSettingsProvider.java
@@ -51,11 +51,7 @@ public abstract class GlobalSettingsProvider extends AbstractDescribableImpl<Glo
     public static final FilePath getSettingsFilePath(GlobalSettingsProvider settings, AbstractBuild<?, ?> build, TaskListener listener) {
         FilePath settingsPath = null;
         if (settings != null) {
-            try {
-                settingsPath = settings.supplySettings(build, listener);
-            } catch (Exception e) {
-                listener.getLogger().print("failed to get the path to the alternate global settings.xml");
-            }
+            settingsPath = settings.supplySettings(build, listener);
         }
         return settingsPath;
     }


### PR DESCRIPTION
If there is a problem providing the Maven global settings file configured by the user, the build
should end in error. This is the behavior of SettingsProvider but not of GlobalSettingsProvider, which
was swallowing the exception and printing only a warning, without details of the exception.
