### PR TITLE
[WiP] improvements required to hack-less one-shot-executor

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1003,7 +1003,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     /**
      * Called by {@link Executor} to kill excessive executors from this computer.
      */
-    /*package*/ void removeExecutor(final Executor e) {
+    protected void removeExecutor(final Executor e) {
         final Runnable task = new Runnable() {
             @Override
             public void run() {

--- a/core/src/main/java/hudson/model/ResourceController.java
+++ b/core/src/main/java/hudson/model/ResourceController.java
@@ -23,6 +23,7 @@
  */
 package hudson.model;
 
+import hudson.model.queue.QueueListener;
 import hudson.util.AdaptedIterator;
 
 import java.util.Set;
@@ -95,6 +96,9 @@ public class ResourceController {
         });
 
         try {
+            for (QueueListener listener : QueueListener.all()) {
+                listener.onTaskExecuted(task);
+            }
             task.run();
         } finally {
            // TODO if AsynchronousExecution, do that later

--- a/core/src/main/java/hudson/model/queue/QueueListener.java
+++ b/core/src/main/java/hudson/model/queue/QueueListener.java
@@ -75,9 +75,15 @@ public abstract class QueueListener implements ExtensionPoint {
     public void onLeft(LeftItem li) {}
 
     /**
+     * A task is going to run on assigned Executor.
+     */
+    public void onTaskExecuted(Runnable task) {}
+
+    /**
      * Returns all the registered {@link QueueListener}s.
      */
     public static ExtensionList<QueueListener> all() {
         return ExtensionList.lookup(QueueListener.class);
     }
+
 }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -156,6 +156,10 @@ public class SlaveComputer extends Computer {
         return os;
     }
 
+    public TaskListener getListener() {
+        return taskListener;
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
One-Shot executor is a pseudo-slave that is tied to a Run, i.e. it only lives for the Run, is created as the Run is started, and can fail the Run if provisioning the executor fails. Typical implementation is a Docker-based executor, while the container image is part of the job configuration / build parameters.
see https://github.com/ndeloof/one-shot-executor-plugin

The current implementation is using various hacks, relying on implementation details. This PR do expose the required hooks so we can avoid this (see https://github.com/ndeloof/one-shot-executor-plugin/tree/core).
