### PR TITLE
[JENKINS-27055] <BUILDID> should now also match numeric build IDs

### DIFF
--- a/core/src/main/java/jenkins/security/s2m/FilePathRuleConfig.java
+++ b/core/src/main/java/jenkins/security/s2m/FilePathRuleConfig.java
@@ -40,7 +40,7 @@ class FilePathRuleConfig extends ConfigDirectory<FilePathRule,List<FilePathRule>
         if (line.isEmpty())     return null;
 
         line = line.replace("<BUILDDIR>","<JOBDIR>/builds/<BUILDID>");
-        line = line.replace("<BUILDID>","[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]-[0-9][0-9]-[0-9][0-9]");
+        line = line.replace("<BUILDID>","(?:[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]-[0-9][0-9]-[0-9][0-9]|[0-9]+)");
         line = line.replace("<JOBDIR>","<JENKINS_HOME>/jobs/.+");
         line = line.replace("<JENKINS_HOME>","\\Q"+Jenkins.getInstance().getRootDir().getPath()+"\\E");
 

--- a/test/src/test/java/jenkins/security/DefaultFilePathFilterTest.java
+++ b/test/src/test/java/jenkins/security/DefaultFilePathFilterTest.java
@@ -33,7 +33,6 @@ import java.io.StringWriter;
 
 import jenkins.security.s2m.AdminWhitelistRule;
 import jenkins.security.s2m.DefaultFilePathFilter;
-import jenkins.security.s2m.MasterKillSwitchConfiguration;
 import org.jenkinsci.remoting.RoleChecker;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +41,7 @@ import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import javax.inject.Inject;
+import org.jvnet.hudson.test.Issue;
 
 public class DefaultFilePathFilterTest {
 
@@ -111,4 +111,12 @@ public class DefaultFilePathFilterTest {
             throw new NoSuchMethodError(); // simulate legacy Callable impls
         }
     }
+
+    @Issue("JENKINS-27055")
+    @Test public void matchBuildDir() throws Exception {
+        File f = new File(r.buildAndAssertSuccess(r.createFreeStyleProject()).getRootDir(), "whatever");
+        rule.setMasterKillSwitch(false);
+        assertTrue(rule.checkFileAccess("write", f));
+    }
+
 }


### PR DESCRIPTION
[JENKINS-27055](https://issues.jenkins-ci.org/browse/JENKINS-27055)

@reviewbybees
