### PR TITLE
[FIXED JENKINS-32844] Options under the drop-down menu at account name in the top bar doesn't work correctly when it contains a slash 

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -188,7 +188,7 @@ ${h.initPageVariables(context)}
                   </j:otherwise>
                 </j:choose>
                 <span style="white-space:nowrap">
-                  <a href="${rootURL}/user/${user.id}" class="model-link inside inverse"><b>${userName}</b></a>
+                  <a href="${rootURL}/me" class="model-link inside inverse"><b>${userName}</b></a>
                   <j:if test="${app.securityRealm.canLogOut()}">
                     |
                     <a href="${rootURL}/logout"><b>${%logout}</b></a>

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealm2Test.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealm2Test.java
@@ -58,7 +58,7 @@ public class HudsonPrivateSecurityRealm2Test {
         signup.enterEmail("alice@nowhere.com");
         HtmlPage success = signup.submit(rule);
         assertThat(success.getElementById("main-panel").getTextContent(), containsString("Success"));
-        assertThat(success.getAnchorByHref("/jenkins/user/alice").getTextContent(), containsString("Alice User"));
+        assertThat(success.getAnchorByHref("/jenkins/me").getTextContent(), containsString("Alice User"));
 
 
         assertEquals("Alice User", securityRealm.getUser("alice").getDisplayName());


### PR DESCRIPTION
To re-produce:
1. Install a fresh Jenkins instance with latest bits
2. Install mock security realm plugin and configure it with an user containing a slash (foo/foo)
3. log-in
4. Options under the account name are not displayed and when clicking in the user link you get a HTTP ERROR 404.

https://issues.jenkins-ci.org/browse/JENKINS-32844

@reviewbybees
