### PR TITLE
Add support for Maven 3.3 .cmd files in Windows

### DIFF
--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -585,12 +585,20 @@ public class Maven extends Builder {
         }
 
         private File getExeFile(String execName) {
-            if(File.separatorChar=='\\')
-                execName += ".bat";
-
             String m2Home = Util.replaceMacro(getHome(),EnvVars.masterEnvVars);
 
-            return new File(m2Home, "bin/" + execName);
+            if(Functions.isWindows()) {
+                File exeFile = new File(m2Home, "bin/" + execName + ".bat");
+
+                // since Maven 3.3 .bat files are replaced with .cmd
+                if (!exeFile.exists()) {
+                    return new File(m2Home, "bin/" + execName + ".cmd");
+                }
+
+                return exeFile;
+            } else {
+                return new File(m2Home, "bin/" + execName);
+            }
         }
 
         /**


### PR DESCRIPTION
Hit this issue on our Jenkins when adding Maven 3.3. Maven 3.3 supplies .cmd files for windows, instead of .bat, which resulted in Jenkins telling us it couldn't find the Maven binary. I updated the getExeFile method to check for a .cmd in case it can't find the .bat file.

To be more specific on this error: most Maven jobs continued to work without this fix. It only appeared for us when we started a post-buid task like Sonar, which then apparantly uses that method.
