### PR TITLE
[FIXED JENKINS-33549] Specify on the logger the job which cannot create a new build

### DIFF
--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -176,13 +176,11 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT,RunT> & Queue.Task & 
             builds.put(lastBuild);
             lastBuild.getPreviousBuild(); // JENKINS-20662: create connection to previous build
             return lastBuild;
-        } catch (InstantiationException e) {
-            throw new Error(e);
-        } catch (IllegalAccessException e) {
-            throw new Error(e);
         } catch (InvocationTargetException e) {
+            LOGGER.log(Level.WARNING, String.format("A new build could not be created in job %s", asJob().getFullName()), e);
             throw handleInvocationTargetException(e);
-        } catch (NoSuchMethodException e) {
+        } catch (ReflectiveOperationException | IllegalStateException e) {
+            LOGGER.log(Level.WARNING, String.format("A new build could not be created in job %s", asJob().getFullName()), e);
             throw new Error(e);
         }
     }


### PR DESCRIPTION
If `$JENKINS_HOME/jobs/*/nextBuildNumber` was somehow reset to a lower value then the stacktrace below will be displayed. It doesn't say what job is affected, so it might be nice to capture this exception and expose the job name.

```
2016-03-10 13:03:58.785+0000 [id=4541756]   SEVERE  hudson.model.Executor#run: Unexpected executor deathjava.lang.IllegalStateException: cannot create a build with number 38 since that (or higher) is already in use among [45]
    at jenkins.model.lazy.AbstractLazyLoadRunMap.proposeNewNumber(AbstractLazyLoadRunMap.java:361)
    at hudson.model.RunMap.put(RunMap.java:190)
    at jenkins.model.lazy.LazyBuildMixIn.newBuild(LazyBuildMixIn.java:178)
    at hudson.model.AbstractProject.newBuild(AbstractProject.java:1010)
    at hudson.model.AbstractProject.createExecutable(AbstractProject.java:1209)
    at hudson.model.AbstractProject.createExecutable(AbstractProject.java:144)
    at hudson.model.Executor$1.call(Executor.java:335)
    at hudson.model.Executor$1.call(Executor.java:317)
    at hudson.model.Queue._withLock(Queue.java:1399)
    at hudson.model.Queue.withLock(Queue.java:1264)
    at hudson.model.Executor.run(Executor.java:317)
```

https://issues.jenkins-ci.org/browse/JENKINS-33549

@reviewbybees
