### PR TITLE
Upgrade remoting to 2.51

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>2.50</version>
+        <version>2.51</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Remoting changelog:
-  [JENKINS-26031](https://issues.jenkins-ci.org/browse/JENKINS-26031) Add extra logging in the event the `NioChannelHub` is terminated.
- Terminate all pipes if a channel goes down.

@reviewbybees
