### PR TITLE
[FIXED JENKINS-29014] fix broken 'REST API' link

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -254,7 +254,9 @@ ${h.initPageVariables(context)}
           <div class="col-md-6" id="footer"></div>
           <div class="col-md-18">
             <span class="page_generated">${%Page generated}: <i:formatDate value="${h.getCurrentTime()}" type="both" dateStyle="medium" timeStyle="medium"/></span>
-            <span class="rest_api"><a href="api/">REST API</a></span>
+            <j:if test="${!empty(it.api)}">
+               <span class="rest_api"><a href="api/">REST API</a></span>
+            </j:if>
             <span class="jenkins_ver"><a href="${h.getFooterURL()}">Jenkins ver. ${h.version}</a></span>
             <j:if test="${extensionsAvailable}">
             <j:forEach var="pd" items="${h.pageDecorators}">


### PR DESCRIPTION
The 'REST API' footer link appears even for objects which do not have an exposed API, and clicking on the link in such cases (i.e. the Configure Global Security page) results in an HTTP 404.  This change checks for the presence of an object's API and renders this link only if the API exists.
