### PR TITLE
Add marker iterface for an Item to indicate no disk syncing

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -193,6 +193,7 @@ import jenkins.ExtensionComponentSet;
 import jenkins.ExtensionRefreshException;
 import jenkins.InitReactorRunner;
 import jenkins.model.ProjectNamingStrategy.DefaultProjectNamingStrategy;
+import jenkins.model.NonDiskItem;
 import jenkins.security.ConfidentialKey;
 import jenkins.security.ConfidentialStore;
 import jenkins.security.SecurityListener;
@@ -2679,7 +2680,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 // retainAll doesn't work well because of CopyOnWriteMap implementation, so remove one by one
                 // hopefully there shouldn't be too many of them.
                 for (String name : items.keySet()) {
-                    if (!loadedNames.contains(name))
+                    if (!loadedNames.contains(name) && !(items.get(name) instanceof NonDiskItem))
                         items.remove(name);
                 }
             }

--- a/core/src/main/java/jenkins/model/NonDiskItem.java
+++ b/core/src/main/java/jenkins/model/NonDiskItem.java
@@ -1,0 +1,7 @@
+package jenkins.model;
+
+/**
+ * This is marker interface for TopLevelItem to inidicate that it shouldn't be synced from the Disk.
+ */
+public interface NonDiskItem {
+}


### PR DESCRIPTION
This is a fix for  trying to load an item from database instead of disk during my plugin's startup , but jenkins seems to assuming that everything is being loaded from the disk and removing my dynamically loaded items.
