### PR TITLE
[JENKINS-27081] Executors are dying because SortedIntList wrongly returns nextBuildNumber is already in use.

### DIFF
--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -357,7 +357,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
     }
 
     protected final synchronized void proposeNewNumber(int number) throws IllegalStateException {
-        if (numberOnDisk.isInRange(numberOnDisk.ceil(number))) {
+        if (numberOnDisk.find(number)>-1) {
             throw new IllegalStateException("cannot create a build with number " + number + " since that (or higher) is already in use among " + numberOnDisk);
         }
     }

--- a/core/src/main/java/jenkins/model/lazy/SortedIntList.java
+++ b/core/src/main/java/jenkins/model/lazy/SortedIntList.java
@@ -131,7 +131,7 @@ class SortedIntList extends AbstractList<Integer> {
     }
 
     public boolean isInRange(int idx) {
-        return 0<=idx && idx<size;
+        return find(idx)>-1;
     }
 
     public void sort() {

--- a/core/src/main/java/jenkins/model/lazy/SortedIntList.java
+++ b/core/src/main/java/jenkins/model/lazy/SortedIntList.java
@@ -131,7 +131,7 @@ class SortedIntList extends AbstractList<Integer> {
     }
 
     public boolean isInRange(int idx) {
-        return find(idx)>-1;
+    	return 0<=idx && idx<size;
     }
 
     public void sort() {

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -344,4 +344,16 @@ public class AbstractLazyLoadRunMapTest {
             assertTrue(a.entrySet().contains(e));
         }
     }
+    
+    @Issue("JENKINS-27081")
+    @Test
+    public void proposeNewNumberInRange() {
+    	assertFalse(a.proposeNewNumberTest(1));
+    }
+    
+    @Issue("JENKINS-27081")
+    @Test
+    public void proposeNewNumberNotInRange() {
+    	assertTrue(a.proposeNewNumberTest(500));
+    }
 }

--- a/core/src/test/java/jenkins/model/lazy/FakeMap.java
+++ b/core/src/test/java/jenkins/model/lazy/FakeMap.java
@@ -47,6 +47,19 @@ public class FakeMap extends AbstractLazyLoadRunMap<Build> {
         //new Exception("loading #" + n).printStackTrace();
         return new Build(Integer.parseInt(n));
     }
+    
+    /**
+     * Created to be possible to call proposeNewNumber in test case.
+     * @return if proposed number is ok.
+     */
+    public boolean proposeNewNumberTest(int number){
+    	try{
+    		proposeNewNumber(number);
+    		return true;
+    	} catch(IllegalStateException ise){
+    		return false;
+    	}
+    }
 }
 
 class Build {


### PR DESCRIPTION
Executors start dying after upgrading Jenkins to 1.599 and having all jobs configured to discard old builds.
SortedIntList.isInRange was not considering the list content.

Check the problem:
https://issues.jenkins-ci.org/browse/JENKINS-27081
