### PR TITLE
[FIXED JENKINS-30502] trim job name upon rename

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1210,7 +1210,8 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
             String newName = req.getParameter("name");
             final ProjectNamingStrategy namingStrategy = Jenkins.getInstance().getProjectNamingStrategy();
-            if (newName != null && !newName.equals(name)) {
+            if (validRename(name, newName)) {
+                newName = newName.trim();
                 // check this error early to avoid HTTP response splitting.
                 Jenkins.checkGoodName(newName);
                 namingStrategy.checkName(newName);
@@ -1229,6 +1230,15 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             Logger.getLogger(Job.class.getName()).log(Level.WARNING, "failed to parse " + json, e);
             sendError(e, req, rsp);
         }
+    }
+
+    private boolean validRename(String oldName, String newName) {
+        if (newName == null) {
+            return false;
+        }
+        boolean noChange = oldName.equals(newName);
+        boolean spaceAdded = oldName.equals(newName.trim());
+        return !noChange && !spaceAdded;
     }
 
     /**


### PR DESCRIPTION
If a job is renamed to a string with trailing whitespace, exceptions are thrown as the application attempts to rename the job directory in the file system, and the job can be neither deleted nor renamed again through the UI. This problem occurs only when renaming a job, and not when initially creating a job, because job names are trimmed when first created.  This change trims the job name for rename operations as well, so that the name-setting behavior is consistent across create/update operations and inadvertent leading/trailing whitespace is removed before it can cause problems.
