### PR TITLE
[JENKINS-33534] - missing installer plugin status indicators

### DIFF
--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -232,6 +232,15 @@ var createPluginSetupWizard = function(appendTarget) {
 
 	// plugin data for the progress panel
 	var installingPlugins = [];
+	var getInstallingPlugin = function(plugName) {
+		for(var i = 0; i < installingPlugins.length; i++) {
+			var p = installingPlugins[i];
+			if(p.name === plugName) {
+				return p;
+			}
+		}
+		return null;
+	};
 
 	// recursively get all the dependencies for a particular plugin, this is used to show 'installing' status
 	// when only dependencies are being installed
@@ -266,28 +275,26 @@ var createPluginSetupWizard = function(appendTarget) {
 	// Initializes the set of installing plugins with pending statuses
 	var initInstallingPluginList = function() {
 		installingPlugins = [];
-		installingPlugins.names = [];
 		for (var i = 0; i < selectedPluginNames.length; i++) {
 			var pluginName = selectedPluginNames[i];
-			var p = availablePlugins[ pluginName];
+			var p = availablePlugins[pluginName];
 			if (p) {
 				var plug = $.extend({
 					installStatus : 'pending'
 				}, p);
 				installingPlugins.push(plug);
-				installingPlugins[plug.name] = plug;
-				installingPlugins.names.push(pluginName);
 			}
 		}
 	};
 
 	// call this to go install the selected set of plugins
 	var installPlugins = function(plugins) {
+		// Switch to the right view but function() to force update when progressPanel re-rendered
+		setPanel(function() { return progressPanel(arguments); }, { installingPlugins : [] });
+
 		pluginManager.installPlugins(plugins, handleGenericError(function() {
 			showInstallProgress();
 		}));
-
-		setPanel(progressPanel, { installingPlugins : installingPlugins });
 	};
 	
 	// toggles visibility of dependency listing for a plugin
@@ -859,11 +866,10 @@ var createPluginSetupWizard = function(appendTarget) {
 							initInstallingPluginList();
 
 							for(var plugName in incompleteStatus) {
-								var j = installingPlugins[plugName];
+								var j = getInstallingPlugin(plugName);
 								
 								if (!j) {
 									console.warn('Plugin "' + plugName + '" not found in the list of installing plugins.');
-									console.warn('\tInstalling plugins: ' + installingPlugins.names);									
 									continue;
 								}
 


### PR DESCRIPTION
This corrects a timing issue which may cause the plugin status indicators not to appear.

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-33534
