### PR TITLE
[FIXED JENKINS-33037] Fixed malformed ranges in RangeSet.fromString()

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -50,6 +50,7 @@ import java.io.EOFException;
 import jenkins.model.FingerprintFacet;
 import jenkins.model.Jenkins;
 import jenkins.model.TransientFingerprintFacetFactory;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -687,21 +688,77 @@ public class Fingerprint implements ModelObject, Saveable {
          */
         public static RangeSet fromString(String list, boolean skipError) {
             RangeSet rs = new RangeSet();
-            for (String s : Util.tokenize(list,",")) {
+
+            // Reject malformed ranges like "1---10", "1,,,,3" etc.
+            if (list.contains("--") || list.contains(",,")) {
+                if (!skipError) {
+                    throw new IllegalArgumentException(
+                            String.format("Unable to parse '%s', expected correct notation M,N or M-N", list));
+                }
+                // ignore malformed notation
+                return rs;
+            }
+
+            String[] items = Util.tokenize(list,",");
+            if(items.length > 1 && items.length <= StringUtils.countMatches(list, ",")) {
+                if (!skipError) {
+                    throw new IllegalArgumentException(
+                            String.format("Unable to parse '%s', expected correct notation M,N or M-N", list));
+                }
+                // ignore malformed notation like ",1,2" or "1,2,"
+                return rs;
+            }
+
+            for (String s : items) {
                 s = s.trim();
                 // s is either single number or range "x-y".
                 // note that the end range is inclusive in this notation, but not in the Range class
                 try {
+                    if (s.isEmpty()) {
+                        if (!skipError) {
+                            throw new IllegalArgumentException(
+                                    String.format("Unable to parse '%s', expected number", list));                        }
+                        // ignore "" element
+                        continue;
+                    }
+
                     if(s.contains("-")) {
+                        if(StringUtils.countMatches(s, "-") > 1) {
+                            if (!skipError) {
+                                throw new IllegalArgumentException(String.format(
+                                        "Unable to parse '%s', expected correct notation M,N or M-N", list));
+                            }
+                            // ignore malformed ranges like "-5-2" or "2-5-"
+                            continue;
+                        }
                         String[] tokens = Util.tokenize(s,"-");
                         if (tokens.length == 2) {
-                            rs.ranges.add(new Range(Integer.parseInt(tokens[0]), Integer.parseInt(tokens[1]) + 1));
+                            int left = Integer.parseInt(tokens[0]);
+                            int right = Integer.parseInt(tokens[1]);
+                            if(left < 0 || right < 0) {
+                                if (!skipError) {
+                                    throw new IllegalArgumentException(
+                                            String.format("Unable to parse '%s', expected number above zero", list));
+                                }
+                                // ignore a range which starts or ends under zero like "-5-3"
+                                continue;
+                            }
+                            if(left > right) {
+                                if (!skipError) {
+                                    throw new IllegalArgumentException(String.format(
+                                            "Unable to parse '%s', expected string with a range M-N where M<N", list));
+                                }
+                                // ignore inverse range like "10-5"
+                                continue;
+                            }
+                            rs.ranges.add(new Range(left, right+1));
                         } else {
                             if (!skipError) {
                                 throw new IllegalArgumentException(
-                                        String.format("Unable to parse %s, expected string with a range M-N", list));
+                                        String.format("Unable to parse '%s', expected string with a range M-N", list));
                             }
                             // ignore malformed text like "1-10-50"
+                            continue;
                         }
                     } else {
                         int n = Integer.parseInt(s);
@@ -710,7 +767,7 @@ public class Fingerprint implements ModelObject, Saveable {
                 } catch (NumberFormatException e) {
                     if (!skipError)
                         throw new IllegalArgumentException(
-                                String.format("Unable to parse %s, expected number", list));
+                                String.format("Unable to parse '%s', expected number", list));
                     // ignore malformed text
                 }
             }

--- a/core/src/test/java/hudson/model/FingerprintTest.java
+++ b/core/src/test/java/hudson/model/FingerprintTest.java
@@ -27,6 +27,9 @@ import hudson.Util;
 import hudson.model.Fingerprint.RangeSet;
 import java.io.File;
 import jenkins.model.FingerprintFacet;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
@@ -259,4 +262,274 @@ public class FingerprintTest {
         }
     }
 
+    @Test public void fromString() throws Exception {
+        //
+        // Single
+        //
+        // Numbers
+        assertThat(RangeSet.fromString("1", true).toString(), equalTo("[1,2)"));
+        assertThat(RangeSet.fromString("1", false).toString(), equalTo("[1,2)"));
+        assertThat(RangeSet.fromString("+1", true).toString(), equalTo("[1,2)"));
+        assertThat(RangeSet.fromString("+1", false).toString(), equalTo("[1,2)"));
+        // Zero
+        assertThat(RangeSet.fromString("0", true).toString(), equalTo("[0,1)"));
+        assertThat(RangeSet.fromString("0", false).toString(), equalTo("[0,1)"));
+        assertThat(RangeSet.fromString("+0", true).toString(), equalTo("[0,1)"));
+        assertThat(RangeSet.fromString("+0", false).toString(), equalTo("[0,1)"));
+        // Negative number
+        assertThat(RangeSet.fromString("-1", true).toString(), equalTo(""));
+        assertThat(expectIAE("-1", "Unable to parse '-1', expected string with a range M-N"), is(true));
+        // Exceeded int number
+        assertThat(RangeSet.fromString("2147483648", true).toString(), equalTo(""));
+        assertThat(expectIAE("2147483648", "Unable to parse '2147483648', expected number"), is(true));
+        // Invalid number
+        assertThat(RangeSet.fromString("1a", true).toString(), equalTo(""));
+        assertThat(expectIAE("1a", "Unable to parse '1a', expected number"), is(true));
+        assertThat(RangeSet.fromString("aa", true).toString(), equalTo(""));
+        assertThat(expectIAE("aa", "Unable to parse 'aa', expected number"), is(true));
+        //Empty
+        assertThat(RangeSet.fromString("", true).toString(), equalTo(""));
+        assertThat(RangeSet.fromString("", false).toString(), equalTo(""));
+        //Space
+        assertThat(RangeSet.fromString(" ", true).toString(), equalTo(""));
+        assertThat(expectIAE(" ", "Unable to parse ' ', expected number"), is(true));
+        // Comma
+        assertThat(RangeSet.fromString(",", true).toString(), equalTo(""));
+        assertThat(RangeSet.fromString(",", false).toString(), equalTo(""));
+        // Hyphen
+        assertThat(RangeSet.fromString("-", true).toString(), equalTo(""));
+        assertThat(expectIAE("-", "Unable to parse '-', expected string with a range M-N"), is(true));
+
+        //
+        // Multiple numbers
+        //
+        // Numbers
+        assertThat(RangeSet.fromString("1,2", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(RangeSet.fromString("1,2", false).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(RangeSet.fromString("1,+2,5", true).toString(), equalTo("[1,2),[2,3),[5,6)"));
+        assertThat(RangeSet.fromString("1,+2,5", false).toString(), equalTo("[1,2),[2,3),[5,6)"));
+        assertThat(RangeSet.fromString("1,1", true).toString(), equalTo("[1,2),[1,2)"));
+        assertThat(RangeSet.fromString("1,1", false).toString(), equalTo("[1,2),[1,2)"));
+        // Zero
+        assertThat(RangeSet.fromString("0,1,2", true).toString(), equalTo("[0,1),[1,2),[2,3)"));
+        assertThat(RangeSet.fromString("0,1,2", false).toString(), equalTo("[0,1),[1,2),[2,3)"));
+        assertThat(RangeSet.fromString("1,0,2", true).toString(), equalTo("[1,2),[0,1),[2,3)"));
+        assertThat(RangeSet.fromString("1,0,2", false).toString(), equalTo("[1,2),[0,1),[2,3)"));
+        assertThat(RangeSet.fromString("1,2,0", true).toString(), equalTo("[1,2),[2,3),[0,1)"));
+        assertThat(RangeSet.fromString("1,2,0", false).toString(), equalTo("[1,2),[2,3),[0,1)"));
+        // Negative number
+        assertThat(RangeSet.fromString("-1,2,3", true).toString(), equalTo("[2,3),[3,4)"));
+        assertThat(expectIAE("-1,2,3", "Unable to parse '-1,2,3', expected string with a range M-N"), is(true));
+        assertThat(RangeSet.fromString("1,-2,3", true).toString(), equalTo("[1,2),[3,4)"));
+        assertThat(expectIAE("1,-2,3", "Unable to parse '1,-2,3', expected string with a range M-N"), is(true));
+        assertThat(RangeSet.fromString("1,2,-3", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(expectIAE("1,2,-3", "Unable to parse '1,2,-3', expected string with a range M-N"), is(true));
+        // Exceeded int number
+        assertThat(RangeSet.fromString("2147483648,2,3", true).toString(), equalTo("[2,3),[3,4)"));
+        assertThat(expectIAE("2147483648,1,2", "Unable to parse '2147483648,1,2', expected number"), is(true));
+        assertThat(RangeSet.fromString("1,2147483648,3", true).toString(), equalTo("[1,2),[3,4)"));
+        assertThat(expectIAE("1,2147483648,2", "Unable to parse '1,2147483648,2', expected number"), is(true));
+        assertThat(RangeSet.fromString("1,2,2147483648", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(expectIAE("1,2,2147483648", "Unable to parse '1,2,2147483648', expected number"), is(true));
+        // Invalid number
+        assertThat(RangeSet.fromString("1a,2,3", true).toString(), equalTo("[2,3),[3,4)"));
+        assertThat(expectIAE("1a,1,2", "Unable to parse '1a,1,2', expected number"), is(true));
+        assertThat(RangeSet.fromString("1,2a,3", true).toString(), equalTo("[1,2),[3,4)"));
+        assertThat(expectIAE("1,2a,2", "Unable to parse '1,2a,2', expected number"), is(true));
+        assertThat(RangeSet.fromString("1,2,3a", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(expectIAE("1,2,3a", "Unable to parse '1,2,3a', expected number"), is(true));
+        assertThat(RangeSet.fromString("aa,2,3", true).toString(), equalTo("[2,3),[3,4)"));
+        assertThat(expectIAE("aa,1,2", "Unable to parse 'aa,1,2', expected number"), is(true));
+        assertThat(RangeSet.fromString("1,aa,3", true).toString(), equalTo("[1,2),[3,4)"));
+        assertThat(expectIAE("1,aa,2", "Unable to parse '1,aa,2', expected number"), is(true));
+        assertThat(RangeSet.fromString("1,2,aa", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(expectIAE("1,2,aa", "Unable to parse '1,2,aa', expected number"), is(true));
+        //Empty
+        assertThat(RangeSet.fromString(",1,2", true).toString(), equalTo(""));
+        assertThat(expectIAE(",1,2", "Unable to parse ',1,2', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("1,,2", true).toString(), equalTo(""));
+        assertThat(expectIAE("1,,2", "Unable to parse '1,,2', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("1,2,", true).toString(), equalTo(""));
+        assertThat(expectIAE("1,2,", "Unable to parse '1,2,', expected correct notation M,N or M-N"), is(true));
+        // Space
+        assertThat(RangeSet.fromString(" ,1,2", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(expectIAE(" ,1,2", "Unable to parse ' ,1,2', expected number"), is(true));
+        assertThat(RangeSet.fromString("1, ,2", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(expectIAE("1, ,2", "Unable to parse '1, ,2', expected number"), is(true));
+        assertThat(RangeSet.fromString("1,2, ", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(expectIAE("1,2, ", "Unable to parse '1,2, ', expected number"), is(true));
+        // Comma
+        assertThat(RangeSet.fromString(",,1,2", true).toString(), equalTo(""));
+        assertThat(expectIAE(",,1,2", "Unable to parse ',,1,2', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("1,,,2", true).toString(), equalTo(""));
+        assertThat(expectIAE("1,,,2", "Unable to parse '1,,,2', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("1,2,,", true).toString(), equalTo(""));
+        assertThat(expectIAE("1,2,,", "Unable to parse '1,2,,', expected correct notation M,N or M-N"), is(true));
+        // Hyphen
+        assertThat(RangeSet.fromString("-,1,2", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(expectIAE("-,1,2", "Unable to parse '-,1,2', expected string with a range M-N"), is(true));
+        assertThat(RangeSet.fromString("1,-,2", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(expectIAE("1,-,2", "Unable to parse '1,-,2', expected string with a range M-N"), is(true));
+        assertThat(RangeSet.fromString("1,2,-", true).toString(), equalTo("[1,2),[2,3)"));
+        assertThat(expectIAE("1,2,-", "Unable to parse '1,2,-', expected string with a range M-N"), is(true));
+
+        //
+        // Single range
+        //
+        // Numbers
+        assertThat(RangeSet.fromString("1-2", true).toString(), equalTo("[1,3)"));
+        assertThat(RangeSet.fromString("1-2", false).toString(), equalTo("[1,3)"));
+        assertThat(RangeSet.fromString("+1-+2", true).toString(), equalTo("[1,3)"));
+        assertThat(RangeSet.fromString("+1-+2", false).toString(), equalTo("[1,3)"));
+        assertThat(RangeSet.fromString("1-1", true).toString(), equalTo("[1,2)"));
+        assertThat(RangeSet.fromString("1-1", false).toString(), equalTo("[1,2)"));
+        assertThat(RangeSet.fromString("+1-+1", true).toString(), equalTo("[1,2)"));
+        assertThat(RangeSet.fromString("+1-+1", false).toString(), equalTo("[1,2)"));
+        assertThat(RangeSet.fromString("1-4", true).toString(), equalTo("[1,5)"));
+        assertThat(RangeSet.fromString("1-4", false).toString(), equalTo("[1,5)"));
+        assertThat(RangeSet.fromString("+1-+4", true).toString(), equalTo("[1,5)"));
+        assertThat(RangeSet.fromString("+1-+4", false).toString(), equalTo("[1,5)"));
+        //Zero
+        assertThat(RangeSet.fromString("0-1", true).toString(), equalTo("[0,2)"));
+        assertThat(RangeSet.fromString("0-1", false).toString(), equalTo("[0,2)"));
+        assertThat(RangeSet.fromString("+0-+1", true).toString(), equalTo("[0,2)"));
+        assertThat(RangeSet.fromString("+0-+1", false).toString(), equalTo("[0,2)"));
+        assertThat(RangeSet.fromString("0-2", true).toString(), equalTo("[0,3)"));
+        assertThat(RangeSet.fromString("0-2", false).toString(), equalTo("[0,3)"));
+        assertThat(RangeSet.fromString("+0-+2", true).toString(), equalTo("[0,3)"));
+        assertThat(RangeSet.fromString("+0-+2", false).toString(), equalTo("[0,3)"));
+        assertThat(RangeSet.fromString("0--1", true).toString(), equalTo(""));
+        assertThat(expectIAE("0--1", "Unable to parse '0--1', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("+0--1", true).toString(), equalTo(""));
+        assertThat(expectIAE("+0--1", "Unable to parse '+0--1', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("0--2", true).toString(), equalTo(""));
+        assertThat(expectIAE("0--2", "Unable to parse '0--2', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("+0--2", true).toString(), equalTo(""));
+        assertThat(expectIAE("+0--2", "Unable to parse '+0--2', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("1-0", true).toString(), equalTo(""));
+        assertThat(expectIAE("1-0", "Unable to parse '1-0', expected string with a range M-N where M<N"), is(true));
+        assertThat(RangeSet.fromString("+1-+0", true).toString(), equalTo(""));
+        assertThat(expectIAE("+1-+0", "Unable to parse '+1-+0', expected string with a range M-N where M<N"), is(true));
+        assertThat(RangeSet.fromString("2-0", true).toString(), equalTo(""));
+        assertThat(expectIAE("2-0", "Unable to parse '2-0', expected string with a range M-N where M<N"), is(true));
+        assertThat(RangeSet.fromString("+2-+0", true).toString(), equalTo(""));
+        assertThat(expectIAE("+2-+0", "Unable to parse '+2-+0', expected string with a range M-N where M<N"), is(true));
+        assertThat(RangeSet.fromString("-1-0", true).toString(), equalTo(""));
+        assertThat(expectIAE("-1-0", "Unable to parse '-1-0', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("-1-+0", true).toString(), equalTo(""));
+        assertThat(expectIAE("-1-+0", "Unable to parse '-1-+0', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("-2-0", true).toString(), equalTo(""));
+        assertThat(expectIAE("-2-0", "Unable to parse '-2-0', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("-2-+0", true).toString(), equalTo(""));
+        assertThat(expectIAE("-2-+0", "Unable to parse '-2-+0', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("0-0", true).toString(), equalTo("[0,1)"));
+        assertThat(RangeSet.fromString("0-0", false).toString(), equalTo("[0,1)"));
+        assertThat(RangeSet.fromString("+0-+0", true).toString(), equalTo("[0,1)"));
+        assertThat(RangeSet.fromString("+0-+0", false).toString(), equalTo("[0,1)"));
+        // Negative number
+        assertThat(RangeSet.fromString("-1-1", true).toString(), equalTo(""));
+        assertThat(expectIAE("-1-1", "Unable to parse '-1-1', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("-1-+1", true).toString(), equalTo(""));
+        assertThat(expectIAE("-1-+1", "Unable to parse '-1-+1', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("-1-2", true).toString(), equalTo(""));
+        assertThat(expectIAE("-1-2", "Unable to parse '-1-2', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("-1-+2", true).toString(), equalTo(""));
+        assertThat(expectIAE("-1-+2", "Unable to parse '-1-+2', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("1--1", true).toString(), equalTo(""));
+        assertThat(expectIAE("1--1", "Unable to parse '1--1', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("+1--1", true).toString(), equalTo(""));
+        assertThat(expectIAE("+1--1", "Unable to parse '+1--1', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("1--2", true).toString(), equalTo(""));
+        assertThat(expectIAE("1--2", "Unable to parse '1--2', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("+1--2", true).toString(), equalTo(""));
+        assertThat(expectIAE("+1--2", "Unable to parse '+1--2', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("-1--1", true).toString(), equalTo(""));
+        assertThat(expectIAE("-1--1", "Unable to parse '-1--1', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("-2--1", true).toString(), equalTo(""));
+        assertThat(expectIAE("-2--1", "Unable to parse '-2--1', expected correct notation M,N or M-N"), is(true));
+        // Exceeded int number
+        assertThat(RangeSet.fromString("0-2147483648", true).toString(), equalTo(""));
+        assertThat(expectIAE("0-2147483648", "Unable to parse '0-2147483648', expected number"), is(true));
+        assertThat(RangeSet.fromString("2147483648-0", true).toString(), equalTo(""));
+        assertThat(expectIAE("2147483648-0", "Unable to parse '2147483648-0', expected number"), is(true));
+        assertThat(RangeSet.fromString("2147483648-2147483648", true).toString(), equalTo(""));
+        assertThat(expectIAE("2147483648-2147483648", "Unable to parse '2147483648-2147483648', expected number"), is(true));
+        // Invalid number
+        assertThat(RangeSet.fromString("1-2a", true).toString(), equalTo(""));
+        assertThat(expectIAE("1-2a", "Unable to parse '1-2a', expected number"), is(true));
+        assertThat(RangeSet.fromString("2a-2", true).toString(), equalTo(""));
+        assertThat(expectIAE("2a-2", "Unable to parse '2a-2', expected number"), is(true));
+        assertThat(RangeSet.fromString("2a-2a", true).toString(), equalTo(""));
+        assertThat(expectIAE("2a-2a", "Unable to parse '2a-2a', expected number"), is(true));
+        assertThat(RangeSet.fromString("aa-2", true).toString(), equalTo(""));
+        assertThat(expectIAE("aa-2", "Unable to parse 'aa-2', expected number"), is(true));
+        assertThat(RangeSet.fromString("1-aa", true).toString(), equalTo(""));
+        assertThat(expectIAE("1-aa", "Unable to parse '1-aa', expected number"), is(true));
+        assertThat(RangeSet.fromString("aa-aa", true).toString(), equalTo(""));
+        assertThat(expectIAE("aa-aa", "Unable to parse 'aa-aa', expected number"), is(true));
+        // Empty
+        assertThat(RangeSet.fromString("-1", true).toString(), equalTo(""));
+        assertThat(expectIAE("-1", "Unable to parse '-1', expected string with a range M-N"), is(true));
+        assertThat(RangeSet.fromString("1-", true).toString(), equalTo(""));
+        assertThat(expectIAE("1-", "Unable to parse '1-', expected string with a range M-N"), is(true));
+        assertThat(RangeSet.fromString("-", true).toString(), equalTo(""));
+        assertThat(expectIAE("-", "Unable to parse '-', expected string with a range M-N"), is(true));
+        // Space
+        assertThat(RangeSet.fromString(" -1", true).toString(), equalTo(""));
+        assertThat(expectIAE(" -1", "Unable to parse ' -1', expected string with a range M-N"), is(true));
+        assertThat(RangeSet.fromString("1- ", true).toString(), equalTo(""));
+        assertThat(expectIAE("1- ", "Unable to parse '1- ', expected string with a range M-N"), is(true));
+        assertThat(RangeSet.fromString(" - ", true).toString(), equalTo(""));
+        assertThat(expectIAE(" - ", "Unable to parse ' - ', expected string with a range M-N"), is(true));
+        // Comma
+        assertThat(RangeSet.fromString(",-1", true).toString(), equalTo(""));
+        assertThat(expectIAE(",-1", "Unable to parse ',-1', expected string with a range M-N"), is(true));
+        assertThat(RangeSet.fromString("1-,", true).toString(), equalTo(""));
+        assertThat(expectIAE("1-,", "Unable to parse '1-,', expected string with a range M-N"), is(true));
+        assertThat(RangeSet.fromString(",-,", true).toString(), equalTo(""));
+        assertThat(expectIAE(",-,", "Unable to parse ',-,', expected string with a range M-N"), is(true));
+        // Hyphen
+        assertThat(RangeSet.fromString("--1", true).toString(), equalTo(""));
+        assertThat(expectIAE("--1", "Unable to parse '--1', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("1--", true).toString(), equalTo(""));
+        assertThat(expectIAE("1--", "Unable to parse '1--', expected correct notation M,N or M-N"), is(true));
+        assertThat(RangeSet.fromString("---", true).toString(), equalTo(""));
+        assertThat(expectIAE("---", "Unable to parse '---', expected correct notation M,N or M-N"), is(true));
+        // Inverse range
+        assertThat(RangeSet.fromString("2-1", true).toString(), equalTo(""));
+        assertThat(expectIAE("2-1", "Unable to parse '2-1', expected string with a range M-N where M<N"), is(true));
+        assertThat(RangeSet.fromString("10-1", true).toString(), equalTo(""));
+        assertThat(expectIAE("10-1", "Unable to parse '10-1', expected string with a range M-N where M<N"), is(true));
+        assertThat(RangeSet.fromString("-1--2", true).toString(), equalTo(""));
+        assertThat(expectIAE("-1--2", "Unable to parse '-1--2', expected correct notation M,N or M-N"), is(true));
+        // Invalid range
+        assertThat(RangeSet.fromString("1-3-", true).toString(), equalTo(""));
+        assertThat(expectIAE("1-3-", "Unable to parse '1-3-', expected correct notation M,N or M-N"), is(true));
+
+        //
+        // Multiple ranges
+        //
+        assertThat(RangeSet.fromString("1-3,3-5", true).toString(), equalTo("[1,4),[3,6)"));
+        assertThat(RangeSet.fromString("1-3,4-6", true).toString(), equalTo("[1,4),[4,7)"));
+        assertThat(RangeSet.fromString("1-3,5-7", true).toString(), equalTo("[1,4),[5,8)"));
+        assertThat(RangeSet.fromString("1-3,2-3", true).toString(), equalTo("[1,4),[2,4)"));
+        assertThat(RangeSet.fromString("1-5,2-3", true).toString(), equalTo("[1,6),[2,4)"));
+    }
+    private boolean expectIAE(final String expr, final String msg) {
+        try {
+            RangeSet.fromString(expr, false);
+        } catch (Throwable e) {
+            if (e instanceof IllegalArgumentException) {
+                if (e.getMessage().isEmpty()) {
+                    return msg.isEmpty();
+                }
+                else {
+                    return msg.isEmpty() ? false : e.getMessage().contains(msg);
+                }
+            }
+        }
+        // Exception wasn't throws or thrown Exception wasn't an instance of IllegalArgumentException
+        fail("Should never be here");
+        return false;
+    }
 }


### PR DESCRIPTION
Fix for rejecting malformed ranges in
hudson.model.Fingerprint.RangeSet.fromString(...)
