### PR TITLE
[FIXED JENKINS-26391] Prevent lazy loading operation when obtaining label information

### DIFF
--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -506,11 +506,11 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return name.hashCode();
     }
 
-    public int compareTo(Label that) {
+    public final int compareTo(Label that) {
         return this.name.compareTo(that.name);
     }
 

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -374,7 +374,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
             for (TopLevelItem topLevelItem : Jenkins.getInstance().getItemMap().values()) {
                 if (topLevelItem instanceof AbstractProject) {
                     final AbstractProject project = (AbstractProject) topLevelItem;
-                    if (this.equals(project.getAssignedLabel())) {
+                    if (this.name.equals(project.getAssignedLabelString())) {
                         result++;
                     }
                 }
@@ -389,7 +389,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
                         for (Item i : parent.getItems()) {
                             if (i instanceof AbstractProject) {
                                 final AbstractProject project = (AbstractProject) i;
-                                if (this.equals(project.getAssignedLabel())) {
+                                if (this.name.equals(project.getAssignedLabelString())) {
                                     result++;
                                 }
                             }

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -514,8 +514,13 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
         return this.name.compareTo(that.name);
     }
 
-    public final boolean matches(String labelString) {
-        return name.equals(labelString);
+
+    /**
+     * Evaluates whether the current label name is equal to the name parameter.
+     *
+     */
+    private final boolean matches(String name) {
+        return this.name.equals(name);
     }
 
     @Override

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -374,7 +374,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
             for (TopLevelItem topLevelItem : Jenkins.getInstance().getItemMap().values()) {
                 if (topLevelItem instanceof AbstractProject) {
                     final AbstractProject project = (AbstractProject) topLevelItem;
-                    if (this.name.equals(project.getAssignedLabelString())) {
+                    if (matches(project.getAssignedLabelString())) {
                         result++;
                     }
                 }
@@ -389,7 +389,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
                         for (Item i : parent.getItems()) {
                             if (i instanceof AbstractProject) {
                                 final AbstractProject project = (AbstractProject) i;
-                                if (this.name.equals(project.getAssignedLabelString())) {
+                                if (matches(project.getAssignedLabelString())) {
                                     result++;
                                 }
                             }
@@ -501,7 +501,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
         if (this == that) return true;
         if (that == null || getClass() != that.getClass()) return false;
 
-        return name.equals(((Label)that).name);
+        return matches(((Label)that).name);
 
     }
 
@@ -512,6 +512,10 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
 
     public final int compareTo(Label that) {
         return this.name.compareTo(that.name);
+    }
+
+    public final boolean matches(String labelString) {
+        return name.equals(labelString);
     }
 
     @Override

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -497,7 +497,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
 
 
     @Override
-    public boolean equals(Object that) {
+    public final boolean equals(Object that) {
         if (this == that) return true;
         if (that == null || getClass() != that.getClass()) return false;
 


### PR DESCRIPTION
[JENKINS-26391](https://issues.jenkins-ci.org/browse/JENKINS-26391)

Viewing a label triggers a lazy loading operation with the maven project type.

@reviewbybees
