### PR TITLE
JENKINS-31253 reduce lock contention on jenkins.model.Nodes.removeNode

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1746,6 +1746,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Removes a {@link Node} from Jenkins.
      */
     public void removeNode(@Nonnull Node n) throws IOException {
+        Computer computer=n.toComputer();
+        if(computer!=null){
+            computer.recordTermination();
+            killComputer(computer);
+        }
         nodes.removeNode(n);
     }
 


### PR DESCRIPTION
avoid call jenkins.updateComputerList() for single node remove.
jenkins's labels,nodes and computers are using CopyOnWriteMap,so they can be manipulated without lock.
Computer.kill is alreday guarded by Queue.withLock
