### PR TITLE
NPE fix for AbstractProject polling when node is not available

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1471,7 +1471,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         Launcher launcher = ws.createLauncher(listener).decorateByEnv(getEnvironment(node,listener));
         WorkspaceList.Lease lease = l.acquire(ws, !concurrentBuild);
         try {
-            listener.getLogger().println("Polling SCM changes on " + node.getSelfLabel().getName());
+            String nodeName = node != null ? node.getSelfLabel().getName() : "[node_unavailable]";
+            listener.getLogger().println("Polling SCM changes on " + nodeName);
             LOGGER.fine("Polling SCM changes of " + getName());
             if (pollingBaseline==null) // see NOTE-NO-BASELINE above
                 calcPollingBaseline(lb,launcher,listener);


### PR DESCRIPTION
I have a scenario where I want to handle SCM polling for a project that was built on a cloud slave (Docker slave) that is no longer available at polling time.  I have implemented a WorkspaceBrowser that uses a copy of the SCM files on the master to handle the polling (used for handling Git user exclusions).  This one log statement in the polling code for AbstractProject assumes the node is available and will throw an NPE when it is not.

This is a simple fix for the case where the node is not available at the time of polling.
