### PR TITLE
Add extension point to load toplevel items

### DIFF
--- a/core/src/main/java/jenkins/model/DiskItemLoader.java
+++ b/core/src/main/java/jenkins/model/DiskItemLoader.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 
 
 @Extension
-public class DiskTaskLoader implements TopLevelItemLoader {
+public class DiskItemLoader extends TopLevelItemLoader {
 
     public Collection<TopLevelItem> load(Jenkins jenkins) throws IOException {
         Collection<TopLevelItem> items = new ArrayList<TopLevelItem>();

--- a/core/src/main/java/jenkins/model/DiskTaskLoader.java
+++ b/core/src/main/java/jenkins/model/DiskTaskLoader.java
@@ -1,0 +1,37 @@
+package jenkins.model;
+
+import hudson.Extension;
+import hudson.model.Items;
+import hudson.model.TopLevelItem;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+
+@Extension
+public class DiskTaskLoader implements TopLevelItemLoader {
+
+    public Collection<TopLevelItem> load(Jenkins jenkins) throws IOException {
+        Collection<TopLevelItem> items = new ArrayList<TopLevelItem>();
+        File[] subdirs = getProjectDir(jenkins).listFiles();
+        for (final File subdir : subdirs) {
+            if(Items.getConfigFile(subdir).exists()) {
+                TopLevelItem item = (TopLevelItem) Items.load(jenkins, subdir);
+                items.add(item);
+            }
+        }
+        return items;
+    }
+    private File getProjectDir(Jenkins jenkins) throws IOException {
+        File projectsDir = new File(jenkins.root,"jobs");
+        if(!projectsDir.getCanonicalFile().isDirectory() && !projectsDir.mkdirs()) {
+            if(projectsDir.exists())
+                throw new IOException(projectsDir+" is not a directory");
+            throw new IOException("Unable to create "+projectsDir+"\nPermission issue? Please create this directory manually.");
+        }
+        return projectsDir;
+    }
+
+}

--- a/core/src/main/java/jenkins/model/TopLevelItemLoader.java
+++ b/core/src/main/java/jenkins/model/TopLevelItemLoader.java
@@ -7,6 +7,6 @@ import java.io.IOException;
 import java.util.Collection;
 
 
-public interface TopLevelItemLoader extends ExtensionPoint {
-     Collection<TopLevelItem> load(Jenkins jenkins) throws IOException;
+public abstract class TopLevelItemLoader implements ExtensionPoint {
+     public abstract Collection<TopLevelItem> load(Jenkins jenkins) throws IOException;
 }

--- a/core/src/main/java/jenkins/model/TopLevelItemLoader.java
+++ b/core/src/main/java/jenkins/model/TopLevelItemLoader.java
@@ -6,6 +6,10 @@ import hudson.model.TopLevelItem;
 import java.io.IOException;
 import java.util.Collection;
 
+/**
+ * Extension point to contribute @TopLevelItem's to Jenkins.
+ * @see DiskItemLoader
+ */
 
 public abstract class TopLevelItemLoader implements ExtensionPoint {
      public abstract Collection<TopLevelItem> load(Jenkins jenkins) throws IOException;

--- a/core/src/main/java/jenkins/model/TopLevelItemLoader.java
+++ b/core/src/main/java/jenkins/model/TopLevelItemLoader.java
@@ -1,0 +1,12 @@
+package jenkins.model;
+
+import hudson.ExtensionPoint;
+import hudson.model.TopLevelItem;
+
+import java.io.IOException;
+import java.util.Collection;
+
+
+public interface TopLevelItemLoader extends ExtensionPoint {
+     Collection<TopLevelItem> load(Jenkins jenkins) throws IOException;
+}


### PR DESCRIPTION
This is a redo of this PR https://github.com/jenkinsci/jenkins/pull/1762. 

It adds an extension point which lets plugins load toplevel items from other sources other than disk. 
For example, I am trying to load toplevel items from database in DotCi.

Thank you for your time.
