### PR TITLE
[JENKINS-30374] Update obsolete help message

### DIFF
--- a/core/src/main/resources/hudson/tools/InstallSourceProperty/help.html
+++ b/core/src/main/resources/hudson/tools/InstallSourceProperty/help.html
@@ -1,6 +1,5 @@
 <div>
-    Choose this option to let Jenkins install this tool for you on demand,
-    to the location you configured above.
+    Choose this option to let Jenkins install this tool for you on demand.
 
     <p>
     If you check this option, you'll then be asked to configure a series


### PR DESCRIPTION
Remove obsolete reference to "location you configured above" since the location is now determined automatically rather than explicitly configured.

@reviewbybees
