### PR TITLE
[JENKINS-30820] pick up the new bytecode-compat-t.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -200,7 +200,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>bytecode-compatibility-transformer</artifactId>
-      <version>1.6.2</version>
+      <version>1.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -797,7 +797,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
         @Override
         protected Class defineClassFromData(File container, byte[] classData, String classname) throws IOException {
             if (!DISABLE_TRANSFORMER)
-                classData = pluginManager.getCompatibilityTransformer().transform(classname, classData);
+                classData = pluginManager.getCompatibilityTransformer().transform(classname, classData, this);
             return super.defineClassFromData(container, classData, classname);
         }
     }


### PR DESCRIPTION
The new version of the BCT does not generate stackMap if the original code
did not contain stack maps.  Further more the new version takes a
classloader to use so that it can load classes when searching for the
common parent class.

@reviewbybees //cc @olivergondza 
[JENKINS-30820](https://issues.jenkins-ci.org/browse/JENKINS-30820)
