### PR TITLE
[JENKINS-33601] - setup wizard: remove 'skip' user creation, include security config

### DIFF
--- a/core/src/main/java/jenkins/install/InstallState.java
+++ b/core/src/main/java/jenkins/install/InstallState.java
@@ -26,6 +26,9 @@ package jenkins.install;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+import hudson.security.HudsonPrivateSecurityRealm;
+import jenkins.model.Jenkins;
+
 /**
  * Jenkins install state.
  *
@@ -42,10 +45,22 @@ public enum InstallState {
      */
     CREATE_ADMIN_USER(false, INITIAL_SETUP_COMPLETED),
     /**
+     * Configure security
+     */
+    CONFIGURE_SECURITY(false, CREATE_ADMIN_USER) {
+        @Override
+        public InstallState getNextState() {
+            if(Jenkins.getInstance().getSecurityRealm() instanceof HudsonPrivateSecurityRealm) {
+                return CREATE_ADMIN_USER;
+            }
+            return INITIAL_SETUP_COMPLETED;
+        }
+    },
+    /**
      * New Jenkins install. The user has kicked off the process of installing an
      * initial set of plugins (via the install wizard).
      */
-    INITIAL_PLUGINS_INSTALLING(false, CREATE_ADMIN_USER),
+    INITIAL_PLUGINS_INSTALLING(false, CONFIGURE_SECURITY),
     /**
      * New Jenkins install.
      */

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
@@ -11,7 +11,7 @@ def f=namespace(lib.FormTagLib)
 def l=namespace(lib.LayoutTagLib)
 def st=namespace("jelly:stapler")
 
-l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
+l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName, cssclass:request.getParameter('decorate')) {
     l.main_panel {
         h1 {
             l.icon(class: 'icon-secure icon-xlg')

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -46,6 +46,8 @@ the security token you used to access the setup wizard.\
 installWizard_addFirstUser_title=Getting Started
 installWizard_configureProxy_label=Configure Proxy
 installWizard_configureProxy_save=Save and Continue
+installWizard_gettingStarted_title=Getting Started
+installWizard_saveSecurity=Save and Continue
 installWizard_skipPluginInstallations=Skip Plugin Installations
 installWizard_installIncomplete_dependenciesLabel=Dependencies
 installWizard_installingConsole_dependencyIndicatorNote=** - required dependency

--- a/war/src/main/js/api/securityConfig.js
+++ b/war/src/main/js/api/securityConfig.js
@@ -29,3 +29,16 @@ exports.saveProxy = function($form, success, error) {
 			error: error
 		});
 };
+
+/**
+ * Calls a stapler post method to save the security configuration
+ */
+exports.saveSecurity = function($form, success, error) {
+	jenkins.staplerPost(
+			'/setupWizard/saveSecurityConfig',
+		$form,
+		success, {
+			dataType: 'html',
+			error: error
+		});
+};

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -114,6 +114,7 @@ var createPluginSetupWizard = function(appendTarget) {
 	var setupCompletePanel = require('./templates/setupCompletePanel.hbs');
 	var proxyConfigPanel = require('./templates/proxyConfigPanel.hbs');
 	var firstUserPanel = require('./templates/firstUserPanel.hbs');
+	var securityPanel = require('./templates/securityPanel.hbs');
 	var offlinePanel = require('./templates/offlinePanel.hbs');
 	var pluginSetupWizard = require('./templates/pluginSetupWizard.hbs');
 	var incompleteInstallationPanel = require('./templates/incompleteInstallationPanel.hbs');
@@ -322,14 +323,38 @@ var createPluginSetupWizard = function(appendTarget) {
 			installPlugins(pluginManager.recommendedPluginNames());
 		});
 	};
