### PR TITLE
fix {@inheritDoc} syntax

### DIFF
--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -147,7 +147,7 @@ public class AnnotatedLargeText<T> extends LargeText {
 
     /**
      * Strips annotations using a {@link PlainTextConsoleOutputStream}.
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override
     public long writeLogTo(long start, OutputStream out) throws IOException {

--- a/core/src/main/java/hudson/model/TaskAction.java
+++ b/core/src/main/java/hudson/model/TaskAction.java
@@ -71,7 +71,7 @@ public abstract class TaskAction extends AbstractModelObject implements Action {
     protected abstract ACL getACL();
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      * @see #getPermission
      */
     @Override public abstract String getIconFileName();

--- a/core/src/main/java/hudson/tasks/BuildStepCompatibilityLayer.java
+++ b/core/src/main/java/hudson/tasks/BuildStepCompatibilityLayer.java
@@ -62,7 +62,7 @@ public abstract class BuildStepCompatibilityLayer implements BuildStep {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      * @return Delegates to {@link SimpleBuildStep#perform(Run, FilePath, Launcher, TaskListener)} if possible, always returning true or throwing an error.
      */
     @Override

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -170,7 +170,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
     /**
      * Compares according to {@link #toURI}.
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override public final boolean equals(Object obj) {
         return obj instanceof VirtualFile && toURI().equals(((VirtualFile) obj).toURI());

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -162,7 +162,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
     /**
      * Does case-insensitive comparison.
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override public final int compareTo(VirtualFile o) {
         return getName().compareToIgnoreCase(o.getName());

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -186,7 +186,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
     /**
      * Displays {@link #toURI}.
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override public final String toString() {
         return toURI().toString();

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -178,7 +178,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
     /**
      * Hashes according to {@link #toURI}.
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override public final int hashCode() {
         return toURI().hashCode();


### PR DESCRIPTION
Since {@inheritDoc} is an in-line Javadoc tag, the correct syntax includes curly braces.  See the official Javadoc documentation at the following URL for more detail:

http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#blockandinlinetags
