### PR TITLE
[FIXED JENKINS-32831] do not fail if there are no metadata for tool installers

### DIFF
--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -136,7 +136,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
                 final DownloadFromUrlInstaller.DescriptorImpl delegate = (DownloadFromUrlInstaller.DescriptorImpl)this;
                 return new Downloadable(getId()) {
                     public JSONObject reduce(List<JSONObject> jsonList) {
-                        if (isDefualtSchema(jsonList)) {
+                        if (isDefaultSchema(jsonList)) {
                             return delegate.reduce(jsonList);
                         } else {
                             //if it's not default schema fall back to the super class implementation
@@ -153,7 +153,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
          * @param jsonList the list of Update centers json files
          * @return true if the schema is the default one (id, name, url), false otherwise
          */
-        private boolean isDefualtSchema(List<JSONObject> jsonList) {
+        private boolean isDefaultSchema(List<JSONObject> jsonList) {
             JSONObject jsonToolInstallerList = jsonList.get(0);
             ToolInstallerList toolInstallerList = (ToolInstallerList) JSONObject.toBean(jsonToolInstallerList, ToolInstallerList.class);
 


### PR DESCRIPTION
Before JENKINS-32328 the tool installers updates were always checked against the default update center.
Now, tools installers are checked against the update centers actually configured. If the experimental update center is the only one configured, there are no json files available for tool installers. So we return the validation error, although the experimental update center has been successfully consulted for what concerns the plugins.
The error message is misleading, the problem is not the signature but the update json files for tool installers not being found. 
