### PR TITLE
Fixed spelling errors in existing Polish translations.

### DIFF
--- a/core/src/main/resources/hudson/model/View/builds_pl.properties
+++ b/core/src/main/resources/hudson/model/View/builds_pl.properties
@@ -21,4 +21,4 @@
 # THE SOFTWARE.
 
 Export\ as\ plain\ XML=Eksportuj jako XML
-buildHistory=Historia komplikacji projektu {0}
+buildHistory=Historia kompilacji projektu {0}

--- a/core/src/main/resources/jenkins/model/Jenkins/login_pl.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/login_pl.properties
@@ -4,5 +4,5 @@ Password=Has\u0142o
 Remember\ me\ on\ this\ computer=Zapami\u0119taj mnie na tym komputerze
 User=Login
 login=zaloguj
-signUp=<a href="signup">Za\u0142u\u017C konto</a> je\u015Bli nie jeste\u015B jeszcze uczestnikiem.
+signUp=<a href="signup">Za\u0142\u00F3\u017C konto</a> je\u015Bli nie jeste\u015B jeszcze uczestnikiem.
 


### PR DESCRIPTION
I've fixed two spelling mistakes in the Polish translation:
- A reference for _login_pl.properties_ can be found [here](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/loginLink_pl.properties) (a really annoying error, which is visible on the main login screen)
- Second change is about replacing "complication history" with "compilation history".
