### PR TITLE
[FIXED JENKINS-33599] write file with admin password for installer

### DIFF
--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -41,7 +41,10 @@ public class SetupWizard {
 
     private final Logger LOGGER = Logger.getLogger(SetupWizard.class.getName());
 
+    private final Jenkins jenkins;
+
     public SetupWizard(Jenkins j) throws IOException, InterruptedException {
+        this.jenkins = j;
         // Create an admin user by default with a 
         // difficult password
         FilePath iapf = getInitialAdminPasswordFile();
@@ -113,19 +116,18 @@ public class SetupWizard {
      */
     @Restricted(NoExternalUse.class) // use by Jelly
     public FilePath getInitialAdminPasswordFile() {
-        return Jenkins.getInstance().getRootPath().child("initialAdminPassword");
+        return jenkins.getRootPath().child("initialAdminPassword");
     }
 
     /**
      * Remove the setupWizard filter, ensure all updates are written to disk, etc
      */
     public HttpResponse doCompleteInstall() throws IOException, ServletException {
-        Jenkins j = Jenkins.getInstance();
-        j.setInstallState(InstallState.INITIAL_SETUP_COMPLETED);
+        jenkins.setInstallState(InstallState.INITIAL_SETUP_COMPLETED);
         InstallUtil.saveLastExecVersion();
         PluginServletFilter.removeFilter(FORCE_SETUP_WIZARD_FILTER);
         // Also, clean up the setup wizard if it's completed
-        j.setSetupWizard(null);
+        jenkins.setSetupWizard(null);
         return HttpResponses.okJSON();
     }
     

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -33,6 +33,8 @@ import jenkins.security.s2m.AdminWhitelistRule;
 /**
  * A Jenkins instance used during first-run to provide a limited set of services while
  * initial installation is in progress
+ * 
+ * @since 2.0
  */
 public class SetupWizard {
     /**

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -116,7 +116,7 @@ public class SetupWizard {
      */
     @Restricted(NoExternalUse.class) // use by Jelly
     public FilePath getInitialAdminPasswordFile() {
-        return jenkins.getRootPath().child("initialAdminPassword");
+        return jenkins.getRootPath().child("secrets/initialAdminPassword");
     }
 
     /**

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -1,10 +1,18 @@
 package jenkins.install;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Locale;
-import java.util.UUID;
-import java.util.logging.Logger;
+import hudson.BulkChange;
+import hudson.FilePath;
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
+import hudson.security.HudsonPrivateSecurityRealm;
+import hudson.security.SecurityRealm;
+import hudson.security.csrf.DefaultCrumbIssuer;
+import hudson.util.HttpResponses;
+import hudson.util.PluginServletFilter;
+import jenkins.model.Jenkins;
+import jenkins.security.s2m.AdminWhitelistRule;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.HttpResponse;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -14,24 +22,10 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
-
-import hudson.FilePath;
-import org.apache.commons.io.FileUtils;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
-
-import hudson.BulkChange;
-import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
-import hudson.security.HudsonPrivateSecurityRealm;
-import hudson.security.SecurityRealm;
-import hudson.security.csrf.DefaultCrumbIssuer;
-import hudson.util.HttpResponses;
-import hudson.util.PluginServletFilter;
-import jenkins.model.Jenkins;
-import jenkins.security.s2m.AdminWhitelistRule;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.logging.Logger;
 
 /**
  * A Jenkins instance used during first-run to provide a limited set of services while
@@ -125,7 +119,7 @@ public class SetupWizard {
     /**
      * Remove the setupWizard filter, ensure all updates are written to disk, etc
      */
-    public HttpResponse doCompleteInstall(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+    public HttpResponse doCompleteInstall() throws IOException, ServletException {
         Jenkins j = Jenkins.getInstance();
         j.setInstallState(InstallState.INITIAL_SETUP_COMPLETED);
         InstallUtil.saveLastExecVersion();

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -17,6 +17,8 @@ import javax.servlet.http.HttpServletRequestWrapper;
 
 import hudson.FilePath;
 import org.apache.commons.io.FileUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -115,6 +117,7 @@ public class SetupWizard {
     /**
      * Gets the file used to store the initial admin password
      */
+    @Restricted(NoExternalUse.class) // use by Jelly
     public FilePath getInitialAdminPasswordFile() {
         return Jenkins.getInstance().getRootPath().child("initialAdminPassword");
     }

--- a/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
@@ -16,7 +16,7 @@
                   
                     <h1>${%Unlock Jenkins}</h1>
                     <p>
-                        ${%jenkins.install.findSecurityTokenMessage(it.initialAdminPasswordFile.canonicalPath)}
+                        ${%jenkins.install.findSecurityTokenMessage(it.initialAdminPasswordFile)}
                     </p>
                     <p>${%Please copy the password and paste it below.}</p>
                     <j:if test="${error}">

--- a/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
@@ -16,22 +16,17 @@
                   
                     <h1>${%Unlock Jenkins}</h1>
                     <p>
-                        ${%To ensure Jenkins is securely set up by the administrator, a setup security token has been printed to the logs.}
-                        <small>
-                            <a href="https://jenkins-ci.org/redirect/find-jenkins-logs" target="_blank">
-                                ${%Not sure where to find the logs?}
-                            </a>
-                        </small>
+                        ${%jenkins.install.findSecurityTokenMessage(it.initialAdminPasswordFile.canonicalPath)}
                     </p>
-                    <p>${%Please copy the token and paste it below.}</p>
+                    <p>${%Please copy the password and paste it below.}</p>
                     <j:if test="${error}">
                         <div class="alert alert-danger">
                           <strong>${%ERROR:} </strong>
-                          ${%There is a problem with the security token, please check the logs for the correct token}
+                          ${%The password entered is incorrect, please check the file for the correct password}
                         </div>
                     </j:if>
                     <div class="form-group ${error ? 'has-error' : ''}">
-                    <label class="control-label" for="security-token">${%Security token}</label>
+                    <label class="control-label" for="security-token">${%Administrator password}</label>
                     <input name="j_username" value="${j.setupWizard.initialSetupAdminUserName}" type="hidden"/>
                     <input id="security-token" class="form-control" name="j_password"/>
                     <link rel="stylesheet" href="${j.installWizardPath}.css" type="text/css" />

--- a/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.properties
+++ b/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.properties
@@ -1,0 +1,2 @@
+jenkins.install.findSecurityTokenMessage=To ensure Jenkins is securely set up by the administrator, \
+a password has been generated and written to the file on the Jenkins server here: <br/><small><code>{0}</code></small>


### PR DESCRIPTION
This takes over PR #2138.

To make finding the initial admin password easier, write it to a file and display the location of the file so the user knows exactly where to look. Also removed tracking in the user object, as this was just so the token was available across restarts (previously using a custom `UserProperty`).

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-33599

In addition to initial PR #2138, the following has been added to address the comments:
- File was moved into `$JENKINS_HOME/secrets` where other files of this nature are in.
- File permission is set to 0640 to allow group users to read this file. There was a lot of discussion about this. 0640 is a nice middle ground, and it is already way more stringent than typical webapps.
- Incorrect use of 'BulkChange' is fixed.
