### PR TITLE
[JENKINS-21249] Update Groovy to 2.4.6

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <staplerFork>true</staplerFork>
     <stapler.version>1.237</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
-    <groovy.version>1.8.9</groovy.version>
+    <groovy.version>2.4.5</groovy.version>
   </properties>
 
   <dependencies>
@@ -411,13 +411,13 @@ THE SOFTWARE.
     <dependency><!-- groovy shell uses this but uses an optional dependency -->
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>1.0</version>
+      <version>2.12</version>
       <scope>compile</scope>
     </dependency>
     <dependency><!-- groovy shell uses this but it doesn't declare this dependency -->
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
-      <version>1.9</version>
+      <version>1.11</version>
     </dependency>
     <dependency>
       <!--

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <staplerFork>true</staplerFork>
     <stapler.version>1.237</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
-    <groovy.version>2.4.5</groovy.version>
+    <groovy.version>2.4.6</groovy.version>
   </properties>
 
   <dependencies>

--- a/core/src/main/java/hudson/cli/GroovyshCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyshCommand.java
@@ -41,7 +41,7 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 
 import jline.UnsupportedTerminal;
-import jline.Terminal;
+import jline.TerminalFactory;
 import org.kohsuke.args4j.Argument;
 
 /**
@@ -65,10 +65,18 @@ public class GroovyshCommand extends CLICommand {
 
         // this being remote means no jline capability is available
         System.setProperty("jline.terminal", UnsupportedTerminal.class.getName());
-        Terminal.resetTerminal();
+        TerminalFactory.reset();
+
+        StringBuilder commandLine = new StringBuilder();
+        for (String arg : args) {
+            if (commandLine.length() > 0) {
+                commandLine.append(" ");
+            }
+            commandLine.append(arg);
+        }
 
         Groovysh shell = createShell(stdin, stdout, stderr);
-        return shell.run(args.toArray(new String[args.size()]));
+        return shell.run(commandLine.toString());
     }
 
     @SuppressWarnings({"unchecked","rawtypes"})
@@ -101,7 +109,7 @@ public class GroovyshCommand extends CLICommand {
             }
         };
         Groovysh shell = new Groovysh(cl, binding, io, registrar);
-        shell.getImports().add("import hudson.model.*");
+        shell.getImports().add("hudson.model.*");
 
         // defaultErrorHook doesn't re-throw IOException, so ShellRunner in
         // Groovysh will keep looping forever if we don't terminate when the

--- a/core/src/main/java/hudson/util/spring/BeanBuilder.java
+++ b/core/src/main/java/hudson/util/spring/BeanBuilder.java
@@ -39,6 +39,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -132,7 +133,7 @@ public class BeanBuilder extends GroovyObjectSupport {
         cc.setScriptBaseClass(ClosureScript.class.getName());
         GroovyShell shell = new GroovyShell(classLoader,binding,cc);
 
-        ClosureScript s = (ClosureScript)shell.parse(script);
+        ClosureScript s = (ClosureScript)shell.parse(new InputStreamReader(script));
         s.setDelegate(this);
         s.run();
     }
@@ -336,7 +337,7 @@ public class BeanBuilder extends GroovyObjectSupport {
 
 		GroovyShell shell = classLoader != null ? new GroovyShell(classLoader,b) : new GroovyShell(b);
         for (Resource resource : resources) {
-            shell.evaluate(resource.getInputStream());
+            shell.evaluate(new InputStreamReader(resource.getInputStream()));
         }
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,17 @@ THE SOFTWARE.
               <artifactId>servlet-api</artifactId>
               <version>2.4</version>
             </dependency>
+            <dependency>
+              <groupId>org.codehaus.gmaven.runtime</groupId>
+              <artifactId>gmaven-runtime-2.0</artifactId>
+              <version>1.5-jenkins-3</version>
+            </dependency>
           </dependencies>
+          <configuration>
+            <!-- 2.4 not yet supported by plugin but 2.0 works
+                 here so long as we provide explicit version -->
+            <providerSelection>2.0</providerSelection>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -724,18 +734,6 @@ THE SOFTWARE.
             </goals>
           </execution>
         </executions>
-        <configuration>
-           <!-- 1.8 not yet supported by plugin but 1.7 works
-                here so long as we provide explicit version -->
-           <providerSelection>1.7</providerSelection>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.gmaven.runtime</groupId>
-            <artifactId>gmaven-runtime-1.7</artifactId>
-            <version>1.3</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -234,15 +234,7 @@ THE SOFTWARE.
             <artifactId>ant-launcher</artifactId>
             <version>1.8.0</version>
           </dependency>
-          <dependency>
-            <groupId>org.codehaus.gmaven.runtime</groupId>
-            <artifactId>gmaven-runtime-2.0</artifactId>
-            <version>1.5-jenkins-1</version>
-          </dependency>
         </dependencies>
-        <configuration>
-          <providerSelection>2.0</providerSelection>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/test/src/test/java/hudson/cli/GroovyshCommandTest.java
+++ b/test/src/test/java/hudson/cli/GroovyshCommandTest.java
@@ -42,7 +42,7 @@ public class GroovyshCommandTest {
     @Test public void authentication() throws Exception {
         CLICommandInvoker.Result result = new CLICommandInvoker(r, new GroovyshCommand())
             .authorizedTo(Jenkins.READ, Jenkins.RUN_SCRIPTS)
-            .withStdin(new StringInputStream("println(jenkins.model.Jenkins.instance.getClass().name)\nquit\n"))
+            .withStdin(new StringInputStream("println(jenkins.model.Jenkins.instance.getClass().name)\n:quit\n"))
             .invoke();
         assertThat(result, succeeded());
         assertThat(result, hasNoErrorOutput());


### PR DESCRIPTION
[JENKINS-21249](https://issues.jenkins-ci.org/browse/JENKINS-21249)

Re-targeted #1085 for 2.0.

A lot of testing has already been done at JUES Copenhagen 2015 by @abayer, @kohsuke, @rsandell 
 and @Vlatombe. See [Groovy 2.4 integration in core](https://trello.com/c/A9i1Trla/16-groovy-2-4-integration-in-core). Almost all tested plugins are working with Groovy 2.4 and most of the issues have been addressed in the meantime. But I'm not sure about the status of Script Security and Pipeline. I will take care of Job DSL.

There are related issues, e.g. [JENKINS-29068 Split Groovy out of core](https://issues.jenkins-ci.org/browse/JENKINS-29068) and [JENKINS-30685 Hide core dependencies in plugin classpath](https://issues.jenkins-ci.org/browse/JENKINS-30685). AFAIK no one is working on those and they can implemented independent from the Groovy update.
