### PR TITLE
[FIXED JENKINS-2327] Do not display 'No changes' if changelog calcula…

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractBuild/changes.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/changes.jelly
@@ -31,7 +31,17 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <t:buildCaption>${%Changes}</t:buildCaption>
-      <st:include page="index.jelly" it="${it.changeSet}" />
+      <j:choose>
+        <j:when test="${it.hasChangeSetComputed()}">
+          <st:include page="index.jelly" it="${it.changeSet}" />
+        </j:when>
+        <j:when test="${it.building}">
+          ${%Not yet determined}
+        </j:when>
+        <j:otherwise>
+          ${%Failed to determine} (<a href="console">${%log}</a>)
+        </j:otherwise>
+      </j:choose>
     </l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION
[JENKINS-2327](https://issues.jenkins-ci.org/browse/JENKINS-2327)

If a job is still computing the SCM changelog, Jenkins will misleading display "No changes" on the Changes page.

On the Status page it was correctly displayed, when the changes were not known yet, it would show "Not yet determined".

I now use that same check that was being done on the Status page on the Changes page.
