### PR TITLE
[FIXED JENKINS-21484]

### DIFF
--- a/core/src/main/resources/windows-service/jenkins.exe.config
+++ b/core/src/main/resources/windows-service/jenkins.exe.config
@@ -1,6 +1,11 @@
-<!-- see http://support.microsoft.com/kb/936707 -->
 <configuration>
   <runtime>
+    <!-- see http://support.microsoft.com/kb/936707 -->
     <generatePublisherEvidence enabled="false"/>
   </runtime>
+  <startup>
+    <!-- this can be hosted either on .NET 2.0 or 4.0 -->
+    <supportedRuntime version="v2.0.50727" />
+    <supportedRuntime version="v4.0" />
+  </startup>
 </configuration>


### PR DESCRIPTION
Don't require ancient .NET 2.0 runtime. .NET 4.0 can host this
executable, too.

See https://github.com/kohsuke/winsw#net-runtime-40

@reviewbybees
