### PR TITLE
WIP: Add os.version property to ArchitectureMonitor

### DIFF
--- a/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
@@ -61,7 +61,8 @@ public class ArchitectureMonitor extends NodeMonitor {
         public String call() {
             String os = System.getProperty("os.name");
             String arch = System.getProperty("os.arch");
-            return os+" ("+arch+')';
+            String version = System.getProperty("os.version");
+            return os + " (" + arch + ")(" + version + ")";
         }
 
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
A user just asked on IRC how to get the OS Version. And I realized this info was actually not retrieved, hence this small PR.

```
[15:11] <       aluft> | I would like the node monitor to show the os version right now it shows only the os arch and os name
[15:11] <       aluft> | how can I get the node monitor to show os name, os arch, and os version?
[15:47] <+     batmat> | aluft: basically you can't https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java#L62L63
[15:48] <+     batmat> | aluft: cause it's not retrieved. 
[15:49] <+     batmat> | aluft: but the good news is that you can file a pull-request to have it too if you wish :). 
[15:49] <+     batmat> | aluft: what format would you like? I think I can handle a PR if you want, as I'm currently into those monitors :)
[15:54] <      aluft> | batmat: thank you, seems like this might fit "Linux(amd64)(1.2.3)"
[15:56] <      aluft> | batmat: some other examples "Windows 7 (amd64)(1.2.3)" "Mac OS X (x86_64)(1.2.3)" "Windows Server 2008 R2 (amd64)(1.2.3)"
```
