### PR TITLE
[JENKINS-30456]Executable can be null in getEstimatedDurationFor

### DIFF
--- a/core/src/main/java/hudson/model/queue/Executables.java
+++ b/core/src/main/java/hudson/model/queue/Executables.java
@@ -27,6 +27,7 @@ import hudson.model.Queue.Executable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
@@ -61,14 +62,19 @@ public class Executables {
 
     /**
      * Returns the estimated duration for the executable.
+     * If the Executable is null the Estimated Duration can't be evaluated, then -1 is returned.
+     * This can happen if Computer.getIdleStartMilliseconds() is called before the executable is set to non-null in Computer.run()
+     * or if the executor thread exits prematurely, see JENKINS-30456
      * Protects against {@link AbstractMethodError}s if the {@link Executable} implementation
      * was compiled against Hudson < 1.383
+     *
+     * @return the estimated duration for a given executable, -1 if the executable is null
      */
-    public static long getEstimatedDurationFor(Executable e) {
+    public static long getEstimatedDurationFor(@CheckForNull Executable e) {
         try {
-            return e.getEstimatedDuration();
+            return (e != null) ? e.getEstimatedDuration() : -1;
         } catch (AbstractMethodError error) {
-            return e.getParent().getEstimatedDuration();
+            return (e != null) ? e.getParent().getEstimatedDuration() : -1;
         }
     }
 


### PR DESCRIPTION
`Executables.getEstimatedDurationFor()` throws`NPE` when the executable is `null`. This can happen if `Computer.getIdleStartMilliseconds()` is called before the executable is set to non-null in `Computer.run()` or if the executor thread exits prematurely (see https://issues.jenkins-ci.org/browse/JENKINS-30456)
