### PR TITLE
[FIXED JENKINS-31768] - Remove monitor lock from setNumberExecutors to avoid deadlock

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -840,6 +840,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      *
      * @param number of executors
      */
+    @GuardedBy("hudson.model.Queue.lock")
     private void setNumExecutors(int n) {
         this.numExecutors = n;
         final int diff = executors.size()-n;

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -828,7 +828,19 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     protected void onRemoved(){
     }
 
-    private synchronized void setNumExecutors(int n) {
+    /**
+     * Calling path, *means protected by Queue.withLock
+     *
+     * Computer.doConfigSubmit -> Computer.replaceBy ->Jenkins.setNodes* ->Computer.setNode
+     * AbstractCIBase.updateComputerList->Computer.inflictMortalWound*
+     * AbstractCIBase.updateComputerList->AbstractCIBase.updateComputer* ->Computer.setNode
+     * AbstractCIBase.updateComputerList->AbstractCIBase.killComputer->Computer.kill
+     * Computer.constructor->Computer.setNode
+     * Computer.kill is called after numExecutors set to zero(Computer.inflictMortalWound) so not need the Queue.lock
+     *
+     * @param number of executors
+     */
+    private void setNumExecutors(int n) {
         this.numExecutors = n;
         final int diff = executors.size()-n;
 


### PR DESCRIPTION
fix JENKINS-31768 dead lock while removing computer

https://issues.jenkins-ci.org/browse/JENKINS-31768
