### PR TITLE
[FIX JENKINS-33767] Only show the upgrade banner when Jenkins is in charge

### DIFF
--- a/core/src/main/java/jenkins/install/UpgradeWizard.java
+++ b/core/src/main/java/jenkins/install/UpgradeWizard.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.FileUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.WebApp;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.inject.Inject;
@@ -84,6 +85,11 @@ public class UpgradeWizard extends PageDecorator {
 
         // only admin users should see this
         if (!jenkins.hasPermission(Jenkins.ADMINISTER))
+            return false;
+
+        // only show when Jenkins is fully up & running
+        WebApp wa = WebApp.getCurrent();
+        if (wa==null || !(wa.getApp() instanceof Jenkins))
             return false;
 
         return System.currentTimeMillis() > getStateFile().lastModified();

--- a/test/src/test/java/jenkins/install/UpgradeWizardTest.java
+++ b/test/src/test/java/jenkins/install/UpgradeWizardTest.java
@@ -10,6 +10,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import javax.inject.Inject;
 
 import java.io.IOException;
+import java.util.concurrent.Callable;
 
 import static org.junit.Assert.*;
 
@@ -30,9 +31,16 @@ public class UpgradeWizardTest {
 
     @Test
     public void snooze() throws Exception {
-        assertTrue(uw.isDue());
-        uw.doSnooze();
-        assertFalse(uw.isDue());
+        j.executeOnServer(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                assertTrue(uw.isDue());
+                uw.doSnooze();
+                assertFalse(uw.isDue());
+
+                return null;
+            }
+        });
     }
 
     /**
@@ -40,12 +48,19 @@ public class UpgradeWizardTest {
      */
     @Test
     public void upgrade() throws Exception {
-        assertTrue(j.jenkins.getUpdateCenter().getJobs().size() == 0);
-        assertTrue(newInstance().isDue());
-        assertNotSame(UpgradeWizard.NOOP, uw.doUpgrade());
+        j.executeOnServer(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                assertTrue(j.jenkins.getUpdateCenter().getJobs().size() == 0);
+                assertTrue(newInstance().isDue());
+                assertNotSame(UpgradeWizard.NOOP, uw.doUpgrade());
 
-        // can't really test this because UC metadata is empty
-        // assertTrue(j.jenkins.getUpdateCenter().getJobs().size() > 0);
+                // can't really test this because UC metadata is empty
+                // assertTrue(j.jenkins.getUpdateCenter().getJobs().size() > 0);
+
+                return null;
+            }
+        });
     }
 
     /**
@@ -70,9 +85,16 @@ public class UpgradeWizardTest {
 
     @Test
     public void freshInstallation() throws Exception {
-        assertTrue(uw.isDue());
-        uw.setCurrentLevel(new VersionNumber("2.0"));
-        assertFalse(uw.isDue());
+        j.executeOnServer(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                assertTrue(uw.isDue());
+                uw.setCurrentLevel(new VersionNumber("2.0"));
+                assertFalse(uw.isDue());
+
+                return null;
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
@daniel-beck noticed that the banner shouldn't show up while Jenkins is starting
