### PR TITLE
[FIX JENKINS-32194] Add time zone to generation date in footer

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -254,7 +254,7 @@ ${h.initPageVariables(context)}
         <div class="row">
           <div class="col-md-6" id="footer"></div>
           <div class="col-md-18">
-            <span class="page_generated">${%Page generated}: <i:formatDate value="${h.getCurrentTime()}" type="both" dateStyle="medium" timeStyle="medium"/></span>
+            <span class="page_generated">${%Page generated}: <i:formatDate value="${h.getCurrentTime()}" type="both" dateStyle="medium" timeStyle="long"/></span>
             <j:if test="${!empty(it.api)}">
                <span class="rest_api"><a href="api/">REST API</a></span>
             </j:if>


### PR DESCRIPTION
This adds the time zone to the footer in all but a few locales. `full` format is ridiculously long in some locales unfortunately (and doesn't necessarily include the TZ either), so I chose `long`. Just adding the TZ name after the time wouldn't be correct either, as some locales print the TZ before the time.

Locales not including the TZ in JRE 7 on OS X:
- Finnish (unspecified country and Finland), 
- Chinese (unspecified and all specific countries), 
- Indonesian (Indonesia), 
- English (South Africa, Australia, New Zealand), 
- Korean (unspecified country and South Korea) 
- and possibly Thai (unspecified country and Thailand),

Some of these wouldn't even include the TZ name in `full` format.
