### PR TITLE
[WiP] Remove not actions and logging null and other kind of objects

### DIFF
--- a/core/src/main/java/hudson/model/Actionable.java
+++ b/core/src/main/java/hudson/model/Actionable.java
@@ -116,7 +116,7 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
                         }
                     }
                 } catch (Exception e) {
-                    if(this instanceof Saveable)
+                    if (this instanceof Saveable)
                         OldDataMonitor.report((Saveable) this, Collections.<Throwable>singleton(e));
 
                         LOGGER.log(Level.SEVERE, "Could not load actions from " + taf + " for " + this, e);

--- a/core/src/main/java/hudson/model/Actionable.java
+++ b/core/src/main/java/hudson/model/Actionable.java
@@ -34,6 +34,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.diagnosis.OldDataMonitor;
 import jenkins.model.ModelObjectWithContextMenu;
 import jenkins.model.TransientActionFactory;
 import org.kohsuke.stapler.StaplerRequest;
@@ -115,7 +116,10 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
                         }
                     }
                 } catch (Exception e) {
-                    LOGGER.log(Level.SEVERE, "Could not load actions from " + taf + " for " + this, e);
+                    if(this instanceof Saveable)
+                        OldDataMonitor.report((Saveable) this, Collections.<Throwable>singleton(e));
+
+                        LOGGER.log(Level.SEVERE, "Could not load actions from " + taf + " for " + this, e);
                 }
             }
         }

--- a/core/src/main/java/hudson/model/Actionable.java
+++ b/core/src/main/java/hudson/model/Actionable.java
@@ -79,12 +79,12 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
                 if (actions == null) {
                     actions = new CopyOnWriteArrayList<Action>();
                 } else {
-                    Iterator actionIterator = actions.iterator();
+                    Iterator<Action> actionIterator = actions.iterator();
                     Action action;
                     while (actionIterator.hasNext()) {
-                        action = (Action) actionIterator.next();
-                        if (action == null) {
-                            LOGGER.log(Level.WARNING, "Null action found in " + this.getClass().getName());
+                        action = actionIterator.next();
+                        if (!(action instanceof Action)) {
+                            LOGGER.log(Level.WARNING, "Not action found in " + this.getClass().getName());
                             actionIterator.remove();
                         }
                     }

--- a/core/src/main/java/hudson/model/Actionable.java
+++ b/core/src/main/java/hudson/model/Actionable.java
@@ -28,6 +28,7 @@ import hudson.Util;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
@@ -78,10 +79,13 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
                 if (actions == null) {
                     actions = new CopyOnWriteArrayList<Action>();
                 } else {
-                    for (Action action : actions) {
+                    Iterator actionIterator = actions.iterator();
+                    Action action;
+                    while (actionIterator.hasNext()) {
+                        action = (Action) actionIterator.next();
                         if (action == null) {
-                            LOGGER.log(Level.WARNING, "Actionable#getActions: Found a null action: " + action.getClass().toString());
-                            actions.remove(action);
+                            LOGGER.log(Level.WARNING, "Null action found in " + this.getClass().getName());
+                            actionIterator.remove();
                         }
                     }
                 }
@@ -107,8 +111,7 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
                         if (action instanceof Action) {
                             _actions.add(action);
                         } else {
-                            LOGGER.log(Level.WARNING, "Actionable#getAllActions: Found a not action: " + action.getClass().toString());
-                            newActions.remove(action);
+                            LOGGER.log(Level.WARNING, "Not action found in " + this.getClass().getName() + "in TransientActionFactory " + taf.getClass().getName());
                         }
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
Remove not actions and logging null and other kind of objects.

Try to make sure that `_actions` really contained only Action instances, no nulls or other kinds of objects, by stripping out anything else and logging a warning explaining what class was responsible for adding the bad element.

This is about JENKINS-27754.

@reviewbybees
