### PR TITLE
Config loading screen style update

### DIFF
--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -31,7 +31,9 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <f:breadcrumb-config-outline />
     <l:main-panel>
-      <div class="behavior-loading">${%LOADING}</div>
+      <div class="behavior-loading">${%LOADING}
+        <div class="progress-bar"><span class="unknown"></span></div>
+      </div>
       <f:form method="post" action="configSubmit" name="config">
         <j:set var="descriptor" value="${it.descriptor}" />
         <j:set var="instance" value="${it}" />

--- a/core/src/main/resources/hudson/model/ParametersDefinitionProperty/index.jelly
+++ b/core/src/main/resources/hudson/model/ParametersDefinitionProperty/index.jelly
@@ -38,7 +38,9 @@ THE SOFTWARE.
   <l:layout title="${it.displayName}" norefresh="true">
     <st:include page="sidepanel.jelly" it="${it.job}"/>
     <l:main-panel>
-      <div class="behavior-loading">${%LOADING}</div>
+      <div class="behavior-loading">${%LOADING}
+        <div class="progress-bar"><span class="unknown"></span></div>
+      </div>
       <h1>${it.job.pronoun} ${it.job.displayName}</h1>
       <p>${%description}</p>
       <j:set var="delay" value="${request.getParameter('delay')}" />

--- a/core/src/main/resources/hudson/model/Run/configure.jelly
+++ b/core/src/main/resources/hudson/model/Run/configure.jelly
@@ -27,7 +27,9 @@ THE SOFTWARE.
   <l:layout title="${it.displayName} Config" norefresh="true">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <div class="behavior-loading">${%LOADING}</div>
+      <div class="behavior-loading">${%LOADING}
+        <div class="progress-bar"><span class="unknown"></span></div>
+      </div>
       <f:form method="post" action="configSubmit" name="config">
         <f:entry title="${%DisplayName}" help="/help/run-config/displayName.html">
           <f:textbox name="displayName" value="${it.hasCustomDisplayName()?it.displayName:''}"/>

--- a/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
@@ -31,7 +31,9 @@ THE SOFTWARE.
   <st:include page="sidepanel.jelly" />
   <f:breadcrumb-config-outline />
   <l:main-panel>
-    <div class="behavior-loading">${%LOADING}</div>
+    <div class="behavior-loading">${%LOADING}
+      <div class="progress-bar"><span class="unknown"></span></div>
+    </div>
     <f:form method="post" name="config" action="configSubmit">
       <j:set var="instance" value="${it}" />
       <j:set var="descriptor" value="${instance.descriptor}" />

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -698,11 +698,24 @@ table.bigtable.pane > tbody > tr > td:last-child {
 }
 
 div.behavior-loading {
-    position: absolute; width: 80%; height:100%;
-    background-color: #e4e4e4; text-align: center; font-size: 300%;
-    opacity: 0.5;
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
-    filter: alpha(opacity=50);
+    position: absolute;
+    width: 80%;
+    height:100%;
+    background-color: #FFF;
+    text-align: center;
+    font-size: 150%;
+    margin: 0 auto;
+    padding-top: 100px;
+}
+
+div.behavior-loading .progress-bar {
+    margin: 0 auto;
+}
+
+div.behavior-loading .progress-bar .unknown {
+    display: block;
+    width: 100%;
+    height: 100%;
 }
 
 LABEL.attach-previous {
@@ -1598,7 +1611,7 @@ TEXTAREA.rich-editor {
 
 /* ========================= progress bar ========================= */
 
-table.progress-bar {
+.progress-bar {
   border-collapse: collapse;
   border: 1px solid #3465a4;
   height: 6px;
@@ -1606,26 +1619,26 @@ table.progress-bar {
   clear: none;
 }
 
-table.progress-bar tr.unknown {
+.progress-bar .unknown {
     background-image:url(../images/progress-unknown.gif);
 }
 
-td.progress-bar-done {
+.progress-bar-done {
   background-color: #3465a4;
 }
 
-td.progress-bar-left {
+.progress-bar-left {
   background-color: #ffffff;
 }
 
-table.progress-bar.red {
+.progress-bar.red {
   border: 1px solid #cc0000;
 }
 
-table.progress-bar.red tr.unknown {
+.progress-bar.red tr.unknown {
     background-image:url(../images/progress-unknown-red.gif);
 }
-table.progress-bar.red td.progress-bar-done {
+.progress-bar.red td.progress-bar-done {
   background-color: #cc0000;
 }
 

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1611,7 +1611,7 @@ TEXTAREA.rich-editor {
 
 /* ========================= progress bar ========================= */
 
-.progress-bar {
+.progress-bar, table.progress-bar {
   border-collapse: collapse;
   border: 1px solid #3465a4;
   height: 6px;
@@ -1635,10 +1635,10 @@ TEXTAREA.rich-editor {
   border: 1px solid #cc0000;
 }
 
-.progress-bar.red tr.unknown {
+.progress-bar.red .unknown {
     background-image:url(../images/progress-unknown-red.gif);
 }
-.progress-bar.red td.progress-bar-done {
+.progress-bar.red .progress-bar-done {
   background-color: #cc0000;
 }
 


### PR DESCRIPTION
Update the style of the "loading" screen when configuring jobs. 
- Uses the "unknown" job progress bar
- Avoids the ugly flash of greyed out content.
- Halved the font size of the "LOADING" text

We could avoid adding additional markup if we used a vector font for the loading progress bar/spinner, but jenkins doesn't use any vector fonts afaik.

Before:
![before](https://cloud.githubusercontent.com/assets/758005/10710467/74bd2e18-7aa3-11e5-92c7-752395c4c354.png)

After:
![after](https://cloud.githubusercontent.com/assets/758005/10710468/7640e2e8-7aa3-11e5-92ab-a9b4e288bea7.png)
