### PR TITLE
[FIXED JENKINS-17290] -  Corrected sort order of tables

### DIFF
--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -178,7 +178,7 @@ var Sortable = (function() {
             var dir = this.pref.direction;
 
             var s = this.getSorter(column);
-            if(dir === arrowTable.up) {// ascending
+            if(dir === arrowTable.down) {// only need to reverse when it's descending
                 s = sorter.reverse(s);
             }
 


### PR DESCRIPTION
Squashed version of #1471. Initial behavior was quite confusing

> It seems that the sort is for sorting ascending order, thus a "desecnding" order should be sorter.reverse()
