### PR TITLE
Deleting bogus class ExceptionInterruption

### DIFF
--- a/core/src/main/java/jenkins/model/CauseOfInterruption.java
+++ b/core/src/main/java/jenkins/model/CauseOfInterruption.java
@@ -70,7 +70,7 @@ public abstract class CauseOfInterruption implements Serializable {
     }
 
     /**
-     * Indicates that the build was interrupted from UI by an user.
+     * Indicates that the build was interrupted from UI.
      */
     public static final class UserInterruption extends CauseOfInterruption {
         private final String user;
@@ -111,33 +111,6 @@ public abstract class CauseOfInterruption implements Serializable {
 
         private static final long serialVersionUID = 1L;
     }
-
-    /**
-     * Indicates that the build was interrupted as a result of another a problem.
-     *
-     * <p>
-     * This is a less specific (thus less desirable) {@link CauseOfInterruption}
-     * in case there's no suitable {@link CauseOfInterruption}. Use sparingly.
-     */
-    class ExceptionInterruption extends CauseOfInterruption {
-        private final Throwable cause;
-
-        public ExceptionInterruption(Throwable cause) {
-            this.cause = cause;
-        }
-
-        public Throwable getCause() {
-            return cause;
-        }
-
-        @Override
-        public String getShortDescription() {
-            return "Exception: "+ cause.getMessage();
-        }
-
-        private static final long serialVersionUID = 1L;
-    }
-
 
     private static final long serialVersionUID = 1L;
 }

--- a/core/src/main/resources/jenkins/model/CauseOfInterruption/ExceptionInterruption/summary.groovy
+++ b/core/src/main/resources/jenkins/model/CauseOfInterruption/ExceptionInterruption/summary.groovy
@@ -1,5 +1,0 @@
-package jenkins.model.CauseOfInterruption.ExceptionInterruption
-
-import hudson.util.FormValidation;
-
-raw(FormValidation.error(my.cause, my.cause.message).renderHtml());


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/commit/68b383e was committed without review or explanation. There appears to be no outside usage of this newly introduced class (and anyway it is package-private so it was not in the Java API).

You might ask about some build record which somehow has a serialized copy of it anyway. But note that @kohsuke forgot to mark this class `static`, so in order to even create it you would need to use the contorted idiom

``` java
public static CauseOfInterruption byException(Throwable cause) {
    return new CauseOfInterruption() {
        @Override public String getShortDescription() {
            throw new UnsupportedOperationException("WTF!");
        }
    }.new ExceptionInterruption(cause);
}
```

@reviewbybees
