### PR TITLE
[FIXES JENKINS-28245] Allow finer-grained tuning of ChannelPinger.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -585,10 +585,15 @@ THE SOFTWARE.
       <systemPath>/usr/local/yjp/lib/yjp.jar</systemPath>
     </dependency-->
 
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- Overriding Stapler’s 1.1.3 version to diagnose JENKINS-20618: -->
     <dependency>
       <groupId>com.jcraft</groupId>

--- a/core/src/test/java/hudson/slaves/ChannelPingerTest.java
+++ b/core/src/test/java/hudson/slaves/ChannelPingerTest.java
@@ -1,0 +1,117 @@
+package hudson.slaves;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyNoMoreInteractions;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import hudson.remoting.Channel;
+
+import java.util.Map;
+import java.util.HashMap;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ ChannelPinger.class })
+public class ChannelPingerTest {
+
+    @Mock private Channel mockChannel;
+
+    private Map<String, String> savedSystemProperties = new HashMap<String, String>();
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        mockStatic(ChannelPinger.class);
+    }
+
+    @Before
+    public void preserveSystemProperties() throws Exception {
+        preserveSystemProperty("hudson.slaves.ChannelPinger.pingInterval");
+        preserveSystemProperty("hudson.slaves.ChannelPinger.pingIntervalSeconds");
+        preserveSystemProperty("hudson.slaves.ChannelPinger.pingTimeoutSeconds");
+    }
+
+    @After
+    public void restoreSystemProperties() throws Exception {
+        for (Map.Entry<String, String> entry : savedSystemProperties.entrySet()) {
+            if (entry.getValue() != null) {
+                System.setProperty(entry.getKey(), entry.getValue());
+            } else {
+                System.clearProperty(entry.getKey());
+            }
+        }
+    }
+
+    private void preserveSystemProperty(String propertyName) {
+        savedSystemProperties.put(propertyName, System.getProperty(propertyName));
+        System.clearProperty(propertyName);
+    }
+
+    @Test
+    public void testDefaults() throws Exception {
+        ChannelPinger channelPinger = new ChannelPinger();
+        channelPinger.install(mockChannel);
+
+        verify(mockChannel).call(eq(new ChannelPinger.SetUpRemotePing(240, 300)));
+        verifyStatic();
+        ChannelPinger.setUpPingForChannel(mockChannel, 240, 300);
+    }
+
+    @Test
+    public void testFromSystemProperties() throws Exception {
+        System.setProperty("hudson.slaves.ChannelPinger.pingTimeoutSeconds", "42");
+        System.setProperty("hudson.slaves.ChannelPinger.pingIntervalSeconds", "73");
+
+        ChannelPinger channelPinger = new ChannelPinger();
+        channelPinger.install(mockChannel);
+
+        verify(mockChannel).call(new ChannelPinger.SetUpRemotePing(42, 73));
+        verifyStatic();
+        ChannelPinger.setUpPingForChannel(mockChannel, 42, 73);
+    }
+
+    @Test
+    public void testFromOldSystemProperty() throws Exception {
+        System.setProperty("hudson.slaves.ChannelPinger.pingInterval", "7");
+
+        ChannelPinger channelPinger = new ChannelPinger();
+        channelPinger.install(mockChannel);
+
+        verify(mockChannel).call(eq(new ChannelPinger.SetUpRemotePing(240, 420)));
+        verifyStatic();
+        ChannelPinger.setUpPingForChannel(mockChannel, 240, 420);
+    }
+
+    @Test
+    public void testNewSystemPropertyTrumpsOld() throws Exception {
+        System.setProperty("hudson.slaves.ChannelPinger.pingIntervalSeconds", "73");
+        System.setProperty("hudson.slaves.ChannelPinger.pingInterval", "7");
+
+        ChannelPinger channelPinger = new ChannelPinger();
+        channelPinger.install(mockChannel);
+
+        verify(mockChannel).call(eq(new ChannelPinger.SetUpRemotePing(240, 73)));
+        verifyStatic();
+        ChannelPinger.setUpPingForChannel(mockChannel, 240, 73);
+    }
+
+    @Test
+    public void testSetUpRemotePingEquality() {
+         new EqualsTester()
+             .addEqualityGroup(new ChannelPinger.SetUpRemotePing(1, 2), new ChannelPinger.SetUpRemotePing(1, 2))
+             .addEqualityGroup(new ChannelPinger.SetUpRemotePing(2, 3), new ChannelPinger.SetUpRemotePing(2, 3))
+             .testEquals();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@ THE SOFTWARE.
     <project.patchManagement.url>https://api.github.com</project.patchManagement.url>
     <patch.tracker.serverId>jenkins-jira</patch.tracker.serverId>
 
+    <guavaVersion>11.0.1</guavaVersion>
     <slf4jVersion>1.7.7</slf4jVersion> <!-- < 1.6.x version didn't specify the license (MIT) -->
     <maven-plugin.version>2.7.1</maven-plugin.version>
     <matrix-project.version>1.4.1</matrix-project.version>
@@ -182,7 +183,12 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>11.0.1</version>
+        <version>${guavaVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-testlib</artifactId>
+        <version>${guavaVersion}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
- Allows customization in seconds, not minutes
- Allows customization of the ping timeout (before, you could set a
  custom interval, but the timeout would always be PingThread's 4
  minute default)

This also drops the serialVersionUID from ChannelPinger.SetUpRemotePing;
without one provided, the JVM will generate one on demand which is
sufficient for the purposes here since these are never persisted and
master & slave run the same compiled code. (And it demonstrably works
since countless other MasterToSlaveCallables fail to specify their own
custom IDs)
