### PR TITLE
[JENKINS-31932] avoid synchronization for Jenkinsget/setJDKs

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -431,7 +431,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     private transient volatile boolean isQuietingDown;
     private transient volatile boolean terminating;
 
-    private List<JDK> jdks = new ArrayList<JDK>();
+    private volatile List<JDK> jdks = new ArrayList<JDK>();
 
     private transient volatile DependencyGraph dependencyGraph;
     private final transient AtomicBoolean dependencyGraphDirty = new AtomicBoolean();
@@ -1663,7 +1663,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return Messages.Hudson_DisplayName();
     }
 
-    public synchronized List<JDK> getJDKs() {
+    public List<JDK> getJDKs() {
         if(jdks==null)
             jdks = new ArrayList<JDK>();
         return jdks;
@@ -1676,7 +1676,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * set JDK installations from external code.
      */
     @Restricted(NoExternalUse.class)
-    public synchronized void setJDKs(Collection<? extends JDK> jdks) {
+    public void setJDKs(Collection<? extends JDK> jdks) {
         this.jdks = new ArrayList<JDK>(jdks);
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -887,6 +887,17 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     /**
+     * Maintains backwards compatibility. Invoked by XStream when this object is de-serialized.
+     */
+    @SuppressWarnings({"unused"})
+    private Object readResolve() {
+        if (jdks == null) {
+            jdks = new ArrayList<>();
+        }
+        return this;
+    }
+
+    /**
      * Executes a reactor.
      *
      * @param is
@@ -1664,8 +1675,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     public List<JDK> getJDKs() {
-        if(jdks==null)
-            jdks = new ArrayList<JDK>();
         return jdks;
     }
 


### PR DESCRIPTION
Use a volatile field instead as suggested by @jtnord, see https://github.com/jenkinsci/jenkins/pull/1947#issuecomment-166580619.

The only currency problem I see is multiple initialization when the field is `null`, see https://github.com/jenkinsci/jenkins/blob/86ec658268c8145c6d41d5ef25dcd7659c695878/core/src/main/java/jenkins/model/Jenkins.java#L1667-L1668. But since the field is already initialized when creating an instance (https://github.com/jenkinsci/jenkins/blob/86ec658268c8145c6d41d5ef25dcd7659c695878/core/src/main/java/jenkins/model/Jenkins.java#L434) and since it's never set to `null` explicitly, it should be only a theoretical problem.

This is a replacement for #1947.
