### PR TITLE
[JENKINS-32393] Don't pass the whole build.environment to launcher as env overrides

### DIFF
--- a/core/src/main/java/hudson/tasks/CommandInterpreter.java
+++ b/core/src/main/java/hudson/tasks/CommandInterpreter.java
@@ -85,7 +85,7 @@ public abstract class CommandInterpreter extends Builder {
             }
 
             try {
-                EnvVars envVars = build.getEnvironment(listener);
+                EnvVars envVars = new EnvVars();
                 // on Windows environment variables are converted to all upper case,
                 // but no such conversions are done on Unix, so to make this cross-platform,
                 // convert variables to all upper cases.


### PR DESCRIPTION
launcher is already set from executor with host environment, so no need to re-inject it again using `env()`, which is designed for overrides (see it's javadoc).
This has side effect in Docker Custom Build Environment Plugin to re-inject the dockerhost computer environment inside the container and break isolation.
