### PR TITLE
[JENKINS-33599] write file with admin password for installer

### DIFF
--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -33,6 +33,8 @@ import jenkins.security.s2m.AdminWhitelistRule;
 /**
  * A Jenkins instance used during first-run to provide a limited set of services while
  * initial installation is in progress
+ * 
+ * @since 2.0
  */
 public class SetupWizard {
     /**

--- a/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
@@ -16,22 +16,17 @@
                   
                     <h1>${%Unlock Jenkins}</h1>
                     <p>
-                        ${%To ensure Jenkins is securely set up by the administrator, a setup security token has been printed to the logs.}
-                        <small>
-                            <a href="https://jenkins-ci.org/redirect/find-jenkins-logs" target="_blank">
-                                ${%Not sure where to find the logs?}
-                            </a>
-                        </small>
+                        ${%jenkins.install.findSecurityTokenMessage(it.initialAdminPasswordFile.canonicalPath)}
                     </p>
-                    <p>${%Please copy the token and paste it below.}</p>
+                    <p>${%Please copy the password and paste it below.}</p>
                     <j:if test="${error}">
                         <div class="alert alert-danger">
                           <strong>${%ERROR:} </strong>
-                          ${%There is a problem with the security token, please check the logs for the correct token}
+                          ${%The password entered is incorrect, please check the file for the correct password}
                         </div>
                     </j:if>
                     <div class="form-group ${error ? 'has-error' : ''}">
-                    <label class="control-label" for="security-token">${%Security token}</label>
+                    <label class="control-label" for="security-token">${%Administrator password}</label>
                     <input name="j_username" value="${j.setupWizard.initialSetupAdminUserName}" type="hidden"/>
                     <input id="security-token" class="form-control" name="j_password"/>
                     <link rel="stylesheet" href="${j.installWizardPath}.css" type="text/css" />

--- a/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.properties
+++ b/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.properties
@@ -1,0 +1,2 @@
+jenkins.install.findSecurityTokenMessage=To ensure Jenkins is securely set up by the administrator, \
+a password has been generated and written to the file on the Jenkins server here: <br/><small><code>{0}</code></small>


### PR DESCRIPTION
To make finding the initial admin password easier, write it to a file and display the location of the file so the user knows exactly where to look. Also removed tracking in the user object, as this was just so the token was available across restarts (previously using a custom UserProperty).

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-33599
