### PR TITLE
Set a smaller font on metadata in log

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1690,7 +1690,7 @@ table.progress-bar.red td.progress-bar-done {
 /* ========================= logRecords.jelly ================== */
 
 .logrecord-metadata {
-    // TODO does not work: font-size: 70%;
+    font-size: 70%;
 }
 
 .logrecord-metadata-new {


### PR DESCRIPTION
Amends change in 535247e169c47c7f4db746c23a9fe9d3a1a770f2:
- actually, `font-size` does work here, I was probably just testing in a browser with a minimum font size set and did not notice
- used incorrect CSS comment syntax

![screenshot](https://cloud.githubusercontent.com/assets/154109/13818932/19eb1702-eb6e-11e5-992a-db306fb53ec7.png)

@reviewbybees
