### PR TITLE
[JENKINS-26582] Making ISE nonfatal

### DIFF
--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -184,7 +185,7 @@ public final class RunMap<R extends Run<?,R>> extends AbstractLazyLoadRunMap<R> 
         // Defense against JENKINS-23152 and its ilk.
         File rootDir = r.getRootDir();
         if (rootDir.isDirectory()) {
-            throw new IllegalStateException(rootDir + " already existed; will not overwite with " + r);
+            LOGGER.log(Level.WARNING, rootDir + " already existed, yet overwriting with " + r + "; current contents: " + Arrays.toString(rootDir.list()), new IllegalStateException("JENKINS-26582"));
         }
         if (!r.getClass().getName().equals("hudson.matrix.MatrixRun")) { // JENKINS-26739: grandfathered in
             proposeNewNumber(r.getNumber());


### PR DESCRIPTION
[JENKINS-26582](https://issues.jenkins-ci.org/browse/JENKINS-26582)

Traditionally there was no protection against two `Run`s using the same build directory: the second to come around would silently overwrite any files defined by the first. In fact this was known to happen for projects using the Gerrit Trigger plugin after reloads.

At @daniel-beck’s suggestion, as of 1.597 I added an assertion to make sure this does not happen. After that, a few people began reporting this assertion being triggered sporadically.

No one has yet come up with a way to reproduce the problem, so fixing the issue is not currently possible. In the meantime this patch allows the clobbering to happen so that at least the (new) build continues to run; the only symptom should then be the stack trace in the log.

@reviewbybees
