### PR TITLE
[FIXED JENKINS-30569] HistoryWidget: fix JS syntax error

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -101,7 +101,9 @@ THE SOFTWARE.
       </tr>
     </j:if>
   </l:pane>
-  <script defer="true">
-    updateBuildHistory("${it.baseUrl}/buildHistory/ajax",${it.nextBuildNumberToFetch});
-  </script>
+  <j:if test="!empty(it.nextBuildNumberToFetch)">
+    <script defer="true">
+      updateBuildHistory("${it.baseUrl}/buildHistory/ajax", ${it.nextBuildNumberToFetch});
+    </script>
+  </j:if>
 </j:jelly>


### PR DESCRIPTION
When the History Widget is collapsed while viewing a Job, the 'nextBuildNumberToFetch' property is empty, and emitting this JS in this case causes a syntax error (i.e. "functionName(firstParam, );" -> "SyntaxError: expected expression, got ')'").  This change checks for this condition and emits the JS only if it will be properly formed.
