### PR TITLE
Enhance SimpleBuildStep readability for workflow

### DIFF
--- a/core/src/main/java/hudson/model/JobProperty.java
+++ b/core/src/main/java/hudson/model/JobProperty.java
@@ -42,6 +42,8 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.ExportedBean;
 
+import javax.annotation.Nonnull;
+
 /**
  * Extensible property of {@link Job}.
  *
@@ -129,6 +131,7 @@ public abstract class JobProperty<J extends Job<?,?>> implements ReconfigurableD
      * @see ProminentProjectAction
      * @see PermalinkProjectAction
      */
+    @Nonnull
     public Collection<? extends Action> getJobActions(J job) {
         // delegate to getJobAction (singular) for backward compatible behavior
         Action a = getJobAction(job);
@@ -166,6 +169,7 @@ public abstract class JobProperty<J extends Job<?,?>> implements ReconfigurableD
         return getJobAction((J)project);
     }
 
+    @Nonnull
     public final Collection<? extends Action> getProjectActions(AbstractProject<?,?> project) {
         return getJobActions((J)project);
     }

--- a/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
+++ b/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import static javax.servlet.http.HttpServletResponse.SC_CREATED;
 import jenkins.model.Jenkins;
@@ -103,6 +104,7 @@ public class ParametersDefinitionProperty extends JobProperty<Job<?, ?>>
         };
     }
 
+    @Nonnull
     @Override
     public Collection<Action> getJobActions(Job<?, ?> job) {
         return Collections.<Action>singleton(this);

--- a/core/src/main/java/hudson/tasks/BuildStep.java
+++ b/core/src/main/java/hudson/tasks/BuildStep.java
@@ -50,6 +50,8 @@ import jenkins.model.Jenkins;
 import jenkins.security.QueueItemAuthenticator;
 import org.acegisecurity.Authentication;
 
+import javax.annotation.Nonnull;
+
 /**
  * One step of the whole build process.
  *
@@ -155,6 +157,7 @@ public interface BuildStep {
      * @return
      *      can be empty but never null.
      */
+    @Nonnull
     Collection<? extends Action> getProjectActions(AbstractProject<?,?> project);
 
 

--- a/core/src/main/java/hudson/tasks/BuildStepCompatibilityLayer.java
+++ b/core/src/main/java/hudson/tasks/BuildStepCompatibilityLayer.java
@@ -41,6 +41,8 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.tasks.SimpleBuildStep;
 
+import javax.annotation.Nonnull;
+
 /**
  * Provides compatibility with {@link BuildStep} before 1.150
  * so that old plugin binaries can continue to function with new Hudson.
@@ -89,6 +91,7 @@ public abstract class BuildStepCompatibilityLayer implements BuildStep {
             return null;
     }
 
+    @Nonnull
     public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
         // delegate to getJobAction (singular) for backward compatible behavior
         Action a = getProjectAction(project);

--- a/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
+++ b/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
@@ -112,8 +112,10 @@ public interface SimpleBuildStep extends BuildStep {
             return Job.class;
         }
 
-        @Override public Collection<? extends Action> createFor(Job j) {
-            List<Action> actions = new LinkedList<Action>();
+        @Nonnull
+        @Override
+        public Collection<? extends Action> createFor(@Nonnull Job j) {
+            List<Action> actions = new LinkedList<>();
             Run r = j.getLastSuccessfulBuild();
             if (r != null) {
                 for (LastBuildAction a : r.getActions(LastBuildAction.class)) {

--- a/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
+++ b/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
@@ -81,18 +81,22 @@ public interface SimpleBuildStep extends BuildStep {
      * @throws InterruptedException if the step is interrupted
      * @throws IOException if something goes wrong; use {@link AbortException} for a polite error
      */
-    void perform(@Nonnull Run<?,?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException;
+    void perform(@Nonnull Run<?,?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+                 @Nonnull TaskListener listener) throws InterruptedException, IOException;
 
     /**
-     * Marker for explicitly added build actions (as {@link Run#addAction}) which should imply a transient project action ({@link Job#getActions}) when present on the {@link Job#getLastSuccessfulBuild}.
-     * This can serve as a substitute for {@link BuildStep#getProjectActions} which does not assume that the project can enumerate the steps it would run before they are actually run.
+     * Marker for explicitly added build actions (as {@link Run#addAction}) which should imply a transient project
+     * action ({@link Job#getActions}) when present on the {@link Job#getLastSuccessfulBuild}.
+     * This can serve as a substitute for {@link BuildStep#getProjectActions} which does not assume that the project
+     * can enumerate the steps it would run before they are actually run.
      * (Use {@link InvisibleAction} as a base class if you do not need to show anything in the build itself.)
      */
     interface LastBuildAction extends Action {
 
         /**
          * Optionally add some actions to the project owning this build.
-         * @return zero or more transient actions; if you need to know the {@link Job}, implement {@link RunAction2} and use {@link Run#getParent}
+         * @return zero or more transient actions;
+         * if you need to know the {@link Job}, implement {@link RunAction2} and use {@link Run#getParent}
          */
         Collection<? extends Action> getProjectActions();
 
@@ -100,9 +104,11 @@ public interface SimpleBuildStep extends BuildStep {
 
     @SuppressWarnings("rawtypes")
     @Restricted(DoNotUse.class)
-    @Extension public static final class LastBuildActionFactory extends TransientActionFactory<Job> {
+    @Extension
+    public static final class LastBuildActionFactory extends TransientActionFactory<Job> {
 
-        @Override public Class<Job> type() {
+        @Override
+        public Class<Job> type() {
             return Job.class;
         }
 
@@ -115,7 +121,8 @@ public interface SimpleBuildStep extends BuildStep {
                 }
             }
             // TODO should there be an option to check lastCompletedBuild even if it failed?
-            // Not useful for, say, TestResultAction, since if you have a build that fails before recording test results, the job would then have no TestResultProjectAction.
+            // Not useful for, say, TestResultAction, since if you have a build that fails before recording test
+            // results, the job would then have no TestResultProjectAction.
             return actions;
         }
 


### PR DESCRIPTION
Mistakenly investigated while workflow support implementation.
I thought that all that now need plugin dev is implement/extend SimpleBuildStep, but it requires implementing optional things and you end in using Builder + SimpleBuildStep pair that contains useless compatibility for old APIs. 
Workflow didn't bring clean API :disappointed: 
