### PR TITLE
[JENKINS-33826] build history badges styling issues

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1124,14 +1124,25 @@ table.parameters > tbody:hover {
 }
 .build-row-cell .build-badge {
   display: inline-block;
-  padding: 2px;
-  width: 70%;
   text-align: right;
+  width: 70%;
+  padding: 2px 0;
 }
-.build-row-cell .build-badge span:after {
-    content: " ";
-    font-size: 0%;
+.build-row-cell .build-badge > span {
+  display: inline-block;
+  max-width: 256px;
+  padding: 0 1px;
+  overflow: hidden;
 }
+.build-row-cell .build-badge > span + span {
+  margin: 0 0 0 2px !important;
+}
+@media (min-width: 1170px) {
+  .build-row-cell .build-badge > span {
+    max-width: 296px;
+  }
+}
+
 .build-row .build-name-controls .pane.build-name,
 .build-row .build-details-controls .pane.build-details {
   width: 70%;


### PR DESCRIPTION
Handles badges with excessive width, which would otherwise overlap the page, potentially cause usability issues:

![image](https://cloud.githubusercontent.com/assets/3009477/14079207/01264d80-f4ca-11e5-82ba-89897ab12920.png)

This should address: https://issues.jenkins-ci.org/browse/JENKINS-33826

@reviewbybees
