### PR TITLE
Make it easier to determine Computer is Unix or Windows

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.OverrideMustInvoke;
 import edu.umd.cs.findbugs.annotations.When;
 import hudson.EnvVars;
 import hudson.Extension;
+import hudson.Functions;
 import hudson.Launcher.ProcStarter;
 import hudson.Util;
 import hudson.cli.declarative.CLIMethod;
@@ -522,7 +523,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     @CLIMethod(name="online-node")
     public void cliOnline() throws ExecutionException, InterruptedException {
         checkPermission(CONNECT);
-        setTemporarilyOffline(false,null);
+        setTemporarilyOffline(false, null);
     }
 
     /**
@@ -543,6 +544,16 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     public @Nonnull String getName() {
         return nodeName != null ? nodeName : "";
+    }
+
+    /**
+     * True if this computer is a Unix machine (as opposed to Windows machine).
+     *
+     * @return
+     *      null if the computer is disconnected and therefore we don't know whether it is Unix or not.
+     */
+    public Boolean isUnix() {
+        return !Functions.isWindows();
     }
 
     /**

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -172,12 +172,7 @@ public class SlaveComputer extends Computer {
         this.acceptingTasks = acceptingTasks;
     }
 
-    /**
-     * True if this computer is a Unix machine (as opposed to Windows machine).
-     *
-     * @return
-     *      null if the computer is disconnected and therefore we don't know whether it is Unix or not.
-     */
+    @Override
     public Boolean isUnix() {
         return isUnix;
     }


### PR DESCRIPTION
Many ToolInstallations have to append ".exe" to executable name when executor is a windows box. SlaveComputer do offer isUnix but not Computer/MasterComputer, which results in re-implementing many time a callable to run Functions#isWindows :-\ 
