### PR TITLE
Reduce logging level

### DIFF
--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -264,7 +264,7 @@ public class NodeProvisioner {
                     int queueLengthSnapshot = snapshot.getQueueLength();
 
                     if (queueLengthSnapshot <= availableSnapshot) {
-                        LOGGER.log(Level.FINE,
+                        LOGGER.log(Level.FINER,
                                 "Queue length {0} is less than the available capacity {1}. No provisioning strategy required",
                                 new Object[]{queueLengthSnapshot, availableSnapshot});
                         provisioningState = null;


### PR DESCRIPTION
Noticed when running

``` sh
mvn -f mock-slave-plugin hpi:run
```

that the message

```
… hudson.slaves.NodeProvisioner$2 run
FINE: Queue length 0 is less than the available capacity 0. No provisioning strategy required
```

was being printed 2–3× per second, which seems excessive even for `FINE` and was drowning out everything else.

@reviewbybees
