### PR TITLE
[FIXED JENKINS-28115] Division by zero in Executor.getProgress()

### DIFF
--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -642,7 +642,7 @@ public class Executor extends Thread implements ModelObject {
         } finally {
             lock.readLock().unlock();
         }
-        if (d < 0) {
+        if (d <= 0) {
             return -1;
         }
 


### PR DESCRIPTION
```
WARNING: Caught exception evaluating: executor.progress in /ajaxExecutors. Reason: java.lang.reflect.InvocationTargetException
java.lang.reflect.InvocationTargetException
...
    at java.lang.Thread.run(Thread.java:744)
Caused by: java.lang.ArithmeticException: / by zero
    at hudson.model.Executor.getProgress(Executor.java:649)
    ... 154 more
```

@reviewbybees
