### PR TITLE
Shell task now errors on substitution of unset variable

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -60,6 +60,9 @@ Upcoming changes</a>
 </div><!--=TRUNK-END=-->
 <h3><a name=v1.622>What's new in 1.622</a> (2015/07/27)</h3>
 <ul class=image>
+  <li class=rfe>
+    The shell task now treat unset variables as an error when substituting (set -u).
+    (<a href="https://github.com/jenkinsci/jenkins/pull/1775">PR 1775</a>)
   <li class=>
 </ul>
 <h3><a name=v1.621>What's new in 1.621</a> (2015/07/19)</h3>

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -82,7 +82,7 @@ public class Shell extends CommandInterpreter {
             args.set(0,args.get(0).substring(2));   // trim off "#!"
             return args.toArray(new String[args.size()]);
         } else 
-            return new String[] { getDescriptor().getShellOrDefault(script.getChannel()), "-xe", script.getRemote()};
+            return new String[] { getDescriptor().getShellOrDefault(script.getChannel()), "-xue", script.getRemote()};
     }
 
     protected String getContents() {

--- a/core/src/main/resources/hudson/tasks/Shell/help.html
+++ b/core/src/main/resources/hudson/tasks/Shell/help.html
@@ -6,9 +6,9 @@
   (like <tt>#!/bin/perl</tt>) or control the options that shell uses.
 
   <p>
-  By default, the shell will be invoked with the "-ex" option. So all of the commands are printed before being executed,
-  and the build is considered a failure if any of the commands exits with a non-zero exit code. Again, add the
-  <tt>#!/bin/...</tt> line to change this behavior.
+  By default, the shell will be invoked with the "-eux" option. So all of the commands are printed before being executed,
+  and the build is considered a failure if a variable is not set during substitution or any of the commands exits with a
+  non-zero exit code.  Again, add the <tt>#!/bin/...</tt> line to change this behavior.
 
   <p>
   As a best practice, try not to put a long shell script in here. Instead, consider adding the shell script

--- a/test/src/test/java/hudson/tasks/ShellTest.java
+++ b/test/src/test/java/hudson/tasks/ShellTest.java
@@ -55,7 +55,7 @@ public class ShellTest {
                 // test the command line argument.
                 List<String> cmds = p.cmds();
                 rule.assertStringContains("/bin/sh",cmds.get(0));
-                rule.assertStringContains("-xe",cmds.get(1));
+                rule.assertStringContains("-xue",cmds.get(1));
                 assertTrue(new File(cmds.get(2)).exists());
 
                 // fake the execution


### PR DESCRIPTION
Use set -u in addition of set -xe.  Whenever a script attempts to
substitute a variable which is unset, it will print a message on STDERR
and exit immediately (unless the shell is run interactively).
