### PR TITLE
[FIXED JENKINS-28601] Revert "[FIXED JENKINS-17290] -  Corrected sort order of tables"

### DIFF
--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -178,7 +178,7 @@ var Sortable = (function() {
             var dir = this.pref.direction;
 
             var s = this.getSorter(column);
-            if(dir === arrowTable.down) {// only need to reverse when it's descending
+            if(dir === arrowTable.up) {// ascending
                 s = sorter.reverse(s);
             }
 


### PR DESCRIPTION
This reverts commit d739bedc0d5cc42aa28868fa28a709081460671c from #1708.

Reason: Massive regressions ([JENKINS-28601](https://issues.jenkins-ci.org/browse/JENKINS-28601))
