### PR TITLE
[WiP] - inform administrator about plugins incompatibilities and missing plugins

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -65,12 +65,7 @@ import org.jvnet.hudson.reactor.Reactor;
 import org.jvnet.hudson.reactor.ReactorException;
 import org.jvnet.hudson.reactor.TaskBuilder;
 import org.jvnet.hudson.reactor.TaskGraphBuilder;
-import org.kohsuke.stapler.HttpRedirect;
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.HttpResponses;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -327,6 +322,35 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                                 }
                             });
 
+
+                            g.followedBy().attains(PLUGINS_LISTED).add("Checking plugin dependencies", new Executable() {
+                                @Override
+                                public void run(Reactor reactor) throws Exception {
+                                    for (PluginWrapper plugin: getPlugins()) {
+                                        String core = plugin.getManifest().getMainAttributes().getValue("Jenkins-Version");
+                                        if (core != null && Jenkins.getVersion().compareTo(new VersionNumber(core)) < 0) {
+                                            String s = "Plugin " + plugin.getShortName() + " required jenkins " + core + " or later.";
+                                            LOGGER.severe(s);
+                                            NOTICE.add(s);
+                                        }
+
+                                        for (Dependency dep : plugin.getDependencies()) {
+                                            if (dep.optional) continue;
+                                            PluginWrapper p = getPlugin(dep.shortName);
+                                            if (p == null) {
+                                                String s = "Plugin " + plugin.getShortName() + " is missing required dependency " + p.getShortName();
+                                                LOGGER.severe(s);
+                                                NOTICE.add(s);
+                                            } else if (p.getVersionNumber().compareTo(new VersionNumber(dep.version)) < 0) {
+                                                String s = "Plugin " + plugin.getShortName() + " require " + p.getShortName() + " " + dep.version + " or later";
+                                                LOGGER.severe(s);
+                                                NOTICE.add(s);
+                                            }
+                                        }
+                                    }
+                                }
+                            });
+
                             // Let's see for a while until we open this functionality up to plugins
 //                            g.followedBy().attains(PLUGINS_LISTED).add("Load compatibility rules", new Executable() {
 //                                public void run(Reactor reactor) throws Exception {
@@ -407,6 +431,29 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             });
         }});
     }
+
+    /**
+     * Used to indicate a missing dependency within installed plugins.
+     */
+    @Extension
+    public final static PluginsRequirementsNotice NOTICE = new PluginsRequirementsNotice();
+
+
+    public static final class PluginsRequirementsNotice extends AdministrativeMonitor {
+
+        public final List<String> errors = new ArrayList<String>();
+
+        void add(String error) {
+            errors.add(error);
+        }
+
+        public boolean isActivated() {
+            return !errors.isEmpty();
+        }
+
+    }
+
+
 
     /*
      * contains operation that considers xxx.hpi and xxx.jpi as equal

--- a/core/src/main/resources/hudson/PluginManager/PluginsRequirementsNotice/message.jelly
+++ b/core/src/main/resources/hudson/PluginManager/PluginsRequirementsNotice/message.jelly
@@ -1,0 +1,11 @@
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <div class="error">
+    <ul>
+      <j:forEach items="${it.errors}" var="error">
+        <li>${error}</li>
+      </j:forEach>
+    </ul>
+  </div>
+</j:jelly>


### PR DESCRIPTION
show alert message on "manage" view and in logs when any plugin doesn't get it's dependency minimal versions installed.

Maybe I could even use same hack the "please wait jenkins to start" message uses to show this at startup, until some user acknowledge and switch to standard UI.
