### PR TITLE
[JENKINS-28120] Bump the core requirement to Java7

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,6 +55,10 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
+  <li class=rfe>
+    As <a href="http://jenkins-ci.org/content/good-bye-java6">promised</a>, shipping
+    with Java7 class files.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28120">issue 28120</a>)
   <li class=bug>
     Under rare conditions Executor.getProgress() can throw a Division by zero exception.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28115">issue 28115</a>)

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -749,7 +749,7 @@ THE SOFTWARE.
         <configuration>
           <forkCount>0.5C</forkCount>
           <reuseForks>true</reuseForks>
-          <argLine>-XX:MaxPermSize=128m</argLine>
+          <argLine>-XX:MaxPermSize=128m -noverify</argLine> <!-- some versions of JDK7/8 causes VerifyError during mock tests: http://code.google.com/p/powermock/issues/detail?id=504 -->
         </configuration>
       </plugin>
       <plugin><!-- set main class -->

--- a/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
@@ -50,10 +50,10 @@ THE SOFTWARE.
         <j:set var="port" value="${request.getParameter('debugPort')}"/>
         <j:choose>
           <j:when test="${port!=null}">
-            <j2se version="1.5+" java-vm-args="${it.launcher.vmargs} -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=${port}" />
+            <j2se version="1.7+" java-vm-args="${it.launcher.vmargs} -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=${port}" />
           </j:when>
           <j:otherwise>
-            <j2se version="1.5+" java-vm-args="${it.launcher.vmargs}"/>
+            <j2se version="1.7+" java-vm-args="${it.launcher.vmargs}"/>
           </j:otherwise>
         </j:choose>
         <jar href="${rootURL}jnlpJars/remoting.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ THE SOFTWARE.
     <matrix-project.version>1.4.1</matrix-project.version>
     <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>
 
-    <java.level>7</java.level>
+    <java.level>6</java.level>
   </properties>
 
   <repositories>
@@ -359,6 +359,7 @@ THE SOFTWARE.
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.16</version> <!-- ignoring ${maven-surefire-plugin.version} -->
           <configuration>
+            <argLine>-noverify</argLine> <!-- some versions of JDK7/8 causes VerifyError during mock tests: http://code.google.com/p/powermock/issues/detail?id=504 -->
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
               <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
@@ -614,7 +615,7 @@ THE SOFTWARE.
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <source>1.${java.level}</source>
-          <target>1.${java.level}</target>
+          <target>1.7</target> <!-- TODO JENKINS-28120 restore to 1.${java.level} -->
           <!-- default reuseCreated is more performant 
           feel free to uncomment if you have any issues on your platform
           <compilerReuseStrategy>alwaysNew</compilerReuseStrategy>
@@ -633,13 +634,13 @@ THE SOFTWARE.
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>1.6.0-18</version>
+                  <version>1.7.0</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>3.0</version>
                 </requireMavenVersion>
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>1.${java.level}</maxJdkVersion>
+                  <maxJdkVersion>1.7</maxJdkVersion> <!-- TODO JENKINS-28120 restore to 1.${java.level} -->
                   <ignoreClasses>
                     <ignoreClass>org.eclipse.jetty.spdy.*</ignoreClass>
                   </ignoreClasses>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ THE SOFTWARE.
     <matrix-project.version>1.4.1</matrix-project.version>
     <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>
 
-    <java.level>6</java.level>
+    <java.level>7</java.level>
   </properties>
 
   <repositories>
@@ -604,7 +604,7 @@ THE SOFTWARE.
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java1${java.level}</artifactId>
+            <artifactId>java16</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -47,7 +47,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>executable-war</artifactId>
-      <version>1.29</version>
+      <version>1.30</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-28120

As the first step of Java7 migration, ship Java7 class files without
requiring Java7 runtime.

Supercedes PR #1677 

@reviewbybees
