### PR TITLE
Null safety for removeExecutor

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -998,7 +998,9 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
                     if (!isAlive()) // TODO except from interrupt/doYank this is called while the executor still isActive(), so how could !this.isAlive()?
                     {
                         AbstractCIBase ciBase = Jenkins.getInstance();
-                        ciBase.removeComputer(Computer.this);
+                        if (ciBase != null) {
+                            ciBase.removeComputer(Computer.this);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Sometimes observed at end of (passing) WorkflowTest.executorStepRestart in 1.596.1:

```
Exception in thread "Executor #0 for slave0 : executing PlaceholderExecutable:job/demo/1/:null" java.lang.NullPointerException
    at hudson.model.Computer.removeExecutor(Computer.java:869)
    at hudson.model.Executor.run(Executor.java:272)
```

`Jenkins.computers` is `transient` so I think it is harmless to ignore an attempt to remove an executor after shutdown.

@reviewbybees
