### PR TITLE
Trim display name before applying it

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -164,7 +164,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     }
     
     public void setDisplayName(String displayName) throws IOException {
-        this.displayName = Util.fixEmpty(displayName);
+        this.displayName = Util.fixEmptyAndTrim(displayName);
         save();
     }
              

--- a/test/src/test/groovy/hudson/model/AbstractBuildTest.groovy
+++ b/test/src/test/groovy/hudson/model/AbstractBuildTest.groovy
@@ -151,6 +151,30 @@ public class AbstractBuildTest {
         assertThat(log, containsString("Build step 'Bogus' marked build as failure"));
     }
 
+    @Test void fixEmptyDisplayName() {
+        FreeStyleProject p = j.createFreeStyleProject("foo");
+        p.setDisplayName("");
+        assertEquals("An empty display name should be ignored.", "foo", p.getDisplayName());
+    }
+
+    @Test void fixBlankDisplayName() {
+        FreeStyleProject p = j.createFreeStyleProject("foo");
+        p.setDisplayName(" ");
+        assertEquals("A blank display name should be ignored.", "foo", p.getDisplayName());
+    }
+
+    @Test void validDisplayName() {
+        FreeStyleProject p = j.createFreeStyleProject("foo");
+        p.setDisplayName("bar");
+        assertEquals("A non-blank display name should be used.", "bar", p.getDisplayName());
+    }
+
+    @Test void trimValidDisplayName() {
+        FreeStyleProject p = j.createFreeStyleProject("foo");
+        p.setDisplayName("    bar    ");
+        assertEquals("A non-blank display name with whitespace should be trimmed.", "bar", p.getDisplayName());
+    }
+
     private static class ThrowBuilder extends org.jvnet.hudson.test.TestBuilder {
         @Override public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
             throw new NullPointerException();


### PR DESCRIPTION
The current implementation is not robust against blank display name

@reviewbybees
