### PR TITLE
Add ability to skip project build from downstream build step configured at Project environment

### DIFF
--- a/core/src/main/java/hudson/model/Build.java
+++ b/core/src/main/java/hudson/model/Build.java
@@ -150,15 +150,23 @@ public abstract class Build <P extends Project<P,B>,B extends Build<P,B>>
                 if (parameters != null)
                     parameters.createBuildWrappers(Build.this,wrappers);
 
+                boolean skipProjectBuilders=false;
                 for( BuildWrapper w : wrappers ) {
                     Environment e = w.setUp((AbstractBuild<?,?>)Build.this, launcher, listener);
                     if(e==null)
                         return (r = FAILURE);
                     buildEnvironments.add(e);
+                    if((e.skipProjectBuilders())) {
+                        skipProjectBuilders=true;
+                    }                    
+                }
+                
+                if(!skipProjectBuilders) {
+                    if(!build(listener,project.getBuilders())) {
+                        r = FAILURE;
+                    }
                 }
 
-                if(!build(listener,project.getBuilders()))
-                    r = FAILURE;
             } catch (InterruptedException e) {
                 r = Executor.currentExecutor().abortResult();
                 // not calling Executor.recordCauseOfInterruption here. We do that where this exception is consumed.

--- a/core/src/main/java/hudson/model/Environment.java
+++ b/core/src/main/java/hudson/model/Environment.java
@@ -96,6 +96,17 @@ public abstract class Environment {
 			throws IOException, InterruptedException {
 		return true;
 	}
+	
+	/**
+     * Notify Jenkins core to skip project builders from downstream build step
+     * such as release-plugin
+     *
+     *@return false by default. If true the default builders will not be performed.
+     */
+    public boolean skipProjectBuilders() {
+
+        return false;
+    }
 
     /**
      * Creates {@link Environment} implementation that just sets the variables as given in the parameter.


### PR DESCRIPTION
This is a enhancement request to add additional interface under Environment interface to notify Project Builder to skip.  This is a great benefit for both Jenkins release-plugin and Jenkins m2-release plugin sothat user can skip the default long build after release completes

Here is the link to the issue this pull is addressing
https://issues.jenkins-ci.org/browse/JENKINS-27875

A pull request is made to the release plugin too for enhancement
https://github.com/glenritchie/release-plugin/pull/1
