### PR TITLE
[JENKINS-32597] Downgrade “termination trace” warnings

### DIFF
--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -466,7 +466,9 @@ public class Executor extends Thread implements ModelObject {
     }
 
     private void finish2() {
-        for (RuntimeException e1: owner.getTerminatedBy()) LOGGER.log(Level.WARNING, String.format("%s termination trace", getName()), e1);
+        for (RuntimeException e1 : owner.getTerminatedBy()) {
+            LOGGER.log(Level.FINE, String.format("%s termination trace", getName()), e1);
+        }
         if (causeOfDeath == null) {// let this thread die and be replaced by a fresh unstarted instance
             owner.removeExecutor(this);
         }


### PR DESCRIPTION
[JENKINS-32597](https://issues.jenkins-ci.org/browse/JENKINS-32597)

Visible in many contexts, for example when running `BuildTriggerTest`. Users have been alarmed by what is, AFAICT, a normal condition. At any rate `Computer.recordTermination` is called for various normal reasons. Might be displayed especially for “one-shot” slaves?

Leaves a `WARNING` printed from `resetWorkUnit`, which sounds more appropriate.

@reviewbybees esp. @stephenc who introduced this in #1596.
