### PR TITLE
Add pipeline stage view to the pipeline plugin set

### DIFF
--- a/war/src/main/js/api/plugins.js
+++ b/war/src/main/js/api/plugins.js
@@ -17,6 +17,7 @@ exports.recommendedPlugins = [
     "script-security",
     "subversion",
     "translation",
+    "pipeline-stage-view",
     "workflow-aggregator",
     "workflow-multibranch"
 ];
@@ -59,7 +60,8 @@ exports.availablePlugins = [
         "plugins": [
             { "name": "workflow-aggregator" },
             { "name": "github-branch-source" },
-            { "name": "workflow-multibranch" }
+            { "name": "workflow-multibranch" },
+            { "name": "pipeline-stage-view" }
         ]
     },
     {


### PR DESCRIPTION
This adds the pipeline stage view plugin to the suggested plugin sets, as part of building out the delivery pipeline user experience for Jenkins 2.0. 

Per the wiki: https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin

As far as the wiki criteria go:
- While it was recently released to the full public, it had 60+ watchers just on the release issue (JENKINS-31154) and social media activity around it, plus people watching the source repo even before content landed, so we can safely say it is of general interest
- It integrates well with Jenkins, of course, since it was part of a tested codebase
- Not just discoverable, features are fairly understandable out-of-box and ease the path for a new user to pipeline (as well as helping people scaling up in Jenkins and moving into full CD use)
- Hosted on JenkinsCI, yes
- Maintained: yes, quite.  _coughs._
