### PR TITLE
Allow computer naturally  died out after executor depleted when it is not accepting tasks

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -64,6 +64,7 @@ import hudson.util.RemotingDiagnostics.HeapDump;
 import hudson.util.RunList;
 import hudson.util.Futures;
 import hudson.util.NamingThreadFactory;
+import jenkins.model.FeatureSwitchConfiguration;
 import jenkins.model.Jenkins;
 import jenkins.util.ContextResettingExecutorService;
 import jenkins.security.MasterToSlaveCallable;
@@ -117,6 +118,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static javax.servlet.http.HttpServletResponse.*;
+import static jenkins.model.FeatureSwitchConfiguration.Feature;
 
 /**
  * Represents the running state of a remote computer that holds {@link Executor}s.
@@ -1018,7 +1020,9 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             public void run() {
                 synchronized (Computer.this) {
                     executors.remove(e);
-                    addNewExecutorIfNecessary();
+                    if (Feature.DEFER_EXECUTOR_CREATION.isOffOr(isAcceptingTasks())) {
+                        addNewExecutorIfNecessary();
+                    }
                     if (!isAlive()) {
                         AbstractCIBase ciBase = Jenkins.getInstanceOrNull();
                         if (ciBase != null) { // TODO confirm safe to assume non-null and use getInstance()

--- a/core/src/main/java/hudson/slaves/DumbSlave.java
+++ b/core/src/main/java/hudson/slaves/DumbSlave.java
@@ -43,6 +43,7 @@ import javax.annotation.Nonnull;
  * @author Kohsuke Kawaguchi
  */
 public final class DumbSlave extends Slave {
+    private boolean acceptingTasks=true;
     /**
      * @deprecated as of 1.286.
      *      Use {@link #DumbSlave(String, String, String, String, Node.Mode, String, ComputerLauncher, RetentionStrategy, List)}
@@ -71,5 +72,22 @@ public final class DumbSlave extends Slave {
         public String getDisplayName() {
             return Messages.DumbSlave_displayName();
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAcceptingTasks() {
+        return acceptingTasks;
+    }
+
+    /**
+     * Whether or not to suspend task scheduling for the slave
+     * This value will be used by {@link #isAcceptingTasks()}.
+     * @param acceptingTasks
+     */
+    public void setAcceptingTasks(boolean acceptingTasks) {
+        this.acceptingTasks = acceptingTasks;
     }
 }

--- a/core/src/main/java/hudson/slaves/DumbSlave.java
+++ b/core/src/main/java/hudson/slaves/DumbSlave.java
@@ -43,7 +43,9 @@ import javax.annotation.Nonnull;
  * @author Kohsuke Kawaguchi
  */
 public final class DumbSlave extends Slave {
-    private boolean acceptingTasks=true;
+    @Nonnull
+    private Boolean acceptingTasks=true;
+
     /**
      * @deprecated as of 1.286.
      *      Use {@link #DumbSlave(String, String, String, String, Node.Mode, String, ComputerLauncher, RetentionStrategy, List)}
@@ -89,5 +91,13 @@ public final class DumbSlave extends Slave {
      */
     public void setAcceptingTasks(boolean acceptingTasks) {
         this.acceptingTasks = acceptingTasks;
+    }
+
+    // Backwards compatibility for older version
+    public Object readResolve() {
+        if(acceptingTasks==null){
+            acceptingTasks=true;
+        }
+        return this;
     }
 }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -724,6 +724,26 @@ public class SlaveComputer extends Computer {
     }
 
     /**
+     * Close channel if there is any
+     * Will log a warning message if computer was removed before node
+     */
+    @Override
+    protected void onRemoved() {
+        if (this.channel != null) {
+            closeChannel();
+        }
+        Node node = super.getNode();
+        if (node != null) {
+            if (node.isAcceptingTasks()) {
+                //normally node should be removed first
+                logger.log(Level.WARNING, "Computer {0} is removed while node still exits", nodeName);
+            } else {
+                logger.log(Level.INFO, "Node {0} become orphan, will disappear from 'Build Executor Status' section", nodeName);
+            }
+        }
+    }
+
+    /**
      * Grabs a {@link ComputerLauncher} out of {@link Node} to keep it in this {@link Computer}.
      * The returned launcher will be set to {@link #launcher} and used to carry out the actual launch operation.
      *

--- a/core/src/main/java/jenkins/model/FeatureSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/model/FeatureSwitchConfiguration.java
@@ -127,7 +127,7 @@ public class FeatureSwitchConfiguration extends GlobalConfiguration {
          * }</pre>
          */
         DEFER_EXECUTOR_CREATION(
-                "Defer executor creation for nodes which are not accepting task"
+                Messages.DeferExecutorCreation()
         );
         private String description;
 

