### PR TITLE
Specify --webroot to the Windows service wrapper

### DIFF
--- a/core/src/main/resources/windows-service/jenkins.xml
+++ b/core/src/main/resources/windows-service/jenkins.xml
@@ -38,7 +38,7 @@ THE SOFTWARE.
     The following value assumes that you have java in your PATH.
   -->
   <executable>java</executable>
-  <arguments>-Xrs -Xmx256m -Dhudson.lifecycle=hudson.lifecycle.WindowsServiceLifecycle -jar "%BASE%\jenkins.war" --httpPort=8080</arguments>
+  <arguments>-Xrs -Xmx256m -Dhudson.lifecycle=hudson.lifecycle.WindowsServiceLifecycle -jar "%BASE%\jenkins.war" --httpPort=8080 --webroot="%BASE%\war"</arguments>
   <!--
     interactive flag causes the empty black Java window to be displayed.
     I'm still debugging this.


### PR DESCRIPTION
Otherwise we [default](https://github.com/jenkinsci/extras-executable-war/blob/56d8d2df80edf7ddc519aaa0a0dfa71469833d3b/src/main/java/Main.java#L176-L182) to the `war` subdirectory of Jenkins home, which is
- inefficient, if this is on a slower shared drive
- dangerous, if using CloudBees high availability

Compare for example the [RPM package](https://github.com/jenkinsci/packaging/blob/a847ec19b614cd5f3fed26fd8f7cc3c9c999631f/rpm/build/SOURCES/jenkins.init.in#L84) which already sets `--webroot`.

@reviewbybees
