### PR TITLE
[JENKINS-27748] Improve exception management in RunMap#retrieve

### DIFF
--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -228,7 +228,7 @@ public final class RunMap<R extends Run<?,R>> extends AbstractLazyLoadRunMap<R> 
                 }
                 return b;
             } catch (IOException e) {
-                throw new IOException();
+                LOGGER.log(Level.WARNING, "could not load " + d, e);
             } catch (InstantiationError e) {
                 LOGGER.log(Level.WARNING, "could not load " + d, e);
             } catch (Exception e) {

--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -228,8 +228,10 @@ public final class RunMap<R extends Run<?,R>> extends AbstractLazyLoadRunMap<R> 
                 }
                 return b;
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "could not load " + d, e);
+                throw new IOException();
             } catch (InstantiationError e) {
+                LOGGER.log(Level.WARNING, "could not load " + d, e);
+            } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "could not load " + d, e);
             }
         }


### PR DESCRIPTION
Capture all the exceptions and logging them instead of throwing them up and also re-throwing IOException. Otherwise, as far as I know, the throws IOException of the function will not have too much sense.

I have seen this stacktrace and I am trying to improve exception management to get more information. All of this related to JENKINS-27748. 

```
WARNING: PROJECT already exists as a downstream project. 
Apr 30, 2015 3:31:03 PM hudson.ExpressionFactory2$JexlExpression evaluate 
WARNING: Caught exception evaluating: job.buildHealthReports in /. Reason: java.lang.reflect.InvocationTargetException 
java.lang.reflect.InvocationTargetException 
at sun.reflect.GeneratedMethodAccessor171.invoke(Unknown Source) 
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) 
at java.lang.reflect.Method.invoke(Method.java:483) 
at org.apache.commons.jexl.util.PropertyExecutor.execute(PropertyExecutor.java:125) 
```

```
Caused by: java.lang.ClassCastException: java.lang.Integer cannot be cast to hudson.model.Action
    at hudson.model.Run.onLoad(Run.java:338)
    at hudson.model.RunMap.retrieve(RunMap.java:221)
    at hudson.model.RunMap.retrieve(RunMap.java:57)
    at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:465)
    at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:448)
    at jenkins.model.lazy.AbstractLazyLoadRunMap.getByNumber(AbstractLazyLoadRunMap.java:356)
    at jenkins.model.lazy.AbstractLazyLoadRunMap.search(AbstractLazyLoadRunMap.java:332)
    at jenkins.model.lazy.AbstractLazyLoadRunMap.newestBuild(AbstractLazyLoadRunMap.java:274)
    at jenkins.model.lazy.LazyBuildMixIn.getLastBuild(LazyBuildMixIn.java:240)
    at hudson.model.AbstractProject.getLastBuild(AbstractProject.java:981)
    at hudson.model.AbstractProject.getLastBuild(AbstractProject.java:144)
    at hudson.model.Job.getBuildHealthReports(Job.java:1076)
    at hudson.model.Job.getBuildHealth(Job.java:1069)
    at com.cloudbees.hudson.plugins.folder.health.FolderHealthMetric.getHealthReport(FolderHealthMetric.java:44)
    at com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric$ReporterImpl.observe(WorstChildHealthMetric.java:68)
    at com.cloudbees.hudson.plugins.folder.Folder.getBuildHealthReports(Folder.java:880)
    ... 155 more
```

@reviewbybees
