### PR TITLE
Artifacts is a valid en_gb spelling.

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractBuild/index_en_GB.properties
+++ b/core/src/main/resources/hudson/model/AbstractBuild/index_en_GB.properties
@@ -1,3 +1,3 @@
 # This file is under the MIT License by authors
 
-Build\ Artifacts=Build Artefacts
+Build\ Artifacts=Build Artifacts


### PR DESCRIPTION
In UK English "Artifacts" is a valid alternate spelling of "Artefacts".

As the rest of the UI uses Artificats - it just looks odd to have this one bit use artefacts.

So rather than trying to be clever and fix up every translation - lets just use Artifacts - as it is accepted in computing terms and will be the same everywhere.

@jenkinsci/code-reviewers - possibly contentious but comes from a native English speaker.
