### PR TITLE
Do not skip tests silently

### DIFF
--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -58,6 +58,7 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Chmod;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -464,7 +465,7 @@ public class FilePathTest {
     }
 
     @Test public void symlinkInTar() throws Exception {
-        if (Functions.isWindows())  return; // can't test on Windows
+        assumeFalse("can't test on Windows", Functions.isWindows());
 
         FilePath tmp = new FilePath(temp.getRoot());
             FilePath in = tmp.child("in");

--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -34,6 +34,8 @@ import java.io.File;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
 import static org.junit.Assert.*;
+
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -46,10 +48,7 @@ public class LauncherTest {
 
     @Issue("JENKINS-4611")
     @Test public void remoteKill() throws Exception {
-        if (File.pathSeparatorChar != ':') {
-            System.err.println("Skipping, currently Unix-specific test");
-            return;
-        }
+        Assume.assumeFalse("Skipping, currently Unix-specific test", Functions.isWindows());
 
         File tmp = temp.newFile();
 

--- a/core/src/test/java/hudson/util/ProcessTreeTest.java
+++ b/core/src/test/java/hudson/util/ProcessTreeTest.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import jenkins.security.MasterToSlaveCallable;
 import static org.junit.Assert.*;
+
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -26,9 +28,7 @@ public class ProcessTreeTest {
     }
     
     @Test public void remoting() throws Exception {
-        // on some platforms where we fail to list any processes, this test will just not work
-        if (ProcessTree.get()==ProcessTree.DEFAULT)
-            return;
+        Assume.assumeFalse("on some platforms where we fail to list any processes", ProcessTree.get()==ProcessTree.DEFAULT);
 
         Tag t = channels.french.call(new MyCallable());
 

--- a/test/src/test/groovy/hudson/model/AbstractProjectTest.groovy
+++ b/test/src/test/groovy/hudson/model/AbstractProjectTest.groovy
@@ -54,7 +54,7 @@ import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.recipes.PresetData;
 import org.jvnet.hudson.test.recipes.PresetData.DataSet
 import org.apache.commons.io.FileUtils;
-
+import org.junit.Assume;
 import org.jvnet.hudson.test.MockFolder
 
 /**
@@ -224,9 +224,7 @@ public class AbstractProjectTest extends HudsonTestCase {
 
     @Issue("JENKINS-1986")
     public void testBuildSymlinks() {
-        // If we're on Windows, don't bother doing this.
-        if (Functions.isWindows())
-            return;
+        Assume.assumeFalse("If we're on Windows, don't bother doing this", Functions.isWindows());
 
         def job = createFreeStyleProject();
         job.buildersList.add(new Shell("echo \"Build #\$BUILD_NUMBER\"\n"));
@@ -260,9 +258,7 @@ public class AbstractProjectTest extends HudsonTestCase {
 
     @Issue("JENKINS-2543")
     public void testSymlinkForPostBuildFailure() {
-        // If we're on Windows, don't bother doing this.
-        if (Functions.isWindows())
-            return;
+        Assume.assumeFalse("If we're on Windows, don't bother doing this", Functions.isWindows());
 
         // Links should be updated after post-build actions when final build result is known
         def job = createFreeStyleProject();

--- a/test/src/test/groovy/jenkins/model/PeepholePermalinkTest.groovy
+++ b/test/src/test/groovy/jenkins/model/PeepholePermalinkTest.groovy
@@ -2,6 +2,8 @@ package jenkins.model
 
 import static org.junit.Assert.assertTrue
 
+import org.junit.Assume;
+
 import hudson.Functions
 import hudson.Util
 import hudson.model.Run
@@ -24,7 +26,7 @@ class PeepholePermalinkTest {
      */
     @Test
     void basics() {
-        if (Functions.isWindows())  return; // can't run on windows because we rely on symlinks
+        Assume.assumeFalse("can't run on windows because we rely on symlinks", Functions.isWindows());
 
         def p = j.createFreeStyleProject()
         def b1 = j.assertBuildStatusSuccess(p.scheduleBuild2(0))
@@ -71,7 +73,7 @@ class PeepholePermalinkTest {
      */
     @Test
     void legacyCompatibility() {
-        if (Functions.isWindows())  return; // can't run on windows because we rely on symlinks
+        Assume.assumeFalse("can't run on windows because we rely on symlinks", Functions.isWindows());
 
         def p = j.createFreeStyleProject()
         def b1 = j.assertBuildStatusSuccess(p.scheduleBuild2(0))

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.ZipFile;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -94,7 +95,7 @@ public class DirectoryBrowserSupportTest {
     @Email("http://www.nabble.com/Status-Code-400-viewing-or-downloading-artifact-whose-filename-contains-two-consecutive-periods-tt21407604.html")
     @Test
     public void doubleDots2() throws Exception {
-        if(Functions.isWindows())  return; // can't test this on Windows
+        Assume.assumeFalse("can't test this on Windows", Functions.isWindows());
 
         // create a problematic file name in the workspace
         FreeStyleProject p = j.createFreeStyleProject();

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -31,31 +31,40 @@ import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.model.Node.Mode;
 import hudson.model.Slave;
-import hudson.remoting.Callable;
 import hudson.remoting.Which;
 import hudson.util.ArgumentListBuilder;
 
 import jenkins.security.SlaveToMasterCallable;
 
 import org.junit.Assume;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.awt.*;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class JNLPLauncherTest extends HudsonTestCase {
+public class JNLPLauncherTest {
+    @Rule public JenkinsRule j = new JenkinsRule();
+
     /**
      * Starts a JNLP slave agent and makes sure it successfully connects to Hudson. 
      */
+    @Test
     public void testLaunch() throws Exception {
         Assume.assumeFalse("Skipping JNLPLauncherTest.testLaunch because we are running headless", GraphicsEnvironment.isHeadless());
 
@@ -67,17 +76,15 @@ public class JNLPLauncherTest extends HudsonTestCase {
      * Tests the '-headless' option.
      * (Although this test doesn't really assert that the agent really is running in a headless mdoe.)
      */
+    @Test
     public void testHeadlessLaunch() throws Exception {
         Computer c = addTestSlave();
         launchJnlpAndVerify(c, buildJnlpArgs(c).add("-arg","-headless"));
         // make sure that onOffline gets called just the right number of times
-        assertEquals(1, listener.offlined);
+        assertEquals(1, ComputerListener.all().get(ListenerImpl.class).offlined);
     }
 
-    @Inject
-    ListenerImpl listener;
-
-    @TestExtension
+    @TestExtension("testHeadlessLaunch")
     public static class ListenerImpl extends ComputerListener {
         int offlined = 0;
 
@@ -87,14 +94,13 @@ public class JNLPLauncherTest extends HudsonTestCase {
             assertTrue(c.isOffline());
         }
     }
-    
-    
+
     private ArgumentListBuilder buildJnlpArgs(Computer c) throws Exception {
         ArgumentListBuilder args = new ArgumentListBuilder();
         args.add(new File(new File(System.getProperty("java.home")),"bin/java").getPath(),"-jar");
         args.add(Which.jarFile(netx.jnlp.runtime.JNLPRuntime.class).getAbsolutePath());
         args.add("-headless","-basedir");
-        args.add(createTmpDir());
+        args.add(j.createTmpDir());
         args.add("-nosecurity","-jnlp", getJnlpLink(c));
         return args;
     }
@@ -103,7 +109,7 @@ public class JNLPLauncherTest extends HudsonTestCase {
      * Launches the JNLP slave agent and asserts its basic operations.
      */
     private void launchJnlpAndVerify(Computer c, ArgumentListBuilder args) throws Exception {
-        Proc proc = createLocalLauncher().launch().cmds(args).stdout(System.out).pwd(".").start();
+        Proc proc = j.createLocalLauncher().launch().cmds(args).stdout(System.out).pwd(".").start();
 
         try {
             // verify that the connection is established, up to 20 secs
@@ -133,7 +139,7 @@ public class JNLPLauncherTest extends HudsonTestCase {
      * Determines the link to the .jnlp file.
      */
     private String getJnlpLink(Computer c) throws Exception {
-        HtmlPage p = new WebClient().goTo("computer/"+c.getName()+"/");
+        HtmlPage p = j.createWebClient().goTo("computer/"+c.getName()+"/");
         String href = ((HtmlAnchor) p.getElementById("jnlp-link")).getHrefAttribute();
         href = new URL(new URL(p.getUrl().toExternalForm()),href).toExternalForm();
         return href;
@@ -143,12 +149,12 @@ public class JNLPLauncherTest extends HudsonTestCase {
      * Adds a JNLP {@link Slave} to the system and returns it.
      */
     private Computer addTestSlave() throws Exception {
-        List<Node> slaves = new ArrayList<Node>(jenkins.getNodes());
+        List<Node> slaves = new ArrayList<Node>(j.jenkins.getNodes());
         File dir = Util.createTempDir();
         slaves.add(new DumbSlave("test","dummy",dir.getAbsolutePath(),"1", Mode.NORMAL, "",
                 new JNLPLauncher(), RetentionStrategy.INSTANCE, new ArrayList<NodeProperty<?>>()));
-        jenkins.setNodes(slaves);
-        Computer c = jenkins.getComputer("test");
+        j.jenkins.setNodes(slaves);
+        Computer c = j.jenkins.getComputer("test");
         assertNotNull(c);
         return c;
     }
@@ -161,12 +167,13 @@ public class JNLPLauncherTest extends HudsonTestCase {
         private static final long serialVersionUID = 1L;
     }
 
+    @Test
     public void testConfigRoundtrip() throws Exception {
-        DumbSlave s = createSlave();
+        DumbSlave s = j.createSlave();
         JNLPLauncher original = new JNLPLauncher("a", "b");
         s.setLauncher(original);
-        HtmlPage p = new WebClient().getPage(s, "configure");
-        submit(p.getFormByName("config"));
-        assertEqualBeans(original,s.getLauncher(),"tunnel,vmargs");
+        HtmlPage p = j.createWebClient().getPage(s, "configure");
+        j.submit(p.getFormByName("config"));
+        j.assertEqualBeans(original,s.getLauncher(),"tunnel,vmargs");
     }
 }

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -36,6 +36,8 @@ import hudson.remoting.Which;
 import hudson.util.ArgumentListBuilder;
 
 import jenkins.security.SlaveToMasterCallable;
+
+import org.junit.Assume;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.TestExtension;
 
@@ -55,12 +57,8 @@ public class JNLPLauncherTest extends HudsonTestCase {
      * Starts a JNLP slave agent and makes sure it successfully connects to Hudson. 
      */
     public void testLaunch() throws Exception {
-        if(GraphicsEnvironment.isHeadless()) {
-            System.err.println("Skipping JNLPLauncherTest.testLaunch because we are running headless");
-            return;
-        }
+        Assume.assumeFalse("Skipping JNLPLauncherTest.testLaunch because we are running headless", GraphicsEnvironment.isHeadless());
 
-        System.err.println("Not in headless mode, continuing with JNLPLauncherTest.testLaunch...");
         Computer c = addTestSlave();
         launchJnlpAndVerify(c, buildJnlpArgs(c));
     }

--- a/test/src/test/java/hudson/tasks/EnvVarsInConfigTasksTest.java
+++ b/test/src/test/java/hudson/tasks/EnvVarsInConfigTasksTest.java
@@ -14,6 +14,7 @@ import hudson.tasks.Ant.AntInstallation;
 import hudson.tasks.Maven.MavenInstallation;
 
 import org.apache.tools.ant.taskdefs.condition.Os;
+import org.junit.Assume;
 import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.HudsonTestCase;
 import static hudson.tasks._ant.Messages.Ant_ExecutableNotFound;
@@ -92,10 +93,11 @@ public class EnvVarsInConfigTasksTest extends HudsonTestCase {
 	}
 
 	public void testFreeStyleAntOnSlave() throws Exception {
-        if (jenkins.getDescriptorByType(Ant.DescriptorImpl.class).getInstallations().length == 0) {
-            System.out.println("Cannot do testFreeStyleAntOnSlave without ANT_HOME");
-            return;
-        }
+		Assume.assumeFalse(
+				"Cannot do testFreeStyleAntOnSlave without ANT_HOME",
+				jenkins.getDescriptorByType(Ant.DescriptorImpl.class).getInstallations().length == 0
+		);
+
 		FreeStyleProject project = createFreeStyleProject();
 		project.setJDK(jenkins.getJDK("varJDK"));
 		project.setScm(new ExtractResourceSCM(getClass().getResource(

--- a/test/src/test/java/hudson/tasks/ShellTest.java
+++ b/test/src/test/java/hudson/tasks/ShellTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -45,9 +46,7 @@ public class ShellTest {
 
     @Test
     public void testBasic() throws Exception {
-        // If we're on Windows, don't bother doing this.
-        if (Functions.isWindows())
-            return;
+        Assume.assumeFalse("If we're on Windows, don't bother doing this", Functions.isWindows());
 
         // TODO: define a FakeLauncher implementation with easymock so that this kind of assertions can be simplified.
         PretendSlave s = rule.createPretendSlave(new FakeLauncher() {

--- a/test/src/test/java/hudson/tools/JDKInstallerTest.java
+++ b/test/src/test/java/hudson/tools/JDKInstallerTest.java
@@ -7,6 +7,8 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlFormUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.tools.JDKInstaller.DescriptorImpl;
+
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -105,9 +107,7 @@ public class JDKInstallerTest {
      */
     @Test
     public void locate() throws Exception {
-        // this is a really time consuming test, so only run it when we really want.
-        if(!Boolean.getBoolean("jenkins.testJDKInstaller"))
-            return;
+        Assume.assumeTrue("this is a really time consuming test, so only run it when we really want", Boolean.getBoolean("jenkins.testJDKInstaller"));
 
         retrieveUpdateCenterData();
 
@@ -148,9 +148,7 @@ public class JDKInstallerTest {
      * End-to-end installation test.
      */
     private void doTestAutoInstallation(String id, String fullversion) throws Exception {
-        // this is a really time consuming test, so only run it when we really want
-        if(!Boolean.getBoolean("jenkins.testJDKInstaller"))
-            return;
+        Assume.assumeTrue("this is a really time consuming test, so only run it when we really want", Boolean.getBoolean("jenkins.testJDKInstaller"));
 
         retrieveUpdateCenterData();
 
@@ -177,9 +175,7 @@ public class JDKInstallerTest {
      */
     @Test
     public void fakeUnixInstall() throws Exception {
-        // If we're on Windows, don't bother doing this.
-        if (Functions.isWindows())
-            return;
+        Assume.assumeFalse("If we're on Windows, don't bother doing this", Functions.isWindows());
 
         File bundle = File.createTempFile("fake-jdk-by-hudson","sh");
         try {

--- a/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
+++ b/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
@@ -10,6 +10,7 @@ import hudson.tasks.Maven;
 import hudson.tasks.Shell;
 import hudson.util.ProcessTreeRemoting.IOSProcess;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.ExtractResourceSCM;
@@ -56,7 +57,7 @@ public class ProcessTreeKillerTest {
     @Issue("JENKINS-22641")
     public void processProperlyKilledUnix() throws Exception {
         ProcessTree.enabled = true;
-        if (Functions.isWindows()) return; // This test does not involve windows.
+        Assume.assumeFalse("This test does not involve windows", Functions.isWindows());
 
         FreeStyleProject sleepProject = j.createFreeStyleProject();
         FreeStyleProject processJob = j.createFreeStyleProject();


### PR DESCRIPTION
Replace early returns in tests with assumptions.

There should be 15 new skipped tests after this refactorization.
