### PR TITLE
[FIXED JENKINS-29888] - Handling all LogRotator exceptions

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1803,11 +1803,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
             try {
                 getParent().logRotate();
-            } catch (IOException e) {
-                LOGGER.log(Level.SEVERE, "Failed to rotate log",e);
-            } catch (InterruptedException e) {
-                LOGGER.log(Level.SEVERE, "Failed to rotate log",e);
-            }
+            } catch (Exception e) {
+		LOGGER.log(Level.SEVERE, "Failed to rotate log",e);
+	    }
         } finally {
             onEndBuilding();
         }


### PR DESCRIPTION
Handling all exceptions returned by logRotator.
In case of parallel threads running the same job, they all try to log rotate and delete the same folders. It results a NoSuchFileException that makes Jenkins stuck (Not detecting the end of the job even if it is succesfull) during finish1 call.
