### PR TITLE
[FIX JENKINS-12379] Allow specifying a base path for archiving

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -683,6 +683,26 @@ public final class FilePath implements Serializable {
 
     }
 
+    /**
+     * Returns true iff the argument is an ancestor of the current file path.
+     * @param ancestor a file path
+     * @return true iff the argument is an ancestor of the current file path.
+     * @since TODO
+     */
+    public boolean isDescendantOf(FilePath ancestor) {
+        if (ancestor.getRemote().equals(".") && !isAbsolute(this.getRemote()) && !this.getRemote().startsWith("..") && !this.getRemote().equals(".")) {
+            // special case: if the ancestor is '.', any relative path not '.' and not starting with '..' is a child
+            return true;
+        }
+        FilePath current = this;
+        while ((current = current.getParent()) != null) {
+            if (current.equals(ancestor)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public int hashCode() {
         return 31 * (channel != null ? channel.hashCode() : 0) + remote.hashCode();

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -248,12 +248,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
                 String path = build.getEnvironment(listener).expand(this.basePath);
                 dir = ws.child(path);
 
-                // add trailing slash so we don't allow '../workspacefoo' to escape the workspace
-                String wsPath = ws.getRemote();
-                wsPath = wsPath.endsWith("/") ? wsPath : wsPath + "/";
-                String dirPath = dir.getRemote() + '/';
-                dirPath = dirPath.endsWith("/") ? dirPath : dirPath + "/";
-                if (!dirPath.startsWith(wsPath)) {
+                if (!dir.equals(ws) && !dir.isDescendantOf(ws)) {
                     listener.error(Messages.ArtifactArchiver_BasePathOutsideWorkspace());
                     build.setResult(Result.FAILURE);
                     return;
@@ -401,7 +396,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
                 reference = ws;
             }
             FilePath filePath = reference.child(basePath);
-            if (!filePath.getRemote().startsWith(reference.getRemote())) {
+            if (!reference.equals(filePath) && !filePath.isDescendantOf(reference)) {
                 return FormValidation.error(Messages.ArtifactArchiver_BasePathOutsideWorkspace());
             }
 

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -254,7 +254,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
                 String dirPath = dir.getRemote() + '/';
                 dirPath = dirPath.endsWith("/") ? dirPath : dirPath + "/";
                 if (!dirPath.startsWith(wsPath)) {
-                    listener.error(Messages.ArtifactArchiver_ContextOutsideWorkspace());
+                    listener.error(Messages.ArtifactArchiver_BasePathOutsideWorkspace());
                     build.setResult(Result.FAILURE);
                     return;
                 }
@@ -288,7 +288,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
                     if (dir == ws) {
                         message = Messages.ArtifactArchiver_NoMatchFound(artifacts);
                     } else {
-                        message = Messages.ArtifactArchiver_NoMatchFoundInContext(artifacts, basePath);
+                        message = Messages.ArtifactArchiver_NoMatchFoundInBasePath(artifacts, basePath);
                     }
 
 
@@ -372,10 +372,10 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
             if (project == null) {
                 return FormValidation.ok();
             }
-            // Make sure context path is valid first, otherwise this suggests files outside the workspace
-            FormValidation contextPathValidation = doCheckBasePath(project, basePath);
-            if (contextPathValidation.kind != FormValidation.Kind.OK) {
-                // if context path is invalid, treat this like no workspace exists rather than e.g. show the same validation error twice
+            // Make sure base path is valid first, otherwise this suggests files outside the workspace
+            FormValidation basePathValidation = doCheckBasePath(project, basePath);
+            if (basePathValidation.kind != FormValidation.Kind.OK) {
+                // if base path is invalid, treat this like no workspace exists rather than e.g. show the same validation error twice
                 return FormValidation.ok();
             }
             FilePath ws = project.getSomeWorkspace();
@@ -391,7 +391,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
             if (project == null) {
                 return FormValidation.ok();
             }
-            FilePath ws = null;
+            FilePath ws = project.getSomeWorkspace();
             FilePath reference;
             if (ws == null) {
                 // we're not writing anything, just checking whether the basePath escapes a reference directory
@@ -400,17 +400,17 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
             } else {
                 reference = ws;
             }
-            FilePath context = reference.child(basePath);
-            if (!context.getRemote().startsWith(reference.getRemote())) {
-                return FormValidation.error(Messages.ArtifactArchiver_ContextOutsideWorkspace());
+            FilePath filePath = reference.child(basePath);
+            if (!filePath.getRemote().startsWith(reference.getRemote())) {
+                return FormValidation.error(Messages.ArtifactArchiver_BasePathOutsideWorkspace());
             }
 
             if (ws != null && ws.exists()) {
-                if (!context.exists()) {
-                    return FormValidation.warning(Messages.ArtifactArchiver_ContextDoesNotExist());
+                if (!filePath.exists()) {
+                    return FormValidation.warning(Messages.ArtifactArchiver_BasePathDoesNotExist());
                 }
-                if (!context.isDirectory()) {
-                    return FormValidation.warning(Messages.ArtifactArchiver_ContextIsFile());
+                if (!filePath.isDirectory()) {
+                    return FormValidation.warning(Messages.ArtifactArchiver_BasePathIsFile());
                 }
             }
 

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
@@ -28,6 +28,9 @@ THE SOFTWARE.
 	  <f:textbox />
 	</f:entry>
   <f:advanced>
+    <f:entry title="${%Search Context}" field="contextPath">
+      <f:textbox />
+    </f:entry>
     <f:entry title="${%Excludes}" field="excludes">
       <f:textbox />
     </f:entry>

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
 	  <f:textbox />
 	</f:entry>
   <f:advanced>
-    <f:entry title="${%Search Context}" field="contextPath">
+    <f:entry title="${%Base Path}" field="basePath">
       <f:textbox />
     </f:entry>
     <f:entry title="${%Excludes}" field="excludes">

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-artifacts.html
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-artifacts.html
@@ -2,6 +2,6 @@
    You can use wildcards like 'module/dist/**/*.zip'.
    See <a href='http://ant.apache.org/manual/Types/fileset.html'>
    the includes attribute of Ant fileset</a> for the exact format.
-   The base directory is <a href='ws/'>the workspace</a>.
+   The base directory is <a href='ws/'>the workspace</a>, unless the advanced option 'Base Path' is used.
    You can only archive files that are located in your workspace.
 </div>

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-basePath.html
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-basePath.html
@@ -1,0 +1,8 @@
+<div>
+    When specifying a path inside the workspace here, Jenkins applies the artifact pattern only to this directory, and
+    artifact paths are relative to this directory. For example, if you want to archive files matching the pattern
+    'module/dist/**/*.zip' but don't want the folders 'module/dist' show up as part of the result artifact paths, you
+    can specify 'module/dist' here, and instead use the pattern '**/*.zip' above. This way, Jenkins archives paths like
+    'foo/bar.zip' rather than 'module/dist/foo/bar.zip'. Only files inside this path (relative to the workspace) can be
+    archived. If left empty, Jenkins applies the archive pattern relative to the workspace.
+</div>

--- a/core/src/main/resources/hudson/tasks/Messages.properties
+++ b/core/src/main/resources/hudson/tasks/Messages.properties
@@ -36,6 +36,10 @@ No artifacts are configured for archiving.\n\
 You probably forgot to set the file pattern, so please go back to the configuration and specify it.\n\
 If you really did mean to archive all the files in the workspace, please specify "**"
 ArtifactArchiver.NoMatchFound=No artifacts found that match the file pattern "{0}". Configuration error?
+ArtifactArchiver.NoMatchFoundInContext=No artifacts found that match the file pattern "{0}" in "{1}". Configuration error?
+ArtifactArchiver.ContextOutsideWorkspace=Search Context must specify a path inside the job workspace
+ArtifactArchiver.ContextDoesNotExist=Search Context does not exist inside workspace
+ArtifactArchiver.ContextIsFile=Search Context must not be a file
 
 BatchFile.DisplayName=Execute Windows batch command
 BatchFile.invalid_exit_code_range=Invalid errorlevel value: {0}. Check help section

--- a/core/src/main/resources/hudson/tasks/Messages.properties
+++ b/core/src/main/resources/hudson/tasks/Messages.properties
@@ -36,10 +36,10 @@ No artifacts are configured for archiving.\n\
 You probably forgot to set the file pattern, so please go back to the configuration and specify it.\n\
 If you really did mean to archive all the files in the workspace, please specify "**"
 ArtifactArchiver.NoMatchFound=No artifacts found that match the file pattern "{0}". Configuration error?
-ArtifactArchiver.NoMatchFoundInContext=No artifacts found that match the file pattern "{0}" in "{1}". Configuration error?
-ArtifactArchiver.ContextOutsideWorkspace=Search Context must specify a path inside the job workspace
-ArtifactArchiver.ContextDoesNotExist=Search Context does not exist inside workspace
-ArtifactArchiver.ContextIsFile=Search Context must not be a file
+ArtifactArchiver.NoMatchFoundInBasePath=No artifacts found that match the file pattern "{0}" in "{1}". Configuration error?
+ArtifactArchiver.BasePathOutsideWorkspace=Base path must specify a path inside the job workspace
+ArtifactArchiver.BasePathDoesNotExist=Base path does not exist inside workspace
+ArtifactArchiver.BasePathIsFile=Base path must not be a file
 
 BatchFile.DisplayName=Execute Windows batch command
 BatchFile.invalid_exit_code_range=Invalid errorlevel value: {0}. Check help section

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -60,6 +60,7 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Chmod;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -386,6 +387,38 @@ public class FilePathTest {
         tmpDirPath.child(tarFile.getName()).untar(outDir, TarCompression.NONE);
         assertEquals("Result file after the roundtrip differs from the initial file",
                 new FilePath(tempFile).digest(), outFile.digest());
+    }
+
+    @Test public void descendantTest() throws Exception {
+        VirtualChannel channel = Mockito.mock(VirtualChannel.class);
+
+        { // tests for '.'
+            File reference = new File(".");
+            FilePath referencePath = new FilePath(reference);
+            assertFalse("same directory", referencePath.isDescendantOf(new FilePath(reference)));
+            assertTrue("child", new FilePath(referencePath, "child").isDescendantOf(referencePath));
+            assertFalse("sibling", new FilePath(referencePath, "../child").isDescendantOf(referencePath));
+            assertFalse("sibling", new FilePath(referencePath, "foo/../../child").isDescendantOf(referencePath));
+            assertTrue("child 2", new FilePath(referencePath, "child").isDescendantOf(new FilePath(reference)));
+            assertTrue("grandchild", new FilePath(referencePath, "child/grandchild").isDescendantOf(referencePath));
+            assertTrue("grandchild 2", new FilePath(referencePath, "child/grandchild").isDescendantOf(new FilePath(reference)));
+            assertFalse("reverse", referencePath.isDescendantOf(new FilePath(referencePath, "child")));
+            assertFalse("different channels", new FilePath(channel, "/somepath").equals(new FilePath((VirtualChannel) null, "/somepath")));
+        }
+
+        { // tests for normal dir name
+            File reference = new File(".");
+            FilePath referencePath = new FilePath(reference);
+            assertFalse("same directory", referencePath.isDescendantOf(new FilePath(reference)));
+            assertTrue("child", new FilePath(referencePath, "child").isDescendantOf(referencePath));
+            assertFalse("sibling", new FilePath(referencePath, "../child").isDescendantOf(referencePath));
+            assertFalse("sibling", new FilePath(referencePath, "foo/../../child").isDescendantOf(referencePath));
+            assertTrue("child 2", new FilePath(referencePath, "child").isDescendantOf(new FilePath(reference)));
+            assertTrue("grandchild", new FilePath(referencePath, "child/grandchild").isDescendantOf(referencePath));
+            assertTrue("grandchild 2", new FilePath(referencePath, "child/grandchild").isDescendantOf(new FilePath(reference)));
+            assertFalse("reverse", referencePath.isDescendantOf(new FilePath(referencePath, "child")));
+            assertFalse("different channels", new FilePath(channel, "/somepath").equals(new FilePath((VirtualChannel) null, "/somepath")));
+        }
     }
 
     @Test public void list() throws Exception {

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -287,7 +287,7 @@ public class ArtifactArchiverTest {
 
         j.buildAndAssertSuccess(p);
         VirtualFile artifacts = p.getBuildByNumber(1).getArtifactManager().root();
-        assertTrue(artifacts.child("target").child("file").exists());
+        assertTrue("file was archived", artifacts.child("target").child("file").exists());
     }
 
     @Test
@@ -302,7 +302,7 @@ public class ArtifactArchiverTest {
         p.getPublishersList().replaceBy(Collections.singleton(archiver));
 
         assertEquals(Result.FAILURE, build(p));
-        assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
+        assertArrayEquals("artifacts list empty", new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
     }
 
     @Test
@@ -316,8 +316,8 @@ public class ArtifactArchiverTest {
         archiver.setBasePath("foo/../..");
         p.getPublishersList().replaceBy(Collections.singleton(archiver));
 
-        assertEquals(Result.FAILURE, build(p));
-        assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
+        assertEquals("build failed", Result.FAILURE, build(p));
+        assertArrayEquals("artifacts list empty", new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
     }
 
     @Test
@@ -332,8 +332,8 @@ public class ArtifactArchiverTest {
         archiver.setBasePath("/");
         p.getPublishersList().replaceBy(Collections.singleton(archiver));
 
-        assertEquals(Result.FAILURE, build(p));
-        assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
+        assertEquals("build failed", Result.FAILURE, build(p));
+        assertArrayEquals("artifacts list empty", new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
     }
 
     @Test
@@ -343,6 +343,7 @@ public class ArtifactArchiverTest {
 
         FreeStyleProject p = j.createFreeStyleProject();
         assertEquals("no workspace", FormValidation.Kind.OK, desc.doCheckBasePath(p, "foo").kind);
+        assertEquals("explicit same directory", FormValidation.Kind.OK, desc.doCheckBasePath(p, ".").kind);
         assertEquals("relative path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "..").kind);
         assertEquals("absolute path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "/").kind);
         assertEquals("absolute path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "../workfoo").kind);
@@ -371,8 +372,8 @@ public class ArtifactArchiverTest {
         archiver.setAllowEmptyArchive(true);
         p.getPublishersList().replaceBy(Collections.singleton(archiver));
 
-        assertEquals(Result.SUCCESS, build(p));
-        Assert.assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
+        assertEquals("build succeeded", Result.SUCCESS, build(p));
+        Assert.assertArrayEquals("artifacts list empty", new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
 
     }
 
@@ -388,8 +389,8 @@ public class ArtifactArchiverTest {
         archiver.setAllowEmptyArchive(true);
         p.getPublishersList().replaceBy(Collections.singleton(archiver));
 
-        assertEquals(Result.SUCCESS, build(p));
-        Assert.assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
+        assertEquals("build succeeded", Result.SUCCESS, build(p));
+        Assert.assertArrayEquals("artifacts list empty", new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
 
     }
 

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -345,6 +345,7 @@ public class ArtifactArchiverTest {
         Assert.assertEquals("no workspace", FormValidation.Kind.OK, desc.doCheckBasePath(p, "foo").kind);
         Assert.assertEquals("relative path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "..").kind);
         Assert.assertEquals("absolute path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "/").kind);
+        Assert.assertEquals("absolute path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "../workfoo").kind);
 
         // create workspace for the project
         p.getBuildersList().replaceBy(Collections.singleton(new CreateFilesForBasePathTest()));
@@ -352,7 +353,7 @@ public class ArtifactArchiverTest {
 
         Assert.assertEquals("workspace exists but path does not", FormValidation.Kind.WARNING, desc.doCheckBasePath(p, "foo").kind);
         Assert.assertEquals("workspace exists and path does", FormValidation.Kind.OK, desc.doCheckBasePath(p, "module").kind);
-        Assert.assertEquals("file specified as context path", FormValidation.Kind.WARNING, desc.doCheckBasePath(p, "module/dist/target/file").kind);
+        Assert.assertEquals("file specified as base path", FormValidation.Kind.WARNING, desc.doCheckBasePath(p, "module/dist/target/file").kind);
         Assert.assertEquals("relative path breakout", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "..").kind);
 
         Assert.assertEquals("absolute path breakout", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "/").kind);
@@ -360,7 +361,7 @@ public class ArtifactArchiverTest {
 
     @Test
     @Issue("JENKINS-12379")
-    public void testContextPathNotExistingButOptional() throws Exception {
+    public void testBasePathNotExistingButOptional() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
 
         p.getBuildersList().replaceBy(Collections.singleton(new CreateFilesForBasePathTest()));
@@ -377,7 +378,7 @@ public class ArtifactArchiverTest {
 
     @Test
     @Issue("JENKINS-12379")
-    public void testContextPathIsAFile() throws Exception {
+    public void testBasePathIsAFile() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
 
         p.getBuildersList().replaceBy(Collections.singleton(new CreateFilesForBasePathTest()));

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -358,6 +358,40 @@ public class ArtifactArchiverTest {
         Assert.assertEquals("absolute path breakout", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "/").kind);
     }
 
+    @Test
+    @Issue("JENKINS-12379")
+    public void testContextPathNotExistingButOptional() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+
+        p.getBuildersList().replaceBy(Collections.singleton(new CreateFilesForBasePathTest()));
+
+        ArtifactArchiver archiver = new ArtifactArchiver("**");
+        archiver.setBasePath("thisDoesNotExist");
+        archiver.setAllowEmptyArchive(true);
+        p.getPublishersList().replaceBy(Collections.singleton(archiver));
+
+        assertEquals(Result.SUCCESS, build(p));
+        Assert.assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
+
+    }
+
+    @Test
+    @Issue("JENKINS-12379")
+    public void testContextPathIsAFile() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+
+        p.getBuildersList().replaceBy(Collections.singleton(new CreateFilesForBasePathTest()));
+
+        ArtifactArchiver archiver = new ArtifactArchiver("**");
+        archiver.setBasePath("module/dist/target/file");
+        archiver.setAllowEmptyArchive(true);
+        p.getPublishersList().replaceBy(Collections.singleton(archiver));
+
+        assertEquals(Result.SUCCESS, build(p));
+        Assert.assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
+
+    }
+
     @LocalData
     @Test public void latestOnlyMigration() throws Exception {
         FreeStyleProject p = j.jenkins.getItemByFullName("sample", FreeStyleProject.class);

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -66,7 +66,7 @@ import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 public class ArtifactArchiverTest {
-    
+
     @Rule public JenkinsRule j = new JenkinsRule();
 
     @Test
@@ -209,12 +209,12 @@ public class ArtifactArchiverTest {
         aa = j.configRoundtrip(aa);
         assertEquals("*.txt", aa.getArtifacts());
         assertNull(Util.fixEmpty(aa.getExcludes()));
-        assertEquals("{artifacts=*.txt}", DescribableModel.uninstantiate_(aa).toString());
+        assertEquals("{artifacts=*.txt, basePath=}", DescribableModel.uninstantiate_(aa).toString());
         aa.setExcludes("README.txt");
         aa = j.configRoundtrip(aa);
         assertEquals("*.txt", aa.getArtifacts());
         assertEquals("README.txt", aa.getExcludes());
-        assertEquals("{artifacts=*.txt, excludes=README.txt}", DescribableModel.uninstantiate_(aa).toString()); // TreeMap, so attributes will be sorted
+        assertEquals("{artifacts=*.txt, basePath=, excludes=README.txt}", DescribableModel.uninstantiate_(aa).toString()); // TreeMap, so attributes will be sorted
     }
 
     static class CreateDefaultExcludesArtifact extends TestBuilder {
@@ -285,7 +285,7 @@ public class ArtifactArchiverTest {
         archiver.setBasePath("module/dist");
         p.getPublishersList().replaceBy(Collections.singleton(archiver));
 
-        assertEquals(Result.SUCCESS, build(p));
+        j.buildAndAssertSuccess(p);
         VirtualFile artifacts = p.getBuildByNumber(1).getArtifactManager().root();
         assertTrue(artifacts.child("target").child("file").exists());
     }
@@ -302,7 +302,7 @@ public class ArtifactArchiverTest {
         p.getPublishersList().replaceBy(Collections.singleton(archiver));
 
         assertEquals(Result.FAILURE, build(p));
-        Assert.assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
+        assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
     }
 
     @Test
@@ -317,7 +317,7 @@ public class ArtifactArchiverTest {
         p.getPublishersList().replaceBy(Collections.singleton(archiver));
 
         assertEquals(Result.FAILURE, build(p));
-        Assert.assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
+        assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
     }
 
     @Test
@@ -333,7 +333,7 @@ public class ArtifactArchiverTest {
         p.getPublishersList().replaceBy(Collections.singleton(archiver));
 
         assertEquals(Result.FAILURE, build(p));
-        Assert.assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
+        assertArrayEquals(new VirtualFile[0], p.getBuildByNumber(1).getArtifactManager().root().list());
     }
 
     @Test
@@ -342,21 +342,21 @@ public class ArtifactArchiverTest {
         ArtifactArchiver.DescriptorImpl desc = (ArtifactArchiver.DescriptorImpl)j.jenkins.getDescriptorOrDie(ArtifactArchiver.class);
 
         FreeStyleProject p = j.createFreeStyleProject();
-        Assert.assertEquals("no workspace", FormValidation.Kind.OK, desc.doCheckBasePath(p, "foo").kind);
-        Assert.assertEquals("relative path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "..").kind);
-        Assert.assertEquals("absolute path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "/").kind);
-        Assert.assertEquals("absolute path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "../workfoo").kind);
+        assertEquals("no workspace", FormValidation.Kind.OK, desc.doCheckBasePath(p, "foo").kind);
+        assertEquals("relative path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "..").kind);
+        assertEquals("absolute path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "/").kind);
+        assertEquals("absolute path breakout without workspace", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "../workfoo").kind);
 
         // create workspace for the project
         p.getBuildersList().replaceBy(Collections.singleton(new CreateFilesForBasePathTest()));
         build(p);
 
-        Assert.assertEquals("workspace exists but path does not", FormValidation.Kind.WARNING, desc.doCheckBasePath(p, "foo").kind);
-        Assert.assertEquals("workspace exists and path does", FormValidation.Kind.OK, desc.doCheckBasePath(p, "module").kind);
-        Assert.assertEquals("file specified as base path", FormValidation.Kind.WARNING, desc.doCheckBasePath(p, "module/dist/target/file").kind);
-        Assert.assertEquals("relative path breakout", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "..").kind);
+        assertEquals("workspace exists but path does not", FormValidation.Kind.WARNING, desc.doCheckBasePath(p, "foo").kind);
+        assertEquals("workspace exists and path does", FormValidation.Kind.OK, desc.doCheckBasePath(p, "module").kind);
+        assertEquals("file specified as base path", FormValidation.Kind.WARNING, desc.doCheckBasePath(p, "module/dist/target/file").kind);
+        assertEquals("relative path breakout", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "..").kind);
 
-        Assert.assertEquals("absolute path breakout", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "/").kind);
+        assertEquals("absolute path breakout", FormValidation.Kind.ERROR, desc.doCheckBasePath(p, "/").kind);
     }
 
     @Test


### PR DESCRIPTION
 This pull request supersedes #1493. Rebased my commits onto a recent master, and renamed _Search Context_ to _Base Path_.

### Changelog

* RFE: Allow specifying a base path for archiving artifacts.
* RFE: Developer: Add `FilePath#isDescendantOf`