### PR TITLE
[JENKINS-33332] add itemBlocked extension point to QueueTaskDispatcher

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1152,12 +1152,21 @@ public class Queue extends ResourceController implements Saveable {
         if (i.task.isBuildBlocked() || !canRun(i.task.getResourceList()))
             return true;
 
-        for (QueueTaskDispatcher d : QueueTaskDispatcher.all()) {
-            if (d.canRun(i)!=null)
-                return true;
+        CauseOfBlockage cause = null;
+        ExtensionList<QueueTaskDispatcher> extList = QueueTaskDispatcher.all();
+
+        for (QueueTaskDispatcher d : extList) {
+            cause = d.canRun(i);
+            if (cause != null)
+                break;
+        }
+        if (cause != null) {
+            for (QueueTaskDispatcher d : extList) {
+                d.itemBlocked(i, cause);
+            }
         }
 
-        return false;
+        return cause != null;
     }
 
     /**

--- a/core/src/main/java/hudson/model/queue/QueueTaskDispatcher.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskDispatcher.java
@@ -135,6 +135,17 @@ public abstract class QueueTaskDispatcher implements ExtensionPoint {
     }
 
     /**
+     * Called whenever {@link Queue} has determined via {@link #canRun(hudson.model.Queue.Item)} that an item is
+     * not yet runnable. This allows the plugin a chance to free any resources that were set aside as part of
+     * clearing the queue item to run when its own implementation of {@link #canRun(hudson.model.Queue.Item)} was called.
+     *
+     * @since 1.652
+     */
+    public void itemBlocked(Queue.Item item, CauseOfBlockage cause) {
+        // do nothing
+    }
+
+    /**
      * All registered {@link QueueTaskDispatcher}s.
      */
     public static ExtensionList<QueueTaskDispatcher> all() {


### PR DESCRIPTION
Some plugins may place a reservation on some internal resources as part of their
implementation of .QueueTaskDispatcher.canRun() clearing a queue item as runnable.
This call back point allows such plugins to be notified of any queue items which
were ultimately blocked for another reason and optionally free up such resources
for use by another job.
