### PR TITLE
[JENKINS-32525] - Handle null @AncestorInPath when selecting Downstream Jobs.

### DIFF
--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -368,7 +368,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
          */
         public FormValidation doCheck(@AncestorInPath AbstractProject project, @QueryParameter String value) {
             // JENKINS-32525: Check that it behaves gracefully for an unknown context
-            if (project == null) return FormValidation.ok();
+            if (project == null) return FormValidation.ok(Messages.BuildTrigger_ok_ancestor_is_null());
             // Require CONFIGURE permission on this project
             if(!project.hasPermission(Item.CONFIGURE))      return FormValidation.ok();
 

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -367,6 +367,8 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
          * Form validation method.
          */
         public FormValidation doCheck(@AncestorInPath AbstractProject project, @QueryParameter String value) {
+            // JENKINS-32525: Check that it behaves gracefully for an unknown context
+            if (project == null) return FormValidation.ok();
             // Require CONFIGURE permission on this project
             if(!project.hasPermission(Item.CONFIGURE))      return FormValidation.ok();
 

--- a/core/src/main/resources/hudson/tasks/Messages.properties
+++ b/core/src/main/resources/hudson/tasks/Messages.properties
@@ -47,6 +47,7 @@ BuildTrigger.NoSuchProject=No such project \u2018{0}\u2019. Did you mean \u2018{
 BuildTrigger.NoProjectSpecified=No project specified
 BuildTrigger.NotBuildable={0} is not buildable
 BuildTrigger.Triggering=Triggering a new build of {0}
+BuildTrigger.ok_ancestor_is_null=Ancestor/Context Unknown: the project specified cannot be validated
 BuildTrigger.warning_access_control_for_builds_in_glo=Warning: \u2018Access Control for Builds\u2019 in global security configuration is empty, so falling back to legacy behavior of permitting any downstream builds to be triggered
 BuildTrigger.warning_this_build_has_no_associated_aut=Warning: this build has no associated authentication, so build permissions may be lacking, and downstream projects which cannot even be seen by an anonymous user will be silently skipped
 BuildTrigger.warning_you_have_no_plugins_providing_ac=Warning: you have no plugins providing access control for builds, so falling back to legacy behavior of permitting any downstream builds to be triggered

--- a/test/src/test/java/hudson/tasks/BuildTriggerTest.java
+++ b/test/src/test/java/hudson/tasks/BuildTriggerTest.java
@@ -222,6 +222,7 @@ public class BuildTriggerTest {
         assertEquals(Collections.singletonList(downstream), upstream.getDownstreamProjects());
         // Downstream projects whose existence we are not aware of will silently not be triggered:
         assertDoCheck(alice, Messages.BuildTrigger_NoSuchProject(downstreamName, "upstream"), upstream, downstreamName);
+        assertDoCheck(alice, null, null, downstreamName);
         FreeStyleBuild b = j.buildAndAssertSuccess(upstream);
         j.assertLogNotContains(downstreamName, b);
         j.waitUntilNoActivity();
@@ -232,6 +233,7 @@ public class BuildTriggerTest {
         AuthorizationMatrixProperty amp = new AuthorizationMatrixProperty(grantedPermissions);
         downstream.addProperty(amp);
         assertDoCheck(alice, Messages.BuildTrigger_you_have_no_permission_to_build_(downstreamName), upstream, downstreamName);
+        assertDoCheck(alice, null, null, downstreamName);
         b = j.buildAndAssertSuccess(upstream);
         j.assertLogContains(downstreamName, b);
         j.waitUntilNoActivity();
@@ -242,6 +244,7 @@ public class BuildTriggerTest {
         amp = new AuthorizationMatrixProperty(grantedPermissions);
         downstream.addProperty(amp);
         assertDoCheck(alice, null, upstream, downstreamName);
+        assertDoCheck(alice, null, null, downstreamName);
         b = j.buildAndAssertSuccess(upstream);
         j.assertLogContains(downstreamName, b);
         j.waitUntilNoActivity();
@@ -251,8 +254,9 @@ public class BuildTriggerTest {
         assertNotNull(cause);
         assertEquals(b, cause.getUpstreamRun());
         // Now if we have configured some QIA’s but they are not active on this job, we should run as anonymous. Which would normally have no permissions:
-        QueueItemAuthenticatorConfiguration.get().getAuthenticators().replace(new MockQueueItemAuthenticator(Collections.<String,Authentication>emptyMap()));
+        QueueItemAuthenticatorConfiguration.get().getAuthenticators().replace(new MockQueueItemAuthenticator(Collections.<String, Authentication>emptyMap()));
         assertDoCheck(alice, Messages.BuildTrigger_you_have_no_permission_to_build_(downstreamName), upstream, downstreamName);
+        assertDoCheck(alice, null, null, downstreamName);
         b = j.buildAndAssertSuccess(upstream);
         j.assertLogNotContains(downstreamName, b);
         j.assertLogContains(Messages.BuildTrigger_warning_this_build_has_no_associated_aut(), b);
@@ -265,6 +269,7 @@ public class BuildTriggerTest {
         amp = new AuthorizationMatrixProperty(grantedPermissions);
         downstream.addProperty(amp);
         assertDoCheck(alice, null, upstream, downstreamName);
+        assertDoCheck(alice, null, null, downstreamName);
         b = j.buildAndAssertSuccess(upstream);
         j.assertLogContains(downstreamName, b);
         j.waitUntilNoActivity();
@@ -280,6 +285,7 @@ public class BuildTriggerTest {
         downstream.addProperty(amp);
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().clear();
         assertDoCheck(alice, Messages.BuildTrigger_NoSuchProject(downstreamName, "upstream"), upstream, downstreamName);
+        assertDoCheck(alice, null, null, downstreamName);
         b = j.buildAndAssertSuccess(upstream);
         j.assertLogContains(downstreamName, b);
         j.assertLogContains(Messages.BuildTrigger_warning_access_control_for_builds_in_glo(), b);


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-32525
