### PR TITLE
[JENKINS-28071] generalise CLI's BuildCommand target from AbstractProject to Job

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -142,7 +142,8 @@ public class BuildCommand extends CLICommand {
         }
 
         if (checkSCM) {
-            if (!SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job).poll(new StreamTaskListener(stdout, getClientCharset())).hasChanges()) {
+            SCMTriggerItem item = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job);
+            if (item != null && !item.poll(new StreamTaskListener(stdout, getClientCharset())).hasChanges()) {
                 return 0;
             }
         }

--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -143,9 +143,10 @@ public class BuildCommand extends CLICommand {
 
         if (checkSCM) {
             SCMTriggerItem item = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job);
-            if (item != null && !item.poll(new StreamTaskListener(stdout, getClientCharset())).hasChanges()) {
+            if (item == null)
+                throw new AbortException(job.getFullDisplayName()+" has no SCM trigger, but checkSCM was specified");
+            if (!item.poll(new StreamTaskListener(stdout, getClientCharset())).hasChanges())
                 return 0;
-            }
         }
 
         if (!job.isBuildable()) {

--- a/core/src/main/java/hudson/cli/handlers/JobOptionHandler.java
+++ b/core/src/main/java/hudson/cli/handlers/JobOptionHandler.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.cli.handlers;
+
+import hudson.model.Job;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.OptionDef;
+import org.kohsuke.args4j.spi.Setter;
+import org.kohsuke.MetaInfServices;
+import org.kohsuke.args4j.spi.OptionHandler;
+
+/**
+ * Refer to {@link Job} by its name.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+@MetaInfServices(OptionHandler.class)
+@SuppressWarnings("rawtypes")
+public class JobOptionHandler extends GenericItemOptionHandler<Job> {
+    public JobOptionHandler(CmdLineParser parser, OptionDef option, Setter<Job> setter) {
+        super(parser, option, setter);
+    }
+
+    @Override protected Class<Job> type() {
+        return Job.class;
+    }
+
+    @Override
+    public String getDefaultMetaVariable() {
+        return "JOB";
+    }
+}


### PR DESCRIPTION
[JENKINS-28071](https://issues.jenkins-ci.org/browse/JENKINS-28071)

This allows e.g. WorkflowJob to build, fixing symptom [JENKINS-29826](https://issues.jenkins-ci.org/browse/JENKINS-29826)

`JobOptionHandler` is based on `AbstractProjectOptionHandler`.  I'm not sure if the latter is still needed. The absence of `JobOptionHandler` only caused a runtime error, so I'm reluctant to remove it.

I didn't yet put any effort into abstracting (or finding an abstraction for) `isDisabled` or `poll`.

TODO: tests
