### PR TITLE
Remove relative resource declarations in the changelog

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -20,7 +20,7 @@ Some tips:
 <head>
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
   <title>Changelog</title>
-  <link rel="stylesheet" TYPE="text/css" href="changelog.css">
+  <link rel="stylesheet" TYPE="text/css" href="/changelog.css">
 <!--[if IE]>
 <style type="text/css">div.rate-offset { bottom: 0.2em !important; left: 5em !important; }</style>
 <![endif]-->
@@ -29,8 +29,8 @@ Some tips:
 <body>
 <div align="right">Legend:
     <span class="iconlegend">
-        <img src="images/rfe2.gif" alt="major RFE">major enhancement <img src="images/rfe.gif" alt="RFE">enhancement
-        <img src="images/bug2.gif" alt="major bug">major bug fix     <img src="images/bug.gif" alt="bug">bug fix
+        <img src="/images/rfe2.gif" alt="major RFE">major enhancement <img src="/images/rfe.gif" alt="RFE">enhancement
+        <img src="/images/bug2.gif" alt="major bug">major bug fix     <img src="/images/bug.gif" alt="bug">bug fix
     </span><span style="visibility:hidden">xxxxx</span>
 </div>
 
@@ -1794,7 +1794,7 @@ Upcoming changes</a>
 </ul>
 
 <p>
-<b>Older changelogs can be found in a <a href="changelog-old.html">separate file</a></b>
+<b>Older changelogs can be found in a <a href="/changelog-old.html">separate file</a></b>
 
 </body>
 </html>


### PR DESCRIPTION
When porting the changelog into the new site, these relative references are causing a little trouble so I'm just moving them to absolute.
