### PR TITLE
[FIXED JENKINS-27067] Larger minimum popup menu height

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list/hetero-list.js
+++ b/core/src/main/resources/lib/form/hetero-list/hetero-list.js
@@ -33,7 +33,7 @@ Behaviour.specify("DIV.hetero-list-container", 'hetero-list', -100, function(e) 
 
         var menuAlign = (btn.getAttribute("menualign")||"tl-bl");
 
-        var menuButton = new YAHOO.widget.Button(btn, { type: "menu", menu: menu, menualignment: menuAlign.split("-") });
+        var menuButton = new YAHOO.widget.Button(btn, { type: "menu", menu: menu, menualignment: menuAlign.split("-"), menuminscrollheight: 250 });
         $(menuButton._button).addClassName(btn.className);    // copy class names
         $(menuButton._button).setAttribute("suffix",btn.getAttribute("suffix"));
         menuButton.getMenu().clickEvent.subscribe(function(type,args,value) {


### PR DESCRIPTION
Prefer showing the menu above the button rather than tiny, scrollable, below, by setting the minimum scrollable height to 250 instead of the default 90.
