### PR TITLE
[JENKINS-26690] Integer overflow in AbstractLazyLoadRunMap.headMap

### DIFF
--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -550,7 +550,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
 
     private static final Comparator<Integer> COMPARATOR = new Comparator<Integer>() {
         @Override public int compare(Integer o1, Integer o2) {
-            return o2 - o1;
+            return -o1.compareTo(o2);
         }
     };
     

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -40,7 +40,6 @@ import java.util.SortedMap;
 import java.util.logging.Level;
 import org.junit.BeforeClass;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.Issue;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -131,6 +130,21 @@ public class AbstractLazyLoadRunMapTest {
         } catch (NoSuchElementException e) {
             // as expected
         }
+    }
+
+    @Issue("JENKINS-26690")
+    @Test public void headMap() {
+        assertEquals("[]", a.headMap(Integer.MAX_VALUE).keySet().toString());
+        assertEquals("[]", a.headMap(6).keySet().toString());
+        assertEquals("[]", a.headMap(5).keySet().toString());
+        assertEquals("[5]", a.headMap(4).keySet().toString());
+        assertEquals("[5]", a.headMap(3).keySet().toString());
+        assertEquals("[5, 3]", a.headMap(2).keySet().toString());
+        assertEquals("[5, 3]", a.headMap(1).keySet().toString());
+        assertEquals("[5, 3, 1]", a.headMap(0).keySet().toString());
+        assertEquals("[5, 3, 1]", a.headMap(-1).keySet().toString());
+        assertEquals("[5, 3, 1]", a.headMap(-2).keySet().toString()); // this failed
+        assertEquals("[5, 3, 1]", a.headMap(Integer.MIN_VALUE).keySet().toString());
     }
 
     @Test


### PR DESCRIPTION
[JENKINS-26690](https://issues.jenkins-ci.org/browse/JENKINS-26690)

Background: the original `COMPARATOR` was needlessly typed to take `Comparable` (the raw type), when it was in fact only used for `Integer`. So I fixed that in #1379, but also simplified the implementation to just subtract, forgetting that `Integer.compareTo` handles `int` overflows. And there was no test coverage of `headMap` so the mistake slipped past.

@reviewbybees
