### PR TITLE
[JENKINS-31596] The kill switch is never relevant if you do not have RUN_SCRIPTS

### DIFF
--- a/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
@@ -48,9 +48,6 @@ public class MasterKillSwitchConfiguration extends GlobalConfiguration {
      * Unless this option is relevant, we don't let users choose this.
      */
     public boolean isRelevant() {
-        if (!jenkins.hasPermission(Jenkins.RUN_SCRIPTS))) {
-            return false;
-        }
         if (rule.getMasterKillSwitch()) {
             return true; // always relevant if it is enabled.
         }

--- a/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
@@ -46,14 +46,7 @@ public class MasterKillSwitchConfiguration extends GlobalConfiguration {
      * Unless this option is relevant, we don't let users choose this.
      */
     public boolean isRelevant() {
-        if (rule.getMasterKillSwitch()) {
-            return true; // always relevant if it is enabled.
-        }
-        return jenkins.isUseSecurity()            // if security is off, there's no point
-            && (jenkins.getComputers().length>1   // if there's no slave,
-                || !jenkins.clouds.isEmpty()      // and no clouds, likewise this is pointless
-            )
-        ;
+        return jenkins.hasPermission(Jenkins.RUN_SCRIPTS) && jenkins.isUseSecurity();
     }
 }
 

--- a/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
@@ -48,6 +48,9 @@ public class MasterKillSwitchConfiguration extends GlobalConfiguration {
      * Unless this option is relevant, we don't let users choose this.
      */
     public boolean isRelevant() {
+        if (!jenkins.hasPermission(Jenkins.RUN_SCRIPTS))) {
+            return false;
+        }
         if (rule.getMasterKillSwitch()) {
             return true; // always relevant if it is enabled.
         }

--- a/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
@@ -1,8 +1,6 @@
 package jenkins.security.s2m;
 
 import hudson.Extension;
-import hudson.ExtensionList;
-import hudson.ExtensionPoint;
 import javax.inject.Inject;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
@@ -54,39 +52,8 @@ public class MasterKillSwitchConfiguration extends GlobalConfiguration {
         return jenkins.isUseSecurity()            // if security is off, there's no point
             && (jenkins.getComputers().length>1   // if there's no slave,
                 || !jenkins.clouds.isEmpty()      // and no clouds, likewise this is pointless
-                || Relevance.fromExtension()      // unless a plugin thinks otherwise
             )
         ;
-    }
-
-    /**
-     * Some plugins may cause the {@link MasterKillSwitchConfiguration} to be relevant for additional reasons,
-     * by implementing this extension point they can indicate such additional conditions.
-     *
-     * @since FIXME
-     */
-    public static abstract class Relevance implements ExtensionPoint {
-
-        /**
-         * Is the {@link MasterKillSwitchConfiguration} relevant.
-         *
-         * @return {@code true} if the {@link MasterKillSwitchConfiguration} relevant.
-         */
-        public abstract boolean isRelevant();
-
-        /**
-         * Is the {@link MasterKillSwitchConfiguration} relevant for any of the {@link Relevance} extensions.
-         *
-         * @return {@code true} if and only if {@link Relevance#isRelevant()} for at least one extension.
-         */
-        public static boolean fromExtension() {
-            for (Relevance r : ExtensionList.lookup(Relevance.class)) {
-                if (r.isRelevant()) {
-                    return true;
-                }
-            }
-            return false;
-        }
     }
 }
 


### PR DESCRIPTION
Follow up to [PR#1917](https://github.com/jenkinsci/jenkins/pull/1917) to prevent 

```
hudson.security.AccessDeniedException2: anonymous is missing the Overall/RunScripts permission
 at hudson.security.ACL.checkPermission(ACL.java:63)
 at hudson.model.Node.checkPermission(Node.java:462)
 at jenkins.security.s2m.AdminWhitelistRule.setMasterKillSwitch(AdminWhitelistRule.java:210)
 at jenkins.security.s2m.MasterKillSwitchConfiguration.configure(MasterKillSwitchConfiguration.java:41)
 at hudson.security.GlobalSecurityConfiguration.configureDescriptor(GlobalSecurityConfiguration.java:126)
 at hudson.security.GlobalSecurityConfiguration.configure(GlobalSecurityConfiguration.java:115)
 at hudson.security.GlobalSecurityConfiguration.doConfigure(GlobalSecurityConfiguration.java:79)
```

@reviewbybees
