### PR TITLE
[JENKINS-33972] The REST API URL has been removed to [..]/itemCategories

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -1041,10 +1041,10 @@ public abstract class View extends AbstractModelObject implements AccessControll
     /**
      * An API REST method to get the allowed {$link TopLevelItem}s and its categories.
      *
-     * @return A {@link Categories} entity that is shown as  JSON file.
+     * @return A {@link Categories} entity that is shown as JSON file.
      */
     @Restricted(DoNotUse.class)
-    public Categories doCategories(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+    public Categories doItemCategories(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         Categories categories = new Categories();
         int order = 0;
         for (TopLevelItemDescriptor descriptor : DescriptorVisibilityFilter.apply(getOwnerItemGroup(), Items.all(Jenkins.getAuthentication(), getOwnerItemGroup()))) {

--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -3,7 +3,7 @@ var $ = require('jquery-detached').getJQuery();
 
 var getItems = function(){
   var d = $.Deferred();
-  $.get('categories?depth=3').done(
+  $.get('itemCategories?depth=3').done(
       function(data){
         d.resolve(data);
       }


### PR DESCRIPTION
[JENKINS-33972](https://issues.jenkins-ci.org/browse/JENKINS-33972)

@reviewbybees, especially @oleg-nenashev and @jglick because this change was asked and agreed by them.
