### PR TITLE
Another random failure

### DIFF
--- a/test/src/test/java/hudson/slaves/CommandLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/CommandLauncherTest.java
@@ -47,6 +47,7 @@ public class CommandLauncherTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
+    @RandomlyFails("EOFException as in commandSucceedsWithoutChannel")
     public void commandFails() throws Exception {
         assumeTrue(!Functions.isWindows());
         DumbSlave slave = createSlave("false");


### PR DESCRIPTION
[Here](https://ci.jenkins-ci.org/job/jenkins_main_trunk/4349/testReport/junit/hudson.slaves/CommandLauncherTest/commandFails/) for example.

@reviewbybees
