### PR TITLE
[FIXED JENKINS-24433] Searchbox doesn't work properly inside a folder

### DIFF
--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -76,7 +76,7 @@ public class Search {
                     SuggestedItem target = find(index, query, smo);
                     if(target!=null) {
                         // found
-                        rsp.sendRedirect2(a.getUrl()+target.getUrl());
+                        rsp.sendRedirect2(req.getContextPath()+target.getUrl());
                         return;
                     }
                 }

--- a/core/src/main/java/hudson/search/SuggestedItem.java
+++ b/core/src/main/java/hudson/search/SuggestedItem.java
@@ -81,7 +81,7 @@ public class SuggestedItem {
     
     private static SuggestedItem build(SearchableModelObject searchContext, Item top) {
         ItemGroup<? extends Item> parent = top.getParent();
-        if (parent instanceof Item && parent != searchContext) {
+        if (parent instanceof Item) {
             Item parentItem = (Item)parent;
             return new SuggestedItem(build(searchContext, parentItem), top);
         }

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -342,7 +342,7 @@ public class SearchTest {
             }
         }
 
-        assertTrue(foundDisplayName);
+		assertTrue(foundDisplayName);
     }
 
     /**

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -298,7 +298,7 @@ public class SearchTest {
             }
         }
 
-		assertTrue(foundDisplayName);
+        assertTrue(foundDisplayName);
     }
 
     @Issue("JENKINS-24433")
@@ -342,7 +342,7 @@ public class SearchTest {
             }
         }
 
-		assertTrue(foundDisplayName);
+        assertTrue(foundDisplayName);
     }
 
     /**

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -253,7 +253,7 @@ public class SearchTest {
                 foundDispayName = true;
             }
         }
-        
+
         assertTrue(foundProjectName);
         assertTrue(foundDispayName);
     }
@@ -270,10 +270,10 @@ public class SearchTest {
         FreeStyleProject project1 = j.createFreeStyleProject(projectName1);
         project1.setDisplayName(displayName1);
 
-		MockFolder myMockFolder = j.createFolder("my-folder-1");
+        MockFolder myMockFolder = j.createFolder("my-folder-1");
 
-		FreeStyleProject project2 = myMockFolder.createProject(FreeStyleProject.class, projectName2);
-		project2.setDisplayName(displayName2);
+        FreeStyleProject project2 = myMockFolder.createProject(FreeStyleProject.class, projectName2);
+        project2.setDisplayName(displayName2);
 
         WebClient wc = j.createWebClient();
         Page result = wc.goTo(myMockFolder.getUrl() + "search/suggest?query=" + projectName1, "application/json");
@@ -313,7 +313,7 @@ public class SearchTest {
         FreeStyleProject project1 = j.createFreeStyleProject(projectName1);
         project1.setDisplayName(displayName1);
 
-		MockFolder myMockFolder = j.createFolder("my-folder-1");
+        MockFolder myMockFolder = j.createFolder("my-folder-1");
 
         FreeStyleProject project2 = myMockFolder.createProject(FreeStyleProject.class, projectName2);
         project2.setDisplayName(displayName2);

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -105,6 +105,40 @@ public class SearchTest {
         assertTrue(contents.contains(String.format("<title>%s [Jenkins]</title>", projectName)));
     }
 
+    @Issue("JENKINS-24433")
+    @Test
+    public void testSearchByProjectNameBehindAFolder() throws Exception {
+        final String projectName = "testSearchByProjectName";
+        j.createFreeStyleProject(projectName);
+        j.createFolder("my-folder-1").createProject(FreeStyleProject.class, "my-job-1");
+
+        Page result = j.createWebClient().goTo("job/my-folder-1/search?q="+ projectName);
+
+        assertNotNull(result);
+        j.assertGoodStatus(result);
+
+        // make sure we've fetched the testSearchByDisplayName project page
+        String contents = result.getWebResponse().getContentAsString();
+        assertTrue(contents.contains(String.format("<title>%s [Jenkins]</title>", projectName)));
+    }
+
+    @Issue("JENKINS-24433")
+    @Test
+    public void testSearchByProjectNameInAFolder() throws Exception {
+        final String projectName = "testSearchByProjectName";
+        j.createFreeStyleProject(projectName);
+        j.createFolder("my-folder-1").createProject(FreeStyleProject.class, "my-job-1");
+
+        Page result = j.createWebClient().goTo("job/my-folder-1/search?q="+ "my-folder-1/my-job-1");
+
+        assertNotNull(result);
+        j.assertGoodStatus(result);
+
+        // make sure we've fetched the testSearchByDisplayName project page
+        String contents = result.getWebResponse().getContentAsString();
+        assertTrue(contents.contains(String.format("<title>%s [Jenkins]</title>", "my-job-1 [my-folder-1]")));
+    }
+
     @Test
     public void testSearchByDisplayName() throws Exception {
         final String displayName = "displayName9999999";
@@ -223,6 +257,95 @@ public class SearchTest {
         
         assertTrue(foundProjectName);
         assertTrue(foundDispayName);
+    }
+
+    @Issue("JENKINS-24433")
+    @Test
+    public void testProjectNameBehindAFolderDisplayName() throws Exception {
+        final String projectName1 = "job-1";
+        final String displayName1 = "job-1";
+
+        final String projectName2 = "job-2";
+        final String displayName2 = "job-2";
+
+        FreeStyleProject project1 = j.createFreeStyleProject(projectName1);
+        project1.setDisplayName(displayName1);
+
+        FreeStyleProject project2 = j.createFolder("my-folder-1").createProject(FreeStyleProject.class, projectName2);
+        project2.setDisplayName(displayName2);
+
+        WebClient wc = j.createWebClient();
+        Page result = wc.goTo("job/my-folder-1/search/suggest?query=" + projectName1, "application/json");
+        assertNotNull(result);
+        j.assertGoodStatus(result);
+
+        String content = result.getWebResponse().getContentAsString();
+        JSONObject jsonContent = (JSONObject)JSONSerializer.toJSON(content);
+        assertNotNull(jsonContent);
+        JSONArray jsonArray = jsonContent.getJSONArray("suggestions");
+        assertNotNull(jsonArray);
+
+        assertEquals(1, jsonArray.size());
+
+        boolean foundProjectName = false;
+        boolean foundDisplayName = false;
+        for(Object suggestion : jsonArray) {
+            JSONObject jsonSuggestion = (JSONObject)suggestion;
+
+            String name = (String)jsonSuggestion.get("name");
+            if(projectName1.equals(name)) {
+                foundProjectName = true;
+            }
+            if(displayName1.equals(name)) {
+                foundDisplayName = true;
+            }
+        }
+
+        assertTrue(foundProjectName);
+        assertTrue(foundDisplayName);
+    }
+
+    @Issue("JENKINS-24433")
+    @Test
+    public void testProjectNameInAFolderDisplayName() throws Exception {
+        final String projectName1 = "job-1";
+        final String displayName1 = "job-1";
+
+        final String projectName2 = "job-2";
+        final String displayName2 = "my-folder-1 job-2";
+
+        FreeStyleProject project1 = j.createFreeStyleProject(projectName1);
+        project1.setDisplayName(displayName1);
+
+        FreeStyleProject project2 = j.createFolder("my-folder-1").createProject(FreeStyleProject.class, projectName2);
+        project2.setDisplayName(displayName2);
+
+
+        WebClient wc = j.createWebClient();
+        Page result = wc.goTo("job/my-folder-1/search/suggest?query=" + projectName2, "application/json");
+        assertNotNull(result);
+        j.assertGoodStatus(result);
+
+        String content = result.getWebResponse().getContentAsString();
+        JSONObject jsonContent = (JSONObject)JSONSerializer.toJSON(content);
+        assertNotNull(jsonContent);
+        JSONArray jsonArray = jsonContent.getJSONArray("suggestions");
+        assertNotNull(jsonArray);
+
+        assertEquals(1, jsonArray.size());
+
+        boolean foundDisplayName = false;
+        for(Object suggestion : jsonArray) {
+            JSONObject jsonSuggestion = (JSONObject)suggestion;
+
+            String name = (String)jsonSuggestion.get("name");
+
+            if(displayName2.equals(name)) {
+                foundDisplayName = true;
+            }
+        }
+
+        assertTrue(foundDisplayName);
     }
 
     /**

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -262,19 +262,21 @@ public class SearchTest {
     @Test
     public void testProjectNameBehindAFolderDisplayName() throws Exception {
         final String projectName1 = "job-1";
-        final String displayName1 = "job-1";
+        final String displayName1 = "job-1 display";
 
         final String projectName2 = "job-2";
-        final String displayName2 = "job-2";
+        final String displayName2 = "job-2 display";
 
         FreeStyleProject project1 = j.createFreeStyleProject(projectName1);
         project1.setDisplayName(displayName1);
 
-        FreeStyleProject project2 = j.createFolder("my-folder-1").createProject(FreeStyleProject.class, projectName2);
-        project2.setDisplayName(displayName2);
+		MockFolder myMockFolder = j.createFolder("my-folder-1");
+
+		FreeStyleProject project2 = myMockFolder.createProject(FreeStyleProject.class, projectName2);
+		project2.setDisplayName(displayName2);
 
         WebClient wc = j.createWebClient();
-        Page result = wc.goTo("job/my-folder-1/search/suggest?query=" + projectName1, "application/json");
+        Page result = wc.goTo(myMockFolder.getUrl() + "search/suggest?query=" + projectName1, "application/json");
         assertNotNull(result);
         j.assertGoodStatus(result);
 
@@ -284,27 +286,26 @@ public class SearchTest {
         JSONArray jsonArray = jsonContent.getJSONArray("suggestions");
         assertNotNull(jsonArray);
 
-        assertEquals(1, jsonArray.size());
+        assertEquals(2, jsonArray.size());
 
-        boolean foundProjectName = false;
         boolean foundDisplayName = false;
         for(Object suggestion : jsonArray) {
             JSONObject jsonSuggestion = (JSONObject)suggestion;
 
             String name = (String)jsonSuggestion.get("name");
-            if(displayName1.equals(name)) {
+            if(projectName1.equals(name)) {
                 foundDisplayName = true;
             }
         }
 
-        assertTrue(foundDisplayName);
+		assertTrue(foundDisplayName);
     }
 
     @Issue("JENKINS-24433")
     @Test
     public void testProjectNameInAFolderDisplayName() throws Exception {
         final String projectName1 = "job-1";
-        final String displayName1 = "job-1";
+        final String displayName1 = "job-1 display";
 
         final String projectName2 = "job-2";
         final String displayName2 = "my-folder-1 job-2";
@@ -312,12 +313,13 @@ public class SearchTest {
         FreeStyleProject project1 = j.createFreeStyleProject(projectName1);
         project1.setDisplayName(displayName1);
 
-        FreeStyleProject project2 = j.createFolder("my-folder-1").createProject(FreeStyleProject.class, projectName2);
+		MockFolder myMockFolder = j.createFolder("my-folder-1");
+
+        FreeStyleProject project2 = myMockFolder.createProject(FreeStyleProject.class, projectName2);
         project2.setDisplayName(displayName2);
 
-
         WebClient wc = j.createWebClient();
-        Page result = wc.goTo("job/my-folder-1/search/suggest?query=" + projectName2, "application/json");
+        Page result = wc.goTo(myMockFolder.getUrl() + "search/suggest?query=" + projectName2, "application/json");
         assertNotNull(result);
         j.assertGoodStatus(result);
 


### PR DESCRIPTION
[JENKINS-24433](https://issues.jenkins-ci.org/browse/JENKINS-24433)

The change in `Search.java` fixes the problem currently there is when you are in a folder, look for job which is behind the folder and try to access to the URL. You should not use `a.getUrl()`, but the current context of the request `req.getContextPath()`.

Change in `SuggestedItem.java` allows you to provide the global context of each item in the tree for the search box. Otherwise, if you are in folder and look for an element behind the folder, then the search box says that this element is in the current context. Better is to provide always global context of all elements.

@reviewbybees