+	
+	// indicates 
+	var transitionPanel = function(state) {
+		if(/CREATE_ADMIN_USER/.test(state)) {
+			setupFirstUser();
+			return true;
+		}
+		if(/CONFIGURE_SECURITY/.test(state)) {
+			setupSecurity();
+			return true;
+		}
+		if(/INITIAL_SETUP_COMPLETED/.test(state)) {
+			setPanel(setupCompletePanel);
+			return true;
+		}
+		if(/INITIAL_PLUGINS_INSTALLING/.test(state)) {
+			showInstallProgress();
+			return true;
+		}
+		return false;
+	};
+	
+	var checkStateAndNavigate = function() {
+		pluginManager.installStatus(handleGenericError(function(data) {
+			transitionPanel(data.state);
+		}));
+	};
 
 	// Define actions
 	var showInstallProgress = function(state) {
-		if(state) {
-			if(/CREATE_ADMIN_USER/.test(state)) {
-				setupFirstUser();
-				return;
-			}
+		if(state && transitionPanel(state)) {
+			return;
 		}
 
 		initInstallingPluginList();
@@ -429,7 +454,7 @@ var createPluginSetupWizard = function(appendTarget) {
 				else {
 					// mark complete
 					$('.progress-bar').css({width: '100%'});
-					setupFirstUser();
+					checkStateAndNavigate();
 				}
 			}));
 		};
@@ -687,33 +712,52 @@ var createPluginSetupWizard = function(appendTarget) {
 		setPanel(firstUserPanel, {}, enableButtonsAfterFrameLoad);
 	};
 	
+	var setupSecurity = function() {
+		setPanel(securityPanel, {}, enableButtonsAfterFrameLoad);
+	};
+	
+	var handleStaplerSubmit = function(data) {
+		if(data.status && data.status > 200) {
+			// Nothing we can really do here
+			setPanel(errorPanel, { errorMessage: data.statusText });
+			return;
+		}
+		
+		try {
+			if(JSON.parse(data).status == 'ok') {
+				checkStateAndNavigate();
+				return;
+			}
+		} catch(e) {
+			// ignore JSON parsing issues, this may be HTML
+		}
+		// we get 200 OK
+		var $page = $(data);
+		var $errors = $page.find('.error');
+		if($errors.length > 0) {
+			var $main = $page.find('#main-panel').detach();
+			if($main.length > 0) {
+				data = data.replace(/body([^>]*)[>](.|[\r\n])+[<][/]body/,'body$1>'+$main.html()+'</body');
+			}
+			var doc = $('iframe[src]').contents()[0];
+			doc.open();
+			doc.write(data);
+			doc.close();
+		}
+		else {
+			checkStateAndNavigate();
+		}
+	};
+	
 	// call to submit the firstuser
 	var saveFirstUser = function() {
 		$('button').prop({disabled:true});
-		var handleSubmit = function(data) {
-			if(data.status && data.status > 200) {
-				// Nothing we can really do here
-				setPanel(errorPanel, { errorMessage: data.statusText });
-				return;
-			}
-			// we get 200 OK
-			var $page = $(data);
-			var $errors = $page.find('.error');
-			if($errors.length > 0) {
-				var $main = $page.find('#main-panel').detach();
-				if($main.length > 0) {
-					data = data.replace(/body([^>]*)[>](.|[\r\n])+[<][/]body/,'body$1>'+$main.html()+'</body');
-				}
-				var doc = $('iframe[src]').contents()[0];
-				doc.open();
-				doc.write(data);
-				doc.close();
-			}
-			else {
-				setPanel(setupCompletePanel);
-			}
-		};
-		securityConfig.saveFirstUser($('iframe[src]').contents().find('form:not(.no-json)'), handleSubmit, handleSubmit);
+		securityConfig.saveFirstUser($('iframe[src]').contents().find('form:not(.no-json)'), handleStaplerSubmit, handleStaplerSubmit);
+	};
+
+	var saveSecurity = function() {
+		$('button').prop({disabled:true});
+		securityConfig.saveSecurity($('iframe[src]').contents().find('form[name=config]'), handleStaplerSubmit, handleStaplerSubmit);
 	};
 	
 	var skipFirstUser = function() {
@@ -732,6 +776,7 @@ var createPluginSetupWizard = function(appendTarget) {
 			jenkins.goTo('/'); // this will re-run connectivity test
 		});
 	};
