### PR TITLE
Documenting IllegalStateException from PosixAPI

### DIFF
--- a/core/src/main/java/hudson/os/PosixAPI.java
+++ b/core/src/main/java/hudson/os/PosixAPI.java
@@ -22,6 +22,7 @@ public class PosixAPI {
     /**
      * Load the JNR implementation of the POSIX APIs for the current platform.
      * Runtime exceptions will be of type {@link PosixException}.
+     * {@link IllegalStateException} will be thrown for methods not implemented on this platform.
      * @return some implementation (even on Windows or unsupported Unix)
      * @since 1.518
      */


### PR DESCRIPTION
Noticed in https://github.com/jenkinsci/durable-task-plugin/pull/14 that catching `PosixException` does not suffice.

@reviewbybees
