### PR TITLE
Add a title for the confusing 'Use browser' option

### DIFF
--- a/core/src/main/resources/jenkins/model/DownloadSettings/config.groovy
+++ b/core/src/main/resources/jenkins/model/DownloadSettings/config.groovy
@@ -2,7 +2,8 @@ package jenkins.security.DownloadSettings
 
 def f = namespace(lib.FormTagLib)
 
-// TODO avoid indentation somehow
-f.entry(field: "useBrowser") {
-    f.checkbox(title: _("Use browser for metadata download"))
+f.section(title:_("Plugin Manager")) {
+	f.entry(field: "useBrowser") {
+		f.checkbox(title: _("Use browser for metadata download"))
+	}
 }


### PR DESCRIPTION
Because this is confusing without the _Plugin Manager_ title.

![screen shot](https://cloud.githubusercontent.com/assets/1831569/13822689/eed330b6-eba6-11e5-89b2-381fe26ad338.png)
