### PR TITLE
Add desription of -noKeyAuth command line option for german translation

### DIFF
--- a/cli/src/main/resources/hudson/cli/client/Messages_de.properties
+++ b/cli/src/main/resources/hudson/cli/client/Messages_de.properties
@@ -3,11 +3,12 @@ CLI.Usage=Jenkins Kommandozeilenschnittstelle (Jenkins CLI)\n\
   Verwendung: java -jar jenkins-cli.jar [-s URL] command [opts...] args...\n\
   Optionen:\n\
   -s URL              : URL des Hudson-Servers (Wert der Umgebungsvariable JENKINS_URL ist der Vorgabewert)\n\
-  -i KEY              : Datei mit privatem SSH-Schlüssel zur Authentisierung\n\
-  -p HOST\:PORT       : HTTP-Proxy-Host und -Port für HTTPS-Proxy-Tunnel. Siehe http://jenkins-ci.org/https-proxy-tunnel\n\
-  -noCertificateCheck : Überspringt die Zertifikatsprüfung bei HTTPS. Bitte mit Vorsicht einsetzen.\n\
+  -i KEY              : Datei mit privatem SSH-Schl\u00fcssel zur Authentisierung\n\
+  -p HOST\:PORT       : HTTP-Proxy-Host und -Port f\u00fcr HTTPS-Proxy-Tunnel. Siehe http://jenkins-ci.org/https-proxy-tunnel\n\
+  -noCertificateCheck : \u00dcberspringt die Zertifikatspr\u00fcfung bei HTTPS. Bitte mit Vorsicht einsetzen.\n\
+  -noKeyAuth          : \u00dcberspringt die Authentifizierung mit einem privaten SSH-Schl\u00fcssel. Nicht kombinierbar mit -i\n\
   \n\
-  Die verfügbaren Kommandos hängen vom kontaktierten Server ab. Verwenden Sie das Kommando help, um eine Liste aller verfügbaren Kommandos anzuzeigen.
+  Die verf\u00fcgbaren Kommandos h\u00e4ngen vom kontaktierten Server ab. Verwenden Sie das Kommando help, um eine Liste aller verf\u00fcgbaren Kommandos anzuzeigen.
 CLI.NoURL=Weder die Option -s noch eine Umgebungsvariable JENKINS_URL wurde spezifiziert.
 CLI.NoSuchFileExists=Diese Datei existiert nicht {0}
 CLI.VersionMismatch=Versionskonflikt: Diese Version von Jenkins CLI ist nicht mit dem kontaktierten Jenkins-Server kompatibel.


### PR DESCRIPTION
I updated the change, fixed the errors and converted the file to \uXXXX syntax.
