### PR TITLE
Provide a default implementation of Descriptor.getDisplayName

### DIFF
--- a/core/src/main/java/hudson/console/ConsoleAnnotationDescriptor.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotationDescriptor.java
@@ -55,7 +55,10 @@ public abstract class ConsoleAnnotationDescriptor extends Descriptor<ConsoleNote
      *
      * Users use this name to enable/disable annotations.
      */
-    public abstract String getDisplayName();
+    @Override
+    public String getDisplayName() {
+        return super.getDisplayName();
+    }
 
     /**
      * Returns true if this descriptor has a JavaScript to be inserted on applicable console page.

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -380,11 +380,6 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
 
     @Extension
     public static class DescriptorImpl extends Descriptor<ComputerSet> {
-        @Override
-        public String getDisplayName() {
-            return "";
-        }
-
         /**
          * Auto-completion for the "copy from" field in the new job page.
          */

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -293,7 +293,8 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
 
     /**
      * Human readable name of this kind of configurable object.
-     * By default, it uses {@link Class#getSimpleName} on {@link #clazz}, but this should be overridden for visible descriptors.
+     * Should be overridden for most descriptors, if the display name is visible somehow.
+     * As a fallback it uses {@link Class#getSimpleName} on {@link #clazz}, so for example {@code MyThing} from {@code some.pkg.MyThing.DescriptorImpl}.
      */
     public String getDisplayName() {
         return clazz.getSimpleName();

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -295,7 +295,10 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
      * Human readable name of this kind of configurable object.
      * Should be overridden for most descriptors, if the display name is visible somehow.
      * As a fallback it uses {@link Class#getSimpleName} on {@link #clazz}, so for example {@code MyThing} from {@code some.pkg.MyThing.DescriptorImpl}.
+     * Historically some implementations returned null as a way of hiding the descriptor from the UI,
+     * but this is generally managed by an explicit method such as {@code isEnabled} or {@code isApplicable}.
      */
+    @Nonnull
     public String getDisplayName() {
         return clazz.getSimpleName();
     }

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -293,8 +293,11 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
 
     /**
      * Human readable name of this kind of configurable object.
+     * By default, it uses {@link Class#getSimpleName} on {@link #clazz}, but this should be overridden for visible descriptors.
      */
-    public abstract String getDisplayName();
+    public String getDisplayName() {
+        return clazz.getSimpleName();
+    }
 
     /**
      * Uniquely identifies this {@link Descriptor} among all the other {@link Descriptor}s.

--- a/core/src/main/java/hudson/model/PageDecorator.java
+++ b/core/src/main/java/hudson/model/PageDecorator.java
@@ -97,14 +97,6 @@ public abstract class PageDecorator extends Descriptor<PageDecorator> implements
     }
 
     /**
-     * Unless this object has additional web presence, display name is not used at all.
-     * So default to "".
-     */
-    public String getDisplayName() {
-        return "";
-    }
-
-    /**
      * Obtains the URL of this object, excluding the context path.
      *
      * <p>

--- a/core/src/main/java/hudson/model/PaneStatusProperties.java
+++ b/core/src/main/java/hudson/model/PaneStatusProperties.java
@@ -52,11 +52,6 @@ public class PaneStatusProperties extends UserProperty implements Saveable {
 		}
 
 		@Override
-		public String getDisplayName() {
-			return null;
-		}
-		
-		@Override
 		public boolean isEnabled() {
 			return false;
 		}

--- a/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
+++ b/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
@@ -108,7 +108,10 @@ public abstract class TopLevelItemDescriptor extends Descriptor<TopLevelItem> {
      * script, which will be used to render the text below the caption
      * that explains the item type.
      */
-    public abstract String getDisplayName();
+    @Override
+    public String getDisplayName() {
+        return super.getDisplayName();
+    }
 
     /**
      * @deprecated since 2007-01-19.

--- a/core/src/main/java/hudson/model/ViewDescriptor.java
+++ b/core/src/main/java/hudson/model/ViewDescriptor.java
@@ -45,7 +45,10 @@ public abstract class ViewDescriptor extends Descriptor<View> {
      * in the view creation screen. The string should look like
      * "Abc Def Ghi".
      */
-    public abstract String getDisplayName();
+    @Override
+    public String getDisplayName() {
+        return super.getDisplayName();
+    }
 
     /**
      * Some special views are not instantiable, and for those

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -541,12 +541,9 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
         @Extension
         public static final class DescriptorImpl extends UserPropertyDescriptor {
+            @Override
             public String getDisplayName() {
-                // this feature is only when HudsonPrivateSecurityRealm is enabled
-                if(isEnabled())
-                    return Messages.HudsonPrivateSecurityRealm_Details_DisplayName();
-                else
-                    return null;
+                return Messages.HudsonPrivateSecurityRealm_Details_DisplayName();
             }
 
             @Override
@@ -568,6 +565,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
             @Override
             public boolean isEnabled() {
+                // this feature is only when HudsonPrivateSecurityRealm is enabled
                 return Jenkins.getInstance().getSecurityRealm() instanceof HudsonPrivateSecurityRealm;
             }
 

--- a/core/src/main/java/hudson/slaves/RetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/RetentionStrategy.java
@@ -28,7 +28,6 @@ import hudson.Util;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.model.*;
-import hudson.model.Queue.*;
 import hudson.util.DescriptorList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -139,11 +138,7 @@ public abstract class RetentionStrategy<T extends Computer> extends AbstractDesc
 
         private final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
-        class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {
-            public String getDisplayName() {
-                return "";
-            }
-        }
+        class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {}
     };
 
     /**

--- a/core/src/main/java/jenkins/model/GlobalConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalConfiguration.java
@@ -51,14 +51,6 @@ public abstract class GlobalConfiguration extends Descriptor<GlobalConfiguration
         return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Unclassified.class);
     }
 
-    /**
-     * Unless this object has additional web presence, display name is not used at all.
-     * So default to "".
-     */
-    public String getDisplayName() {
-        return "";
-    }
-
     @Override
     public String getGlobalConfigPage() {
         return getConfigPage();

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1805,10 +1805,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         @Extension
         public static final DescriptorImpl INSTANCE = new DescriptorImpl();
 
-        public String getDisplayName() {
-            return "";
-        }
-
         @Override
         public boolean isInstantiable() {
             return false;

--- a/core/src/main/java/jenkins/security/LastGrantedAuthoritiesProperty.java
+++ b/core/src/main/java/jenkins/security/LastGrantedAuthoritiesProperty.java
@@ -148,10 +148,6 @@ public class LastGrantedAuthoritiesProperty extends UserProperty {
 
     @Extension
     public static final class DescriptorImpl extends UserPropertyDescriptor {
-        public String getDisplayName() {
-            return null;    // not visible
-        }
-
         @Override
         public LastGrantedAuthoritiesProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             return new LastGrantedAuthoritiesProperty();

--- a/core/src/main/java/jenkins/security/LastGrantedAuthoritiesProperty.java
+++ b/core/src/main/java/jenkins/security/LastGrantedAuthoritiesProperty.java
@@ -149,10 +149,10 @@ public class LastGrantedAuthoritiesProperty extends UserProperty {
     @Extension
     public static final class DescriptorImpl extends UserPropertyDescriptor {
         @Override
-        public LastGrantedAuthoritiesProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return new LastGrantedAuthoritiesProperty();
+        public boolean isEnabled() {
+            return false;
         }
-
+        
         public UserProperty newInstance(User user) {
             return null;
         }

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/Details/config.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/Details/config.jelly
@@ -24,12 +24,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <j:if test="${descriptor.enabled}">
     <f:entry title="${%Password}:">
       <input name="user.password" type="password" value="${instance.protectedPassword}" />
     </f:entry>
     <f:entry title="${%Confirm Password}:">
       <input name="user.password2" type="password" value="${instance.protectedPassword}" />
     </f:entry>
-  </j:if>
 </j:jelly>

--- a/test/src/main/java/org/jvnet/hudson/test/ComputerConnectorTester.java
+++ b/test/src/main/java/org/jvnet/hudson/test/ComputerConnectorTester.java
@@ -57,10 +57,5 @@ public class ComputerConnectorTester extends AbstractDescribableImpl<ComputerCon
     }
     
     @Extension
-    public static class DescriptorImpl extends Descriptor<ComputerConnectorTester> {
-        @Override
-        public String getDisplayName() {
-            return "";
-        }
-    }
+    public static class DescriptorImpl extends Descriptor<ComputerConnectorTester> {}
 }

--- a/test/src/main/java/org/jvnet/hudson/test/ExtractResourceWithChangesSCM.java
+++ b/test/src/main/java/org/jvnet/hudson/test/ExtractResourceWithChangesSCM.java
@@ -142,11 +142,7 @@ public class ExtractResourceWithChangesSCM extends NullSCM {
     private Object writeReplace() { return new Object(); }
 
     @Override public SCMDescriptor<?> getDescriptor() {
-        return new SCMDescriptor<ExtractResourceWithChangesSCM>(ExtractResourceWithChangesSCM.class, null) {
-            @Override public String getDisplayName() {
-                return "ExtractResourceWithChangesSCM";
-            }
-        };
+        return new SCMDescriptor<ExtractResourceWithChangesSCM>(ExtractResourceWithChangesSCM.class, null) {};
     }
 
 }

--- a/test/src/main/java/org/jvnet/hudson/test/FailureBuilder.java
+++ b/test/src/main/java/org/jvnet/hudson/test/FailureBuilder.java
@@ -42,9 +42,6 @@ public class FailureBuilder extends MockBuilder {
 
     @Extension
     public static final class DescriptorImpl extends Descriptor<Builder> {
-        public String getDisplayName() {
-            return "Always fail";
-        }
         public FailureBuilder newInstance(StaplerRequest req, JSONObject data) {
             return new FailureBuilder();
         }

--- a/test/src/main/java/org/jvnet/hudson/test/FakeChangeLogSCM.java
+++ b/test/src/main/java/org/jvnet/hudson/test/FakeChangeLogSCM.java
@@ -77,11 +77,7 @@ public class FakeChangeLogSCM extends NullSCM {
     }
 
     @Override public SCMDescriptor<?> getDescriptor() {
-        return new SCMDescriptor<SCM>(null) {
-            @Override public String getDisplayName() {
-                return "";
-            }
-        };
+        return new SCMDescriptor<SCM>(null) {};
     }
 
     public static class ChangelogAction extends InvisibleAction {

--- a/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
+++ b/test/src/main/java/org/jvnet/hudson/test/HudsonTestCase.java
@@ -2049,11 +2049,6 @@ public abstract class HudsonTestCase extends TestCase implements RootAction {
             public BuildWrapper newInstance(StaplerRequest req, JSONObject formData) {
                 throw new UnsupportedOperationException();
             }
-
-            @Override
-            public String getDisplayName() {
-                return this.getClass().getName();
-            }
         }
     }
 }

--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsComputerConnectorTester.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsComputerConnectorTester.java
@@ -58,10 +58,5 @@ public class JenkinsComputerConnectorTester extends AbstractDescribableImpl<Jenk
     }
     
     @Extension
-    public static class DescriptorImpl extends Descriptor<JenkinsComputerConnectorTester> {
-        @Override
-        public String getDisplayName() {
-            return "";
-        }
-    }
+    public static class DescriptorImpl extends Descriptor<JenkinsComputerConnectorTester> {}
 }

--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -2358,11 +2358,6 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
             public BuildWrapper newInstance(StaplerRequest req, JSONObject formData) {
                 throw new UnsupportedOperationException();
             }
-
-            @Override
-            public String getDisplayName() {
-                return this.getClass().getName();
-            }
         }
     }
 

--- a/test/src/main/java/org/jvnet/hudson/test/MockBuilder.java
+++ b/test/src/main/java/org/jvnet/hudson/test/MockBuilder.java
@@ -41,10 +41,6 @@ public class MockBuilder extends Builder {
         public Builder newInstance(StaplerRequest req, JSONObject data) {
             throw new UnsupportedOperationException();
         }
-
-        public String getDisplayName() {
-            return "Force the build result";
-        }
     }
 }
 

--- a/test/src/main/java/org/jvnet/hudson/test/MockFolder.java
+++ b/test/src/main/java/org/jvnet/hudson/test/MockFolder.java
@@ -271,10 +271,6 @@ public class MockFolder extends AbstractItem implements DirectlyModifiableTopLev
 
     @Extension public static class DescriptorImpl extends TopLevelItemDescriptor {
 
-        @Override public String getDisplayName() {
-            return "MockFolder";
-        }
-
         @Override public TopLevelItem newInstance(ItemGroup parent, String name) {
             return new MockFolder(parent, name);
         }

--- a/test/src/main/java/org/jvnet/hudson/test/MockQueueItemAuthenticator.java
+++ b/test/src/main/java/org/jvnet/hudson/test/MockQueueItemAuthenticator.java
@@ -61,12 +61,6 @@ public final class MockQueueItemAuthenticator extends QueueItemAuthenticator {
         }
     }
     
-    @Extension public static final class DescriptorImpl extends QueueItemAuthenticatorDescriptor {
-        
-        @Override public String getDisplayName() {
-            return "MockQueueItemAuthenticator";
-        }
-
-    }
+    @Extension public static final class DescriptorImpl extends QueueItemAuthenticatorDescriptor {}
 
 }

--- a/test/src/main/java/org/jvnet/hudson/test/PretendSlave.java
+++ b/test/src/main/java/org/jvnet/hudson/test/PretendSlave.java
@@ -53,9 +53,5 @@ public class PretendSlave extends Slave {
     }
 
     @Extension
-    public static final class DescriptorImpl extends SlaveDescriptor {
-        public String getDisplayName() {
-            return "Test mock up slave";
-        }
-    }
+    public static final class DescriptorImpl extends SlaveDescriptor {}
 }

