### PR TITLE
[JENKINS-29064] dropdownDescriptorSelector should accept descriptors without configurations.

### DIFF
--- a/core/src/main/resources/lib/form/dropdownDescriptorSelector.jelly
+++ b/core/src/main/resources/lib/form/dropdownDescriptorSelector.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
         lazy="descriptor">
         <l:ajax>
           <j:set var="instance" value="${current.descriptor==descriptor ? current : null}" />
-          <st:include from="${descriptor}" page="${descriptor.configPage}" />
+          <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true" />
         </l:ajax>
       </f:dropdownListBlock>
     </j:forEach>


### PR DESCRIPTION
[JENKINS-29064](https://issues.jenkins-ci.org/browse/JENKINS-29064).

`f:dropdownDescriptorSelector` is used to have users select a component to use.
e.g. "Which build"(`BuildSelector`) in [copyartifact-plugin|https://wiki.jenkins-ci.org/display/JENKINS/Copy+Artifact+Plugin].

It's often the case that that component doesn't have fields to configure, and doesn't have config.jelly.
`f:dropdownDescriptorSelector` shouldn't require config.jelly and should treat it optional.
