### PR TITLE
Added test for env var expansion in SimpleBuildWrapper

### DIFF
--- a/test/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
+++ b/test/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
@@ -98,7 +98,7 @@ public class SimpleBuildWrapperTest {
         p.getBuildersList().add(captureEnvironment);
         p.getBuildersList().add(new Shell("echo effective PATH=$PATH"));
         FreeStyleBuild b = r.buildAndAssertSuccess(p);
-        String expected = "/home/jenkins/bin:/opt/jdk/bin:/usr/bin:/bin";
+        String expected = "/home/jenkins/extra/bin:/opt/jdk/bin:/usr/bin:/bin";
         assertEquals(expected, captureEnvironment.getEnvVars().get("PATH"));
         // TODO why is /opt/jdk/bin added twice? In CommandInterpreter.perform, envVars right before Launcher.launch is correct, but this somehow sneaks in.
         r.assertLogContains("effective PATH=/opt/jdk/bin:" + expected, b);
@@ -107,7 +107,8 @@ public class SimpleBuildWrapperTest {
         @Override public void setUp(Context context, Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
             assertEquals("/opt/jdk/bin:/usr/bin:/bin", initialEnvironment.get("PATH"));
             assertEquals("/home/jenkins", initialEnvironment.get("HOME"));
-            context.env("PATH+STUFF", "${HOME}/bin");
+            context.env("EXTRA", "${HOME}/extra");
+            context.env("PATH+EXTRA", "${EXTRA}/bin");
         }
         @TestExtension("envOverrideExpand") public static class DescriptorImpl extends BuildWrapperDescriptor {
             @Override public String getDisplayName() {

--- a/test/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
+++ b/test/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
@@ -26,18 +26,31 @@ package jenkins.tasks;
 
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.model.AbstractProject;
+import hudson.model.Computer;
+import hudson.model.Descriptor;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.JDK;
 import hudson.model.Run;
+import hudson.model.Slave;
 import hudson.model.TaskListener;
+import hudson.slaves.CommandLauncher;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.RetentionStrategy;
+import hudson.slaves.SlaveComputer;
 import hudson.tasks.BuildWrapperDescriptor;
+import hudson.tasks.Shell;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.Assume;
 import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
@@ -45,6 +58,7 @@ import org.jvnet.hudson.test.TestExtension;
 public class SimpleBuildWrapperTest {
 
     @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
     @Test public void envOverride() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject();
@@ -67,6 +81,60 @@ public class SimpleBuildWrapperTest {
             @Override public boolean isApplicable(AbstractProject<?,?> item) {
                 return true;
             }
+        }
+    }
+
+    @Test public void envOverrideExpand() throws Exception {
+        Assume.assumeFalse(Functions.isWindows());
+        FreeStyleProject p = r.createFreeStyleProject();
+        p.getBuildWrappersList().add(new WrapperWithEnvOverrideExpand());
+        SpecialEnvSlave slave = new SpecialEnvSlave(tmp.getRoot(), r.createComputerLauncher(null));
+        r.jenkins.addNode(slave);
+        p.setAssignedNode(slave);
+        JDK jdk = new JDK("test", "/opt/jdk");
+        r.jenkins.getJDKs().add(jdk);
+        p.setJDK(jdk);
+        CaptureEnvironmentBuilder captureEnvironment = new CaptureEnvironmentBuilder();
+        p.getBuildersList().add(captureEnvironment);
+        p.getBuildersList().add(new Shell("echo effective PATH=$PATH"));
+        FreeStyleBuild b = r.buildAndAssertSuccess(p);
+        String expected = "/home/jenkins/bin:/opt/jdk/bin:/usr/bin:/bin";
+        assertEquals(expected, captureEnvironment.getEnvVars().get("PATH"));
+        // TODO why is /opt/jdk/bin added twice? In CommandInterpreter.perform, envVars right before Launcher.launch is correct, but this somehow sneaks in.
+        r.assertLogContains("effective PATH=/opt/jdk/bin:" + expected, b);
+    }
+    public static class WrapperWithEnvOverrideExpand extends SimpleBuildWrapper {
+        @Override public void setUp(Context context, Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
+            assertEquals("/opt/jdk/bin:/usr/bin:/bin", initialEnvironment.get("PATH"));
+            assertEquals("/home/jenkins", initialEnvironment.get("HOME"));
+            context.env("PATH+STUFF", "${HOME}/bin");
+        }
+        @TestExtension("envOverrideExpand") public static class DescriptorImpl extends BuildWrapperDescriptor {
+            @Override public String getDisplayName() {
+                return "WrapperWithEnvOverrideExpand";
+            }
+            @Override public boolean isApplicable(AbstractProject<?,?> item) {
+                return true;
+            }
+        }
+    }
+    private static class SpecialEnvSlave extends Slave {
+        SpecialEnvSlave(File remoteFS, CommandLauncher launcher) throws Descriptor.FormException, IOException {
+            super("special", "SpecialEnvSlave", remoteFS.getAbsolutePath(), 1, Mode.NORMAL, "", launcher, RetentionStrategy.NOOP, Collections.<NodeProperty<?>>emptyList());
+        }
+        @Override public Computer createComputer() {
+            return new SpecialEnvComputer(this);
+        }
+    }
+    private static class SpecialEnvComputer extends SlaveComputer {
+        SpecialEnvComputer(SpecialEnvSlave slave) {
+            super(slave);
+        }
+        @Override public EnvVars getEnvironment() throws IOException, InterruptedException {
+            EnvVars env = super.getEnvironment();
+            env.put("PATH", "/usr/bin:/bin");
+            env.put("HOME", "/home/jenkins");
+            return env;
         }
     }
 


### PR DESCRIPTION
Follow-up to #1530. `SimpleBuildWrapper.EnvironmentWrapper.buildEnvVars` calls `EnvVars.overrideAll`, which handles for example `PATH+EXTRA=/extra/bin`. In discussion with @cyrille-leclerc I was reminded that some build wrappers additionally need something like `PATH+EXTRA=${HOME}/extra/bin`.

A call to `overrideExpandingAll` would do that, but it seems to be unnecessary, since the result is eventually used only by `AbstractBuild.getEnvironment`, which already calls `EnvVars.resolve` as a final step. Potentially there is some marginal case that `resolve` does not fix because it does not use `OverrideOrderCalculator` like `overrideExpandingAll` does.

@reviewbybees