--- a/test/src/main/java/org/jvnet/hudson/test/SleepBuilder.java
+++ b/test/src/main/java/org/jvnet/hudson/test/SleepBuilder.java
@@ -53,9 +53,5 @@ public class SleepBuilder extends Builder {
     }
 
     @Extension
-    public static final class DescriptorImpl extends Descriptor<Builder> {
-        public String getDisplayName() {
-            return "Sleep";
-        }
-    }
+    public static final class DescriptorImpl extends Descriptor<Builder> {}
 }

--- a/test/src/main/java/org/jvnet/hudson/test/TestBuilder.java
+++ b/test/src/main/java/org/jvnet/hudson/test/TestBuilder.java
@@ -53,11 +53,6 @@ public abstract class TestBuilder extends Builder {
             public boolean isApplicable(Class<? extends AbstractProject> jobType) {
                 return true;
             }
-
-            @Override
-            public String getDisplayName() {
-                return "Bogus";
-            }
         };
     }
 

--- a/test/src/main/java/org/jvnet/hudson/test/TestCrumbIssuer.java
+++ b/test/src/main/java/org/jvnet/hudson/test/TestCrumbIssuer.java
@@ -42,11 +42,6 @@ public class TestCrumbIssuer extends CrumbIssuer
             load();
         }
 
