### PR TITLE
[JENKINS-27505] Preserve an empty line at the beginning of a textarea

### DIFF
--- a/core/src/main/resources/lib/form/textarea.jelly
+++ b/core/src/main/resources/lib/form/textarea.jelly
@@ -89,6 +89,7 @@ THE SOFTWARE.
             readonly="${attrs.readonly}"
             codemirror-mode="${attrs['codemirror-mode']}"
             codemirror-config="${attrs['codemirror-config']}">
+    <j:if test="${value != null &amp;&amp; !empty(value.toString()) &amp;&amp; (value.toString().codePointAt(0) == 10 || value.toString().codePointAt(0) == 13)}"><j:whitespace>&#10;</j:whitespace></j:if>
     <st:out value="${value}" />
   </textarea>
   <j:if test="${customizedFields != null and attrs.field != null and value != default}">

--- a/test/src/test/groovy/lib/form/TextAreaTest.groovy
+++ b/test/src/test/groovy/lib/form/TextAreaTest.groovy
@@ -73,36 +73,37 @@ class TextAreaTest {
 
     }
     
+    @Issue("JENKINS-27505")
     @Test
     public void testText() {
-        def TEXT_TO_TEST = "some\nvalue\n";
-        def p = j.createFreeStyleProject();
-        def target = new TextareaTestBuilder(TEXT_TO_TEST);
-        p.buildersList.add(target);
-        j.configRoundtrip(p);
-        j.assertEqualDataBoundBeans(target, p.getBuildersList().get(TextareaTestBuilder.class));
-    }
-
-    @Issue("JENKINS-27505")
-    @Test
-    public void testTextBeginningWithEmptyLine() {
-        def TEXT_TO_TEST = "\nbegin\n\nwith\nempty\nline\n\n";
-        def p = j.createFreeStyleProject();
-        def target = new TextareaTestBuilder(TEXT_TO_TEST);
-        p.buildersList.add(target);
-        j.configRoundtrip(p);
-        j.assertEqualDataBoundBeans(target, p.getBuildersList().get(TextareaTestBuilder.class));
-    }
-
-    @Issue("JENKINS-27505")
-    @Test
-    public void testTextBeginningWithTwoEmptyLines() {
-        def TEXT_TO_TEST = "\n\nbegin\n\nwith\ntwo\nempty\nline\n\n";
-        def p = j.createFreeStyleProject();
-        def target = new TextareaTestBuilder(TEXT_TO_TEST);
-        p.buildersList.add(target);
-        j.configRoundtrip(p);
-        j.assertEqualDataBoundBeans(target, p.getBuildersList().get(TextareaTestBuilder.class));
+        T1:{
+            def TEXT_TO_TEST = "some\nvalue\n";
+            def p = j.createFreeStyleProject();
+            def target = new TextareaTestBuilder(TEXT_TO_TEST);
+            p.buildersList.add(target);
+            j.configRoundtrip(p);
+            j.assertEqualDataBoundBeans(target, p.getBuildersList().get(TextareaTestBuilder.class));
+        }
+        
+        // test for a textarea beginning with a empty line.
+        T2:{
+            def TEXT_TO_TEST = "\nbegin\n\nwith\nempty\nline\n\n";
+            def p = j.createFreeStyleProject();
+            def target = new TextareaTestBuilder(TEXT_TO_TEST);
+            p.buildersList.add(target);
+            j.configRoundtrip(p);
+            j.assertEqualDataBoundBeans(target, p.getBuildersList().get(TextareaTestBuilder.class));
+        }
+        
+        // test for a textarea beginning with two empty lines.
+        T3:{
+            def TEXT_TO_TEST = "\n\nbegin\n\nwith\ntwo\nempty\nline\n\n";
+            def p = j.createFreeStyleProject();
+            def target = new TextareaTestBuilder(TEXT_TO_TEST);
+            p.buildersList.add(target);
+            j.configRoundtrip(p);
+            j.assertEqualDataBoundBeans(target, p.getBuildersList().get(TextareaTestBuilder.class));
+        }
     }
 
     public static class TextareaTestBuilder extends Builder {

--- a/test/src/test/groovy/lib/form/TextAreaTest.groovy
+++ b/test/src/test/groovy/lib/form/TextAreaTest.groovy
@@ -77,10 +77,10 @@ class TextAreaTest {
     public void testText() {
         def TEXT_TO_TEST = "some\nvalue\n";
         def p = j.createFreeStyleProject();
-        p.buildersList.add(new TextareaTestBuilder(TEXT_TO_TEST));
-        assertEquals(TEXT_TO_TEST, p.getBuildersList().get(TextareaTestBuilder.class).getText());
+        def target = new TextareaTestBuilder(TEXT_TO_TEST);
+        p.buildersList.add(target);
         j.configRoundtrip(p);
-        assertEquals(TEXT_TO_TEST, p.getBuildersList().get(TextareaTestBuilder.class).getText());
+        j.assertEqualDataBoundBeans(target, p.getBuildersList().get(TextareaTestBuilder.class));
     }
 
     @Issue("JENKINS-27505")
@@ -88,10 +88,21 @@ class TextAreaTest {
     public void testTextBeginningWithEmptyLine() {
         def TEXT_TO_TEST = "\nbegin\n\nwith\nempty\nline\n\n";
         def p = j.createFreeStyleProject();
-        p.buildersList.add(new TextareaTestBuilder(TEXT_TO_TEST));
-        assertEquals(TEXT_TO_TEST, p.getBuildersList().get(TextareaTestBuilder.class).getText());
+        def target = new TextareaTestBuilder(TEXT_TO_TEST);
+        p.buildersList.add(target);
         j.configRoundtrip(p);
-        assertEquals(TEXT_TO_TEST, p.getBuildersList().get(TextareaTestBuilder.class).getText());
+        j.assertEqualDataBoundBeans(target, p.getBuildersList().get(TextareaTestBuilder.class));
+    }
+
+    @Issue("JENKINS-27505")
+    @Test
+    public void testTextBeginningWithTwoEmptyLines() {
+        def TEXT_TO_TEST = "\n\nbegin\n\nwith\ntwo\nempty\nline\n\n";
+        def p = j.createFreeStyleProject();
+        def target = new TextareaTestBuilder(TEXT_TO_TEST);
+        p.buildersList.add(target);
+        j.configRoundtrip(p);
+        j.assertEqualDataBoundBeans(target, p.getBuildersList().get(TextareaTestBuilder.class));
     }
 
     public static class TextareaTestBuilder extends Builder {

--- a/test/src/test/groovy/lib/form/TextAreaTest.groovy
+++ b/test/src/test/groovy/lib/form/TextAreaTest.groovy
@@ -14,6 +14,8 @@ import org.kohsuke.stapler.QueryParameter
 
 import javax.inject.Inject
 
+import static org.junit.Assert.*
+
 /**
  *
  *
@@ -61,6 +63,52 @@ class TextAreaTest {
             FormValidation doCheckText2(@QueryParameter String text1) {
                 this.text2 = "Received "+text1;
                 return FormValidation.ok();
+            }
+
+            @Override
+            String getDisplayName() {
+                return this.class.name;
+            }
+        }
+
+    }
+    
+    @Test
+    public void testText() {
+        def TEXT_TO_TEST = "some\nvalue\n";
+        def p = j.createFreeStyleProject();
+        p.buildersList.add(new TextareaTestBuilder(TEXT_TO_TEST));
+        assertEquals(TEXT_TO_TEST, p.getBuildersList().get(TextareaTestBuilder.class).getText());
+        j.configRoundtrip(p);
+        assertEquals(TEXT_TO_TEST, p.getBuildersList().get(TextareaTestBuilder.class).getText());
+    }
+
+    @Issue("JENKINS-27505")
+    @Test
+    public void testTextBeginningWithEmptyLine() {
+        def TEXT_TO_TEST = "\nbegin\n\nwith\nempty\nline\n\n";
+        def p = j.createFreeStyleProject();
+        p.buildersList.add(new TextareaTestBuilder(TEXT_TO_TEST));
+        assertEquals(TEXT_TO_TEST, p.getBuildersList().get(TextareaTestBuilder.class).getText());
+        j.configRoundtrip(p);
+        assertEquals(TEXT_TO_TEST, p.getBuildersList().get(TextareaTestBuilder.class).getText());
+    }
+
+    public static class TextareaTestBuilder extends Builder {
+        private text;
+        
+        @DataBoundConstructor
+        TextareaTestBuilder(String text) {
+            this.text = text;
+        }
+
+        public String getText() { return text; }
+
+        @TestExtension
+        public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+            @Override
+            boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
             }
 
             @Override

--- a/test/src/test/resources/lib/form/TextAreaTest/TextareaTestBuilder/config.jelly
+++ b/test/src/test/resources/lib/form/TextAreaTest/TextareaTestBuilder/config.jelly
@@ -1,0 +1,7 @@
+<!-- no config -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry field="text" title="${%Text}">
+    <f:textarea/>
+  </f:entry>
+</j:jelly>


### PR DESCRIPTION
[JENKINS-27505](https://issues.jenkins-ci.org/browse/JENKINS-27505)
A blank line in the beginning of a textarea is removed.
It is caused for the specification of HTML:
http://www.w3.org/TR/html5/syntax.html#syntax-newlines

> A single newline may be placed immediately after the start tag of pre and textarea elements. If the element's contents are intended to start with a newline, two consecutive newlines thus need to be included by the author.

(I could not found the description in HTML4.01)

I think my change gets too complicated as I don't know the best way to handle `\r` and `\n` in jelly files
(jelly doesn't seem to handle backslashes).
I want help of an expert of jelly.
