### PR TITLE
[JENKINS-31618] Fix JellyTagException in loginLink.jelly session is not created or "from" is null

### DIFF
--- a/core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
+++ b/core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
@@ -25,8 +25,11 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <j:set var="fromRaw" value="${ if (request.getSession(false)!=null) request.session.attribute('from');}" />
+  <j:set var="fromRaw" value="${ (fromRaw!=null)?fromRaw:request.getParameter('from');}" />
+  <j:set var="fromRaw" defaultValue="/" value="${if (fromRaw!=null) fromRaw; else if (request.requestURI==null || request.requestURI=='/loginError' || request.requestURI=='/login') '/'; else request.requestURI;}" />
   <j:invokeStatic var="from" className="java.net.URLEncoder" method="encode">
-    <j:arg value="${if (request.session.attribute('from')!=null) request.session.getAttribute('from');  else if (request.getParameter('from')!=null) request.getParameter('from'); else if (request.requestURI=='/loginError' || request.requestURI=='/login') '/'; else request.requestURI;}"/>
+    <j:arg value="${fromRaw.toString()}" type="java.lang.String" />
     <j:arg value="UTF-8"/>
   </j:invokeStatic>
   <a href="${rootURL}/${app.securityRealm.loginUrl}?from=${from}"><b>${%login}</b></a>


### PR DESCRIPTION
expands code to be more readable and fix issue when session is not created or "from" is null ( URLEncoder will not work is the 1st param is not string )

https://issues.jenkins-ci.org/browse/JENKINS-31618
