### PR TITLE
[JENKINS-20509] Move doCheckJobName to View

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3581,20 +3581,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         // looks good
     }
 
-    /**
-     * Makes sure that the given name is good as a job name.
-     * @return trimmed name if valid; throws Failure if not
-     */
-    private String checkJobName(String name) throws Failure {
-        checkGoodName(name);
-        name = name.trim();
-        projectNamingStrategy.checkName(name);
-        if(getItem(name)!=null)
-            throw new Failure(Messages.Hudson_JobAlreadyExists(name));
-        // looks good
-        return name;
-    }
-
     private static String toPrintableName(String name) {
         StringBuilder printableName = new StringBuilder();
         for( int i=0; i<name.length(); i++ ) {
@@ -4120,25 +4106,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return FormValidation.ok();
         else
             return FormValidation.errorWithMarkup(Messages.Hudson_NoJavaInPath(request.getContextPath()));
-    }
-
-    /**
-     * Makes sure that the given name is good as a job name.
-     */
-    public FormValidation doCheckJobName(@QueryParameter String value) {
-        // this method can be used to check if a file exists anywhere in the file system,
-        // so it should be protected.
-        checkPermission(Item.CREATE);
-
-        if(fixEmpty(value)==null)
-            return FormValidation.ok();
-
-        try {
-            checkJobName(value);
-            return FormValidation.ok();
-        } catch (Failure e) {
-            return FormValidation.error(e.getMessage());
-        }
     }
 
     /**

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -45,17 +45,24 @@ import org.jvnet.hudson.test.Email;
 import org.w3c.dom.Text;
 
 import static hudson.model.Messages.Hudson_ViewName;
+import hudson.security.ACL;
+import hudson.security.AccessDeniedException2;
 import hudson.slaves.DumbSlave;
+import hudson.util.FormValidation;
 import hudson.util.HudsonIsLoading;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import jenkins.model.ProjectNamingStrategy;
+import jenkins.security.NotReallyRoleSensitiveCallable;
 import static org.junit.Assert.*;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -428,4 +435,75 @@ public class ViewTest {
             }
         }
     }
+
+    @Issue("JENKINS-20509")
+    @Test public void checkJobName() throws Exception {
+        j.createFreeStyleProject("topprj");
+        final MockFolder d1 = j.createFolder("d1");
+        d1.createProject(FreeStyleProject.class, "subprj");
+        final MockFolder d2 = j.createFolder("d2");
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
+            grant(Jenkins.ADMINISTER).everywhere().to("admin").
+            grant(Jenkins.READ).everywhere().toEveryone().
+            grant(Job.READ).everywhere().toEveryone().
+            grant(Item.CREATE).onFolders(d1).to("dev")); // not on root or d2
+        ACL.impersonate(Jenkins.ANONYMOUS, new NotReallyRoleSensitiveCallable<Void,Exception>() {
+            @Override
+            public Void call() throws Exception {
+                try {
+                    assertCheckJobName(j.jenkins, "whatever", FormValidation.Kind.OK);
+                    fail("should not have been allowed");
+                } catch (AccessDeniedException2 x) {
+                    // OK
+                }
+                return null;
+            }
+        });
+        ACL.impersonate(User.get("dev").impersonate(), new NotReallyRoleSensitiveCallable<Void,Exception>() {
+            @Override
+            public Void call() throws Exception {
+                try {
+                    assertCheckJobName(j.jenkins, "whatever", FormValidation.Kind.OK);
+                    fail("should not have been allowed");
+                } catch (AccessDeniedException2 x) {
+                    // OK
+                }
+                try {
+                    assertCheckJobName(d2, "whatever", FormValidation.Kind.OK);
+                    fail("should not have been allowed");
+                } catch (AccessDeniedException2 x) {
+                    // OK
+                }
+                assertCheckJobName(d1, "whatever", FormValidation.Kind.OK);
+                return null;
+            }
+        });
+        ACL.impersonate(User.get("admin").impersonate(), new NotReallyRoleSensitiveCallable<Void,Exception>() {
+            @Override
+            public Void call() throws Exception {
+                assertCheckJobName(j.jenkins, "whatever", FormValidation.Kind.OK);
+                assertCheckJobName(d1, "whatever", FormValidation.Kind.OK);
+                assertCheckJobName(d2, "whatever", FormValidation.Kind.OK);
+                assertCheckJobName(j.jenkins, "d1", FormValidation.Kind.ERROR);
+                assertCheckJobName(j.jenkins, "topprj", FormValidation.Kind.ERROR);
+                assertCheckJobName(d1, "subprj", FormValidation.Kind.ERROR);
+                assertCheckJobName(j.jenkins, "", FormValidation.Kind.OK);
+                assertCheckJobName(j.jenkins, "foo/bie", FormValidation.Kind.ERROR);
+                assertCheckJobName(d2, "New", FormValidation.Kind.OK);
+                j.jenkins.setProjectNamingStrategy(new ProjectNamingStrategy.PatternProjectNamingStrategy("[a-z]+", "", true));
+                assertCheckJobName(d2, "New", FormValidation.Kind.ERROR);
+                assertCheckJobName(d2, "new", FormValidation.Kind.OK);
+                return null;
+            }
+        });
+        JenkinsRule.WebClient wc = j.createWebClient().login("admin");
+        assertEquals("original ${rootURL}/checkJobName still supported", "<div/>", wc.goTo("checkJobName?value=stuff").getWebResponse().getContentAsString());
+        assertEquals("but now possible on a view in a folder", "<div/>", wc.goTo("job/d1/view/All/checkJobName?value=stuff").getWebResponse().getContentAsString());
+    }
+
+    private void assertCheckJobName(ViewGroup context, String name, FormValidation.Kind expected) {
+        assertEquals(expected, context.getPrimaryView().doCheckJobName(name).kind);
+    }
+
 }


### PR DESCRIPTION
[JENKINS-20509](https://issues.jenkins-ci.org/browse/JENKINS-20509)

Useless on its own because we are still awaiting a fix of [JENKINS-33755](https://issues.jenkins-ci.org/browse/JENKINS-33755) that would actually call this endpoint, but at least sets up the right backend.

@reviewbybees
