### PR TITLE
[JENKINS-28384] NPE when Node.toComputer → null

### DIFF
--- a/core/src/main/java/hudson/model/LoadStatistics.java
+++ b/core/src/main/java/hudson/model/LoadStatistics.java
@@ -51,6 +51,7 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
+import javax.annotation.CheckForNull;
 
 /**
  * Utilization statistics for a node or a set of nodes.
@@ -614,13 +615,17 @@ public abstract class LoadStatistics {
                 return this;
             }
 
-            public Builder with(Node node) {
-                if (node != null)
-                return with(node.toComputer());
+            public Builder with(@CheckForNull Node node) {
+                if (node != null) {
+                    return with(node.toComputer());
+                }
                 return this;
             }
 
-            public Builder with(Computer computer) {
+            public Builder with(@CheckForNull Computer computer) {
+                if (computer == null) {
+                    return this;
+                }
                 if (computer.isOnline()) {
                     final List<Executor> executors = computer.getExecutors();
                     final boolean acceptingTasks = computer.isAcceptingTasks();


### PR DESCRIPTION
[JENKINS-28384](https://issues.jenkins-ci.org/browse/JENKINS-28384)

I think this occurs when a slave has all of its executors killed, but not sure how to reproduce. Anyway I think FindBugs would have warned about this, since `toComputer` is `@CheckForNull`.

@reviewbybees but especially @stephenc whose code this is (I think).
