### PR TITLE
Fix a display issue with the French locale

### DIFF
--- a/core/src/main/resources/hudson/security/Messages_fr.properties
+++ b/core/src/main/resources/hudson/security/Messages_fr.properties
@@ -1,17 +1,17 @@
 # The MIT License
-# 
+#
 # Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Eric Lefevre-Ardant, Damien Finck
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -48,7 +48,7 @@ LegacySecurityRealm.Displayname=D\u00e9l\u00e9guer au conteneur de servlets
 
 UserDetailsServiceProxy.UnableToQuery=Impossible de r\u00e9cup\u00e9rer les informations utilisateur: {0}
 
-PAMSecurityRealm.DisplayName=Base de donn\u00e9es des utilisateurs &amp; des groupes Unix
+PAMSecurityRealm.DisplayName=Base de donn\u00e9es des utilisateurs et des groupes Unix
 PAMSecurityRealm.ReadPermission=Jenkins doit \u00eatre capable de lire /etc/shadow
 PAMSecurityRealm.Success=Succ\u00e8s
 PAMSecurityRealm.CurrentUser=Utilisateur courant


### PR DESCRIPTION
Shows '&amp;' 
- remove trailing whitespaces
