### PR TITLE
[FIXED JENKINS-33848] - Do not try to resolve empty strings in Items:fromNameList()

### DIFF
--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -182,15 +182,21 @@ public class Items {
      * Does the opposite of {@link #toNameList(Collection)}.
      */
     public static <T extends Item> List<T> fromNameList(ItemGroup context, @Nonnull String list, @Nonnull Class<T> type) {
-        Jenkins hudson = Jenkins.getInstance();
-
+        final Jenkins jenkins = Jenkins.getInstance();
+        
         List<T> r = new ArrayList<T>();
+        if (jenkins == null) {
+            return r;
+        }
+        
         StringTokenizer tokens = new StringTokenizer(list,",");
         while(tokens.hasMoreTokens()) {
             String fullName = tokens.nextToken().trim();
-            T item = hudson.getItem(fullName, context, type);
-            if(item!=null)
-                r.add(item);
+            if (StringUtils.isNotEmpty(fullName)) {
+                T item = jenkins.getItem(fullName, context, type);
+                if(item!=null)
+                    r.add(item);
+            }
         }
         return r;
     }


### PR DESCRIPTION
ReverseBuildTrigger autocompletes lists of jobs by delimiters when you select items, so sometimes you get the "Jib1, Job2, " in the form submission. Then ReverseBuildTrigger invokes Items::fromNameList() in order to resolve the dependency graph.

In this method Jenkins splits the string, trims it and then tries to resolve jobs. In such case an empty string is being passed to the resolution code. It may be unsafe since items (e.g. folders) may somehow override and mishandle the logic.

It would be useful to avoid such resolution attempts.

https://issues.jenkins-ci.org/browse/JENKINS-33848

@reviewbybees
