### PR TITLE
[JENKINS-28011] ${descriptor} is not necessarily ${attrs.descriptor}

### DIFF
--- a/core/src/main/resources/lib/form/class-entry.jelly
+++ b/core/src/main/resources/lib/form/class-entry.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
   <j:set var="clazz" value="${attrs.clazz ?: attrs.descriptor.clazz.name}" />
   <f:invisibleEntry>
     <j:choose>
-      <j:when test="${descriptor != null and descriptor.id != clazz}">
+      <j:when test="${attrs.descriptor != null and attrs.descriptor.id != clazz}">
         <input type="hidden" name="kind" value="${attrs.descriptor.id}" />
       </j:when>
       <j:otherwise>


### PR DESCRIPTION
[JENKINS-28011](https://issues.jenkins-ci.org/browse/JENKINS-28011)

Inside the unusual and possibly unnecessary `copyartifact/selectorList.jelly`, `staplerClass` is defined for `f:dropdownListBlock`, which becomes `clazz` in `f:class-entry`, yet the loop variable is called `bsDescriptor`, so `descriptor` is inherited from the parent config block. Thus whereas in older versions of Jenkins you get submitted JSON of the form

``` json
"selector":{"stapler-class":"hudson.plugins.copyartifact.StatusBuildSelector","stableOnly":true}
```

in 1.610 you get

``` json
"selector":{"stableOnly":true,"kind":""}
```

which is clearly wrong, because `clazz` is `StatusBuildSelector` yet `attrs.descriptor` is null and `descriptor` is `CopyArtifact` (not `StatusBuildSelector`). 901194ae77358b49016a32e6c97e74a70cbbb261 from #1563 mistakenly assumed that `descriptor == attrs.descriptor`.

I am not sure if other plugins are affected. If you just switch `CopyArtifact/config.jelly` to use the normal `f:dropdownDescriptorSelector`, it is fine, because that uses `descriptor` as the loop variable.

I believe `dropdownDescriptorSelector` is still incorrect, since it uses `dropdownListBlock` which passes in `clazz` and not `descriptor` and thus will not work for descriptors overriding `getId`, but that is another topic—would probably only manifest as a bug if some plugin were selecting a `Builder`/`Publisher` as a single-selection dropdown (rather than the usual list), and you tried to use that plugin with `cloudbees-template` templatized build steps.

The root evils here are the poorly specified contracts between Jelly controls, and the mixture of dynamic and lexical scopes without type checking.

@reviewbybees and @ikedam is probably also interested.
