### PR TITLE
[FIXED JENKINS-27549] job loading can be broken by a NPE in a build trigger

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -325,8 +325,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         for (Trigger t : triggers()) {
             try {
                 t.start(this, Items.currentlyUpdatingByXml());
-            } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "could not start trigger while loading project '" + name + "'", e);
+            } catch (Throwable e) {
+                LOGGER.log(Level.WARNING, "could not start trigger while loading project '" + getFullName() + "'", e);
             }
         }
         if(scm==null)

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -323,7 +323,11 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         builds = buildMixIn.getRunMap();
         triggers().setOwner(this);
         for (Trigger t : triggers()) {
-            t.start(this, Items.currentlyUpdatingByXml());
+            try {
+                t.start(this, Items.currentlyUpdatingByXml());
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "could not start trigger while loading project '" + name + "'", e);
+            }
         }
         if(scm==null)
             scm = new NullSCM(); // perhaps it was pointing to a plugin that no longer exists.

--- a/test/src/test/groovy/hudson/model/AbstractProjectTest.groovy
+++ b/test/src/test/groovy/hudson/model/AbstractProjectTest.groovy
@@ -48,6 +48,7 @@ import hudson.Util;
 import hudson.tasks.ArtifactArchiver
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger
+import hudson.triggers.Trigger
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.StreamTaskListener;
 import hudson.util.OneShotEvent
@@ -58,6 +59,7 @@ import org.jvnet.hudson.test.HudsonTestCase
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.MemoryAssert
 import org.jvnet.hudson.test.SequenceLock;
+import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.recipes.PresetData;
 import org.jvnet.hudson.test.recipes.PresetData.DataSet
 import org.apache.commons.io.FileUtils;
@@ -593,5 +595,37 @@ public class AbstractProjectTest extends HudsonTestCase {
             s.write(xml.bytes)
         }
         return con
+    }
+
+    @Issue("JENKINS-27549")
+    public void testLoadingWithNPEOnTriggerStart() {
+        AbstractProject project = jenkins.createProjectFromXML("foo", getClass().getResourceAsStream("AbstractProjectTest/npeTrigger.xml"))
+
+        assert project.triggers().size() == 1
+    }
+
+    static class MockBuildTriggerThrowsNPEOnStart<Item> extends Trigger {
+        @Override
+        public void start(hudson.model.Item project, boolean newInstance) { throw new NullPointerException(); }
+
+        @Override
+        public TriggerDescriptor getDescriptor() {
+            return DESCRIPTOR;
+        }
+
+        public static final TriggerDescriptor DESCRIPTOR = new DescriptorImpl()
+
+        @TestExtension("testLoadingWithNPEOnTriggerStart")
+        static class DescriptorImpl extends TriggerDescriptor {
+
+            public boolean isApplicable(hudson.model.Item item) {
+                return false;
+            }
+
+            @Override
+            String getDisplayName() {
+                return "test";
+            }
+        }
     }
 }

--- a/test/src/test/resources/hudson/model/AbstractProjectTest/npeTrigger.xml
+++ b/test/src/test/resources/hudson/model/AbstractProjectTest/npeTrigger.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+    <triggers>
+        <hudson.model.AbstractProjectTest_-MockBuildTriggerThrowsNPEOnStart>
+            <spec></spec>
+        </hudson.model.AbstractProjectTest_-MockBuildTriggerThrowsNPEOnStart>
+    </triggers>
+</project>


### PR DESCRIPTION
[JENKINS-27549](https://issues.jenkins-ci.org/browse/JENKINS-27549)
