### PR TITLE
Update javadoc-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.8</version>
+          <version>2.10.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
According to changelog jdk7, jdk8 support and different things.
`2.8 Release date: 06/May/11`

Tested locally `javadoc:javadoc` works fine
