### PR TITLE
In PluginManager, also throw an exception when skipping entities.

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1054,6 +1054,13 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     return RestrictiveEntityResolver.INSTANCE.resolveEntity(publicId, systemId);
                 }
 
+                @Override public void skippedEntity(String name) throws SAXException {
+                    // The underlying JAXP may have skipped resolving the entity avoiding the
+                    // exception thrown in resolveEntity. But for the sake of testing/logging
+                    // malicious behavior, go ahead and throw an exception when an entity
+                    // is skipped.
+                    throw new SAXException("Refusing to resolve entity: " + name);
+                }
             });
         } catch (SAXException x) {
             throw new IOException("Failed to parse XML",x);

--- a/core/src/test/java/hudson/PluginManagerTest.java
+++ b/core/src/test/java/hudson/PluginManagerTest.java
@@ -40,8 +40,16 @@ public class PluginManagerTest {
     @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
     @Test public void parseRequestedPlugins() throws Exception {
+      String XML =
+              "<root>\n" +
+              "  <stuff plugin='stuff@1.0'>\n" +
+              "    <more plugin='other@2.0'>\n" +
+              "      <things plugin='stuff@1.2'/>\n" +
+              "    </more>\n" +
+              "  </stuff>\n" +
+              "</root>\n";
         assertEquals("{other=2.0, stuff=1.2}", new LocalPluginManager(tmp.getRoot())
-                .parseRequestedPlugins(new StringInputStream("<root><stuff plugin='stuff@1.0'><more plugin='other@2.0'><things plugin='stuff@1.2'/></more></stuff></root>")).toString());
+                .parseRequestedPlugins(new StringInputStream(XML)).toString());
     }
 
     @Issue("SECURITY-167")
@@ -58,14 +66,13 @@ public class PluginManagerTest {
                 "  </stuff>\n" +
                 "</root>\n";
 
-        PluginManager pluginManager = new LocalPluginManager(Util.createTempDir());
+        PluginManager pluginManager = new LocalPluginManager(tmp.getRoot());
         try {
             pluginManager.parseRequestedPlugins(new StringInputStream(evilXML));
             fail("XML contains an external entity, but no exception was thrown.");
-        }
-        catch (IOException ex) {
+        } catch (IOException ex) {
             assertThat(ex.getCause(), instanceOf(SAXException.class));
-            assertThat(ex.getCause().getMessage(), containsString("Refusing to resolve entity with publicId(null) and systemId (file:///)"));
+            assertThat(ex.getCause().getMessage(), containsString("Refusing to resolve entity"));
         }
     }
 }


### PR DESCRIPTION
Depending on the underlying parser, resolveEntity may be completely
bypassed. Other tests (AbstractItemSecurityTest, XMLUtilsTest) were
already detecting the absence of the resolved entity and accepting that,
but PluginManagerTest didn't, nor does the returned data provide a
convenient way to look for the unresolved entity.

Throwing an exception so it gets noticed rather than potentially
silently ignoring entities seems like the better approach anyways,
though I did NOT update the other callers to behave as such.
