### PR TITLE
[JENKINS-9283] Timezone Support for Scheduling

### DIFF
--- a/core/src/main/java/hudson/scheduler/CronTabList.java
+++ b/core/src/main/java/hudson/scheduler/CronTabList.java
@@ -25,11 +25,15 @@ package hudson.scheduler;
 
 import antlr.ANTLRException;
 import java.util.Calendar;
+import java.util.TimeZone;
 import java.util.Collection;
 import java.util.Vector;
 import javax.annotation.CheckForNull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * {@link CronTab} list (logically OR-ed).
@@ -71,6 +75,20 @@ public final class CronTabList {
         return null;
     }
 
+    /**
+     * Checks if given timezone string is supported by TimeZone and returns
+     * the same string if valid, null otherwise
+     */
+    public static @CheckForNull String getValidTimezone(String timezone) {
+        String[] validIDs = TimeZone.getAvailableIDs();
+        for (String str : validIDs) {
+              if (str != null && str.equals(timezone)) {
+                    return timezone;
+              }
+        }
+        return null;
+    }
+
     public static CronTabList create(String format) throws ANTLRException {
         return create(format,null);
     }
@@ -78,17 +96,31 @@ public final class CronTabList {
     public static CronTabList create(String format, Hash hash) throws ANTLRException {
         Vector<CronTab> r = new Vector<CronTab>();
         int lineNumber = 0;
+        String timezone = null;
+
         for (String line : format.split("\\r?\\n")) {
             lineNumber++;
             line = line.trim();
+            
+            if(lineNumber == 1 && line.startsWith("TZ=")) {
+                timezone = getValidTimezone(line.replace("TZ=",""));
+                if(timezone != null) {
+                    LOGGER.log(Level.CONFIG, "cron with timezone {0}", timezone);
+                } else {
+                    LOGGER.log(Level.CONFIG, "invalid timezone {0}", line);
+                }
+                continue;
+            }
+
             if(line.length()==0 || line.startsWith("#"))
                 continue;   // ignorable line
             try {
-                r.add(new CronTab(line,lineNumber,hash));
+                r.add(new CronTab(line,lineNumber,hash,timezone));
             } catch (ANTLRException e) {
                 throw new ANTLRException(Messages.CronTabList_InvalidInput(line,e.toString()),e);
             }
         }
+        
         return new CronTabList(r);
     }
 
@@ -115,5 +147,6 @@ public final class CronTabList {
         }
         return nearest;
     }
-
+    
+    private static final Logger LOGGER = Logger.getLogger(CronTabList.class.getName());
 }

--- a/core/src/test/java/hudson/scheduler/CronTabTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabTest.java
@@ -27,6 +27,7 @@ import antlr.ANTLRException;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.TimeZone;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 
@@ -301,4 +302,17 @@ public class CronTabTest {
             // ok
         }
     }
+
+    @Issue("JENKINS-9283")
+    @Test public void testTimezone() throws Exception {
+        CronTabList tabs = CronTabList.create("TZ=Australia/Sydney\nH * * * *\nH * * * *", Hash.from("seed"));
+        List<Integer> times = new ArrayList<Integer>();
+        for (int i = 0; i < 60; i++) {
+            if (tabs.check(new GregorianCalendar(2013, 3, 3, 11, i, 0))) {
+                times.add(i);
+            }
+        }
+        assertEquals("[35, 56]", times.toString());
+    }
+
 }


### PR DESCRIPTION
This will allow to define a timezone in the scheduling text input field like in some cron implementations. If there's for example TZ=Australia/Sydney defined in the first line, each cron definition in that field will trigger the job based on that timezone. The timezone defined in the job does not affect the date/times for the execution history. Those times are still in the systems timezone.

Supported timezones are those from TimeZone.getAvailableIDs()
