### PR TITLE
[JENKINS-30395] Work around ClosedByInterruptException in JenkinsRule

### DIFF
--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -322,7 +322,7 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      */
     public void before() throws Throwable {
         if (Thread.interrupted()) { // JENKINS-30395
-            System.err.println("was interrupted before start");
+            LOGGER.warning("was interrupted before start");
         }
 
         if(Functions.isWindows()) {

--- a/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
+++ b/test/src/main/java/org/jvnet/hudson/test/JenkinsRule.java
@@ -321,6 +321,10 @@ public class JenkinsRule implements TestRule, MethodRule, RootAction {
      * @throws Throwable if setup fails (which will disable {@code after}
      */
     public void before() throws Throwable {
+        if (Thread.interrupted()) { // JENKINS-30395
+            System.err.println("was interrupted before start");
+        }
+
         if(Functions.isWindows()) {
             // JENKINS-4409.
             // URLConnection caches handles to jar files by default,


### PR DESCRIPTION
[JENKINS-30395](https://issues.jenkins-ci.org/browse/JENKINS-30395)

Follows up #1826 with what I think is an actual fix, not just a skip. Based on trick found in https://github.com/jenkinsci/workflow-plugin/pull/277. All attempts to find the cause of the thread interruption failed, but it seems that clearing the interrupt flag before the test starts suffices to let everything work.

@reviewbybees
