### PR TITLE
[FIX JENKINS-33246] Add a footnote about ** in setup wizard

### DIFF
--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -48,3 +48,4 @@ installWizard_configureProxy_label=Configure Proxy
 installWizard_configureProxy_save=Save and Continue
 installWizard_skipPluginInstallations=Skip Plugin Installations
 installWizard_installIncomplete_dependenciesLabel=Dependencies
+installWizard_installingConsole_dependencyIndicatorNote=** - required dependency

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -415,7 +415,7 @@ var createPluginSetupWizard = function(appendTarget) {
 					}
 				}
 
-				$c = $('.install-console');
+				$c = $('.install-console-scroll');
 				if($c.is(':visible')) {
 					$c.scrollTop($c[0].scrollHeight);
 				}

--- a/war/src/main/js/templates/progressPanel.hbs
+++ b/war/src/main/js/templates/progressPanel.hbs
@@ -17,5 +17,10 @@
 		{{/each}}
 	</div>
 
-	<div class="install-console"><div class="install-text"></div></div>
+	<div class="install-console">
+	  <div class="install-console-scroll">
+	    <div class="install-text"></div>
+	  </div>
+	  <div class="dependency-legend">{{translations.installWizard_installingConsole_dependencyIndicatorNote}}</div>
+	</div>
 </div>

--- a/war/src/main/less/pluginSetupWizard.less
+++ b/war/src/main/less/pluginSetupWizard.less
@@ -521,9 +521,17 @@
     z-index: 5;
     top: 33.3%;
     width: 25%;
-    padding: 6px 0;
-    overflow:auto;
-
+    
+    .install-console-scroll {
+        position: absolute;
+        top: 6px;
+        right: 0;
+        bottom: 2em;
+        left: 0;
+        overflow:auto;
+        font: 12px monospace;
+    }
+    
      @media screen and (max-width: 992px) {
        width: 100%;
        position:static;
@@ -544,11 +552,23 @@
 
         .dependent {
             color: #aaa;
-            padding-left: .4em;
+            padding-left: 10px;
 
             &:before {
                 content: ' ** ';
             }
+        }
+        
+        .dependency-legend {
+            color: #aaa;
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            border-top: 1px solid #ccc;
+            background: #f8f8f8;
+            padding: 4px 10px;
+            font: 12px monospace;
         }
     }
 

--- a/war/src/main/less/pluginSetupWizard.less
+++ b/war/src/main/less/pluginSetupWizard.less
@@ -551,7 +551,7 @@
         }
 
         .dependent {
-            color: #aaa;
+            color: #777;
             padding-left: 10px;
 
             &:before {
@@ -560,7 +560,7 @@
         }
         
         .dependency-legend {
-            color: #aaa;
+            color: #777;
             position: absolute;
             bottom: 0;
             left: 0;


### PR DESCRIPTION
Explain what the *\* indicator is during plugin installation in the setup wizard.

![image](https://cloud.githubusercontent.com/assets/3009477/13965636/74a6a626-f045-11e5-8802-9c1415fa1176.png)

![image](https://cloud.githubusercontent.com/assets/3009477/13965644/7a5212fe-f045-11e5-815e-dc1870bd8fed.png)

@reviewbybees esp. @daniel-beck 
