### PR TITLE
Jenkins 2.0 Install Wizard: Only show the dependencies if the user really wants to see them

### DIFF
--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -21,6 +21,7 @@ installWizard_installCustom_selectNone=None
 installWizard_installCustom_selectRecommended=Recommended
 installWizard_installCustom_selected=Selected
 installWizard_installCustom_dependenciesPrefix=Dependencies
+installWizard_installCustom_dependsOn=depends on
 installWizard_installCustom_pluginListDesc=Note that the full list of plugins is not shown here. Additional plugins can be installed in the <strong>Plugin Manager</strong> once the initial setup is complete. <a href="https://wiki.jenkins-ci.org/display/JENKINS/Installing+Jenkins#InstallingJenkins-InstallationWizard" target="_blank">See the Wiki for more information</a>.
 installWizard_goBack=Back
 installWizard_goInstall=Install

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -131,20 +131,42 @@ var createPluginSetupWizard = function() {
 	$wizard.appendTo('body');
 	var $container = $wizard.find('.modal-content');
 	var currentPanel;
+    var wizardContainer = $bs('.plugin-setup-wizard');
 
 	// show tooltips; this is done here to work around a bootstrap/prototype incompatibility
-	$(document).on('mouseenter', '*[data-tooltip]', function() {
-		var $tip = $bs(this);
-		var text = $tip.attr('data-tooltip');
-		if(!text) {
-			return;
-		}
+	wizardContainer.on('mouseenter', '.plugins-for-category .plugin-label', function() {
 		// prototype/bootstrap tooltip incompatibility - triggering main element to be hidden
-		this.hide = undefined;
-		$tip.tooltip({
-			html: true,
-			title: text
-		}).tooltip('show');
+        this.hide = undefined;
+        var pluginLabel = $bs(this);
+        $bs('.dependencies', pluginLabel).show();
+	});
+	wizardContainer.on('mouseleave', '.plugins-for-category .plugin-label', function() {
+        var pluginLabel = $bs(this);
+        $bs('.dependencies', pluginLabel).hide();
+	});
+	wizardContainer.on('mouseenter', '.plugin-label .dependencies', function() {
+		var $this = $bs(this);
+		var text = $this.attr('data-tooltip');
+        var pluginLabel = $this.closest('.plugin-label');
+        var pluginLabelEl = pluginLabel.get();
+        
+        // Make sure we only add the tooltip once.
+        if (!pluginLabelEl.hasTooltip) {
+    		// prototype/bootstrap tooltip incompatibility - triggering main element to be hidden
+            pluginLabelEl.hide = undefined;
+            
+            pluginLabel.tooltip({
+                html: true,
+                title: text,
+                trigger: 'manual'
+            });
+            pluginLabelEl.hasTooltip = true;
+        }
+		pluginLabel.tooltip('show');
+	});
+	wizardContainer.on('mouseleave', '.plugin-label .dependencies', function() {
+        var pluginLabel = $bs(this).closest('.plugin-label');
+		pluginLabel.tooltip('hide');
 	});
 
 	// localized messages

--- a/war/src/main/js/templates/pluginSelectionPanel.hbs
+++ b/war/src/main/js/templates/pluginSelectionPanel.hbs
@@ -31,11 +31,13 @@
 			<h2 id="{{id @key}}" class="expanded">{{@key}} {{pluginCountForCategory @key}}</h2>
 			<div class="plugins-for-category">
 				{{#each this}}
-				<label class="{{#inSelectedPlugins plugin.name}}selected{{/inSelectedPlugins}}" id="row-{{plugin.name}}"
-					{{#hasDependencies plugin.name}}data-tooltip="{{../../../translations.installWizard_installCustom_dependenciesPrefix}}: {{dependencyText ../plugin.name}}"{{/hasDependencies}}>
+				<label class="plugin-label {{#inSelectedPlugins plugin.name}}selected{{/inSelectedPlugins}}" id="row-{{plugin.name}}">
 					<span class="title">
 						<input type="checkbox" id="chk-{{plugin.name}}" name="{{plugin.name}}" value="{{searchTerm}}" {{#inSelectedPlugins plugin.name}}checked="checked"{{/inSelectedPlugins}}/>
 						{{plugin.title}}
+                        {{#hasDependencies plugin.name}}
+                        <span class="dependencies" data-tooltip="{{../../../translations.installWizard_installCustom_dependenciesPrefix}}: {{dependencyText ../plugin.name}}">{{../../../translations.installWizard_installCustom_dependsOn}}</span>
+                        {{/hasDependencies}}
 					</span>
 					<span class="description">
 						{{{plugin.excerpt}}}

--- a/war/src/main/less/pluginSetupWizard.less
+++ b/war/src/main/less/pluginSetupWizard.less
@@ -359,6 +359,16 @@
 						font-weight: bold;
 						white-space: nowrap;
 						position: relative;
+                      
+                        .dependencies {
+                          display: none;
+                          position: absolute;
+                          top: 0px;
+                          right: 5px;
+                          margin-left: 10px;
+                          font-weight: normal;
+                          opacity: 0.5;
+                        }
 					}
 
 					.description {


### PR DESCRIPTION
At the moment, the dependency list of a plugin is shoved into the users face whether they want to see it or not. This change makes it optionally visible.

![screenshot 2016-02-01 11 43 44](https://cloud.githubusercontent.com/assets/429311/12716549/562b2052-c8d9-11e5-9332-dde63e473755.png)
