### PR TITLE
Added "What to Use Jenkins for and When to Use It"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 # About
 In a nutshell, Jenkins CI is the leading open-source continuous integration server. Built with Java, it provides over 1000 plugins to support building and testing virtually any project.
 
+# What to Use Jenkins for and When to Use It
+
+Use Jenkins to automate your development workflow so you can focus on work that matters most. Jenkins is commonly used for:
+
+- Building projects
+- Running tests to detect bugs and other issues as soon as they are introduced
+- Static code analysis
+- Deployment
+
+Execute repetitive tasks, save time, and optimize your development process with Jenkins.
+
 # Downloads
 Non-source downloads such as WAR files and several Linux packages can be found on our [Mirrors].
 


### PR DESCRIPTION
To make Jenkins more approachable to a larger number of users—from informed developers to curious passersby and new and interested visitors—I have added a new section to the Jenkins README. The section is entitled **What to Use Jenkins for and When to Use It**. As the name suggests, the new section, a brief paragraph, explains in plain and straightforward language what technologyRepo is used for and when one should use it.

Other repositories may begin to use this new informative and catchy section soon, as my colleagues contact open-source technologies in an effort to make them more accessible to the tens of thousands of new users learning to code and thousands joining GitHub every day.
