### PR TITLE
[JENKINS-29631] Introduce a lightweight polling phase

### DIFF
--- a/core/src/main/java/hudson/scm/PollingResult.java
+++ b/core/src/main/java/hudson/scm/PollingResult.java
@@ -59,6 +59,11 @@ public final class PollingResult implements Serializable {
          */
         INSIGNIFICANT,
         /**
+         * There are some changes between states, but the polling was not able to establish if the are significant or
+         * not. This value is designed for use when polling without a workspace, to trigger a full polling cycle.
+         */
+        UNCERTAIN,
+        /**
          * There are changes between states that warrant a new build. Jenkins will eventually
          * schedule a new build for this change, subject to other considerations
          * such as the quiet period.
@@ -92,13 +97,15 @@ public final class PollingResult implements Serializable {
     }
 
     public boolean hasChanges() {
-        return change.ordinal() > Change.INSIGNIFICANT.ordinal();
+        return change.ordinal() >= Change.SIGNIFICANT.ordinal();
     }
 
     /**
      * Constant to indicate no changes in the remote repository.
      */
     public static final PollingResult NO_CHANGES = new PollingResult(Change.NONE);
+
+    public static final PollingResult UNCERTAIN = new PollingResult(Change.UNCERTAIN);
 
     public static final PollingResult SIGNIFICANT = new PollingResult(Change.SIGNIFICANT);
 

--- a/core/src/main/java/hudson/scm/SCM.java
+++ b/core/src/main/java/hudson/scm/SCM.java
@@ -341,18 +341,22 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
      * If the lightweight check can determine there's no change, returning ${@link PollingResult.Change#NONE}, then
      * the polling mechanism can just stop and won't need to acquire a workspace.
      * <p>
-     * If the lightweight check can determine changes, returning ${@link PollingResult.Change#SIGNIFICANT}, and
-     * ${@link #requiresWorkspaceForPolling()} return <code>false</code>, a full polling cycle will be executed,
-     * invoking {@link #compareRemoteRevisionWith(Job, Launcher, FilePath, TaskListener, SCMRevisionState)}.
-     * with a workspace.
+     * If the lightweight check can determine changes, returning ${@link PollingResult.Change#SIGNIFICANT}, a build
+     * will be triggered immediately.
+     * <p>
+     * If the lightweight check can detect changes on remote repository, but can't determine if they are significant
+     * enough to require a build, returning ${@link PollingResult#UNCERTAIN} will run a further polling by invoking
+     * {@link #compareRemoteRevisionWith(Job, Launcher, FilePath, TaskListener, SCMRevisionState)} with a workspace.
      * @since TODO
      */
     public PollingResult compareRemoteRevisionWith(@Nonnull Job<?,?> project, @Nullable Launcher launcher, @Nonnull TaskListener listener, @Nonnull SCMRevisionState baseline) throws IOException, InterruptedException {
         if (requiresWorkspaceForPolling())
-             return PollingResult.SIGNIFICANT;
+            // can't be determined without a workspace
+            return PollingResult.UNCERTAIN;
         else
-             // for backward compatibility, we invoke compareRemoteRevisionWith with workspace=null
-             return compareRemoteRevisionWith(project, launcher, null, listener, baseline);
+            // for binary backward compatibility, we invoke compareRemoteRevisionWith with workspace=null,
+            // just like the API was designed before 1.TODO
+            return compareRemoteRevisionWith(project, launcher, null, listener, baseline);
     }
 
 

--- a/core/src/main/java/hudson/scm/SCM.java
+++ b/core/src/main/java/hudson/scm/SCM.java
@@ -162,7 +162,9 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
      * if a build is currently using a workspace.
      *
      * <p>
-     * The default implementation returns true.
+     * The default implementation returns true. If polling without workspace is supported, then
+     * ${@link #compareRemoteRevisionWith(Job, Launcher, TaskListener, SCMRevisionState)} shoulc
+     * be overridden to implement workspace-free polling.
      *
      * <p>
      * See issue #1348 for more discussion of this feature.
@@ -326,7 +328,34 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
     public SCMRevisionState _calcRevisionsFromBuild(AbstractBuild<?, ?> build, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
         return calcRevisionsFromBuild(build, launcher, listener);
     }
-    
+
+
+    /**
+     * Compares the current state of the remote repository against the given baseline {@link SCMRevisionState}.
+     * <p>
+     * This method is intended to <i>estimate</i> if the remote repository state has changed compared to current
+     * baseline, as a lightweight check, and as a result can trigger a finer grained comparison using
+     * {@link #compareRemoteRevisionWith(Job, Launcher, FilePath, TaskListener, SCMRevisionState)} if the SCM
+     * implementation do claim it require a workspace - see ${@link #requiresWorkspaceForPolling()}.
+     * <p>
+     * If the lightweight check can determine there's no change, returning ${@link PollingResult.Change#NONE}, then
+     * the polling mechanism can just stop and won't need to acquire a workspace.
+     * <p>
+     * If the lightweight check can determine changes, returning ${@link PollingResult.Change#SIGNIFICANT}, and
+     * ${@link #requiresWorkspaceForPolling()} return <code>false</code>, a full polling cycle will be executed,
+     * invoking {@link #compareRemoteRevisionWith(Job, Launcher, FilePath, TaskListener, SCMRevisionState)}.
+     * with a workspace.
+     * @since TODO
+     */
+    public PollingResult compareRemoteRevisionWith(@Nonnull Job<?,?> project, @Nullable Launcher launcher, @Nonnull TaskListener listener, @Nonnull SCMRevisionState baseline) throws IOException, InterruptedException {
+        if (requiresWorkspaceForPolling())
+             return PollingResult.SIGNIFICANT;
+        else
+             // for backward compatibility, we invoke compareRemoteRevisionWith with workspace=null
+             return compareRemoteRevisionWith(project, launcher, null, listener, baseline);
+    }
+
+
     /**
      * Compares the current state of the remote repository against the given baseline {@link SCMRevisionState}.
      *
@@ -347,8 +376,9 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
      *      Abstraction of the machine where the polling will take place. If SCM declares
      *      that {@linkplain #requiresWorkspaceForPolling() the polling doesn't require a workspace}, this parameter is null.
      * @param workspace
-     *      The workspace directory that contains baseline files. If SCM declares
-     *      that {@linkplain #requiresWorkspaceForPolling() the polling doesn't require a workspace}, this parameter is null.
+     *      The workspace directory that contains baseline files. Before 1.TODO workspace could be null to support polling
+     *      without a workspace. If SCM implementation do support this feature, better override
+     *      ${@link #compareRemoteRevisionWith(Job, Launcher, TaskListener, SCMRevisionState)}
      * @param listener
      *      Logs during the polling should be sent here.
      * @param baseline
@@ -368,7 +398,7 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
      *      this exception should be simply propagated all the way up.
      * @since 1.568
      */
-    public PollingResult compareRemoteRevisionWith(@Nonnull Job<?,?> project, @Nullable Launcher launcher, @Nullable FilePath workspace, @Nonnull TaskListener listener, @Nonnull SCMRevisionState baseline) throws IOException, InterruptedException {
+    public PollingResult compareRemoteRevisionWith(@Nonnull Job<?,?> project, @Nullable Launcher launcher, @Nonnull FilePath workspace, @Nonnull TaskListener listener, @Nonnull SCMRevisionState baseline) throws IOException, InterruptedException {
         if (project instanceof AbstractProject && Util.isOverridden(SCM.class, getClass(), "compareRemoteRevisionWith", AbstractProject.class, Launcher.class, FilePath.class, TaskListener.class, SCMRevisionState.class)) {
             return compareRemoteRevisionWith((AbstractProject) project, launcher, workspace, listener, baseline);
         } else {


### PR DESCRIPTION
Allows to run some pre-polling (typically, using `git ls-remote`) to determine if some changes occurred and might require a full polling (allocating a workspace if required) to actually evaluate a complete PollingResult. For simpler use-cases, this lightweight pre-polling will be enough to determine no change did occurred on remote repository and then avoid using a workspace for polling.

see https://github.com/jenkinsci/git-plugin/pull/351 as usage sample
