### PR TITLE
[JENKINS-26755] cache node environment

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -164,6 +164,13 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     private volatile String cachedHostName;
     private volatile boolean hostNameCached;
 
+    /**
+     * @see #getEnvironment()
+     */
+    private volatile EnvVars cachedEnvironment;
+    private volatile boolean environmentCached;
+
+
     private final WorkspaceList workspaceList = new WorkspaceList();
 
     protected transient List<Action> transientActions;
@@ -339,6 +346,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      *      make much sense because as soon as {@link Computer} is connected it can be disconnected by some other threads.)
      */
     public final Future<?> connect(boolean forceReconnect) {
+        environmentCached = false;
     	connectTime = System.currentTimeMillis();
     	return _connect(forceReconnect);
     }
@@ -939,7 +947,13 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      * If this is the master, it returns the system property of the master computer.
      */
     public EnvVars getEnvironment() throws IOException, InterruptedException {
-        return EnvVars.getRemote(getChannel());
+        if (environmentCached) {
+            return cachedEnvironment;
+        }
+
+        cachedEnvironment = EnvVars.getRemote(getChannel());
+        environmentCached = true;
+        return cachedEnvironment;
     }
 
     /**

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -168,7 +168,6 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      * @see #getEnvironment()
      */
     private volatile EnvVars cachedEnvironment;
-    private volatile boolean environmentCached;
 
 
     private final WorkspaceList workspaceList = new WorkspaceList();
@@ -346,7 +345,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      *      make much sense because as soon as {@link Computer} is connected it can be disconnected by some other threads.)
      */
     public final Future<?> connect(boolean forceReconnect) {
-        environmentCached = false;
+        this.cachedEnvironment = null;
     	connectTime = System.currentTimeMillis();
     	return _connect(forceReconnect);
     }
@@ -947,12 +946,13 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      * If this is the master, it returns the system property of the master computer.
      */
     public EnvVars getEnvironment() throws IOException, InterruptedException {
-        if (environmentCached) {
+        EnvVars cachedEnvironment = this.cachedEnvironment;
+        if (cachedEnvironment != null) {
             return cachedEnvironment;
         }
 
         cachedEnvironment = EnvVars.getRemote(getChannel());
-        environmentCached = true;
+        this.cachedEnvironment = cachedEnvironment;
         return cachedEnvironment;
     }
 


### PR DESCRIPTION
[JENKINS-26755](https://issues.jenkins-ci.org/browse/JENKINS-26755)

prevent inefficient channel overuse
