### PR TITLE
[JENKINS-28192] SecretRewriter.rewriteRecursive fails to resolve symbolic links on Windows

### DIFF
--- a/core/src/main/java/hudson/util/SecretRewriter.java
+++ b/core/src/main/java/hudson/util/SecretRewriter.java
@@ -1,6 +1,8 @@
 package hudson.util;
 
 import com.trilead.ssh2.crypto.Base64;
+
+import hudson.Util;
 import hudson.model.TaskListener;
 import org.apache.commons.io.FileUtils;
 
@@ -145,7 +147,7 @@ public class SecretRewriter {
     private int rewriteRecursive(File dir, String relative, TaskListener listener) throws InvalidKeyException {
         String canonical;
         try {
-            canonical = dir.getCanonicalPath();
+            canonical = Util.getRealPath(dir);
         } catch (IOException e) {
             canonical = dir.getAbsolutePath(); //
         }


### PR DESCRIPTION
[JENKINS-28192](https://issues.jenkins-ci.org/browse/JENKINS-28192)

`SecretRewriter.rewriteRecursive` fails to resolve symbolic links on Windows,
and fails to detect symbolic links.
This results `SecretRewriterTest#recursionDetection` doesn't finish on Windows.

This is caused for `File#getCanonicalPath` resolves symbolic links only on *nix systems, not on Windows.
This change uses `java.nio.file.Path#toRealPath` instead. It's provided only on Java 7 and falls back to `File#getCanonicalPath` on Java 6.
