### PR TITLE
[FIXED JENKINS-33857] Make initial admin password file end with a newline

### DIFF
--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -71,7 +71,7 @@ public class SetupWizard {
                 // JENKINS-33599 - write to a file in the jenkins home directory
                 // most native packages of Jenkins creates a machine user account 'jenkins' to run Jenkins,
                 // and use group 'jenkins' for admins. So we allo groups to read this file
-                iapf.write(randomUUID, "UTF-8");
+                iapf.write(randomUUID + System.lineSeparator(), "UTF-8");
                 iapf.chmod(0640);
 
                 // Lock Jenkins down:


### PR DESCRIPTION
This makes it a tiny bit more convenient to `cat` the file and copy the password to your clipboard.  Previously, the file did not have a line ending, so the password would run into your shell prompt, making copying the text harder.

Before:

```
chris$ cat /Users/chris/code/jenkins/jenkins/war/work/secrets/initialAdminPassword
244f31e1d1f844b388a5b62dbc0a0c8bchris$
```

After:

```
chris$ cat /Users/chris/code/jenkins/jenkins/war/work/secrets/initialAdminPassword
244f31e1d1f844b388a5b62dbc0a0c8b
chris$
```
