### PR TITLE
[JENKINS-32273] Jenkins CLI unification of error handling and returning

### DIFF
--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -37,6 +37,7 @@ import hudson.remoting.ChannelProperty;
 import hudson.security.CliAuthenticator;
 import hudson.security.SecurityRealm;
 import jenkins.security.MasterToSlaveCallable;
+import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.BadCredentialsException;
 import org.acegisecurity.context.SecurityContext;
@@ -239,6 +240,9 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
             stderr.println(e.getMessage());
             printUsage(stderr, p);
             return -1;
+        } catch (AccessDeniedException e) {
+            stderr.println(e.getMessage());
+            return -1;
         } catch (AbortException e) {
             // signals an error without stack trace
             stderr.println(e.getMessage());
@@ -251,6 +255,10 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
             stderr.println("Bad Credentials. Search the server log for "+id+" for more details.");
             return -1;
         } catch (Exception e) {
+            final String errorMsg = String.format("Unexpected exception occurred while performing %s command!",
+                    getName());
+            stderr.println(errorMsg);
+            LOGGER.log(Level.WARNING, errorMsg, e);
             e.printStackTrace(stderr);
             return -1;
         } finally {


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-32273

Extended exception handling and logging in CLICommand class.

This is the first step which shouldn't break anything existing (fully backward compatible).

Next (dependent) part will follow - to re-factorize CLI commands already implemented in CLI module to unify error handling and returning - this part can't be fully backward compatible and I anticipate a longer discussion about it - that's the reason I'm dividing this effort to two separate parts and PRs. 

I believe it is worth and better for the future to do such an unification sooner than later even it isn't fully backward compatible.
