### PR TITLE
[JENKINS-26739] Suppress monotonicity assertion for MatrixRun

### DIFF
--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -186,7 +186,9 @@ public final class RunMap<R extends Run<?,R>> extends AbstractLazyLoadRunMap<R> 
         if (rootDir.isDirectory()) {
             throw new IllegalStateException(rootDir + " already existed; will not overwite with " + r);
         }
-        proposeNewNumber(r.getNumber());
+        if (!r.getClass().getName().equals("hudson.matrix.MatrixRun")) { // JENKINS-26739: grandfathered in
+            proposeNewNumber(r.getNumber());
+        }
         rootDir.mkdirs();
         return super._put(r);
     }


### PR DESCRIPTION
[JENKINS-26739](https://issues.jenkins-ci.org/browse/JENKINS-26739)

The `MatrixConfiguration.getNextBuildNumber`/`assignBuildNumber` overrides show that matrix runs do not follow the normal model of build histories in Jenkins, and it does not look straightforward to change that. Disabling this assertion for `MatrixRun` (leaving in place the more important assertion that a single build is not overwritten, which JENKINS-26582 seems to be violating).

@reviewbybees and @daniel-beck who suggested the cause.
