### PR TITLE
[JENKINS-32945] JS error when checking for changes in an empty select box

### DIFF
--- a/core/src/main/resources/lib/form/select/select.js
+++ b/core/src/main/resources/lib/form/select/select.js
@@ -43,6 +43,10 @@ function updateListBox(listBox,url,config) {
 Behaviour.specify("SELECT.select", 'select', 1000, function(e) {
 
         function hasChanged(selectEl, originalValue) {
+            if (selectEl.options.length == 0) {
+                // There are no options to select, so there is no possible change
+                return false;
+            }
             var firstValue = selectEl.options[0].value;
             var selectedValue = selectEl.value;
             if (originalValue == "" && selectedValue == firstValue) {


### PR DESCRIPTION
[JENKINS-32945](https://issues.jenkins-ci.org/browse/JENKINS-32945)

This error is only showing up when a plugin adds two select boxes where the second one depends on the value of the first one, and only before saving the job for the first time (any subsequent render work properly without this fix). If the plugin adds default values for the second select box nothing fails, and this is the right way to it. So this fix is really a defensive check for non usual implementations.

Reproducible by using [this example plugin](https://github.com/oserna/jenkins-plugin-example).

Please @jenkinsci/code-reviewers consider this PR.
