### PR TITLE
[FIXED JENKINS-28704] Regression for build-history link not opening console

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -55,7 +55,9 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
-  <li class=>
+  <li class=bug>
+    Regression in build-history causing ball to not open console
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28704">issue 28704</a>) 
 </ul>
 </div><!--=TRUNK-END=-->
 <h3><a name=v1.616>What's new in 1.616</a> (2015/05/31)</h3>

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1069,7 +1069,10 @@ table.parameters > tbody:hover {
   border-left: 1px solid #cdcdcd;
 }
 
-.build-row-cell .pane.build-name .display-name,
+.build-row-cell .pane.build-name .display-name {
+  margin-left: 20px;
+}
+
 .build-row-cell .indent-multiline {
   padding-left: 20px !important;  /* Sync changes with func expandControlsTo50Percent in hudson-behavior.js */
 }


### PR DESCRIPTION
[JENKINS-28704](https://issues.jenkins-ci.org/browse/JENKINS-28704)
