### PR TITLE
Transcoding from iso-8859-1 to utf-8

### DIFF
--- a/core/src/main/resources/hudson/model/Node/help-numExecutors_fr.html
+++ b/core/src/main/resources/hudson/model/Node/help-numExecutors_fr.html
@@ -1,16 +1,16 @@
 <div>
-  Ceci contrôle le nombre de builds simultanés que Jenkins peut exécuter.
-  Cette valeur impacte donc la charge générale du système.
+  Ceci contrÃ´le le nombre de builds simultanÃ©s que Jenkins peut exÃ©cuter.
+  Cette valeur impacte donc la charge gÃ©nÃ©rale du systÃ¨me.
   Une bonne valeur pour commencer serait le nombre de processeurs sur
-  votre systéme.
+  votre systÃ©me.
 
   <p>
-  Un nombre de builds simultanés supérieur à cette valeur augmentera la
-  durée individuelle de chaque build. Néanmoins, la capacité globale
-  peut être supérieure, puisqu'un processeur peut se charger d'un build
-  pendant qu'un autre build est en attente sur les entrées/sorties.
+  Un nombre de builds simultanÃ©s supÃ©rieur Ã  cette valeur augmentera la
+  durÃ©e individuelle de chaque build. NÃ©anmoins, la capacitÃ© globale
+  peut Ãªtre supÃ©rieure, puisqu'un processeur peut se charger d'un build
+  pendant qu'un autre build est en attente sur les entrÃ©es/sorties.
 
   <p>
-  En mode maître/esclave, une valeur de 0 garantit que le maître ne fera
-  pas lui-même de build.
+  En mode maÃ®tre/esclave, une valeur de 0 garantit que le maÃ®tre ne fera
+  pas lui-mÃªme de build.
 </div>

--- a/core/src/main/resources/hudson/tasks/Shell/help_fr.html
+++ b/core/src/main/resources/hudson/tasks/Shell/help_fr.html
@@ -1,19 +1,19 @@
 <div>
-  Lance un script Shell (par défaut à l'aide de <tt>sh</tt>, mais cela est configurable) pour construire le projet.
-  Le script sera lancé avec le workspace comme répertoire courant.
+  Lance un script Shell (par dÃ©faut Ã  l'aide de <tt>sh</tt>, mais cela est configurable) pour construire le projet.
+  Le script sera lancÃ© avec le workspace comme rÃ©pertoire courant.
   Entrez le contenu de votre script shell. Si votre script n'a pas de ligne de titre du type <tt>#!/bin/sh</tt>,
-  alors le shell configuré pour l'ensemble du système sera utilisé.
+  alors le shell configurÃ© pour l'ensemble du systÃ¨me sera utilisÃ©.
   Si votre script contient une telle ligne, vous pourrez utiliser un autre langage de script
-  (comme <tt>#!/bin/perl</tt>) ou contrôler les options que le shell utilise.
+  (comme <tt>#!/bin/perl</tt>) ou contrÃ´ler les options que le shell utilise.
 
   <p>
-  Par défaut, le shell sera invoqué avec l'option "-ex". Par conséquent, toutes les commandes seront
-  affichées avant d'être exécutées et le build sera considéré en èchec si l'une de ces commandes
-  renvoie un code de retour différent de zéro.
+  Par dÃ©faut, le shell sera invoquÃ© avec l'option "-ex". Par consÃ©quent, toutes les commandes seront
+  affichÃ©es avant d'Ãªtre exÃ©cutÃ©es et le build sera considÃ©rÃ© en Ã¨chec si l'une de ces commandes
+  renvoie un code de retour diffÃ©rent de zÃ©ro.
   Encore une fois, vous pouvez ajouter la ligne <tt>#!/bin/...</tt> pour modifier ce comportement.
 
   <p>
-  Une bonne pratique est de ne pas mettre un long script ici. A la place, pensez à ajouter le script shell
+  Une bonne pratique est de ne pas mettre un long script ici. A la place, pensez Ã  ajouter le script shell
   dans l'outil de gestion de configuration et appelez simplement ce script depuis Jenkins.
-  Ainsi, vous garderez trace des changements apportés à votre script.
+  Ainsi, vous garderez trace des changements apportÃ©s Ã  votre script.
 </div>


### PR DESCRIPTION
That file was wrongly stored as ISO-8859-1, resulting in screwed accents
in the Jenkins UI.

Note that GH seems to be autodetecting the encoding for the UI, hence masking that issue while browsing in the GH UI. 

![image](https://cloud.githubusercontent.com/assets/223853/12294700/a66665ae-b9fc-11e5-8727-aae48406c581.png)
