### PR TITLE
[FIXED JENKINS-33019] Use FQN for BuildDiscarderProperty

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,9 +12,9 @@
 def runTests = true
 
 // Only keep the 10 most recent builds.
-properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator',
-                                                          numToKeepStr: '50',
-                                                          artifactNumToKeepStr: '20']]])
+properties([[$class: 'jenkins.model.BuildDiscarderProperty', strategy: [$class: 'LogRotator',
+                                                                        numToKeepStr: '50',
+                                                                        artifactNumToKeepStr: '20']]])
 
 String packagingBranch = (binding.hasVariable('packagingBranch')) ? packagingBranch : 'master'
 


### PR DESCRIPTION
BuildDiscarderProperty was moved to core from Pipeline, but not in
time for the 1.642 LTS line. So you need to explicitly use the fully
qualified class name when using it as long as you might be running on
1.642 or earlier LTSes.

cc @reviewbybees, @rtyler 
