### PR TITLE
[JENKINS-31152] Add Pipeline plugins, select by default

### DIFF
--- a/war/src/main/js/api/plugins.js
+++ b/war/src/main/js/api/plugins.js
@@ -10,12 +10,15 @@
 exports.recommendedPlugins = [
     "antisamy-markup-formatter",
     "credentials",
+    "github-branch-source",
     "junit",
     "mailer",
     "matrix-auth",
     "script-security",
     "subversion",
-    "translation"
+    "translation",
+    "workflow-aggregator",
+    "workflow-multibranch"
 ];
 
 //
@@ -49,6 +52,14 @@ exports.availablePlugins = [
         "plugins": [
             { "name": "javadoc" },
             { "name": "junit" }
+        ]
+    },
+    {
+        "category":"Pipelines and Continuous Delivery",
+        "plugins": [
+            { "name": "workflow-aggregator" },
+            { "name": "github-branch-source" },
+            { "name": "workflow-multibranch" }
         ]
     },
     {


### PR DESCRIPTION
This implements part of [JENKINS-31152](https://issues.jenkins-ci.org/browse/JENKINS-31152):

> this feature should be made available out of the box by default, unless users opt out

It uses the category as proposed on [the wiki](https://wiki.jenkins-ci.org/display/JENKINS/Plugin+Selection+for+the+Setup+Dialog).

Notes on content:
- Stage View release is around the corner, but I'd rather amend this than wait for that. Therefore it's not included in this PR.
- GitHub Organization folders require a restart after installation to appear. I've been told this will be fixed very soon. Otherwise I'll need to back out this plugin again.
- Further plugin selection changes are coming soon, but as Pipeline-as-Code is a major part of 2.0, this should be in in time for the first alpha releases.

@reviewbybees 
