### PR TITLE
[JENKINS-33828] - setup wizard was modifying the recommended plugin list

### DIFF
--- a/war/src/main/js/api/pluginManager.js
+++ b/war/src/main/js/api/pluginManager.js
@@ -46,7 +46,7 @@ exports.pluginNames = function() {
  * @returns The subset of plugins (subset of the plugin list) that are recommended by default.
  */
 exports.recommendedPluginNames = function() {
-    return plugins.recommendedPlugins;
+    return plugins.recommendedPlugins.slice(); // copy this
 };
 
 /**

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -288,11 +288,13 @@ var createPluginSetupWizard = function(appendTarget) {
 	};
 
 	// call this to go install the selected set of plugins
-	var installPlugins = function(plugins) {
+	var installPlugins = function(pluginNames) {
+		// make sure to have the correct list of selected plugins
+		selectedPluginNames = pluginNames;
 		// Switch to the right view but function() to force update when progressPanel re-rendered
 		setPanel(function() { return progressPanel(arguments); }, { installingPlugins : [] });
 
-		pluginManager.installPlugins(plugins, handleGenericError(function() {
+		pluginManager.installPlugins(pluginNames, handleGenericError(function() {
 			showInstallProgress();
 		}));
 	};


### PR DESCRIPTION
The setup wizard was returning a reference to the recommended plugin array as the selected plugins, allowing it to be modified and resulting in unexpected behavior in certain cases.

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-33828

@reviewbybees esp. @daniel-beck 
