### PR TITLE
[JENKINS-10547, JENKINS-22685] Update windows-slave-installer dependency to 1.5

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -119,7 +119,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>windows-slave-installer</artifactId>
-      <version>1.5</version>
+      <version>1.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
Jenkins issues: [JENKINS-10547](https://issues.jenkins-ci.org/browse/JENKINS-10547), [JENKINS-22685](https://issues.jenkins-ci.org/browse/JENKINS-22685)

Changes in winsw:
- https://github.com/kohsuke/winsw/issues?q=milestone%3Awinsw-1.17
- kohsuke/winsw@2bf9e85

Changes in the module:
- https://github.com/jenkinsci/windows-slave-installer-module/commit/a4d2121812fe9fe1b38bbe9d2cb57b9cd5435a0d
- https://github.com/jenkinsci/windows-slave-installer-module/commit/3fbc8434aba05d5d36f52f345d9d0176e98459be
