### PR TITLE
Some FB annotations and java7 diamonds (low prio)

### DIFF
--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -204,7 +204,7 @@ public class Items {
         String[] c = context.getFullName().split("/");
         String[] p = path.split("/");
 
-        Stack<String> name = new Stack<String>();
+        Stack<String> name = new Stack<>();
         for (int i=0; i<c.length;i++) {
             if (i==0 && c[i].equals("")) continue;
             name.push(c[i]);
@@ -248,7 +248,7 @@ public class Items {
     public static String computeRelativeNamesAfterRenaming(String oldFullName, String newFullName, String relativeNames, ItemGroup context) {
 
         StringTokenizer tokens = new StringTokenizer(relativeNames,",");
-        List<String> newValue = new ArrayList<String>();
+        List<String> newValue = new ArrayList<>();
         while(tokens.hasMoreTokens()) {
             String relativeName = tokens.nextToken().trim();
             String canonicalName = getCanonicalName(context, relativeName);
@@ -267,7 +267,7 @@ public class Items {
     }
 
     // Had difficulty adapting the version in Functions to use no live items, so rewrote it:
-    static String getRelativeNameFrom(String itemFullName, String groupFullName) {
+    static String getRelativeNameFrom(@Nonnull String itemFullName, @Nonnull String groupFullName) {
         String[] itemFullNameA = itemFullName.isEmpty() ? new String[0] : itemFullName.split("/");
         String[] groupFullNameA = groupFullName.isEmpty() ? new String[0] : groupFullName.split("/");
         for (int i = 0; ; i++) {
@@ -354,7 +354,7 @@ public class Items {
         return r;
     }
     private static <T extends Item> void getAllItems(final ItemGroup root, Class<T> type, List<T> r) {
-        List<Item> items = new ArrayList<Item>(((ItemGroup<?>) root).getItems());
+        List<Item> items = new ArrayList<>(((ItemGroup<?>) root).getItems());
         Collections.sort(items, new Comparator<Item>() {
             @Override public int compare(Item i1, Item i2) {
                 return name(i1).compareToIgnoreCase(name(i2));

--- a/core/src/main/java/hudson/scheduler/CronTabList.java
+++ b/core/src/main/java/hudson/scheduler/CronTabList.java
@@ -29,6 +29,8 @@ import java.util.TimeZone;
 import java.util.Collection;
 import java.util.Vector;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -44,7 +46,7 @@ public final class CronTabList {
     private final Vector<CronTab> tabs;
 
     public CronTabList(Collection<CronTab> tabs) {
-        this.tabs = new Vector<CronTab>(tabs);
+        this.tabs = new Vector<>(tabs);
     }
 
     /**
@@ -90,12 +92,12 @@ public final class CronTabList {
         return null;
     }
 
-    public static CronTabList create(String format) throws ANTLRException {
+    public static CronTabList create(@Nonnull String format) throws ANTLRException {
         return create(format,null);
     }
 
-    public static CronTabList create(String format, Hash hash) throws ANTLRException {
-        Vector<CronTab> r = new Vector<CronTab>();
+    public static CronTabList create(@Nonnull String format, Hash hash) throws ANTLRException {
+        Vector<CronTab> r = new Vector<>();
         int lineNumber = 0;
         String timezone = null;
 

--- a/core/src/main/java/hudson/triggers/TimerTrigger.java
+++ b/core/src/main/java/hudson/triggers/TimerTrigger.java
@@ -38,6 +38,8 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
+import javax.annotation.Nonnull;
+
 /**
  * {@link Trigger} that runs a job periodically.
  *
@@ -46,7 +48,7 @@ import org.kohsuke.stapler.QueryParameter;
 public class TimerTrigger extends Trigger<BuildableItem> {
 
     @DataBoundConstructor
-    public TimerTrigger(String spec) throws ANTLRException {
+    public TimerTrigger(@Nonnull String spec) throws ANTLRException {
         super(spec);
     }
 

--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -57,6 +57,8 @@ import java.util.logging.Logger;
 
 import antlr.ANTLRException;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import hudson.model.Items;
 import jenkins.model.ParameterizedJobMixIn;
@@ -156,7 +158,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
      * periodically. This is useful when your trigger does
      * some polling work.
      */
-    protected Trigger(String cronTabSpec) throws ANTLRException {
+    protected Trigger(@Nonnull String cronTabSpec) throws ANTLRException {
         this.spec = cronTabSpec;
         this.tabs = CronTabList.create(cronTabSpec);
     }
@@ -316,7 +318,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
      * Returns a subset of {@link TriggerDescriptor}s that applys to the given item.
      */
     public static List<TriggerDescriptor> for_(Item i) {
-        List<TriggerDescriptor> r = new ArrayList<TriggerDescriptor>();
+        List<TriggerDescriptor> r = new ArrayList<>();
         for (TriggerDescriptor t : all()) {
             if(!t.isApplicable(i))  continue;
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2344,7 +2344,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *
      * Note that the look up is case-insensitive.
      */
-    @Override public TopLevelItem getItem(String name) throws AccessDeniedException {
+    @CheckForNull
+    @Override
+    public TopLevelItem getItem(@Nullable String name) throws AccessDeniedException {
         if (name==null)    return null;
     	TopLevelItem item = items.get(name);
         if (item==null)
@@ -2372,7 +2374,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *      null is interpreted as {@link Jenkins}. Base 'directory' of the interpretation.
      * @since 1.406
      */
-    public Item getItem(String pathName, ItemGroup context) {
+    @CheckForNull
+    public Item getItem(@Nullable String pathName, @Nullable ItemGroup context) {
         if (context==null)  context = this;
         if (pathName==null) return null;
 
@@ -2417,19 +2420,22 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return getItemByFullName(pathName);
     }
 
-    public final Item getItem(String pathName, Item context) {
-        return getItem(pathName,context!=null?context.getParent():null);
+    @CheckForNull
+    public final Item getItem(@Nullable String pathName, @Nullable Item context) {
+        return getItem(pathName, context!=null ? context.getParent() : null);
     }
 
-    public final <T extends Item> T getItem(String pathName, ItemGroup context, @Nonnull Class<T> type) {
+    @CheckForNull
+    public final <T extends Item> T getItem(@Nullable String pathName, @Nullable ItemGroup context, @Nonnull Class<T> type) {
         Item r = getItem(pathName, context);
         if (type.isInstance(r))
             return type.cast(r);
         return null;
     }
 
-    public final <T extends Item> T getItem(String pathName, Item context, Class<T> type) {
-        return getItem(pathName,context!=null?context.getParent():null,type);
+    @CheckForNull
+    public final <T extends Item> T getItem(@Nullable String pathName, @Nullable Item context, @Nonnull Class<T> type) {
+        return getItem(pathName, context!=null ? context.getParent() : null, type);
     }
 
     public File getRootDirFor(TopLevelItem child) {
@@ -2503,7 +2509,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * <p>
      * This is a short cut for deleting an existing job and adding a new one.
      */
-    public synchronized void putItem(TopLevelItem item) throws IOException, InterruptedException {
+    public synchronized void putItem(@Nonnull TopLevelItem item) throws IOException, InterruptedException {
         String name = item.getName();
         TopLevelItem old = items.get(name);
         if (old ==item)  return; // noop

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -72,6 +72,8 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
+import javax.annotation.Nonnull;
+
 /**
  * Like {@link BuildTrigger} but defined on the downstream project.
  * Operates via {@link BuildTrigger#execute} and {@link DependencyGraph},
@@ -84,12 +86,13 @@ import org.kohsuke.stapler.QueryParameter;
 public final class ReverseBuildTrigger extends Trigger<Job> implements DependencyDeclarer {
 
     private static final Logger LOGGER = Logger.getLogger(ReverseBuildTrigger.class.getName());
-    private static final Map<Job,Collection<ReverseBuildTrigger>> upstream2Trigger = new WeakHashMap<Job,Collection<ReverseBuildTrigger>>();
+    private static final Map<Job,Collection<ReverseBuildTrigger>> upstream2Trigger = new WeakHashMap<>();
 
     private String upstreamProjects;
     private final Result threshold;
 
-    @DataBoundConstructor public ReverseBuildTrigger(String upstreamProjects, Result threshold) {
+    @DataBoundConstructor
+    public ReverseBuildTrigger(String upstreamProjects, Result threshold) {
         this.upstreamProjects = upstreamProjects;
         this.threshold = threshold;
     }
@@ -155,7 +158,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
                 synchronized (upstream2Trigger) {
                     Collection<ReverseBuildTrigger> triggers = upstream2Trigger.get(upstream);
                     if (triggers == null) {
-                        triggers = new LinkedList<ReverseBuildTrigger>();
+                        triggers = new LinkedList<>();
                         upstream2Trigger.put(upstream, triggers);
                     }
                     triggers.remove(this);
@@ -222,14 +225,14 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     }
 
     @Extension public static final class RunListenerImpl extends RunListener<Run> {
-        @Override public void onCompleted(Run r, TaskListener listener) {
+        @Override public void onCompleted(@Nonnull Run r, @Nonnull TaskListener listener) {
             Collection<ReverseBuildTrigger> triggers;
             synchronized (upstream2Trigger) {
                 Collection<ReverseBuildTrigger> _triggers = upstream2Trigger.get(r.getParent());
                 if (_triggers == null || _triggers.isEmpty()) {
                     return;
                 }
-                triggers = new ArrayList<ReverseBuildTrigger>(_triggers);
+                triggers = new ArrayList<>(_triggers);
             }
             for (final ReverseBuildTrigger trigger : triggers) {
                 if (trigger.shouldTrigger(r, listener)) {


### PR DESCRIPTION
After #1783 started tracing FB annotations and found that:
- Diamonds can be used now for less code. 
- Very late realised that `getItem` coming from Jenkins.class that can be actively changed. 
  Checked last two pages with PRs, only two small PRs can may conflict (or even not).
- Spaces in `getItem()` required for better readability, either it unclear how many arguments does it have and what at all is in ternary operator.
- Separated in multiple commits for better cherry-picking. 

@olivergondza btw, can some jenkins versions (or 1) may have window for doing such minor changes without affecting back-porting? after 1.609.3 nothing will be backported and new LTS wouldn't be picked in the same time. (if i didn't miss how/when lts is picked) 
