### PR TITLE
prevent removing artifact when build isn’t completed yet

### DIFF
--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -187,6 +187,10 @@ public class LogRotator extends BuildDiscarder {
             LOGGER.log(FINER, "{0} is not to be removed or purged of artifacts because it’s the last stable build", r);
             return true;
         }
+        if (r.isBuilding()) {
+            LOGGER.log(FINER, "{0} is not to be removed or purged of artifacts because it’s still building", r);
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
When concurrent builds are enabled, artifact retention policy may delete artifact being used by an actually running build. This use to not be an issue as the archiving is in most case the last post-build action, but in a workflow context a manual step can be set that will hung the execution, and further steps may rely on the archived artifact. 

@reviewbybees also see ZD-24695