-        @Override
-        public String getDisplayName() {
-            return "Test Crumb";
-        }
-        
         public TestCrumbIssuer newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             return new TestCrumbIssuer();
         }

--- a/test/src/main/java/org/jvnet/hudson/test/TestNotifier.java
+++ b/test/src/main/java/org/jvnet/hudson/test/TestNotifier.java
@@ -41,11 +41,6 @@ public abstract class TestNotifier extends Notifier {
             public boolean isApplicable(Class<? extends AbstractProject> jobType) {
                 return true;
             }
-
-            @Override
-            public String getDisplayName() {
-                return "Bogus";
-            }
         };
     }
 

--- a/test/src/main/java/org/jvnet/hudson/test/UnstableBuilder.java
+++ b/test/src/main/java/org/jvnet/hudson/test/UnstableBuilder.java
@@ -42,9 +42,6 @@ public class UnstableBuilder extends MockBuilder {
 
     @Extension
     public static final class DescriptorImpl extends Descriptor<Builder> {
-        public String getDisplayName() {
-            return "Make build unstable";
-        }
         public UnstableBuilder newInstance(StaplerRequest req, JSONObject data) {
             return new UnstableBuilder();
         }

--- a/test/src/test/groovy/hudson/RelativePathTest.groovy
+++ b/test/src/test/groovy/hudson/RelativePathTest.groovy
@@ -38,22 +38,12 @@ class RelativePathTest extends HudsonTestCase implements Describable<RelativePat
     }
 
     @TestExtension
-    static class DescriptorImpl extends Descriptor<RelativePathTest> {
-        @Override
-        String getDisplayName() {
-            return "";
-        }
-    }
+    static class DescriptorImpl extends Descriptor<RelativePathTest> {}
 
     static class Model extends AbstractDescribableImpl<Model> {
         @TestExtension
         static class DescriptorImpl extends Descriptor<Model> {
             boolean touched;
-
-            @Override
-            String getDisplayName() {
-                return "test";
-            }
 
             ListBoxModel doFillAbcItems(@RelativePath("..") @QueryParameter String name) {
                 assert name=="Alice";

--- a/test/src/test/groovy/hudson/cli/BuildCommandTest.groovy
+++ b/test/src/test/groovy/hudson/cli/BuildCommandTest.groovy
@@ -292,12 +292,6 @@ public class BuildCommandTest {
         }
         
         @Extension
-        public static class DescriptorImpl extends ParameterDescriptor {
-
-            @Override
-            public String getDisplayName() {
-                return "Parameter with the default NULL value"; 
-            }   
-        }
+        public static class DescriptorImpl extends ParameterDescriptor {}
     }
 }

--- a/test/src/test/groovy/hudson/model/AbstractBuildTest.groovy
+++ b/test/src/test/groovy/hudson/model/AbstractBuildTest.groovy
@@ -28,13 +28,16 @@ import java.io.IOException;
 import com.gargoylesoftware.htmlunit.Page
 
 import hudson.Launcher;
+import hudson.model.Descriptor;
 import hudson.slaves.EnvironmentVariablesNodeProperty
 import hudson.slaves.EnvironmentVariablesNodeProperty.Entry
+import hudson.tasks.Builder
 
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder
 import org.jvnet.hudson.test.GroovyJenkinsRule
 import org.jvnet.hudson.test.FakeChangeLogSCM
 import org.jvnet.hudson.test.FailureBuilder
+import org.jvnet.hudson.test.TestExtension
 import org.jvnet.hudson.test.UnstableBuilder
 
 import static org.junit.Assert.*
@@ -140,7 +143,7 @@ public class AbstractBuildTest {
         assertEquals(null, b1.getNextBuild());
     }
 
-    @Test void doNotInteruptBuildAbruptlyWhenExceptionThrownFromBuildStep() {
+    @Test void doNotInterruptBuildAbruptlyWhenExceptionThrownFromBuildStep() {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildersList().add(new ThrowBuilder());
         def build = p.scheduleBuild2(0).get();
@@ -148,7 +151,7 @@ public class AbstractBuildTest {
 
         def log = build.log;
         assertThat(log, containsString("Finished: FAILURE"));
-        assertThat(log, containsString("Build step 'Bogus' marked build as failure"));
+        assertThat(log, containsString("Build step 'ThrowBuilder' marked build as failure"));
     }
 
     @Test void fixEmptyDisplayName() {
@@ -175,9 +178,11 @@ public class AbstractBuildTest {
         assertEquals("A non-blank display name with whitespace should be trimmed.", "bar", p.getDisplayName());
     }
 
-    private static class ThrowBuilder extends org.jvnet.hudson.test.TestBuilder {
+    private static class ThrowBuilder extends Builder {
         @Override public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
             throw new NullPointerException();
         }
+        @TestExtension("doNotInterruptBuildAbruptlyWhenExceptionThrownFromBuildStep")
+        public static class DescriptorImpl extends Descriptor<Builder> {}
     }
 }

--- a/test/src/test/groovy/hudson/model/AbstractProjectTest.groovy
+++ b/test/src/test/groovy/hudson/model/AbstractProjectTest.groovy
@@ -193,11 +193,7 @@ public class AbstractProjectTest extends HudsonTestCase {
                 return true;
             }
             @Override public SCMDescriptor<?> getDescriptor() {
-                return new SCMDescriptor<SCM>(null) {
-                    @Override public String getDisplayName() {
-                        return "";
-                    }
-                };
+                return new SCMDescriptor<SCM>(null) {};
             }
         };
         Thread t = new Thread() {
@@ -625,11 +621,6 @@ public class AbstractProjectTest extends HudsonTestCase {
 
             public boolean isApplicable(hudson.model.Item item) {
                 return false;
-            }
-
-            @Override
-            String getDisplayName() {
-                return "test";
             }
         }
     }

--- a/test/src/test/groovy/jenkins/bugs/Jenkins19124Test.groovy
+++ b/test/src/test/groovy/jenkins/bugs/Jenkins19124Test.groovy
@@ -71,11 +71,6 @@ class Jenkins19124Test {
             super(Foo.class)
         }
 
-        @Override
-        String getDisplayName() {
-            return "---";
-        }
-
         FormValidation doCheckAlpha(@QueryParameter String value, @QueryParameter String bravo) {
             this.alpha = value;
             this.bravo = bravo;

--- a/test/src/test/groovy/lib/form/TextAreaTest.groovy
+++ b/test/src/test/groovy/lib/form/TextAreaTest.groovy
@@ -62,11 +62,6 @@ class TextAreaTest {
                 this.text2 = "Received "+text1;
                 return FormValidation.ok();
             }
-
-            @Override
-            String getDisplayName() {
-                return this.class.name;
-            }
         }
 
     }

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -90,11 +90,7 @@ public class ExtensionListTest {
 //
 //
 
-    public static abstract class FishDescriptor extends Descriptor<Fish> {
-        public String getDisplayName() {
-            return clazz.getName();
-        }
-    }
+    public static abstract class FishDescriptor extends Descriptor<Fish> {}
 
     public static abstract class Fish implements Describable<Fish> {
         public Descriptor<Fish> getDescriptor() {

--- a/test/src/test/java/hudson/ProcStarterTest.java
+++ b/test/src/test/java/hudson/ProcStarterTest.java
@@ -33,6 +33,7 @@ import hudson.tasks.BuildWrapperDescriptor;
 import java.io.IOException;
 import org.jvnet.hudson.test.Issue;
 import hudson.Launcher.DecoratedLauncher;
+import hudson.Launcher.ProcStarter;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -71,11 +72,6 @@ public class ProcStarterTest {
         @Override
         public boolean isApplicable(AbstractProject<?, ?> ap) {
             return true;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "testStub";
         }
     }
 

--- a/test/src/test/java/hudson/console/ConsoleAnnotatorTest.java
+++ b/test/src/test/java/hudson/console/ConsoleAnnotatorTest.java
@@ -272,11 +272,7 @@ public class ConsoleAnnotatorTest {
         }
 
         @TestExtension
-        public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
-            public String getDisplayName() {
-                return "Dollar mark";
-            }
-        }
+        public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {}
     }
 
 
@@ -299,11 +295,7 @@ public class ConsoleAnnotatorTest {
         }
 
         @TestExtension("scriptInclusion")
-        public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
-            public String getDisplayName() {
-                return "just to include a script";
-            }
-        }
+        public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {}
     }
 
     @TestExtension("scriptInclusion")
@@ -373,11 +365,6 @@ public class ConsoleAnnotatorTest {
         public static final class DescriptorImpl extends SCMDescriptor<PollingSCM> {
             public DescriptorImpl() {
                 super(PollingSCM.class, RepositoryBrowser.class);
-            }
-
-            @Override
-            public String getDisplayName() {
-                return "Test SCM";
             }
         }
     }

--- a/test/src/test/java/hudson/markup/MarkupFormatterTest.java
+++ b/test/src/test/java/hudson/markup/MarkupFormatterTest.java
@@ -67,11 +67,6 @@ public class MarkupFormatterTest {
         }
 
         @TestExtension
-        public static class DescriptorImpl extends MarkupFormatterDescriptor {
-            @Override
-            public String getDisplayName() {
-                return "dummy";
-            }
-        }
+        public static class DescriptorImpl extends MarkupFormatterDescriptor {}
     }
 }

