### PR TITLE
[JENKINS-26781] Revise #1443 to support descriptors with ID != clazz.name

### DIFF
--- a/core/src/main/java/hudson/DescriptorExtensionList.java
+++ b/core/src/main/java/hudson/DescriptorExtensionList.java
@@ -109,6 +109,7 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
      *
      * @param fqcn
      *      Fully qualified name of the descriptor, not the describable.
+     * @deprecated {@link Descriptor#getId} is supposed to be used for new code, not the descriptor class name.
      */
     public D find(String fqcn) {
         return Descriptor.find(this,fqcn);

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -289,7 +289,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
 
         JSONObject formData = req.getSubmittedForm();
         formData.put("name", fixedName);
-
+        
         // TODO type is probably NodeDescriptor.id but confirm
         Node result = NodeDescriptor.all().find(type).newInstance(req, formData);
         app.addNode(result);

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -289,7 +289,8 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
 
         JSONObject formData = req.getSubmittedForm();
         formData.put("name", fixedName);
-        
+
+        // TODO type is probably NodeDescriptor.id but confirm
         Node result = NodeDescriptor.all().find(type).newInstance(req, formData);
         app.addNode(result);
 

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -916,7 +916,8 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
                 }
                 if (d == null) {
                   kind = jo.getString("$class");
-                  d = findByClassName(descriptors, kind);
+                  d = findByDescribableClassName(descriptors, kind);
+                  if (d == null) d = findByClassName(descriptors, kind);
                 }
                 if (d != null) {
                     items.add(d.newInstance(req, jo));
@@ -947,6 +948,17 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
     public static @CheckForNull <T extends Descriptor> T findByClassName(Collection<? extends T> list, String className) {
         for (T d : list) {
             if(d.getClass().getName().equals(className))
+                return d;
+        }
+        return null;
+    }
+
+    /**
+     * Finds a descriptor from a collection by the class name of the Describable it describes.
+     */
+    public static @CheckForNull <T extends Descriptor> T findByDescribableClassName(Collection<? extends T> list, String className) {
+        for (T d : list) {
+            if(d.clazz.getName().equals(className))
                 return d;
         }
         return null;

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -909,14 +909,19 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
         if (formData!=null) {
             for (Object o : JSONArray.fromObject(formData)) {
                 JSONObject jo = (JSONObject)o;
-                String kind = jo.optString("$class", null);
-                if (kind == null) {
-                  // Legacy: Remove once plugins have been staged onto $class
-                  kind = jo.getString("kind");
+                Descriptor<T> d = null;
+                String kind = jo.optString("kind", null);
+                if (kind != null) {
+                    d = find(descriptors, kind);
                 }
-                Descriptor<T> d = find(descriptors, kind);
+                if (d == null) {
+                  kind = jo.getString("$class");
+                  d = find(descriptors, kind);
+                }
                 if (d != null) {
                     items.add(d.newInstance(req, jo));
+                } else {
+                    LOGGER.warning("Received unexpected formData for descriptor " + kind);
                 }
             }
         }

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -910,6 +910,9 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
             for (Object o : JSONArray.fromObject(formData)) {
                 JSONObject jo = (JSONObject)o;
                 Descriptor<T> d = null;
+                // 'kind' and '$class' are mutually exclusive (see class-entry.jelly), but to be more lenient on the reader side,
+                // we check them both anyway. 'kind' (which maps to ID) is more unique than '$class', which can have multiple matching
+                // Descriptors, so we prefer 'kind' if it's present.
                 String kind = jo.optString("kind", null);
                 if (kind != null) {
                     d = findById(descriptors, kind);

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -931,7 +931,8 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
     }
 
     /**
-     * Finds a descriptor from a collection by its id.
+     * Finds a descriptor from a collection by its ID.
+     * @param id should match {@link #getId}
      * @since TODO
      */
     public static @CheckForNull <T extends Descriptor> T findById(Collection<? extends T> list, String id) {
@@ -956,7 +957,8 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
     }
 
     /**
-     * Finds a descriptor from a collection by the class name of the Describable it describes.
+     * Finds a descriptor from a collection by the class name of the {@link Describable} it describes.
+     * @param className should match {@link Class#getName} of a {@link #clazz}
      * @since TODO
      */
     public static @CheckForNull <T extends Descriptor> T findByDescribableClassName(Collection<? extends T> list, String className) {
@@ -969,7 +971,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
 
     /**
      * Finds a descriptor from a collection by its class name or ID.
-     * @deprecated choose between {@link #findById(java.util.Collection, String)} or {@link #findByClassName(java.util.Collection, String)}
+     * @deprecated choose between {@link #findById} or {@link #findByDescribableClassName}
      */
     public static @CheckForNull <T extends Descriptor> T find(Collection<? extends T> list, String string) {
         T d = findByClassName(list, string);
@@ -979,6 +981,9 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
         return findById(list, string);
     }
 
+    /**
+     * @deprecated choose between {@link #findById} or {@link #findByDescribableClassName}
+     */
     public static @CheckForNull Descriptor find(String className) {
         return find(ExtensionList.lookup(Descriptor.class),className);
     }

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -944,11 +944,10 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
     }
 
     /**
-     * Finds a descriptor from a collection by its class name.
-     * @deprecated Since we introduced {@link Descriptor#getId()}, it is a preferred method of identifying descriptor by a string.
-     * @since TODO
+     * Finds a descriptor from a collection by the class name of the {@link Descriptor}.
+     * This is useless as of the introduction of {@link #getId} and so only very old compatibility code needs it.
      */
-    public static @CheckForNull <T extends Descriptor> T findByClassName(Collection<? extends T> list, String className) {
+    private static @CheckForNull <T extends Descriptor> T findByClassName(Collection<? extends T> list, String className) {
         for (T d : list) {
             if(d.getClass().getName().equals(className))
                 return d;

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -912,11 +912,11 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
                 Descriptor<T> d = null;
                 String kind = jo.optString("kind", null);
                 if (kind != null) {
-                    d = find(descriptors, kind);
+                    d = findById(descriptors, kind);
                 }
                 if (d == null) {
                   kind = jo.getString("$class");
-                  d = find(descriptors, kind);
+                  d = findByClassName(descriptors, kind);
                 }
                 if (d != null) {
                     items.add(d.newInstance(req, jo));
@@ -930,20 +930,38 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
     }
 
     /**
-     * Finds a descriptor from a collection by its class name.
+     * Finds a descriptor from a collection by its id.
      */
-    public static @CheckForNull <T extends Descriptor> T find(Collection<? extends T> list, String className) {
+    public static @CheckForNull <T extends Descriptor> T findById(Collection<? extends T> list, String id) {
+        for (T d : list) {
+            if(d.getId().equals(id))
+                return d;
+        }
+        return null;
+    }
+
+    /**
+     * Finds a descriptor from a collection by its class name.
+     * @deprecated Since we introduced {@link Descriptor#getId()}, it is a preferred method of identifying descriptor by a string.
+     */
+    public static @CheckForNull <T extends Descriptor> T findByClassName(Collection<? extends T> list, String className) {
         for (T d : list) {
             if(d.getClass().getName().equals(className))
                 return d;
         }
-        // Since we introduced Descriptor.getId(), it is a preferred method of identifying descriptor by a string.
-        // To make that migration easier without breaking compatibility, let's also match up with the id.
-        for (T d : list) {
-            if(d.getId().equals(className))
+        return null;
+    }
+
+    /**
+     * Finds a descriptor from a collection by its class name or ID.
+     * @deprecated choose between {@link #findById(java.util.Collection, String)} or {@link #findByClassName(java.util.Collection, String)}
+     */
+    public static @CheckForNull <T extends Descriptor> T find(Collection<? extends T> list, String string) {
+        T d = findByClassName(list, string);
+        if (d != null) {
                 return d;
         }
-        return null;
+        return findById(list, string);
     }
 
     public static @CheckForNull Descriptor find(String className) {

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -932,6 +932,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
 
     /**
      * Finds a descriptor from a collection by its id.
+     * @since TODO
      */
     public static @CheckForNull <T extends Descriptor> T findById(Collection<? extends T> list, String id) {
         for (T d : list) {
@@ -944,6 +945,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
     /**
      * Finds a descriptor from a collection by its class name.
      * @deprecated Since we introduced {@link Descriptor#getId()}, it is a preferred method of identifying descriptor by a string.
+     * @since TODO
      */
     public static @CheckForNull <T extends Descriptor> T findByClassName(Collection<? extends T> list, String className) {
         for (T d : list) {
@@ -955,6 +957,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
 
     /**
      * Finds a descriptor from a collection by the class name of the Describable it describes.
+     * @since TODO
      */
     public static @CheckForNull <T extends Descriptor> T findByDescribableClassName(Collection<? extends T> list, String className) {
         for (T d : list) {

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -148,6 +148,9 @@ public class Items {
         return result;
     }
 
+    /**
+     * @deprecated Underspecified what the parameter is. {@link Descriptor#getId}? A {@link Describable} class name?
+     */
     public static TopLevelItemDescriptor getDescriptor(String fqcn) {
         return Descriptor.find(all(), fqcn);
     }

--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -122,7 +122,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
         }
 
         protected Downloadable createDownloadable() {
-            return new Downloadable(getId());
+            return new Downloadable(getDownloadableId());
         }
 
         /**
@@ -130,7 +130,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
          * <p>
          * By default we use the fully-qualified class name of the {@link DownloadFromUrlInstaller} subtype.
          */
-        public String getId() {
+        public String getDownloadableId() {
             return clazz.getName().replace('$','.');
         }
 
@@ -144,7 +144,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
          * @return never null.
          */
         public List<? extends Installable> getInstallables() throws IOException {
-            JSONObject d = Downloadable.get(getId()).getData();
+            JSONObject d = Downloadable.get(getDownloadableId()).getData();
             if(d==null)     return Collections.emptyList();
             return Arrays.asList(((InstallableList)JSONObject.toBean(d,InstallableList.class)).list);
         }

--- a/core/src/main/java/hudson/tools/ToolLocationNodeProperty.java
+++ b/core/src/main/java/hudson/tools/ToolLocationNodeProperty.java
@@ -167,6 +167,7 @@ public class ToolLocationNodeProperty extends NodeProperty<Node> {
             return home;
         }
 
+        @SuppressWarnings("deprecation") // TODO this was mistakenly made to be the ToolDescriptor class name, rather than .id as you would expect; now baked into serial form
         public ToolDescriptor getType() {
             if (descriptor == null) {
                 descriptor = (ToolDescriptor) Descriptor.find(type);

--- a/core/src/main/java/hudson/util/DescriptorList.java
+++ b/core/src/main/java/hudson/util/DescriptorList.java
@@ -196,6 +196,7 @@ public final class DescriptorList<T extends Describable<T>> extends AbstractList
 
     /**
      * Finds the descriptor that has the matching fully-qualified class name.
+     * @deprecated Underspecified what the parameter is. {@link Descriptor#getId}? A {@link Describable} class name?
      */
     public Descriptor<T> find(String fqcn) {
         return Descriptor.find(this,fqcn);

--- a/core/src/main/resources/lib/form/class-entry.jelly
+++ b/core/src/main/resources/lib/form/class-entry.jelly
@@ -36,11 +36,15 @@ THE SOFTWARE.
   </st:documentation>
   <j:set var="clazz" value="${attrs.clazz ?: attrs.descriptor.clazz.name}" />
   <f:invisibleEntry>
-    <j:if test="${attrs.descriptor != null}">
-      <input type="hidden" name="kind" value="${attrs.descriptor.id}" />
-    </j:if>
-    <!-- Legacy: Remove once plugins have been staged onto $class -->
-    <input type="hidden" name="stapler-class" value="${clazz}" />
-    <input type="hidden" name="$class" value="${clazz}" />
+    <j:choose>
+      <j:when test="${descriptor != null and descriptor.id != clazz}">
+        <input type="hidden" name="kind" value="${attrs.descriptor.id}" />
+      </j:when>
+      <j:otherwise>
+        <!-- Legacy: Remove once plugins have been staged onto $class -->
+        <input type="hidden" name="stapler-class" value="${clazz}" />
+        <input type="hidden" name="$class" value="${clazz}" />
+      </j:otherwise>
+    </j:choose>
   </f:invisibleEntry>
 </j:jelly>

--- a/core/src/main/resources/lib/form/class-entry.jelly
+++ b/core/src/main/resources/lib/form/class-entry.jelly
@@ -41,8 +41,7 @@ THE SOFTWARE.
         <input type="hidden" name="kind" value="${attrs.descriptor.id}" />
       </j:when>
       <j:otherwise>
-        <!-- Legacy: Remove once plugins have been staged onto $class -->
-        <input type="hidden" name="stapler-class" value="${clazz}" />
+        <input type="hidden" name="stapler-class" value="${clazz}" />  <!-- Legacy: Remove once plugins have been staged onto $class -->
         <input type="hidden" name="$class" value="${clazz}" />
       </j:otherwise>
     </j:choose>

--- a/core/src/main/resources/lib/form/class-entry.jelly
+++ b/core/src/main/resources/lib/form/class-entry.jelly
@@ -26,6 +26,16 @@ THE SOFTWARE.
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Invisible &lt;f:entry> type for embedding a descriptor's $class field.
+
+    Most of the time a Descriptor has an unique class name that we can use to instantiate the right Describable
+    class, so we use the '$class' to represent that to clarify the intent.
+    
+    In some other times, such as templates, there are multiple Descriptors with the same Descriptor.clazz
+    but different IDs, and in that case we put 'kind' to indicate that. In this case, to avoid confusing
+    readers we do not put non-unique '$class'.
+
+    See Descriptor.newInstancesFromHeteroList for how the reader side is handled.
+
     <st:attribute name="clazz">
       The describable class that we are instantiating via structured form submission.
     </st:attribute>

--- a/core/src/main/resources/lib/form/class-entry.jelly
+++ b/core/src/main/resources/lib/form/class-entry.jelly
@@ -36,12 +36,11 @@ THE SOFTWARE.
   </st:documentation>
   <j:set var="clazz" value="${attrs.clazz ?: attrs.descriptor.clazz.name}" />
   <f:invisibleEntry>
-    <!-- Legacy: Remove once plugins have been staged onto $class -->
-    <input type="hidden" name="stapler-class" value="${clazz}" />
-    <!-- Legacy: Remove once plugins have been staged onto $class -->
     <j:if test="${attrs.descriptor != null}">
       <input type="hidden" name="kind" value="${attrs.descriptor.id}" />
     </j:if>
+    <!-- Legacy: Remove once plugins have been staged onto $class -->
+    <input type="hidden" name="stapler-class" value="${clazz}" />
     <input type="hidden" name="$class" value="${clazz}" />
   </f:invisibleEntry>
 </j:jelly>

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -24,14 +24,25 @@
 
 package hudson.model;
 
+import hudson.Launcher;
 import hudson.model.Descriptor.PropertyType;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
 import hudson.tasks.Shell;
+import java.io.IOException;
+import java.util.List;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
 import static org.junit.Assert.*;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.StaplerRequest;
 
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class DescriptorTest {
 
     public @Rule JenkinsRule rule = new JenkinsRule();
@@ -50,5 +61,59 @@ public class DescriptorTest {
             }
         }
     }
+
+    @Ignore("TODO currently fails: after first configRoundtrip, builders list is empty because in newInstancesFromHeteroList $class is BuilderImpl (like stapler-class), kind=builder-a is ignored, and so d is null")
+    @Issue("JENKINS-26781")
+    @Test public void overriddenId() throws Exception {
+        FreeStyleProject p = rule.createFreeStyleProject();
+        p.getBuildersList().add(new BuilderImpl("builder-a"));
+        rule.configRoundtrip(p);
+        List<Builder> builders = p.getBuildersList();
+        assertEquals(1, builders.size());
+        assertEquals(BuilderImpl.class, builders.get(0).getClass());
+        assertEquals("builder-a", ((BuilderImpl) builders.get(0)).id);
+        rule.assertLogContains("running builder-a", rule.buildAndAssertSuccess(p));
+        p.getBuildersList().replace(new BuilderImpl("builder-b"));
+        rule.configRoundtrip(p);
+        builders = p.getBuildersList();
+        assertEquals(1, builders.size());
+        assertEquals(BuilderImpl.class, builders.get(0).getClass());
+        assertEquals("builder-b", ((BuilderImpl) builders.get(0)).id);
+        rule.assertLogContains("running builder-b", rule.buildAndAssertSuccess(p));
+    }
+    private static final class BuilderImpl extends Builder {
+        private final String id;
+        BuilderImpl(String id) {
+            this.id = id;
+        }
+        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            listener.getLogger().println("running " + getDescriptor().getId());
+            return true;
+        }
+        @Override public Descriptor<Builder> getDescriptor() {
+            return (Descriptor<Builder>) Jenkins.getInstance().getDescriptorByName(id);
+        }
+    }
+    private static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        private final String id;
+        DescriptorImpl(String id) {
+            super(BuilderImpl.class);
+            this.id = id;
+        }
+        @Override public String getId() {
+            return id;
+        }
+        @Override public Builder newInstance(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
+            return new BuilderImpl(id);
+        }
+        @Override public String getDisplayName() {
+            return id;
+        }
+        @Override public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+    }
+    @TestExtension("overriddenId") public static final BuildStepDescriptor<Builder> builderA = new DescriptorImpl("builder-a");
+    @TestExtension("overriddenId") public static final BuildStepDescriptor<Builder> builderB = new DescriptorImpl("builder-b");
 
 }

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import static org.junit.Assert.*;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -62,7 +61,6 @@ public class DescriptorTest {
         }
     }
 
-    @Ignore("TODO currently fails: after first configRoundtrip, builders list is empty because in newInstancesFromHeteroList $class is BuilderImpl (like stapler-class), kind=builder-a is ignored, and so d is null")
     @Issue("JENKINS-26781")
     @Test public void overriddenId() throws Exception {
         FreeStyleProject p = rule.createFreeStyleProject();


### PR DESCRIPTION
[JENKINS-26781](https://issues.jenkins-ci.org/browse/JENKINS-26781)

so descriptor can be retrieved by ID, which _may_ not be clazz.name

@reviewbybees
