### PR TITLE
typofix - https://github.com/vlajos/misspell_fixer

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -175,7 +175,7 @@ import org.jenkinsci.remoting.RoleSensitive;
  * </pre>
  *
  * <p>
- * When {@link FileCallable} is transfered to a remote node, it will be done so
+ * When {@link FileCallable} is transferred to a remote node, it will be done so
  * by using the same Java serialization scheme that the remoting module uses.
  * See {@link Channel} for more about this. 
  *

--- a/core/src/main/java/hudson/FileSystemProvisioner.java
+++ b/core/src/main/java/hudson/FileSystemProvisioner.java
@@ -238,7 +238,7 @@ public abstract class FileSystemProvisioner implements ExtensionPoint, Describab
         @Extension
         public static final class DescriptorImpl extends FileSystemProvisionerDescriptor {
             public boolean discard(FilePath ws, TaskListener listener) throws IOException, InterruptedException {
-                // the default provisioner doens't do anything special,
+                // the default provisioner does not do anything special,
                 // so allow other types to manage it
                 return false;
             }

--- a/core/src/main/java/hudson/FileSystemProvisionerDescriptor.java
+++ b/core/src/main/java/hudson/FileSystemProvisionerDescriptor.java
@@ -39,7 +39,7 @@ public abstract class FileSystemProvisionerDescriptor extends Descriptor<FileSys
      *
      * <p>
      * Because users may modify the file system behind Hudson, and slaves may come and go when
-     * configuration changes hapen, in general case Hudson is unable to keep track of which jobs
+     * configuration changes happen, in general case Hudson is unable to keep track of which jobs
      * have workspaces in which slaves.
      *
      * <p>

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1385,7 +1385,7 @@ public class Functions {
     /**
      * If the value exists, return that value. Otherwise return the default value.
      * <p>
-     * Starting 1.294, JEXL supports the elvis operator "x?:y" that supercedes this.
+     * Starting 1.294, JEXL supports the elvis operator "x?:y" that supersedes this.
      *
      * @since 1.150
      */

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -63,7 +63,7 @@ import javax.annotation.CheckForNull;
  * for Jenkins to control {@link Plugin}.
  *
  * <p>
- * A plug-in is packaged into a jar file whose extension is <tt>".jpi"</tt> (or <tt>".hpi"</tt> for backward compatability),
+ * A plug-in is packaged into a jar file whose extension is <tt>".jpi"</tt> (or <tt>".hpi"</tt> for backward compatibility),
  * A plugin needs to have a special manifest entry to identify what it is.
  *
  * <p>

--- a/core/src/main/java/hudson/cli/CloneableCLICommand.java
+++ b/core/src/main/java/hudson/cli/CloneableCLICommand.java
@@ -26,7 +26,7 @@ package hudson.cli;
 /**
  * {@link Cloneable} {@link CLICommand}.
  *
- * Uses {@link #clone()} instead of "new" to create a copy for exection.
+ * Uses {@link #clone()} instead of "new" to create a copy for execution.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
@@ -17,20 +17,24 @@ import java.util.Arrays;
  * @author huybrechts
  */
 public class ChoiceParameterDefinition extends SimpleParameterDefinition {
-    public static final String CHOICES_DELIMETER = "\\r?\\n";
+    public static final String CHOICES_DELIMITER = "\\r?\\n";
+
+    @Deprecated
+    public static final String CHOICES_DELIMETER = CHOICES_DELIMITER;
+
 
     private final List<String> choices;
     private final String defaultValue;
 
     public static boolean areValidChoices(String choices) {
         String strippedChoices = choices.trim();
-        return !StringUtils.isEmpty(strippedChoices) && strippedChoices.split(CHOICES_DELIMETER).length > 0;
+        return !StringUtils.isEmpty(strippedChoices) && strippedChoices.split(CHOICES_DELIMITER).length > 0;
     }
 
     @DataBoundConstructor
     public ChoiceParameterDefinition(String name, String choices, String description) {
         super(name, description);
-        this.choices = Arrays.asList(choices.split(CHOICES_DELIMETER));
+        this.choices = Arrays.asList(choices.split(CHOICES_DELIMITER));
         defaultValue = null;
     }
 

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1566,8 +1566,8 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             if (m.matches()) {
                 File newLocation = new File(dir, "logs/slaves/" + m.group(1) + "/slave.log" + Util.fixNull(m.group(2)));
                 newLocation.getParentFile().mkdirs();
-                boolean relocationSuccessfull=f.renameTo(newLocation);
-                if (relocationSuccessfull) { // The operation will fail if mkdir fails
+                boolean relocationSuccessful=f.renameTo(newLocation);
+                if (relocationSuccessful) { // The operation will fail if mkdir fails
                     LOGGER.log(Level.INFO, "Relocated log file {0} to {1}",new Object[] {f.getPath(),newLocation.getPath()});
                 } else {
                     LOGGER.log(Level.WARNING, "Cannot relocate log file {0} to {1}",new Object[] {f.getPath(),newLocation.getPath()});

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -197,10 +197,10 @@ public class UsageStatistics extends PageDecorator {
     }
 
     /**
-     * Assymetric cipher is slow and in case of Sun RSA implementation it can only encyrypt the first block.
+     * Asymmetric cipher is slow and in case of Sun RSA implementation it can only encyrypt the first block.
      *
      * So first create a symmetric key, then place this key in the beginning of the stream by encrypting it
-     * with the assymetric cipher. The rest of the stream will be encrypted by a symmetric cipher.
+     * with the asymmetric cipher. The rest of the stream will be encrypted by a symmetric cipher.
      */
     public static final class CombinedCipherOutputStream extends FilterOutputStream {
         public CombinedCipherOutputStream(OutputStream out, Cipher asym, String algorithm) throws IOException, GeneralSecurityException {

--- a/core/src/main/java/hudson/os/SU.java
+++ b/core/src/main/java/hudson/os/SU.java
@@ -62,7 +62,7 @@ public abstract class SU {
     }
 
     /**
-     * Returns a {@link VirtualChannel} that's connected to the priviledge-escalated environment.
+     * Returns a {@link VirtualChannel} that's connected to the privilege-escalated environment.
      *
      * @param listener
      *      What this method is doing (such as what process it's invoking) will be sent here.
@@ -122,7 +122,7 @@ public abstract class SU {
     }
 
     /**
-     * Starts a new priviledge-escalated environment, execute a closure, and shut it down.
+     * Starts a new privilege-escalated environment, execute a closure, and shut it down.
      */
     public static <V,T extends Throwable> V execute(TaskListener listener, String rootUsername, String rootPassword, final Callable<V, T> closure) throws T, IOException, InterruptedException {
         VirtualChannel ch = start(listener, rootUsername, rootPassword);

--- a/core/src/main/java/hudson/scheduler/CronTab.java
+++ b/core/src/main/java/hudson/scheduler/CronTab.java
@@ -92,7 +92,7 @@ public final class CronTab {
 
     /**
      * @param timezone
-     *      Used to schedule cron in a differnt timezone. Null to use the default system 
+     *      Used to schedule cron in a different timezone. Null to use the default system 
      *      timezone
      * @since 1.615
      */

--- a/core/src/main/java/hudson/security/ACL.java
+++ b/core/src/main/java/hudson/security/ACL.java
@@ -127,7 +127,7 @@ public abstract class ACL {
      *
      * <p>
      * This doesn't need to be included in {@link Authentication#getAuthorities()},
-     * but {@link ACL} is responsible for checking it nontheless, as if it was the
+     * but {@link ACL} is responsible for checking it nonetheless, as if it was the
      * last entry in the granted authority.
      */
     public static final Sid EVERYONE = new Sid() {

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -357,7 +357,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
      * @param fetchMembers if {@code true} then try and fetch the members of the group if it exists. Trying does not
      *                     imply that the members will be fetched and {@link hudson.security.GroupDetails#getMembers()}
      *                     may still return {@code null}
-     * @throws UserMayOrMayNotExistException if no conclusive result could be determined regarding the group existance.
+     * @throws UserMayOrMayNotExistException if no conclusive result could be determined regarding the group existence.
      * @throws UsernameNotFoundException     if the group does not exist.
      * @throws DataAccessException           if the backing security realm could not be connected to.
      * @since 1.549

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -460,7 +460,7 @@ public class Maven extends Builder {
         /**
          * @deprecated since 2009-02-25.
          */
-        @Deprecated // kept for backward compatiblity - use getHome()
+        @Deprecated // kept for backward compatibility - use getHome()
         private transient String mavenHome;
 
         /**

--- a/core/src/main/java/hudson/util/ChartUtil.java
+++ b/core/src/main/java/hudson/util/ChartUtil.java
@@ -113,7 +113,7 @@ public class ChartUtil {
      *
      * @param defaultSize
      *      The size of the picture to be generated. These values can be overridden
-     *      by the query paramter 'width' and 'height' in the request.
+     *      by the query parameter 'width' and 'height' in the request.
      * @deprecated as of 1.320
      *      Bind {@link Graph} to the URL space. See {@code hudson.tasks.junit.History} as an example (note that doing so involves
      *      a bit of URL structure change.)
@@ -129,7 +129,7 @@ public class ChartUtil {
      * @param defaultW
      * @param defaultH
      *      The size of the picture to be generated. These values can be overridden
-     *      by the query paramter 'width' and 'height' in the request.
+     *      by the query parameter 'width' and 'height' in the request.
      * @deprecated as of 1.320
      *      Bind {@link Graph} to the URL space. See {@code hudson.tasks.junit.History} as an example (note that doing so involves
      *      a bit of URL structure change.)

--- a/core/src/main/java/hudson/util/DoubleLaunchChecker.java
+++ b/core/src/main/java/hudson/util/DoubleLaunchChecker.java
@@ -51,7 +51,7 @@ import java.lang.reflect.Method;
  * to forestall the problem of running multiple instances of Hudson that point to the same data directory.
  *
  * <p>
- * This set up error occasionally happens especialy when the user is trying to reassign the context path of the app,
+ * This set up error occasionally happens especially when the user is trying to reassign the context path of the app,
  * and it results in a hard-to-diagnose error, so we actively check this.
  *
  * <p>

--- a/core/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/core/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -44,7 +44,7 @@ import java.util.ArrayList;
 /** StringTokenizer with Quoting support.
  *
  * This class is a copy of the java.util.StringTokenizer API and
- * the behaviour is the same, except that single and doulbe quoted
+ * the behaviour is the same, except that single and double quoted
  * string values are recognized.
  * Delimiters within quotes are not considered delimiters.
  * Quotes can be escaped with '\'.
@@ -328,7 +328,7 @@ public class QuotedStringTokenizer
     /* ------------------------------------------------------------ */
     /** Quote a string.
      * The string is quoted only if quoting is required due to
-     * embeded delimiters, quote characters or the
+     * embedded delimiters, quote characters or the
      * empty string.
      * @param s The string to quote.
      * @return quoted string
@@ -358,7 +358,7 @@ public class QuotedStringTokenizer
     /* ------------------------------------------------------------ */
     /** Quote a string.
      * The string is quoted only if quoting is required due to
-     * embeded delimiters, quote characters or the
+     * embedded delimiters, quote characters or the
      * empty string.
      * @param s The string to quote.
      * @return quoted string

--- a/core/src/main/java/hudson/util/jna/DotNet.java
+++ b/core/src/main/java/hudson/util/jna/DotNet.java
@@ -46,7 +46,7 @@ public class DotNet {
         try {
             // see http://support.microsoft.com/?scid=kb;en-us;315291 for the basic algorithm
             // observation in my registry shows that the actual key name can be things like "v2.0 SP1"
-            // or "v2.0.50727", so the regexp is written to accomodate this.
+            // or "v2.0.50727", so the regexp is written to accommodate this.
             RegistryKey key = RegistryKey.LOCAL_MACHINE.openReadonly("SOFTWARE\\Microsoft\\.NETFramework");
             try {
                 for( String keyName : key.getSubKeys() ) {

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -77,7 +77,7 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
 
     /**
      * Gets the service administrator e-mail address.
-     * @return Admin adress or &quot;address not configured&quot; stub
+     * @return Admin address or &quot;address not configured&quot; stub
      */
     public @Nonnull String getAdminAddress() {
         String v = adminAddress;
@@ -92,7 +92,7 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
     public void setAdminAddress(@CheckForNull String adminAddress) {
         String address = Util.nullify(adminAddress);
         if(address != null && address.startsWith("\"") && address.endsWith("\"")) {
-            // some users apparently quote the whole thing. Don't konw why
+            // some users apparently quote the whole thing. Don't know why
             // anyone does this, but it's a machine's job to forgive human mistake
             address = address.substring(1,address.length()-1);
         }

--- a/core/src/main/java/jenkins/slaves/restarter/SlaveRestarter.java
+++ b/core/src/main/java/jenkins/slaves/restarter/SlaveRestarter.java
@@ -11,7 +11,7 @@ import java.util.logging.Logger;
  * Extension point to control how to restart JNLP slave when it loses the connection with the master.
  *
  * <p>
- * Objects are instantiated on the master, then transfered to a slave via serialization.
+ * Objects are instantiated on the master, then transferred to a slave via serialization.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/resources/jenkins/security/s2m/filepath-filter.conf
+++ b/core/src/main/resources/jenkins/security/s2m/filepath-filter.conf
@@ -36,5 +36,5 @@ allow create,mkdirs,read,stat,write <BUILDDIR>/.+
 # cobertura also writes out annotated sources to a dir under the job:
 allow create,mkdirs,read,stat,write <JENKINS_HOME>/jobs/.+/cobertura.*
 
-# all the other accesses that aren't specified here will be left upto other rules in this directory.
+# all the other accesses that aren't specified here will be left up to other rules in this directory.
 # if no rules in those other files matches, then the access will be rejected.

--- a/core/src/site/markdown/index.md
+++ b/core/src/site/markdown/index.md
@@ -1,1 +1,1 @@
-Collection of Maven auto-generated reports. The primary interest is probably [Jelly tag libary reference](jelly-taglib-ref.html).
+Collection of Maven auto-generated reports. The primary interest is probably [Jelly tag library reference](jelly-taglib-ref.html).

--- a/core/src/test/java/hudson/model/ParametersActionTest.java
+++ b/core/src/test/java/hudson/model/ParametersActionTest.java
@@ -89,7 +89,7 @@ public class ParametersActionTest {
     
     @Test
     @Issue("JENKINS-15094")
-    public void checkNullParamaterValues() {
+    public void checkNullParameterValues() {
         SubTask subtask = mock(SubTask.class);
         Build build = mock(Build.class);
                    

--- a/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
+++ b/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
@@ -41,7 +41,7 @@ public class ArgumentListBuilderTest {
         builder.add("arg");
         builder.add("other", "arguments");
 
-        assertFalse("There shouldnt be any masked arguments", builder.hasMaskedArguments());
+        assertFalse("There should not be any masked arguments", builder.hasMaskedArguments());
         boolean[] array = builder.toMaskArray();
         assertNotNull("The mask array should not be null", array);
         assertThat("The mask array was incorrect", array, is(new boolean[] { false, false, false }));
@@ -166,7 +166,7 @@ public class ArgumentListBuilderTest {
         ArgumentListBuilder builder = new ArgumentListBuilder();
         builder.addKeyValuePairs(null, KEY_VALUES);
 
-        assertFalse("There shouldnt be any masked arguments", builder.hasMaskedArguments());
+        assertFalse("There should not be any masked arguments", builder.hasMaskedArguments());
         boolean[] array = builder.toMaskArray();
         assertNotNull("The mask array should not be null", array);
         assertThat("The mask array was incorrect", array, is(new boolean[] { false, false, false }));

--- a/test/src/main/java/org/jvnet/hudson/test/ExtractResourceSCM.java
+++ b/test/src/main/java/org/jvnet/hudson/test/ExtractResourceSCM.java
@@ -57,7 +57,7 @@ public class ExtractResourceSCM extends NullSCM {
 
     /**
      * with this constructor your zip can contains a folder
-     * more usefull to create a project test zip foo.zip foo
+     * more useful to create a project test zip foo.zip foo
      * @param zip
      * @param parentFolder
      */

--- a/test/src/test/java/hudson/cli/SetBuildDisplayNameCommandTest.java
+++ b/test/src/test/java/hudson/cli/SetBuildDisplayNameCommandTest.java
@@ -62,7 +62,7 @@ public class SetBuildDisplayNameCommandTest {
         assertThat(result, failedWith(-1));
     }
 
-    @Test public void setDescriptionSuccesfully() throws Exception {
+    @Test public void setDescriptionSuccessfully() throws Exception {
 
         FreeStyleProject job = j.createFreeStyleProject("project");
         FreeStyleBuild build = job.scheduleBuild2(0).get();

--- a/test/src/test/java/hudson/model/JobQueueTest.java
+++ b/test/src/test/java/hudson/model/JobQueueTest.java
@@ -89,7 +89,7 @@ public class JobQueueTest {
             assertTrue(j.jenkins.getQueue().getItem(project) instanceof BlockedItem); //check is it is blocked
         }
         else {
-            fail("The maximum attemps for checking if the job is in POST_PRODUCTION State have reached");
+            fail("The maximum attempts for checking if the job is in POST_PRODUCTION State have reached");
         }
         count=0;
         while(!JobQueueTest.fireFinalizeFlag && count<100) {
@@ -104,7 +104,7 @@ public class JobQueueTest {
             assertFalse(j.jenkins.getQueue().getItem(project) instanceof BlockedItem);
         }
         else {
-            fail("The maximum attemps for checking if the job is in COMPLETED State have reached");
+            fail("The maximum attempts for checking if the job is in COMPLETED State have reached");
         }
         Thread.sleep(1000); //Sleep till job completes.
     }

--- a/test/src/test/java/hudson/model/MyViewsPropertyTest.java
+++ b/test/src/test/java/hudson/model/MyViewsPropertyTest.java
@@ -186,7 +186,7 @@ public class MyViewsPropertyTest {
         user.addProperty(property);
         View view = new ListView("foo", property);
         property.addView(view);
-        assertTrue("Property should contians view " + view.name, property.getViews().contains(view));
+        assertTrue("Property should contains view " + view.name, property.getViews().contains(view));
         User.reload();
         user = User.get("User");
         property = user.getProperty(property.getClass());

--- a/test/src/test/java/hudson/model/SimpleJobTest.java
+++ b/test/src/test/java/hudson/model/SimpleJobTest.java
@@ -102,7 +102,7 @@ public class SimpleJobTest {
         TestBuild lastBuild = new TestBuild(project, Result.FAILURE, 50, previousBuild);
         runs.put(1, lastBuild);
 
-        // failed builds must not be used, if there are succesfulBuilds available.
+        // failed builds must not be used, if there are successfulBuilds available.
         assertEquals(1, project.getEstimatedDuration());
     }
     

--- a/test/src/test/java/hudson/model/UserTest.java
+++ b/test/src/test/java/hudson/model/UserTest.java
@@ -302,7 +302,7 @@ public class UserTest {
         assertNotNull("User should not be null.", user);
         user.clear();
         user = User.get("John Smith", false, Collections.emptyMap());
-        assertNull("User shoudl be null", user);       
+        assertNull("User should be null", user);       
     }
 
     @Test

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -362,7 +362,7 @@ public class ViewTest {
         ListView view2 = listView("foo");
         try{
             view2.rename("renamed");
-            fail("Attemt to rename job with a name used by another view with the same owner should throw exception");
+            fail("Attempt to rename job with a name used by another view with the same owner should throw exception");
         }
         catch(Exception Exception){
         }

--- a/test/src/test/java/hudson/model/queue/WideExecutionTest.java
+++ b/test/src/test/java/hudson/model/queue/WideExecutionTest.java
@@ -50,7 +50,7 @@ public class WideExecutionTest {
     public JenkinsRule j = new JenkinsRule();
 
     @TestExtension
-    public static class Contributer extends SubTaskContributor {
+    public static class Contributor extends SubTaskContributor {
         public Collection<? extends SubTask> forProject(final AbstractProject<?, ?> p) {
             return Collections.singleton(new AbstractSubTask() {
                 private final AbstractSubTask outer = this;

--- a/test/src/test/java/lib/form/RepeatableTest.java
+++ b/test/src/test/java/lib/form/RepeatableTest.java
@@ -340,7 +340,7 @@ public class RepeatableTest extends HudsonTestCase {
         }
     }
 
-    /** Tests nested repeatable and use of @DataBoundContructor to process formData */
+    /** Tests nested repeatable and use of @DataBoundConstructor to process formData */
     public void testNested() throws Exception {
         HtmlPage p = createWebClient().goTo("self/testNested");
         HtmlForm f = p.getFormByName("config");

--- a/translation-tool.pl
+++ b/translation-tool.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 # The MIT License
 #
-# Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributers
+# Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number of other of contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/war/src/main/webapp/help/project-config/custom-workspace.html
+++ b/war/src/main/webapp/help/project-config/custom-workspace.html
@@ -18,7 +18,7 @@
   If you are in a distributed build environment, unless you tie a job to a specific node, Jenkins may still
   move around jobs to different slaves. Sometimes this is desirable, sometimes this is not. Also,
   you can map multiple projects to have the same workspace, but if you do so, make sure concurrent executions
-  of those jobs won't have nasty interferance with each other.
+  of those jobs won't have nasty interference with each other.
 
   <p>
   If this path is relative, it's resolved against the "remote FS root" directory of the slave, or <tt>$JENKINS_HOME</tt>


### PR DESCRIPTION
core/src/main/java/hudson/os/solaris/ZFSInstaller.java and core/src/main/java/hudson/os/solaris/ZFSProvisioner.java contain `fs.destory` which are suspicious, but assuming they work as it is.
I reverted them.
