### PR TITLE
Easier to see sections on the configuration pages.

### DIFF
--- a/core/src/main/resources/lib/form/section_.css
+++ b/core/src/main/resources/lib/form/section_.css
@@ -1,7 +1,7 @@
 .section-header {
-    font-weight: bold;
-    border-bottom: 1px solid #e0e0e0;
+    font-weight: lighter;
     margin-bottom: 0.2em;
-    margin-top: 0.4em;
+    margin-top: 1.4em;
     padding-bottom: 3px;
+    font-size: 2em;
 }

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -37,6 +37,14 @@ body {
   margin-left: auto;
 }
 
+a:link {
+  text-decoration: none;
+}
+
+h1 {
+  font-weight: normal;
+}
+
 #header {
   background-color: #000000;
   height: 40px;

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -37,10 +37,6 @@ body {
   margin-left: auto;
 }
 
-a:link {
-  text-decoration: none;
-}
-
 h1 {
   font-weight: normal;
 }
@@ -239,7 +235,7 @@ dt {
 }
 
 a:link {
-  text-decoration: underline;
+  text-decoration: none;
   color: #204A87;
 }
 

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -234,14 +234,9 @@ dt {
     color: #ccc;
 }
 
-a:link {
+a:link, a:visited {
   text-decoration: none;
-  color: #204A87;
-}
-
-a:visited {
-  text-decoration: underline;
-  color: #5c3566;
+  color: #204AAE;
 }
 
 a.lowkey:link {


### PR DESCRIPTION
The current styling doesn't have enough contrast between headings and the body. This commit fixes that problem. I could keep going with other parts of the design, but this seems the most important (and really simple) improvement.

![screen shot 2015-06-22 at 10 12 28am](https://cloud.githubusercontent.com/assets/27023/8273979/3a2d82ea-18c7-11e5-896b-7f976083d5a3.png)
