### PR TITLE
[FIXED JENKINS-28635] Show URL used by autoinstaller

### DIFF
--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -4,13 +4,18 @@ import hudson.FilePath;
 import hudson.model.DownloadService.Downloadable;
 import hudson.model.Node;
 import hudson.model.TaskListener;
-import net.sf.json.JSONObject;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.net.URL;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
 
 /**
  * Partial convenience implementation of {@link ToolInstaller} that just downloads
@@ -137,16 +142,30 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
         /**
          * List of installable tools.
          *
-         * <p>
-         * The UI uses this information to populate the drop-down. Subtypes can override this method
-         * if it wants to change the way the list is filled.
-         *
          * @return never null.
          */
         public List<? extends Installable> getInstallables() throws IOException {
             JSONObject d = Downloadable.get(getId()).getData();
             if(d==null)     return Collections.emptyList();
             return Arrays.asList(((InstallableList)JSONObject.toBean(d,InstallableList.class)).list);
+        }
+        
+        /**
+         * The UI uses this information to populate the drop-down.
+         * 
+         * @return JSON array of installable tools, never null
+         * @since 1.617
+         */
+        @Restricted(DoNotUse.class)
+        public JSONArray getInstallablesJson() throws IOException {
+            JSONArray tools = new JSONArray();
+            final Downloadable d = Downloadable.get(getId());
+            if (d != null) {
+                final JSONObject data = d.getData();
+                if (data != null)
+                    tools = data.getJSONArray("list");
+            }
+            return tools;
         }
     }
 

--- a/core/src/main/resources/hudson/tools/DownloadFromUrlInstaller/config.jelly
+++ b/core/src/main/resources/hudson/tools/DownloadFromUrlInstaller/config.jelly
@@ -24,19 +24,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Version}" field="id">
-    <j:choose>
-      <j:set var="tools" value="${descriptor.installables}"/>
-      <j:when test="${empty(tools)}">
-        <!-- if the list is not available, fall back to text box -->
-        <f:textbox />
-      </j:when>
-      <j:otherwise>
-        <select name="_.id">
-          <j:forEach var="tool" items="${tools}">
-            <f:option value="${tool.id}" selected="${tool.id==instance.id}">${tool.name}</f:option>
-          </j:forEach>
-        </select>
-      </j:otherwise>
-    </j:choose>
+    <f:installableSelect tools="${descriptor.installablesJson}"/>
   </f:entry>
 </j:jelly>

--- a/core/src/main/resources/lib/form/installableSelect.jelly
+++ b/core/src/main/resources/lib/form/installableSelect.jelly
@@ -1,0 +1,73 @@
+<!--
+The MIT License
+
+Copyright (c) 2015, Vojtech Juranek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation>
+    Select for installable tool, which show possible download URL.
+    
+    <st:attribute name="tools" use="required">
+      JSON array with installable tools
+    </st:attribute>
+  </st:documentation>
+
+  <j:choose>
+    <j:when test="${empty(tools)}">
+      <!-- if the list is not available, fall back to text box -->
+      <f:textbox />
+    </j:when>
+    <j:otherwise>
+      <select name="_.id" onChange="showDownloadURL(this, ${tools})">
+        <j:forEach var="tool" items="${tools}">
+          <f:option value="${tool.id}" selected="${tool.id==instance.id}">${tool.name}
+          </f:option>
+        </j:forEach>
+      </select>
+      <span name="_.tool.url" style="color:gray">
+        &amp;nbsp;&amp;nbsp;
+        <a href="javascript:void(0)" onclick="makeUrlVisible(this, ${tools})">(Show download URL)</a>
+        <span name="_.tool.url.visible" style="display:none"></span>
+      </span>
+    </j:otherwise>
+  </j:choose>
+  <script>
+    function getDownloadURL(id, tools) {
+      for(var i = 0; i &lt; tools.length; i++) {
+        if(id === tools[i].id) {
+          return tools[i].url;
+        }
+      }
+    }
+
+    function showDownloadURL(elem, tools) {
+      elem.nextSibling.childNodes[2].innerHTML = '&amp;nbsp;&amp;nbsp;' + getDownloadURL(elem.value, tools);
+    }
+
+    function makeUrlVisible(elem, tools) {
+      elem.style.display = 'none';
+      elem.nextSibling.style.display = 'inline';
+      showDownloadURL(elem.parentNode.previousSibling, tools);
+    }
+  </script>
+</j:jelly>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-28635
Adds link on the right of the version select
![jenkins-28635_1](https://cloud.githubusercontent.com/assets/494573/7871753/2f9bcc9e-0592-11e5-9f17-8a05bcc77fd8.png)
when clicked, shows URL to use for the download
![jenkins-28635_2](https://cloud.githubusercontent.com/assets/494573/7871754/32a3a128-0592-11e5-8771-0ed6eb39eebb.png)
