### PR TITLE
[FIXED JENKINS-30730] Make Abstractbuild::reportError() to work with any build step

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -744,17 +744,17 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         private void reportError(BuildStep bs, Throwable e, BuildListener listener, boolean phase) {
             final String buildStep;
 
-            if (bs instanceof Publisher) {
-                buildStep = ((Publisher) bs).getDescriptor().getDisplayName();
+            if (bs instanceof Describable) {
+                buildStep = ((Describable) bs).getDescriptor().getDisplayName();
             } else {
                 buildStep = bs.getClass().getName();
             }
 
             if (e instanceof AbortException) {
                 LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, buildStep});
-                listener.error(buildStep + "' failed: " + e.getMessage());
+                listener.error("Step '" + buildStep + "' failed: " + e.getMessage());
             } else {
-                String msg = buildStep + "' aborted due to exception: ";
+                String msg = "Step '" + buildStep + "' aborted due to exception: ";
                 e.printStackTrace(listener.error(msg));
                 LOGGER.log(WARNING, msg, e);
             }

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -742,13 +742,19 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         }
 
         private void reportError(BuildStep bs, Throwable e, BuildListener listener, boolean phase) {
-            final String publisher = ((Publisher) bs).getDescriptor().getDisplayName();
+            final String buildStep;
+
+            if (bs instanceof Publisher) {
+                buildStep = ((Publisher) bs).getDescriptor().getDisplayName();
+            } else {
+                buildStep = bs.getClass().getName();
+            }
 
             if (e instanceof AbortException) {
-                LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, publisher});
-                listener.error("Publisher '" + publisher + "' failed: " + e.getMessage());
+                LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, buildStep});
+                listener.error(buildStep + "' failed: " + e.getMessage());
             } else {
-                String msg = "Publisher '" + publisher + "' aborted due to exception: ";
+                String msg = buildStep + "' aborted due to exception: ";
                 e.printStackTrace(listener.error(msg));
                 LOGGER.log(WARNING, msg, e);
             }

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -752,9 +752,9 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
 
             if (e instanceof AbortException) {
                 LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, buildStep});
-                listener.error("Step '" + buildStep + "' failed: " + e.getMessage());
+                listener.error("Step ‘" + buildStep + "’ failed: " + e.getMessage());
             } else {
-                String msg = "Step '" + buildStep + "' aborted due to exception: ";
+                String msg = "Step ‘" + buildStep + "’ aborted due to exception: ";
                 e.printStackTrace(listener.error(msg));
                 LOGGER.log(WARNING, msg, e);
             }

--- a/test/src/test/java/hudson/model/AbstractBuildTest2.java
+++ b/test/src/test/java/hudson/model/AbstractBuildTest2.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.model;
+
+import hudson.Launcher;
+import hudson.model.queue.QueueTaskFuture;
+import java.io.IOException;
+import java.util.Arrays;
+import org.hamcrest.Matchers;
+import static org.junit.Assert.assertThat;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+/**
+ * Unit tests of {@link AbstractBuild}.
+ * @author Oleg Nenashev
+ */
+public class AbstractBuildTest2 {
+    
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
+    
+    @Test
+    @Issue("JENKINS-30730")
+    @SuppressWarnings("deprecation")
+    public void reportErrorShouldNotFailForNionPublisherClass() throws Exception {
+        FreeStyleProject prj = rule.createFreeStyleProject();
+        prj.addProperty(new ErrorneousJobProperty());
+        QueueTaskFuture<FreeStyleBuild> future = prj.scheduleBuild2(0);     
+        assertThat("Build was actually scheduled", future, Matchers.notNullValue());
+        FreeStyleBuild build = future.get();
+        assertThat("Build log contains the error message", build.getLog(), 
+                Matchers.stringContainsInOrder(Arrays.asList(ErrorneousJobProperty.ERROR_MESSAGE)));
+        assertThat("Build log does not contain the class cast error", build.getLog(), 
+                Matchers.not(Matchers.stringContainsInOrder(Arrays.asList(ClassCastException.class.getName()))));
+    }
+    
+    /**
+     * Job property, which always fails with an exception.
+     */
+    public static class ErrorneousJobProperty extends JobProperty<FreeStyleProject> {
+
+        public static final String ERROR_MESSAGE = "This publisher fails by design";
+        
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            throw new IOException(ERROR_MESSAGE);
+        }
+        
+        @TestExtension("reportErrorShouldNotFailForNionPublisherClass")
+        public static class DescriptorImpl extends JobPropertyDescriptor {
+
+            @Override
+            public String getDisplayName() {
+                return "Always throws exception in perform()";
+            }
+            
+        }
+    }
+}

