### PR TITLE
[JENKINS-34767] - Prevent RSS ID collisions for items with same name in different folders

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2394,7 +2394,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         public String getEntryID(Run entry) {
             return "tag:" + "hudson.dev.java.net,"
                 + entry.getTimestamp().get(Calendar.YEAR) + ":"
-                + entry.getParent().getName()+':'+entry.getId();
+                + entry.getParent().getFullName()+':'+entry.getId();
         }
 
         public String getEntryDescription(Run entry) {


### PR DESCRIPTION
Without this change if you have two or more builds with the same name in
different folders they end up with the same RSS id, which breaks feed
readers.

For example folderA/a and folderB/a would both have the following in the
RSS

``` xml
<id>tag:hudson.dev.java.net,2015:a:1</id>
```

After the change they would have

``` xml
<id>tag:hudson.dev.java.net,2015:folderA/a:1</id>
```

for folderA/a
and

``` xml
<id>tag:hudson.dev.java.net,2015:folderB/a:1</id>
```

for folderB/a
