### PR TITLE
[Fixed JENKINS-33304] prevent bad characters in usernames.

### DIFF
--- a/core/src/main/java/hudson/security/ContainerAuthentication.java
+++ b/core/src/main/java/hudson/security/ContainerAuthentication.java
@@ -28,10 +28,14 @@ import org.acegisecurity.Authentication;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
 
+import hudson.model.User;
+
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.ArrayList;
 
 /**
@@ -45,28 +49,35 @@ import java.util.ArrayList;
  * @author Kohsuke Kawaguchi
  */
 public final class ContainerAuthentication implements Authentication {
-    private final Principal principal;
+
+    private final static Logger LOG = Logger.getLogger(ContainerAuthentication.class.getName());
+
+    private final SafePrincipal principal;
     private GrantedAuthority[] authorities;
 
     /**
      * Servlet container can tie a {@link ServletRequest} to the request handling thread,
      * so we need to capture all the information upfront to allow {@link Authentication}
-     * to be passed to other threads, like update center does. See HUDSON-5382. 
+     * to be passed to other threads, like update center does. See JENKINS-5382. 
      */
     public ContainerAuthentication(HttpServletRequest request) {
-        this.principal = request.getUserPrincipal();
-        if (principal==null)
+        Principal originalPrincipal = request.getUserPrincipal();
+        if (originalPrincipal==null) {
             throw new IllegalStateException(); // for anonymous users, we just don't call SecurityContextHolder.getContext().setAuthentication.   
-
+        }
+        principal = new SafePrincipal(originalPrincipal.getName());
         // Servlet API doesn't provide a way to list up all roles the current user
         // has, so we need to ask AuthorizationStrategy what roles it is going to check against.
         List<GrantedAuthority> l = new ArrayList<GrantedAuthority>();
         for( String g : Jenkins.getInstance().getAuthorizationStrategy().getGroups()) {
-            if(request.isUserInRole(g))
+            if(request.isUserInRole(g)) {
                 l.add(new GrantedAuthorityImpl(g));
+            }
         }
         l.add(SecurityRealm.AUTHENTICATED_AUTHORITY);
         authorities = l.toArray(new GrantedAuthority[l.size()]);
+        
+        fixupUserFullName();
     }
 
     public GrantedAuthority[] getAuthorities() {
@@ -94,6 +105,81 @@ public final class ContainerAuthentication implements Authentication {
     }
 
     public String getName() {
-        return getPrincipal();
+        return principal.getName();
+    }
+
+    /**
+     * As we potentially munge the users id from containing unsafe characters we want to set
+     * the displayname to be the original un munged id (if the user has not changed it).
+     */
+    private final void fixupUserFullName() {
+        User u = User.get(principal.getName());
+        LOG.log(Level.FINEST, "u.id: {1}\nu.fullname: {1}, ca.originalName: {2}", new Object[] {u.getId(), u.getFullName(), principal.getOriginalName()});
+        if (u.getId().equals(u.getFullName()) /* default is set*/
+                                        && !u.getFullName().equals(principal.getOriginalName())) {
+            LOG.log(Level.FINE, "Setting users full name to {}", principal.getOriginalName());
+            u.setFullName(principal.getOriginalName());
+        }
+        else {
+            LOG.log(Level.FINE, "Not setting users FullName");
+        }
+    }
+
+    /**
+     * A simple Principal that will replace some potentially unsafe characters with ones that are more safe for Direct use.
+     */
+    private final static class SafePrincipal implements Principal {
+
+        private final static Logger LOG = Logger.getLogger(ContainerAuthentication.class.getName());
+
+        private String originalName;
+        private String name;
+
+        SafePrincipal(String principalName) {
+            originalName = principalName;
+            // replace any unsafe characters \:/ with underscores
+            // unsafe here is something we can't pass down to the filesystem  
+            // see IdStrategy.filenameOf(String)
+            name = principalName.replaceAll("[\\\\:/]", "_");
+            LOG.log(Level.FINE, "Mapped user {0} to {1}", new Object[] {principalName, name});
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        String getOriginalName() {
+            return originalName;
+        }
+
+        @Override
+        public String toString() {
+            return originalName;
+        }
+
+        @Override
+        public int hashCode() {
+            return originalName.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            SafePrincipal other = (SafePrincipal) obj;
+            if (!getClass().equals(other.getClass()))
+                return false;
+            if (originalName == null) {
+                if (other.originalName != null)
+                    return false;
+            } else if (!originalName.equals(other.originalName))
+                return false;
+            return true;
+        }
     }
 }

--- a/core/src/main/resources/hudson/security/LegacySecurityRealm/help.html
+++ b/core/src/main/resources/hudson/security/LegacySecurityRealm/help.html
@@ -13,4 +13,6 @@
       or custom implementations to connect to a specific user realm.) 
     </li>
   </ol>
+  <strong>Note:</strong> if any of the characters <tt>\:/</tt> appear in the username they will be
+  replaced by the underscore (<tt>_</tt>) character.
 </div>


### PR DESCRIPTION
[JENKINS-33304](https://issues.jenkins-ci.org/browse/JENKINS-33304)

The container authentication can pass us whatever it feels like as a user
name.  The User class and the IdStrategy assume a username is safe for use
on the filesystem.
Mostly this is the case - but some 3rd party integrations such as
Waffle and AD this is not true as we can be passed users of the form
DOMAIN\user

This causes several things to break and there are reports of chrome and IE
not working correctly (although firefor is reported to be ok) with passing
.
The other areas that do not work where the url escaping of the `\` which
then was being munged to an underscore rather than a backslash causing things
like my views in the upper right hand drop down to not work correctly.

Whilst a much bigger fix could be done the scale of the problem is larger
as it requires symmetrical remapping (`IdStrategy.filenameOf() <->
IdStrategy.idFromFileName()`) and the User to keep track of the original
username and the munged user name, hence this is a little small hack that
does just about enough.

One area that is known to be odd now - is that the users name in the API
Token will show the munged name rather than the correct name, however I
fell that users will likely know their username - at least now they can
see the token which before you had to know how to get to it via the /me
URL.

The following translations could do with the note about name munging adding - but not a blocker.
- [de](https://github.com/jenkinsci/jenkins/blob/08045c7b75b44a745a1504ce3e94e43aba14ee4f/core/src/main/resources/hudson/security/LegacySecurityRealm/help_de.html)
- [fr](https://github.com/jenkinsci/jenkins/blob/08045c7b75b44a745a1504ce3e94e43aba14ee4f/core/src/main/resources/hudson/security/LegacySecurityRealm/help_fr.html)
- [ja](https://github.com/jenkinsci/jenkins/blob/08045c7b75b44a745a1504ce3e94e43aba14ee4f/core/src/main/resources/hudson/security/LegacySecurityRealm/help_ja.html)
- [pt_BR](https://github.com/jenkinsci/jenkins/blob/08045c7b75b44a745a1504ce3e94e43aba14ee4f/core/src/main/resources/hudson/security/LegacySecurityRealm/help_pt_BR.html)
- [ru](https://github.com/jenkinsci/jenkins/blob/08045c7b75b44a745a1504ce3e94e43aba14ee4f/core/src/main/resources/hudson/security/LegacySecurityRealm/help_ru.html)
- [tr](https://github.com/jenkinsci/jenkins/blob/08045c7b75b44a745a1504ce3e94e43aba14ee4f/core/src/main/resources/hudson/security/LegacySecurityRealm/help_tr.html)
- [zh_CN](https://github.com/jenkinsci/jenkins/blob/08045c7b75b44a745a1504ce3e94e43aba14ee4f/core/src/main/resources/hudson/security/LegacySecurityRealm/help_zh_CN.html)
- [zh_TW](https://github.com/jenkinsci/jenkins/blob/08045c7b75b44a745a1504ce3e94e43aba14ee4f/core/src/main/resources/hudson/security/LegacySecurityRealm/help_zh_TW.html)

[JENKINS-33304](https://issues.jenkins-ci.org/browse/JENKINS-33304)
@reviewbybees
