### PR TITLE
[FIXED JENKINS-28227] Switch to Enblish locale in RunTest#getDurationString to test messages.

### DIFF
--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -29,6 +29,7 @@ import hudson.model.Run.Artifact;
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -39,6 +40,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.localizer.LocaleProvider;
 import org.mockito.Mockito;
 
 
@@ -127,6 +129,16 @@ public class RunTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void getDurationString() throws IOException {
+      LocaleProvider providerToRestore = LocaleProvider.getProvider();
+      try {
+        // This test expects English texts.
+        LocaleProvider.setProvider(new LocaleProvider() {
+            @Override
+            public Locale get() {
+                return Locale.ENGLISH;
+            }
+        });
+        
         Run r = new Run(new StubJob(), 0) {};
         assertEquals("Not started yet", r.getDurationString());
         r.onStartBuilding();
@@ -136,6 +148,9 @@ public class RunTest {
         r.onEndBuilding();
         msg = r.getDurationString();
         assertFalse(msg, msg.endsWith(" and counting"));
+      } finally {
+        LocaleProvider.setProvider(providerToRestore);
+      }
     }
 
     @Issue("JENKINS-27441")


### PR DESCRIPTION
[JENKINS-28227](https://issues.jenkins-ci.org/browse/JENKINS-28227)

`RunTest#getDurationString` fails on non-English locale like this:

```
Running hudson.model.RunTest
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.39 sec <<< FAILURE! - in hudson.model.RunTest
getDurationString(hudson.model.RunTest)  Time elapsed: 0.312 sec  <<< FAILURE!
java.lang.AssertionError: 0 ms 以上
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at hudson.model.RunTest.getDurationString(RunTest.java:126)
```

The test expects a message "0 ms and continuing", but actually the message is "0 ms 以上" (a Japanese text) for its locale.
This change switches the locale to English in that test.
