### PR TITLE
Change AsynchPeople column from last active to last commit activity.

### DIFF
--- a/core/src/main/resources/hudson/model/View/AsynchPeople/index.jelly
+++ b/core/src/main/resources/hudson/model/View/AsynchPeople/index.jelly
@@ -103,7 +103,7 @@ THE SOFTWARE.
           <th />
           <th>${%User Id}</th>
           <th>${%Name}</th>
-          <th initialSortDir="up">${%Last Active}</th>
+          <th initialSortDir="up">${%Last Commit Activity}</th>
           <th>${%On}</th>
         </tr>
       </table>


### PR DESCRIPTION
The chart from the `JENKINS_URL/asynchpeople` has a `Last Active` column which to some may be misinterpreted as being the last online activity on the site instead of the last commit activity. @reviewbybees
