### PR TITLE
[JENKINS-31753] Fields are aligned at the bottom

### DIFF
--- a/core/src/main/resources/hudson/model/ParametersAction/index.jelly
+++ b/core/src/main/resources/hudson/model/ParametersAction/index.jelly
@@ -35,12 +35,21 @@ THE SOFTWARE.
 		<st:include page="sidepanel.jelly" it="${build}" />
 		<l:main-panel>
 			<h1>${%Build} ${build.displayName}</h1>
-			<l:pane title="${%Parameters}" width="3">
-			<j:forEach var="parameterValue" items="${it.parameters}">
-				<st:include it="${parameterValue}"
-					page="value.jelly" />
-			</j:forEach>
-			</l:pane>
+			<div class="container-fluid pane-frame">
+				<div class="row">
+					<div class="col-xs-24 pane-header">${%Parameters}</div>
+					<div class="row col-xs-24 pane-content">
+						<table class="pane">
+							<j:forEach var="parameterValue" items="${it.parameters}">
+								<tbody>
+									<st:include it="${parameterValue}"
+									page="value.jelly" />
+								</tbody>
+							</j:forEach>
+						</table>
+					</div>
+				</div>
+			 </div>
 		</l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION
before :
![before_modif](https://cloud.githubusercontent.com/assets/16716158/12395699/81758742-be03-11e5-971d-cdcbc8b770ba.jpg)
after : 
![after_modif2](https://cloud.githubusercontent.com/assets/16716158/12395717/88f1adfc-be03-11e5-808f-a7ded0d6aeb4.jpg)
