### PR TITLE
Do not show f:breadcrumb-config-outline for configuration pages with tabs

### DIFF
--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -28,7 +28,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName} Config" cssclass="main-panel-only" norefresh="true" permission="${it.EXTENDED_READ}">
-    <f:breadcrumb-config-outline />
     <l:main-panel>
       <l:js src="jsbundles/config-scrollspy.js" />
       <l:css src="jsbundles/config-scrollspy.css" />


### PR DESCRIPTION
Otherwise you get
![screenshot](https://cloud.githubusercontent.com/assets/154109/13957101/a129aaf0-f021-11e5-8b47-a301ca2f3f0d.png)
which is both broken and superfluous.

No need to make it work [for folders](https://github.com/jenkinsci/cloudbees-folder-plugin/blob/d53c2ee8c296a16f0ce892e816d0b76d90b4f444/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly#L28) either.

@reviewbybees esp. @gusreiber
