### PR TITLE
Refine the plugin selection

### DIFF
--- a/war/src/main/js/api/plugins.js
+++ b/war/src/main/js/api/plugins.js
@@ -136,7 +136,7 @@ exports.availablePlugins = [
             { "name": "emailext-template" },
             { "name": "mailer" },
             { "name": "publish-over-ssh" },
-            // { "name": "slack" }, // JENKINS-33571
+            { "name": "slack" },
             { "name": "ssh" }
         ]
     }

--- a/war/src/main/js/api/plugins.js
+++ b/war/src/main/js/api/plugins.js
@@ -136,7 +136,7 @@ exports.availablePlugins = [
             { "name": "emailext-template" },
             { "name": "mailer" },
             { "name": "publish-over-ssh" },
-            { "name": "slack" },
+            // { "name": "slack" }, // JENKINS-33571, https://github.com/jenkinsci/slack-plugin/issues/191
             { "name": "ssh" }
         ]
     }

--- a/war/src/main/js/api/plugins.js
+++ b/war/src/main/js/api/plugins.js
@@ -53,6 +53,7 @@ exports.availablePlugins = [
             { "name": "build-timeout" },
             { "name": "config-file-provider" },
             { "name": "credentials-binding" },
+            { "name": "embeddable-build-status" },
             { "name": "rebuild" },
             { "name": "ssh-agent" },
             { "name": "throttle-concurrents" },
@@ -76,7 +77,6 @@ exports.availablePlugins = [
             { "name": "cobertura" },
             { "name": "htmlpublisher" },
             { "name": "junit" },
-            { "name": "sonar" },
             { "name": "warnings" },
             { "name": "xunit" }
         ]

--- a/war/src/main/js/api/plugins.js
+++ b/war/src/main/js/api/plugins.js
@@ -48,7 +48,6 @@ exports.availablePlugins = [
         "category":"Build Features",
         "description":"Add general purpose features to your jobs",
         "plugins": [
-            { "name": "ansicolor" },
             { "name": "build-name-setter" },
             { "name": "build-timeout" },
             { "name": "config-file-provider" },


### PR DESCRIPTION
- `embeddable-build-status` has been suggested by @svanoort.
- `sonar` is not hosted in jenkinsci and therefore ineligible for inclusion.
- `slack` appears to have resolved the cause for JENKINS-33571 (#2134) as https://github.com/jenkinsci/slack-plugin/issues/191
