### PR TITLE
Don't go through init sequence twice

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -443,6 +443,14 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     session.addAll(g.discoverTasks(session));
                 }
             });
+
+            // All plugins are loaded. Now we can figure out who depends on who.
+            requires(PLUGINS_PREPARED).attains(COMPLETED).add("Resolving Dependant Plugins Graph", new Executable() {
+                @Override
+                public void run(Reactor reactor) throws Exception {
+                    resolveDependantPlugins();
+                }
+            });
         }});
     }
 

--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -225,6 +225,11 @@ public class WebAppMain implements ServletContextListener {
                     boolean success = false;
                     try {
                         Jenkins instance = new Hudson(_home, context);
+
+                        // one last check to make sure everything is in order before we go live
+                        if (Thread.interrupted())
+                            throw new InterruptedException();
+
                         context.setAttribute(APP, instance);
 
                         BootFailure.getBootFailureFile(_home).delete();

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -896,28 +896,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                             System.currentTimeMillis()-itemListenerStart,l.getClass().getName()));
             }
 
-            // All plugins are loaded. Now we can figure out who depends on who.
-            resolveDependantPlugins();
-
             if (LOG_STARTUP_PERFORMANCE)
                 LOGGER.info(String.format("Took %dms for complete Jenkins startup",
                         System.currentTimeMillis()-start));
         } finally {
             SecurityContextHolder.clearContext();
         }
-    }
-
-    private void resolveDependantPlugins() throws InterruptedException, ReactorException, IOException {
-        TaskGraphBuilder graphBuilder = new TaskGraphBuilder();
-
-        graphBuilder.add("Resolving Dependant Plugins Graph", new Executable() {
-            @Override
-            public void run(Reactor reactor) throws Exception {
-                pluginManager.resolveDependantPlugins();
-            }
-        });
-
-        executeReactor(null, graphBuilder);
     }
 
     /**

--- a/test/src/test/java/hudson/util/BootFailureTest.java
+++ b/test/src/test/java/hudson/util/BootFailureTest.java
@@ -154,8 +154,6 @@ public class BootFailureTest {
         @Override
         public void onLoaded() {
             wa.contextDestroyed(null);
-            // make the Jenkins.<init> thread abort
-            throw new Error();
         }
     }
 

--- a/test/src/test/java/hudson/util/BootFailureTest.java
+++ b/test/src/test/java/hudson/util/BootFailureTest.java
@@ -154,6 +154,8 @@ public class BootFailureTest {
         @Override
         public void onLoaded() {
             wa.contextDestroyed(null);
+            // make the Jenkins.<init> thread abort
+            throw new Error();
         }
     }
 


### PR DESCRIPTION
As a part of #1847, 3b5424e507be introduced a second invocation to
executeReactor. This is causing a problem in that it exectes
InitMilestone progression twice. If you are looking at
Jenkins.getInitLevel() it will go through STARTED ... COMPLETED once,
then it goes back to STARTED and then go to COMPLETED again.

And this code looks bit odd anyway. Why execute a whole reactor
just to make one method invocation? But I didn't see any discussion of
this in PR 1847.

This change fixes this oddity by making this a part of the main
(and sole) initialization reactor session. It's not clear what
milestone should be the pre-requisite, but given that it's only looking
at dependency chain, PLUGINS_PREPARED should be adequate.

@reviewbybees in particular @tfennelly who wrote the original change
