### PR TITLE
initializer annotation on instance methods

### DIFF
--- a/core/src/main/java/hudson/diagnosis/NullIdDescriptorMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/NullIdDescriptorMonitor.java
@@ -60,7 +60,8 @@ public class NullIdDescriptorMonitor extends AdministrativeMonitor {
         return Collections.unmodifiableList(problems);
     }
 
-    private void verify() {
+    @Initializer(after=EXTENSIONS_AUGMENTED)
+    public void verify() {
         Jenkins h = Jenkins.getInstance();
         for (Descriptor d : h.getExtensionList(Descriptor.class)) {
             PluginWrapper p = h.getPluginManager().whichPlugin(d.getClass());
@@ -79,11 +80,6 @@ public class NullIdDescriptorMonitor extends AdministrativeMonitor {
                 problems.add(d);
             }
         }
-    }
-
-    @Initializer(after=EXTENSIONS_AUGMENTED)
-    public static void verifyId() {
-        AdministrativeMonitor.all().get(NullIdDescriptorMonitor.class).verify();
     }
 
     private static final Logger LOGGER = Logger.getLogger(NullIdDescriptorMonitor.class.getName());

--- a/core/src/main/java/hudson/init/Initializer.java
+++ b/core/src/main/java/hudson/init/Initializer.java
@@ -23,6 +23,7 @@
  */
 package hudson.init;
 
+import hudson.Extension;
 import org.jvnet.hudson.annotation_indexer.Indexed;
 import org.jvnet.hudson.reactor.Task;
 
@@ -36,7 +37,7 @@ import static hudson.init.InitMilestone.STARTED;
 import static hudson.init.InitMilestone.COMPLETED;
 
 /**
- * Placed on static methods to indicate that this method is to be run during the Jenkins start up to perform
+ * Placed on methods to indicate that this method is to be run during the Jenkins start up to perform
  * some sort of initialization tasks.
  *
  * <h3>Example</h3>
@@ -46,6 +47,11 @@ import static hudson.init.InitMilestone.COMPLETED;
        ....
    }
  * </pre>
+ *
+ * <p>
+ * The method in question can be either {@code static} or an instance method. When used with instance
+ * methods, those methods have to be on a class annotated with {@link Extension} and marked as
+ * {@link #after()} {@link InitMilestone#PLUGINS_PREPARED}.
  * 
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/init/TaskMethodFinder.java
+++ b/core/src/main/java/hudson/init/TaskMethodFinder.java
@@ -56,9 +56,6 @@ abstract class TaskMethodFinder<T extends Annotation> extends TaskBuilder {
         for (Method e : Index.list(type, cl, Method.class)) {
             if (filter(e)) continue;   // already reported once
 
-            if (!Modifier.isStatic(e.getModifiers()))
-                throw new IOException(e+" is not a static method");
-
             T i = e.getAnnotation(type);
             if (i==null)        continue; // stale index
 
@@ -103,7 +100,10 @@ abstract class TaskMethodFinder<T extends Annotation> extends TaskBuilder {
             Object[] args = new Object[pt.length];
             for (int i=0; i<args.length; i++)
                 args[i] = lookUp(pt[i]);
-            e.invoke(null,args);
+
+            e.invoke(
+                Modifier.isStatic(e.getModifiers()) ? null : lookUp(e.getDeclaringClass()),
+                args);
         } catch (IllegalAccessException x) {
             throw (Error)new IllegalAccessError().initCause(x);
         } catch (InvocationTargetException x) {
@@ -149,7 +149,7 @@ abstract class TaskMethodFinder<T extends Annotation> extends TaskBuilder {
         }
 
         /**
-         * Static method that runs the initialization, that this task wraps.
+         * Method that runs the initialization, that this task wraps.
          */
         public Method getMethod() {
             return e;

--- a/core/src/main/java/hudson/init/Terminator.java
+++ b/core/src/main/java/hudson/init/Terminator.java
@@ -11,6 +11,8 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
+ * Like {@link Initializer} but used during the shut down.
+ *
  * @author Kohsuke Kawaguchi
  */
 @Indexed

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -970,6 +970,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             @Override
             protected void onInitMilestoneAttained(InitMilestone milestone) {
                 initLevel = milestone;
+                if (milestone==PLUGINS_PREPARED) {
+                    // set up Guice to enable injection as early as possible
+                    // before this milestone, ExtensionList.ensureLoaded() won't actually try to locate instances
+                    ExtensionList.lookup(ExtensionFinder.class).getComponents();
+                }
             }
         }.run(reactor);
     }

--- a/core/src/main/java/jenkins/model/Uptime.java
+++ b/core/src/main/java/jenkins/model/Uptime.java
@@ -27,7 +27,7 @@ public class Uptime {
     }
 
     @Initializer(after=InitMilestone.JOB_LOADED)
-    public static void init() {
-        ExtensionList.lookup(Uptime.class).get(0).startTime = System.currentTimeMillis();
+    public void init() {
+        startTime = System.currentTimeMillis();
     }
 }

--- a/core/src/main/java/jenkins/security/RekeySecretAdminMonitor.java
+++ b/core/src/main/java/jenkins/security/RekeySecretAdminMonitor.java
@@ -113,13 +113,11 @@ public class RekeySecretAdminMonitor extends AsynchronousAdministrativeMonitor i
 
     @Initializer(fatal=false,after=InitMilestone.PLUGINS_STARTED,before=InitMilestone.EXTENSIONS_AUGMENTED)
     // as early as possible, but this needs to be late enough that the ConfidentialStore is available
-    public static void scanOnReboot() throws InterruptedException, IOException, GeneralSecurityException {
-        RekeySecretAdminMonitor m = new RekeySecretAdminMonitor();  // throw-away instance
-
-        FileBoolean flag = m.scanOnBoot;
+    public void scanOnReboot() throws InterruptedException, IOException, GeneralSecurityException {
+        FileBoolean flag = scanOnBoot;
         if (flag.isOn()) {
             flag.off();
-            m.start(false).join();
+            start(false).join();
             // block the boot until the rewrite process is complete
             // don't let the failure in RekeyThread block Jenkins boot.
         }

--- a/core/src/main/java/jenkins/slaves/NioChannelSelector.java
+++ b/core/src/main/java/jenkins/slaves/NioChannelSelector.java
@@ -1,6 +1,7 @@
 package jenkins.slaves;
 
 import hudson.Extension;
+import hudson.init.Terminator;
 import hudson.model.Computer;
 import org.jenkinsci.remoting.nio.NioChannelHub;
 
@@ -32,6 +33,14 @@ public class NioChannelSelector {
 
     public NioChannelHub getHub() {
         return hub;
+    }
+
+    @Terminator
+    public void cleanUp() throws IOException {
+        if (hub!=null) {
+            hub.close();
+            hub = null;
+        }
     }
 
     /**


### PR DESCRIPTION
Improve the `@Initializer` annotation by allowing it to be on instance methods. This often eliminates the need of instance lookup via `ExtensionList` and others.

This PR also contains `NioChannelSelector` termination, which leaks `NioChannelHub`, which is what got me looking into this space in the first place. This problem manifests itself in unit tests that show tons of leaked threads.

Yes, I know, I know, one shouldn't put two changes in one PR.

@reviewbybees
