### PR TITLE
[JENKINS-32190] Check init status in UsageStatistics

### DIFF
--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -31,6 +31,7 @@ import hudson.node_monitors.ArchitectureMonitor.DescriptorImpl;
 import hudson.util.IOUtils;
 import hudson.util.Secret;
 import static hudson.util.TimeUnit2.DAYS;
+import static hudson.init.InitMilestone.COMPLETED;
 
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -95,9 +96,12 @@ public class UsageStatistics extends PageDecorator {
      * Returns true if it's time for us to check for new version.
      */
     public boolean isDue() {
-        // user opted out. no data collection.
-        if(!Jenkins.getInstance().isUsageStatisticsCollected() || DISABLED)     return false;
-        
+        final Jenkins j = Jenkins.getInstance();
+        // user opted out or Jenkins not fully initialized. no data collection.
+        if (j == null || j.isUsageStatisticsCollected() || DISABLED || COMPLETED.compareTo(j.getInitLevel()) > 0) {
+            return false;
+        }
+
         long now = System.currentTimeMillis();
         if(now - lastAttempt > DAY) {
             lastAttempt = now;


### PR DESCRIPTION
[JENKINS-32190](https://issues.jenkins-ci.org/browse/JENKINS-32190)

`UsageStatistics#getStatData` may get called while Jenkins is not completely initialized. As it navigates all top level items, it may cause unexpected effects in extensions and plugins affecting those items.

This PR makes `UsageStatistics#isDue` check the Jenkins init level before allowing a new collection.

@reviewbybees
