### PR TITLE
[JENKINS-32164] CLI class improvements

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -49,6 +49,12 @@
       <artifactId>trilead-ssh2</artifactId>
       <version>build214-jenkins-1</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+      <version>3.0.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -89,13 +89,16 @@ public class CLI {
     private final String httpsProxyTunnel;
     private final String authorization;
 
+    /**
+     * @deprecated Use {@link #CLI(hudson.cli.CLIConnectionFactory)
+     */
+    @Deprecated
     public CLI(URL jenkins) throws IOException, InterruptedException {
         this(jenkins,null);
     }
 
     /**
-     * @deprecated
-     *      Use {@link CLIConnectionFactory} to create {@link CLI}
+     * @deprecated Use {@link #CLI(hudson.cli.CLIConnectionFactory)
      */
     @Deprecated
     public CLI(URL jenkins, ExecutorService exec) throws IOException, InterruptedException {
@@ -103,16 +106,22 @@ public class CLI {
     }
 
     /**
-     * @deprecated 
-     *      Use {@link CLIConnectionFactory} to create {@link CLI}
+     * @deprecated Use {@link #CLI(hudson.cli.CLIConnectionFactory)
      */
     @Deprecated
     public CLI(URL jenkins, ExecutorService exec, String httpsProxyTunnel) throws IOException, InterruptedException {
         this(new CLIConnectionFactory().url(jenkins).executorService(exec).httpsProxyTunnel(httpsProxyTunnel));
     }
-    
-    /*package*/ CLI(CLIConnectionFactory factory) throws IOException, InterruptedException {
+
+    /**
+     * CLI connection to jenkins.
+     * @param factory builder with settings required for connection.
+     */
+    public CLI(CLIConnectionFactory factory) throws IOException, InterruptedException {
         URL jenkins = factory.jenkins;
+        if (jenkins == null) {
+            throw new IllegalArgumentException("Jenkins url must be specified in CLIConnectionFactory");
+        }
         this.httpsProxyTunnel = factory.httpsProxyTunnel;
         this.authorization = factory.authorization;
         ExecutorService exec = factory.exec;

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -131,11 +131,16 @@ public class CLI {
 
         ownsPool = exec==null;
         pool = exec!=null ? exec : Executors.newCachedThreadPool();
+        CliPort cliPort = factory.cliPort != null ? factory.cliPort : getCliTcpPort(url);
 
         Channel _channel;
         try {
-            _channel = connectViaCliPort(jenkins, getCliTcpPort(url));
+            _channel = connectViaCliPort(jenkins, cliPort);
         } catch (IOException e) {
+            if (factory.onlyCliPortConnection) {
+                throw e;
+            }
+
             LOGGER.log(Level.FINE,"Failed to connect via CLI port. Falling back to HTTP",e);
             try {
                 _channel = connectViaHttp(url);

--- a/cli/src/main/java/hudson/cli/CLIConnectionFactory.java
+++ b/cli/src/main/java/hudson/cli/CLIConnectionFactory.java
@@ -2,6 +2,8 @@ package hudson.cli;
 
 import org.apache.commons.codec.binary.Base64;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -17,6 +19,11 @@ public class CLIConnectionFactory {
     ExecutorService exec;
     String httpsProxyTunnel;
     String authorization;
+
+    @CheckForNull
+    CliPort cliPort;
+
+    boolean onlyCliPortConnection = false;
 
     /**
      * Top URL of the Jenkins to connect to.
@@ -54,6 +61,22 @@ public class CLIConnectionFactory {
      */
     public CLIConnectionFactory authorization(String value) {
         this.authorization = value;
+        return this;
+    }
+
+    /**
+     * Use specified CliPort configuration instead of searching configuration from http headers.
+     */
+    public CLIConnectionFactory cliPort(CliPort cliPort) {
+        this.cliPort = cliPort;
+        return this;
+    }
+
+    /**
+     * Enforces CLI to use CliPort connection, either fail connection.
+     */
+    public CLIConnectionFactory onlyCliPortConnection(boolean onlyCliPortConnection) {
+        this.onlyCliPortConnection = onlyCliPortConnection;
         return this;
     }
 

--- a/cli/src/main/java/hudson/cli/CliPort.java
+++ b/cli/src/main/java/hudson/cli/CliPort.java
@@ -2,6 +2,7 @@ package hudson.cli;
 
 import org.apache.commons.codec.binary.Base64;
 
+import javax.annotation.CheckForNull;
 import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
@@ -36,6 +37,7 @@ public final class CliPort {
     /**
      * Gets the public part of the RSA key that represents the server identity.
      */
+    @CheckForNull
     public PublicKey getIdentity() throws GeneralSecurityException {
         if (identity==null) return null;
         byte[] image = Base64.decodeBase64(identity);


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-32164 + some clean-ups

Doesn't look perfect, but i have no ideas how make this private/protected classes configurable and usable outside this package.

Connection from constructor doesn't allow subclass CLI and override `getCliTcpPort()` with additional arguments because sub-class must call defined super.
