### PR TITLE
[JENKINS-26718] OldDataMonitor: Handle poorly written project types

### DIFF
--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -355,10 +355,12 @@ public class OldDataMonitor extends AdministrativeMonitor {
 
     private static SaveableReference referTo(Saveable s) {
         if (s instanceof Run) {
-            return new RunSaveableReference((Run) s);
-        } else {
-            return new SimpleSaveableReference(s);
+            Job parent = ((Run) s).getParent();
+            if (Jenkins.getInstance().getItemByFullName(parent.getFullName()) == parent) {
+                return new RunSaveableReference((Run) s);
+            }
         }
+        return new SimpleSaveableReference(s);
     }
 
     private static final class SimpleSaveableReference implements SaveableReference {


### PR DESCRIPTION
[JENKINS-26718](https://issues.jenkins-ci.org/browse/JENKINS-26718)

Allow runs to be discarded even if their project can't be found by its fullname, such as Promotions in promoted builds