--- a/test/src/test/java/hudson/model/AbstractBuildTest2.java
+++ b/test/src/test/java/hudson/model/AbstractBuildTest2.java
@@ -71,12 +71,6 @@ public class AbstractBuildTest2 {
         }
         
         @TestExtension("reportErrorShouldNotFailForNonPublisherClass")
-        public static class DescriptorImpl extends JobPropertyDescriptor {
-
-            @Override
-            public String getDisplayName() {
-                return "Always throws exception in perform()";
-            }  
-        }
+        public static class DescriptorImpl extends JobPropertyDescriptor {}
     }
 }

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -107,9 +107,6 @@ public class DescriptorTest {
         @Override public Builder newInstance(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
             return new BuilderImpl(id);
         }
-        @Override public String getDisplayName() {
-            return id;
-        }
         @Override public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
         }
@@ -130,14 +127,12 @@ public class DescriptorTest {
     public static class D1 extends D {
         @DataBoundConstructor public D1() {}
         @TestExtension("nestedDescribableOverridingId") public static class DescriptorImpl extends Descriptor<D> {
-            @Override public String getDisplayName() {return "D 1";}
             @Override public String getId() {return "D1-id";}
         }
     }
     public static class D2 extends D {
         @DataBoundConstructor public D2() {}
         @TestExtension("nestedDescribableOverridingId") public static class DescriptorImpl extends Descriptor<D> {
-            @Override public String getDisplayName() {return "D 2";}
             @Override public String getId() {return "D2-id";}
         }
     }
@@ -150,9 +145,7 @@ public class DescriptorTest {
             listener.getLogger().println(ds);
             return true;
         }
-        @TestExtension("nestedDescribableOverridingId") public static class DescriptorImpl extends Descriptor<Builder> {
-            @Override public String getDisplayName() {return "B1";}
-        }
+        @TestExtension("nestedDescribableOverridingId") public static class DescriptorImpl extends Descriptor<Builder> {}
     }
 
     @Ignore("never worked: TypePair.convertJSON looks for @DataBoundConstructor on D3 (Stapler does not grok Descriptor)")
