### PR TITLE
Fix typos in changelog

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -1485,7 +1485,7 @@ Upcoming changes</a>
 <h3><a name=v1.563>What's new in 1.563</a> (2014/05/11)</h3>
 <ul class=image>
   <li class="major bug">
-    Memory exhausion in remoting channel since 1.560.
+    Memory exhaustion in remoting channel since 1.560.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22734">issue 22734</a>)
   <li class="rfe">
     Configurable size for log buffer.
@@ -1629,7 +1629,7 @@ Upcoming changes</a>
     Fixed NoSuchMethodException when destroying processes using JDK1.8.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21341">issue 21341</a>)
   <li class=rfe>
-    Avoid irrelevant job queing while node is offline.
+    Avoid irrelevant job queuing while node is offline.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21394">issue 21394</a>)
   <li class=rfe>
     Debian package now creates 'jenkins' group


### PR DESCRIPTION
`exhausion` → `exhaustion`
`queing` → `queuing`