--- a/test/src/test/java/hudson/model/AbstractBuildTest2.java
+++ b/test/src/test/java/hudson/model/AbstractBuildTest2.java
@@ -27,13 +27,14 @@ import hudson.Launcher;
 import hudson.model.queue.QueueTaskFuture;
 import java.io.IOException;
 import java.util.Arrays;
-import org.hamcrest.Matchers;
-import static org.junit.Assert.assertThat;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
 
 /**
  * Unit tests of {@link AbstractBuild}.
@@ -51,12 +52,12 @@ public class AbstractBuildTest2 {
         FreeStyleProject prj = rule.createFreeStyleProject();
         prj.addProperty(new ErrorneousJobProperty());
         QueueTaskFuture<FreeStyleBuild> future = prj.scheduleBuild2(0);     
-        assertThat("Build was actually scheduled", future, Matchers.notNullValue());
+        assertThat("Build should be actually scheduled by Jenkins", future, notNullValue());
         FreeStyleBuild build = future.get();
-        assertThat("Build log contains the error message", build.getLog(), 
-                Matchers.stringContainsInOrder(Arrays.asList(ErrorneousJobProperty.ERROR_MESSAGE)));
-        assertThat("Build log does not contain the class cast error", build.getLog(), 
-                Matchers.not(Matchers.stringContainsInOrder(Arrays.asList(ClassCastException.class.getName()))));
+        assertThat("Build should contain the error message", build.getLog(), 
+                stringContainsInOrder(Arrays.asList(ErrorneousJobProperty.ERROR_MESSAGE)));
+        assertThat("Build log should not contain the class cast error", build.getLog(), 
+                not(stringContainsInOrder(Arrays.asList(ClassCastException.class.getName()))));
     }
     
     /**

--- a/test/src/test/java/hudson/model/AbstractBuildTest2.java
+++ b/test/src/test/java/hudson/model/AbstractBuildTest2.java
@@ -26,7 +26,6 @@ package hudson.model;
 import hudson.Launcher;
 import hudson.model.queue.QueueTaskFuture;
 import java.io.IOException;
-import java.util.Arrays;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -50,14 +49,13 @@ public class AbstractBuildTest2 {
     @SuppressWarnings("deprecation")
     public void reportErrorShouldNotFailForNonPublisherClass() throws Exception {
         FreeStyleProject prj = rule.createFreeStyleProject();
-        prj.addProperty(new ErrorneousJobProperty());
+        ErrorneousJobProperty errorneousJobProperty = new ErrorneousJobProperty();
+        prj.addProperty(errorneousJobProperty);
         QueueTaskFuture<FreeStyleBuild> future = prj.scheduleBuild2(0);     
         assertThat("Build should be actually scheduled by Jenkins", future, notNullValue());
         FreeStyleBuild build = future.get();
-        assertThat("Build should contain the error message", build.getLog(), 
-                stringContainsInOrder(Arrays.asList(ErrorneousJobProperty.ERROR_MESSAGE)));
-        assertThat("Build log should not contain the class cast error", build.getLog(), 
-                not(stringContainsInOrder(Arrays.asList(ClassCastException.class.getName()))));
+        rule.assertLogContains(ErrorneousJobProperty.ERROR_MESSAGE, build);
+        rule.assertLogNotContains(ClassCastException.class.getName(), build);
     }
     
     /**

--- a/test/src/test/java/hudson/model/AbstractBuildTest2.java
+++ b/test/src/test/java/hudson/model/AbstractBuildTest2.java
@@ -48,7 +48,7 @@ public class AbstractBuildTest2 {
     @Test
     @Issue("JENKINS-30730")
     @SuppressWarnings("deprecation")
-    public void reportErrorShouldNotFailForNionPublisherClass() throws Exception {
+    public void reportErrorShouldNotFailForNonPublisherClass() throws Exception {
         FreeStyleProject prj = rule.createFreeStyleProject();
         prj.addProperty(new ErrorneousJobProperty());
         QueueTaskFuture<FreeStyleBuild> future = prj.scheduleBuild2(0);     
@@ -72,14 +72,13 @@ public class AbstractBuildTest2 {
             throw new IOException(ERROR_MESSAGE);
         }
         
-        @TestExtension("reportErrorShouldNotFailForNionPublisherClass")
+        @TestExtension("reportErrorShouldNotFailForNonPublisherClass")
         public static class DescriptorImpl extends JobPropertyDescriptor {
 
             @Override
             public String getDisplayName() {
                 return "Always throws exception in perform()";
-            }
-            
+            }  
         }
     }
 }


### PR DESCRIPTION
It's a reworked version of #1846 

`AbstractBuildExecution#reportError` should work will any kind of Build Step.

Right now, `reportError` supposes that all the build steps are Publishers, but according with the code it should work with any kind of BuildStep.

https://issues.jenkins-ci.org/browse/JENKINS-30730

@reviewbybees @KostyaSha
