### PR TITLE
Integrate newer version of test-harness

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -63,7 +63,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2.0</version>
+      <version>2.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/src/test/java/hudson/model/ComputerConfigDotXmlTest.java
+++ b/test/src/test/java/hudson/model/ComputerConfigDotXmlTest.java
@@ -38,8 +38,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -147,8 +149,17 @@ public class ComputerConfigDotXmlTest {
 
             @Override
             public void write(int b) throws IOException {
-
                 baos.write(b);
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener writeListener) {
+                throw new UnsupportedOperationException();
             }
         });
 
@@ -162,14 +173,27 @@ public class ComputerConfigDotXmlTest {
             private final InputStream inner;
 
             public Stream(final InputStream inner) {
-
                 this.inner = inner;
             }
 
             @Override
             public int read() throws IOException {
-
                 return inner.read();
+            }
+
+            @Override
+            public boolean isFinished() {
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+                throw new UnsupportedOperationException();
             }
         }
 

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -103,6 +103,10 @@ import org.apache.commons.io.FileUtils;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.*;
 
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -114,10 +118,6 @@ import org.jvnet.hudson.test.SleepBuilder;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.recipes.LocalData;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.servlet.ServletHandler;
-import org.mortbay.jetty.servlet.ServletHolder;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -283,12 +283,12 @@ public class QueueTest {
 
 
         Server server = new Server();
-        SocketConnector connector = new SocketConnector();
+        ServerConnector connector = new ServerConnector(server);
         server.addConnector(connector);
 
         ServletHandler handler = new ServletHandler();
         handler.addServletWithMapping(new ServletHolder(new FileItemPersistenceTestServlet()),"/");
-        server.addHandler(handler);
+        server.setHandler(handler);
 
         server.start();
 
@@ -581,7 +581,6 @@ public class QueueTest {
      * Make sure that the running build actually carries an credential.
      */
     @Test public void accessControl() throws Exception {
-        r.configureUserRealm();
         FreeStyleProject p = r.createFreeStyleProject();
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new MockQueueItemAuthenticator(Collections.singletonMap(p.getFullName(), alice)));
         p.getBuildersList().add(new TestBuilder() {
@@ -608,7 +607,6 @@ public class QueueTest {
         DumbSlave s1 = r.createSlave();
         DumbSlave s2 = r.createSlave();
 
-        r.configureUserRealm();
         FreeStyleProject p = r.createFreeStyleProject();
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new MockQueueItemAuthenticator(Collections.singletonMap(p.getFullName(), alice)));
         p.getBuildersList().add(new TestBuilder() {

--- a/test/src/test/java/hudson/model/UpdateSiteTest.java
+++ b/test/src/test/java/hudson/model/UpdateSiteTest.java
@@ -42,15 +42,16 @@ import javax.servlet.http.HttpServletResponse;
 import static org.junit.Assert.*;
 
 import org.apache.commons.io.FileUtils;
+import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.mortbay.jetty.HttpConnection;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.handler.AbstractHandler;
 
 public class UpdateSiteTest {
 
@@ -76,18 +77,17 @@ public class UpdateSiteTest {
     @Before
     public void setUpWebServer() throws Exception {
         server = new Server();
-        SocketConnector connector = new SocketConnector();
+        ServerConnector connector = new ServerConnector(server);
         server.addConnector(connector);
         server.setHandler(new AbstractHandler() {
-            public void handle(String target, HttpServletRequest request,
-                    HttpServletResponse response, int dispatch) throws IOException,
-                    ServletException {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
                 if (target.startsWith(RELATIVE_BASE)) {
                     target = target.substring(RELATIVE_BASE.length());
                 }
                 String responseBody = getResource(target);
                 if (responseBody != null) {
-                    HttpConnection.getCurrentConnection().getRequest().setHandled(true);
+                    baseRequest.setHandled(true);
                     response.setContentType("text/plain; charset=utf-8");
                     response.setStatus(HttpServletResponse.SC_OK);
                     response.getOutputStream().write(responseBody.getBytes());

--- a/test/src/test/java/hudson/util/XStream2Security247Test.java
+++ b/test/src/test/java/hudson/util/XStream2Security247Test.java
@@ -14,6 +14,7 @@ import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -115,6 +116,21 @@ public class XStream2Security247Test {
         @Override
         public int read() throws IOException {
             return inner.read();
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new UnsupportedOperationException();
         }
     }
 }


### PR DESCRIPTION
In relation to [JENKINS-23378](https://issues.jenkins-ci.org/browse/JENKINS-23378), we need the master branch to use a newer version of the test harness that brings in Jetty 9.2.

This requires some changes to tests that directly manipulate Jetty classes.

@reviewbybees
