### PR TITLE
allow JenkinsLocationConfiguration adminAddress to be null

### DIFF
--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -80,7 +80,7 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
     }
 
     public void setAdminAddress(String adminAddress) {
-        if(adminAddress.startsWith("\"") && adminAddress.endsWith("\"")) {
+        if(adminAddress != null && adminAddress.startsWith("\"") && adminAddress.endsWith("\"")) {
             // some users apparently quote the whole thing. Don't konw why
             // anyone does this, but it's a machine's job to forgive human mistake
             adminAddress = adminAddress.substring(1,adminAddress.length()-1);


### PR DESCRIPTION
The default value for the adminAddress field is null.  The setAdminAddress
setter method prevents this field from being [re]set to null as it does not
validate its string param as being not null before attempting string comparison
operations.  This simple fix skips string comparison checks if the string is
null.
