### PR TITLE
[JENKINS-29547] plugins can't set an assigned node of 'master'

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -425,7 +425,10 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * Gets the textual representation of the assigned label as it was entered by the user.
      */
     public String getAssignedLabelString() {
-        if (canRoam || assignedNode==null)    return null;
+        if (canRoam)    return null;
+        if (assignedNode == null) {
+            return Jenkins.getInstance().getSelfLabel().getExpression();
+        }
         try {
             LabelExpression.parseExpression(assignedNode);
             return assignedNode;

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -175,9 +175,9 @@ public class ProjectTest {
     public void testGetAssignedLabelString() throws Exception{
         FreeStyleProject p = j.createFreeStyleProject("project");
         Slave slave = j.createOnlineSlave();
-        assertNull("Project should not have any label.", p.getAssignedLabelString());
+        assertEquals("Project should have jenkins master label.", j.jenkins.getSelfLabel().name, p.getAssignedLabelString());
         p.setAssignedLabel(j.jenkins.getSelfLabel());
-        assertNull("Project should return null, because assigned label is Jenkins.", p.getAssignedLabelString());
+        assertEquals("Project should have jenkins master label after set explicitly", j.jenkins.getSelfLabel().name, p.getAssignedLabelString());
         p.setAssignedLabel(slave.getSelfLabel());
         assertEquals("Project should return name of slave.", slave.getSelfLabel().name, p.getAssignedLabelString());
     }


### PR DESCRIPTION
Plugins need to use the setter/getter pair, because the 'assignedNode'
field is final.  But the AbstractProject uses different functions to read
and write the value, and didn't previously follow the same invariants as
the get/set pair.
getAssignedLabelString() for example, treats a true 'canRoam' the same as
a null 'assignedNode' field, but these represent different things.
This patch fixes getAssignedLabelString, so that users viewing the config
page will see the right string.
