### PR TITLE
Range 9-16/2 will always pick 9, 11, 13, 15

### DIFF
--- a/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.html
+++ b/core/src/main/resources/hudson/triggers/TimerTrigger/help-spec.html
@@ -73,7 +73,7 @@
 H/15 * * * *
 # every ten minutes in the first half of every hour (three times, perhaps at :04, :14, :24)
 H(0-29)/10 * * * *
-# once every two hours every weekday (perhaps at 10:38 AM, 12:38 PM, 2:38 PM, 4:38 PM)
+# once every two hours every weekday (perhaps at 9:38 AM, 11:38 AM, 1:38 PM, 3:38 PM)
 H 9-16/2 * * 1-5
 # once a day on the 1st and 15th of every month except December
 H H 1,15 1-11 *


### PR DESCRIPTION
Now if it was `H(9-16)/2` then the original text would have been correct.

@reviewbybees @jenkinsci/code-reviewers 
