### PR TITLE
[FIXED JENKINS-31649] Check should be against AccessControlled not Item

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -799,8 +799,9 @@ public class Queue extends ResourceController implements Saveable {
     }
 
     private List<Item> filterItemListBasedOnPermissions(List<Item> r, Item t) {
-        if (t.task instanceof hudson.model.Item) {
-            if (((hudson.model.Item)t.task).hasPermission(hudson.model.Item.READ)) {
+        if (t.task instanceof hudson.security.AccessControlled) {
+            if (((hudson.security.AccessControlled)t.task).hasPermission(hudson.model.Item.READ)
+                    || ((hudson.security.AccessControlled) t.task).hasPermission(hudson.security.Permission.READ)) {
                 r.add(t);
             }
         }


### PR DESCRIPTION
- The previous check was to narrow.
- We now check on AccessControlled (which is implemented by Item)
- We now also check on Permission.READ (which is the generic read permission)

This should allow subtasks who's task may not be an Item to at least implement AccessControlled to alow visibility.

There remains an open question as to whether tasks that are not AccessControlled should ever be visible in the UI

@reviewbybees esp @varmenise 
