### PR TITLE
[JENKINS-22358] disable JSESSIONID in URL on JBoss 

### DIFF
--- a/war/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/war/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,12 @@
+<!DOCTYPE jboss-web>
+<jboss-web xmlns="http://www.jboss.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.jboss.org/schema/jbossas
+    http://www.jboss.org/schema/jbossas/jboss-web_7_2.xsd">
+    <!-- Configure usage of the security domain "other" -->
+    <session-config>
+        <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+</jboss-web>
+
+


### PR DESCRIPTION
As per discussion in https://issues.jenkins-ci.org/browse/JENKINS-22358, I noticed that it is missing a configuration to disable URL sessions in deployment on JBoss. 
In Undertow (Wildfly 8+, EAP7 ) URL sessions are enabled by default and due this reason the implementation of  `response.encodeRedirectURL` appends the JSESSIONID in the encoded URL.

This configuration overrides the default and allows only cookie based http sessions, as a result `response.encodeRedirectURL` doesn't append the JSESSIONID in the encoded URL

Related issue: https://issues.jboss.org/browse/WFLY-4782