@@ -187,9 +180,6 @@ public class DescriptorTest {
         @Override public D3 newInstance(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
             return new D3(id);
         }
-        @Override public String getDisplayName() {
-            return id;
-        }
     }
     @TestExtension("nestedDescribableSharingClass") public static final Descriptor<D3> d3a = new D3D("d3a");
     @TestExtension("nestedDescribableSharingClass") public static final Descriptor<D3> d3b = new D3D("d3b");
@@ -202,9 +192,7 @@ public class DescriptorTest {
             listener.getLogger().println(ds);
             return true;
         }
-        @TestExtension("nestedDescribableSharingClass") public static class DescriptorImpl extends Descriptor<Builder> {
-            @Override public String getDisplayName() {return "B2";}
-        }
+        @TestExtension("nestedDescribableSharingClass") public static class DescriptorImpl extends Descriptor<Builder> {}
     }
 
 }

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -119,7 +119,7 @@ public class DescriptorTest {
         FreeStyleProject p = rule.createFreeStyleProject("p");
         p.getBuildersList().add(new B1(Arrays.asList(new D1(), new D2())));
         rule.configRoundtrip(p);
-        rule.assertLogContains("[D 1, D 2]", rule.buildAndAssertSuccess(p));
+        rule.assertLogContains("[D1, D2]", rule.buildAndAssertSuccess(p));
     }
     public static abstract class D extends AbstractDescribableImpl<D> {
         @Override public String toString() {return getDescriptor().getDisplayName();}

--- a/test/src/test/java/hudson/model/ExecutorTest.java
+++ b/test/src/test/java/hudson/model/ExecutorTest.java
@@ -9,6 +9,7 @@ import hudson.Launcher;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
+import hudson.tasks.Builder;
 import hudson.util.OneShotEvent;
 import jenkins.model.CauseOfInterruption.UserInterruption;
 import jenkins.model.InterruptedBuildAction;
@@ -17,11 +18,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.TestBuilder;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.jvnet.hudson.test.TestExtension;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -139,7 +139,7 @@ public class ExecutorTest {
         String log = b.getLog();
         assertEquals(b.getResult(), Result.FAILURE);
         assertThat(log, containsString("Finished: FAILURE"));
-        assertThat(log, containsString("Build step 'Bogus' marked build as failure"));
+        assertThat(log, containsString("Build step 'BlockingBuilder' marked build as failure"));
         assertThat(log, containsString("Slave went offline during the build"));
         assertThat(log, containsString("Disconnected by Johnny : Taking offline to break your buil"));
     }
@@ -156,7 +156,7 @@ public class ExecutorTest {
         return r;
     }
 
-    private static final class BlockingBuilder extends TestBuilder {
+    private static final class BlockingBuilder extends Builder {
         private final OneShotEvent e;
 
         private BlockingBuilder(OneShotEvent e) {
@@ -175,5 +175,7 @@ public class ExecutorTest {
                 Thread.sleep(100);
             }
         }
+        @TestExtension("disconnectCause")
+        public static class DescriptorImpl extends Descriptor<Builder> {}
     }
 }

--- a/test/src/test/java/hudson/model/HelpLinkTest.java
+++ b/test/src/test/java/hudson/model/HelpLinkTest.java
@@ -79,10 +79,6 @@ public class HelpLinkTest {
             public String getHelpFile() {
                 return "no-such-file/exists";
             }
-
-            public String getDisplayName() {
-                return "I don't have the help file";
-            }
         }
 
         public BuildStepMonitor getRequiredMonitorService() {

--- a/test/src/test/java/hudson/model/HudsonTest.java
+++ b/test/src/test/java/hudson/model/HudsonTest.java
@@ -184,11 +184,7 @@ public class HudsonTest {
     @Test
     @Email("http://www.nabble.com/1.286-version-and-description-The-requested-resource-%28%29-is-not--available.-td22233801.html")
     public void legacyDescriptorLookup() throws Exception {
-        Descriptor dummy = new Descriptor(HudsonTest.class) {
-            public String getDisplayName() {
-                return "dummy";
-            }
-        };
+        Descriptor dummy = new Descriptor(HudsonTest.class) {};
 
         BuildStep.PUBLISHERS.addRecorder(dummy);
         assertSame(dummy, j.jenkins.getDescriptor(HudsonTest.class.getName()));

--- a/test/src/test/java/hudson/model/ItemGroupMixInTest.java
+++ b/test/src/test/java/hudson/model/ItemGroupMixInTest.java
@@ -129,11 +129,6 @@ public class ItemGroupMixInTest {
       public boolean isApplicable(AbstractProject<?, ?> item) {
         return true;
       }
-
-      @Override
-      public String getDisplayName() {
-        return null;
-      }
     }
   }
 
@@ -149,11 +144,6 @@ public class ItemGroupMixInTest {
       @Override
       public boolean isApplicable(Class jobType) {
         return false;
-      }
-
-      @Override
-      public String getDisplayName() {
-        return null;
       }
     }
   }
@@ -186,11 +176,6 @@ public class ItemGroupMixInTest {
       @Override
       public boolean isApplicable(Class jobType) {
         return false;
-      }
-
-      @Override
-      public String getDisplayName() {
-        return null;
       }
     }
   }

--- a/test/src/test/java/hudson/model/JobPropertyTest.java
+++ b/test/src/test/java/hudson/model/JobPropertyTest.java
@@ -89,11 +89,6 @@ public class JobPropertyTest {
             public boolean isApplicable(Class<? extends Job> jobType) {
                 return false;
             }
-
-            @Override
-            public String getDisplayName() {
-                return "Fake job property";
-            }
         }
     }
 
