### PR TITLE
[FIXED JENKINS-21486] Fail a plugin if its dependencies doesn't exist

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -526,15 +526,15 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
         List<String> missingDependencies = new ArrayList<String>();
         // make sure dependencies exist
         for (Dependency d : dependencies) {
-            if (parent.getPlugin(d.shortName) == null)
+            if (parent.getPlugin(d.shortName) == null || !(parent.getPlugin(d.shortName).active))
                 missingDependencies.add(d.toString());
         }
         if (!missingDependencies.isEmpty())
             throw new IOException("Dependency "+Util.join(missingDependencies, ", ")+" doesn't exist");
 
-        // add the optional dependencies that exists
+        // add the optional dependencies that exists and are actives
         for (Dependency d : optionalDependencies) {
-            if (parent.getPlugin(d.shortName) != null)
+            if (parent.getPlugin(d.shortName) != null && parent.getPlugin(d.shortName).active)
                 dependencies.add(d);
         }
     }


### PR DESCRIPTION
1. Install a fresh Jenkins instance
2. Install Support Core plugin
3. Disable metrics plugin

Then, Jenkins will not start showing the image below:

<img width="1438" alt="screen shot 2016-01-21 at 17 40 05" src="https://cloud.githubusercontent.com/assets/3898648/12487357/1e27f7a4-c067-11e5-99ae-ffffdab0c12d.png">

All the details in:

https://issues.jenkins-ci.org/browse/JENKINS-32558

@reviewbybees
