### PR TITLE
[JENKINS-33800] - fileNotFound exception / more accurately determine if this is an upgrade

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1193,7 +1193,6 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     }
 			updateCenter.persistInstallStatus();
                     jenkins.setInstallState(InstallState.INITIAL_PLUGINS_INSTALLING.getNextState());
-                    InstallUtil.saveLastExecVersion();
                 }
             }.start();
         }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -53,7 +53,6 @@ import hudson.util.IOUtils;
 import hudson.util.PersistedList;
 import hudson.util.XStream2;
 import jenkins.RestartRequiredException;
-import jenkins.install.InstallState;
 import jenkins.install.InstallUtil;
 import jenkins.model.Jenkins;
 import jenkins.util.io.OnMaster;
@@ -1913,18 +1912,14 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     @Initializer(after=PLUGINS_STARTED, fatal=false)
     public static void init(Jenkins h) throws IOException {
         h.getUpdateCenter().load();
-        if (Jenkins.getActiveInstance().getInstallState() == InstallState.NEW) {
-            LOGGER.log(INFO, "This is a new Jenkins instance. The Plugin Install Wizard will be launched.");
-            // Force update of the default site file (updates/default.json).
-            updateDefaultSite();
-        }
     }
 
-    private static void updateDefaultSite() {
+    @Restricted(NoExternalUse.class)
+    public static void updateDefaultSite() {
         try {
             // Need to do the following because the plugin manager will attempt to access
             // $JENKINS_HOME/updates/default.json. Needs to be up to date.
-            Jenkins.getActiveInstance().getUpdateCenter().getSite(UpdateCenter.ID_DEFAULT).updateDirectlyNow(true);
+            Jenkins.getInstance().getUpdateCenter().getSite(UpdateCenter.ID_DEFAULT).updateDirectlyNow(true);
         } catch (Exception e) {
             LOGGER.log(WARNING, "Upgrading Jenkins. Failed to update default UpdateSite. Plugin upgrades may fail.", e);
         }

--- a/core/src/main/java/jenkins/install/InstallState.java
+++ b/core/src/main/java/jenkins/install/InstallState.java
@@ -23,6 +23,8 @@
  */
 package jenkins.install;
 
+import javax.annotation.CheckForNull;
+
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -33,6 +35,10 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  */
 @Restricted(NoExternalUse.class)
 public enum InstallState {
+    /**
+     * Need InstallState != NEW for tests by default
+     */
+    UNKNOWN(true, null),
     /**
      * The initial set up has been completed
      */
@@ -90,6 +96,7 @@ public enum InstallState {
     /**
      * Gets the next state
      */
+    @CheckForNull
     public InstallState getNextState() {
         return nextState;
     }

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -45,6 +45,7 @@ import com.thoughtworks.xstream.XStream;
 import hudson.Functions;
 import hudson.model.UpdateCenter.DownloadJob.InstallationStatus;
 import hudson.model.UpdateCenter.DownloadJob.Installing;
+import hudson.security.SecurityRealm;
 import hudson.model.UpdateCenter.InstallationJob;
 import hudson.model.UpdateCenter.UpdateCenterJob;
 import hudson.util.VersionNumber;
@@ -88,7 +89,8 @@ public class InstallUtil {
             // Edge case: used Jenkins 1 but did not save the system config page,
             // the version is not persisted and returns 1.0, so try to check if
             // they actually did anything
-            if (!Jenkins.getInstance().getItemMap().isEmpty()) {
+            if (!Jenkins.getInstance().getItemMap().isEmpty()
+                    || Jenkins.getInstance().getSecurityRealm() != SecurityRealm.NO_AUTHENTICATION) {
                 return InstallState.UPGRADE;
             }
             return InstallState.NEW;

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -107,29 +107,43 @@ public class SetupWizard {
             }
         }
 
-        String setupKey = iapf.readToString().trim();
-        String ls = System.lineSeparator();
-        LOGGER.info(ls + ls + "*************************************************************" + ls
-                + "*************************************************************" + ls
-                + "*************************************************************" + ls
-                + ls
-                + "Jenkins initial setup is required. An admin user has been created and "
-                + "a password generated." + ls
-                + "Please use the following password to proceed to installation:" + ls
-                + ls
-                + setupKey + ls
-                + ls
-                + "This may also be found at: " + iapf.getRemote() + ls
-                + ls
-                + "*************************************************************" + ls
-                + "*************************************************************" + ls
-                + "*************************************************************" + ls);
+        if(iapf.exists()) {
+            String setupKey = iapf.readToString().trim();
+            String ls = System.lineSeparator();
+            LOGGER.info(ls + ls + "*************************************************************" + ls
+                    + "*************************************************************" + ls
+                    + "*************************************************************" + ls
+                    + ls
+                    + "Jenkins initial setup is required. An admin user has been created and "
+                    + "a password generated." + ls
+                    + "Please use the following password to proceed to installation:" + ls
+                    + ls
+                    + setupKey + ls
+                    + ls
+                    + "This may also be found at: " + iapf.getRemote() + ls
+                    + ls
+                    + "*************************************************************" + ls
+                    + "*************************************************************" + ls
+                    + "*************************************************************" + ls);
+        }
         
         try {
             PluginServletFilter.addFilter(FORCE_SETUP_WIZARD_FILTER);
         } catch (ServletException e) {
             throw new AssertionError(e);
         }
+    }
+    
+    /**
+     * Indicates a generated password should be used - e.g. this is a new install, no security realm set up
+     */
+    public boolean useGeneratedPassword() {
+        try {
+            return getInitialAdminPasswordFile().exists();
+        } catch (Exception e) {
+            // ignore
+        }
+        return false;
     }
 
     /**

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -3,6 +3,7 @@ package jenkins.install;
 import java.io.IOException;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.Filter;
@@ -25,6 +26,7 @@ import org.kohsuke.stapler.StaplerResponse;
 
 import hudson.BulkChange;
 import hudson.FilePath;
+import hudson.model.UpdateCenter;
 import hudson.model.User;
 import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
 import hudson.security.HudsonPrivateSecurityRealm;
@@ -32,6 +34,7 @@ import hudson.security.SecurityRealm;
 import hudson.security.csrf.DefaultCrumbIssuer;
 import hudson.util.HttpResponses;
 import hudson.util.PluginServletFilter;
+import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import jenkins.security.s2m.AdminWhitelistRule;
 
@@ -58,7 +61,7 @@ public class SetupWizard {
         // this was determined to be a new install, don't run the update wizard here
         UpgradeWizard uw = jenkins.getInjector().getInstance(UpgradeWizard.class);
         if (uw!=null)
-            uw.setCurrentLevel(Jenkins.getVersion());
+            uw.setCurrentLevel(new VersionNumber("2.0"));
         
         // Create an admin user by default with a 
         // difficult password
@@ -125,6 +128,13 @@ public class SetupWizard {
             PluginServletFilter.addFilter(FORCE_SETUP_WIZARD_FILTER);
         } catch (ServletException e) {
             throw new AssertionError(e);
+        }
+        
+        try {
+            // Make sure plugin metadata is up to date
+            UpdateCenter.updateDefaultSite();
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, e.getMessage(), e);
         }
     }
     

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -342,7 +342,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * The Jenkins instance startup type i.e. NEW, UPGRADE etc
      */
-    private transient InstallState installState = InstallState.NEW;
+    private transient InstallState installState = InstallState.UNKNOWN;
     
     /**
      * If we're in the process of an initial setup, 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -810,11 +810,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 throw new IllegalStateException("second instance");
             theInstance = this;
 
-            installState = InstallUtil.getInstallState();
-            if (installState == InstallState.RESTART || installState == InstallState.DOWNGRADE) {
-                InstallUtil.saveLastExecVersion();
-            }
-            
             if (!new File(root,"jobs").exists()) {
                 // if this is a fresh install, use more modern default layout that's consistent with agents
                 workspaceDir = "${JENKINS_HOME}/workspace/${ITEM_FULLNAME}";
@@ -875,6 +870,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             if(KILL_AFTER_LOAD)
                 System.exit(0);
 
+            installState = InstallUtil.getInstallState();
+            if (installState == InstallState.RESTART || installState == InstallState.DOWNGRADE) {
+                InstallUtil.saveLastExecVersion();
+            }
+            
             if(!installState.isSetupComplete()) {
                 // Start immediately with the setup wizard for new installs
                 setupWizard = new SetupWizard(this);

--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:choose>
-  <j:when test="${it.setupWizard.useGeneratedPassword()}">
+  <j:when test="${it.setupWizard != null and it.setupWizard.useGeneratedPassword()}">
     <st:include it="${it.setupWizard}" page="authenticate-security-token"/>
   </j:when>
   <j:otherwise>

--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -24,10 +24,11 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <j:if test="${it.setupWizard != null}">
+  <j:choose>
+  <j:when test="${it.setupWizard.useGeneratedPassword()}">
     <st:include it="${it.setupWizard}" page="authenticate-security-token"/>
-  </j:if>
-  <j:if test="${it.setupWizard == null}">
+  </j:when>
+  <j:otherwise>
   <l:layout norefresh="true">
     <l:hasPermission permission="${app.READ}">
       <st:include page="sidepanel.jelly" />
@@ -74,5 +75,6 @@ THE SOFTWARE.
       </div>
     </l:main-panel>
   </l:layout>
-  </j:if>
+  </j:otherwise>
+  </j:choose>
 </j:jelly>

--- a/core/src/main/resources/jenkins/model/Jenkins/loginError.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/loginError.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:choose>
     <j:new var="h" className="hudson.Functions" />
-    <j:when test="${app.setupWizard != null}">
+    <j:when test="${app.setupWizard.useGeneratedPassword()}">
       <j:set var="error" value="true"/>
       <st:include it="${app.setupWizard}" page="authenticate-security-token"/>
     </j:when>

--- a/core/src/main/resources/jenkins/model/Jenkins/loginError.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/loginError.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:choose>
     <j:new var="h" className="hudson.Functions" />
-    <j:when test="${app.setupWizard.useGeneratedPassword()}">
+    <j:when test="${app.setupWizard != null and app.setupWizard.useGeneratedPassword()}">
       <j:set var="error" value="true"/>
       <st:include it="${app.setupWizard}" page="authenticate-security-token"/>
     </j:when>


### PR DESCRIPTION
If the Jenkins 1 global settings are never saved and no jobs were created, the setup wizard may treat this case as a new installation. In the case the security config is saved, this causes an issue - this more "accurately" determines if this instance is actually an upgrade vs. a new install and prevents a fileNotFound exception looking for the setup token.

This addresses issue: https://issues.jenkins-ci.org/browse/JENKINS-33800

@reviewbybees
