### PR TITLE
[JENKINS-31458] Call Descriptor.newInstance even on nested data-bound objects

### DIFF
--- a/test/src/test/java/hudson/model/ParametersDefinitionPropertyTest.java
+++ b/test/src/test/java/hudson/model/ParametersDefinitionPropertyTest.java
@@ -28,7 +28,6 @@ import java.util.Locale;
 import net.sf.json.JSONObject;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -40,7 +39,6 @@ public class ParametersDefinitionPropertyTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
-    @Ignore("TODO after 600b1f0 (#1888): NoStaplerConstructorException: There's no @DataBoundConstructor on any constructor of class hudson.model.ParametersDefinitionPropertyTest$KrazyParameterDefinition")
     @Issue("JENKINS-31458")
     @Test
     public void customNewInstance() throws Exception {

--- a/test/src/test/java/hudson/model/ParametersDefinitionPropertyTest.java
+++ b/test/src/test/java/hudson/model/ParametersDefinitionPropertyTest.java
@@ -25,9 +25,14 @@
 package hudson.model;
 
 import java.util.Locale;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.sf.json.JSONObject;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -35,6 +40,15 @@ import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.StaplerRequest;
 
 public class ParametersDefinitionPropertyTest {
+
+    private static final Logger logger = Logger.getLogger(Descriptor.class.getName());
+    @BeforeClass
+    public static void logging() {
+        logger.setLevel(Level.ALL);
+        Handler handler = new ConsoleHandler();
+        handler.setLevel(Level.ALL);
+        logger.addHandler(handler);
+    }
 
     @Rule
     public JenkinsRule r = new JenkinsRule();

--- a/test/src/test/java/hudson/model/ParametersDefinitionPropertyTest.java
+++ b/test/src/test/java/hudson/model/ParametersDefinitionPropertyTest.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model;
+
+import java.util.Locale;
+import net.sf.json.JSONObject;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.StaplerRequest;
+
+public class ParametersDefinitionPropertyTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Ignore("TODO after 600b1f0 (#1888): NoStaplerConstructorException: There's no @DataBoundConstructor on any constructor of class hudson.model.ParametersDefinitionPropertyTest$KrazyParameterDefinition")
+    @Issue("JENKINS-31458")
+    @Test
+    public void customNewInstance() throws Exception {
+        KrazyParameterDefinition kpd = new KrazyParameterDefinition("kpd", "desc", "KrAzY");
+        FreeStyleProject p = r.createFreeStyleProject();
+        ParametersDefinitionProperty pdp = new ParametersDefinitionProperty(kpd);
+        p.addProperty(pdp);
+        r.configRoundtrip(p);
+        pdp = p.getProperty(ParametersDefinitionProperty.class);
+        kpd = (KrazyParameterDefinition) pdp.getParameterDefinition("kpd");
+        assertEquals("desc", kpd.getDescription());
+        assertEquals("krazy", kpd.field);
+    }
+
+    public static class KrazyParameterDefinition extends ParameterDefinition {
+
+        public final String field;
+
+        // not @DataBoundConstructor
+        public KrazyParameterDefinition(String name, String description, String field) {
+            super(name, description);
+            this.field = field;
+        }
+
+        @Override
+        public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ParameterValue createValue(StaplerRequest req) {
+            throw new UnsupportedOperationException();
+        }
+
+        @TestExtension("customNewInstance")
+        public static class DescriptorImpl extends ParameterDescriptor {
+
+            @Override
+            public ParameterDefinition newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+                return new KrazyParameterDefinition(formData.getString("name"), formData.getString("description"), formData.getString("field").toLowerCase(Locale.ENGLISH));
+            }
+
+        }
+
+    }
+
+}

--- a/test/src/test/java/hudson/slaves/NodePropertyTest.java
+++ b/test/src/test/java/hudson/slaves/NodePropertyTest.java
@@ -9,9 +9,15 @@ import static org.junit.Assert.assertTrue;
 import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlLabel;
+import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Slave;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.sf.json.JSONObject;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -23,6 +29,15 @@ import org.kohsuke.stapler.StaplerRequest;
  * @author Kohsuke Kawaguchi
  */
 public class NodePropertyTest {
+
+    private static final Logger logger = Logger.getLogger(Descriptor.class.getName());
+    @BeforeClass
+    public static void logging() {
+        logger.setLevel(Level.ALL);
+        Handler handler = new ConsoleHandler();
+        handler.setLevel(Level.ALL);
+        logger.addHandler(handler);
+    }
 
     @Rule
     public JenkinsRule j = new JenkinsRule();

--- a/test/src/test/resources/hudson/model/ParametersDefinitionPropertyTest/KrazyParameterDefinition/config.jelly
+++ b/test/src/test/resources/hudson/model/ParametersDefinitionPropertyTest/KrazyParameterDefinition/config.jelly
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2015 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="name" title="name">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="description" title="description">
+        <f:textarea/>
+    </f:entry>
+    <f:entry title="field">
+        <f:textbox name="field" value="${instance.field.toUpperCase()}"/>
+    </f:entry>
+</j:jelly>


### PR DESCRIPTION
[JENKINS-31458](https://issues.jenkins-ci.org/browse/JENKINS-31458)
#1888 introduced a regression for `ParameterDefinition` implementations with customized `newInstance` overrides. This could probably have been fixed by restoring the old `ParametersDefinitionProperty.DescriptorImpl.newInstance` override, which (indirectly) called `newInstance` on the `ParameterDescriptor`s.

However this is merely one case of a longstanding design flaw in Jenkins data binding, that Stapler knows nothing about `Descriptor.newInstance` and so any calls to `newInstance` on a “top-level” object (one instantiated directly by Jenkins code) will not in turn pay attention to custom `newInstance` implementations in nested objects. I have noticed this problem repeatedly in `workflow-plugin`, where I often need to use configuration snippets of `Describable`s at a different level of nesting than Jenkins would normally use.

The fix is to use the existing but rarely implemented `BindInterceptor` hook in Stapler to override the creation of nested `Describable`s to call `newInstance`. In most cases that uses the default implementation (perhaps called as a `super` method from an override), which just asks Stapler to do the work, so we need per-request state to track which JSON fragments we have already encountered, to avoid a `StackOverflowError`.

@reviewbybees esp. @kohsuke since this is pretty fundamental.
