### PR TITLE
Excluded jenkins-war from the test harness.

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -65,6 +65,12 @@ THE SOFTWARE.
       <artifactId>jenkins-test-harness</artifactId>
       <version>2.5</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>jenkins-war</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Whilst this is not used in the dependencies, the enforcer plugin downloads
the 1.580.1 war-for-tests jar so it can scan it.  Most likely a bug in the
extra-enforcer-rules but we obviously don't need it as we have an explicit
dependency on the latest version!

@reviewbybees
