### PR TITLE
JENKINS-31217 Treat null as a default JDK name.

### DIFF
--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -67,7 +67,7 @@ public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, En
             // DEFAULT_NAME took this value prior to 1.598.
             return true;
         }
-        return DEFAULT_NAME.equals(name);
+        return DEFAULT_NAME.equals(name) || name == null;
     }
 
     /**

--- a/core/src/test/java/jenkins/model/JDKNameTest.java
+++ b/core/src/test/java/jenkins/model/JDKNameTest.java
@@ -36,8 +36,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 public class JDKNameTest {
     @Test
-    public void nullIsNotDefaultName() {
-        assertThat(JDK.isDefaultName(null), is(false));
+    public void nullIsDefaultName() {
+        assertThat(JDK.isDefaultName(null), is(true));
     }
     
     @Test


### PR DESCRIPTION
Fixes JENKINS-31217 as discussed in https://github.com/jenkinsci/jenkins/pull/1528.
