### PR TITLE
[FIXED JENKINS-28419] - JenkinsLocationConfiguration::adminAddress can be reset

### DIFF
--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -133,7 +133,7 @@ public class ExtensionList<T> extends AbstractList<T> {
      * Looks for the extension instance of the given type (subclasses excluded),
      * or return null.
      */
-    public <U extends T> U get(Class<U> type) {
+    public @CheckForNull <U extends T> U get(Class<U> type) {
         for (T ext : this)
             if(ext.getClass()==type)
                 return type.cast(ext);

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -85,13 +85,18 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
         return v;
     }
 
-    public void setAdminAddress(@Nonnull String adminAddress) {
-        if(adminAddress.startsWith("\"") && adminAddress.endsWith("\"")) {
+    /**
+     * Sets the e-mail address of Jenkins administrator.
+     * @param adminAddress Admin address. Use null to reset the value to default.
+     */
+    public void setAdminAddress(@CheckForNull String adminAddress) {
+        String address = Util.nullify(adminAddress);
+        if(address != null && address.startsWith("\"") && address.endsWith("\"")) {
             // some users apparently quote the whole thing. Don't konw why
             // anyone does this, but it's a machine's job to forgive human mistake
-            adminAddress = adminAddress.substring(1,adminAddress.length()-1);
+            address = address.substring(1,address.length()-1);
         }
-        this.adminAddress = adminAddress;
+        this.adminAddress = address;
         save();
     }
 

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -20,6 +20,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static hudson.Util.fixNull;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * Stores the location of Jenkins (e-mail address and the HTTP URL.)
@@ -30,7 +32,7 @@ import static hudson.Util.fixNull;
 @Extension
 public class JenkinsLocationConfiguration extends GlobalConfiguration {
     /**
-     * @deprecated
+     * @deprecated replaced by {@link #jenkinsUrl}
      */
     @Deprecated
     private transient String hudsonUrl;
@@ -40,7 +42,7 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
     // just to suppress warnings
     private transient String charset,useSsl;
 
-    public static JenkinsLocationConfiguration get() {
+    public static @CheckForNull JenkinsLocationConfiguration get() {
         return GlobalConfiguration.all().get(JenkinsLocationConfiguration.class);
     }
 
@@ -73,13 +75,17 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
         updateSecureSessionFlag();
     }
 
-    public String getAdminAddress() {
+    /**
+     * Gets the service administrator e-mail address.
+     * @return Admin adress or &quot;address not configured&quot; stub
+     */
+    public @Nonnull String getAdminAddress() {
         String v = adminAddress;
         if(v==null)     v = Messages.Mailer_Address_Not_Configured();
         return v;
     }
 
-    public void setAdminAddress(String adminAddress) {
+    public void setAdminAddress(@Nonnull String adminAddress) {
         if(adminAddress.startsWith("\"") && adminAddress.endsWith("\"")) {
             // some users apparently quote the whole thing. Don't konw why
             // anyone does this, but it's a machine's job to forgive human mistake
@@ -89,12 +95,12 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
         save();
     }
 
-    public String getUrl() {
+    public @CheckForNull String getUrl() {
         return jenkinsUrl;
     }
 
-    public void setUrl(String hudsonUrl) {
-        String url = Util.nullify(hudsonUrl);
+    public void setUrl(@CheckForNull String jenkinsUrl) {
+        String url = Util.nullify(jenkinsUrl);
         if(url!=null && !url.endsWith("/"))
             url += '/';
         this.jenkinsUrl = url;

--- a/core/src/test/java/jenkins/model/JenkinsLocationConfigurationTest.java
+++ b/core/src/test/java/jenkins/model/JenkinsLocationConfigurationTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees Inc., Oleg Nenashev.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model;
+
+import java.io.IOException;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Tests for {@link JenkinsLocationConfiguration}.
+ * @author Oleg Nenashev
+ */
+public class JenkinsLocationConfigurationTest {
+    
+    JenkinsLocationConfiguration config;
+    
+    @Before
+    public void setUp() {
+        config = mock(JenkinsLocationConfiguration.class, Mockito.CALLS_REAL_METHODS);
+        Answer<String> mockVoid = new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return "stub";
+            }
+        };
+        Mockito.doAnswer(mockVoid).when(config).save();      
+        Mockito.doAnswer(mockVoid).when(config).save();
+    }
+    
+    @Test
+    public void setAdminEmail() {
+        final String email="test@foo.bar";
+        final String email2="test@bar.foo";
+        
+        // Assert the default value
+        assertEquals(Messages.Mailer_Address_Not_Configured(), config.getAdminAddress());
+        
+        // Basic case
+        config.setAdminAddress(email);
+        assertEquals(email, config.getAdminAddress());
+        
+        // Quoted value
+        config.setAdminAddress("\""+email2+"\"");
+        assertEquals(email2, config.getAdminAddress());
+    }
+    
+    @Test
+    @Issue("JENKINS-28419")
+    public void resetAdminEmail() {
+        final String email="test@foo.bar";
+        
+        // Set the e-mail
+        config.setAdminAddress(email);
+        assertEquals(email, config.getAdminAddress());
+        
+        // Reset it
+        config.setAdminAddress(null);
+        assertEquals(Messages.Mailer_Address_Not_Configured(), config.getAdminAddress());
+    }
+}


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-28419

This pull request resolves a potential NPE, which may happen when a user tries to reset the admin e-mail. Changes:
- Annotation of <code>JenkinsLocationConfiguration</code> methods
- Some unit tests
- Fix of <code> setAdminAddress()</code> behavior
