### PR TITLE
Remove unnecessary null check.

### DIFF
--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -83,8 +83,7 @@ public class ApiTokenProperty extends UserProperty {
     public void changeApiToken() throws IOException {
         user.checkPermission(Jenkins.ADMINISTER);
         _changeApiToken();
-        if (user!=null)
-            user.save();
+        user.save();
     }
 
     private void _changeApiToken() {


### PR DESCRIPTION
UserPropery promises it's set, and even if it somehow wasn't, this would
have thrown a NullPointerException two lines earlier.
