### PR TITLE
Fix advertised JNLP Port

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1925,7 +1925,7 @@ public class Functions {
 
             TcpSlaveAgentListener tal = j.tcpSlaveAgentListener;
             if (tal !=null) {
-                int p = TcpSlaveAgentListener.CLI_PORT !=null ? TcpSlaveAgentListener.CLI_PORT : tal.getPort();
+                int p = tal.getAdvertisedPort();
                 rsp.setIntHeader("X-Hudson-CLI-Port", p);
                 rsp.setIntHeader("X-Jenkins-CLI-Port", p);
                 rsp.setIntHeader("X-Jenkins-CLI2-Port", p);

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -94,6 +94,13 @@ public final class TcpSlaveAgentListener extends Thread {
         return serverSocket.socket().getLocalPort();
     }
 
+    /**
+     * Gets the TCP port number in which we are advertising.
+     */
+    public int getAdvertisedPort() {
+        return CLI_PORT != null ? CLI_PORT : getPort();
+    }
+
     @Override
     public void run() {
         try {

--- a/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
+++ b/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
@@ -28,8 +28,8 @@ THE SOFTWARE.
     Publicize the TCP port number for JNLP slave agents so that they know where to conenct.
     Keep the legacy header for better backward compatibility
   -->
-  <st:header name="X-Hudson-JNLP-Port" value="${app.tcpSlaveAgentListener.port}" />
-  <st:header name="X-Jenkins-JNLP-Port" value="${app.tcpSlaveAgentListener.port}" />
+  <st:header name="X-Hudson-JNLP-Port" value="${app.tcpSlaveAgentListener.advertisedPort}" />
+  <st:header name="X-Jenkins-JNLP-Port" value="${app.tcpSlaveAgentListener.advertisedPort}" />
   <!--
     if the host name is overriden, advertise that as well
   -->


### PR DESCRIPTION
As far as I can figure, the /TcpSlaveAgentListener/ endpoint headers
tell the slaves what the JNLP port is. When I'm running jenkins behind a
proxy (marathon using the mesos plugin, which bridged networking), even
though I was setting the advertised port per a thread[1], it was not
accurately being returned in the header. This patch fixes that.

[1] https://groups.google.com/d/topic/jenkins-mesos/qUrXpDY07TQ/discussion
