### PR TITLE
Ensure the "Getting Started" dialogue title is consistent between views

### DIFF
--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -15,7 +15,7 @@ You may choose to continue by configuring a proxy or skipping plugin installatio
 installWizard_error_header=An error occurred
 installWizard_error_message=An error occurred during installation:
 installWizard_error_connection=Unable to connect to Jenkins
-installWizard_installCustom_title=Plugin Selection
+installWizard_installCustom_title=Getting Started
 installWizard_installCustom_selectAll=All
 installWizard_installCustom_selectNone=None
 installWizard_installCustom_selectRecommended=Recommended
@@ -24,9 +24,9 @@ installWizard_installCustom_dependenciesPrefix=Dependencies
 installWizard_installCustom_pluginListDesc=Note that the full list of plugins is not shown here. Additional plugins can be installed in the <strong>Plugin Manager</strong> once the initial setup is complete. <a href="https://wiki.jenkins-ci.org/display/JENKINS/Installing+Jenkins#InstallingJenkins-InstallationWizard" target="_blank">See the Wiki for more information</a>.
 installWizard_goBack=Back
 installWizard_goInstall=Install
-installWizard_installing_title=Installing...
+installWizard_installing_title=Getting Started
 installWizard_installing_detailsLink=Details...
-installWizard_installComplete_title=Installed
+installWizard_installComplete_title=Getting Started
 installWizard_installComplete_banner=Jenkins is ready!
 installWizard_pluginsInstalled_message=Your plugin installations are complete.
 installWizard_installComplete_message=Your Jenkins setup is complete.
@@ -43,7 +43,7 @@ installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
 You've skipped creating an admin user. To log in, use the username: 'admin' and \
 the security token you used to access the setup wizard.\
 </div>
-installWizard_addFirstUser_title=Create an Admin User
+installWizard_addFirstUser_title=Getting Started
 installWizard_configureProxy_label=Configure Proxy
 installWizard_configureProxy_save=Save and Continue
 installWizard_skipPluginInstallations=Skip Plugin Installations


### PR DESCRIPTION
The different views are distinguished by the header (h1) tags, for example
"Customize Jenkins" or "Jenkins is ready!" and I find it jarring to have the
dialogue title change.

The context of the whole series of views in the dialogue is "Getting Started" so
I think the dialogue title should reflect that scoping of actions.

![consistent-titles](https://cloud.githubusercontent.com/assets/26594/13761949/fb878a32-e9f8-11e5-94bd-a72f429b0520.png)
