### PR TITLE
[JENKINS-33728] - Remove stray getActiveInstance call in layout.jelly

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -158,9 +158,6 @@ ${h.initPageVariables(context)}
       </j:forEach>
     </j:if>
 
-	<j:invokeStatic var="j" className="jenkins.model.Jenkins" method="getActiveInstance" />
-    <j:set var="installState" value="${j.installState.name()}" />
-
     <j:if test="${isMSIE}">
       <script src="${resURL}/scripts/msie.js" type="text/javascript"/>
     </j:if>


### PR DESCRIPTION
layout.jelly had a call to Jenkins.getActiveInstance, which was no longer necessary and caused an exception during the startup wait time.

@reviewbybees esp. @oleg-nenashev 

This should address: https://issues.jenkins-ci.org/browse/JENKINS-33728
