### PR TITLE
[FIXED JENKINS-10629] - Support of big files archiving (>8Gb)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -277,6 +277,11 @@ THE SOFTWARE.
       <version>1.8.3</version>
     </dependency>
     <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.9</version>
+    </dependency>
+    <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>mail</artifactId>
       <version>1.4.4</version>

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -33,7 +33,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Computer;
 import hudson.model.Item;
 import hudson.model.TaskListener;
-import hudson.org.apache.tools.tar.TarInputStream;
 import hudson.os.PosixAPI;
 import hudson.os.PosixException;
 import hudson.remoting.Callable;
@@ -70,7 +69,6 @@ import org.apache.commons.io.input.CountingInputStream;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
-import org.apache.tools.tar.TarEntry;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipFile;
 import org.kohsuke.stapler.Stapler;
@@ -120,6 +118,8 @@ import static hudson.Util.*;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import jenkins.security.MasterToSlaveCallable;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.jenkinsci.remoting.RoleChecker;
 import org.jenkinsci.remoting.RoleSensitive;
         
@@ -2266,12 +2266,15 @@ public final class FilePath implements Serializable {
 
     /**
      * Reads from a tar stream and stores obtained files to the base dir.
+     * @since TODO supports large files > 10 GB, migration to commons-compress
      */
     private void readFromTar(String name, File baseDir, InputStream in) throws IOException {
-        TarInputStream t = new TarInputStream(in);
+        TarArchiveInputStream t = new TarArchiveInputStream(in);
+        
+        // TarInputStream t = new TarInputStream(in);
         try {
-            TarEntry te;
-            while ((te = t.getNextEntry()) != null) {
+            TarArchiveEntry te;
+            while ((te = t.getNextTarEntry()) != null) {
                 File f = new File(baseDir,te.getName());
                 if(te.isDirectory()) {
                     mkdirs(f);
@@ -2280,8 +2283,7 @@ public final class FilePath implements Serializable {
                     if (parent != null) mkdirs(parent);
                     writing(f);
 
-                    byte linkFlag = (Byte) LINKFLAG_FIELD.get(te);
-                    if (linkFlag==TarEntry.LF_SYMLINK) {
+                    if (te.isSymbolicLink()) {
                         new FilePath(f).symlinkTo(te.getLinkName(), TaskListener.NULL);
                     } else {
                         IOUtils.copy(t,f);
@@ -2297,8 +2299,6 @@ public final class FilePath implements Serializable {
             throw new IOException("Failed to extract "+name,e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt(); // process this later
-            throw new IOException("Failed to extract "+name,e);
-        } catch (IllegalAccessException e) {
             throw new IOException("Failed to extract "+name,e);
         } finally {
             t.close();
@@ -2721,20 +2721,6 @@ public final class FilePath implements Serializable {
             return o1.length()-o2.length();
         }
     };
-
-    private static final Field LINKFLAG_FIELD = getTarEntryLinkFlagField();
-
-    private static Field getTarEntryLinkFlagField() {
-        try {
-            Field f = TarEntry.class.getDeclaredField("linkFlag");
-            f.setAccessible(true);
-            return f;
-        } catch (SecurityException e) {
-            throw new AssertionError(e);
-        } catch (NoSuchFieldException e) {
-            throw new AssertionError(e);
-        }
-    }
 
     /**
      * Gets the {@link FilePath} representation of the "~" directory

--- a/core/src/main/java/hudson/org/apache/tools/tar/TarInputStream.java
+++ b/core/src/main/java/hudson/org/apache/tools/tar/TarInputStream.java
@@ -37,8 +37,9 @@ import java.io.ByteArrayOutputStream;
  * methods are provided to position at each successive entry in
  * the archive, and the read each entry as a normal input stream
  * using read().
- *
+ * @deprecated Use {@link org.apache.commons.compress.archivers.tar.TarArchiveInputStream} instead
  */
+@Deprecated
 public class TarInputStream extends FilterInputStream {
 
     // CheckStyle:VisibilityModifier OFF - bc

--- a/core/src/main/java/hudson/org/apache/tools/tar/TarOutputStream.java
+++ b/core/src/main/java/hudson/org/apache/tools/tar/TarOutputStream.java
@@ -35,8 +35,11 @@ import java.io.IOException;
  * The TarOutputStream writes a UNIX tar archive as an OutputStream.
  * Methods are provided to put entries, and then write their contents
  * by writing to this stream using write().
+ * 
+ * @deprecated Use {@link org.apache.commons.compress.archivers.tar.TarArchiveOutputStream} instead
  *
  */
+@Deprecated
 public class TarOutputStream extends FilterOutputStream {
     /** Fail if a long file name is required in the archive. */
     public static final int LONGFILE_ERROR = 0;

--- a/core/src/main/java/hudson/util/io/TarArchiver.java
+++ b/core/src/main/java/hudson/util/io/TarArchiver.java
@@ -37,6 +37,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 
 import static org.apache.tools.tar.TarConstants.LF_SYMLINK;
 
@@ -47,10 +49,10 @@ import static org.apache.tools.tar.TarConstants.LF_SYMLINK;
  */
 final class TarArchiver extends Archiver {
     private final byte[] buf = new byte[8192];
-    private final TarOutputStream tar;
+    private final TarArchiveOutputStream tar;
 
     TarArchiver(OutputStream out) {
-        tar = new TarOutputStream(new BufferedOutputStream(out) {
+        tar = new TarArchiveOutputStream(new BufferedOutputStream(out) {
             // TarOutputStream uses TarBuffer internally,
             // which flushes the stream for each block. this creates unnecessary
             // data stream fragmentation, and flush request to a remote, which slows things down.
@@ -58,13 +60,13 @@ final class TarArchiver extends Archiver {
             public void flush() throws IOException {
                 // so don't do anything in flush
             }
-        });
-        tar.setLongFileMode(TarOutputStream.LONGFILE_GNU);
+        });    
+        tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
     }
 
     @Override
     public void visitSymlink(File link, String target, String relativePath) throws IOException {
-        TarEntry e = new TarEntry(relativePath, LF_SYMLINK);
+        TarArchiveEntry e = new TarArchiveEntry(relativePath, LF_SYMLINK);
         try {
             int mode = IOUtils.mode(link);
             if (mode != -1) {
@@ -73,16 +75,11 @@ final class TarArchiver extends Archiver {
         } catch (PosixException x) {
             // ignore
         }
+        
+        e.setLinkName(target);
 
-        try {
-            StringBuffer linkName = (StringBuffer) LINKNAME_FIELD.get(e);
-            linkName.setLength(0);
-            linkName.append(target);
-        } catch (IllegalAccessException x) {
-            throw new IOException("Failed to set linkName", x);
-        }
-
-        tar.putNextEntry(e);
+        tar.putArchiveEntry(e);
+        tar.closeArchiveEntry();
         entriesWritten++;
     }
 
@@ -97,14 +94,14 @@ final class TarArchiver extends Archiver {
 
         if(file.isDirectory())
             relativePath+='/';
-        TarEntry te = new TarEntry(relativePath);
+        TarArchiveEntry te = new TarArchiveEntry(relativePath);
         int mode = IOUtils.mode(file);
         if (mode!=-1)   te.setMode(mode);
         te.setModTime(file.lastModified());
         if(!file.isDirectory())
             te.setSize(file.length());
 
-        tar.putNextEntry(te);
+        tar.putArchiveEntry(te);
 
         if (!file.isDirectory()) {
             FileInputStream in = new FileInputStream(file);
@@ -117,25 +114,11 @@ final class TarArchiver extends Archiver {
             }
         }
 
-        tar.closeEntry();
+        tar.closeArchiveEntry();
         entriesWritten++;
     }
 
     public void close() throws IOException {
         tar.close();
-    }
-
-    private static final Field LINKNAME_FIELD = getTarEntryLinkNameField();
-
-    private static Field getTarEntryLinkNameField() {
-        try {
-            Field f = TarEntry.class.getDeclaredField("linkName");
-            f.setAccessible(true);
-            return f;
-        } catch (SecurityException e) {
-            throw new AssertionError(e);
-        } catch (NoSuchFieldException e) {
-            throw new AssertionError(e);
-        }
     }
 }

--- a/core/src/main/java/hudson/util/io/TarArchiver.java
+++ b/core/src/main/java/hudson/util/io/TarArchiver.java
@@ -61,6 +61,7 @@ final class TarArchiver extends Archiver {
                 // so don't do anything in flush
             }
         });    
+        tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_STAR);
         tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
     }
 


### PR DESCRIPTION
[JENKINS-10629](https://issues.jenkins-ci.org/browse/JENKINS-10629)

Summary:
- Migrate the core to commons-compress instead of the local implementation
  - According to the investigation, local changes in <code>TarInputStream</code> have been fixed in the original source as well
- Enable BigNumber mode (STAR implementation, which uses GNU extensions)

I've tested the change locally, but I'm not sure if it makes sense to introduce such kind of tests in unit or harness test suites (high memory utilisation, tmp files for harness).

@reviewbybees
