### PR TITLE
[JENKINS-2180] Always use earlier scheduling date.

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -648,17 +648,9 @@ public class Queue extends ResourceController implements Saveable {
 
             boolean queueUpdated = false;
             for (WaitingItem wi : Util.filter(duplicatesInQueue, WaitingItem.class)) {
-                if (quietPeriod <= 0) {
-                    // the user really wants to build now, and they mean NOW.
-                    // so let's pull in the timestamp if we can.
-                    if (wi.timestamp.before(due))
-                        continue;
-                } else {
-                    // otherwise we do the normal quiet period implementation
-                    if (wi.timestamp.after(due))
-                        continue;
-                    // quiet period timer reset. start the period over again
-                }
+                // make sure to always use the shorter of the available due times
+                if (wi.timestamp.before(due))
+                    continue;
 
                 // waitingList is sorted, so when we change a timestamp we need to maintain order
                 wi.leave(this);


### PR DESCRIPTION
This resolves a weird behavior when configuring a shorter SCM polling interval than quiet period: The job will never be started by SCM polling. There will be a build in the queue, but its start date will be reset to `now + quiet period` whenever SCM polling determines the project needs to be built.
