### PR TITLE
[FIX JENKINS-32485] New extension point for contributing usage statistics / preparatory for JENKINS-26466

### DIFF
--- a/core/src/main/java/jenkins/model/statistics/CoreUsageStatistics.java
+++ b/core/src/main/java/jenkins/model/statistics/CoreUsageStatistics.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2016, Sun Microsystems, Inc., Kohsuke Kawaguchi, Baptiste Mathus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model.statistics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import hudson.Extension;
+import hudson.PluginWrapper;
+import hudson.model.Items;
+import hudson.model.TopLevelItem;
+import hudson.model.TopLevelItemDescriptor;
+import jenkins.model.Jenkins;
+import jenkins.model.statistics.UsageStatisticsContributor;
+import net.sf.json.JSONObject;
+
+@Extension
+public class CoreUsageStatistics extends UsageStatisticsContributor {
+
+    @Override
+    public void contributeData(JSONObject o) {
+        Jenkins j = Jenkins.getInstance();
+        o.put("stat", 1);
+        o.put("install", j.getLegacyInstanceId());
+        o.put("servletContainer", j.servletContext.getServerInfo());
+        o.put("version", Jenkins.VERSION);
+
+        List<JSONObject> plugins = new ArrayList<JSONObject>();
+        for (PluginWrapper pw : j.getPluginManager().getPlugins()) {
+            if (!pw.isActive())
+                continue; // treat disabled plugins as if they are uninstalled
+            JSONObject p = new JSONObject();
+            p.put("name", pw.getShortName());
+            p.put("version", pw.getVersion());
+            plugins.add(p);
+        }
+        o.put("plugins", plugins);
+
+        JSONObject jobs = new JSONObject();
+        List<TopLevelItem> items = j.getAllItems(TopLevelItem.class);
+        for (TopLevelItemDescriptor d : Items.all()) {
+            int cnt = 0;
+            for (TopLevelItem item : items) {
+                if (item.getDescriptor() == d)
+                    cnt++;
+            }
+            jobs.put(d.getJsonSafeClassName(), cnt);
+        }
+        o.put("jobs", jobs);
+    }
+}

--- a/core/src/main/java/jenkins/model/statistics/NodesDetailsUsageStatisticsContributor.java
+++ b/core/src/main/java/jenkins/model/statistics/NodesDetailsUsageStatisticsContributor.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2016, Kohsuke Kawaguchi, Baptiste Mathus
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model.statistics;
+
+import hudson.Extension;
+import hudson.model.Computer;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+
+/**
+ * Publishes informations about the used VM, number of executors and so on
+ * for each node of the Jenkins cluster to the usage statistics subsystem.
+ */
+@Extension
+public class NodesDetailsUsageStatisticsContributor extends UsageStatisticsContributor {
+
+    @Override
+    public void contributeNodeData(Computer c, JSONObject n) {
+        Jenkins j = Jenkins.getInstance();
+        if (c.getNode() == j) {
+            n.put("master", true);
+            n.put("jvm-vendor", System.getProperty("java.vm.vendor"));
+            n.put("jvm-name", System.getProperty("java.vm.name"));
+            n.put("jvm-version", System.getProperty("java.version"));
+        }
+        n.put("executors", c.getNumExecutors());
+    }
+}

--- a/core/src/main/java/jenkins/model/statistics/UsageStatisticsContributor.java
+++ b/core/src/main/java/jenkins/model/statistics/UsageStatisticsContributor.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, Baptiste Mathus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model.statistics;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.Computer;
+import hudson.model.UsageStatistics;
+import net.sf.json.JSONObject;
+
+import javax.annotation.Nonnull;
+
+/**
+ * <p>
+ * Extension point to contribute usage statistics to the {@link UsageStatistics} class and associated infrastructure
+ * (see below).
+ * </p>
+ * <p/>
+ * <p>
+ * When adding a new implementation:
+ * </p>
+ * <ul>
+ * <li>You'll have to document the requirement at the
+ * <a href="https://github.com/jenkinsci/infra-statistics">infra-statistics</a> project so that your data can be
+ * processed ;</li>
+ * <li><strong>WARNING:</strong> Because there can be security/privacy implications, before adding a new implementation
+ * of this extension point in your plugin, it is <strong>strongly recommended</strong> to get your code reviewed by the
+ * community in general, and by the
+ * <a href="https://wiki.jenkins-ci.org/display/JENKINS/Governance+Board#GovernanceBoard-Security">Jenkins Security
+ * Officer</a> in particular.</li>
+ * </ul>
+ * <p/>
+ */
+public abstract class UsageStatisticsContributor implements ExtensionPoint {
+
+    /**
+     * Every {@link UsageStatisticsContributor} instances.
+     *
+     * @return all the {@link UsageStatisticsContributor} instances.
+     */
+    public static ExtensionList<UsageStatisticsContributor> all() {
+        return ExtensionList.lookup(UsageStatisticsContributor.class);
+    }
+
+    /**
+     * Gets the information to be contributed to the usage statistics subsystem.
+     *
+     * @param data the data to enrich.
+     */
+    public void contributeData(@Nonnull JSONObject data) {
+    }
+
+    /**
+     * Called for each {@link Computer} of the Jenkins cluster.
+     *
+     * @param computer the current machine.
+     * @param nodeData the data to enrich.
+     */
+    public void contributeNodeData(@Nonnull Computer computer, @Nonnull JSONObject nodeData) {
+    }
+}

--- a/core/src/main/java/jenkins/node_monitors/NodeOSUsageStatisticsContributor.java
+++ b/core/src/main/java/jenkins/node_monitors/NodeOSUsageStatisticsContributor.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, Kohsuke Kawaguchi, Baptiste Mathus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.node_monitors;
+
+import hudson.Extension;
+import hudson.model.Computer;
+import hudson.node_monitors.ArchitectureMonitor;
+import jenkins.model.Jenkins;
+import jenkins.model.statistics.UsageStatisticsContributor;
+import net.sf.json.JSONObject;
+
+/**
+ * Publishes OS information for each node of the Jenkins cluster to the usage statistics subsystem.
+ *
+ * @see ArchitectureMonitor
+ */
+@Extension
+public class NodeOSUsageStatisticsContributor extends UsageStatisticsContributor {
+
+    @Override
+    public void contributeNodeData(Computer c, JSONObject n) {
+        Jenkins j = Jenkins.getInstance();
+        ArchitectureMonitor.DescriptorImpl descriptor = j.getDescriptorByType(ArchitectureMonitor.DescriptorImpl.class);
+        n.put("os", descriptor.get(c));
+    }
+}


### PR DESCRIPTION
This pull request introduces [a new feature/JENKINS-32485](https://issues.jenkins-ci.org/browse/JENKINS-32485): now the UsageStatistics class doesn't know the stats it's going to send anymore.

It delegates to a new UsageStatisticsContributor extension point, and iterates through the implementations to find what to send.

---

This PR also includes the refactoring for the coupling between UsageStatistics and ArchitectureMonitor (preparatory for [JENKINS-26466](https://issues.jenkins-ci.org/browse/JENKINS-26466)). 

I hesitated to include it in another PR, but finally thought it would be good to:
- illustrate what it would be useful for directly here (i.e. breaking some undesirable relationships between some classes in this case). 
- And also proving that it actually enables it through a concrete usage and I haven't missed something to make it usable.

Thanks for your feedback. Thanks to @jglick for his help on the design.

Ping @jenkinsci/code-reviewers 
