### PR TITLE
[FIX JENKINS-33891] scrollToPosition doesn't work in some conditions …

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1358,8 +1358,11 @@ function updateOptionalBlock(c,scroll) {
     var checked = xor(c.checked,Element.hasClassName(c,"negative"));
 
     vg.rowVisibilityGroup.makeInnerVisisble(checked);
-
-    if(checked && scroll) {
+    //FIXME: This scrollIntoView behavior breaks in v1 with FF on OSX.
+    // The scrolling behavior doesn't seem to add much utility, so this conditionally
+    // removes it from the v2 config page.
+    var legacyConfig =  $$('body.main-panel-only').length === 0;
+    if(checked && scroll && legacyConfig) {
         var D = YAHOO.util.Dom;
 
         var r = D.getRegion(s);


### PR DESCRIPTION
…in 1.0 not needed in 2.0

@reviewbybees

Not exactly sure how to handle this bug. The issue exists in v1 and doesn't seem to reproduce in Chrome. The old Jenkins config will attempt to scroll newly expanded divs from optional blocks into view, but because the page geometry is constantly changing, it often messes up the math. When it works, the behavior is nice enough, especially when a checkbox is at the bottom of the screen, but is mostly unnecessary fluff. 

Personally, I would kill it from v1 as well.
