### PR TITLE
[JENKINS-33068] AsyncPeriodicWork/AsyncAperiodicWork log files rotation

### DIFF
--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -151,23 +151,23 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
             if ((lastRotateMillis + logRotateMillis < System.currentTimeMillis())
                     || (logRotateSize > 0 && f.length() > logRotateSize)) {
                 lastRotateMillis = System.currentTimeMillis();
-                File p = null;
+                File prev = null;
                 for (int i = 5; i >= 0; i--) {
-                    File o = i == 0 ? f : new File(f.getParentFile(), f.getName() + "." + i);
-                    if (o.isFile()) {
-                        if (p != null && !p.exists()) {
-                            if (!o.renameTo(p)) {
+                    File curr = i == 0 ? f : new File(f.getParentFile(), f.getName() + "." + i);
+                    if (curr.isFile()) {
+                        if (prev != null && !prev.exists()) {
+                            if (!curr.renameTo(prev)) {
                                 logger.log(getErrorLoggingLevel(), "Could not rotate log files {0} to {1}",
-                                        new Object[]{o, p});
+                                        new Object[]{curr, prev});
                             }
                         } else {
-                            if (!o.delete()) {
+                            if (!curr.delete()) {
                                 logger.log(getErrorLoggingLevel(), "Could not delete log file {0} to enable rotation",
-                                        o);
+                                        curr);
                             }
                         }
                     }
-                    p = o;
+                    prev = curr;
                 }
             }
         } else {
@@ -179,10 +179,10 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
                 if (!newFile.isFile()) {
                     // if there has never been rotation then this is the first time
                     if (oldFile.renameTo(newFile)) {
-                        logger.log(getNormalLoggingLevel(), "Moved {0} to {1}.1", new Object[]{oldFile, f});
+                        logger.log(getNormalLoggingLevel(), "Moved {0} to {1}", new Object[]{oldFile, newFile});
                     } else {
-                        logger.log(getErrorLoggingLevel(), "Could not move {0} to {1}.1",
-                                new Object[]{oldFile, f});
+                        logger.log(getErrorLoggingLevel(), "Could not move {0} to {1}",
+                                new Object[]{oldFile, newFile});
                     }
                 }
             }

--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -164,6 +164,11 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
                 }
             }
         }
