### PR TITLE
[FIXED JENKINS-33453] Improve logging and error message when JNLP is already in use

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1001,9 +1001,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                         }
                     }
                 } catch (BindException e) {
+                    LOGGER.log(Level.WARNING, String.format("Failed to listen to incoming slave connections through JNLP port %s. Change the JNLP port number", slaveAgentPort), e);
                     new AdministrativeError(administrativeMonitorId,
-                            "Failed to listen to incoming slave connection",
-                            "Failed to listen to incoming slave connection. <a href='configure'>Change the port number</a> to solve the problem.", e);
+                            "Failed to listen to incoming slave connections through JNLP",
+                            "Failed to listen to incoming slave connections through JNLP. <a href='configureSecurity'>Change the JNLP port number</a> to solve the problem.", e);
                 }
             }
         }


### PR DESCRIPTION
Currently when saving you will get a BindException, but it will be great to add a logger as well.

There is an Administrative monitor, but it points to configure instead of configure security and the error message is perhaps not clear.

https://issues.jenkins-ci.org/browse/JENKINS-33453

@reviewbybees CC @daniel-beck @oleg-nenashev @varmenise @escoem
