### PR TITLE
Exclude junit dep from jline.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -413,6 +413,13 @@ THE SOFTWARE.
       <artifactId>jline</artifactId>
       <version>0.9.94</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <!-- erronous dep in the version of jline -->
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency><!-- groovy shell uses this but it doesn't declare this dependency -->
       <groupId>org.fusesource.jansi</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -408,18 +408,11 @@ THE SOFTWARE.
       <artifactId>groovy-all</artifactId>
       <version>${groovy.version}</version>
     </dependency>
-    <dependency><!-- groovy shell uses this but it doesn't declare this dependency -->
+    <dependency><!-- groovy shell uses this but uses an optional dependency -->
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>0.9.94</version>
+      <version>1.0</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <!-- erronous dep in the version of jline -->
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency><!-- groovy shell uses this but it doesn't declare this dependency -->
       <groupId>org.fusesource.jansi</groupId>


### PR DESCRIPTION
The jline code appears to not use junit at all and this erronous dep
causes us to pull in junit and hamcrest without any good reason.

@reviewbybees
