### PR TITLE
Ensure that no warnings appear during startup

### DIFF
--- a/core/src/main/java/hudson/DNSMultiCast.java
+++ b/core/src/main/java/hudson/DNSMultiCast.java
@@ -66,7 +66,8 @@ public class DNSMultiCast implements Closeable {
                     jmdns.registerService(ServiceInfo.create("_http._tcp.local.","Jenkins",
                             jenkins_port,0,0,props));
                 } catch (IOException e) {
-                    LOGGER.log(Level.WARNING,"Failed to advertise the service to DNS multi-cast",e);
+                    LOGGER.log(Level.INFO, "Cannot advertise service to DNS multi-cast, skipping: {0}", e);
+                    LOGGER.log(Level.FINE, null, e);
                 }
                 return null;
             }

--- a/core/src/main/java/hudson/UDPBroadcastThread.java
+++ b/core/src/main/java/hudson/UDPBroadcastThread.java
@@ -29,11 +29,11 @@ import jenkins.model.Jenkins;
 import hudson.util.OneShotEvent;
 
 import java.io.IOException;
-import java.net.BindException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.MulticastSocket;
 import java.net.SocketAddress;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.channels.ClosedByInterruptException;
 import java.util.logging.Level;
@@ -103,10 +103,13 @@ public class UDPBroadcastThread extends Thread {
             }
         } catch (ClosedByInterruptException e) {
             // shut down
-        } catch (BindException e) {
-            // if we failed to listen to UDP, just silently abandon it, as a stack trace
+        } catch (SocketException e) {
+            if (shutdown) { // forcibly closed
+                return;
+            }            // if we failed to listen to UDP, just silently abandon it, as a stack trace
             // makes people unnecessarily concerned, for a feature that currently does no good.
-            LOGGER.log(Level.WARNING, "Failed to listen to UDP port "+PORT,e);
+            LOGGER.log(Level.INFO, "Cannot listen to UDP port {0}, skipping: {1}", new Object[] {PORT, e});
+            LOGGER.log(Level.FINE, null, e);
         } catch (IOException e) {
             if (shutdown)   return; // forcibly closed
             LOGGER.log(Level.WARNING, "UDP handling problem",e);

--- a/test/src/test/java/jenkins/model/StartupTest.java
+++ b/test/src/test/java/jenkins/model/StartupTest.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model;
+
+import hudson.util.RingBufferLogHandler;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class StartupTest {
+
+    private static final Logger logger = Logger.getLogger("");
+
+    private static final RingBufferLogHandler handler = new RingBufferLogHandler() {
+        @Override
+        public synchronized void publish(LogRecord record) {
+            if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+                super.publish(record);
+            }
+        }
+    };
+
+    @BeforeClass
+    public static void logging() {
+        logger.addHandler(handler);
+    }
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void noWarnings() throws Exception {
+        Formatter f = new SimpleFormatter();
+        List<String> warnings = new ArrayList<>();
+        for (LogRecord lr : handler.getView()) {
+            warnings.add(f.format(lr).trim());
+        }
+        assertEquals(Collections.emptyList(), warnings);
+    }
+
+}


### PR DESCRIPTION
While trying to debug a stack trace during Jenkins startup (that turned out to be due to a bogus file in my local Maven repository), I found that there is no functional test asserting that there are no warnings during startup (on a new home dir)! This seems like a basic sanity check we should do.

@reviewbybees
