### PR TITLE
[FIXED JENKINS-33693] Do not hardcode .bat extension.

### DIFF
--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -250,8 +250,6 @@ public class Maven extends Builder {
                 seed = new File(ws,"project.xml").exists() ? "maven" : "mvn";
             }
 
-            if(Functions.isWindows())
-                seed += ".bat";
             return seed;
         }
     }


### PR DESCRIPTION
As the default maven command is on the path we can not hard code the
command to mvn.bat as since maven 3.something it has been mvn.cmd

As this is on the path we can just use mvn and let Windows do its thing
with PATHEXT which will has both .BAT and .CMD by default.

This fixes ATH failures when the ATH is run on windows.

prior to the change

```
Started by user anonymous
Building in workspace C:\workarea\wars\JE_HOME\jobs\maven_test\workspace
[workspace] $ cmd.exe /C '"mvn.bat --version && exit %%ERRORLEVEL%%"'
'mvn.bat' is not recognized as an internal or external command,
operable program or batch file.
Build step 'Invoke top-level Maven targets' marked build as failure
Finished: FAILURE
```

post change

```
Started by user anonymous
Building in workspace C:\workarea\wars\JE_HOME\jobs\maven_test\workspace
[workspace] $ cmd.exe /C '"mvn --version && exit %%ERRORLEVEL%%"'
Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-10T16:41:47+00:00)
Maven home: c:\Java\maven-3.3.9\bin\..
Java version: 1.8.0_71, vendor: Oracle Corporation
Java home: c:\Java\jdk1.8.0_71_x64\jre
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 10", version: "10.0", arch: "amd64", family: "dos"
Finished: SUCCESS
```

@reviewbybees [JENKINS-33693](https://issues.jenkins-ci.org/browse/JENKINS-33693)
