### PR TITLE
[JENKINS-9104] Add process killing whitelist

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -539,7 +539,8 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 // kill run-away processes that are left
                 // use multiple environment variables so that people can escape this massacre by overriding an environment
                 // variable for some processes
-                launcher.kill(getCharacteristicEnvVars());
+                // Takes the killing whitelist into account
+                launcher.kill(getCharacteristicEnvVars(), Jenkins.getInstance().getProcessCleanupWhitelistList());
             }
 
             // this is ugly, but for historical reason, if non-null value is returned

--- a/core/src/main/java/hudson/util/ProcessTreeRemoting.java
+++ b/core/src/main/java/hudson/util/ProcessTreeRemoting.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public class ProcessTreeRemoting {
     public interface IProcessTree {
         void killAll(Map<String, String> modelEnvVars) throws InterruptedException;
+        void killAll(Map<String, String> modelEnvVars, List<String> whitelist) throws InterruptedException;
     }
 
     public interface IOSProcess {

--- a/core/src/main/java/jenkins/model/GlobalProcessWhitelistConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalProcessWhitelistConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, Daniel Weber
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model;
+
+import hudson.Extension;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+
+/**
+ * Configures a whitelist for processes that should not be killed 
+ * 
+ * @author Daniel Weber
+ */
+@Extension(ordinal=401)
+public class GlobalProcessWhitelistConfiguration extends GlobalConfiguration {
+
+	public String getProcessWhitelist(){
+		return Jenkins.getInstance().getProcessCleanupWhitelist();
+	}
+	
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    	String whitelist = (String) json.get("processCleanupWhitelist");
+    	try {
+            Jenkins.getInstance().setProcessCleanupWhitelist(whitelist);
+        } catch (IOException e) {
+            throw new FormException(e, "processCleanupWhitelist");
+        }
+    	return true;
+    }
+}

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -27,6 +27,7 @@
 package jenkins.model;
 
 import antlr.ANTLRException;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.inject.Injector;
@@ -521,6 +522,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Global default for {@link AbstractProject#getScmCheckoutRetryCount()}
      */
     /*package*/ int scmCheckoutRetryCount;
+    
+    /**
+     * A list of process names to be excluded from the process killing after a job has finished.
+     */
+    private String processCleanupWhitelist;
 
     /**
      * {@link View}s.
@@ -4257,4 +4263,26 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
     }
 
+    public String getProcessCleanupWhitelist() {
+        return processCleanupWhitelist;
+    }
+
+    public void setProcessCleanupWhitelist(String processCleanupWhitelist) throws IOException {
+        this.processCleanupWhitelist = processCleanupWhitelist;
+        save();
+    }
+
+    /**
+     * @return A list of process whitelist entries. May be empty but never null 
+     */
+    public List<String> getProcessCleanupWhitelistList() {
+        if (Strings.isNullOrEmpty(processCleanupWhitelist))
+            return Collections.emptyList();
+        
+        List<String> whitelist = Lists.newArrayList();
+        for (String entry : processCleanupWhitelist.split(",")) {
+            whitelist.add(entry.trim());
+        }
+        return whitelist;
+    }
 }

--- a/core/src/main/resources/jenkins/model/GlobalProcessWhitelistConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/GlobalProcessWhitelistConfiguration/config.groovy
@@ -1,0 +1,9 @@
+package jenkins.model.GlobalProcessWhitelistConfiguration
+
+
+def f=namespace(lib.FormTagLib)
+
+f.entry(title:_("Process cleanup whitelist"), field:"processCleanupWhitelist") {
+    f.textbox()
+}
+

--- a/core/src/main/resources/jenkins/model/GlobalProcessWhitelistConfiguration/help-processCleanupWhitelist.html
+++ b/core/src/main/resources/jenkins/model/GlobalProcessWhitelistConfiguration/help-processCleanupWhitelist.html
@@ -1,0 +1,14 @@
+<div>
+  A comma separated list of process names to exclude from the killing after a build has finished. Only the binary name needs to be specified, file extensions will be ignored to allow for portability.
+  E.g. set to "mspdbsrv" to make mspdbsrv.exe survive process cleanup. 
+  <p/>
+  Jenkins checks for processes that have been started during a build and are still running when the build is complete.
+  It kills all leftover processes to make sure the build leaves a clean environment behind. These processes are identified 
+  by a characteristic set of environment variables.
+  <p/>
+  In some cases, you don't want all processes to be killed. E.g. Microsoft's compiler and linker use a central mspdbsrv process to access .pdb files. Once started, the service shall remain running and will be used by subsequent builds. If Jenkins kills mspdbsrv, this leads to other builds that are running at the same time to fail.
+  <p/>
+  If you want a process being started during a build to survive, list its name here.
+  <p/>
+  Note: For this to work, the daemon process and all its parents need to be whitelisted since Jenkins kills processes including all children.
+</div>

--- a/core/src/test/java/hudson/util/ProcessTreeTest.java
+++ b/core/src/test/java/hudson/util/ProcessTreeTest.java
@@ -4,12 +4,21 @@ import hudson.ChannelRule;
 import hudson.remoting.VirtualChannel;
 import hudson.util.ProcessTree.OSProcess;
 import hudson.util.ProcessTree.ProcessCallable;
+
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.List;
+
 import jenkins.security.MasterToSlaveCallable;
 import static org.junit.Assert.*;
+
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -18,13 +27,21 @@ public class ProcessTreeTest {
 
     @Rule public ChannelRule channels = new ChannelRule();
 
-    static class  Tag implements Serializable {
+    static class Tag implements Serializable {
         ProcessTree tree;
         OSProcess p;
         int id;
         private static final long serialVersionUID = 1L;
     }
-    
+
+    private Process process;
+
+    @After
+    public void tearDown() throws Exception {
+        if (null != process)
+            process.destroy();
+    }
+
     @Test public void remoting() throws Exception {
         // on some platforms where we fail to list any processes, this test will just not work
         if (ProcessTree.get()==ProcessTree.DEFAULT)
@@ -42,6 +59,45 @@ public class ProcessTreeTest {
         assertEquals(t.id,t.p.getPid());
 
         t.p.act(new ProcessCallableImpl());
+    }
+
+    @Test
+    public void testKillingWhiteList() throws Exception {
+        // on some platforms where we fail to list any processes, this test will
+        // just not work
+        if (ProcessTree.get() == ProcessTree.DEFAULT)
+            return;
+
+        // kick off a process we (shouldn't) kill
+        ProcessBuilder pb = new ProcessBuilder();
+        pb.environment().put("cookie", "testKeepDaemonsAlive");
+        List<String> whitelist;
+        if (File.pathSeparatorChar == ';') {
+            pb.command("cmd");
+            whitelist = ImmutableList.of("cmd");
+        } else {
+            pb.command("sleep", "5m");
+            whitelist = ImmutableList.of("sleep");
+        }
+
+        process = pb.start();
+
+        ProcessTree processTree = ProcessTree.get();
+        processTree.killAll(ImmutableMap.of("cookie", "testKeepDaemonsAlive"),whitelist);
+        try {
+            process.exitValue();
+            fail("Process should have been excluded from the killing");
+        } catch (IllegalThreadStateException e) {
+            // Means the process is still running
+        }
+
+        processTree.killAll(ImmutableMap.of("cookie", "testKeepDaemonsAlive"),ImmutableList.of("nothing"));
+        try {
+            process.exitValue();
+        } catch (IllegalThreadStateException e) {
+            // Means the process is still running
+            fail("Process should have been killed this time (" + e.getMessage() + ")");
+        }
     }
 
     private static class MyCallable extends MasterToSlaveCallable<Tag, IOException> implements Serializable {


### PR DESCRIPTION
In order to let daemon processes like mspdbsrv.exe survive after-build process cleanup, people
can now configure a list of process names which should not be killed.
