### PR TITLE
Re-enable installer tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,29 +125,33 @@ timestampedNode('docker') {
 stage "Package testing"
 
 if (runTests) {
-    // NOTE: As of now, a lot of package tests will fail. See https://issues.jenkins-ci.org/issues/?filter=15257 for
-    // possible open JIRAs.
+    if (!env.BRANCH_NAME.startsWith("PR")) {
+        // NOTE: As of now, a lot of package tests will fail. See https://issues.jenkins-ci.org/issues/?filter=15257 for
+        // possible open JIRAs.
 
-    // Basic parameters
-    String artifactName = (binding.hasVariable('artifactName')) ? artifactName : 'jenkins'
-    String jenkinsPort = (binding.hasVariable('jenkinsPort')) ? jenkinsPort : '8080'
+        // Basic parameters
+        String artifactName = (binding.hasVariable('artifactName')) ? artifactName : 'jenkins'
+        String jenkinsPort = (binding.hasVariable('jenkinsPort')) ? jenkinsPort : '8080'
 
-    // Set up
-    String debfile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/debian/${debFileName}"
-    String rpmfile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/rpm/${rpmFileName}"
-    String susefile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/suse/${suseFileName}"
+        // Set up
+        String debfile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/debian/${debFileName}"
+        String rpmfile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/rpm/${rpmFileName}"
+        String susefile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/suse/${suseFileName}"
 
-    timestampedNode("docker") {
-        stage "Load Lib"
-        dir('workflowlib') {
-            deleteDir()
-            git branch: packagingBranch, url: 'https://github.com/jenkinsci/packaging.git'
-            flow = load 'workflow/installertest.groovy'
+        timestampedNode("docker") {
+            stage "Load Lib"
+            dir('workflowlib') {
+                deleteDir()
+                git branch: packagingBranch, url: 'https://github.com/jenkinsci/packaging.git'
+                flow = load 'workflow/installertest.groovy'
+            }
         }
+        // Run the real tests within docker node label
+        flow.fetchAndRunJenkinsInstallerTest("docker", rpmfile, susefile, debfile,
+            packagingBranch, artifactName, jenkinsPort)
+    } else {
+        echo "Not running package testing against pull requests"
     }
-    // Run the real tests within docker node label
-    flow.fetchAndRunJenkinsInstallerTest("docker", rpmfile, susefile, debfile,
-        packagingBranch, artifactName, jenkinsPort)
 } else {
     echo "Skipping package tests"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,38 +122,36 @@ timestampedNode('docker') {
 
 }
 
-// Installer testing currently disabled - it hangs periodically and doesn't actually *pass* anyway, so holding off on running it for now.
-if (false) {
-    stage "Package testing"
+stage "Package testing"
 
-    if (runTests) {
-        // NOTE: As of now, a lot of package tests will fail. See https://issues.jenkins-ci.org/issues/?filter=15257 for
-        // possible open JIRAs.
+if (runTests) {
+    // NOTE: As of now, a lot of package tests will fail. See https://issues.jenkins-ci.org/issues/?filter=15257 for
+    // possible open JIRAs.
 
-        // Basic parameters
-        String artifactName = (binding.hasVariable('artifactName')) ? artifactName : 'jenkins'
-        String jenkinsPort = (binding.hasVariable('jenkinsPort')) ? jenkinsPort : '8080'
+    // Basic parameters
+    String artifactName = (binding.hasVariable('artifactName')) ? artifactName : 'jenkins'
+    String jenkinsPort = (binding.hasVariable('jenkinsPort')) ? jenkinsPort : '8080'
 
-        // Set up
-        String debfile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/debian/${debFileName}"
-        String rpmfile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/rpm/${rpmFileName}"
-        String susefile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/suse/${suseFileName}"
+    // Set up
+    String debfile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/debian/${debFileName}"
+    String rpmfile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/rpm/${rpmFileName}"
+    String susefile = "artifact://${env.JOB_NAME}/${env.BUILD_NUMBER}#target/suse/${suseFileName}"
 
-        timestampedNode("docker") {
-            stage "Load Lib"
-            dir('workflowlib') {
-                deleteDir()
-                git branch: packagingBranch, url: 'https://github.com/jenkinsci/packaging.git'
-                flow = load 'workflow/installertest.groovy'
-            }
+    timestampedNode("docker") {
+        stage "Load Lib"
+        dir('workflowlib') {
+            deleteDir()
+            git branch: packagingBranch, url: 'https://github.com/jenkinsci/packaging.git'
+            flow = load 'workflow/installertest.groovy'
         }
-        // Run the real tests within docker node label
-        flow.fetchAndRunJenkinsInstallerTest("docker", rpmfile, susefile, debfile,
-                packagingBranch, artifactName, jenkinsPort)
-    } else {
-        echo "Skipping package tests"
     }
+    // Run the real tests within docker node label
+    flow.fetchAndRunJenkinsInstallerTest("docker", rpmfile, susefile, debfile,
+        packagingBranch, artifactName, jenkinsPort)
+} else {
+    echo "Skipping package tests"
 }
+
 
 // This method sets up the Maven and JDK tools, puts them in the environment along
 // with whatever other arbitrary environment variables we passed in, and runs the


### PR DESCRIPTION
Now that we're using sh2ju for installer tests and not failing the
build for test failures, instead going unstable, let's re-enable
installer tests for 2.0.

cc @reviewbybees
