### PR TITLE
[FIXED JENKINS-31871] Properly handle single quotes in item names

### DIFF
--- a/core/src/main/java/hudson/util/FormValidation.java
+++ b/core/src/main/java/hudson/util/FormValidation.java
@@ -638,7 +638,7 @@ public abstract class FormValidation extends IOException implements HttpResponse
          */
         public String toStemUrl() {
             if (names==null)    return null;
-            return jsStringEscape(Descriptor.getCurrentDescriptorByNameUrl()) + '/' + relativePath();
+            return Descriptor.getCurrentDescriptorByNameUrl() + '/' + relativePath();
         }
 
         public String getDependsOn() {


### PR DESCRIPTION
Single quotes in item names should be prohibited
https://issues.jenkins-ci.org/browse/JENKINS-31871

@reviewbybees @oleg-nenashev @varmenise 
