### PR TITLE
[FIX JENKINS-33801] showing label as title element for buttons

### DIFF
--- a/core/src/main/resources/lib/form/repeatableDeleteButton.jelly
+++ b/core/src/main/resources/lib/form/repeatableDeleteButton.jelly
@@ -32,5 +32,5 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
   <st:adjunct includes="lib.form.repeatable.repeatable"/>
-  <input type="button" value="${attrs.value ?: '%Delete'}" class="repeatable-delete danger" />
+  <input type="button" value="${attrs.value ?: '%Delete'}" title="${attrs.value ?: '%Delete'}" class="repeatable-delete danger" />
 </j:jelly>

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -520,9 +520,9 @@ function makeButton(e,onclick) {
         btn.addListener("click",h);
     var be = btn.get("element");
     Element.addClassName(be,clsName);
+    be.setAttribute("title",e.value);
     if(n){ // copy the name
         be.setAttribute("name",n);
-        be.setAttribute("title",n);
     }
     return btn;
 }

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -520,8 +520,10 @@ function makeButton(e,onclick) {
         btn.addListener("click",h);
     var be = btn.get("element");
     Element.addClassName(be,clsName);
-    if(n) // copy the name
+    if(n){ // copy the name
         be.setAttribute("name",n);
+        be.setAttribute("title",n);
+    }
     return btn;
 }
 

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -520,7 +520,6 @@ function makeButton(e,onclick) {
         btn.addListener("click",h);
     var be = btn.get("element");
     Element.addClassName(be,clsName);
-    be.setAttribute("title",e.value);
     if(n){ // copy the name
         be.setAttribute("name",n);
     }


### PR DESCRIPTION
@reviewbybees

The display string for button in the config form are now also shown as the value of the "title" attribute, to add a bit of tool-tip text. This is particularly important for the new delete buttons which don't otherwise have text.
