### PR TITLE
Update bundled LDAP plugin in order to restore missing help files

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -322,7 +322,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>ldap</artifactId>
-                  <version>1.6</version>
+                  <version>1.11</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
In e91782e78f1ade105c5f9ce11088bf9c95618180 some help files were removed from core because they were moved to LDAP plugin in https://github.com/jenkinsci/ldap-plugin/commit/98db72371cc3bcb6d2184cd41254cebe7f45811f. 

Unfortunately, these help files are not available in LDAP plugin versions prior to 1.11 and thus missing in current Jenkins releases.

An alternative would be to recover the help files in Jenkins core. But this would result in duplicated content when the user manually updates the LDAP plugin.
