### PR TITLE
Use rerunFailingTestsCount rather than @RandomlyFails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.16</version> <!-- ignoring ${maven-surefire-plugin.version} -->
+          <version>2.19.1</version> <!-- ignoring ${maven-surefire-plugin.version} -->
           <configuration>
             <argLine>-noverify</argLine> <!-- some versions of JDK7/8 causes VerifyError during mock tests: http://code.google.com/p/powermock/issues/detail?id=504 -->
             <systemPropertyVariables>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -39,7 +39,6 @@ THE SOFTWARE.
   <properties>
     <concurrency>2</concurrency> <!-- may use e.g. 2C for 2 × (number of cores) -->
     <mavenDebug>false</mavenDebug>
-    <ignore.random.failures>false</ignore.random.failures>
     <jacocoSurefireArgs /><!-- empty by default -->
   </properties>
 
@@ -208,7 +207,6 @@ THE SOFTWARE.
               <hudson.ClassicPluginStrategy.useAntClassLoader>true</hudson.ClassicPluginStrategy.useAntClassLoader>
               <hudson.maven.debug>${mavenDebug}</hudson.maven.debug>
               <buildDirectory>${project.build.directory}</buildDirectory>
-              <ignore.random.failures>${ignore.random.failures}</ignore.random.failures>
           </systemPropertyVariables>
           <reuseForks>true</reuseForks>
           <forkCount>${concurrency}</forkCount>
@@ -269,6 +267,7 @@ THE SOFTWARE.
       </activation>
       <properties>
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
+        <surefire.rerunFailingTestsCount>4</surefire.rerunFailingTestsCount>
       </properties>
     </profile>
     <profile>

--- a/test/src/test/groovy/hudson/cli/BuildCommandTest.groovy
+++ b/test/src/test/groovy/hudson/cli/BuildCommandTest.groovy
@@ -35,7 +35,6 @@ import org.junit.Test
 import org.jvnet.hudson.test.Issue
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder
 import org.jvnet.hudson.test.JenkinsRule
-import org.jvnet.hudson.test.RandomlyFails
 import org.jvnet.hudson.test.TestBuilder
 import org.jvnet.hudson.test.TestExtension
 import org.kohsuke.stapler.StaplerRequest
@@ -159,7 +158,7 @@ public class BuildCommandTest {
         }
     }
 
-    @RandomlyFails("Started test0 #1")
+    // TODO randomly fails: Started test0 #1
     @Test void consoleOutput() {
         def p = j.createFreeStyleProject()
         def cli = new CLI(j.URL)
@@ -174,7 +173,7 @@ public class BuildCommandTest {
         }
     }
 
