### PR TITLE
Use getInstance() in place of getInstanceOrNull() for execution paths that cannot have a null

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -216,7 +216,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
      */
     public static URLConnection open(URL url) throws IOException {
         Jenkins h = Jenkins.getInstanceOrNull(); // this code might run on slaves
-        ProxyConfiguration p = h!=null ? h.proxy : null;
+        final ProxyConfiguration p = h!=null ? h.proxy : null;
         if(p==null)
             return url.openConnection();
 
@@ -227,9 +227,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
                 @Override
                 public PasswordAuthentication getPasswordAuthentication() {
                     if (getRequestorType()!=RequestorType.PROXY)    return null;
-                    ProxyConfiguration p = Jenkins.getInstance().proxy;
-                    return new PasswordAuthentication(p.getUserName(),
-                            p.getPassword().toCharArray());
+                    return new PasswordAuthentication(p.getUserName(), p.getPassword().toCharArray());
                 }
             });
         }

--- a/core/src/main/java/hudson/diagnosis/NullIdDescriptorMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/NullIdDescriptorMonitor.java
@@ -61,10 +61,7 @@ public class NullIdDescriptorMonitor extends AdministrativeMonitor {
     }
 
     private void verify() {
-        Jenkins h = Jenkins.getInstanceOrNull();
-        if (h == null) {
-            return;
-        }
+        Jenkins h = Jenkins.getInstance();
         for (Descriptor d : h.getExtensionList(Descriptor.class)) {
             PluginWrapper p = h.getPluginManager().whichPlugin(d.getClass());
             String id;

--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -205,7 +205,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
         }
         if (buf.length() == 0) return;
         Jenkins j = Jenkins.getInstanceOrNull();
-        if (j == null) { // TODO confirm this can never be true
+        if (j == null) { // Need this path, at least for unit tests, but also in case of very broken startup
             // Startup failed, something is very broken, so report what we can.
             for (Throwable t : errors) {
                 LOGGER.log(Level.WARNING, "could not read " + obj + " (and Jenkins did not start up)", t);

--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -105,20 +105,18 @@ public class OldDataMonitor extends AdministrativeMonitor {
     }
 
     private static void remove(Saveable obj, boolean isDelete) {
-        Jenkins j = Jenkins.getInstanceOrNull();
-        if (j != null) {
-            OldDataMonitor odm = get(j);
-            SecurityContext oldContext = ACL.impersonate(ACL.SYSTEM);
-            try {
-                odm.data.remove(referTo(obj));
-                if (isDelete && obj instanceof Job<?, ?>) {
-                    for (Run r : ((Job<?, ?>) obj).getBuilds()) {
-                        odm.data.remove(referTo(r));
-                    }
+        Jenkins j = Jenkins.getInstance();
+        OldDataMonitor odm = get(j);
+        SecurityContext oldContext = ACL.impersonate(ACL.SYSTEM);
+        try {
+            odm.data.remove(referTo(obj));
+            if (isDelete && obj instanceof Job<?, ?>) {
+                for (Run r : ((Job<?, ?>) obj).getBuilds()) {
+                    odm.data.remove(referTo(r));
                 }
-            } finally {
-                SecurityContextHolder.setContext(oldContext);
             }
+        } finally {
+            SecurityContextHolder.setContext(oldContext);
         }
     }
 
@@ -207,7 +205,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
         }
         if (buf.length() == 0) return;
         Jenkins j = Jenkins.getInstanceOrNull();
-        if (j == null) {
+        if (j == null) { // TODO confirm this can never be true
             // Startup failed, something is very broken, so report what we can.
             for (Throwable t : errors) {
                 LOGGER.log(Level.WARNING, "could not read " + obj + " (and Jenkins did not start up)", t);

--- a/core/src/main/java/hudson/init/TaskMethodFinder.java
+++ b/core/src/main/java/hudson/init/TaskMethodFinder.java
@@ -116,8 +116,8 @@ abstract class TaskMethodFinder<T extends Annotation> extends TaskBuilder {
      */
     private Object lookUp(Class<?> type) {
         if (type==Jenkins.class || type==Hudson.class)
-            return Jenkins.getInstanceOrNull();
-        Jenkins j = Jenkins.getInstanceOrNull();
+            return Jenkins.getInstance();
+        Jenkins j = Jenkins.getInstance();
         if (j!=null) {
             Injector i = j.getInjector();
             if (i!=null)

--- a/core/src/main/java/hudson/init/TaskMethodFinder.java
+++ b/core/src/main/java/hudson/init/TaskMethodFinder.java
@@ -115,14 +115,13 @@ abstract class TaskMethodFinder<T extends Annotation> extends TaskBuilder {
      * Determines the parameter injection of the initialization method.
      */
     private Object lookUp(Class<?> type) {
-        if (type==Jenkins.class || type==Hudson.class)
-            return Jenkins.getInstance();
         Jenkins j = Jenkins.getInstance();
-        if (j!=null) {
-            Injector i = j.getInjector();
-            if (i!=null)
-                return i.getInstance(type);
-        }
+        assert j != null : "This method is only invoked after the Jenkins singleton instance has been set";
+        if (type==Jenkins.class || type==Hudson.class)
+            return j;
+        Injector i = j.getInjector();
+        if (i!=null)
+            return i.getInstance(type);
         throw new IllegalArgumentException("Unable to inject "+type);
     }
 

--- a/core/src/main/java/hudson/lifecycle/SolarisSMFLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SolarisSMFLifecycle.java
@@ -38,7 +38,7 @@ public class SolarisSMFLifecycle extends Lifecycle {
      */
     @Override
     public void restart() throws IOException, InterruptedException {
-        Jenkins h = Jenkins.getInstanceOrNull();
+        Jenkins h = Jenkins.getInstanceOrNull(); // TODO confirm safe to assume non-null and use getInstance()
         if (h != null)
             h.cleanUp();
         System.exit(0);

--- a/core/src/main/java/hudson/lifecycle/SolarisSMFLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SolarisSMFLifecycle.java
@@ -38,7 +38,7 @@ public class SolarisSMFLifecycle extends Lifecycle {
      */
     @Override
     public void restart() throws IOException, InterruptedException {
-        Jenkins h = Jenkins.getInstanceOrNull(); // TODO confirm safe to assume non-null and use getInstance()
+        Jenkins h = Jenkins.getInstanceOrNull(); // guard against repeated concurrent calls to restart
         if (h != null)
             h.cleanUp();
         System.exit(0);

--- a/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
@@ -65,7 +65,7 @@ public class UnixLifecycle extends Lifecycle {
 
     @Override
     public void restart() throws IOException, InterruptedException {
-        Jenkins h = Jenkins.getInstanceOrNull(); // TODO confirm safe to assume non-null and use getInstance()
+        Jenkins h = Jenkins.getInstanceOrNull(); // guard against repeated concurrent calls to restart
         if (h != null)
             h.cleanUp();
 

--- a/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
@@ -65,7 +65,7 @@ public class UnixLifecycle extends Lifecycle {
 
     @Override
     public void restart() throws IOException, InterruptedException {
-        Jenkins h = Jenkins.getInstanceOrNull();
+        Jenkins h = Jenkins.getInstanceOrNull(); // TODO confirm safe to assume non-null and use getInstance()
         if (h != null)
             h.cleanUp();
 

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -2077,10 +2077,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
                 return FormValidation.error(e,
                         Messages.AbstractProject_AssignedLabelString_InvalidBooleanExpression(e.getMessage()));
             }
-            Jenkins j = Jenkins.getInstanceOrNull();
-            if (j == null) {
-                return FormValidation.ok(); // ?
-            }
+            Jenkins j = Jenkins.getInstance();
             Label l = j.getLabel(value);
             if (l.isEmpty()) {
                 for (LabelAtom a : l.listAtoms()) {

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -566,7 +566,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     @CheckForNull
     public Node getNode() {
-        Jenkins j = Jenkins.getInstanceOrNull();
+        Jenkins j = Jenkins.getInstanceOrNull(); // TODO confirm safe to assume non-null and use getInstance()
         if (j == null) {
             return null;
         }
@@ -1013,7 +1013,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
                     addNewExecutorIfNecessary();
                     if (!isAlive()) {
                         AbstractCIBase ciBase = Jenkins.getInstanceOrNull();
-                        if (ciBase != null) {
+                        if (ciBase != null) { // TODO confirm safe to assume non-null and use getInstance()
                             ciBase.removeComputer(Computer.this);
                         }
                     }

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -960,7 +960,7 @@ public class Executor extends Thread implements ModelObject {
      */
     @CheckForNull
     public static Executor of(Executable executable) {
-        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        Jenkins jenkins = Jenkins.getInstanceOrNull(); // TODO confirm safe to assume non-null and use getInstance()
         if (jenkins == null) {
             return null;
         }

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -128,8 +128,8 @@ public class Fingerprint implements ModelObject, Saveable {
         private boolean hasPermissionToDiscoverBuild() {
             // We expose the data to Jenkins administrators in order to
             // let them manage the data for deleted jobs (also works for SYSTEM)
-            final Jenkins instance = Jenkins.getInstanceOrNull();
-            if (instance != null && instance.hasPermission(Jenkins.ADMINISTER)) {
+            final Jenkins instance = Jenkins.getInstance();
+            if (instance.hasPermission(Jenkins.ADMINISTER)) {
                 return true;
             }
             
@@ -941,11 +941,7 @@ public class Fingerprint implements ModelObject, Saveable {
     @Exported(name="usage")
     public @Nonnull List<RangeItem> _getUsages() {
         List<RangeItem> r = new ArrayList<RangeItem>();
-        final Jenkins instance = Jenkins.getInstanceOrNull();
-        if (instance == null) {
-            return r;
-        }
-        
+        final Jenkins instance = Jenkins.getInstance();
         for (Entry<String, RangeSet> e : usages.entrySet()) {
             final String itemName = e.getKey();
             if (instance.hasPermission(Jenkins.ADMINISTER) || canDiscoverItem(itemName)) {
@@ -1368,11 +1364,8 @@ public class Fingerprint implements ModelObject, Saveable {
      * @return {@code true} if the user can discover the item
      */
     private static boolean canDiscoverItem(@Nonnull final String fullName) {
-        final Jenkins jenkins = Jenkins.getInstanceOrNull();
-        if (jenkins == null) {
-            return false;
-        }
-        
+        final Jenkins jenkins = Jenkins.getInstance();
+
         // Fast check to avoid security context switches
         Item item = null;
         try {

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -848,6 +848,9 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      * @see RunMap
      */
     public File getBuildDir() {
+        // we use the null check variant so that people can write true unit tests with a mock ItemParent
+        // and without a JenkinsRule. Such tests are of limited utility as there is a high risk of hitting
+        // some code that needs the singleton, but for persistence migration test cases it makes sense to permit
         Jenkins j = Jenkins.getInstanceOrNull();
         if (j == null) {
             return new File(getRootDir(), "builds");

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1182,6 +1182,7 @@ public class Queue extends ResourceController implements Saveable {
      */
     public static void withLock(Runnable runnable) {
         final Jenkins jenkins = Jenkins.getInstanceOrNull();
+        // TODO confirm safe to assume non-null and use getInstance()
         final Queue queue = jenkins == null ? null : jenkins.getQueue();
         if (queue == null) {
             runnable.run();
@@ -1203,6 +1204,7 @@ public class Queue extends ResourceController implements Saveable {
      */
     public static <V, T extends Throwable> V withLock(hudson.remoting.Callable<V, T> callable) throws T {
         final Jenkins jenkins = Jenkins.getInstanceOrNull();
+        // TODO confirm safe to assume non-null and use getInstance()
         final Queue queue = jenkins == null ? null : jenkins.getQueue();
         if (queue == null) {
             return callable.call();
@@ -1223,6 +1225,7 @@ public class Queue extends ResourceController implements Saveable {
      */
     public static <V> V withLock(java.util.concurrent.Callable<V> callable) throws Exception {
         final Jenkins jenkins = Jenkins.getInstanceOrNull();
+        // TODO confirm safe to assume non-null and use getInstance()
         final Queue queue = jenkins == null ? null : jenkins.getQueue();
         if (queue == null) {
             return callable.call();
@@ -1240,6 +1243,7 @@ public class Queue extends ResourceController implements Saveable {
      */
     public static boolean tryWithLock(Runnable runnable) {
         final Jenkins jenkins = Jenkins.getInstanceOrNull();
+        // TODO confirm safe to assume non-null and use getInstance()
         final Queue queue = jenkins == null ? null : jenkins.getQueue();
         if (queue == null) {
             runnable.run();
@@ -1256,6 +1260,7 @@ public class Queue extends ResourceController implements Saveable {
      */
     public static Runnable wrapWithLock(Runnable runnable) {
         final Jenkins jenkins = Jenkins.getInstanceOrNull();
+        // TODO confirm safe to assume non-null and use getInstance()
         final Queue queue = jenkins == null ? null : jenkins.getQueue();
         return queue == null ? runnable : new LockedRunnable(runnable);
     }
@@ -1268,6 +1273,7 @@ public class Queue extends ResourceController implements Saveable {
      */
     public static <V, T extends Throwable> hudson.remoting.Callable<V, T> wrapWithLock(hudson.remoting.Callable<V, T> callable) {
         final Jenkins jenkins = Jenkins.getInstanceOrNull();
+        // TODO confirm safe to assume non-null and use getInstance()
         final Queue queue = jenkins == null ? null : jenkins.getQueue();
         return queue == null ? callable : new LockedHRCallable<>(callable);
     }
@@ -1280,6 +1286,7 @@ public class Queue extends ResourceController implements Saveable {
      */
     public static <V> java.util.concurrent.Callable<V> wrapWithLock(java.util.concurrent.Callable<V> callable) {
         final Jenkins jenkins = Jenkins.getInstanceOrNull();
+        // TODO confirm safe to assume non-null and use getInstance()
         final Queue queue = jenkins == null ? null : jenkins.getQueue();
         return queue == null ? callable : new LockedJUCCallable<V>(callable);
     }

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2275,10 +2275,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         } catch (NumberFormatException x) {
             throw new IllegalArgumentException(x);
         }
-        Jenkins j = Jenkins.getInstanceOrNull();
-        if (j == null) {
-            return null;
-        }
+        Jenkins j = Jenkins.getInstance();
         Job<?,?> job = j.getItemByFullName(jobName, Job.class);
         if (job == null) {
             return null;

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -96,7 +96,7 @@ public class UsageStatistics extends PageDecorator {
      * Returns true if it's time for us to check for new version.
      */
     public boolean isDue() {
-        final Jenkins j = Jenkins.getInstanceOrNull();
+        final Jenkins j = Jenkins.getInstanceOrNull(); // TODO getInsance once JENKINS-33377 is merged
         // user opted out or Jenkins not fully initialized. no data collection.
         if (j == null || j.isUsageStatisticsCollected() || DISABLED || COMPLETED.compareTo(j.getInitLevel()) > 0) {
             return false;

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -150,10 +150,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
      */
     @Nonnull
     public static IdStrategy idStrategy() {
-        Jenkins j = Jenkins.getInstanceOrNull();
-        if (j == null) {
-            return IdStrategy.CASE_INSENSITIVE;
-        }
+        Jenkins j = Jenkins.getInstance();
         SecurityRealm realm = j.getSecurityRealm();
         if (realm == null) {
             return IdStrategy.CASE_INSENSITIVE;

--- a/core/src/main/java/hudson/model/listeners/RunListener.java
+++ b/core/src/main/java/hudson/model/listeners/RunListener.java
@@ -28,6 +28,7 @@ import hudson.ExtensionListView;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -223,7 +224,7 @@ public abstract class RunListener<R extends Run> implements ExtensionPoint {
      * Fires the {@link #onFinalized(Run)} event.
      */
     public static void fireFinalized(Run r) {
-        if (Jenkins.getInstanceOrNull() == null) {
+        if (Jenkins.getInstanceOrNull() == null) { // TODO use !Functions.isExtensionsAvailable() once JENKINS-33377
             return;
         }
         for (RunListener l : all()) {

--- a/core/src/main/java/hudson/model/listeners/SCMListener.java
+++ b/core/src/main/java/hudson/model/listeners/SCMListener.java
@@ -127,7 +127,7 @@ public abstract class SCMListener implements ExtensionPoint {
     @SuppressWarnings("deprecation")
     public static Collection<? extends SCMListener> all() {
         Jenkins j = Jenkins.getInstanceOrNull();
-        if (j == null) {
+        if (j == null) { // TODO use !Functions.isExtensionsAvailable() once JENKINS-33377
             return Collections.emptySet();
         }
         List<SCMListener> r = new ArrayList<SCMListener>(j.getExtensionList(SCMListener.class));
@@ -140,20 +140,12 @@ public abstract class SCMListener implements ExtensionPoint {
     /** @deprecated Use {@link Extension} instead. */
     @Deprecated
     public final void register() {
-        Jenkins j = Jenkins.getInstanceOrNull();
-        if (j != null) {
-            j.getSCMListeners().add(this);
-        }
+        Jenkins.getInstance().getSCMListeners().add(this);
     }
 
     /** @deprecated Use {@link Extension} instead. */
     @Deprecated
     public final boolean unregister() {
-        Jenkins j = Jenkins.getInstanceOrNull();
-        if (j != null) {
-            return j.getSCMListeners().remove(this);
-        } else {
-            return false;
-        }
+        return Jenkins.getInstance().getSCMListeners().remove(this);
     }
 }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -835,7 +835,7 @@ public class SlaveComputer extends Computer {
      * @since 1.362
      */
     public static VirtualChannel getChannelToMaster() {
-        if (Jenkins.getInstanceOrNull()!=null)
+        if (Jenkins.getInstanceOrNull()!=null) // check if calling thread is on master or on slave
             return FilePath.localChannel;
 
         // if this method is called from within the slave computation thread, this should work

--- a/core/src/main/java/hudson/tools/JDKInstaller.java
+++ b/core/src/main/java/hudson/tools/JDKInstaller.java
@@ -448,8 +448,7 @@ public class JDKInstaller extends ToolInstaller {
 
         HttpClient hc = new HttpClient();
         hc.getParams().setParameter("http.useragent","Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US)");
-        Jenkins j = Jenkins.getInstanceOrNull();
-        ProxyConfiguration jpc = j!=null ? j.proxy : null;
+        ProxyConfiguration jpc = Jenkins.getInstance().proxy;
         if(jpc != null) {
             hc.getHostConfiguration().setProxy(jpc.name, jpc.port);
             if(jpc.getUserName() != null)

--- a/core/src/main/java/hudson/util/ProcessKillingVeto.java
+++ b/core/src/main/java/hudson/util/ProcessKillingVeto.java
@@ -74,9 +74,10 @@ public abstract class ProcessKillingVeto implements ExtensionPoint {
      *         list if Jenkins is not available, never null.
      */
     public static List<ProcessKillingVeto> all() {
+        // check if we are a thread running on the master JVM or a thread running in a remote JVM
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins == null)
-            return Collections.emptyList();
+            return Collections.emptyList(); // we are remote, no body gets to veto
         return jenkins.getExtensionList(ProcessKillingVeto.class);
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4131,7 +4131,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     /**
-     * Shortcut for {@code Jenkins.getInstance().lookup.get(type)}
+     * Shortcut for {@code Jenkins.getInstanceOrNull()?.lookup.get(type)}
      */
     public static @CheckForNull <T> T lookup(Class<T> type) {
         Jenkins j = Jenkins.getInstanceOrNull();

--- a/core/src/main/java/jenkins/model/UnlabeledLoadStatistics.java
+++ b/core/src/main/java/jenkins/model/UnlabeledLoadStatistics.java
@@ -78,11 +78,7 @@ public class UnlabeledLoadStatistics extends LoadStatistics {
 
     @Override
     public int computeQueueLength() {
-        final Jenkins j = Jenkins.getInstanceOrNull();
-        if (j == null) { // Consider queue as empty when Jenkins is inactive
-            return 0;
-        }
-        return j.getQueue().strictCountBuildableItemsFor(null); 
+        return Jenkins.getInstance().getQueue().strictCountBuildableItemsFor(null);
     }
 
     @Override

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -118,11 +118,8 @@ public class ApiTokenProperty extends UserProperty {
     }
     
     private boolean hasPermissionToSeeToken() {
-        final Jenkins jenkins = Jenkins.getInstanceOrNull();
-        if (jenkins == null) {
-            return false; // Should not happen - we don't display UIs in this stage
-        }
-        
+        final Jenkins jenkins = Jenkins.getInstance();
+
         // Administrators can do whatever they want
         if (SHOW_TOKEN_TO_ADMINS && jenkins.hasPermission(Jenkins.ADMINISTER)) {
             return true;

--- a/core/src/main/java/jenkins/security/QueueItemAuthenticatorProvider.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticatorProvider.java
@@ -2,6 +2,7 @@ package jenkins.security;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import jenkins.model.Jenkins;
 
@@ -32,10 +33,7 @@ public abstract class QueueItemAuthenticatorProvider implements ExtensionPoint {
         private Iterator<QueueItemAuthenticator> delegate = null;
 
         private IteratorImpl() {
-            final Jenkins jenkins = Jenkins.getInstanceOrNull();
-            providers = new ArrayList<QueueItemAuthenticatorProvider>(jenkins == null
-                    ? Collections.<QueueItemAuthenticatorProvider>emptyList()
-                    : jenkins.getExtensionList(QueueItemAuthenticatorProvider.class)).iterator();
+            providers = ExtensionList.lookup(QueueItemAuthenticatorProvider.class).iterator();
         }
 
         @Override

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -106,8 +106,8 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     }
 
     private boolean shouldTrigger(Run upstreamBuild, TaskListener listener) {
-        Jenkins jenkins = Jenkins.getInstanceOrNull();
-        if (jenkins == null || job == null) {
+        Jenkins jenkins = Jenkins.getInstance();
+        if (job == null) {
             return false;
         }
         // This checks Item.READ also on parent folders; note we are checking as the upstream auth currently:

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -202,11 +202,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
             while(tokens.hasMoreTokens()) {
                 String projectName = tokens.nextToken().trim();
                 if (StringUtils.isNotBlank(projectName)) {
-                    Jenkins jenkins = Jenkins.getInstanceOrNull();
-                    if (jenkins == null) {
-                        return FormValidation.ok();
-                    }
-                    Job item = jenkins.getItem(projectName, project, Job.class);
+                    Job item = Jenkins.getInstance().getItem(projectName, project, Job.class);
                     if (item == null) {
                         Job nearest = Items.findNearest(Job.class, projectName, project.getParent());
                         String alternative = nearest != null ? nearest.getRelativeNameFrom(project) : "?";
@@ -253,11 +249,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
 
     @Extension public static class ItemListenerImpl extends ItemListener {
         @Override public void onLocationChanged(Item item, String oldFullName, String newFullName) {
-            Jenkins jenkins = Jenkins.getInstanceOrNull();
-            if (jenkins == null) {
-                return;
-            }
-            for (Job<?,?> p : jenkins.getAllItems(Job.class)) {
+            for (Job<?,?> p : Jenkins.getInstance().getAllItems(Job.class)) {
                 ReverseBuildTrigger t = ParameterizedJobMixIn.getTrigger(p, ReverseBuildTrigger.class);
                 if (t != null) {
                     String revised = Items.computeRelativeNamesAfterRenaming(oldFullName, newFullName, t.upstreamProjects, p.getParent());

--- a/core/src/main/java/jenkins/util/JSONSignatureValidator.java
+++ b/core/src/main/java/jenkins/util/JSONSignatureValidator.java
@@ -134,10 +134,7 @@ public class JSONSignatureValidator {
         // if we trust default root CAs, we end up trusting anyone who has a valid certificate,
         // which isn't useful at all
         Set<TrustAnchor> anchors = new HashSet<TrustAnchor>(); // CertificateUtil.getDefaultRootCAs();
-        Jenkins j = Jenkins.getInstanceOrNull();
-        if (j == null) {
-            return anchors;
-        }
+        Jenkins j = Jenkins.getInstance();
         for (String cert : (Set<String>) j.servletContext.getResourcePaths("/WEB-INF/update-center-rootCAs")) {
             if (cert.endsWith("/") || cert.endsWith(".txt"))  {
                 continue;       // skip directories also any text files that are meant to be documentation


### PR DESCRIPTION
bb7c8fc follow-up that removes 20 of the uses of `Jenkins.getInstanceOrNull()` that can never have an execution code path that results in a `null` return value.

I also note 13 cases where I am highly confident that they can be replaced but need to perform a more in-depth analysis of potential code paths available within core.

That leaves a total of 29 valid use cases for `Jenkins.getInstanceOrNull()` another couple of those could probably be removed if we had an `ExtensionList.isAvailable()` style static helper method that lets plugins write code that can run on both the master JVM and a remote JVM but needs to operate differently when run remotely

@jenkinsci/code-reviewers @reviewbybees
- Also fixed a minor race condition bug in `ProxyConfiguration.open(URL)`
