### PR TITLE
[JENKINS-26684] Escape special chars in maven build step arguments

### DIFF
--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -322,6 +322,10 @@ public class Maven extends Builder {
             wrapUpArguments(args,normalizedTarget,build,launcher,listener);
 
             buildEnvVars(env, mi);
+            
+            if (!launcher.isUnix()) {
+                args = args.toWindowsCommand();
+            }
 
             try {
                 MavenConsoleAnnotator mca = new MavenConsoleAnnotator(listener.getLogger(),build.getCharset());

--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -268,4 +268,41 @@ public class MavenTest {
         assertEquals("{}", env.toString());
     }
 
+    @Issue("JENKINS-26684")
+    @Test public void specialCharsInBuildVariablesPassedAsProperties() throws Exception {
+        j.configureDefaultMaven();
+
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new Maven("--help", null));
+        p.addProperty(new ParametersDefinitionProperty(
+                new StringParameterDefinition("tilde", "~"),
+                new StringParameterDefinition("exclamation_mark", "!"),
+                new StringParameterDefinition("at_sign", "@"),
+                new StringParameterDefinition("sharp", "#"),
+                new StringParameterDefinition("dolar", "$"),
+                new StringParameterDefinition("percent", "%"),
+                new StringParameterDefinition("circumflex", "^"),
+                new StringParameterDefinition("ampersand", "&"),
+                new StringParameterDefinition("asterix", "*"),
+                new StringParameterDefinition("parentheses", "()"),
+                new StringParameterDefinition("underscore", "_"),
+                new StringParameterDefinition("plus", "+"),
+                new StringParameterDefinition("braces", "{}"),
+                new StringParameterDefinition("brackets", "[]"),
+                new StringParameterDefinition("colon", ":"),
+                new StringParameterDefinition("semicolon", ";"),
+                new StringParameterDefinition("quote", "\""),
+                new StringParameterDefinition("apostrophe", "'"),
+                new StringParameterDefinition("backslash", "\\"),
+                new StringParameterDefinition("pipe", "|"),
+                new StringParameterDefinition("angle_brackets", "<>"),
+                new StringParameterDefinition("comma", ","),
+                new StringParameterDefinition("period", "."),
+                new StringParameterDefinition("slash", "/"),
+                new StringParameterDefinition("question_mark", "?"),
+                new StringParameterDefinition("space", " ")
+        ));
+
+        FreeStyleBuild build = j.buildAndAssertSuccess(p);
+    }
 }


### PR DESCRIPTION
More conservative approach than https://github.com/jenkinsci/jenkins/pull/1556.
