### PR TITLE
[JENKINS-32865] Bump instance-identity to 1.5.1

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>1.4</version>
+      <version>1.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
this indirectly upgrades bouncycaslte to 1.54
@reviewbybees
