### PR TITLE
[JENKINS-30366] - Proper handling of null job field in SCMTrigger

### DIFF
--- a/core/src/main/java/jenkins/triggers/SCMTriggerItem.java
+++ b/core/src/main/java/jenkins/triggers/SCMTriggerItem.java
@@ -88,7 +88,7 @@ public interface SCMTriggerItem {
          * @return itself, if a {@link SCMTriggerItem}, or an adapter, if an {@link hudson.model.SCMedItem}, else null
          */
         @SuppressWarnings("deprecation")
-        public static @CheckForNull SCMTriggerItem asSCMTriggerItem(Item item) {
+        public static @CheckForNull SCMTriggerItem asSCMTriggerItem(@CheckForNull Item item) {
             if (item instanceof SCMTriggerItem) {
                 return (SCMTriggerItem) item;
             } else if (item instanceof hudson.model.SCMedItem) {


### PR DESCRIPTION
This change adds the required null checks to the trigger and adds the proper annotations for the future use. There's still a risk of the concurrency issues in the case of the improper usage, but it's out of the scope of the PR.

https://issues.jenkins-ci.org/browse/JENKINS-30366
