### PR TITLE
JENKINS-23197: add datestamp to node-offline message

### DIFF
--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -53,9 +53,10 @@ public abstract class OfflineCause {
      * {@link OfflineCause} that renders a static text,
      * but without any further UI.
      */
+    static Date timestamp;
+
     public static class SimpleOfflineCause extends OfflineCause {
         public final Localizable description;
-        public final Date timestamp;
 
         /**
          * @since 1.571
@@ -85,6 +86,7 @@ public abstract class OfflineCause {
 
         public ChannelTermination(Exception cause) {
             this.cause = cause;
+            this.timestamp = new Date();
         }
 
         public String getShortDescription() {
@@ -92,7 +94,7 @@ public abstract class OfflineCause {
         }
 
         @Override public String toString() {
-            return Messages.OfflineCause_connection_was_broken_(Functions.printThrowable(cause));
+            return "[" + timestamp.toString() + "]" + Messages.OfflineCause_connection_was_broken_(Functions.printThrowable(cause));
         }
     }
 
@@ -100,9 +102,10 @@ public abstract class OfflineCause {
      * Caused by failure to launch.
      */
     public static class LaunchFailed extends OfflineCause {
+
         @Override
         public String toString() {
-            return Messages.OfflineCause_LaunchFailed();
+            return "[" + timestamp.toString() + "]" + Messages.OfflineCause_LaunchFailed();
         }
     }
 

--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -33,6 +33,7 @@ import org.acegisecurity.Authentication;
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.export.Exported;
+import java.util.Date;
 
 /**
  * Represents a cause that puts a {@linkplain Computer#isOffline() computer offline}.
@@ -113,7 +114,7 @@ public abstract class OfflineCause {
         public UserCause(User user, String message) {
             super(hudson.slaves.Messages._SlaveComputer_DisconnectedBy(
                     user!=null ? user.getId() : Jenkins.ANONYMOUS.getName(),
-                    message != null ? " : " + message : ""
+                    " [ " + new Date()  + " ] "  + (message != null ? " : " + message : "")
             ));
             this.user = user;
         }

--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -55,17 +55,19 @@ public abstract class OfflineCause {
      */
     public static class SimpleOfflineCause extends OfflineCause {
         public final Localizable description;
+        public final Date timestamp;
 
         /**
          * @since 1.571
          */
         protected SimpleOfflineCause(Localizable description) {
             this.description = description;
+            this.timestamp = new Date();
         }
 
         @Exported(name="description") @Override
         public String toString() {
-            return description.toString();
+            return "[" + timestamp.toString() + "] " + description.toString();
         }
     }
 
@@ -114,7 +116,7 @@ public abstract class OfflineCause {
         public UserCause(User user, String message) {
             super(hudson.slaves.Messages._SlaveComputer_DisconnectedBy(
                     user!=null ? user.getId() : Jenkins.ANONYMOUS.getName(),
-                    " [ " + new Date()  + " ] "  + (message != null ? " : " + message : "")
+                    message != null ? " : " + message : ""
             ));
             this.user = user;
         }

--- a/test/src/test/java/hudson/model/NodeTest.java
+++ b/test/src/test/java/hudson/model/NodeTest.java
@@ -102,7 +102,7 @@ public class NodeTest {
 
         computer.doToggleOffline("original message");
         cause = (UserCause) computer.getOfflineCause();
-        assertEquals("Disconnected by someone@somewhere.com : original message", cause.toString());
+        assertTrue(cause.toString(), cause.toString().matches("^.*?Disconnected by someone@somewhere.com : original message"));
         assertEquals(someone, cause.getUser());
 
         final User root = User.get("root@localhost");

--- a/test/src/test/java/hudson/model/NodeTest.java
+++ b/test/src/test/java/hudson/model/NodeTest.java
@@ -110,7 +110,7 @@ public class NodeTest {
 
         computer.doChangeOfflineCause("new message");
         cause = (UserCause) computer.getOfflineCause();
-        assertEquals("Disconnected by root@localhost : new message", cause.toString());
+        assertTrue(cause.toString(), cause.toString().matches("^.*?Disconnected by root@localhost : new message"));
         assertEquals(root, cause.getUser());
 
         computer.doToggleOffline(null);


### PR DESCRIPTION
When a node is taken offline, the offline cause message automatically includes a username but lacks a timestamp. The timestamp is handy because it lets admins know how long a slave node has been offline as well as who took it offline. This simple edit adds a timestamp between square brackets. Example:

Disconnected by anonymous [ Fri Mar 13 12:08:55 PDT 2015 ] : Offline for debugging