-    @RandomlyFails("Started test0 #1")
+    // TODO randomly fails: Started test0 #1
     @Test void consoleOutputWhenBuildSchedulingRefused() {
         def p = j.createFreeStyleProject()
         def cli = new CLI(j.URL)

--- a/test/src/test/java/hudson/model/UpdateCenter2Test.java
+++ b/test/src/test/java/hudson/model/UpdateCenter2Test.java
@@ -31,9 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.RandomlyFails;
-
-import java.io.IOException;
 
 /**
  *
@@ -47,7 +44,7 @@ public class UpdateCenter2Test {
     /**
      * Makes sure a plugin installs fine.
      */
-    @RandomlyFails("SocketTimeoutException from goTo due to GET http://localhost:…/update-center.json?…")
+    // TODO randomly fails: SocketTimeoutException from goTo due to GET http://localhost:…/update-center.json?…
     @Test public void install() throws Exception {
         UpdateSite.neverUpdate = false;
         j.jenkins.pluginManager.doCheckUpdatesServer(); // load the metadata

--- a/test/src/test/java/hudson/model/UpdateCenterTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterTest.java
@@ -47,11 +47,8 @@ public class UpdateCenterTest {
             doData("http://updates.jenkins-ci.org/update-center.json?version=build");
             doData("http://updates.jenkins-ci.org/stable/update-center.json?version=build");
         } catch (Exception x) {
-            if (Boolean.getBoolean("ignore.random.failures")) {
-                assumeNoException("Might be no Internet connectivity, or might start failing due to expiring certificate through no fault of code changes", x);
-            } else {
-                throw x;
-            }
+            // TODO this should not be in core at all; should be in repo built by a separate job somewhere
+            assumeNoException("Might be no Internet connectivity, or might start failing due to expiring certificate through no fault of code changes", x);
         }
     }
     private void doData(String location) throws Exception {

--- a/test/src/test/java/hudson/slaves/CommandLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/CommandLauncherTest.java
@@ -39,7 +39,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.RandomlyFails;
 
 public class CommandLauncherTest {
 
@@ -47,7 +46,7 @@ public class CommandLauncherTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
-    @RandomlyFails("EOFException as in commandSucceedsWithoutChannel")
+    // TODO sometimes gets EOFException as in commandSucceedsWithoutChannel
     public void commandFails() throws Exception {
         assumeTrue(!Functions.isWindows());
         DumbSlave slave = createSlave("false");
@@ -58,7 +57,7 @@ public class CommandLauncherTest {
         assertThat(log, not(containsString("ERROR: Process terminated with exit code 0")));
     }
 
-    @RandomlyFails("Sometimes gets `EOFException: unexpected stream termination` before then on CI builder; maybe needs to wait in a loop for a message to appear?")
+    // TODO Sometimes gets `EOFException: unexpected stream termination` before then on CI builder; maybe needs to wait in a loop for a message to appear?
     @Test
     public void commandSucceedsWithoutChannel() throws Exception {
         assumeTrue(!Functions.isWindows());

--- a/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
+++ b/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
@@ -39,7 +39,6 @@ import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.RandomlyFails;
 import org.jvnet.hudson.test.SleepBuilder;
 
 /**
@@ -85,7 +84,7 @@ public class NodeProvisionerTest {
     /**
      * Scenario: schedule a build and see if one slave is provisioned.
      */
-    @RandomlyFails("fragile")
+    // TODO fragile
     @Test public void autoProvision() throws Exception {
         BulkChange bc = new BulkChange(r.jenkins);
         try {
@@ -107,7 +106,7 @@ public class NodeProvisionerTest {
     /**
      * Scenario: we got a lot of jobs all of the sudden, and we need to fire up a few nodes.
      */
-    @RandomlyFails("fragile")
+    // TODO fragile
     @Test public void loadSpike() throws Exception {
         BulkChange bc = new BulkChange(r.jenkins);
         try {
@@ -126,7 +125,7 @@ public class NodeProvisionerTest {
     /**
      * Scenario: make sure we take advantage of statically configured slaves.
      */
-    @RandomlyFails("fragile")
+    // TODO fragile
     @Test public void baselineSlaveUsage() throws Exception {
         BulkChange bc = new BulkChange(r.jenkins);
         try {
@@ -147,7 +146,7 @@ public class NodeProvisionerTest {
     /**
      * Scenario: loads on one label shouldn't translate to load on another label.
      */
-    @RandomlyFails("fragile")
+    // TODO fragile
     @Test public void labels() throws Exception {
         BulkChange bc = new BulkChange(r.jenkins);
         try {

--- a/test/src/test/java/hudson/tasks/FingerprinterTest.java
+++ b/test/src/test/java/hudson/tasks/FingerprinterTest.java
@@ -53,7 +53,6 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.RandomlyFails;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
@@ -314,7 +313,7 @@ public class FingerprinterTest {
     }
 
     @SuppressWarnings("unchecked")
-    @RandomlyFails("for p3.upstreamProjects expected:<[hudson.model.FreeStyleProject@590e5b8[test0]]> but was:<[]>")
+    // TODO randomly fails: for p3.upstreamProjects expected:<[hudson.model.FreeStyleProject@590e5b8[test0]]> but was:<[]>
     @Issue("JENKINS-18417")
     @Test
     public void fingerprintCleanup() throws Exception {


### PR DESCRIPTION
Switching to the Surefire feature that we are already using in `plugin-pom` but had not yet adopted in core. There were many failures in PRs unrelated to the text of the PR. For example [this](https://jenkins.ci.cloudbees.com/job/core/job/jenkins-core/4585/testReport/junit/hudson.slaves/CommandLauncherTest/commandFails/) was on a test marked `@RandomlyFails`, yet the job was not passing `-Dignore.random.failures`. [This](https://jenkins.ci.cloudbees.com/job/core/job/jenkins-core/4585/testReport/junit/hudson.model/ViewTest/privateView/) was just some other unreproducible failure; we have never managed to track them all down.

@reviewbybees
