### PR TITLE
[FIX JENKINS-32303] Fix readonly behavior for f:checkbox

### DIFF
--- a/core/src/main/resources/lib/form/checkbox.jelly
+++ b/core/src/main/resources/lib/form/checkbox.jelly
@@ -44,6 +44,9 @@ THE SOFTWARE.
     <st:attribute name="onclick" />
     <st:attribute name="class" />
     <st:attribute name="negative" />
+    <st:attribute name="readonly">
+      If set to true, this will take precedence over the onclick attribute and prevent the state of the checkbox from being changed.
+    </st:attribute>
     <st:attribute name="field">
       Used for databinding. TBD.
     </st:attribute>
@@ -63,7 +66,7 @@ THE SOFTWARE.
          name="${name}"
          value="${attrs.value}"
          title="${attrs.tooltip}"
-         onclick="${attrs.onclick}" id="${attrs.id}" class="${attrs.negative!=null ? 'negative' : null} ${attrs.checkUrl!=null?'validated':''}"
+         onclick="${attrs.readonly=='true' ? 'return false;' : attrs.onclick}" id="${attrs.id}" class="${attrs.negative!=null ? 'negative' : null} ${attrs.checkUrl!=null?'validated':''}"
          checkUrl="${attrs.checkUrl}" checkDependsOn="${attrs.checkDependsOn}" json="${attrs.json}"
          checked="${value ? 'true' : null}"/>
   <j:if test="${attrs.title!=null}">


### PR DESCRIPTION
Checkboxes change their _checkedness_, not their _value_, and for some reason, this makes a difference for the `readonly` attribute, even though it should not (at least not according to HTML 5).

Used e.g. in `BooleanParameterValue/value.jelly` as described in [JENKINS-32303](https://issues.jenkins-ci.org/browse/JENKINS-32303).

@reviewbybees
