### PR TITLE
[FIXED JENKINS-28455] Build History badges don't wrap

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1037,6 +1037,10 @@ table.parameters > tbody:hover {
   width: 70%;
   text-align: right;
 }
+.build-row-cell .build-badge span:after {
+    content: " ";
+    font-size: 0%;
+}
 .build-row .build-name-controls .pane.build-name,
 .build-row .build-details-controls .pane.build-details {
   width: 70%;


### PR DESCRIPTION
Following on from #1705, this CSS tweak makes Groovy Postbuild plugin badges appear a bit more cleanly.

Before:

![screenshot 2015-05-18 15 51 58](https://cloud.githubusercontent.com/assets/429311/7683347/60d5fa2e-fd76-11e4-9d1f-2b651591a802.png)

After:

![screenshot 2015-05-18 15 51 28](https://cloud.githubusercontent.com/assets/429311/7683353/6a49c0d6-fd76-11e4-82dc-afd3282ff458.png)
