### PR TITLE
Bump powermock to 1.5.6 that support java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,18 +152,18 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.8.5</version>
+        <version>1.9.5</version>
       </dependency>
       
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
-        <version>1.4.10</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito</artifactId>
-        <version>1.4.10</version>
+        <version>1.5.6</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Otherwise I am seeing lot of these: `Failed to transform class with name hudson.model.Run. Reason: java.io.IOException: invalid constant type: 15`
