### PR TITLE
[Fix JENKINS-33245] core asset artifacts bloated due to faulty build assembly step

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -139,19 +139,19 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>jquery-detached</artifactId>
-      <version>1.2</version>
+      <version>1.2.1</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>bootstrap</artifactId>
-      <version>1.3.1</version>
+      <version>1.3.2</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>handlebars</artifactId>
-      <version>1.1</version>
+      <version>1.1.1</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>


### PR DESCRIPTION
See [JENKINS-33245](https://issues.jenkins-ci.org/browse/JENKINS-33245).
