### PR TITLE
[FIX JENKINS-33706] Remove ineligible build-monitor-plugin

### DIFF
--- a/war/src/main/js/api/plugins.js
+++ b/war/src/main/js/api/plugins.js
@@ -10,7 +10,6 @@
 exports.recommendedPlugins = [
     "ant",
     "antisamy-markup-formatter",
-    "build-monitor-plugin",
     "build-timeout",
     "cloudbees-folder",
     "credentials-binding",
@@ -39,7 +38,6 @@ exports.availablePlugins = [
         "category":"Organization and Administration",
         "plugins": [
             { "name": "dashboard-view" },
-            { "name": "build-monitor-plugin" },
             { "name": "cloudbees-folder" },
             { "name": "antisamy-markup-formatter" }
         ]


### PR DESCRIPTION
[JENKINS-33706](https://issues.jenkins-ci.org/browse/JENKINS-33706)

While @rtyler filed the issue originally due to a possibly undesirable privacy issue, it turns out the plugin is ineligible anyway, as it's not hosted in the `jenkinsci` organization.
