### PR TITLE
Add SCM plugins

### DIFF
--- a/war/src/main/js/api/plugins.js
+++ b/war/src/main/js/api/plugins.js
@@ -10,6 +10,7 @@
 exports.recommendedPlugins = [
     "antisamy-markup-formatter",
     "credentials",
+    "git",
     "github-branch-source",
     "junit",
     "mailer",
@@ -63,10 +64,21 @@ exports.availablePlugins = [
         ]
     },
     {
-        "category":"SCM",
+        "category":"Source Code Management",
         "plugins": [
+            { "name": "git" },
+            { "name": "subversion" },
+            { "name": "clearcase" },
             { "name": "cvs" },
-            { "name": "subversion" }
+            { "name": "gitbucket" },
+            { "name": "github" },
+            { "name": "gitlab-merge-request-jenkins" },
+            { "name": "gitlab-plugin" },
+            { "name": "mercurial" },
+            { "name": "p4" },
+            { "name": "repo" },
+            { "name": "teamconcert" },
+            { "name": "tfs" }
         ]
     },
     {


### PR DESCRIPTION
This PR adds SCM plugins to the initial setup dialog as proposed [on the wiki](https://wiki.jenkins-ci.org/display/JENKINS/Plugin+Selection+for+the+Setup+Dialog) and in the mailing list thread linked from there.

As the proposal considers SCM plugins to be special, with rules different from other plugins, this is a separate PR.