--- a/core/src/main/java/jenkins/model/FeatureSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/model/FeatureSwitchConfiguration.java
@@ -1,0 +1,165 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Ted Shaw.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model;
+
+import hudson.Extension;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.*;
+
+/**
+ * Allow user to turn on/off selected experimental features. such features'
+ * behavior subject to change without notice
+ *
+ * @since TODO update version after merge
+ */
+@Restricted(NoExternalUse.class)
+@Extension
+public class FeatureSwitchConfiguration extends GlobalConfiguration {
+
+    //the feature list will be small, size less than 20
+    private List<String> disabledFeatureStr = new ArrayList<String>();
+
+    public EnumSet<Feature> getDisabledSet() {
+        return disabledSet;
+    }
+
+    /**
+     * Update the disabled feature list
+     * used by {@link #configure(StaplerRequest req, JSONObject json)}.
+     *
+     * @param disabledSet
+     */
+    public void setDisabledSet(EnumSet<Feature> disabledSet) {
+        this.disabledSet = disabledSet;
+        this.disabledFeatureStr.clear();
+        for (Feature feature : disabledSet) {
+            disabledFeatureStr.add(feature.name());
+        }
+        save();
+    }
+
+    //Allow enum to be removed in future release, avoid serialization/deserialization
+    transient EnumSet<Feature> disabledSet = EnumSet.noneOf(Feature.class);
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        return true;
+    }
+
+    public FeatureSwitchConfiguration() {
+        //Load configure data from disk
+        load();
+        updateFeatureSet();
+    }
+
+    public static FeatureSwitchConfiguration get() {
+        return GlobalConfiguration.all().get(FeatureSwitchConfiguration.class);
+    }
+
+    /**
+     * Convert string to enum, removed feature(no matching enum item)
+     * will be discarded
+     */
+    private void updateFeatureSet() {
+        for (Feature feature : Feature.values()) {
+            if (disabledFeatureStr.contains(feature.name())) {
+                disabledSet.add(feature);
+            }
+        }
+    }
+
+    /**
+     * Check the feature is enabled or not
+     *
+     * @param feature
+     * @return a boolean flag indicating the feature disabled or not
+     */
+    public static boolean isDisabled(Feature feature) {
+        return get().getDisabledSet().contains(feature);
+    }
+
+    public enum Feature {
+        /**
+         * User can leverage the feature to fast node remove
+         * <pre>{@code
+         *  SomeRetentionStrategy extends RetentionStrategy<SlaveComputer> implements ExecutorListener {
+         *     @Override
+         *     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
+         *         final SomeCloudSlave slaveNode=(SomeCloudSlave)executor.getOwner().getNode();
+         *         if(slaveNode!=null && slaveNode.isOnetimeUse()){
+         *             slaveNode.setAcceptingTasks(false);
+         *             Computer.threadPoolForRemoting.submit(new Runnable() {
+         *                 public void run() {
+         *                     //some cleanup code here
+         *                     //remove node after cleanup
+         *                     Jenkins.getInstance().removeNode(slaveNode);
+         *                 }
+         *             });
+         *         }
+         *     }
+         *  }
+         * }</pre>
+         */
+        DEFER_EXECUTOR_CREATION(
+                "Defer executor creation for nodes which are not accepting task"
+        );
+        private String description;
+
+        Feature(String description) {
+            this.description = description;
+        }
+
+        /**
+         * @return description of the feature
+         */
+        public String getDescription() {
+            return description;
+        }
+
+        /**
+         * Called in config page
+         *
+         * @return description of the feature
+         */
+        @Override
+        public String toString() {
+            return description;
+        }
+
+        /**
+         * Always return true if feature is disabled, otherwise return the condition
+         *
+         * @param condition checked condition
+         * @return true as passed, false as rejected
+         */
+        public boolean isOffOr(boolean condition) {
+            return condition || isDisabled(this);
+        }
+    }
+}

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -55,6 +55,8 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static jenkins.model.FeatureSwitchConfiguration.Feature;
+
 /**
  * Manages all the nodes for Jenkins.
  *
@@ -216,7 +218,9 @@ public class Nodes implements Saveable {
                         c.disconnect(OfflineCause.create(hudson.model.Messages._Hudson_NodeBeingRemoved()));
                     }
                     if (node == nodes.remove(node.getNodeName())) {
-                        jenkins.updateComputerList();
+                        if(Feature.DEFER_EXECUTOR_CREATION.isOffOr(c!=null)){
+                            jenkins.updateComputerList();
+                        }
                         jenkins.trimLabels();
                     }
                 }

--- a/core/src/main/resources/jenkins/model/FeatureSwitchConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/FeatureSwitchConfiguration/config.groovy
@@ -1,0 +1,10 @@
+package jenkins.model.FeatureSwitchConfiguration
+
+def f = namespace(lib.FormTagLib)
+
+f.section(title: _("Disable experimental feature(s)")) {
+    f.entry(field: "disabledSet") {
+        f.enumSet()
+    }
+
+}

--- a/core/src/main/resources/jenkins/model/Messages.properties
+++ b/core/src/main/resources/jenkins/model/Messages.properties
@@ -70,3 +70,4 @@ ParameterizedJobMixIn.build_now=Build Now
 BlockedBecauseOfBuildInProgress.shortDescription=Build #{0} is already in progress{1}
 BlockedBecauseOfBuildInProgress.ETA=\ (ETA:{0})
 BuildDiscarderProperty.displayName=Discard old builds
+DeferExecutorCreation=Defer executor creation for nodes which are not accepting task

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -63,6 +63,22 @@ public class ComputerTest {
         assertTrue("Slave log should be kept", keep.toComputer().getLogFile().exists());
     }
 
+    @Test
+    public void idleComputerCanBeRemoved() throws Exception{
+        DumbSlave idleNode = j.createOnlineSlave(Jenkins.getInstance().getLabelAtom("nodeNotTakingTask"));
+        //try terminate idle executors
+        File logFile=idleNode.toComputer().getLogFile();
+        assertFalse(idleNode.toComputer().getExecutors().isEmpty());
+        idleNode.setAcceptingTasks(false);
+        idleNode.toComputer().kill();
+        assertNull("Computer should be removed once all idle executors are killed", idleNode.toComputer());
+        assertFalse("Slave log should be cleaned", logFile.exists());
+        Jenkins.getInstance().updateComputerList(true);
+        assertNull("No computer created for node which is not accepting task", idleNode.toComputer());
+        Jenkins.getInstance().removeNode(idleNode);
+        assertNull(Jenkins.getInstance().getNode(idleNode.getNodeName()));
+    }
+
     /**
      * Verify we can't rename a node over an existing node.
      */


### PR DESCRIPTION
we have hundreds on-demand cloud slaves which will be used only once for doing single build, then terminated, and found out lock contention for node deletion, and it prevents us from scale to over 400 slaves, terminate slaves without  updateComputerList can ease the pain
