### PR TITLE
JENKINS-33659 - Basic fix for scrollspy width issues

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1940,5 +1940,13 @@ body.main-panel-only #side-panel {
 }
 body.main-panel-only #main-panel {
     margin: 0 auto !important;
-    max-width: 75em !important;
+    min-width: 100%;
+    padding: 2em 2em;
+    display: inline-block;
+    width: auto;
+}
+@media screen and (min-width: 1024px) {
+    body.main-panel-only #main-panel {
+        padding: 2em 10%;
+    }
 }


### PR DESCRIPTION
A trivial fix for the config page to prevent wide input fields from breaking out of the UI and allowing use of much of the screen (currently 90%-100%).

![image](https://cloud.githubusercontent.com/assets/3009477/13943196/f1e91364-efd0-11e5-868b-8a2527c904fa.png)

![image](https://cloud.githubusercontent.com/assets/3009477/13943280/56650f82-efd1-11e5-91c8-8f4af177916f.png)

As opposed to currently:

![image](https://cloud.githubusercontent.com/assets/3009477/13959806/008ced04-f02c-11e5-80b6-254b72b4c455.png)
