### PR TITLE
LoadStatistics: fix spacing issue in message bundle

### DIFF
--- a/core/src/main/resources/hudson/model/LoadStatistics/main.properties
+++ b/core/src/main/resources/hudson/model/LoadStatistics/main.properties
@@ -57,8 +57,8 @@ blurb=\
       adding more computers.\
     </dd>\
   </dl>\
-  <p><b>Note:</b>The number of busy executors and the number of available executors need not \
-  necessarily be equal to the number of online executors as executors can be suspended from\
+  <p><b>Note:</b> The number of busy executors and the number of available executors need not \
+  necessarily be equal to the number of online executors as executors can be suspended from \
   accepting builds and thus be neither busy nor available.</p>\
   <p>The graph is an exponential moving average of periodically collected data values. \
   3 timespans are updated every 10 seconds, 1 minute and 1 hour respectively.</p>


### PR DESCRIPTION
pretty minor, but some words were joined together when rendering the
message in the load statistics page.
