### PR TITLE
[FIXED JENKINS-26751] Do not run /script on offline slave

### DIFF
--- a/core/src/main/java/hudson/util/RemotingDiagnostics.java
+++ b/core/src/main/java/hudson/util/RemotingDiagnostics.java
@@ -34,15 +34,18 @@ import hudson.remoting.Future;
 import hudson.remoting.VirtualChannel;
 import hudson.security.AccessControlled;
 import jenkins.security.MasterToSlaveCallable;
+
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.WebMethod;
 
+import javax.annotation.Nonnull;
 import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -104,7 +107,7 @@ public final class RemotingDiagnostics {
     /**
      * Executes Groovy script remotely.
      */
-    public static String executeGroovy(String script, VirtualChannel channel) throws IOException, InterruptedException {
+    public static String executeGroovy(String script, @Nonnull VirtualChannel channel) throws IOException, InterruptedException {
         return channel.call(new Script(script));
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3527,6 +3527,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             if (!"POST".equals(req.getMethod())) {
                 throw HttpResponses.error(HttpURLConnection.HTTP_BAD_METHOD, "requires POST");
             }
+
+            if (channel == null) {
+                throw HttpResponses.error(HttpURLConnection.HTTP_NOT_FOUND, "Node is offline");
+            }
+
             try {
                 req.setAttribute("output",
                         RemotingDiagnostics.executeGroovy(text, channel));

--- a/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
@@ -36,7 +36,9 @@ THE SOFTWARE.
       <l:task href="${rootURL}/${it.url}configure" icon="icon-setting icon-md" permission="${it.CONFIGURE}" title="${%Configure}"/>
       <l:task href="${rootURL}/${it.url}builds" icon="icon-notepad icon-md" title="${%Build History}"/>
       <l:task href="${rootURL}/${it.url}load-statistics" icon="icon-monitor icon-md" title="${%Load Statistics}"/>
-      <l:task href="${rootURL}/${it.url}script" icon="icon-terminal icon-md" permission="${app.RUN_SCRIPTS}" title="${%Script Console}"/>
+      <j:if test="${it.channel!=null}">
+        <l:task href="${rootURL}/${it.url}script" icon="icon-terminal icon-md" permission="${app.RUN_SCRIPTS}" title="${%Script Console}"/>
+      </j:if>
       <st:include page="sidepanel2.jelly" optional="true" /><!-- hook for derived class to add more items -->
       <t:actions />
     </l:tasks>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -31,29 +31,36 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
 
     <l:main-panel>
-      <h1>${%Script Console}</h1>
+      <h1><img src="${imagesURL}/48x48/${it.icon}" width="48" height="48" alt=""/> ${%Script Console}</h1>
 
-      <p>
-        ${%description}
-      </p>
-      <!-- this is where the example goes -->
-      <d:invokeBody />
-      <p>
-        ${%description2}
-      </p>
+      <j:choose>
+        <j:when test="${it.channel != null}">
+          <p>
+            ${%description}
+          </p>
+          <!-- this is where the example goes -->
+          <d:invokeBody />
+          <p>
+            ${%description2}
+          </p>
 
-      <form action="script" method="post">
-        <textarea id="script" name="script" class="script">${request.getParameter('script')}</textarea>
-        <div align="right">
-          <f:submit  value="${%Run}"/>
-        </div>
-      </form>
-      <st:adjunct includes="org.kohsuke.stapler.codemirror.mode.groovy.groovy"/>
-      <st:adjunct includes="org.kohsuke.stapler.codemirror.theme.default"/>
-      <j:if test="${output!=null}">
-        <h2>${%Result}</h2>
-        <pre><st:out value="${output}"/></pre>
-      </j:if>
+          <form action="script" method="post">
+            <textarea id="script" name="script" class="script">${request.getParameter('script')}</textarea>
+            <div align="right">
+              <f:submit  value="${%Run}"/>
+            </div>
+          </form>
+          <st:adjunct includes="org.kohsuke.stapler.codemirror.mode.groovy.groovy"/>
+          <st:adjunct includes="org.kohsuke.stapler.codemirror.theme.default"/>
+          <j:if test="${output!=null}">
+            <h2>${%Result}</h2>
+            <pre><st:out value="${output}"/></pre>
+          </j:if>
+        </j:when>
+        <j:otherwise>
+          ${%It is not possible to run scripts when slave is offline.}
+        </j:otherwise>
+      </j:choose>
     </l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION
[JENKINS-26751](https://issues.jenkins-ci.org/browse/JENKINS-26751)

On offline slave:
- Hide the _Script Console_ link
- Hide the script form (when user navigate to /script directly)
- Meaningful HTTP status to REST clients
