### PR TITLE
[WIP][FIXED JENKINS-26684] Sanitize arguments when launching processes on Windows

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -813,6 +813,10 @@ public abstract class Launcher {
             for ( int idx = 0 ; idx < jobCmd.length; idx++ )
             	jobCmd[idx] = jobEnv.expand(ps.commands.get(idx));
 
+            if (Functions.isWindows()) {
+                jobCmd = new ArgumentListBuilder(jobCmd).toWindowsCommand().toCommandArray();
+            }
+
             return new LocalProc(jobCmd, Util.mapToEnv(jobEnv),
                     ps.reverseStdin ?LocalProc.SELFPUMP_INPUT:ps.stdin,
                     ps.reverseStdout?LocalProc.SELFPUMP_OUTPUT:ps.stdout,

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -39,6 +39,7 @@ import hudson.util.StreamCopyThread;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.ProcessTree;
 import jenkins.security.MasterToSlaveCallable;
+
 import org.apache.commons.io.input.NullInputStream;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -386,6 +387,7 @@ public abstract class Launcher {
          * Starts the process and waits for its completion.
          */
         public int join() throws IOException, InterruptedException {
+            LOGGER.info("Launching process with: " + commands);
             return start().join();
         }
 
@@ -813,8 +815,8 @@ public abstract class Launcher {
             for ( int idx = 0 ; idx < jobCmd.length; idx++ )
             	jobCmd[idx] = jobEnv.expand(ps.commands.get(idx));
 
-            if (Functions.isWindows()) {
-                jobCmd = new ArgumentListBuilder(jobCmd).toWindowsCommand().toCommandArray();
+            if (!isUnix()) {
+                jobCmd = escapeForWindows(jobCmd);
             }
 
             return new LocalProc(jobCmd, Util.mapToEnv(jobEnv),
@@ -822,6 +824,44 @@ public abstract class Launcher {
                     ps.reverseStdout?LocalProc.SELFPUMP_OUTPUT:ps.stdout,
                     ps.reverseStderr?LocalProc.SELFPUMP_OUTPUT:ps.stderr,
                     toFile(ps.pwd));
+        }
+
+        private static String[] escapeForWindows(String... args) {
+          StringBuilder quotedArgs = new StringBuilder("'");
+          boolean quoted;
+          for (String arg : args) {
+              quoted = false;
+              for (int i = 0; i < arg.length(); i++) {
+                  char c = arg.charAt(i);
+                  if (!quoted && (c == ' ' || c == '*' || c == '?' || c == ',' || c == ';')) {
+                      quoted = startQuoting(quotedArgs, arg, i);
+                  }
+                  else if (c == '^' || c == '&' || c == '<' || c == '>' || c == '|') {
+                      if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
+                      // quotedArgs.append('^'); See note in javadoc above
+                  }
+                  else if (c == '"') {
+                      if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
+                      quotedArgs.append('"');
+                  }
+                  if (quoted) quotedArgs.append(c);
+              }
+              if (quoted) quotedArgs.append('"'); else quotedArgs.append(arg);
+              quotedArgs.append(' ');
+          }
+          // (comment copied from old code in hudson.tasks.Ant)
+          // on Windows, executing batch file can't return the correct error code,
+          // so we need to wrap it into cmd.exe.
+          // double %% is needed because we want ERRORLEVEL to be expanded after
+          // batch file executed, not before. This alone shows how broken Windows is...
+          quotedArgs.append("&& exit %%ERRORLEVEL%%");
+          quotedArgs.append('"');
+          return new String[] {"cmd.exe", "/C", quotedArgs.toString()};
+        }
+
+        private static boolean startQuoting(StringBuilder buf, String arg, int atIndex) {
+            buf.append('"').append(arg.substring(0, atIndex));
+            return true;
         }
 
         private File toFile(FilePath f) {

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -46,7 +46,7 @@ import java.util.Set;
  * @author Kohsuke Kawaguchi
  */
 public class ArgumentListBuilder implements Serializable, Cloneable {
-    private final List<String> args = new ArrayList<String>();
+    protected final List<String> args = new ArrayList<String>();
     /**
      * Bit mask indicating arguments that shouldn't be echoed-back (e.g., password)
      */
@@ -57,6 +57,11 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
 
     public ArgumentListBuilder(String... args) {
         add(args);
+    }
+
+    protected ArgumentListBuilder(ArgumentListBuilder alb) {
+        add(alb.toCommandArray());
+        this.mask = (BitSet) alb.mask.clone();
     }
 
     public ArgumentListBuilder add(Object a) {
@@ -249,8 +254,9 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
         };
     }
 
-    public String[] toCommandArray() {
-        return args.toArray(new String[args.size()]);
+    public final String[] toCommandArray() {
+        List<String> list = toList();
+        return list.toArray(new String[list.size()]);
     }
     
     @Override
@@ -279,7 +285,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      */
     public String toStringWithQuote() {
         StringBuilder buf = new StringBuilder();
-        for (String arg : args) {
+        for (String arg : toList()) {
             if(buf.length()>0)  buf.append(' ');
 
             if(arg.indexOf(' ')>=0 || arg.length()==0)
@@ -292,72 +298,21 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
 
     /**
      * Wrap command in a CMD.EXE call so we can return the exit code (ERRORLEVEL).
-     * This method takes care of escaping special characters in the command, which
-     * is needed since the command is now passed as a string to the CMD.EXE shell.
-     * This is done as follows:
-     * Wrap arguments in double quotes if they contain any of:
-     *   space *?,;^&<>|"
-     *   and if escapeVars is true, % followed by a letter.
-     * <br/> When testing from command prompt, these characters also need to be
-     * prepended with a ^ character: ^&<>|  -- however, invoking cmd.exe from
-     * Jenkins does not seem to require this extra escaping so it is not added by
-     * this method.
-     * <br/> A " is prepended with another " character.  Note: Windows has issues
-     * escaping some combinations of quotes and spaces.  Quotes should be avoided.
-     * <br/> If escapeVars is true, a % followed by a letter has that letter wrapped
-     * in double quotes, to avoid possible variable expansion.
-     * ie, %foo% becomes "%"f"oo%".  The second % does not need special handling
-     * because it is not followed by a letter. <br/>
-     * Example: "-Dfoo=*abc?def;ghi^jkl&mno<pqr>stu|vwx""yz%"e"nd"
+     *
      * @param escapeVars True to escape %VAR% references; false to leave these alone
      *                   so they may be expanded when the command is run
      * @return new ArgumentListBuilder that runs given command through cmd.exe /C
      * @since 1.386
      */
     public ArgumentListBuilder toWindowsCommand(boolean escapeVars) {
-        StringBuilder quotedArgs = new StringBuilder();
-        boolean quoted, percent;
-        for (String arg : args) {
-            quoted = percent = false;
-            for (int i = 0; i < arg.length(); i++) {
-                char c = arg.charAt(i);
-                if (!quoted && (c == ' ' || c == '*' || c == '?' || c == ',' || c == ';')) {
-                    quoted = startQuoting(quotedArgs, arg, i);
-                }
-                else if (c == '^' || c == '&' || c == '<' || c == '>' || c == '|') {
-                    if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
-                    // quotedArgs.append('^'); See note in javadoc above
-                }
-                else if (c == '"') {
-                    if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
-                    quotedArgs.append('"');
-                }
-                else if (percent && escapeVars
-                         && ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))) {
-                    if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
-                    quotedArgs.append('"').append(c);
-                    c = '"';
-                }
-                percent = (c == '%');
-                if (quoted) quotedArgs.append(c);
-            }
-            if (quoted) quotedArgs.append('"'); else quotedArgs.append(arg);
-            quotedArgs.append(' ');
-        }
-        // (comment copied from old code in hudson.tasks.Ant)
-        // on Windows, executing batch file can't return the correct error code,
-        // so we need to wrap it into cmd.exe.
-        // double %% is needed because we want ERRORLEVEL to be expanded after
-        // batch file executed, not before. This alone shows how broken Windows is...
-        quotedArgs.append("&& exit %%ERRORLEVEL%%");
-        return new ArgumentListBuilder().add("cmd.exe", "/C").addQuoted(quotedArgs.toString());
+        return new Windows(this, escapeVars);
     }
 
     /**
      * Calls toWindowsCommand(false)
      * @see #toWindowsCommand(boolean)
      */
-    public ArgumentListBuilder toWindowsCommand() {
+    public final ArgumentListBuilder toWindowsCommand() {
         return toWindowsCommand(false);
     }
 
@@ -401,9 +356,10 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      * Debug/error message friendly output.
      */
     public String toString() {
+        List<String> list = toList();
         StringBuilder buf = new StringBuilder();
-        for (int i=0; i<args.size(); i++) {
-            String arg = args.get(i);
+        for (int i=0; i<list.size(); i++) {
+            String arg = list.get(i);
             if (mask.get(i))
                 arg = "******";
 
@@ -415,6 +371,88 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
                 buf.append(arg);
         }
         return buf.toString();
+    }
+
+    /**
+     * This subclass takes care of escaping special characters in the command, which
+     * is needed since the command is now passed as a string to the CMD.EXE shell.
+     * This is done as follows:
+     * Wrap arguments in double quotes if they contain any of:
+     *   space *?,;^&<>|"
+     *   and if escapeVars is true, % followed by a letter.
+     * <br/> When testing from command prompt, these characters also need to be
+     * prepended with a ^ character: ^&<>|  -- however, invoking cmd.exe from
+     * Jenkins does not seem to require this extra escaping so it is not added by
+     * this method.
+     * <br/> A " is prepended with another " character.  Note: Windows has issues
+     * escaping some combinations of quotes and spaces.  Quotes should be avoided.
+     * <br/> If escapeVars is true, a % followed by a letter has that letter wrapped
+     * in double quotes, to avoid possible variable expansion.
+     * ie, %foo% becomes "%"f"oo%".  The second % does not need special handling
+     * because it is not followed by a letter. <br/>
+     * Example: "-Dfoo=*abc?def;ghi^jkl&mno<pqr>stu|vwx""yz%"e"nd"
+     */
+    private static final class Windows extends ArgumentListBuilder {
+
+        private boolean escapeVars;
+
+        public Windows(ArgumentListBuilder alb, boolean escapeVars) {
+            super(alb);
+            this.escapeVars = escapeVars;
+        }
+
+        @Override
+        public ArgumentListBuilder clone() {
+            return new Windows(this, escapeVars);
+        }
+
+        @Override
+        public ArgumentListBuilder toWindowsCommand(boolean escapeVars) {
+            this.escapeVars = escapeVars;
+            return this;
+        }
+
+        @Override
+        public List<String> toList() {
+            StringBuilder quotedArgs = new StringBuilder();
+            boolean quoted, percent;
+            for (String arg : args) {
+                quoted = percent = false;
+                for (int i = 0; i < arg.length(); i++) {
+                    char c = arg.charAt(i);
+                    if (!quoted && (c == ' ' || c == '*' || c == '?' || c == ',' || c == ';')) {
+                        quoted = startQuoting(quotedArgs, arg, i);
+                    }
+                    else if (c == '^' || c == '&' || c == '<' || c == '>' || c == '|') {
+                        if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
+                        // quotedArgs.append('^'); See note in javadoc above
+                    }
+                    else if (c == '"') {
+                        if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
+                        quotedArgs.append('"');
+                    }
+                    else if (percent && escapeVars
+                             && ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))) {
+                        if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
+                        quotedArgs.append('"').append(c);
+                        c = '"';
+                    }
+                    percent = (c == '%');
+                    if (quoted) quotedArgs.append(c);
+                }
+                if (quoted) quotedArgs.append('"'); else quotedArgs.append(arg);
+                quotedArgs.append(' ');
+            }
+            // (comment copied from old code in hudson.tasks.Ant)
+            // on Windows, executing batch file can't return the correct error code,
+            // so we need to wrap it into cmd.exe.
+            // double %% is needed because we want ERRORLEVEL to be expanded after
+            // batch file executed, not before. This alone shows how broken Windows is...
+            quotedArgs.append("&& exit %%ERRORLEVEL%%");
+            return new ArgumentListBuilder("cmd.exe", "/C").addQuoted(quotedArgs.toString()).toList();
+        }
+
+        private static final long serialVersionUID = 2L;
     }
 
     private static final long serialVersionUID = 1L;

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -46,7 +46,7 @@ import java.util.Set;
  * @author Kohsuke Kawaguchi
  */
 public class ArgumentListBuilder implements Serializable, Cloneable {
-    protected final List<String> args = new ArrayList<String>();
+    private final List<String> args = new ArrayList<String>();
     /**
      * Bit mask indicating arguments that shouldn't be echoed-back (e.g., password)
      */
@@ -57,11 +57,6 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
 
     public ArgumentListBuilder(String... args) {
         add(args);
-    }
-
-    protected ArgumentListBuilder(ArgumentListBuilder alb) {
-        add(alb.toCommandArray());
-        this.mask = (BitSet) alb.mask.clone();
     }
 
     public ArgumentListBuilder add(Object a) {
@@ -254,9 +249,8 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
         };
     }
 
-    public final String[] toCommandArray() {
-        List<String> list = toList();
-        return list.toArray(new String[list.size()]);
+    public String[] toCommandArray() {
+        return args.toArray(new String[args.size()]);
     }
     
     @Override
@@ -285,7 +279,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      */
     public String toStringWithQuote() {
         StringBuilder buf = new StringBuilder();
-        for (String arg : toList()) {
+        for (String arg : args) {
             if(buf.length()>0)  buf.append(' ');
 
             if(arg.indexOf(' ')>=0 || arg.length()==0)
@@ -297,28 +291,24 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
     }
 
     /**
-     * Wrap command in a CMD.EXE call so we can return the exit code (ERRORLEVEL).
+     * This is noop.
      *
-     * @param escapeVars True to escape %VAR% references; false to leave these alone
-     *                   so they may be expanded when the command is run
-     * @return new ArgumentListBuilder that runs given command through cmd.exe /C
      * @since 1.386
+     * @deprecated since TODO
      */
+    @Deprecated
     public ArgumentListBuilder toWindowsCommand(boolean escapeVars) {
-        return new Windows(this, escapeVars);
+        return this;
     }
 
     /**
-     * Calls toWindowsCommand(false)
-     * @see #toWindowsCommand(boolean)
+     * This is noop.
+     *
+     * @deprecated since TODO
      */
-    public final ArgumentListBuilder toWindowsCommand() {
-        return toWindowsCommand(false);
-    }
-
-    private static boolean startQuoting(StringBuilder buf, String arg, int atIndex) {
-        buf.append('"').append(arg.substring(0, atIndex));
-        return true;
+    @Deprecated
+    public ArgumentListBuilder toWindowsCommand() {
+        return this;
     }
 
     /**
@@ -355,11 +345,11 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
     /**
      * Debug/error message friendly output.
      */
+    @Override
     public String toString() {
-        List<String> list = toList();
         StringBuilder buf = new StringBuilder();
-        for (int i=0; i<list.size(); i++) {
-            String arg = list.get(i);
+        for (int i=0; i<args.size(); i++) {
+            String arg = args.get(i);
             if (mask.get(i))
                 arg = "******";
 
@@ -371,88 +361,6 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
                 buf.append(arg);
         }
         return buf.toString();
-    }
-
-    /**
-     * This subclass takes care of escaping special characters in the command, which
-     * is needed since the command is now passed as a string to the CMD.EXE shell.
-     * This is done as follows:
-     * Wrap arguments in double quotes if they contain any of:
-     *   space *?,;^&<>|"
-     *   and if escapeVars is true, % followed by a letter.
-     * <br/> When testing from command prompt, these characters also need to be
-     * prepended with a ^ character: ^&<>|  -- however, invoking cmd.exe from
-     * Jenkins does not seem to require this extra escaping so it is not added by
-     * this method.
-     * <br/> A " is prepended with another " character.  Note: Windows has issues
-     * escaping some combinations of quotes and spaces.  Quotes should be avoided.
-     * <br/> If escapeVars is true, a % followed by a letter has that letter wrapped
-     * in double quotes, to avoid possible variable expansion.
-     * ie, %foo% becomes "%"f"oo%".  The second % does not need special handling
-     * because it is not followed by a letter. <br/>
-     * Example: "-Dfoo=*abc?def;ghi^jkl&mno<pqr>stu|vwx""yz%"e"nd"
-     */
-    private static final class Windows extends ArgumentListBuilder {
-
-        private boolean escapeVars;
-
-        public Windows(ArgumentListBuilder alb, boolean escapeVars) {
-            super(alb);
-            this.escapeVars = escapeVars;
-        }
-
-        @Override
-        public ArgumentListBuilder clone() {
-            return new Windows(this, escapeVars);
-        }
-
-        @Override
-        public ArgumentListBuilder toWindowsCommand(boolean escapeVars) {
-            this.escapeVars = escapeVars;
-            return this;
-        }
-
-        @Override
-        public List<String> toList() {
-            StringBuilder quotedArgs = new StringBuilder();
-            boolean quoted, percent;
-            for (String arg : args) {
-                quoted = percent = false;
-                for (int i = 0; i < arg.length(); i++) {
-                    char c = arg.charAt(i);
-                    if (!quoted && (c == ' ' || c == '*' || c == '?' || c == ',' || c == ';')) {
-                        quoted = startQuoting(quotedArgs, arg, i);
-                    }
-                    else if (c == '^' || c == '&' || c == '<' || c == '>' || c == '|') {
-                        if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
-                        // quotedArgs.append('^'); See note in javadoc above
-                    }
-                    else if (c == '"') {
-                        if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
-                        quotedArgs.append('"');
-                    }
-                    else if (percent && escapeVars
-                             && ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))) {
-                        if (!quoted) quoted = startQuoting(quotedArgs, arg, i);
-                        quotedArgs.append('"').append(c);
-                        c = '"';
-                    }
-                    percent = (c == '%');
-                    if (quoted) quotedArgs.append(c);
-                }
-                if (quoted) quotedArgs.append('"'); else quotedArgs.append(arg);
-                quotedArgs.append(' ');
-            }
-            // (comment copied from old code in hudson.tasks.Ant)
-            // on Windows, executing batch file can't return the correct error code,
-            // so we need to wrap it into cmd.exe.
-            // double %% is needed because we want ERRORLEVEL to be expanded after
-            // batch file executed, not before. This alone shows how broken Windows is...
-            quotedArgs.append("&& exit %%ERRORLEVEL%%");
-            return new ArgumentListBuilder("cmd.exe", "/C").addQuoted(quotedArgs.toString()).toList();
-        }
-
-        private static final long serialVersionUID = 2L;
     }
 
     private static final long serialVersionUID = 1L;

--- a/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
+++ b/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
@@ -123,6 +123,16 @@ public class ArgumentListBuilderTest {
                 + " \"-Dfoo6=<xml>&here;</xml>\" \"-Dfoo7=foo|bar\"\"baz\""
                 + " \"-Dfoo8=% %\"Q\"ED% %\"c\"omspec% %-%(%.%\""
                 + " -Dfoo9=%'''%%@% && exit %%ERRORLEVEL%%\"" }));
+
+        // toWindowsCommand should be idempotent
+        assertThat(
+                builder.toWindowsCommand().toCommandArray(),
+                is(builder.toWindowsCommand().toWindowsCommand().toCommandArray())
+        );
+        assertThat(
+                builder.toWindowsCommand(true).toList(),
+                is(builder.toWindowsCommand(true).toWindowsCommand(true).toList())
+        );
     }
 
     @Test


### PR DESCRIPTION
[JENKINS-26684](https://issues.jenkins-ci.org/browse/JENKINS-26684)

This fix makes `Launcher`s in core platform aware and quote arguments transparently. Do not merge yet as I still struggle with jenkins-test-harness run on windows. Review needed.
