### PR TITLE
[JENKINS-32958] - Avoid "EmptyStackException: null" in Items#getCanonicalName

### DIFF
--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -204,7 +204,7 @@ public class Items {
         String[] c = context.getFullName().split("/");
         String[] p = path.split("/");
 
-        Stack name = new Stack();
+        Stack<String> name = new Stack<String>();
         for (int i=0; i<c.length;i++) {
             if (i==0 && c[i].equals("")) continue;
             name.push(c[i]);
@@ -216,6 +216,11 @@ public class Items {
                 continue;
             }
             if (p[i].equals("..")) {
+                if (name.size() == 0) {
+                    throw new IllegalArgumentException(String.format(
+                            "Illegal relative path '%s' within context '%s'", path, context.getFullName()
+                    ));
+                }
                 name.pop();
                 continue;
             }

--- a/core/src/test/java/hudson/model/ItemsTest.java
+++ b/core/src/test/java/hudson/model/ItemsTest.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 /**
@@ -44,6 +45,27 @@ public class ItemsTest {
         assertEquals("foo/bar", Items.getCanonicalName(foo, "./bar"));
         assertEquals("foo/bar/baz/qux", Items.getCanonicalName(foo_bar, "baz/qux"));
         assertEquals("foo/baz/qux", Items.getCanonicalName(foo_bar, "../baz/qux"));
+
+        try {
+            Items.getCanonicalName(root, "..");
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Illegal relative path '..' within context ''", ex.getMessage());
+        }
+
+        try {
+            Items.getCanonicalName(foo, "../..");
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Illegal relative path '../..' within context 'foo'", ex.getMessage());
+        }
+
+        try {
+            Items.getCanonicalName(root, "foo/../..");
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertEquals("Illegal relative path 'foo/../..' within context ''", ex.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Present meaningful exception instead of:

```
java.util.EmptyStackException: null
    at java.util.Stack.peek(Stack.java:102)
    at java.util.Stack.pop(Stack.java:84)
```

in case the relative path escapes root.
