### PR TITLE
Use ConsistentHash's mass-add method.

### DIFF
--- a/core/src/main/java/hudson/model/LoadBalancer.java
+++ b/core/src/main/java/hudson/model/LoadBalancer.java
@@ -23,6 +23,7 @@
  */
 package hudson.model;
 
+import com.google.common.collect.Maps;
 import hudson.Extension;
 import hudson.ExtensionPoint;
 import hudson.model.Queue.Task;
@@ -34,6 +35,7 @@ import hudson.util.ConsistentHash.Hash;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Strategy that decides which {@link Task} gets run on which {@link Executor}.
@@ -84,8 +86,14 @@ public abstract class LoadBalancer implements ExtensionPoint {
                         return node.getName();
                     }
                 });
-                for (ExecutorChunk ec : ws.works(i).applicableExecutorChunks())
-                    hash.add(ec,ec.size()*100);
+
+                // Build a Map to pass in rather than repeatedly calling hash.add() because each call does lots of expensive work
+                List<ExecutorChunk> chunks = ws.works(i).applicableExecutorChunks();
+                Map<ExecutorChunk, Integer> toAdd = Maps.newHashMapWithExpectedSize(chunks.size());
+                for (ExecutorChunk ec : chunks) {
+                    toAdd.put(ec, ec.size()*100);
+                }
+                hash.addAll(toAdd);
 
                 hashes.add(hash);
             }


### PR DESCRIPTION
Calling hash.add() in a tight loop gets very expensive. With a
good-sized queue & slave pool, this cost tens of seconds, but now it
costs tens of milliseconds.
