### PR TITLE
JDK installer on OSX

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,6 +55,8 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
+  <li class="rfe">
+    JDK auto-installer for Mac OSX
   <li class='major bug'>
     Build format change migrator in 1.597 did not work on some Windows systems.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26519">issue 26519</a>)


### PR DESCRIPTION
This installer allows to download official Oracle JDK and install automatically. It mount DMG bundle and unpack the installer's pkg to only extract the actual JDK. 
