### PR TITLE
Use slf4j adapters for logging.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -401,10 +401,6 @@ THE SOFTWARE.
           <groupId>org.springframework</groupId>
           <artifactId>spring-support</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -473,8 +469,8 @@ THE SOFTWARE.
       <version>1.1.0</version>
     </dependency>
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -477,6 +477,11 @@ THE SOFTWARE.
       <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.sun.xml.txw2</groupId>
       <artifactId>txw2</artifactId>
       <version>20110809</version>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -118,6 +118,31 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-banned-dependencies</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.sonatype.sisu:sisu-guice</exclude>
+                    <exclude>log4j:log4j:*:jar:compile</exclude>
+                    <exclude>log4j:log4j:*:jar:runtime</exclude>
+                    <exclude>commons-logging:commons-logging:*:jar:compile</exclude>
+                    <exclude>commons-logging:commons-logging:*:jar:runtime</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <extensions>true</extensions>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -34,6 +34,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <concurrency>2</concurrency> <!-- may use e.g. 2C for 2 × (number of cores) -->
+    <!-- same version as in org.jenkins-ci.main:pom -->
+    <slf4jVersion>1.7.7</slf4jVersion>
   </properties>
 
   <dependencies>
@@ -79,6 +81,32 @@
       <version>1.9</version>
       <scope>provided</scope>
       <optional>true</optional><!-- no need to have this at runtime -->
+    </dependency>
+    <!-- mark logging dependencies as provided by war -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4jVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>${slf4jVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${slf4jVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- make binding to java.util.logging available during tests -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <version>${slf4jVersion}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -37,7 +37,23 @@
     <!-- same version as in org.jenkins-ci.main:pom -->
     <slf4jVersion>1.7.7</slf4jVersion>
   </properties>
-
+  <dependencyManagement>
+    <!-- mark logging dependencies as provided by war -->
+    <dependencies>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.1.3</version>
+        <scope>provided</scope><!-- by jcl-over-slf4j -->
+      </dependency>
+      <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>1.2.17</version>
+        <scope>provided</scope><!-- by log4j-over-slf4j -->
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
@@ -82,26 +98,27 @@
       <scope>provided</scope>
       <optional>true</optional><!-- no need to have this at runtime -->
     </dependency>
-    <!-- mark logging dependencies as provided by war -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4jVersion}</version>
-      <scope>provided</scope>
+      <scope>compile</scope>
+      <!-- mark the API as optional so it is not packaged in the HPI but available during compile -->
+      <optional>true</optional>
     </dependency>
+    <!-- make slf4j bindings to java.util.logging available during tests -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
       <version>${slf4jVersion}</version>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
       <version>${slf4jVersion}</version>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
-    <!-- make binding to java.util.logging available during tests -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -671,6 +671,8 @@ THE SOFTWARE.
                 <bannedDependencies>
                   <excludes>
                     <exclude>org.sonatype.sisu:sisu-guice</exclude>
+                    <exclude>log4j:log4j</exclude>
+                    <exclude>commons-logging:commons-logging</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -215,14 +215,21 @@ THE SOFTWARE.
         <version>${slf4jVersion}</version>
       </dependency>
       <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.1.3</version>
+        <scope>provided</scope><!-- by jcl-over-slf4j -->
+      </dependency>
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
         <version>${slf4jVersion}</version>
       </dependency>
       <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>1.1.3</version>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>1.2.17</version>
+        <scope>provided</scope><!-- by log4j-over-slf4j -->
       </dependency>
       <dependency>
         <groupId>org.samba.jcifs</groupId>
@@ -664,7 +671,6 @@ THE SOFTWARE.
                 <bannedDependencies>
                   <excludes>
                     <exclude>org.sonatype.sisu:sisu-guice</exclude>
-                    <exclude>log4j:log4j</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -671,8 +671,10 @@ THE SOFTWARE.
                 <bannedDependencies>
                   <excludes>
                     <exclude>org.sonatype.sisu:sisu-guice</exclude>
-                    <exclude>log4j:log4j</exclude>
-                    <exclude>commons-logging:commons-logging</exclude>
+                    <exclude>log4j:log4j:*:jar:compile</exclude>
+                    <exclude>log4j:log4j:*:jar:runtime</exclude>
+                    <exclude>commons-logging:commons-logging:*:jar:compile</exclude>
+                    <exclude>commons-logging:commons-logging:*:jar:runtime</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>


### PR DESCRIPTION
- By introducing adapters for log4j and commons-logging and
- including the original log4j and commons-logging dependencies as provided
  all logging should be redirected to slf4j and finally java.util.logging.

This is an enhancement to #1765
