### PR TITLE
[JENKINS-33038] correctly set executor in FutureImpl

### DIFF
--- a/core/src/main/java/hudson/model/queue/WorkUnit.java
+++ b/core/src/main/java/hudson/model/queue/WorkUnit.java
@@ -71,6 +71,9 @@ public final class WorkUnit {
 
     public void setExecutor(@CheckForNull Executor e) {
         executor = e;
+        if (e != null) {
+            context.future.addExecutor(e);
+        }
     }
 
     /**

--- a/core/src/main/java/hudson/model/queue/WorkUnitContext.java
+++ b/core/src/main/java/hudson/model/queue/WorkUnitContext.java
@@ -88,14 +88,9 @@ public final class WorkUnitContext {
     }
 
     /**
-     * Called by the executor that executes a member {@link SubTask} that belongs to this task
-     * to create its {@link WorkUnit}.
+     * Called within the queue maintenance process to create a {@link WorkUnit} for the given {@link SubTask}
      */
     public WorkUnit createWorkUnit(SubTask execUnit) {
-        Executor executor = Executor.currentExecutor();
-        if (executor != null) { // TODO is it legal for this to be called by a non-executor thread?
-            future.addExecutor(executor);
-        }
         WorkUnit wu = new WorkUnit(this, execUnit);
         workUnits.add(wu);
         return wu;


### PR DESCRIPTION
[JENKINS-33038](https://issues.jenkins-ci.org/browse/JENKINS-33038)

This patch fixes cancellation of the build linked to the Future object. Before, the `executor` set in `FutureImpl` was always empty, because `WorkUnitContext.createWorkUnit()` is not called from an Executor thread anymore. Instead, I now set it in `WorkUnit.setExecutor()`, which is called just before the executor thread starts executing the unit of work.

This is a tentative fix. I'm not sure to understand the big picture. The patch has been tested on freestyle and matrix jobs.

@reviewbybees
