### PR TITLE
[JENKINS-33557] - connectivity checks may cause setup wizard to hang for a long time

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -78,7 +78,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
      * Holds a default TCP connect timeout set on all connections returned from this class,
      * note this is value is in milliseconds, it's passed directly to {@link URLConnection#setConnectTimeout(int)}
      */
-    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = Integer.getInteger("jenkins.proxy.default_connect_timeout_millis", 20 * 1000);
+    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = Integer.getInteger("hudson.ProxyConfiguration.DEFAULT_CONNECT_TIMEOUT_MILLIS", 20 * 1000);
     
     public final String name;
     public final int port;

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -77,6 +77,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.HttpRetryException;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -1132,7 +1134,18 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
 
         private void testConnection(URL url) throws IOException {
             try {
-                Util.copyStreamAndClose(ProxyConfiguration.open(url).getInputStream(),new NullOutputStream());
+                URLConnection connection = (URLConnection) ProxyConfiguration.open(url);
+                connection.setConnectTimeout(20000); // JENKINS-33557 lower connection test timeout (20 sec)
+                connection.connect();
+
+                if(connection instanceof HttpURLConnection) {
+                    int responseCode = ((HttpURLConnection)connection).getResponseCode();
+                    if(HttpURLConnection.HTTP_OK != responseCode) {
+                        throw new HttpRetryException("Invalid response code (" + responseCode + ") from URL: " + url.toString(), responseCode);
+                    }
+                } else {
+                    Util.copyStreamAndClose(connection.getInputStream(),new NullOutputStream());
+                }
             } catch (SSLHandshakeException e) {
                 if (e.getMessage().contains("PKIX path building failed"))
                    // fix up this crappy error message from JDK
@@ -1315,22 +1328,29 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 return;
             }
             LOGGER.fine("Doing a connectivity check");
+            Future<?> internetCheck = null;
             try {
-                String connectionCheckUrl = site.getConnectionCheckUrl();
+                final String connectionCheckUrl = site.getConnectionCheckUrl();
                 if (connectionCheckUrl!=null) {
                     connectionStates.put(ConnectionStatus.INTERNET, ConnectionStatus.CHECKING);
                     statuses.add(Messages.UpdateCenter_Status_CheckingInternet());
-                    try {
-                        config.checkConnection(this, connectionCheckUrl);
-                    } catch (Exception e) {
-                        if(e.getMessage().contains("Connection timed out")) {
-                            // Google can't be down, so this is probably a proxy issue
-                            connectionStates.put(ConnectionStatus.INTERNET, ConnectionStatus.FAILED);
-                            statuses.add(Messages.UpdateCenter_Status_ConnectionFailed(connectionCheckUrl));
-                            return;
+                    // Run the internet check in parallel
+                    internetCheck = updateService.submit(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                config.checkConnection(ConnectionCheckJob.this, connectionCheckUrl);
+                            } catch (Exception e) {
+                                if(e.getMessage().contains("Connection timed out")) {
+                                    // Google can't be down, so this is probably a proxy issue
+                                    connectionStates.put(ConnectionStatus.INTERNET, ConnectionStatus.FAILED);
+                                    statuses.add(Messages.UpdateCenter_Status_ConnectionFailed(connectionCheckUrl));
+                                    return;
+                                }
+                            }
+                            connectionStates.put(ConnectionStatus.INTERNET, ConnectionStatus.OK);
                         }
-                    }
-                    connectionStates.put(ConnectionStatus.INTERNET, ConnectionStatus.OK);
+                    });
                 }
 
                 connectionStates.put(ConnectionStatus.UPDATE_SITE, ConnectionStatus.CHECKING);
@@ -1349,6 +1369,15 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 connectionStates.put(ConnectionStatus.UPDATE_SITE, ConnectionStatus.FAILED);
                 statuses.add(Functions.printThrowable(e));
                 error = e;
+            }
+            
+            if(internetCheck != null) {
+                try {
+                    // Wait for internet check to complete
+                    internetCheck.get();
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Error completing internet connectivity check: " + e.getMessage(), e);
+                }
             }
         }
 

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1135,13 +1135,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         private void testConnection(URL url) throws IOException {
             try {
                 URLConnection connection = (URLConnection) ProxyConfiguration.open(url);
-                connection.setConnectTimeout(20000); // JENKINS-33557 lower connection test timeout (20 sec)
-                connection.connect();
 
                 if(connection instanceof HttpURLConnection) {
                     int responseCode = ((HttpURLConnection)connection).getResponseCode();
                     if(HttpURLConnection.HTTP_OK != responseCode) {
-                        throw new HttpRetryException("Invalid response code (" + responseCode + ") from URL: " + url.toString(), responseCode);
+                        throw new HttpRetryException("Invalid response code (" + responseCode + ") from URL: " + url, responseCode);
                     }
                 } else {
                     Util.copyStreamAndClose(connection.getInputStream(),new NullOutputStream());

--- a/test/src/test/java/hudson/model/UpdateCenterConnectionStatusTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterConnectionStatusTest.java
@@ -99,7 +99,7 @@ public class UpdateCenterConnectionStatusTest {
         job.run();
 
         Assert.assertEquals(ConnectionStatus.FAILED, job.connectionStates.get(ConnectionStatus.INTERNET));
-        Assert.assertEquals(ConnectionStatus.UNCHECKED, job.connectionStates.get(ConnectionStatus.UPDATE_SITE));
+        Assert.assertEquals(ConnectionStatus.OK, job.connectionStates.get(ConnectionStatus.UPDATE_SITE));
     }
 
     @Test


### PR DESCRIPTION
Issues with internet connectivity can manifest as very long wait times during Jenkins install. This reduces the wait time to 20 seconds and runs all (2) checks in parallel.

@jenkinsci/code-reviewers @reviewbybees esp. @tfennelly 

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-33557
