### PR TITLE
[JENKINS-26687] Better exception message for JSONSignatureValidator.verifySignature()

### DIFF
--- a/core/src/main/java/jenkins/util/JSONSignatureValidator.java
+++ b/core/src/main/java/jenkins/util/JSONSignatureValidator.java
@@ -1,5 +1,7 @@
 package jenkins.util;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
 import com.trilead.ssh2.crypto.Base64;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
@@ -73,7 +75,17 @@ public class JSONSignatureValidator {
                     certs.add(c);
                 }
 
-                CertificateUtil.validatePath(certs, loadTrustAnchors(cf));
+                try {
+                    CertificateUtil.validatePath(certs, loadTrustAnchors(cf));
+                } catch (GeneralSecurityException | IOException e) {
+                    Iterable<Object> certSubjectDNs = Iterables.transform(certs, new Function<X509Certificate, Object>() {
+                        @Override
+                        public Object apply(X509Certificate cert) {
+                            return cert == null ? null : cert.getSubjectDN();
+                        }
+                    });
+                    return FormValidation.warning(e,String.format("Certificate validation failed with certs %s in %s", certSubjectDNs.toString(), name));
+                }
             }
 
             // this is for computing a digest to check sanity

--- a/core/src/main/java/jenkins/util/JSONSignatureValidator.java
+++ b/core/src/main/java/jenkins/util/JSONSignatureValidator.java
@@ -77,14 +77,14 @@ public class JSONSignatureValidator {
 
                 try {
                     CertificateUtil.validatePath(certs, loadTrustAnchors(cf));
-                } catch (GeneralSecurityException | IOException e) {
+                } catch (GeneralSecurityException e) {
                     Iterable<Object> certSubjectDNs = Iterables.transform(certs, new Function<X509Certificate, Object>() {
                         @Override
                         public Object apply(X509Certificate cert) {
                             return cert == null ? null : cert.getSubjectDN();
                         }
                     });
-                    return FormValidation.warning(e,String.format("Certificate validation failed with certs %s in %s", certSubjectDNs.toString(), name));
+                    return FormValidation.warning(e,String.format("Certificate validation failed with certs %s for %s: %s", certSubjectDNs.toString(), name, e.toString()));
                 }
             }
 


### PR DESCRIPTION
[JENKINS-26687](https://issues.jenkins-ci.org/browse/JENKINS-26687)

Add the SubjectDN of the evaluated X509 certificates when the validation of the JSON file of a "Downloadable Tool Installer" fails.
