### PR TITLE
[JENKINS-16284] catch unexpected launcher error

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -249,6 +249,9 @@ public class SlaveComputer extends Computer {
                     } catch (InterruptedException e) {
                         e.printStackTrace(taskListener.error(Messages.ComputerLauncher_abortedLaunch()));
                         throw e;
+                    } catch (Exception e) {
+                        e.printStackTrace(taskListener.error(Messages.ComputerLauncher_unexpectedError()));
+                        throw e;
                     }
                 } finally {
                     if (channel==null) {


### PR DESCRIPTION
Investigating [JENKINS-16284](https://issues.jenkins-ci.org/browse/JENKINS-16284) I noticed Launcher throwing an unexpected Exception just produces empty log without any diagnostic information.
