### PR TITLE
[JENKINS-28440] Additional fixes for #1715

### DIFF
--- a/core/src/main/java/jenkins/util/xstream/CriticalXStreamException.java
+++ b/core/src/main/java/jenkins/util/xstream/CriticalXStreamException.java
@@ -29,6 +29,8 @@ import com.thoughtworks.xstream.converters.ConversionException;
 
 /**
  * Wraps {@link XStreamException} to indicate it is critical for Jenkins.
+ * 
+ * @since 1.625
  */
 public class CriticalXStreamException extends ConversionException {
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Fixes for comments in #1715 after merging.
- Added `@since` for CriticalXStreamException.
- Usec `CLICommandInvoker` in tests to execute CLIs.