@@ -120,10 +115,7 @@ public class JobPropertyTest {
         }
 
         @TestExtension("configRoundtrip")
-        public static class DescriptorImpl extends JobPropertyDescriptor {
-            @Override
-            public String getDisplayName() { return null; }
-        }
+        public static class DescriptorImpl extends JobPropertyDescriptor {}
     }
 
     @Test
@@ -147,9 +139,6 @@ public class JobPropertyTest {
         }
 
         @TestExtension("invisibleProperty")
-        public static class DescriptorImpl extends JobPropertyDescriptor {
-            @Override
-            public String getDisplayName() { return null; }
-        }
+        public static class DescriptorImpl extends JobPropertyDescriptor {}
     }
 }

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -836,11 +836,7 @@ public class ProjectTest {
             return true;
         }
         @Override public SCMDescriptor<?> getDescriptor() {
-            return new SCMDescriptor<SCM>(null) {
-                @Override public String getDisplayName() {
-                    return "";
-                }
-            };
+            return new SCMDescriptor<SCM>(null) {};
         }
         
         @Override

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -658,11 +658,6 @@ public class QueueTest {
                      }
             };
         }
-
-            @Override
-            public String getDisplayName() {
-                return "simulate-error";
-            }
         };
         FreeStyleProject projectError = (FreeStyleProject) r.jenkins.createProject(descriptor, "throw-error");
         project1.setAssignedLabel(r.jenkins.getSelfLabel());
@@ -894,11 +889,6 @@ public class QueueTest {
         }
 
         @TestExtension("shouldBeAbleToBlockFlyWeightTaskOnLastMinute")
-        public static class DescriptorImpl extends NodePropertyDescriptor {
-            @Override
-            public String getDisplayName() {
-                return "Some Property";
-            }
-        }
+        public static class DescriptorImpl extends NodePropertyDescriptor {}
     }
 }

--- a/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
@@ -279,11 +279,7 @@ public class RunParameterDefinitionTest {
         }
 
         public Descriptor<Publisher> getDescriptor() {
-            return new Descriptor<Publisher>(ResultPublisher.class) {
-                public String getDisplayName() {
-                    return "ResultPublisher";
-                }
-            };
+            return new Descriptor<Publisher>(ResultPublisher.class) {};
         }
     }
 }

