### PR TITLE
Macosx newsyslog

### DIFF
--- a/osx/scripts/postinstall-launchd
+++ b/osx/scripts/postinstall-launchd
@@ -16,7 +16,7 @@ chown daemon:daemon /var/log/jenkins
 cat <<_EOT_ > /etc/newsyslog.d/jenkins.conf
 # logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
 # Rotate jenkins log at midnight, and preserve old logs in 3 days
-/var/log/jenkins/jenkins.log            644  3     *    \$D0   J
+/var/log/jenkins/jenkins.log      daemon:daemon      644  3     *    \$D0   J
 _EOT_
 
 # Load and start the launch daemon

--- a/osx/scripts/postinstall-launchd-jenkins
+++ b/osx/scripts/postinstall-launchd-jenkins
@@ -44,7 +44,13 @@ else
     dscl . -append /Groups/jenkins GroupMembership jenkins
 fi
 
-find "$JENKINS_HOMEDIR" \( -not -user jenkins -or -not -group jenkins \) -print0 | xargs -0 chown jenkins:jenkins
+# identify the real default group name for user jenkins
+groupid=`dscl . read /Users/jenkins PrimaryGroupID | awk '{print $2}'`
+gname=`id -n -g $groupid`
+
+echo "Using jenkins:${gname} as file owner and group for jenkins daemon files"
+
+find "$JENKINS_HOMEDIR" \( -not -user jenkins -or -not -group ${gname} \) -print0 | xargs -0 chown jenkins:${gname}
 
 # Add defaults for heap sizing
 arch=$(uname -m)
@@ -65,17 +71,17 @@ fi
 JENKINS_TMPDIR="$JENKINS_HOMEDIR/tmp"
 defaults write $DEFAULTS_PLIST tmpdir $JENKINS_TMPDIR
 mkdir -p $JENKINS_TMPDIR
-chown jenkins:jenkins $JENKINS_TMPDIR
+chown jenkins:${gname} $JENKINS_TMPDIR
 
 # Create log directory, which can be written by Jenkins daemon
 mkdir -p /var/log/jenkins
-chown jenkins:jenkins /var/log/jenkins
+chown jenkins:${gname} /var/log/jenkins
 
 # Enable log rotation by newsyslog
 cat <<_EOT_ > /etc/newsyslog.d/jenkins.conf
 # logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
 # Rotate jenkins log at midnight, and preserve old logs in 3 days
-/var/log/jenkins/jenkins.log     jenkins:jenkins       644  3     *    \$D0   J
+/var/log/jenkins/jenkins.log     jenkins:${gname}       644  3     *    \$D0   J
 _EOT_
 
 # Load and start the launch daemon

--- a/osx/scripts/postinstall-launchd-jenkins
+++ b/osx/scripts/postinstall-launchd-jenkins
@@ -75,7 +75,7 @@ chown jenkins:jenkins /var/log/jenkins
 cat <<_EOT_ > /etc/newsyslog.d/jenkins.conf
 # logfilename          [owner:group]    mode count size when  flags [/pid_file] [sig_num]
 # Rotate jenkins log at midnight, and preserve old logs in 3 days
-/var/log/jenkins/jenkins.log            644  3     *    \$D0   J
+/var/log/jenkins/jenkins.log     jenkins:jenkins       644  3     *    \$D0   J
 _EOT_
 
 # Load and start the launch daemon


### PR DESCRIPTION
These 2 commits fix 2 issues:
- reuse the existing default groupd for the jenkins user (if it was created beforehand)
- configure newsyslog to use proper permissions

I tested this PR doing the following:

```
$ sudo dscl . create /Users/jenkins
$ sudo dscl . create /Users/jenkins UserShell /bin/bash
$ sudo dscl . create /Users/jenkins RealName "Jenkins"
$ sudo dscl . create /Users/jenkins UniqueID 503
$ sudo dscl . create /Users/jenkins PrimaryGroupID 1
$ mkdir /Users/Shared/Jenkins
$ sudo dscl . create /Users/jenkins NFSHomeDirectory /Users/Shared/Jenkins
$ sudo dscl . passwd /Users/jenkins "jenkins"

$ ./build.sh ~/Downloads/jenkins.war 

$ version=1.580.3
$ sudo installer -pkg  "jenkins-${version}.pkg" -target /
installer: Package name is Jenkins 1.580.3
installer: Installing at base path /
installer: The install was successful.
$ ls -la /var/log/jenkins/
total 8
drwxr-xr-x   3 jenkins  daemon   102 Feb 18 17:18 .
drwxr-xr-x  96 root     wheel   3264 Feb 18 17:18 ..
-rw-r--r--   1 jenkins  daemon  2354 Feb 18 17:19 jenkins.log
```
