### PR TITLE
[FIXED JENKINS-30730] Make reportError to work with any build step

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -742,13 +742,18 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         }
 
         private void reportError(BuildStep bs, Throwable e, BuildListener listener, boolean phase) {
-            final String publisher = ((Publisher) bs).getDescriptor().getDisplayName();
+            final String buildStep;
+
+            if (bs instanceof Publisher)
+                buildStep = ((Publisher) bs).getDescriptor().getDisplayName();
+            else
+                buildStep = bs.getClass().getName();
 
             if (e instanceof AbortException) {
-                LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, publisher});
-                listener.error("Publisher '" + publisher + "' failed: " + e.getMessage());
+                LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, buildStep});
+                listener.error(buildStep + "' failed: " + e.getMessage());
             } else {
-                String msg = "Publisher '" + publisher + "' aborted due to exception: ";
+                String msg = buildStep + "' aborted due to exception: ";
                 e.printStackTrace(listener.error(msg));
                 LOGGER.log(WARNING, msg, e);
             }

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -744,10 +744,11 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         private void reportError(BuildStep bs, Throwable e, BuildListener listener, boolean phase) {
             final String buildStep;
 
-            if (bs instanceof Publisher)
+            if (bs instanceof Publisher) {
                 buildStep = ((Publisher) bs).getDescriptor().getDisplayName();
-            else
+            } else {
                 buildStep = bs.getClass().getName();
+            }
 
             if (e instanceof AbortException) {
                 LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, buildStep});


### PR DESCRIPTION
`AbstractBuildExecution#reportError` should work will any kind of Build Step.

Right now, `reportError` supposes that all the build steps are Publishers, but according with the code it should work with any kind of BuildStep.

https://issues.jenkins-ci.org/browse/JENKINS-30730

@reviewbybees
