### PR TITLE
Make Fingerprint's XSTREAM field public

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1469,7 +1469,7 @@ public class Fingerprint implements ModelObject, Saveable {
         return res[0];
     }
 
-    private static final XStream XSTREAM = new XStream2();
+    public static final XStream XSTREAM = new XStream2();
     static {
         XSTREAM.alias("fingerprint",Fingerprint.class);
         XSTREAM.alias("range",Range.class);

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1471,6 +1471,13 @@ public class Fingerprint implements ModelObject, Saveable {
 
     private static final XStream2 XSTREAM = new XStream2();
 
+    /**
+     * Provides the XStream instance this class is using for serialization.
+     *
+     * @return the XStream instance
+     * @since FIXME
+     */
+    @Nonnull
     public static XStream2 getXStream() {
         return XSTREAM;
     }

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1469,7 +1469,12 @@ public class Fingerprint implements ModelObject, Saveable {
         return res[0];
     }
 
-    public static final XStream XSTREAM = new XStream2();
+    private static final XStream2 XSTREAM = new XStream2();
+
+    public static XStream2 getXStream() {
+        return XSTREAM;
+    }
+
     static {
         XSTREAM.alias("fingerprint",Fingerprint.class);
         XSTREAM.alias("range",Range.class);


### PR DESCRIPTION
Some plugins needs to register compatibility alias etc for
their FingerprintFacets.

See for example https://github.com/jenkinsci/dockerhub-notification-plugin/pull/11

@reviewbybees 
