### PR TITLE
[FIX JENKINS-27739] Clear cached env vars when node goes online

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1595,7 +1595,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             return true;
         }
 
-        @Extension
+        @Extension(ordinal = Double.MAX_VALUE)
         @Restricted(DoNotUse.class)
         public static class InternalComputerListener extends ComputerListener {
             @Override

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -27,6 +27,7 @@ package hudson.model;
 import edu.umd.cs.findbugs.annotations.OverrideMustInvoke;
 import edu.umd.cs.findbugs.annotations.When;
 import hudson.EnvVars;
+import hudson.Extension;
 import hudson.Launcher.ProcStarter;
 import hudson.Util;
 import hudson.cli.declarative.CLIMethod;
@@ -66,6 +67,7 @@ import jenkins.model.queue.AsynchronousExecution;
 import jenkins.util.ContextResettingExecutorService;
 import jenkins.security.MasterToSlaveCallable;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
@@ -403,7 +405,6 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      *      make much sense because as soon as {@link Computer} is connected it can be disconnected by some other threads.)
      */
     public final Future<?> connect(boolean forceReconnect) {
-        this.cachedEnvironment = null;
     	connectTime = System.currentTimeMillis();
     	return _connect(forceReconnect);
     }
@@ -1592,6 +1593,15 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             }
 
             return true;
+        }
+
+        @Extension
+        @Restricted(DoNotUse.class)
+        public static class InternalComputerListener extends ComputerListener {
+            @Override
+            public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
+                c.cachedEnvironment = null;
+            }
         }
 
         @Override


### PR DESCRIPTION
PR #1559 cleared the cached node environment on `connect()`, but that only got called when Jenkins launches the slave itself, resulting in all JNLP slaves never refreshing their node environment. `JnlpSlaveAgentProtocol.Handler.jnlpConnect(Computer)` doesn't work like that.

So I moved the environment cache reset to a new `ComputerListener`'s `onOnline(…)`.

@reviewbybees
