### PR TITLE
Grammer fix

### DIFF
--- a/core/src/main/resources/hudson/model/Computer/sidepanel_nl.properties
+++ b/core/src/main/resources/hudson/model/Computer/sidepanel_nl.properties
@@ -24,6 +24,6 @@ Back\ to\ List=Terug naar overzicht
 Build\ History=Bouwhistorie
 Configure=Configureren
 Delete\ Slave=Verwijderen
-Load\ Statistics=Belasting statistieken
+Load\ Statistics=Belastings statistieken
 Script\ Console=Scriptconsole
 Status=Status


### PR DESCRIPTION
missing an s at the end. Without the s at the end its about TAX stats with the s its load stats
