### PR TITLE
AbstractItem.java: replace non-Javadoc comment

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -699,8 +699,8 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     }
 
 
-    /* (non-Javadoc)
-     * @see hudson.model.AbstractModelObject#getSearchName()
+    /**
+     * {@inheritDoc}
      */
     @Override
     public String getSearchName() {


### PR DESCRIPTION
Eclipse places "non-Javadoc" comments on methods that override methods
from supertypes, but these are nonstandard.  This change replaces this
comment with the standard Javadoc convention for this case.
