### PR TITLE
[JENKINS-27178] Return copy of EnvVars to prevent outside modification.

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -942,18 +942,18 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     /**
-     * Gets the environment variables of the JVM on this computer.
+     * Returns cached environment variables (copy to prevent modification) for the JVM on this computer.
      * If this is the master, it returns the system property of the master computer.
      */
     public EnvVars getEnvironment() throws IOException, InterruptedException {
         EnvVars cachedEnvironment = this.cachedEnvironment;
         if (cachedEnvironment != null) {
-            return cachedEnvironment;
+            return new EnvVars(cachedEnvironment);
         }
 
         cachedEnvironment = EnvVars.getRemote(getChannel());
         this.cachedEnvironment = cachedEnvironment;
-        return cachedEnvironment;
+        return new EnvVars(cachedEnvironment);
     }
 
     /**

--- a/test/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
+++ b/test/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
@@ -46,12 +46,14 @@ import hudson.tasks.Shell;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 
@@ -82,6 +84,20 @@ public class SimpleBuildWrapperTest {
                 return true;
             }
         }
+    }
+
+    @Issue("JENKINS-27188")
+    @Test public void envPropertiesImmutable() throws Exception {
+        SpecialEnvSlave slave = new SpecialEnvSlave(tmp.getRoot(), r.createComputerLauncher(null));
+        r.jenkins.addNode(slave);
+
+        String propertyKey = "JENKINS-27188";
+        EnvVars envVars = slave.getComputer().getEnvironment();
+        envVars.put(propertyKey, "huuhaa");
+        assertTrue(envVars.containsKey(propertyKey));
+        assertFalse(slave.getComputer().getEnvironment().containsKey(propertyKey));
+
+        assertNotSame(slave.getComputer().getEnvironment(), slave.getComputer().getEnvironment());
     }
 
     @Test public void envOverrideExpand() throws Exception {


### PR DESCRIPTION
[JENKINS-27178](https://issues.jenkins-ci.org/browse/JENKINS-27178)

Found by danielbeck, original behaviour of EnvVars.getRemote(getChannel()) always returned a new instance of EnvVars..

``` java
public EnvVars call() {
    return new EnvVars(EnvVars.masterEnvVars);
}
```

by not returning a copy of the cached environment variables we end up with all sorts of fail as the return map is mutable..
