### PR TITLE
[FIX JENKINS-33571] Remove Slack Plugin from the list

### DIFF
--- a/war/src/main/js/api/plugins.js
+++ b/war/src/main/js/api/plugins.js
@@ -136,7 +136,7 @@ exports.availablePlugins = [
             { "name": "emailext-template" },
             { "name": "mailer" },
             { "name": "publish-over-ssh" },
-            { "name": "slack" },
+            // { "name": "slack" }, // JENKINS-33571
             { "name": "ssh" }
         ]
     }


### PR DESCRIPTION
The current version of the Slack plugin seems to be broken, so let's remove it from the list for now.

https://issues.jenkins-ci.org/browse/JENKINS-33571
