### PR TITLE
[JENKINS-32517] Deprecate Queue#getApproximateItemsQuickly

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -480,6 +480,11 @@ public abstract class View extends AbstractModelObject implements AccessControll
         return filterQueue(Arrays.asList(Jenkins.getInstance().getQueue().getItems()));
     }
 
+    /**
+     * @deprecated Use {@link #getQueueItems()}. As of 1.607 the approximation is no longer needed.
+     * @return The items in the queue.
+     */
+    @Deprecated
     public List<Queue.Item> getApproximateQueueItemsQuickly() {
         return filterQueue(Jenkins.getInstance().getQueue().getApproximateItemsQuickly());
     }

--- a/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
@@ -63,7 +63,7 @@ public class BuildHistoryWidget<T> extends HistoryWidget<Task,T> {
      */
     public List<Item> getQueuedItems() {
         LinkedList<Item> list = new LinkedList<Item>();
-        for (Item item : Jenkins.getInstance().getQueue().getApproximateItemsQuickly()) {
+        for (Item item : Jenkins.getInstance().getQueue().getItems()) {
             if (item.task == owner) {
                 list.addFirst(item);
             }

--- a/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
       <l:task href="new" icon="icon-new-computer icon-md" permission="${createPermission}" title="${%New Node}"/>
       <l:task href="configure" icon="icon-setting icon-md" permission="${app.ADMINISTER}" title="${%Configure}"/>
     </l:tasks>
-    <t:queue items="${app.queue.approximateItemsQuickly}" />
+    <t:queue items="${app.queue.items}" />
     <t:executors />
   </l:side-panel>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/View/ajaxBuildQueue.jelly
+++ b/core/src/main/resources/hudson/model/View/ajaxBuildQueue.jelly
@@ -28,6 +28,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:ajax>
-    <t:queue items="${it.approximateQueueItemsQuickly}" filtered="${it.isFilterQueue()}" />
+    <t:queue items="${it.queueItems}" filtered="${it.isFilterQueue()}" />
   </l:ajax>
 </j:jelly>

--- a/core/src/main/resources/jenkins/widgets/BuildQueueWidget/index.groovy
+++ b/core/src/main/resources/jenkins/widgets/BuildQueueWidget/index.groovy
@@ -2,4 +2,4 @@ package jenkins.widgets.BuildQueueWidget;
 
 def t = namespace(lib.JenkinsTagLib.class)
 
-t.queue(items:view.approximateQueueItemsQuickly, it:view, filtered:view.filterQueue)
+t.queue(items:view.queueItems, it:view, filtered:view.filterQueue)

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     Displays the build queue as &lt;l:pane>
 
     <st:attribute name="items" use="required">
-      Queue items to be displayed. Normally you should specify ${app.queue.approximateItemsQuickly},
+      Queue items to be displayed. Normally you should specify ${app.queue.items},
       but for example you can specify a sublist after some filtering to narrow down
       the list.
     </st:attribute>

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -404,7 +404,7 @@ public class QueueTest {
         try {
             build = m.scheduleBuild2(0).get(60, TimeUnit.SECONDS);
         } catch (TimeoutException x) {
-            throw (AssertionError) new AssertionError(r.jenkins.getQueue().getApproximateItemsQuickly().toString()).initCause(x);
+            throw (AssertionError) new AssertionError(r.jenkins.getQueue().getItems().toString()).initCause(x);
         }
         r.assertBuildStatusSuccess(build);
         assertEquals("", build.getBuiltOnStr());


### PR DESCRIPTION
Queue#getApproximateItemsQuickly can cache invalid results.

Now that the item list is obtained lock-free the cache is no longer needed.
Besides, the cache could be returning invalid results for requests with different authorization to the one that cached the result (in any case this invalid result is transient).

References to the deprecated method are updated accordingly.

@reviewbybees
