### PR TITLE
[FIXED JENKINS-28274] Update to the latest versions of maven-jar-plugin and maven-war-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,12 +347,12 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.4</version>
+          <version>2.6</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>2.3</version>
+          <version>2.6</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As it says in JIRA, these versions are 2-2.5 years old & in my environment spin indefinitely.

I've been hacking it locally for a while to use the modern versions with no problems.
