### PR TITLE
[JENKINS-31378] Add JDK8 SSL/ECDH support

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -84,7 +84,7 @@ THE SOFTWARE.
       <groupId>${project.groupId}</groupId>
       <artifactId>remoting</artifactId>
       <!-- specified in the parent -->
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>cli</artifactId>
@@ -104,7 +104,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>1.4</version>
+      <version>1.5</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
@@ -443,7 +443,7 @@ THE SOFTWARE.
           <additionalClassesDirectories>
             <!-- load resoures straight from source -->
             <additionalClassesDirectory>../core/src/main/resources</additionalClassesDirectory>
-            
+
             <!--
               read directly from core module's output directory,
               so that changes are picked up right away without running mvn.


### PR DESCRIPTION
Update identity module to 1.5
- Updates Bouncycastle to 1.53
  - JDK8 support
  - ECDH support

The following two releases must occur before this can be merged:

identity-module 1.5
[ssh-agent-plugin](https://github.com/jenkinsci/ssh-agent-plugin) 1.9
