### PR TITLE
[FIXED JENKINS-27289] Make MaskingClassLoader work on slaves

### DIFF
--- a/core/src/main/java/hudson/util/MaskingClassLoader.java
+++ b/core/src/main/java/hudson/util/MaskingClassLoader.java
@@ -42,9 +42,9 @@ public class MaskingClassLoader extends ClassLoader {
     /**
      * Prefix of the packages that should be hidden.
      */
-    private List<String> masksClasses;
+    private final List<String> masksClasses = new ArrayList<String>();
 
-    private List<String> masksResources;
+    private final List<String> masksResources = new ArrayList<String>();
 
     public MaskingClassLoader(ClassLoader parent, String... masks) {
         this(parent, Arrays.asList(masks));
@@ -52,8 +52,7 @@ public class MaskingClassLoader extends ClassLoader {
 
     public MaskingClassLoader(ClassLoader parent, Collection<String> masks) {
         super(parent);
-        this.masksClasses = new ArrayList<String>(masks);
-        this.masksResources = new ArrayList<String>();
+        this.masksClasses.addAll(masks);
 
         /**
          * The name of a resource is a '/'-separated path name

--- a/test/src/test/java/hudson/ClassicPluginStrategyTest.java
+++ b/test/src/test/java/hudson/ClassicPluginStrategyTest.java
@@ -100,7 +100,7 @@ public class ClassicPluginStrategyTest extends HudsonTestCase {
         Class<?> clazz = pw.classLoader.loadClass("org.apache.http.impl.io.SocketInputBuffer");
         ClassLoader cl = clazz.getClassLoader();
         URL url = cl.getResource("org/apache/http/impl/io/SocketInputBuffer.class");
-        assert url != null;
+        assertNotNull(url);
         assertTrue("expected to find the class from foo1 plugin", url.toString().contains("plugins/foo1"));
     }
 }


### PR DESCRIPTION
Masking classLoader doesn`t work on remote Slave

After upgrading the Apache **httpClient** to 4.4, I found that other plugins such as Git-Client/Maven-plugin that also uses httpClient with different versions collapses with ours. So After I added the Mask-Classes attribute the problem was gone, but it looks like this isolated environment dose not apply for Slaves.
I found out that in the `RemoteClassLoader` while it tries to find a specific class URL, `Which.classFileUrl(class)` uses the `getResource` method. This method is not override by the `hudson.util.MaskingClassLoader`. So the class comes from the right source under the plugin itself, but the resource URL of the same class can came from other source such as other plugins that contain the same classes.

Link to Jira: https://issues.jenkins-ci.org/browse/JENKINS-27289
