### PR TITLE
WIP Wrap JobProperty in optionalProperty for UI

### DIFF
--- a/core/src/main/java/hudson/model/JobPropertyDescriptor.java
+++ b/core/src/main/java/hudson/model/JobPropertyDescriptor.java
@@ -57,6 +57,17 @@ public abstract class JobPropertyDescriptor extends Descriptor<JobProperty<?>> {
     }
 
     /**
+     * Defines whether JobProperty in job configuration UI need to be wrapped in optionalProperty.
+     * Recommended to do your project properties optional to exclude unnecessary data be attached to jobs/builds.
+     * For backward compatibility false by default.
+     *
+     * @since TODO
+     */
+    public boolean isOptional() {
+        return false;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @return

--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -54,8 +54,33 @@ THE SOFTWARE.
           </f:optionalBlock>
         </j:if>
 
-        <!-- job property configurations. This should have been <f:descriptorList> -->
-        <f:descriptorList field="properties" descriptors="${h.getJobPropertyDescriptors(it.getClass())}" forceRowSet="true" />
+        <!-- JobProperty -->
+        <j:set var="instances" value="${it.properties}" />
+        <j:set var="descriptor" value="${d}"/>
+
+        <f:section title="${null}" name="properties">
+
+          <j:if test="${instances!=null}">
+            <tr>
+              <td>
+                <input type="hidden" name="stapler-class-bag" value="true" />
+              </td>
+            </tr>
+          </j:if>
+
+          <j:forEach var="d" items="${h.getJobPropertyDescriptors(it.getClass())}" varStatus="loop">
+            <j:scope>
+              <j:set var="instance" value="${instances[d]}" />
+
+              <f:optionalBlock title="${d.optional==true?d.displayName:null}" checked="${instance!=null}"
+                               name="${d.jsonSafeClassName}" help="${d.helpFile}">
+                <st:include from="${d}" page="${d.configPage}" optional="true"/>
+              </f:optionalBlock>
+            </j:scope>
+          </j:forEach>
+        </f:section>
+
+        <!--<f:descriptorList field="properties" descriptors="${h.getJobPropertyDescriptors(it.getClass())}" forceRowSet="true" />-->
 
         <!-- additional entries from derived classes -->
         <st:include page="configure-entries.jelly" />


### PR DESCRIPTION
Refers to 3417dc04ccee454deb387f003a53dfb6697444b0 where rowSet was set to true.
Should allow avoid optionalBlock wrappers in JobProperty implementations.

Property save doesn't work because DescriptorList binding is not fully simulated. Some jelly magic not fully generated...

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jenkins/1656)

<!-- Reviewable:end -->
