### PR TITLE
add missing @Override annotations

### DIFF
--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -156,7 +156,6 @@ public class AnnotatedLargeText<T> extends LargeText {
 
     /**
      * Calls {@link LargeText#writeLogTo(long, OutputStream)} without stripping annotations as {@link #writeLogTo(long, OutputStream)} would.
-     * @inheritDoc
      * @since 1.577
      */
     public long writeRawLogTo(long start, OutputStream out) throws IOException {

--- a/core/src/main/java/hudson/model/AbstractDescribableImpl.java
+++ b/core/src/main/java/hudson/model/AbstractDescribableImpl.java
@@ -37,6 +37,7 @@ public abstract class AbstractDescribableImpl<T extends AbstractDescribableImpl<
      * By default looks for a nested class (conventionally named {@code DescriptorImpl}) implementing {@link Descriptor} and marked with {@link Extension}.
      * <p>{@inheritDoc}
      */
+    @Override
     public Descriptor<T> getDescriptor() {
         return Jenkins.getInstance().getDescriptorOrDie(getClass());
     }

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1090,6 +1090,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * or if the blockBuildWhenUpstreamBuilding option is true and an upstream
      * project is building, but derived classes can also check other conditions.
      */
+    @Override
     public boolean isBuildBlocked() {
         return getCauseOfBlockage()!=null;
     }

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -587,6 +587,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     /**
      * {@inheritDoc}
      */
+    @Override
     public void taskAccepted(Executor executor, Queue.Task task) {
         // dummy implementation
     }
@@ -594,6 +595,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     /**
      * {@inheritDoc}
      */
+    @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
         // dummy implementation
     }
@@ -601,6 +603,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     /**
      * {@inheritDoc}
      */
+    @Override
     public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
         // dummy implementation
     }

--- a/core/src/main/java/hudson/model/HealthReport.java
+++ b/core/src/main/java/hudson/model/HealthReport.java
@@ -325,6 +325,7 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public int compareTo(HealthReport o) {
         return (this.score < o.score ? -1 : (this.score == o.score ? 0 : 1));
     }

--- a/core/src/main/java/hudson/model/JobProperty.java
+++ b/core/src/main/java/hudson/model/JobProperty.java
@@ -99,6 +99,7 @@ public abstract class JobProperty<J extends Job<?,?>> implements ReconfigurableD
     /**
      * {@inheritDoc}
      */
+    @Override
     public JobPropertyDescriptor getDescriptor() {
         return (JobPropertyDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
     }
@@ -153,6 +154,7 @@ public abstract class JobProperty<J extends Job<?,?>> implements ReconfigurableD
      * <p>
      * Invoked after {@link Publisher}s have run.
      */
+    @Override
     public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         return true;
     }

--- a/core/src/main/java/hudson/model/ManagementLink.java
+++ b/core/src/main/java/hudson/model/ManagementLink.java
@@ -79,6 +79,7 @@ public abstract class ManagementLink implements ExtensionPoint, Action {
      * In case of {@link ManagementLink}, this value is put straight into the href attribute,
      * so relative paths are interpreted against the root {@link Jenkins} object.
      */
+    @Override
     public abstract String getUrlName();
 
     /**

--- a/core/src/main/java/hudson/model/ParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ParameterDefinition.java
@@ -155,6 +155,7 @@ public abstract class ParameterDefinition implements
     /**
      * {@inheritDoc}
      */
+    @Override
     public ParameterDescriptor getDescriptor() {
         return (ParameterDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
     }

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -202,6 +202,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
      * it's always configured through <tt>config.jelly</tt> and never with
      * <tt>global.jelly</tt>. 
      */
+    @Override
     public Descriptor<SecurityRealm> getDescriptor() {
         return super.getDescriptor();
     }

--- a/core/src/main/java/hudson/security/csrf/CrumbFilter.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbFilter.java
@@ -104,6 +104,7 @@ public class CrumbFilter implements Filter {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void destroy() {
     }
 

--- a/core/src/main/java/hudson/slaves/ComputerRetentionWork.java
+++ b/core/src/main/java/hudson/slaves/ComputerRetentionWork.java
@@ -55,6 +55,7 @@ public class ComputerRetentionWork extends PeriodicWork {
      * {@inheritDoc}
      */
     @SuppressWarnings("unchecked")
+    @Override
     protected void doRun() {
         final long startRun = System.currentTimeMillis();
         for (final Computer c : Jenkins.getInstance().getComputers()) {

--- a/core/src/main/java/hudson/tasks/BuildStepCompatibilityLayer.java
+++ b/core/src/main/java/hudson/tasks/BuildStepCompatibilityLayer.java
@@ -65,6 +65,7 @@ public abstract class BuildStepCompatibilityLayer implements BuildStep {
      * @inheritDoc
      * @return Delegates to {@link SimpleBuildStep#perform(Run, FilePath, Launcher, TaskListener)} if possible, always returning true or throwing an error.
      */
+    @Override
     public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         if (this instanceof SimpleBuildStep) {
             // delegate to the overloaded version defined in SimpleBuildStep

--- a/core/src/main/java/jenkins/model/IdStrategy.java
+++ b/core/src/main/java/jenkins/model/IdStrategy.java
@@ -161,6 +161,7 @@ public abstract class IdStrategy extends AbstractDescribableImpl<IdStrategy> imp
         /**
          * {@inheritDoc}
          */
+        @Override
         @Nonnull
         public String keyFor(@Nonnull String id) {
             return id.toLowerCase(Locale.ENGLISH);
@@ -288,6 +289,7 @@ public abstract class IdStrategy extends AbstractDescribableImpl<IdStrategy> imp
         /**
          * {@inheritDoc}
          */
+        @Override
         @Nonnull
         public String keyFor(@Nonnull String id) {
             return id;
@@ -348,6 +350,7 @@ public abstract class IdStrategy extends AbstractDescribableImpl<IdStrategy> imp
         /**
          * {@inheritDoc}
          */
+        @Override
         @Nonnull
         public String keyFor(@Nonnull String id) {
             int index = id.lastIndexOf('@'); // The @ can be used in local-part if quoted correctly


### PR DESCRIPTION
Adding these annotations increases safety through increased compile-time checking and allows for better static analysis and tooling.
