### PR TITLE
[JENKINS-31661] Jenkins.rootUrl too often unset or incorrect

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -233,7 +233,7 @@ public class Functions {
 
         // The path starts with a "/" character but does not end with a "/" character.
         context.setVariable("rootURL", rootURL);
-        Jenkins.getActiveInstance().setCatchedRootUrl(rootURL);
+        Jenkins.getActiveInstance().setCachedRootUrl(rootURL);
 
         /*
             load static resources from the path dedicated to a specific version.

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -233,7 +233,8 @@ public class Functions {
 
         // The path starts with a "/" character but does not end with a "/" character.
         context.setVariable("rootURL", rootURL);
-        Jenkins.getActiveInstance().setCachedRootUrl(rootURL);
+        Jenkins jenkins = Jenkins.getActiveInstance();
+        jenkins.setCachedRootUrl(jenkins.getRootUrlFromRequest());
 
         /*
             load static resources from the path dedicated to a specific version.

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -233,8 +233,10 @@ public class Functions {
 
         // The path starts with a "/" character but does not end with a "/" character.
         context.setVariable("rootURL", rootURL);
-        Jenkins jenkins = Jenkins.getActiveInstance();
-        jenkins.setCachedRootUrl(jenkins.getRootUrlFromRequest());
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins != null) {
+            jenkins.setCachedRootUrl(jenkins.getRootUrlFromRequest());
+        }
 
         /*
             load static resources from the path dedicated to a specific version.

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -233,6 +233,7 @@ public class Functions {
 
         // The path starts with a "/" character but does not end with a "/" character.
         context.setVariable("rootURL", rootURL);
+        Jenkins.getActiveInstance().setCatchedRootUrl(rootURL);
 
         /*
             load static resources from the path dedicated to a specific version.

--- a/core/src/main/java/jenkins/diagnostics/UnsetRootUrlMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/UnsetRootUrlMonitor.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Antonio Muñiz.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.diagnostics;
+
+import java.io.IOException;
+
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.QueryParameter;
+
+import hudson.Extension;
+import hudson.model.AdministrativeMonitor;
+import jenkins.model.JenkinsLocationConfiguration;
+
+/**
+ * Jenkins root URL is required for a lot of operations in both core and plugins.
+ * There is a default behavior (infer the URL from the request object), but innacurate in some scenarios.
+ */
+@Extension
+public class UnsetRootUrlMonitor extends AdministrativeMonitor {
+
+    @Override
+    public boolean isActivated() {
+        return JenkinsLocationConfiguration.get().getUrl() == null;
+    }
+
+    public HttpResponse doAct(@QueryParameter String no) throws IOException {
+        if(no != null) { // Dismiss
+            disable(true);
+            return HttpResponses.redirectViaContextPath("/manage");
+        } else { // Configure
+            return HttpResponses.redirectViaContextPath("/configure");
+        }
+    }
+
+}

--- a/core/src/main/java/jenkins/diagnostics/UnsetRootUrlMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/UnsetRootUrlMonitor.java
@@ -24,12 +24,8 @@
 
 package jenkins.diagnostics;
 
-import java.io.IOException;
-
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
@@ -47,14 +43,6 @@ public class UnsetRootUrlMonitor extends AdministrativeMonitor {
     public boolean isActivated() {
         JenkinsLocationConfiguration loc = JenkinsLocationConfiguration.get();
         return loc == null || (loc != null && loc.getUrl() == null);
-    }
-
-    public void doAct(StaplerRequest req, StaplerResponse rsp) throws IOException {
-        if(req.hasParameter("no")) { // Dismiss
-            doDisable(req, rsp);
-        } else { // Configure
-            rsp.sendRedirect(req.getContextPath() + "/configure");
-        }
     }
 
 }

--- a/core/src/main/java/jenkins/diagnostics/UnsetRootUrlMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/UnsetRootUrlMonitor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2015 Antonio Muñiz.
+ * Copyright 2015 Cloudbees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +28,8 @@ import java.io.IOException;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.HttpResponses;
-import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
@@ -49,12 +48,11 @@ public class UnsetRootUrlMonitor extends AdministrativeMonitor {
         return JenkinsLocationConfiguration.get().getUrl() == null;
     }
 
-    public HttpResponse doAct(@QueryParameter String no) throws IOException {
-        if(no != null) { // Dismiss
-            disable(true);
-            return HttpResponses.redirectViaContextPath("/manage");
+    public void doAct(StaplerRequest req, StaplerResponse rsp) throws IOException {
+        if(req.hasParameter("no")) { // Dismiss
+            doDisable(req, rsp);
         } else { // Configure
-            return HttpResponses.redirectViaContextPath("/configure");
+            rsp.sendRedirect(req.getContextPath() + "/configure");
         }
     }
 

--- a/core/src/main/java/jenkins/diagnostics/UnsetRootUrlMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/UnsetRootUrlMonitor.java
@@ -26,6 +26,8 @@ package jenkins.diagnostics;
 
 import java.io.IOException;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
@@ -39,6 +41,7 @@ import jenkins.model.JenkinsLocationConfiguration;
  * There is a default behavior (infer the URL from the request object), but innacurate in some scenarios.
  */
 @Extension
+@Restricted(NoExternalUse.class)
 public class UnsetRootUrlMonitor extends AdministrativeMonitor {
 
     @Override

--- a/core/src/main/java/jenkins/diagnostics/UnsetRootUrlMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/UnsetRootUrlMonitor.java
@@ -45,7 +45,8 @@ public class UnsetRootUrlMonitor extends AdministrativeMonitor {
 
     @Override
     public boolean isActivated() {
-        return JenkinsLocationConfiguration.get().getUrl() == null;
+        JenkinsLocationConfiguration loc = JenkinsLocationConfiguration.get();
+        return loc == null || (loc != null && loc.getUrl() == null);
     }
 
     public void doAct(StaplerRequest req, StaplerResponse rsp) throws IOException {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1968,7 +1968,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * to infere the value fail.
      * @see #cachedRootUrl
      */
-    public void setCachedRootUrl(String url) {
+    @Restricted(NoExternalUse.class)
+    public void setCachedRootUrl(@Nonnull String url) {
         this.cachedRootUrl = url;
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -670,6 +670,15 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
     };
 
+    /**
+     * Cached root URL.
+     *
+     * Updated by {@link Functions#initPageVariables(org.apache.commons.jelly.JellyContext)} on every HTTP
+     * request so {@link #getRootUrl()} returns a sensible value if a explicit value is not set in
+     * general configuration.
+     */
+    private transient String cachedRootUrl = null;
+
 
     /**
      * Hook for a test harness to intercept Jenkins.getInstance()
@@ -1948,7 +1957,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         StaplerRequest req = Stapler.getCurrentRequest();
         if(req!=null)
             return getRootUrlFromRequest();
+        if (cachedRootUrl != null) {
+            return Util.ensureEndsWith(cachedRootUrl, "/");
+        }
         return null;
+    }
+
+    public void setCatchedRootUrl(String url) {
+        this.cachedRootUrl = url;
     }
 
     /**

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1963,7 +1963,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return null;
     }
 
-    public void setCatchedRootUrl(String url) {
+    /**
+     * Sets the last known root URL that will be used as fallback in {@link #getRootUrl()} if any other way
+     * to infere the value fail.
+     * @see #cachedRootUrl
+     */
+    public void setCachedRootUrl(String url) {
         this.cachedRootUrl = url;
     }
 

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -6,6 +6,8 @@ import hudson.XmlFile;
 import hudson.util.FormValidation;
 import hudson.util.XStream2;
 import net.sf.json.JSONObject;
+
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -156,7 +158,7 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
      * Checks the URL in <tt>global.jelly</tt>
      */
     public FormValidation doCheckUrl(@QueryParameter String value) {
-        if (value.isEmpty()) {
+        if (StringUtils.isBlank(value)) {
             return FormValidation.warning(Messages.Jenkins_EmptyRootUrl());
         }
         if(value.startsWith("http://localhost"))

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -156,6 +156,9 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
      * Checks the URL in <tt>global.jelly</tt>
      */
     public FormValidation doCheckUrl(@QueryParameter String value) {
+        if (value.isEmpty()) {
+            return FormValidation.warning(Messages.Jenkins_EmptyRootUrl());
+        }
         if(value.startsWith("http://localhost"))
             return FormValidation.warning(Messages.Mailer_Localhost_Error());
         return FormValidation.ok();

--- a/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.jelly
@@ -25,12 +25,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="warning">
-    <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
-      <div style="float:right">
-        <f:submit name="yes" value="${%Configure}"/>
-        <f:submit name="no" value="${%Dismiss}"/>
-      </div>
-      ${%blurb}
-    </form>
+      ${%blurb} (Or you can <a href="${it.url}/disable">dismiss</a> this message)
   </div>
 </j:jelly>

--- a/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2015 Antonio Muñiz
+Copyright 2015 Cloudbees, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.jelly
@@ -1,0 +1,36 @@
+<!--
+The MIT License
+
+Copyright (c) 2015 Antonio Muñiz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <div class="warning">
+    <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
+      <div style="float:right">
+        <f:submit name="yes" value="${%Configure}"/>
+        <f:submit name="no" value="${%Dismiss}"/>
+      </div>
+      ${%blurb}
+    </form>
+  </div>
+</j:jelly>

--- a/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.properties
+++ b/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.properties
@@ -21,5 +21,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-blurb=Jenkins root URL is required for much operations in both core and plugins. \
-  Consider to set the correct value.
+blurb=Jenkins root URL is required for the correct operation of many Jenkins features. \
+  Please configure the correct value in Jenkins configuration.

--- a/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.properties
+++ b/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.properties
@@ -1,7 +1,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2015, Antonio Muñiz
+# Copyright 2015 Cloudbees, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.properties
+++ b/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.properties
@@ -1,0 +1,25 @@
+#
+# The MIT License
+#
+# Copyright (c) 2015, Antonio Muñiz
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+blurb=Jenkins root URL is required for much operations in both core and plugins. \
+  Consider to set the correct value.

--- a/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.properties
+++ b/core/src/main/resources/jenkins/diagnostics/UnsetRootUrlMonitor/message.properties
@@ -22,4 +22,4 @@
 # THE SOFTWARE.
 #
 blurb=Jenkins root URL is required for the correct operation of many Jenkins features. \
-  Please configure the correct value in Jenkins configuration.
+  Please <a href="configure">configure</a> the correct value in Jenkins configuration.

--- a/core/src/main/resources/jenkins/model/JenkinsLocationConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/JenkinsLocationConfiguration/config.groovy
@@ -6,7 +6,7 @@ def f=namespace(lib.FormTagLib)
 
 f.section(title:_("Jenkins Location")) {
     f.entry(title:_("Jenkins URL"), field:"url") {
-        f.textbox(default: Functions.inferHudsonURL(request))
+        f.textbox()
     }
     f.entry(title:_("System Admin e-mail address"), field:"adminAddress") {
         f.textbox()

--- a/core/src/main/resources/jenkins/model/Messages.properties
+++ b/core/src/main/resources/jenkins/model/Messages.properties
@@ -72,4 +72,4 @@ BlockedBecauseOfBuildInProgress.shortDescription=Build #{0} is already in progre
 BlockedBecauseOfBuildInProgress.ETA=\ (ETA:{0})
 BuildDiscarderProperty.displayName=Discard Old Builds
 
-Jenkins.EmptyRootUrl=Please set a valid host name
+Jenkins.EmptyRootUrl=Please set a valid URL

--- a/core/src/main/resources/jenkins/model/Messages.properties
+++ b/core/src/main/resources/jenkins/model/Messages.properties
@@ -71,3 +71,5 @@ ParameterizedJobMixIn.build_now=Build Now
 BlockedBecauseOfBuildInProgress.shortDescription=Build #{0} is already in progress{1}
 BlockedBecauseOfBuildInProgress.ETA=\ (ETA:{0})
 BuildDiscarderProperty.displayName=Discard Old Builds
+
+Jenkins.EmptyRootUrl=Please set a valid host name


### PR DESCRIPTION
[JENKINS-31661](https://issues.jenkins-ci.org/browse/JENKINS-31661)
- [x] Avoid to set a -confusing- default value in the configuration form field
- [x] Add an `AdministrativeMonitor` to point users to set a correct root URL.
- [x] Caching the last-inferred root URL on every page load and use it as fallback if any other way to get the URL fails.

@reviewbybees
