### PR TITLE
walkmod execution to remove dead code

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -150,19 +150,43 @@ THE SOFTWARE.
       <version>1.0</version>
     </dependency>
     <dependency>
+       <groupId>org.zeroturnaround</groupId>
+       <artifactId>javarebel-sdk</artifactId>
+       <version>2.0.2</version>
+       <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler-adjunct-zeroclipboard</artifactId>
       <version>1.3.5-1</version>
+      <exclusions>
+         <exclusion>
+           <groupId>org.kohsuke.stapler</groupId>
+           <artifactId>stapler</artifactId>
+         </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler-adjunct-timeline</artifactId>
       <version>1.4</version>
+      <exclusions>
+         <exclusion>
+           <groupId>org.kohsuke.stapler</groupId>
+           <artifactId>stapler</artifactId>
+         </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler-adjunct-codemirror</artifactId>
       <version>1.3</version>
+      <exclusions>
+         <exclusion>
+           <groupId>org.kohsuke.stapler</groupId>
+           <artifactId>stapler</artifactId>
+         </exclusion>
+      </exclusions>
     </dependency>
     <dependency><!-- this helps us see the source code of the control while we edit Jenkins. -->
       <groupId>org.kohsuke.stapler</groupId>
@@ -170,6 +194,12 @@ THE SOFTWARE.
       <version>1.4</version>
       <classifier>tests</classifier>
       <scope>test</scope>
+      <exclusions>
+         <exclusion>
+           <groupId>org.kohsuke.stapler</groupId>
+           <artifactId>stapler</artifactId>
+         </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1601,7 +1601,7 @@ public final class FilePath implements Serializable {
         PosixAPI.jnr().chmod(f.getAbsolutePath(),mask);
     }
 
-    private static boolean CHMOD_WARNED = false;
+    
 
     /**
      * Gets the file permission bit mask.

--- a/core/src/main/java/hudson/cli/handlers/package-info.java
+++ b/core/src/main/java/hudson/cli/handlers/package-info.java
@@ -3,4 +3,3 @@
  */
 package hudson.cli.handlers;
 
-import org.kohsuke.args4j.spi.OptionHandler;

--- a/core/src/main/java/hudson/init/package-info.java
+++ b/core/src/main/java/hudson/init/package-info.java
@@ -44,4 +44,3 @@
  */
 package hudson.init;
 
-import org.jvnet.hudson.reactor.Task;

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -674,7 +674,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     @Override
     public void movedTo(DirectlyModifiableTopLevelItemGroup destination, AbstractItem newItem, File destDir) throws IOException {
-        Job newJob = (Job) newItem; // Missing covariant parameters type here.
+         // Missing covariant parameters type here.
         File oldBuildDir = getBuildDir();
         super.movedTo(destination, newItem, destDir);
         File newBuildDir = getBuildDir();

--- a/core/src/main/java/hudson/model/LoadStatistics.java
+++ b/core/src/main/java/hudson/model/LoadStatistics.java
@@ -27,7 +27,7 @@ import hudson.Extension;
 import hudson.model.MultiStageTimeSeries.TimeScale;
 import hudson.model.MultiStageTimeSeries.TrendChart;
 import hudson.model.queue.SubTask;
-import hudson.model.queue.Tasks;
+
 import hudson.util.ColorPalette;
 import hudson.util.NoOverlapCategoryAxis;
 import jenkins.model.Jenkins;
@@ -401,15 +401,7 @@ public abstract class LoadStatistics {
             j.overallLoad.updateCounts(j.overallLoad.computeSnapshot(bis));
         }
 
-        private int count(List<Queue.BuildableItem> bis, Label l) {
-            int q=0;
-            for (Queue.BuildableItem bi : bis) {
-                for (SubTask st : Tasks.getSubTasksOf(bi.task))
-                    if (bi.getAssignedLabelFor(st)==l)
-                        q++;
-            }
-            return q;
-        }
+        
     }
 
     /**

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -65,7 +65,7 @@ import hudson.model.queue.CauseOfBlockage.BecauseLabelIsOffline;
 import hudson.model.queue.CauseOfBlockage.BecauseNodeIsBusy;
 import hudson.model.queue.WorkUnitContext;
 import hudson.security.AccessControlled;
-import hudson.security.Permission;
+
 import jenkins.security.QueueItemAuthenticatorProvider;
 import jenkins.util.Timer;
 import hudson.triggers.SafeTimerTask;

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -52,10 +52,10 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
-import java.util.Arrays;
+
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
+
 
 import javax.servlet.ServletException;
 

--- a/core/src/main/java/hudson/model/TransientUserActionFactory.java
+++ b/core/src/main/java/hudson/model/TransientUserActionFactory.java
@@ -26,7 +26,7 @@ package hudson.model;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
-import jenkins.model.Jenkins;
+
 import java.util.Collection;
 import java.util.Collections;
 

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -62,11 +62,11 @@ import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import javax.annotation.Nonnull;
+
 import javax.net.ssl.SSLHandshakeException;
 import javax.servlet.ServletException;
 import java.io.File;
-import java.io.FileInputStream;
+
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -74,7 +74,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
-import java.security.DigestInputStream;
+
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -175,12 +175,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
         return record.data.get(c);
     }
 
-    /**
-     * Is the monitoring activity currently in progress?
-     */
-    private synchronized boolean isInProgress() {
-        return inProgress !=null && inProgress.isAlive();
-    }
+    
 
     /**
      * The timestamp that indicates when the last round of the monitoring has completed.

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -23,7 +23,7 @@
  */
 package hudson.node_monitors;
 
