### PR TITLE
[JENKINS-28192] SecretRewriter.rewriteRecursive fails to resolve symbolic links on Windows

### DIFF
--- a/core/src/main/java/hudson/util/SecretRewriter.java
+++ b/core/src/main/java/hudson/util/SecretRewriter.java
@@ -13,6 +13,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.nio.file.LinkOption;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.util.HashSet;
@@ -145,7 +146,7 @@ public class SecretRewriter {
     private int rewriteRecursive(File dir, String relative, TaskListener listener) throws InvalidKeyException {
         String canonical;
         try {
-            canonical = dir.getCanonicalPath();
+            canonical = dir.toPath().toRealPath(new LinkOption[0]).toString();
         } catch (IOException e) {
             canonical = dir.getAbsolutePath(); //
         }

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URI;
+import java.nio.file.LinkOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -297,8 +298,8 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
             }
         private boolean isIllegalSymlink() { // TODO JENKINS-26838
             try {
-                String myPath = f.getCanonicalPath();
-                String rootPath = root.getCanonicalPath();
+                String myPath = f.toPath().toRealPath(new LinkOption[0]).toString();
+                String rootPath = root.toPath().toRealPath(new LinkOption[0]).toString();
                 if (!myPath.equals(rootPath) && !myPath.startsWith(rootPath + File.separatorChar)) {
                     return true;
                 }


### PR DESCRIPTION
Return of #1685 
[JENKINS-28192](https://issues.jenkins-ci.org/browse/JENKINS-28192)

`SecretRewriter.rewriteRecursive` and `VirtualFile#isIllegalSymlink` fails to resolve and detect symbolic links on Windows.
This results
- `SecretRewriterTest#recursionDetection` doesn't finish on Windows.
- `VirtualFileTest#outsideSymlinks` fails on Windows (and that causes a security issue).

This is caused for `File#getCanonicalPath` resolves symbolic links only on *nix systems, not on Windows.
This change uses `java.nio.file.Path#toRealPath` instead.
Jenkins supports Java7 since 1.615 (6496a946848204dc908c503452fc294c7daebb73).
