### PR TITLE
[FIXED JENKINS-26240] Use backwards compatible gzip compression

### DIFF
--- a/debian/build.sh
+++ b/debian/build.sh
@@ -30,4 +30,4 @@ d=$(dirname $0)
 cp "$1" $d/jenkins.war
 
 cd $d
-exec debuild -us -uc -A
+exec debuild -us -uc -Zgzip -A


### PR DESCRIPTION
Untested change, but according to

http://man.he.net/man1/debuild
&rarr; http://man.he.net/man1/dpkg-buildpackage
 &rarr; http://man.he.net/man1/dpkg-source

this should work. @kohsuke please review.
