### PR TITLE
[FIXED JENKINS-31395] fix IE footer positioning

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,6 +56,9 @@ Upcoming changes</a>
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
   <li class="bug">
+    Fix IE footer positioning.
+    (<a href="https://issues.jenkins-ci.org/browse/JENKINS-31395">issue 31395</a>)
+  <li class="bug">
     Multiple workspace browser features broken on Windows masters since 1.634.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-31015">issue 31015</a>)
 </ul>

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -133,7 +133,7 @@ footer {
   background-color: #f6faf2;
   border-top: 1px solid #d3d7cf;
   width: 100%;
-  position: absolute;
+  position: fixed;
   bottom: 0;
   left: 0;
   font-size: 12px;


### PR DESCRIPTION
This has been broken since LTS 1.625.1.  Problem details can be found in the bug ticket:

https://issues.jenkins-ci.org/browse/JENKINS-31395

Tested this fix in IE 11 (native), 10 (emulation mode), 9 (emulation mode), Firefox 41.0.2, Chrome 46.0.2490.80.
