### PR TITLE
[JENKINS-34683] - Do not print stack trace if plugin is missing dependencies

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -48,6 +48,7 @@ import hudson.util.VersionNumber;
 import hudson.util.XStream2;
 import jenkins.ClassLoaderReflectionToolkit;
 import jenkins.InitReactorRunner;
+import jenkins.MissingDependencyException;
 import jenkins.RestartRequiredException;
 import jenkins.YesNoMaybe;
 import jenkins.install.InstallState;
@@ -413,6 +414,12 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                                 try {
                                     p.resolvePluginDependencies();
                                     strategy.load(p);
+                                } catch (MissingDependencyException e) {
+                                    failedPlugins.add(new FailedPlugin(p.getShortName(), e));
+                                    activePlugins.remove(p);
+                                    plugins.remove(p);
+                                    LOGGER.log(Level.SEVERE, "Failed to install {0}: {1}", new Object[] { p.getShortName(), e.getMessage() });
+                                    return;
                                 } catch (IOException e) {
                                     failedPlugins.add(new FailedPlugin(p.getShortName(), e));
                                     activePlugins.remove(p);

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import hudson.PluginManager.PluginInstanceStore;
 import hudson.model.Api;
 import hudson.model.ModelObject;
+import jenkins.MissingDependencyException;
 import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import hudson.model.UpdateCenter;
@@ -513,14 +514,14 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      *             thrown if one or several mandatory dependencies doesn't exists.
      */
     /*package*/ void resolvePluginDependencies() throws IOException {
-        List<String> missingDependencies = new ArrayList<String>();
+        List<Dependency> missingDependencies = new ArrayList<>();
         // make sure dependencies exist
         for (Dependency d : dependencies) {
             if (parent.getPlugin(d.shortName) == null)
-                missingDependencies.add(d.toString());
+                missingDependencies.add(d);
         }
         if (!missingDependencies.isEmpty())
-            throw new IOException("Dependency "+Util.join(missingDependencies, ", ")+" doesn't exist");
+            throw new MissingDependencyException(this.shortName, missingDependencies);
 
         // add the optional dependencies that exists
         for (Dependency d : optionalDependencies) {

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -52,6 +52,7 @@ import hudson.util.IOException2;
 import hudson.util.IOUtils;
 import hudson.util.PersistedList;
 import hudson.util.XStream2;
+import jenkins.MissingDependencyException;
 import jenkins.RestartRequiredException;
 import jenkins.install.InstallUtil;
 import jenkins.model.Jenkins;
@@ -1518,6 +1519,10 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 status = e;
                 if (status.isSuccess()) onSuccess();
                 requiresRestart |= status.requiresRestart();
+            } catch (MissingDependencyException e) {
+                LOGGER.log(Level.SEVERE, "Failed to install {0}: {1}", new Object[] { getName(), e.getMessage() });
+                status = new Failure(e);
+                error = e;
             } catch (Throwable e) {
                 LOGGER.log(Level.SEVERE, "Failed to install "+getName(),e);
                 status = new Failure(e);

--- a/core/src/main/java/jenkins/MissingDependencyException.java
+++ b/core/src/main/java/jenkins/MissingDependencyException.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins;
+
+import java.io.IOException;
+import java.util.List;
+
+import hudson.PluginWrapper.Dependency;
+import hudson.Util;
+
+/**
+ * Exception thrown if plugin resolution fails due to missing dependencies
+ * 
+ * @author Carlos Sanchez
+ * @since TODO
+ *
+ */
+public class MissingDependencyException extends IOException {
+
+    private String pluginShortName;
+    private List<Dependency> missingDependencies;
+
+    public MissingDependencyException(String pluginShortName, List<Dependency> missingDependencies) {
+        super("One or more dependencies could not be resolved for " + pluginShortName + " : "
+                + Util.join(missingDependencies, ", "));
+        this.pluginShortName = pluginShortName;
+        this.missingDependencies = missingDependencies;
+    }
+
+    public List<Dependency> getMissingDependencies() {
+        return missingDependencies;
+    }
+
+    public String getPluginShortName() {
+        return pluginShortName;
+    }
+
+}


### PR DESCRIPTION
Avoid stack traces in log if plugin resolution fails due to a well know cause as it is a missing dependency

@reviewbybees