-import hudson.Util;
+
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.remoting.Callable;

--- a/core/src/main/java/hudson/util/LRUStringConverter.java
+++ b/core/src/main/java/hudson/util/LRUStringConverter.java
@@ -1,11 +1,11 @@
 package hudson.util;
 
 import com.thoughtworks.xstream.converters.basic.AbstractSingleValueConverter;
-import com.thoughtworks.xstream.converters.basic.StringConverter;
+
 import org.apache.commons.collections.map.LRUMap;
 
 import java.util.Collections;
-import java.util.HashMap;
+
 import java.util.Map;
 
 public class LRUStringConverter extends AbstractSingleValueConverter {

--- a/core/src/main/java/jenkins/model/GlobalConfigurationCategory.java
+++ b/core/src/main/java/jenkins/model/GlobalConfigurationCategory.java
@@ -4,7 +4,7 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.ModelObject;
-import hudson.security.*;
+
 import hudson.security.Messages;
 
 /**

--- a/core/walkmod.xml
+++ b/core/walkmod.xml
@@ -7,6 +7,7 @@
         <transformation type="dead-code-cleaner">
             <param name="ignoreSerializableMethods">true</param>
             <param name="excludedMethods">["hudson.FilePath#_syncIO()"]</param>
+            <param name="excludedFields">["hudson.model.Slave#labels", "hudson.model.JenkinsLocationConfiguration#charset", "jenkins.model.JenkinsLocationConfiguration#useSsl"]</param>
         </transformation>
         <writer path="src/main/java" type="org.walkmod:walkmod-javalang-plugin:string-writer"/>
     </chain>

--- a/core/walkmod.xml
+++ b/core/walkmod.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE walkmod PUBLIC "-//WALKMOD//DTD" "http://www.walkmod.com/dtd/walkmod-1.1.dtd">
+<walkmod>
+    <conf-providers>
+        <conf-provider type="maven"/>
+    </conf-providers>
+    <chain name="default">
+        <transformation type="dead-code-cleaner"/>
+        <writer path="src/main/java" type="org.walkmod:walkmod-javalang-plugin:string-writer"/>
+    </chain>
+</walkmod>

--- a/core/walkmod.xml
+++ b/core/walkmod.xml
@@ -4,7 +4,10 @@
         <conf-provider type="maven"/>
     </conf-providers>
     <chain name="default">
-        <transformation type="dead-code-cleaner"/>
+        <transformation type="dead-code-cleaner">
+            <param name="ignoreSerializableMethods">true</param>
+            <param name="excludedMethods">["hudson.FilePath#_syncIO()"]</param>
+        </transformation>
         <writer path="src/main/java" type="org.walkmod:walkmod-javalang-plugin:string-writer"/>
     </chain>
 </walkmod>


### PR DESCRIPTION
Hi,

I have executed walkmod, an open source tool to apply code conventions. In this case, I just tried to remove dead code in the core module. After executing it, the results are as follows:
- Deletes of unused imports
- Deletes of private variables and fields
- Deletes of some private "readResolve" methods because classes are not Serializable.

Moreover, executing walkmod I have discovered some dependency conflicts that I have specified as "exclusions" and a missing runtime dependency.

Let me know if the results seem interesting to you :) and thank you for your time.
