### PR TITLE
[JENKINS-30745] - Revert trigger optimisation

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -325,13 +325,11 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         buildMixIn.onLoad(parent, name);
         builds = buildMixIn.getRunMap();
         triggers().setOwner(this);
-        if (isBuildable()) {
-            for (Trigger t : triggers()) {
-                try {
-                    t.start(this, Items.currentlyUpdatingByXml());
-                } catch (Throwable e) {
-                    LOGGER.log(Level.WARNING, "could not start trigger while loading project '" + getFullName() + "'", e);
-                }
+        for (Trigger t : triggers()) {
+            try {
+                t.start(this, Items.currentlyUpdatingByXml());
+            } catch (Throwable e) {
+                LOGGER.log(Level.WARNING, "could not start trigger while loading project '" + getFullName() + "'", e);
             }
         }
         if(scm==null)
@@ -1874,10 +1872,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         for (Trigger t : triggers())
             t.stop();
         triggers.replaceBy(buildDescribable(req, Trigger.for_(this)));
-        if (isBuildable()) {
-            for (Trigger t : triggers())
-                t.start(this, true);
-        }
+        for (Trigger t : triggers())
+            t.start(this,true);
     }
 
     /**

--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -247,10 +247,6 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
                 // FIXME allow to set a global crontab spec
                 previousSynchronousPolling = scmd.getExecutor().submit(new DependencyRunner(new ProjectRunnable() {
                     public void run(AbstractProject p) {
-                        if (!p.isBuildable()) {
-                            return; //skip disabled/copied project
-                        }
-
                         for (Trigger t : (Collection<Trigger>) p.getTriggers().values()) {
                             if (t instanceof SCMTrigger) {
                                 LOGGER.fine("synchronously triggering SCMTrigger for project " + t.job.getName());
@@ -266,12 +262,6 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
 
         // Process all triggers, except SCMTriggers when synchronousPolling is set
         for (ParameterizedJobMixIn.ParameterizedJob p : inst.getAllItems(ParameterizedJobMixIn.ParameterizedJob.class)) {
-            if (p instanceof AbstractProject<?, ?>) {
-               if (!((AbstractProject) p).isBuildable()) {
-                   continue; // skip disabled/copied project
-               }
-            }
-
             for (Trigger t : p.getTriggers().values()) {
                 if (! (t instanceof SCMTrigger && scmd.synchronousPolling)) {
                     LOGGER.log(Level.FINE, "cron checking {0} with spec ‘{1}’", new Object[] {p, t.spec.trim()});


### PR DESCRIPTION
I don't want (and have no time) continue fixing this crappy APIs. 

My result:
- i fixed some existed possible NPEs in plugins and core for Triggers API
- added tests
- users are not happy https://issues.jenkins-ci.org/browse/JENKINS-30745 as it exposed bad job API
- filled https://issues.jenkins-ci.org/browse/JENKINS-30802
- revert same as in LTS (make @olivergondza happy)
