### PR TITLE
AbstractScmTagAction.getBuild is deprecated in favor of getRun

### DIFF
--- a/core/src/main/resources/hudson/scm/AbstractScmTagAction/badge.jelly
+++ b/core/src/main/resources/hudson/scm/AbstractScmTagAction/badge.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:if xmlns:j="jelly:core" xmlns:l="/lib/layout" test="${it.isTagged()}">
-  <a href="${rootURL}/${it.build.url}tagBuild/">
+  <a href="${rootURL}/${it.run.url}tagBuild/">
     <l:icon class="icon-save icon-sm" tooltip="${it.tooltip}"/>
   </a>
 </j:if>

--- a/core/src/main/resources/hudson/scm/AbstractScmTagAction/inProgress.jelly
+++ b/core/src/main/resources/hudson/scm/AbstractScmTagAction/inProgress.jelly
@@ -25,9 +25,9 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true">
-    <st:include it="${it.build}" page="sidepanel.jelly" />
+    <st:include it="${it.run}" page="sidepanel.jelly" />
     <l:main-panel>
-      <h1>Build ${it.build.displayName}</h1>
+      <h1>Build ${it.run.displayName}</h1>
       <p>
         ${%Tagging is in progress:}
       </p>


### PR DESCRIPTION
Without this, `TagAction` in the `p4` plugin is known to create a broken link on a Workflow build.

Cf. https://github.com/jenkinsci/subversion-plugin/pull/119.

@reviewbybees and @p4paul
