### PR TITLE
[JENKINS-27363] - Annotate AbstractBuild::getSensitiveBuildVariables()

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -978,9 +978,11 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
      * keys returned by {@link #getBuildVariables()} that should have their
      * values masked for display purposes.
      *
+     * @return Set of variable names. The method may return both empty set
+     *         or null if there is no such variables
      * @since 1.378
      */
-    public Set<String> getSensitiveBuildVariables() {
+    public @CheckForNull Set<String> getSensitiveBuildVariables() {
         Set<String> s = new HashSet<String>();
 
         ParametersAction parameters = getAction(ParametersAction.class);

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -311,7 +311,7 @@ public class Maven extends Builder {
                 }
             }
 
-            Set<String> sensitiveVars = build.getSensitiveBuildVariables();
+            final Set<String> sensitiveVars = build.getSensitiveBuildVariables();
 
             args.addKeyValuePairs("-D",build.getBuildVariables(),sensitiveVars);
             final VariableResolver<String> resolver = new Union<String>(new ByMap<String>(env), vr);

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -39,6 +39,7 @@ import java.io.Serializable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
+import javax.annotation.CheckForNull;
 
 /**
  * Used to build up arguments for a process invocation.
@@ -176,7 +177,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      *      names that do not exist in the set will be added unmasked.
      * @since 1.378
      */
-    public ArgumentListBuilder addKeyValuePairs(String prefix, Map<String,String> props, Set<String> propsToMask) {
+    public ArgumentListBuilder addKeyValuePairs(String prefix, Map<String,String> props, @CheckForNull Set<String> propsToMask) {
         for (Entry<String,String> e : props.entrySet()) {
             addKeyValuePair(prefix, e.getKey(), e.getValue(), (propsToMask == null) ? false : propsToMask.contains(e.getKey()));
         }
@@ -214,7 +215,8 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      *      names that do not exist in the set will be added unmasked.
      * @since 1.378
      */
-    public ArgumentListBuilder addKeyValuePairsFromPropertyString(String prefix, String properties, VariableResolver<String> vr, Set<String> propsToMask) throws IOException {
+    public ArgumentListBuilder addKeyValuePairsFromPropertyString(String prefix, String properties, VariableResolver<String> vr, 
+            @CheckForNull Set<String> propsToMask) throws IOException {
         if(properties==null)    return this;
 
         properties = Util.replaceMacro(properties, propertiesGeneratingResolver(vr));


### PR DESCRIPTION
AbstractBuild::getSensitiveBuildVariables() may return null from implementations child classes
- There's no Javadoc in the core to define the correct behavior => plugins behave "correctly"
- All calls of AbstractBuild::getSensitiveBuildVariables() in the core process null values

Noting is not required.

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
