### PR TITLE
[FIXED JENKINS-27183] Avoid deadlock when using build-monitor-plugin 

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -216,6 +216,8 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     protected void renameTo(final String newName) throws IOException {
         // always synchronize from bigger objects first
         final ItemGroup parent = getParent();
+        String oldName = this.name;
+        String oldFullName = getFullName();
         synchronized (parent) {
             synchronized (this) {
                 // sanity check
@@ -248,9 +250,6 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                     }
                 });
 
-
-                String oldName = this.name;
-                String oldFullName = getFullName();
                 File oldRoot = this.getRootDir();
 
                 doSetName(newName);
@@ -324,10 +323,9 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                 } catch (AbstractMethodError _) {
                     // ignore
                 }
-
-                ItemListener.fireLocationChange(this, oldFullName);
             }
         }
+        ItemListener.fireLocationChange(this, oldFullName);
     }
 
 


### PR DESCRIPTION
`AbstractItem.renameTo` might need to call `ItemListener.fireLocationChange` outside the synchronized block to avoid deadlocks.

```
"Handling POST /jenkins/view/proces/job/MY_JOB/doRename : …" … waiting for monitor entry […]
   java.lang.Thread.State: BLOCKED (on object monitor)
    at hudson.model.ListView$Listener.renameViewItem(ListView.java:421)
    - waiting to lock <…> (a com.smartcodeltd.jenkinsci.plugins.buildmonitor.BuildMonitorView)
    at hudson.model.ListView$Listener.onLocationChanged(ListView.java:404)
    at hudson.model.listeners.ItemListener.fireLocationChange(ItemListener.java:208)
    at hudson.model.AbstractItem.renameTo(AbstractItem.java:317)
    - locked <…> (a hudson.maven.MavenModuleSet)
    - locked <…> (a hudson.model.Hudson)
    at hudson.model.Job.renameTo(Job.java:617)
    at hudson.model.Job.doDoRename(Job.java:1403)
```

@reviewbybees
