### PR TITLE
[FIXED JENKINS-32985] Binary compatibility for callers of GroovyHookScript.<init>(String).

### DIFF
--- a/core/src/main/java/jenkins/util/groovy/GroovyHookScript.java
+++ b/core/src/main/java/jenkins/util/groovy/GroovyHookScript.java
@@ -14,6 +14,7 @@ import static java.util.logging.Level.WARNING;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletContext;
+import jenkins.model.Jenkins;
 
 /**
  * A collection of Groovy scripts that are executed as various hooks.
@@ -42,6 +43,15 @@ public class GroovyHookScript {
     private final ServletContext servletContext;
     private final File home;
     private final ClassLoader loader;
+
+    @Deprecated
+    public GroovyHookScript(String hook) {
+        this(hook, Jenkins.getActiveInstance());
+    }
+
+    private GroovyHookScript(String hook, Jenkins j) {
+        this(hook, j.servletContext, j.getRootDir(), j.getPluginManager().uberClassLoader);
+    }
 
     public GroovyHookScript(String hook, @Nonnull ServletContext servletContext, @Nonnull File home, @Nonnull ClassLoader loader) {
         this.hook = hook;


### PR DESCRIPTION
The PR integrates the commit, which has not been backported into 1.642.2

https://issues.jenkins-ci.org/browse/JENKINS-32985

@reviewbybees @olivergondza 