+        if (!f.getParentFile().isDirectory()) {
+            if (!f.getParentFile().mkdirs()) {
+                logger.log(getErrorLoggingLevel(), "Could not create directory {0}", f.getParentFile());
+            }
+        }
         try {
             return new StreamTaskListener(f, true, null);
         } catch (IOException e) {
@@ -175,7 +180,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      * Determines the log file that records the result of this task.
      */
     protected File getLogFile() {
-        return new File(Jenkins.getInstance().getRootDir(),name+".log");
+        return new File(Jenkins.getInstance().getRootDir(),"logs/tasks/"+name+".log");
     }
 
     /**

--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -75,11 +75,12 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      */
     private final long logRotateSize;
     /**
-     * The last time the log files were rotated.
+     * The last time the log files were rotated. On start-up this will be {@link Long#MIN_VALUE} to ensure that the
+     * logs are always rotated every time Jenkins starts up to make it easier to correlate events with the main log.
      *
      * @since 1.650
      */
-    private Long lastRotateMillis;
+    private long lastRotateMillis = Long.MIN_VALUE;
     /**
      * Name of the work.
      */
@@ -142,8 +143,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
     protected StreamTaskListener createListener() {
         File f = getLogFile();
         if (f.isFile()) {
-            if ((lastRotateMillis == null)
-                    || (lastRotateMillis + logRotateMillis < System.currentTimeMillis())
+            if ((lastRotateMillis + logRotateMillis < System.currentTimeMillis())
                     || (logRotateSize > 0 && f.length() > logRotateSize)) {
                 lastRotateMillis = System.currentTimeMillis();
                 File p = null;

--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -46,7 +46,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      * Each individual AsyncAperiodicWork can also have a per-extension override using the system property
      * based on their fully qualified class name with {@code .logRotateMinutes} appended.
      *
-     * @since 1.650
+     * @since 1.651
      */
     private static final long LOG_ROTATE_MINUTES = Long.getLong(AsyncAperiodicWork.class.getName() +
             ".logRotateMinutes", TimeUnit.DAYS.toMinutes(1));
@@ -57,28 +57,28 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      * Each individual AsyncAperiodicWork can also have a per-extension override using the system property
      * based on their fully qualified class name with {@code .logRotateSize} appended.
      *
-     * @since 1.650
+     * @since 1.651
      */
     private static final long LOG_ROTATE_SIZE = Long.getLong(AsyncAperiodicWork.class.getName() + ".logRotateSize",
             -1L);
     /**
      * The number of milliseconds (since startup or previous rotation) after which to try and rotate the log file.
      *
-     * @since 1.650
+     * @since 1.651
      */
     private final long logRotateMillis;
     /**
      * {@code -1L} disabled file size based log rotation, otherwise when starting an {@link #execute(TaskListener)},
      * if the log file size is above this number of bytes then the log file will be rotated beforehand.
      *
-     * @since 1.650
+     * @since 1.651
      */
     private final long logRotateSize;
     /**
      * The last time the log files were rotated. On start-up this will be {@link Long#MIN_VALUE} to ensure that the
      * logs are always rotated every time Jenkins starts up to make it easier to correlate events with the main log.
      *
-     * @since 1.650
+     * @since 1.651
      */
     private long lastRotateMillis = Long.MIN_VALUE;
     /**
@@ -205,7 +205,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      * Returns the logging level at which normal messages are displayed.
      *
      * @return The logging level.
-     * @since 1.650
+     * @since 1.651
      */
     protected Level getNormalLoggingLevel() {
         return Level.INFO;
@@ -215,7 +215,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      * Returns the logging level at which previous task still executing messages is displayed.
      *
      * @return The logging level.
-     * @since 1.650
+     * @since 1.651
      */
     protected Level getSlowLoggingLevel() {
         return getNormalLoggingLevel();
@@ -225,7 +225,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      * Returns the logging level at which error messages are displayed.
      *
      * @return The logging level.
-     * @since 1.650
+     * @since 1.651
      */
     protected Level getErrorLoggingLevel() {
         return Level.SEVERE;

--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -198,7 +198,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      * Determines the log file that records the result of this task.
      */
     protected File getLogFile() {
-        return new File(Jenkins.getInstance().getRootDir(),"logs/tasks/"+name+".log");
+        return new File(Jenkins.getActiveInstance().getRootDir(),"logs/tasks/"+name+".log");
     }
 
     /**

--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -25,11 +25,11 @@ package hudson.model;
 
 import hudson.security.ACL;
 import hudson.util.StreamTaskListener;
-
 import java.io.File;
 import java.io.IOException;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-
 import jenkins.model.Jenkins;
 
 /**
@@ -40,8 +40,46 @@ import jenkins.model.Jenkins;
  * @since 1.410
  */
 public abstract class AsyncAperiodicWork extends AperiodicWork {
-	
-	/**
+    /**
+     * The default number of minutes after which to try and rotate the log file used by {@link #createListener()}.
+     * This value is controlled by the system property {@code hudson.model.AsyncAperiodicWork.logRotateMinutes}.
+     * Each individual AsyncAperiodicWork can also have a per-extension override using the system property
+     * based on their fully qualified class name with {@code .logRotateMinutes} appended.
+     *
+     * @since 1.650
+     */
+    private static Long LOG_ROTATE_MINUTES = Long.getLong(AsyncAperiodicWork.class.getName() + ".logRotateMinutes",
+            TimeUnit.DAYS.toMinutes(1));
+    /**
+     * The default file size after which to try and rotate the log file used by {@link #createListener()}.
+     * A value of {@code -1L} disables rotation based on file size.
+     * This value is controlled by the system property {@code hudson.model.AsyncAperiodicWork.logRotateSize}.
+     * Each individual AsyncAperiodicWork can also have a per-extension override using the system property
+     * based on their fully qualified class name with {@code .logRotateSize} appended.
+     *
+     * @since 1.650
+     */
+    private static Long LOG_ROTATE_SIZE = Long.getLong(AsyncAperiodicWork.class.getName() + ".logRotateSize", -1L);
+    /**
+     * The number of milliseconds (since startup or previous rotation) after which to try and rotate the log file.
+     *
+     * @since 1.650
+     */
+    private final long logRotateMillis;
+    /**
+     * {@code -1L} disabled file size based log rotation, otherwise when starting an {@link #execute(TaskListener)},
+     * if the log file size is above this number of bytes then the log file will be rotated beforehand.
+     *
+     * @since 1.650
+     */
+    private final long logRotateSize;
+    /**
+     * The last time the log files were rotated.
+     *
+     * @since 1.650
+     */
+    private Long lastRotateMillis;
+    /**
      * Name of the work.
      */
     public final String name;
@@ -50,6 +88,9 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
 
     protected AsyncAperiodicWork(String name) {
         this.name = name;
+        this.logRotateMillis = TimeUnit.MINUTES.toMillis(
+                Long.getLong(getClass().getName()+".logRotateMinutes", LOG_ROTATE_MINUTES));
+        this.logRotateSize = Long.getLong(getClass().getName() +".logRotateSize", LOG_ROTATE_SIZE);
     }
 
     /**
@@ -59,19 +100,25 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
     public final void doAperiodicRun() {
         try {
             if(thread!=null && thread.isAlive()) {
-                logger.log(Level.INFO, name+" thread is still running. Execution aborted.");
+                logger.log(getSlowLoggingLevel(), name+" thread is still running. Execution aborted.");
                 return;
             }
             thread = new Thread(new Runnable() {
                 public void run() {
-                    logger.log(Level.INFO, "Started "+name);
+                    logger.log(getNormalLoggingLevel(), "Started "+name);
                     long startTime = System.currentTimeMillis();
 
                     StreamTaskListener l = createListener();
                     try {
+                        l.getLogger().printf("Started at %tc%n", new Date(startTime));
                         ACL.impersonate(ACL.SYSTEM);
 
-                        execute(l);
+                        try {
+                            execute(l);
+                        } finally {
+                            long stopTime = System.currentTimeMillis();
+                            l.getLogger().printf("Finished at %tc. %dms%n", new Date(stopTime), stopTime - startTime);
+                        }
                     } catch (IOException e) {
                         e.printStackTrace(l.fatalError(e.getMessage()));
                     } catch (InterruptedException e) {
@@ -80,8 +127,8 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
                         l.closeQuietly();
                     }
 
-                    logger.log(Level.INFO, "Finished "+name+". "+
-                        (System.currentTimeMillis()-startTime)+" ms");
+                    logger.log(getNormalLoggingLevel(), "Finished {0}. {1,number} ms",
+                            new Object[]{name, System.currentTimeMillis() - startTime});
                 }
             },name+" thread");
             thread.start(); 
@@ -91,8 +138,34 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
     }
 
     protected StreamTaskListener createListener() {
+        File f = getLogFile();
+        if (f.isFile()) {
+            if ((lastRotateMillis == null)
+                    || (lastRotateMillis + logRotateMillis < System.currentTimeMillis())
+                    || (logRotateSize > 0 && f.length() > logRotateSize)) {
+                lastRotateMillis = System.currentTimeMillis();
+                File p = null;
+                for (int i = 5; i >= 0; i--) {
+                    File o = i == 0 ? f : new File(f.getParentFile(), f.getName() + "." + i);
+                    if (o.isFile()) {
+                        if (p != null && !p.exists()) {
+                            if (!o.renameTo(p)) {
+                                logger.log(getErrorLoggingLevel(), "Could not rotate log files {0} to {1}",
+                                        new Object[]{o, p});
+                            }
+                        } else {
+                            if (!o.delete()) {
+                                logger.log(getErrorLoggingLevel(), "Could not delete log files {0} to enable rotation",
+                                        o);
+                            }
+                        }
+                        p = o;
+                    }
+                }
+            }
+        }
         try {
-            return new StreamTaskListener(getLogFile());
+            return new StreamTaskListener(f, true, null);
         } catch (IOException e) {
             throw new Error(e);
         }
@@ -103,6 +176,36 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      */
     protected File getLogFile() {
         return new File(Jenkins.getInstance().getRootDir(),name+".log");
+    }
+
+    /**
+     * Returns the logging level at which normal messages are displayed.
+     *
+     * @return The logging level.
+     * @since 1.650
+     */
+    protected Level getNormalLoggingLevel() {
+        return Level.INFO;
+    }
+
+    /**
+     * Returns the logging level at which previous task still executing messages is displayed.
+     *
+     * @return The logging level.
+     * @since 1.650
+     */
+    protected Level getSlowLoggingLevel() {
+        return getNormalLoggingLevel();
+    }
+
+    /**
+     * Returns the logging level at which error messages are displayed.
+     *
+     * @return The logging level.
+     * @since 1.650
+     */
+    protected Level getErrorLoggingLevel() {
+        return Level.SEVERE;
     }
 
     /**

--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -161,8 +161,8 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
                                         o);
                             }
                         }
-                        p = o;
                     }
+                    p = o;
                 }
             }
         }

--- a/core/src/main/java/hudson/model/AsyncPeriodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncPeriodicWork.java
@@ -144,8 +144,8 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
                                         o);
                             }
                         }
-                        p = o;
                     }
+                    p = o;
                 }
             }
         }

--- a/core/src/main/java/hudson/model/AsyncPeriodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncPeriodicWork.java
@@ -55,11 +55,12 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
      */
     private final long logRotateSize;
     /**
-     * The last time the log files were rotated.
+     * The last time the log files were rotated. On start-up this will be {@link Long#MIN_VALUE} to ensure that the
+     * logs are always rotated every time Jenkins starts up to make it easier to correlate events with the main log.
      *
      * @since 1.650
      */
-    private Long lastRotateMillis;
+    private long lastRotateMillis = Long.MIN_VALUE;
     /**
      * Human readable name of the work.
      */
@@ -125,8 +126,7 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
     protected StreamTaskListener createListener() {
         File f = getLogFile();
         if (f.isFile()) {
-            if ((lastRotateMillis == null)
-                    || (lastRotateMillis + logRotateMillis < System.currentTimeMillis())
+            if ((lastRotateMillis + logRotateMillis < System.currentTimeMillis())
                     || (logRotateSize > 0 && f.length() > logRotateSize)) {
                 lastRotateMillis = System.currentTimeMillis();
                 File p = null;

--- a/core/src/main/java/hudson/model/AsyncPeriodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncPeriodicWork.java
@@ -134,23 +134,23 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
             if ((lastRotateMillis + logRotateMillis < System.currentTimeMillis())
                     || (logRotateSize > 0 && f.length() > logRotateSize)) {
                 lastRotateMillis = System.currentTimeMillis();
-                File p = null;
+                File prev = null;
                 for (int i = 5; i >= 0; i--) {
-                    File o = i == 0 ? f : new File(f.getParentFile(), f.getName() + "." + i);
-                    if (o.isFile()) {
-                        if (p != null && !p.exists()) {
-                            if (!o.renameTo(p)) {
+                    File curr = i == 0 ? f : new File(f.getParentFile(), f.getName() + "." + i);
+                    if (curr.isFile()) {
+                        if (prev != null && !prev.exists()) {
+                            if (!curr.renameTo(prev)) {
                                 logger.log(getErrorLoggingLevel(), "Could not rotate log files {0} to {1}",
-                                        new Object[]{o, p});
+                                        new Object[]{curr, prev});
                             }
                         } else {
-                            if (!o.delete()) {
+                            if (!curr.delete()) {
                                 logger.log(getErrorLoggingLevel(), "Could not delete log file {0} to enable rotation",
-                                        o);
+                                        curr);
                             }
                         }
                     }
-                    p = o;
+                    prev = curr;
                 }
             }
         } else {
@@ -162,10 +162,10 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
                 if (!newFile.isFile()) {
                     // if there has never been rotation then this is the first time
                     if (oldFile.renameTo(newFile)) {
-                        logger.log(getNormalLoggingLevel(), "Moved {0} to {1}.1", new Object[]{oldFile, f});
+                        logger.log(getNormalLoggingLevel(), "Moved {0} to {1}", new Object[]{oldFile, newFile});
                     } else {
-                        logger.log(getErrorLoggingLevel(), "Could not move {0} to {1}.1",
-                                new Object[]{oldFile, f});
+                        logger.log(getErrorLoggingLevel(), "Could not move {0} to {1}",
+                                new Object[]{oldFile, newFile});
                     }
                 }
             }

--- a/core/src/main/java/hudson/model/AsyncPeriodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncPeriodicWork.java
@@ -27,7 +27,7 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
      * Each individual AsyncPeriodicWork can also have a per-extension override using the system property
      * based on their fully qualified class name with {@code .logRotateMinutes} appended.
      *
-     * @since 1.650
+     * @since 1.651
      */
     private static final long LOG_ROTATE_MINUTES = Long.getLong(AsyncPeriodicWork.class.getName() + ".logRotateMinutes",
             TimeUnit.DAYS.toMinutes(1));
@@ -38,27 +38,27 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
      * Each individual AsyncPeriodicWork can also have a per-extension override using the system property
      * based on their fully qualified class name with {@code .logRotateSize} appended.
      *
-     * @since 1.650
+     * @since 1.651
      */
     private static final long LOG_ROTATE_SIZE = Long.getLong(AsyncPeriodicWork.class.getName() + ".logRotateSize", -1L);
     /**
      * The number of milliseconds (since startup or previous rotation) after which to try and rotate the log file.
      *
-     * @since 1.650
+     * @since 1.651
      */
     private final long logRotateMillis;
     /**
      * {@code -1L} disabled file size based log rotation, otherwise when starting an {@link #execute(TaskListener)},
      * if the log file size is above this number of bytes then the log file will be rotated beforehand.
      *
-     * @since 1.650
+     * @since 1.651
      */
     private final long logRotateSize;
     /**
      * The last time the log files were rotated. On start-up this will be {@link Long#MIN_VALUE} to ensure that the
      * logs are always rotated every time Jenkins starts up to make it easier to correlate events with the main log.
      *
-     * @since 1.650
+     * @since 1.651
      */
     private long lastRotateMillis = Long.MIN_VALUE;
     /**

--- a/core/src/main/java/hudson/model/AsyncPeriodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncPeriodicWork.java
@@ -148,6 +148,11 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
                 }
             }
         }
+        if (!f.getParentFile().isDirectory()) {
+            if (!f.getParentFile().mkdirs()) {
+                logger.log(getErrorLoggingLevel(), "Could not create directory {0}", f.getParentFile());
+            }
+        }
         try {
             return new StreamTaskListener(f, true, null);
         } catch (IOException e) {
@@ -159,7 +164,7 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
      * Determines the log file that records the result of this task.
      */
     protected File getLogFile() {
-        return new File(Jenkins.getInstance().getRootDir(),name+".log");
+        return new File(Jenkins.getInstance().getRootDir(),"logs/tasks/"+name+".log");
     }
     
     /**

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -104,7 +104,7 @@ public class StreamTaskListener extends AbstractTaskListener implements Serializ
      * @param append  if {@code true}, then output will be written to the end of the file rather than the beginning.
      * @param charset if non-{@code null} then the charset to use when writing.
      * @throws IOException if the file could not be opened.
-     * @since 1.650
+     * @since 1.651
      */
     public StreamTaskListener(File out, boolean append, Charset charset) throws IOException {
         // don't do buffering so that what's written to the listener

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -98,6 +98,13 @@ public class StreamTaskListener extends AbstractTaskListener implements Serializ
         this(new FileOutputStream(out),charset);
     }
 
+    public StreamTaskListener(File out, boolean append, Charset charset) throws IOException {
+        // don't do buffering so that what's written to the listener
+        // gets reflected to the file immediately, which can then be
+        // served to the browser immediately
+        this(new FileOutputStream(out, append),charset);
+    }
+
     public StreamTaskListener(Writer w) throws IOException {
         this(new WriterOutputStream(w));
     }

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -28,8 +28,6 @@ import hudson.console.ConsoleNote;
 import hudson.console.HudsonExceptionNote;
 import hudson.model.TaskListener;
 import hudson.remoting.RemoteOutputStream;
-import org.kohsuke.stapler.framework.io.WriterOutputStream;
-
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -46,6 +44,7 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.kohsuke.stapler.framework.io.WriterOutputStream;
 
 /**
  * {@link TaskListener} that generates output into a single stream.
@@ -98,6 +97,15 @@ public class StreamTaskListener extends AbstractTaskListener implements Serializ
         this(new FileOutputStream(out),charset);
     }
 
+    /**
+     * Constructs a {@link StreamTaskListener} that sends the output to a specified file.
+     *
+     * @param out     the file.
+     * @param append  if {@code true}, then output will be written to the end of the file rather than the beginning.
+     * @param charset if non-{@code null} then the charset to use when writing.
+     * @throws IOException if the file could not be opened.
+     * @since 1.650
+     */
     public StreamTaskListener(File out, boolean append, Charset charset) throws IOException {
         // don't do buffering so that what's written to the listener
         // gets reflected to the file immediately, which can then be


### PR DESCRIPTION
See [JENKINS-33068](https://issues.jenkins-ci.org/browse/JENKINS-33068)

Before this change the log file would be overwritten every execution... which makes finding any failures of a short period work almost impossible.
