### PR TITLE
[JENKINS-28013,JENKINS-28012] - Revert changes for JENKINS-10629

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -277,11 +277,6 @@ THE SOFTWARE.
       <version>1.8.3</version>
     </dependency>
     <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-compress</artifactId>
-        <version>1.9</version>
-    </dependency>
-    <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>mail</artifactId>
       <version>1.4.4</version>

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -33,6 +33,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Computer;
 import hudson.model.Item;
 import hudson.model.TaskListener;
+import hudson.org.apache.tools.tar.TarInputStream;
 import hudson.os.PosixAPI;
 import hudson.os.PosixException;
 import hudson.remoting.Callable;
@@ -69,6 +70,7 @@ import org.apache.commons.io.input.CountingInputStream;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.tar.TarEntry;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipFile;
 import org.kohsuke.stapler.Stapler;
@@ -118,8 +120,6 @@ import static hudson.Util.*;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import jenkins.security.MasterToSlaveCallable;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.jenkinsci.remoting.RoleChecker;
 import org.jenkinsci.remoting.RoleSensitive;
         
@@ -2266,15 +2266,12 @@ public final class FilePath implements Serializable {
 
     /**
      * Reads from a tar stream and stores obtained files to the base dir.
-     * @since TODO supports large files > 10 GB, migration to commons-compress
      */
     private void readFromTar(String name, File baseDir, InputStream in) throws IOException {
-        TarArchiveInputStream t = new TarArchiveInputStream(in);
-        
-        // TarInputStream t = new TarInputStream(in);
+        TarInputStream t = new TarInputStream(in);
         try {
-            TarArchiveEntry te;
-            while ((te = t.getNextTarEntry()) != null) {
+            TarEntry te;
+            while ((te = t.getNextEntry()) != null) {
                 File f = new File(baseDir,te.getName());
                 if(te.isDirectory()) {
                     mkdirs(f);
@@ -2283,7 +2280,8 @@ public final class FilePath implements Serializable {
                     if (parent != null) mkdirs(parent);
                     writing(f);
 
-                    if (te.isSymbolicLink()) {
+                    byte linkFlag = (Byte) LINKFLAG_FIELD.get(te);
+                    if (linkFlag==TarEntry.LF_SYMLINK) {
                         new FilePath(f).symlinkTo(te.getLinkName(), TaskListener.NULL);
                     } else {
                         IOUtils.copy(t,f);
@@ -2299,6 +2297,8 @@ public final class FilePath implements Serializable {
             throw new IOException("Failed to extract "+name,e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt(); // process this later
+            throw new IOException("Failed to extract "+name,e);
+        } catch (IllegalAccessException e) {
             throw new IOException("Failed to extract "+name,e);
         } finally {
             t.close();
@@ -2721,6 +2721,20 @@ public final class FilePath implements Serializable {
             return o1.length()-o2.length();
         }
     };
+
+    private static final Field LINKFLAG_FIELD = getTarEntryLinkFlagField();
+
+    private static Field getTarEntryLinkFlagField() {
+        try {
+            Field f = TarEntry.class.getDeclaredField("linkFlag");
+            f.setAccessible(true);
+            return f;
+        } catch (SecurityException e) {
+            throw new AssertionError(e);
+        } catch (NoSuchFieldException e) {
+            throw new AssertionError(e);
+        }
+    }
 
     /**
      * Gets the {@link FilePath} representation of the "~" directory

--- a/core/src/main/java/hudson/org/apache/tools/tar/TarInputStream.java
+++ b/core/src/main/java/hudson/org/apache/tools/tar/TarInputStream.java
@@ -37,9 +37,8 @@ import java.io.ByteArrayOutputStream;
  * methods are provided to position at each successive entry in
  * the archive, and the read each entry as a normal input stream
  * using read().
- * @deprecated Use {@link org.apache.commons.compress.archivers.tar.TarArchiveInputStream} instead
+ *
  */
-@Deprecated
 public class TarInputStream extends FilterInputStream {
 
     // CheckStyle:VisibilityModifier OFF - bc

--- a/core/src/main/java/hudson/org/apache/tools/tar/TarOutputStream.java
+++ b/core/src/main/java/hudson/org/apache/tools/tar/TarOutputStream.java
@@ -35,11 +35,8 @@ import java.io.IOException;
  * The TarOutputStream writes a UNIX tar archive as an OutputStream.
  * Methods are provided to put entries, and then write their contents
  * by writing to this stream using write().
- * 
- * @deprecated Use {@link org.apache.commons.compress.archivers.tar.TarArchiveOutputStream} instead
  *
  */
-@Deprecated
 public class TarOutputStream extends FilterOutputStream {
     /** Fail if a long file name is required in the archive. */
     public static final int LONGFILE_ERROR = 0;

--- a/core/src/main/java/hudson/util/io/TarArchiver.java
+++ b/core/src/main/java/hudson/util/io/TarArchiver.java
@@ -61,7 +61,6 @@ final class TarArchiver extends Archiver {
                 // so don't do anything in flush
             }
         });    
-        tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_STAR);
         tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
     }
 


### PR DESCRIPTION
Thanks to @KostyaSha, we were able to create a 100%-reproducible test case for JENKINS-28013. The issue requires additional investigation and much more unit tests, so I propose to revert changes for JENKINS-10629 (excluding additional unit-tests) in order to release a stable core

@reviewbybees
