### PR TITLE
Add FINER logging for process leak descriptors

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1479,6 +1479,23 @@ public class Util {
     }
 
     /**
+     * Convert a list of {@link StackTraceElement}s to a String with a new line for each element.
+     *
+     * @param elements List of elements
+     * @return String representation of the elements
+     */
+    @Nonnull
+    public static String stackTraceArrayToString(@Nullable StackTraceElement[] elements) {
+        StringBuilder b = new StringBuilder();
+        if (elements != null) {
+            for (StackTraceElement e : elements) {
+                b.append(e).append('\n');
+            }
+        }
+        return b.toString();
+    }
+
+    /**
      * Return true if the systemId denotes an absolute URI .
      *
      * The same algorithm can be seen in {@link URI}, but


### PR DESCRIPTION
In the event there is a process leak descriptor we add some extra logging information in `Level.FINER` which records the PID, and the stack trace for the thread which has the leak currently. This can provide us with some information like if the leak descriptor came from within a plugin, or an external command.

@reviewbybees
