### PR TITLE
Use Run#getLogReader() with built-in encoding management when accessing run logs

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1911,7 +1911,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */
     @Deprecated
     public @Nonnull String getLog() throws IOException {
-        return IOUtils.toString(getLogReader());
+        try (Reader log = getLogReader()) {
+            return IOUtils.toString(log);
+        }
     }
 
     /**

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1345,6 +1345,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * @return An input stream from the log file. 
      *   If the log file does not exist, the error message will be returned to the output.
      * @since 1.349
+     * @deprecated use {@link #getLogReader()} to ensure encoding is handled correctly
      */
     public @Nonnull InputStream getLogInputStream() throws IOException {
     	File logFile = getLogFile();
@@ -1910,7 +1911,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */
     @Deprecated
     public @Nonnull String getLog() throws IOException {
-        return Util.loadFile(getLogFile(),getCharset());
+        return IOUtils.toString(getLogReader());
     }
 
     /**
@@ -1928,7 +1929,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         if (maxLines == 0) {
             return logLines;
         }
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(getLogFile()),getCharset()));
+        BufferedReader reader = new BufferedReader(getLogReader());
         try {
             for (String line = reader.readLine(); line != null; line = reader.readLine()) {
                 logLines.add(line);


### PR DESCRIPTION
Prefer Reader over InputStream to ensure configured charset is used.
@reviewbybees
