### PR TITLE
Add task-icon-link class to left menu

### DIFF
--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -167,7 +167,7 @@ THE SOFTWARE.
 
           <j:choose>
             <j:when test="${requiresConfirmation and not attrs.onClick}">
-              <l:confirmationLink href="${href}" post="${post}" message="${confirmationMessage ?: title}">
+              <l:confirmationLink class="task-icon-link" href="${href}" post="${post}" message="${confirmationMessage ?: title}">
                 <j:choose>
                   <j:when test="${iconMetadata != null}">
                     <l:icon class="${iconMetadata.classSpec}" style="width: 24px; height: 24px; margin: 2px;" />


### PR DESCRIPTION
I'm trying to customize Jenkins theme but two positions of left menu didn't have task-icon-link class.
Added it.
![left menu](http://i.imgur.com/BICPPZw.png?1)
