### PR TITLE
[JENKINS-21720] JS alert preventing to leave a configuration page without changes

### DIFF
--- a/core/src/main/resources/lib/form/confirm.js
+++ b/core/src/main/resources/lib/form/confirm.js
@@ -33,9 +33,6 @@
     }
 
     function initConfirm() {
-      // Timeout is needed since some events get sent on page load for some reason.
-      // Shouldn't hurt anything for this to only start monitoring events after a few millis;.
-      setTimeout(function() {
       var configForm = document.getElementsByName("config");
       if (configForm.length > 0) {
         configForm = configForm[0]
@@ -78,7 +75,6 @@
       for ( var i = 0; i < inputs.length; i++) {
         $(inputs[i]).on('input', confirm);
       }
-      }, 100);
     }
 
     window.onbeforeunload = confirmExit;

--- a/core/src/main/resources/lib/form/select/select.js
+++ b/core/src/main/resources/lib/form/select/select.js
@@ -41,6 +41,19 @@ function updateListBox(listBox,url,config) {
 }
 
 Behaviour.specify("SELECT.select", 'select', 1000, function(e) {
+
+        function hasChanged(selectEl, originalValue) {
+            var firstValue = selectEl.options[0].value;
+            var selectedValue = selectEl.value;
+            if (originalValue == "" && selectedValue == firstValue) {
+                // There was no value pre-selected but after the call to updateListBox the first value is selected by
+                // default. This must not be considered a change.
+                return false;
+            } else {
+                return originalValue != selectedValue;
+            }
+        };
+
         // controls that this SELECT box depends on
         refillOnChange(e,function(params) {
             var value = e.value;
@@ -60,7 +73,9 @@ Behaviour.specify("SELECT.select", 'select', 1000, function(e) {
                     fireEvent(e,"filled"); // let other interested parties know that the items have changed
 
                     // if the update changed the current selection, others listening to this control needs to be notified.
-                    if (e.value!=value) fireEvent(e,"change");
+                    if (hasChanged(e, value)) {
+                        fireEvent(e,"change");
+                    }
                 }
             });
         });


### PR DESCRIPTION
[JENKINS-21720](https://issues.jenkins-ci.org/browse/JENKINS-21720) reopened.

The JS alert is being shown when it must not and it's [producing fails in ATH](https://jenkins.ci.cloudbees.com/job/core/job/acceptance-test-harness/1246/testReport/junit/core/BuildHistoryTest/view_build_history).

`<select>` tags have a default behavior in Jenkins which is to select the first option if there is no value stored for it, but initially (before to call any AJAX endpoint to retrieve data) the default value for the `<select>` is `""`, then the first value coming in the AJAX request is set as default, and this value is not `""` (empty string) but `0`, `1` or whatever. So after setting the value a change is detected and the JS shown when leaving the page.

The original fix was to delay 100 ms to start monitoring for changes in the formulary. This workaround was really hiding to underlying issue. Under high load circumstances some HTTP requests (made to load `<select>` options) surpasses this time limit, which leads on triggering the "change" event when there was no real changes.

@reviewbybees
