### PR TITLE
[JENKINS-32978] updated windows-package-checker to 1.2 to avoid compile time warnings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -147,7 +147,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>windows-package-checker</artifactId>
-      <version>1.0</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
this is a low-risk change, see:
https://github.com/kohsuke/windows-package-checker/compare/windows-package-checker-1.0...windows-package-checker-1.2

[JENKINS-32978](https://issues.jenkins-ci.org/browse/JENKINS-32978)
