### PR TITLE
[JENKINS-27034] Fix counting of "buildable items" (Subtasks)

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -437,7 +437,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             assignedNode = null;
         } else {
             canRoam = false;
-            if(l== Jenkins.getInstance().getSelfLabel())  assignedNode = null;
+            if(l.equals(Jenkins.getInstance().getSelfLabel()))  assignedNode = null;
             else                                        assignedNode = l.getExpression();
         }
         save();

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -117,7 +117,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
             @Override
             protected boolean matches(Queue.Item item, SubTask subTask) {
                 final Label l = item.getAssignedLabelFor(subTask);
-                return l != null && Label.this.matches(l.name);
+                return Label.this.equals(l);
             }
         };
         this.nodeProvisioner = new NodeProvisioner(this, loadStatistics);
@@ -511,7 +511,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     @Override
     public final boolean equals(Object that) {
         if (this == that) return true;
-        if (that == null || getClass() != that.getClass()) return false;
+        if (that == null || !(that instanceof Label)) return false;
 
         return matches(((Label)that).name);
 

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -24,6 +24,7 @@
  */
 package hudson.model;
 
+import com.google.common.base.Objects;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
@@ -936,27 +937,37 @@ public class Queue extends ResourceController implements Saveable {
     }
 
     /**
-     * How many {@link BuildableItem}s are assigned for the given label?
+     * Counts all the {@link SubTask}s assigned for the given label.
+     *
+     * This method is a misnomer
      */
     public int countBuildableItemsFor(Label l) {
         Snapshot snapshot = this.snapshot;
         int r = 0;
         for (BuildableItem bi : snapshot.buildables)
             for (SubTask st : bi.task.getSubTasks())
-                if (null == l || bi.getAssignedLabelFor(st) == l)
+                if (Objects.equal(l,bi.getAssignedLabelFor(st)))
                     r++;
         for (BuildableItem bi : snapshot.pendings)
             for (SubTask st : bi.task.getSubTasks())
-                if (null == l || bi.getAssignedLabelFor(st) == l)
+                if (Objects.equal(l,bi.getAssignedLabelFor(st)))
                     r++;
         return r;
     }
 
     /**
-     * Counts all the {@link BuildableItem}s currently in the queue.
+     * Counts all the {@link SubTask}s currently in the queue.
+     *
+     * This method is a misnomer
      */
     public int countBuildableItems() {
-        return countBuildableItemsFor(null);
+        int r = 0;
+        Snapshot snapshot = this.snapshot;
+        for (BuildableItem bi : snapshot.buildables)
+            r += bi.task.getSubTasks().size();
+        for (BuildableItem bi : snapshot.pendings)
+            r += bi.task.getSubTasks().size();
+        return r;
     }
 
     /**

--- a/test/src/main/java/hudson/model/LabelTestBuild.java
+++ b/test/src/main/java/hudson/model/LabelTestBuild.java
@@ -1,0 +1,19 @@
+package hudson.model;
+
+import java.io.*;
+
+public class LabelTestBuild extends Build<LabelTestProject,LabelTestBuild> {
+    public LabelTestBuild(LabelTestProject project) throws IOException {
+        super(project);
+    }
+
+    public LabelTestBuild(LabelTestProject project, File buildDir) throws IOException {
+        super(project, buildDir);
+    }
+
+    @Override
+    public void run() {
+        execute(new BuildExecution());
+    }
+}
+

--- a/test/src/main/java/hudson/model/LabelTestProject.java
+++ b/test/src/main/java/hudson/model/LabelTestProject.java
@@ -1,0 +1,45 @@
+package hudson.model;
+
+import hudson.Extension;
+import jenkins.model.Jenkins;
+
+public class LabelTestProject extends Project<LabelTestProject,LabelTestBuild> implements TopLevelItem {
+    public LabelTestProject(ItemGroup parent, String name) {
+        super(parent, name);
+    }
+
+    //Override AbstractProject's label assignment to preserve the label instance
+    Label l = null;
+
+    @Override
+    public void setAssignedLabel(Label l) {
+        this.l = l;
+    }
+
+    @Override
+    public Label getAssignedLabel() {
+        return l;
+    }
+
+    @Override
+    protected Class<LabelTestBuild> getBuildClass() {
+        return LabelTestBuild.class;
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl)Jenkins.getInstance().getDescriptorOrDie(getClass());
+    }
+
+    @Extension(ordinal=1000)
+    public static final class DescriptorImpl extends AbstractProjectDescriptor {
+        public String getDisplayName() {
+            return "LabelTestProject";
+        }
+
+        public LabelTestProject newInstance(ItemGroup parent, String name) {
+            return new LabelTestProject(parent,name);
+        }
+    }
+}
+


### PR DESCRIPTION
[JENKINS-27034](https://issues.jenkins-ci.org/browse/JENKINS-27034)
- Fix comparing labels using == instead of equals()
- Restore the "null" label counting "free roam" jobs (Broken in 2013)
- Fix LoadStatistics counting SubTasks for labels and Queue.BuildableItem's for totals
- De-duplicate counting code in LoadStatistics