--- a/test/src/test/java/hudson/model/UserPropertyTest.java
+++ b/test/src/test/java/hudson/model/UserPropertyTest.java
@@ -29,10 +29,6 @@ public class UserPropertyTest {
     public static class UserProperty1 extends UserProperty {
         @TestExtension
         public static class DescriptorImpl extends UserPropertyDescriptor {
-            public String getDisplayName() {
-                return "UserProperty1";
-            }
-
             @Override
             public UserProperty newInstance(User user) {
                 return new UserProperty1();
@@ -43,10 +39,6 @@ public class UserPropertyTest {
     public static class UserProperty2 extends UserProperty {
         @TestExtension
         public static class DescriptorImpl extends UserPropertyDescriptor {
-            public String getDisplayName() {
-                return "UserProperty2";
-            }
-
             @Override
             public boolean isEnabled() {
                 return false;

--- a/test/src/test/java/hudson/model/UserTest.java
+++ b/test/src/test/java/hudson/model/UserTest.java
@@ -101,11 +101,6 @@ public class UserTest {
           public UserProperty newInstance(User user) {
               return null;
           }
-
-          @Override
-          public String getDisplayName() {
-              return "Property";
-          }
       }
     }
 
@@ -546,10 +541,6 @@ public class UserTest {
          
         @TestExtension
         public static class DescriptorImpl extends UserPropertyDescriptor {
-            public String getDisplayName() {
-                return "UserProperty1";
-            }
-
             @Override
             public UserProperty newInstance(User user) {
                 return new SomeUserProperty();

--- a/test/src/test/java/hudson/model/ViewJobTest.java
+++ b/test/src/test/java/hudson/model/ViewJobTest.java
@@ -69,10 +69,6 @@ public class ViewJobTest {
 
         @TestExtension public static final class DescriptorImpl extends TopLevelItemDescriptor {
 
-            @Override public String getDisplayName() {
-                return "J";
-            }
-
             @Override public TopLevelItem newInstance(ItemGroup parent, String name) {
                 return new J(parent, name);
             }

--- a/test/src/test/java/hudson/model/ViewPropertyTest.java
+++ b/test/src/test/java/hudson/model/ViewPropertyTest.java
@@ -65,12 +65,7 @@ public class ViewPropertyTest extends HudsonTestCase {
         }
 
         @TestExtension
-        public static class DescriptorImpl extends ViewPropertyDescriptor {
-            @Override
-            public String getDisplayName() {
-                return "Debug Property";
-            }
-        }
+        public static class DescriptorImpl extends ViewPropertyDescriptor {}
     }
 
     public void testInvisibleProperty() throws Exception {
@@ -98,11 +93,6 @@ public class ViewPropertyTest extends HudsonTestCase {
         }
 
         @TestExtension
-        public static class DescriptorImpl extends ViewPropertyDescriptor {
-            @Override
-            public String getDisplayName() {
-                return null;
-            }
-        }
+        public static class DescriptorImpl extends ViewPropertyDescriptor {}
     }
 }

--- a/test/src/test/java/hudson/model/ViewPropertyTest.java
+++ b/test/src/test/java/hudson/model/ViewPropertyTest.java
@@ -43,7 +43,7 @@ public class ViewPropertyTest extends HudsonTestCase {
 
         // make sure it renders as optionalBlock
         HtmlForm f = createWebClient().getPage(foo, "configure").getFormByName("viewConfig");
-        ((HtmlLabel) DomNodeUtil.selectSingleNode(f, ".//LABEL[text()='Debug Property']")).click();
+        ((HtmlLabel) DomNodeUtil.selectSingleNode(f, ".//LABEL[text()='ViewPropertyImpl']")).click();
         submit(f);
         ViewPropertyImpl vp = foo.getProperties().get(ViewPropertyImpl.class);
         assertEquals("Duke",vp.name);

--- a/test/src/test/java/hudson/model/labels/LabelAtomPropertyTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelAtomPropertyTest.java
@@ -49,12 +49,7 @@ public class LabelAtomPropertyTest {
         }
 
         @TestExtension
-        public static class DescriptorImpl extends LabelAtomPropertyDescriptor {
-            @Override
-            public String getDisplayName() {
-                return "Test label atom property";
-            }
-        }
+        public static class DescriptorImpl extends LabelAtomPropertyDescriptor {}
     }
 
     /**

--- a/test/src/test/java/hudson/model/utils/AbortExceptionPublisher.java
+++ b/test/src/test/java/hudson/model/utils/AbortExceptionPublisher.java
@@ -28,8 +28,6 @@ public class AbortExceptionPublisher extends Recorder {
     @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         @Override
-        public String getDisplayName() { return "ThrowAbortExceptionRecorder"; }
-        @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) { return true; }
     }
 }

--- a/test/src/test/java/hudson/model/utils/IOExceptionPublisher.java
+++ b/test/src/test/java/hudson/model/utils/IOExceptionPublisher.java
@@ -28,8 +28,6 @@ public class IOExceptionPublisher extends Recorder {
     @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         @Override
-        public String getDisplayName() { return "Throw IOException Publisher"; }
-        @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) { return true; }
     }
 }

--- a/test/src/test/java/hudson/model/utils/ResultWriterPublisher.java
+++ b/test/src/test/java/hudson/model/utils/ResultWriterPublisher.java
@@ -40,8 +40,6 @@ public class ResultWriterPublisher extends Recorder {
     @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         @Override
-        public String getDisplayName() { return "wrote result to file"; }
-        @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) { return true; }
     }
 }

--- a/test/src/test/java/hudson/model/utils/TrueFalsePublisher.java
+++ b/test/src/test/java/hudson/model/utils/TrueFalsePublisher.java
@@ -35,8 +35,6 @@ public class TrueFalsePublisher extends Recorder {
     @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         @Override
-        public String getDisplayName() { return "return true or false"; }
-        @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) { return true; }
     }
 }

--- a/test/src/test/java/hudson/pages/SystemConfigurationTestCase.java
+++ b/test/src/test/java/hudson/pages/SystemConfigurationTestCase.java
@@ -74,11 +74,6 @@ public class SystemConfigurationTestCase {
             return true;
         }
 
-        @Override
-        public String getDisplayName() {
-            return "PageDecoratorImpl";
-        }
-
         public String getDecoratorId() {
             return decoratorId;
         }

--- a/test/src/test/java/hudson/slaves/NodePropertyTest.java
+++ b/test/src/test/java/hudson/slaves/NodePropertyTest.java
@@ -59,7 +59,7 @@ public class NodePropertyTest {
     public void basicConfigRoundtrip() throws Exception {
         DumbSlave s = j.createSlave();
         HtmlForm f = j.createWebClient().goTo("computer/" + s.getNodeName() + "/configure").getFormByName("config");
-        ((HtmlLabel)DomNodeUtil.selectSingleNode(f, ".//LABEL[text()='Some Property']")).click();
+        ((HtmlLabel)DomNodeUtil.selectSingleNode(f, ".//LABEL[text()='PropertyImpl']")).click();
         j.submit(f);
         PropertyImpl p = j.jenkins.getNode(s.getNodeName()).getNodeProperties().get(PropertyImpl.class);
         assertEquals("Duke",p.name);

--- a/test/src/test/java/hudson/slaves/NodePropertyTest.java
+++ b/test/src/test/java/hudson/slaves/NodePropertyTest.java
@@ -52,12 +52,7 @@ public class NodePropertyTest {
         }
 
         @TestExtension("invisibleProperty")
-        public static class DescriptorImpl extends NodePropertyDescriptor {
-            @Override
-            public String getDisplayName() {
-                return null;
-            }
-        }
+        public static class DescriptorImpl extends NodePropertyDescriptor {}
     }
 
     @Test
@@ -86,11 +81,6 @@ public class NodePropertyTest {
         }
 
         @TestExtension("basicConfigRoundtrip")
-        public static class DescriptorImpl extends NodePropertyDescriptor {
-            @Override
-            public String getDisplayName() {
-                return "Some Property";
-            }
-        }
+        public static class DescriptorImpl extends NodePropertyDescriptor {}
     }
 }

--- a/test/src/test/java/hudson/tasks/LogRotatorTest.java
+++ b/test/src/test/java/hudson/tasks/LogRotatorTest.java
@@ -220,11 +220,7 @@ public class LogRotatorTest {
         }
 
         public Descriptor<Publisher> getDescriptor() {
-            return new Descriptor<Publisher>(TestsFail.class) {
-                public String getDisplayName() {
-                    return "TestsFail";
-                }
-            };
+            return new Descriptor<Publisher>(TestsFail.class) {};
         }
     }
     

--- a/test/src/test/java/hudson/triggers/TriggerStartTest.java
+++ b/test/src/test/java/hudson/triggers/TriggerStartTest.java
@@ -127,10 +127,6 @@ public class TriggerStartTest {
                 return true;
             }
 
-            @Override public String getDisplayName() {
-                return "mock trigger";
-            }
-
         }
 
     }

--- a/test/src/test/java/hudson/util/FormFieldValidatorTest.java
+++ b/test/src/test/java/hudson/util/FormFieldValidatorTest.java
@@ -63,10 +63,6 @@ public class FormFieldValidatorTest {
             public void doCheckXyz() {
                 throw new Error("doCheckXyz is broken");
             }
-
-            public String getDisplayName() {
-                return "I have broken form field validation";
-            }
         }
 
         public BuildStepMonitor getRequiredMonitorService() {

--- a/test/src/test/java/jenkins/scm/SCMCheckoutStrategyTest.java
+++ b/test/src/test/java/jenkins/scm/SCMCheckoutStrategyTest.java
@@ -74,11 +74,6 @@ public class SCMCheckoutStrategyTest {
             public boolean isApplicable(AbstractProject project) {
                 return true;
             }
-
-            @Override
-            public String getDisplayName() {
-                return getClass().getName();
-            }
         }
     }
 }

--- a/test/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
+++ b/test/src/test/java/jenkins/tasks/SimpleBuildWrapperTest.java
@@ -87,9 +87,6 @@ public class SimpleBuildWrapperTest {
             context.env("PATH+STUFF", workspace.child("bin").getRemote());
         }
         @TestExtension("envOverride") public static class DescriptorImpl extends BuildWrapperDescriptor {
-            @Override public String getDisplayName() {
-                return "WrapperWithEnvOverride";
-            }
             @Override public boolean isApplicable(AbstractProject<?,?> item) {
                 return true;
             }
@@ -123,9 +120,6 @@ public class SimpleBuildWrapperTest {
             context.env("PATH+EXTRA", "${EXTRA}/bin");
         }
         @TestExtension("envOverrideExpand") public static class DescriptorImpl extends BuildWrapperDescriptor {
-            @Override public String getDisplayName() {
-                return "WrapperWithEnvOverrideExpand";
-            }
             @Override public boolean isApplicable(AbstractProject<?,?> item) {
                 return true;
             }
@@ -167,9 +161,6 @@ public class SimpleBuildWrapperTest {
             }
         }
         @TestExtension("disposer") public static class DescriptorImpl extends BuildWrapperDescriptor {
-            @Override public String getDisplayName() {
-                return "WrapperWithDisposer";
-            }
             @Override public boolean isApplicable(AbstractProject<?,?> item) {
                 return true;
             }
@@ -205,9 +196,6 @@ public class SimpleBuildWrapperTest {
             }
         }
         @TestExtension("loggerDecorator") public static class DescriptorImpl extends BuildWrapperDescriptor {
-            @Override public String getDisplayName() {
-                return "WrapperWithLogger";
-            }
             @Override public boolean isApplicable(AbstractProject<?,?> item) {
                 return true;
             }

--- a/test/src/test/java/lib/form/ComboBoxTest.java
+++ b/test/src/test/java/lib/form/ComboBoxTest.java
@@ -71,10 +71,6 @@ public class ComboBoxTest extends HudsonTestCase {
                 }
                 return new ComboBoxModel(abc, xyz);
             }
-
-            public String getDisplayName() {
-                return "Compound Field used to populate combobox";
-            }
         }
 
         public CompoundField getCompoundField() {
@@ -109,9 +105,7 @@ public class ComboBoxTest extends HudsonTestCase {
         }
         
         @Extension
-        public static final class DescriptorImpl extends Descriptor<CompoundField> {
-            public String getDisplayName() { return ""; }
-        }
+        public static final class DescriptorImpl extends Descriptor<CompoundField> {}
     }
 
     /**

--- a/test/src/test/java/lib/form/PasswordTest.java
+++ b/test/src/test/java/lib/form/PasswordTest.java
@@ -50,9 +50,5 @@ public class PasswordTest extends HudsonTestCase implements Describable<Password
     }
 
     @Extension
-    public static final class DescriptorImpl extends Descriptor<PasswordTest> {
-        public String getDisplayName() {
-            return null;
-        }
-    }
+    public static final class DescriptorImpl extends Descriptor<PasswordTest> {}
 }

--- a/test/src/test/java/lib/form/RepeatablePropertyTest.java
+++ b/test/src/test/java/lib/form/RepeatablePropertyTest.java
@@ -107,12 +107,7 @@ public class RepeatablePropertyTest extends HudsonTestCase implements Describabl
     }
 
     @Extension
-    public static final class DescriptorImpl extends Descriptor<RepeatablePropertyTest> {
-        @Override
-        public String getDisplayName() {
-            return "RepeatablePropertyTest";
-        }
-    }
+    public static final class DescriptorImpl extends Descriptor<RepeatablePropertyTest> {}
         
     public static final class ExcitingObject implements Describable<ExcitingObject> {
         private final String greatProperty;
@@ -148,10 +143,6 @@ public class RepeatablePropertyTest extends HudsonTestCase implements Describabl
         public static final class ExcitingDescriptor extends Descriptor<ExcitingObject> {
             public ExcitingDescriptor() {
                 super(ExcitingObject.class);
-            }
-            @Override
-            public String getDisplayName() {
-                return "This is an awesome thing!";
             }
         }
     }

--- a/test/src/test/java/lib/form/RepeatableTest.java
+++ b/test/src/test/java/lib/form/RepeatableTest.java
@@ -268,9 +268,6 @@ public class RepeatableTest extends HudsonTestCase {
         public FruitDescriptor(Class<? extends Fruit> clazz) {
             super(clazz);
         }
-        public String getDisplayName() {
-            return clazz.getSimpleName();
-        }
     }
 
     public static class Apple extends Fruit {

--- a/test/src/test/java/lib/form/RowVisibilityGroupTest.java
+++ b/test/src/test/java/lib/form/RowVisibilityGroupTest.java
@@ -115,11 +115,7 @@ public class RowVisibilityGroupTest extends HudsonTestCase implements Describabl
     }
 
     @TestExtension
-    public static final class DescriptorImpl extends Descriptor<RowVisibilityGroupTest> {
-        public String getDisplayName() {
-            return null;
-        }
-    }
+    public static final class DescriptorImpl extends Descriptor<RowVisibilityGroupTest> {}
 
     public static class Nested {
         public String textbox2;
@@ -147,12 +143,7 @@ public class RowVisibilityGroupTest extends HudsonTestCase implements Describabl
         }
 
         @TestExtension
-        public static class DescriptorImpl extends Descriptor<Drink> {
-            @Override
-            public String getDisplayName() {
-                return "Beer";
-            }
-        }
+        public static class DescriptorImpl extends Descriptor<Drink> {}
     }
 
     public static class Coke extends Drink {
@@ -162,11 +153,6 @@ public class RowVisibilityGroupTest extends HudsonTestCase implements Describabl
         }
 
         @TestExtension
-        public static class DescriptorImpl extends Descriptor<Drink> {
-            @Override
-            public String getDisplayName() {
-                return "Coke";
-            }
-        }
+        public static class DescriptorImpl extends Descriptor<Drink> {}
     }
 }

--- a/test/src/test/java/lib/form/ValidateButtonTest.java
+++ b/test/src/test/java/lib/form/ValidateButtonTest.java
@@ -58,10 +58,6 @@ public class ValidateButtonTest extends HudsonTestCase implements Describable<Va
     public static final class DescriptorImpl extends Descriptor<ValidateButtonTest> {
         private Exception test1Outcome;
 
-        public String getDisplayName() {
-            return null;
-        }
-
         public void doValidateTest1(@QueryParameter("a") String a, @QueryParameter("b") boolean b,
                                     @QueryParameter("c") boolean c, @QueryParameter("d") String d,
                                     @QueryParameter("e") String e) {


### PR DESCRIPTION
Forcing every `Descriptor` implementation to override `getDisplayName` leads to a lot of boilerplate in functional tests, prototype code, and even production code which is simply implementing one of the kinds of descriptors whose display names are never shown in the UI.

@reviewbybees
