### PR TITLE
[JENKINS-27218] expose X-Jenkins-JNLP-Host

### DIFF
--- a/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
+++ b/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
@@ -30,6 +30,10 @@ THE SOFTWARE.
   -->
   <st:header name="X-Hudson-JNLP-Port" value="${app.tcpSlaveAgentListener.port}" />
   <st:header name="X-Jenkins-JNLP-Port" value="${app.tcpSlaveAgentListener.port}" />
+  <j:getStatic var="host" className="hudson.TcpSlaveAgentListener" field="CLI_HOST_NAME"/>
+  <j:if test="${host != null}">
+    <st:header name="X-Jenkins-JNLP-Host" value="${host}" />
+  </j:if>
 
   Jenkins
 </j:jelly>


### PR DESCRIPTION
will require remoting released with https://github.com/jenkinsci/remoting/pull/36 to get JENKINS-27218 fixed.
