### PR TITLE
[JENKINS-33296] - plugin dependency issues during install

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -275,6 +275,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
     /**
      * Returns all the plugin dependencies that are implicit based on a particular Jenkins version
      */
+    @Nonnull
     public static List<PluginWrapper.Dependency> getImpliedDependencies(String pluginName, String jenkinsVersion) {
         List<PluginWrapper.Dependency> out = new ArrayList<>();
         for (DetachedPlugin detached : DETACHED_LIST) {

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -259,6 +259,19 @@ public class ClassicPluginStrategy implements PluginStrategy {
         return new PluginWrapper(pluginManager, archive, manifest, baseResourceURL,
                 createClassLoader(paths, dependencyLoader, atts), disableFile, dependencies, optionalDependencies);
     }
+    
+    /**
+     * Returns all the bundled plugin dependencies for a particular Jenkins version
+     */
+    public static List<PluginWrapper.Dependency> getPreviouslyBundledDependencies(String jenkinsVersion) {
+        List<PluginWrapper.Dependency> out = new ArrayList<>();
+        for (DetachedPlugin detached : DETACHED_LIST) {
+            if (jenkinsVersion == null || jenkinsVersion.equals("null") || new VersionNumber(jenkinsVersion).compareTo(detached.splitWhen) <= 0) {
+                out.add(new PluginWrapper.Dependency(detached.shortName + ':' + detached.requireVersion));
+            }
+        }
+        return out;
+    }
 
     @Deprecated
     protected ClassLoader createClassLoader(List<File> paths, ClassLoader parent) throws IOException {

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -261,10 +261,8 @@ public class ClassicPluginStrategy implements PluginStrategy {
     }
 
     private static void fix(Attributes atts, List<PluginWrapper.Dependency> optionalDependencies) {
-        // don't fix the dependency for yourself, or else we'll have a cycle
         String pluginName = atts.getValue("Short-Name");
         
-        // some earlier versions of maven-hpi-plugin apparently puts "null" as a literal in Hudson-Version. watch out for them.
         String jenkinsVersion = atts.getValue("Jenkins-Version");
         if (jenkinsVersion==null)
             jenkinsVersion = atts.getValue("Hudson-Version");
@@ -274,11 +272,13 @@ public class ClassicPluginStrategy implements PluginStrategy {
     
     /**
      * Returns all the plugin dependencies that are implicit based on a particular Jenkins version
+     * @since 2.0
      */
     @Nonnull
     public static List<PluginWrapper.Dependency> getImpliedDependencies(String pluginName, String jenkinsVersion) {
         List<PluginWrapper.Dependency> out = new ArrayList<>();
         for (DetachedPlugin detached : DETACHED_LIST) {
+            // don't fix the dependency for itself, or else we'll have a cycle
             if (detached.shortName.equals(pluginName)) {
                 continue;
             }
@@ -286,6 +286,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
                 LOGGER.log(Level.FINE, "skipping implicit dependency {0} → {1}", new Object[] {pluginName, detached.shortName});
                 continue;
             }
+            // some earlier versions of maven-hpi-plugin apparently puts "null" as a literal in Hudson-Version. watch out for them.
             if (jenkinsVersion == null || jenkinsVersion.equals("null") || new VersionNumber(jenkinsVersion).compareTo(detached.splitWhen) <= 0) {
                 out.add(new PluginWrapper.Dependency(detached.shortName + ':' + detached.requireVersion));
                 LOGGER.log(Level.FINE, "adding implicit dependency {0} → {1} because of {2}", new Object[] {pluginName, detached.shortName, jenkinsVersion});

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1156,19 +1156,6 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             if (p == null) {
                 throw new Failure("No such plugin: " + n);
             }
-            
-            // JENKINS-33308 - automatically install implied/previously bundled dependencies for older plugins that may need them
-            for(PluginWrapper.Dependency previouslyBundledDependency : ClassicPluginStrategy.getImpliedDependencies(p.name, p.requiredCore)) {
-                // if they aren't already installed, note the dependencies show 'need restart' messages if installed multiple times
-                // but it can't be prevented here
-                if(getPlugin(previouslyBundledDependency.shortName) == null) {
-                    // as these are basically jenkins core, these should always be installed from the default update center
-                    UpdateSite.Plugin previouslyBundledPlugin = getPlugin(previouslyBundledDependency.shortName, UpdateCenter.ID_DEFAULT);
-                    Future<UpdateCenter.UpdateCenterJob> jobFuture = previouslyBundledPlugin.deploy(dynamicLoad, correlationId);
-                    installJobs.add(jobFuture);
-                }
-            }
-            
             Future<UpdateCenter.UpdateCenterJob> jobFuture = p.deploy(dynamicLoad, correlationId);
             installJobs.add(jobFuture);
         }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1140,7 +1140,9 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     String pluginName = n.substring(0, index);
                     String siteName = n.substring(index + 1);
                     UpdateSite.Plugin plugin = getPlugin(pluginName, siteName);
-                    // TODO: Someone that understands what the following logic is about, please add a comment.
+                    // There could be cases like:
+                    // 'plugin.ambiguous.updatesite' where both
+                    // 'plugin' @ 'ambigiuous.updatesite' and 'plugin.ambiguous' @ 'updatesite' resolve to valid plugins
                     if (plugin != null) {
                         if (p != null) {
                             throw new Failure("Ambiguous plugin: " + n);
@@ -1150,9 +1152,23 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     index = n.indexOf('.', index + 1);
                 }
             }
+            
             if (p == null) {
                 throw new Failure("No such plugin: " + n);
             }
+            
+            // JENKINS-33308 - automatically install implied/previously bundled dependencies for older plugins that may need them
+            for(PluginWrapper.Dependency previouslyBundledDependency : ClassicPluginStrategy.getPreviouslyBundledDependencies(p.requiredCore)) {
+                // if they aren't already installed, note the dependencies show 'need restart' messages if installed multiple times
+                // but it can't be prevented here
+                if(getPlugin(previouslyBundledDependency.shortName) == null) {
+                    // as these are basically jenkins core, these should always be installed from the default update center
+                    UpdateSite.Plugin previouslyBundledPlugin = getPlugin(previouslyBundledDependency.shortName, UpdateCenter.ID_DEFAULT);
+                    Future<UpdateCenter.UpdateCenterJob> jobFuture = previouslyBundledPlugin.deploy(dynamicLoad, correlationId);
+                    installJobs.add(jobFuture);
+                }
+            }
+            
             Future<UpdateCenter.UpdateCenterJob> jobFuture = p.deploy(dynamicLoad, correlationId);
             installJobs.add(jobFuture);
         }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1158,7 +1158,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             }
             
             // JENKINS-33308 - automatically install implied/previously bundled dependencies for older plugins that may need them
-            for(PluginWrapper.Dependency previouslyBundledDependency : ClassicPluginStrategy.getPreviouslyBundledDependencies(p.requiredCore)) {
+            for(PluginWrapper.Dependency previouslyBundledDependency : ClassicPluginStrategy.getImpliedDependencies(p.name, p.requiredCore)) {
                 // if they aren't already installed, note the dependencies show 'need restart' messages if installed multiple times
                 // but it can't be prevented here
                 if(getPlugin(previouslyBundledDependency.shortName) == null) {

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -634,10 +634,8 @@ public class UpdateSite {
             this.categories = o.has("labels") ? (String[])o.getJSONArray("labels").toArray(new String[0]) : null;
             for(Object jo : o.getJSONArray("dependencies")) {
                 JSONObject depObj = (JSONObject) jo;
-                // Make sure there's a name attribute, that that name isn't maven-plugin - we ignore that one -
-                // and that the optional value isn't true.
-                if (get(depObj,"name")!=null
-                    && !get(depObj,"name").equals("maven-plugin")) {
+                // Make sure there's a name attribute and that the optional value isn't true.
+                if (get(depObj,"name")!=null) {
                     if (get(depObj, "optional").equals("false")) {
                         dependencies.put(get(depObj, "name"), get(depObj, "version"));
                     } else {

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -358,7 +358,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         if(si.fullname==null || si.fullname.length()==0)
             si.fullname = si.username;
 
-        if(si.email==null || !si.email.contains("@"))
+        if(isMailerPluginPresent() && (si.email==null || !si.email.contains("@")))
             si.errorMessage = Messages.HudsonPrivateSecurityRealm_CreateAccount_InvalidEmailAddress();
 
         if (! User.isIdOrFullnameAllowed(si.username)) {
@@ -379,18 +379,30 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         // register the user
         User user = createAccount(si.username,si.password1);
         user.setFullName(si.fullname);
-        try {
-            // legacy hack. mail support has moved out to a separate plugin
-            Class<?> up = Jenkins.getInstance().pluginManager.uberClassLoader.loadClass("hudson.tasks.Mailer$UserProperty");
-            Constructor<?> c = up.getDeclaredConstructor(String.class);
-            user.addProperty((UserProperty)c.newInstance(si.email));
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to set the e-mail address",e);
+        if(isMailerPluginPresent()) {
+            try {
+                // legacy hack. mail support has moved out to a separate plugin
+                Class<?> up = Jenkins.getInstance().pluginManager.uberClassLoader.loadClass("hudson.tasks.Mailer$UserProperty");
+                Constructor<?> c = up.getDeclaredConstructor(String.class);
+                user.addProperty((UserProperty)c.newInstance(si.email));
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
         user.save();
         return user;
+    }
+    
+    public boolean isMailerPluginPresent() {
+        try {
+            // mail support has moved to a separate plugin
+            return null != Jenkins.getInstance().pluginManager.uberClassLoader.loadClass("hudson.tasks.Mailer$UserProperty");
+        } catch (ClassNotFoundException e) {
+            LOGGER.finer("Mailer plugin not present");
+        }
+        return false;
     }
 
     /**

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -81,7 +81,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -385,9 +384,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
                 Class<?> up = Jenkins.getInstance().pluginManager.uberClassLoader.loadClass("hudson.tasks.Mailer$UserProperty");
                 Constructor<?> c = up.getDeclaredConstructor(String.class);
                 user.addProperty((UserProperty)c.newInstance(si.email));
-            } catch (RuntimeException e) {
-                throw e;
-            } catch (Exception e) {
+            } catch (ReflectiveOperationException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -395,6 +392,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         return user;
     }
     
+    @Restricted(NoExternalUse.class)
     public boolean isMailerPluginPresent() {
         try {
             // mail support has moved to a separate plugin

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<!-- tag file sed by both signup.jelly and addUser.jelly -->
+<!-- tag file used by both signup.jelly and addUser.jelly -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <h1>${title}</h1>
@@ -49,10 +49,12 @@ THE SOFTWARE.
           <td>${%Full name}:</td>
           <td><input type="text" name="fullname" value="${data.fullname}" /></td>
         </tr>
+        <j:if test="${it.mailerPluginPresent}">
         <tr>
           <td>${%E-mail address}:</td>
           <td><input type="text" name="email" value="${data.email}" /></td>
         </tr>
+        </j:if>
         <j:if test="${captcha}">
           <tr>
             <td>${%Enter text as shown}:</td>

--- a/war/src/main/js/api/plugins.js
+++ b/war/src/main/js/api/plugins.js
@@ -19,7 +19,7 @@ exports.recommendedPlugins = [
     "gradle",
     "ldap",
     "mailer",
-    // "matrix-auth",
+    "matrix-auth",
     "pam-auth",
     "pipeline-stage-view",
     "ssh-slaves",
@@ -38,7 +38,7 @@ exports.availablePlugins = [
     {
         "category":"Organization and Administration",
         "plugins": [
-            // { "name": "dashboard-view" },
+            { "name": "dashboard-view" },
             { "name": "build-monitor-plugin" },
             { "name": "cloudbees-folder" },
             { "name": "antisamy-markup-formatter" }
@@ -49,15 +49,15 @@ exports.availablePlugins = [
         "description":"Add general purpose features to your jobs",
         "plugins": [
             { "name": "ansicolor" },
-            // { "name": "build-name-setter" },
+            { "name": "build-name-setter" },
             { "name": "build-timeout" },
             { "name": "config-file-provider" },
             { "name": "credentials-binding" },
             { "name": "rebuild" },
             { "name": "ssh-agent" },
-            // { "name": "throttle-concurrents" },
-            { "name": "timestamper" }
-            // { "name": "ws-cleanup" }
+            { "name": "throttle-concurrents" },
+            { "name": "timestamper" },
+            { "name": "ws-cleanup" }
         ]
     },
     {
@@ -72,12 +72,12 @@ exports.availablePlugins = [
     {
         "category":"Build Analysis and Reporting",
         "plugins": [
-            // { "name": "checkstyle" },
-            // { "name": "cobertura" },
+            { "name": "checkstyle" },
+            { "name": "cobertura" },
             { "name": "htmlpublisher" },
             { "name": "junit" },
-            // { "name": "sonar" },
-            // { "name": "warnings" },
+            { "name": "sonar" },
+            { "name": "warnings" },
             { "name": "xunit" }
         ]
     },
@@ -88,8 +88,8 @@ exports.availablePlugins = [
             { "name": "github-organization-folder" },
             { "name": "pipeline-stage-view" },
             { "name": "build-pipeline-plugin" },
-            // { "name": "conditional-buildstep" },
-            // { "name": "jenkins-multijob-plugin" },
+            { "name": "conditional-buildstep" },
+            { "name": "jenkins-multijob-plugin" },
             { "name": "parameterized-trigger" },
             { "name": "copyartifact" }
         ]
@@ -122,10 +122,10 @@ exports.availablePlugins = [
     {
         "category":"User Management and Security",
         "plugins": [            
-            // { "name": "matrix-auth" },
+            { "name": "matrix-auth" },
             { "name": "pam-auth" },
             { "name": "ldap" },
-            // { "name": "role-strategy" },
+            { "name": "role-strategy" },
             { "name": "active-directory" }
         ]
     },

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -599,7 +599,13 @@ var createPluginSetupWizard = function(appendTarget) {
 				$('.plugin-list .selected').addClass('match');
 			}
 			else {
-				var matches = findElementsWithText($pl[0], text.toLowerCase(), function(d) { return d.toLowerCase(); });
+				var matches = [];
+				$containers.find('.title,.description').each(function() {
+					var localMatches = findElementsWithText(this, text.toLowerCase(), function(d) { return d.toLowerCase(); });
+					if(localMatches.length > 0) {
+						matches = matches.concat(localMatches);
+					}
+				});
 				$(matches).parents('.plugin').addClass('match');
 				if(lastSearch !== text && scroll) {
 					scrollPlugin($pl, matches, text);


### PR DESCRIPTION
This addresses a few issues with dependent plugins:
- previously "implied" plugin dependencies are not available without explicit dependency references
- maven-plugin was being explicitly excluded as a dependency, causing many failures
- mailer had explicit dependencies in the main codebase for functionality, including saving the 'email' address field for Jenkins user accounts
- dependencies were included in client-side search text in the installer

This addresses:
https://issues.jenkins-ci.org/browse/JENKINS-33296
https://issues.jenkins-ci.org/browse/JENKINS-33308

@jenkinsci/code-reviewers 
