### PR TITLE
Add background color options to plot URLs

### DIFF
--- a/core/src/main/java/hudson/util/Graph.java
+++ b/core/src/main/java/hudson/util/Graph.java
@@ -26,6 +26,7 @@ package hudson.util;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.ChartRenderingInfo;
 import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.plot.Plot;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -84,8 +85,27 @@ public abstract class Graph {
         String h = req.getParameter("height");
         if(h==null)     h=String.valueOf(defaultH);
 
+        Color graphBg = stringToColor(req.getParameter("graphBg"));
+        Color plotBg = stringToColor(req.getParameter("plotBg"));
+
         if (graph==null)    graph = createGraph();
+        graph.setBackgroundPaint(graphBg);
+        Plot p = graph.getPlot();
+        p.setBackgroundPaint(plotBg);
+
         return graph.createBufferedImage(Integer.parseInt(w),Integer.parseInt(h),info);
+    }
+
+    private static Color stringToColor(String s) {
+        if (s != null) {
+            try {
+                return Color.decode("0x" + s);
+            } catch (NumberFormatException e) {
+                return Color.WHITE;
+            }
+        } else {
+            return Color.WHITE;
+        }
     }
 
     /**

--- a/core/src/main/java/hudson/util/Graph.java
+++ b/core/src/main/java/hudson/util/Graph.java
@@ -36,6 +36,8 @@ import java.io.IOException;
 import java.util.Calendar;
 import java.awt.image.BufferedImage;
 import java.awt.*;
+import javax.annotation.Nonnull;
+import javax.annotation.CheckForNull;
 
 /**
  * A JFreeChart-generated graph that's bound to UI.
@@ -96,7 +98,7 @@ public abstract class Graph {
         return graph.createBufferedImage(Integer.parseInt(w),Integer.parseInt(h),info);
     }
 
-    private static Color stringToColor(String s) {
+    @Nonnull private static Color stringToColor(@CheckForNull String s) {
         if (s != null) {
             try {
                 return Color.decode("0x" + s);


### PR DESCRIPTION
In addition to specifying width and height, you can now pass the graphBg=[hex color code, no prefix] and plotBg=[hex color code, no prefix] arguments to set the background colors of generated plots. 

For example: http://jenkins.url/job/jobName/buildTimeGraph/png?plotBg=E0E0E0&graphBg=E0E0E0 now generates a build time graph with a light gray background.
