### PR TITLE
A Job is always an Item

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -1038,11 +1038,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * <p>
      * See http://wiki.jenkins-ci.org/display/JENKINS/Unit+Test#UnitTest-Configurationroundtriptesting
      */
-    public <P extends Job> P configRoundtrip(P job) throws Exception {
-        submit(createWebClient().getPage(job,"configure").getFormByName("config"));
-        return job;
-    }
-
     public <P extends Item> P configRoundtrip(P job) throws Exception {
         submit(createWebClient().getPage(job, "configure").getFormByName("config"));
         return job;


### PR DESCRIPTION
A Job is an Item so the removed method results in ambigious calls when using `configRoundTrip(FreeStyleProject)` or the like

@reviewbybees
