### PR TITLE
[JENKINS-28781] update the bct library to 1.6.2.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -200,7 +200,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>bytecode-compatibility-transformer</artifactId>
-      <version>1.5</version>
+      <version>1.6.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
Pickup the changes in the bytecode-compatibility-transformer for
[JENKINS-28781](https://issues.jenkins-ci.org/browse/JENKINS-28781)
