### PR TITLE
[JENKINS-4409] Disable URLConnection.useCache in tests on Windows

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -101,6 +101,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -276,6 +277,8 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
      */
     protected File explodedWarDir;
 
+    private boolean origDefaultUseCache = true;
+
     protected HudsonTestCase(String name) {
         super(name);
     }
@@ -298,6 +301,18 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
 
     @Override
     protected void  setUp() throws Exception {
+        if(Functions.isWindows()) {
+            // JENKINS-4409.
+            // URLConnection caches handles to jar files by default,
+            // and it prevents delete temporary directories on Windows.
+            // Disables caching here.
+            // Though defaultUseCache is a static field,
+            // its setter and getter are provided as instance methods.
+            URLConnection aConnection = new File(".").toURI().toURL().openConnection();
+            origDefaultUseCache = aConnection.getDefaultUseCaches();
+            aConnection.setDefaultUseCaches(false);
+        }
+        
         env.pin();
         recipe();
         for (Runner r : recipes) {
@@ -420,6 +435,12 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             // at some later point, leading to possible file descriptor overflow. So encourage GC now.
             // see http://bugs.sun.com/view_bug.do?bug_id=4950148
             System.gc();
+            
+            // restore defaultUseCache
+            if(Functions.isWindows()) {
+                URLConnection aConnection = new File(".").toURI().toURL().openConnection();
+                aConnection.setDefaultUseCaches(origDefaultUseCache);
+            }
         }
     }
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-4409

Plugin tests on Windows leave %TEMP%\hudsonXXXXXXXXXXtmp with output like this (this doesn't affect test results):

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 62.997 sec - in hudson.plugins.copyartifact.BuildSelectorParameterTest
java.nio.file.FileSystemException: C:\Users\ikedam\AppData\Local\Temp\hudson7190248855254390892tmp\credentials\WEB-INF\lib\classes.jar: The process cannot access the file because it is being used by another process.

        at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:86)
        at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:97)
        at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:102)
        at sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:269)
        at sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:103)
        at java.nio.file.Files.delete(Files.java:1077)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at hudson.Util.deleteFile(Util.java:247)
        at hudson.Util.deleteRecursive(Util.java:310)
        at hudson.Util.deleteContentsRecursive(Util.java:212)
        at hudson.Util.deleteRecursive(Util.java:301)
        at hudson.Util.deleteContentsRecursive(Util.java:212)
        at hudson.Util.deleteRecursive(Util.java:301)
        at hudson.Util.deleteContentsRecursive(Util.java:212)
        at hudson.Util.deleteRecursive(Util.java:301)
        at hudson.Util.deleteContentsRecursive(Util.java:212)
        at hudson.Util.deleteRecursive(Util.java:301)
        at org.jvnet.hudson.test.TestPluginManager$1.run(TestPluginManager.java:146)

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

This is caused for [localizer](https://github.com/kohsuke/localizer/) and [sezpoz](https://github.com/jglick/sezpoz) read streams from classes.jar and `URLConnection` doesn't release the handle to classes.jar even after they closed streams.

 This change disables the caching by `URLConnection` in tests on Windows.

This is an alternate approach for kohsuke/localizer#9 and jglick/sezpoz#9.
This affects only tests on Windows, and never cause performance issues in production environments.
But I'm not sure disabling caching in `URLConnection` really cause performance issues.
I expect reviews by experts of performance.

If jglick/sezpoz#9 is merged to sezpoz, we no longer need this change.
