### PR TITLE
[FIX JENKINS-33799] Enforce correct icon size in list view

### DIFF
--- a/core/src/main/resources/lib/hudson/ballColorTd.jelly
+++ b/core/src/main/resources/lib/hudson/ballColorTd.jelly
@@ -71,7 +71,7 @@ THE SOFTWARE.
             <j:otherwise>
               <!-- We don't seem to have this icon in the IconSet... fallback again... -->
               <j:set var="iconUrl" value="${it.getImageOf(iconSize)}"/>
-              <l:icon src="${iconUrl}" alt="${it.description}" tooltip="${it.description}" style="${attrs.style}" />
+              <l:icon src="${iconUrl}" class="${iconSizeClass}" alt="${it.description}" tooltip="${it.description}" style="${attrs.style}" />
             </j:otherwise>
           </j:choose>
         </j:otherwise>

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1975,3 +1975,23 @@ body.main-panel-only #main-panel {
         padding: 2em 10%;
     }
 }
+
+IMG.icon-sm {
+    width: 16px;
+    height: 16px;
+}
+
+IMG.icon-md {
+    width: 24px;
+    height: 24px;
+}
+
+IMG.icon-lg {
+    width: 32px;
+    height: 32px;
+}
+
+IMG.icon-xl {
+    width: 48px;
+    height: 48px;
+}

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1976,22 +1976,23 @@ body.main-panel-only #main-panel {
     }
 }
 
-img.icon-sm {
+/* see the Icon class for the definition of these CSS classes */
+.icon-sm {
     width: 16px;
     height: 16px;
 }
 
-img.icon-md {
+.icon-md {
     width: 24px;
     height: 24px;
 }
 
-img.icon-lg {
+.icon-lg {
     width: 32px;
     height: 32px;
 }
 
-img.icon-xl {
+.icon-xlg {
     width: 48px;
     height: 48px;
 }

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1976,22 +1976,22 @@ body.main-panel-only #main-panel {
     }
 }
 
-IMG.icon-sm {
+img.icon-sm {
     width: 16px;
     height: 16px;
 }
 
-IMG.icon-md {
+img.icon-md {
     width: 24px;
     height: 24px;
 }
 
-IMG.icon-lg {
+img.icon-lg {
     width: 32px;
     height: 32px;
 }
 
-IMG.icon-xl {
+img.icon-xl {
     width: 48px;
     height: 48px;
 }


### PR DESCRIPTION
Fix the width & height of the icon via CSS.

Previously, we were relying on the actual image being served as a
correct size. This is fine for icons we ship in Jenkins, but when
plugins use avatars as icons, those images might not come in the correct
size.

@reviewbybees in particular @tfennelly 
