### PR TITLE
[JENKINS-33813] - fix issues when errors happen during setup wizard

### DIFF
--- a/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
@@ -29,7 +29,6 @@
                     <label class="control-label" for="security-token">${%Administrator password}</label>
                     <input name="j_username" value="${j.setupWizard.initialSetupAdminUserName}" type="hidden"/>
                     <input id="security-token" class="form-control" type="password" name="j_password"/>
-                    <link rel="stylesheet" href="${j.installWizardPath}.css" type="text/css" />
                     </div>
                     
                   </div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -49,3 +49,4 @@ installWizard_configureProxy_save=Save and Continue
 installWizard_skipPluginInstallations=Skip Plugin Installations
 installWizard_installIncomplete_dependenciesLabel=Dependencies
 installWizard_installingConsole_dependencyIndicatorNote=** - required dependency
+installWizard_retry=Retry

--- a/core/src/main/resources/lib/layout/html.jelly
+++ b/core/src/main/resources/lib/layout/html.jelly
@@ -155,9 +155,8 @@ ${h.initPageVariables(context)}
       </j:forEach>
     </j:if>
 
-  <j:invokeStatic var="j" className="jenkins.model.Jenkins" method="getActiveInstance" />
-    <j:set var="installState" value="${j.installState.name()}" />
-    <j:if test="${installState == 'NEW' || installState == 'INITIAL_PLUGINS_INSTALLING'}">
+    <j:invokeStatic var="j" className="jenkins.model.Jenkins" method="getInstance" />
+    <j:if test="${!j.installState.setupComplete}">
       <script src="${resURL}/${j.installWizardPath}.js" type="text/javascript"/>
       <link rel="stylesheet" href="${resURL}/${j.installWizardPath}.css" type="text/css" />
     </j:if>

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -777,6 +777,10 @@ var createPluginSetupWizard = function(appendTarget) {
 			jenkins.goTo('/');
 		}));
 	};
+	
+	var startOver = function() {
+		jenkins.goTo('/');
+	};
 
 	// scoped click handler, prevents default actions automatically
 	var bindClickHandler = function(cls, action) {
@@ -807,7 +811,8 @@ var createPluginSetupWizard = function(appendTarget) {
 		'.skip-first-user': skipFirstUser,
 		'.show-proxy-config': setupProxy,
 		'.save-proxy-config': saveProxyConfig,
-		'.skip-plugin-installs': function() { installPlugins([]); }
+		'.skip-plugin-installs': function() { installPlugins([]); },
+		'.start-over': startOver
 	};
 	for(var cls in actions) {
 		bindClickHandler(cls, actions[cls]);

--- a/war/src/main/js/templates/errorPanel.hbs
+++ b/war/src/main/js/templates/errorPanel.hbs
@@ -2,10 +2,15 @@
 	<h4 class="modal-title">Error</h4>
 </div>
 <div class="modal-body">
-	<div class="container error-container">
+	<div class="container error-container" id="error-message">
 		<h1>{{translations.installWizard_error_header}}</h1>
 		<div class="alert alert-danger fade in">
 			{{errorMessage}}
 		</div>
 	</div>
+</div>
+<div class="modal-footer">
+	<button type="button" class="btn btn-primary start-over">
+		{{translations.installWizard_retry}}
+	</button>
 </div>

--- a/war/src/main/less/pluginSetupWizard.less
+++ b/war/src/main/less/pluginSetupWizard.less
@@ -78,7 +78,8 @@
 
     .container.error-container {
         padding: 4em 3em;
-
+        max-width: 100%;
+        
         h1 {
         color: #a94442;
     }


### PR DESCRIPTION
This corrects a few things during the setup wizard:
- styling issues on the security token page after plugins installed
- styling on the error page
- add option to retry the setup wizard (e.g. if session times out)

![image](https://cloud.githubusercontent.com/assets/3009477/14092641/70da0792-f516-11e5-866e-260e5afd812f.png)

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-33813

@reviewbybees
