### PR TITLE
Fix issues running initial setup in dev mode

### DIFF
--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -50,17 +50,17 @@ public class SetupWizard {
         FilePath iapf = getInitialAdminPasswordFile();
         if(j.getSecurityRealm() == null || j.getSecurityRealm() == SecurityRealm.NO_AUTHENTICATION) { // this seems very fragile
             BulkChange bc = new BulkChange(j);
-            try{
+            try {
                 HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
                 j.setSecurityRealm(securityRealm);
-                String randomUUID = UUID.randomUUID().toString().replace("-", "").toLowerCase(Locale.ENGLISH);
+                String randomUUID = System.getProperty("jenkins.install.initialAdminPassword", UUID.randomUUID().toString().replace("-", "").toLowerCase(Locale.ENGLISH));
 
                 // create an admin user
                 securityRealm.createAccount(SetupWizard.initialSetupAdminUserName, randomUUID);
 
                 // JENKINS-33599 - write to a file in the jenkins home directory
                 // most native packages of Jenkins creates a machine user account 'jenkins' to run Jenkins,
-                // and use group 'jenkins' for admins. So we allo groups to read this file
+                // and use group 'jenkins' for admins. So we allow groups to read this file
                 iapf.write(randomUUID, "UTF-8");
                 iapf.chmod(0640);
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -208,6 +208,7 @@ import jenkins.slaves.WorkspaceLocator;
 import jenkins.util.JenkinsJVM;
 import jenkins.util.Timer;
 import jenkins.util.io.FileBoolean;
+import jenkins.util.xml.XMLUtils;
 import net.jcip.annotations.GuardedBy;
 import net.sf.json.JSONObject;
 import org.acegisecurity.AccessDeniedException;
@@ -4608,6 +4609,20 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
         String ver = props.getProperty("version");
         if(ver==null)   ver = UNCOMPUTED_VERSION;
+        if("${build.version}".equals(ver)) {
+            // in dev mode?
+            try {
+                File pom = new File("../pom.xml");
+                if(pom.exists()) {
+                    pom =  pom.getCanonicalFile();
+                    LOGGER.info("Reading version from: " + pom.getAbsolutePath());
+                    ver = XMLUtils.getValue("/project/version", pom);
+                }
+                LOGGER.info("Jenkins is in dev mode, using version: " + ver);
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Unable to read Jenkins version: " + e.getMessage(), e);
+            }
+        }
         VERSION = ver;
         context.setAttribute("version",ver);
 


### PR DESCRIPTION
Minor tweaks to make it easier to run & work on the setup wizard when running in development mode:
- set the Jenkins version based on the maven pom
- add option to set initial password from the command line

@jenkinsci/code-reviewers 
