### PR TITLE
Fix url presented by JenkinsRule#interactiveBreak

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -967,7 +967,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * This is useful during debugging a test so that one can inspect the state of Hudson through the web browser.
      */
     public void interactiveBreak() throws Exception {
-        System.out.println("Jenkins is running at http://localhost:"+localPort+"/");
+        System.out.println("Jenkins is running at " + getURL());
         new BufferedReader(new InputStreamReader(System.in)).readLine();
     }
 


### PR DESCRIPTION
Context path is missing.