+	
 	
 	// Call this to resume an installation after restart
 	var resumeInstallation = function() {
@@ -807,6 +852,7 @@ var createPluginSetupWizard = function(appendTarget) {
 		'.skip-first-user': skipFirstUser,
 		'.show-proxy-config': setupProxy,
 		'.save-proxy-config': saveProxyConfig,
+		'.save-security': saveSecurity,
 		'.skip-plugin-installs': function() { installPlugins([]); }
 	};
 	for(var cls in actions) {

--- a/war/src/main/js/templates/firstUserPanel.hbs
+++ b/war/src/main/js/templates/firstUserPanel.hbs
@@ -7,9 +7,6 @@
 	</div>
 </div>
 <div class="modal-footer">
-    <button type="button" class="btn btn-link skip-first-user" disabled>
-        {{translations.installWizard_skipFirstUser}}
-    </button>
 	<button type="button" class="btn btn-primary save-first-user" disabled>
 		{{translations.installWizard_saveFirstUser}}
 	</button>

--- a/war/src/main/js/templates/securityPanel.hbs
+++ b/war/src/main/js/templates/securityPanel.hbs
@@ -1,0 +1,13 @@
+<div class="modal-header">
+	<h4 class="modal-title">{{translations.installWizard_gettingStarted_title}}</h4>
+</div>
+<div class="modal-body">
+	<div class="jumbotron welcome-panel security-panel">
+		<iframe src="{{baseUrl}}/configureSecurity?decorate=no-decoration+no-sticker"></iframe>
+	</div>
+</div>
+<div class="modal-footer">
+	<button type="button" class="btn btn-primary save-security" disabled>
+		{{translations.installWizard_saveSecurity}}
+	</button>
+</div>

--- a/war/src/main/js/util/jenkins.js
+++ b/war/src/main/js/util/jenkins.js
@@ -224,9 +224,11 @@ exports.getWindow = function($form) {
 	$(top.document).find('iframe').each(function() {
 		var windowFrame = this.contentWindow;
 		var $f = $(this).contents().find('form');
-		if($f.length > 0 && $form[0] === $f[0]) {
-			wnd = windowFrame;
-		}
+		$f.each(function() {
+			if($form[0] === this) {
+				wnd = windowFrame;
+			}
+		});
 	});
 	return wnd;
 };

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1976,6 +1976,18 @@ body.main-panel-only #main-panel {
     }
 }
 
+body.no-decoration #main-panel {
+    margin: 0 auto !important;
+}
+body.no-decoration #page-head,
+body.no-decoration #side-panel,
+body.no-decoration footer {
+    display: none;
+}
+body.no-sticker #bottom-sticker {
+    display: none;
+}
+
 /* see the Icon class for the definition of these CSS classes */
 .icon-sm {
     width: 16px;

--- a/war/src/test/js/pluginSetupWizard-spec.js
+++ b/war/src/test/js/pluginSetupWizard-spec.js
@@ -355,10 +355,10 @@ describe("pluginSetupWizard.js", function () {
         setTimeout(function() {
                 expect($('.install-done').is(':visible')).toBe(false);
 
-                expect($('.save-first-user').is(':visible')).toBe(true);
+                expect($('.installing-panel').is(':visible')).toBe(true);
 
                 done();
-        }, 500);
+        }, 1);
 
             goButton.click();
         }, ajaxMappings);


### PR DESCRIPTION
Removes the 'skip' option when using HudsonPrivateSecurityRealm, adds security config as step in the setup wizard.

Even if it's decided not to include the security config in setup wizard at this point, this PR is probably still beneficial to include, as it has some changes that make it easier to rearrange or add steps to the setup wizard, which will be useful for using it as an upgrade wizard.

Addresses: https://issues.jenkins-ci.org/browse/JENKINS-33601
