### PR TITLE
[DO NOT MERGE] System/Job Config page scrollspy tab overflow

### DIFF
--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
       <l:css src="jsbundles/config-scrollspy.css" />
 
       <div class="behavior-loading">${%LOADING}</div>
-      <f:form method="post" action="configSubmit" name="config" tableClass="config-table scrollspy">
+      <f:form method="post" action="configSubmit" name="config" tableClass="config-table scrollspy nowrap">
         <j:set var="descriptor" value="${it.descriptor}" />
         <j:set var="instance" value="${it}" />
 

--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -29,8 +29,8 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName} Config" cssclass="main-panel-only" norefresh="true" permission="${it.EXTENDED_READ}">
     <l:main-panel>
-      <l:js src="jsbundles/config-scrollspy.js" />
       <l:css src="jsbundles/config-scrollspy.css" />
+      <l:js src="jsbundles/config-scrollspy.js" />
 
       <div class="behavior-loading">${%LOADING}</div>
       <f:form method="post" action="configSubmit" name="config" tableClass="config-table scrollspy nowrap">

--- a/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
@@ -27,12 +27,13 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:layout norefresh="true" permission="${it.ADMINISTER}" title="${%Configure System}">
-  <st:include page="sidepanel.jelly" />
+<l:layout norefresh="true" permission="${it.ADMINISTER}" cssclass="main-panel-only" title="${%Configure System}">
+  <l:css src="jsbundles/config-scrollspy.css" />
+  <l:js src="jsbundles/config-scrollspy.js" />
   <f:breadcrumb-config-outline />
   <l:main-panel>
     <div class="behavior-loading">${%LOADING}</div>
-    <f:form method="post" name="config" action="configSubmit">
+    <f:form method="post" name="config" action="configSubmit" tableClass="config-table scrollspy nowrap">
       <j:set var="instance" value="${it}" />
       <j:set var="descriptor" value="${instance.descriptor}" />
 

--- a/war/src/main/js/config-scrollspy.js
+++ b/war/src/main/js/config-scrollspy.js
@@ -136,12 +136,12 @@ function stickTabbar(tabBar) {
             'margin': '0 auto !important'
         });
         configTable.css({'margin-top': widgetBox.outerHeight() + 'px'});
-        win.resize(setWidth);
+        win.on('resize.jenkins.config_scrollspy', setWidth);
         return true;
     } else {
         widgetBox.removeAttr('style');
         configTable.removeAttr('style');
-        win.unbind('resize', setWidth);
+        win.off('resize.jenkins.config_scrollspy');
         return false;
     }
 }

--- a/war/src/main/js/widgets/config/model/ConfigSection.js
+++ b/war/src/main/js/widgets/config/model/ConfigSection.js
@@ -115,9 +115,20 @@ ConfigSection.prototype.getRows = function() {
  * Set the element (jquery) that activates the section (on click).
  */
 ConfigSection.prototype.setActivator = function(activator) {
-    this.activator = activator;
-
     var section = this;
+
+    section.activator = activator;
+
+    // we do not want to use inline styles for this, so lets
+    // remove an inline 'display' styles.
+    var inlineDisplay = section.activator.css('display');
+    if (inlineDisplay) {
+        section.activator.css('display', null);
+        if (inlineDisplay === 'none') {
+            section.activator.addClass('hidden');
+        }
+    }
+
     section.activator.click(function() {
         section.parentCMD.showSection(section);
     });

--- a/war/src/main/js/widgets/config/model/ConfigSection.js
+++ b/war/src/main/js/widgets/config/model/ConfigSection.js
@@ -135,6 +135,10 @@ ConfigSection.prototype.markAsActive = function() {
     this.parentCMD.hideSection();
     this.activator.addClass('active');
     this.markRowsAsActive();
+
+    if (this.parentCMD.tabBarOverflow) {
+        this.parentCMD.tabBarOverflow.onTabActivate(this.activator);
+    }
 };
 
 ConfigSection.prototype.markRowsAsActive = function() {

--- a/war/src/main/js/widgets/config/model/ConfigTableMetaData.js
+++ b/war/src/main/js/widgets/config/model/ConfigTableMetaData.js
@@ -329,7 +329,18 @@ ConfigTableMetaData.prototype.trackSectionVisibility = function() {
     if (this.tabBarOverflow) {
         // We don't track tab visibility here if tabbar overflow handling
         // is enabled. The TabBarOverflow instance takes care of it.
-        this.tabBarOverflow.trackTabVisibility();
+        var thisCMD = this;
+        thisCMD.tabBarOverflow.trackTabVisibility(function (tab) {
+            // Look for the section that has this tab and check that the
+            // section is visible.
+            for (var i = 0; i < thisCMD.sections.length; i++) {
+                var section = thisCMD.sections[i];
+                if (section.activator === tab) {
+                    return section.isVisible();
+                }
+            }
+            return false;
+        });
         return;
     }
 

--- a/war/src/main/js/widgets/config/model/ConfigTableMetaData.js
+++ b/war/src/main/js/widgets/config/model/ConfigTableMetaData.js
@@ -326,6 +326,12 @@ ConfigTableMetaData.prototype.trackSectionVisibility = function() {
     if (isTestEnv()) {
         return;
     }
+    if (this.tabBarOverflow) {
+        // We don't track tab visibility here if tabbar overflow handling
+        // is enabled. The TabBarOverflow instance takes care of it.
+        this.tabBarOverflow.trackTabVisibility();
+        return;
+    }
 
     var thisConfig = this;
     

--- a/war/src/main/js/widgets/config/model/ConfigTableMetaData.js
+++ b/war/src/main/js/widgets/config/model/ConfigTableMetaData.js
@@ -326,9 +326,7 @@ ConfigTableMetaData.prototype.trackSectionVisibility = function() {
     if (isTestEnv()) {
         return;
     }
-    if (this.tabBarOverflow) {
-        // We don't track tab visibility here if tabbar overflow handling
-        // is enabled. The TabBarOverflow instance takes care of it.
+    if (this.tabBarOverflow && !this.tabBarOverflow.tabVisibleChecker) {
         var thisCMD = this;
         thisCMD.tabBarOverflow.trackTabVisibility(function (tab) {
             // Look for the section that has this tab and check that the
@@ -341,7 +339,6 @@ ConfigTableMetaData.prototype.trackSectionVisibility = function() {
             }
             return false;
         });
-        return;
     }
 
     var thisConfig = this;
@@ -349,10 +346,14 @@ ConfigTableMetaData.prototype.trackSectionVisibility = function() {
     try {
         for (var i = 0; i < this.sections.length; i++) {
             var section = this.sections[i];
-            if (section.isVisible()) {
-                section.activator.show();
-            } else {
-                section.activator.hide();
+            var isActivatorVisible = !section.activator.hasClass('hidden');
+            if (section.isVisible() !== isActivatorVisible) {
+                if (section.isVisible()) {
+                    section.activator.removeClass('hidden');
+                } else {
+                    section.activator.addClass('hidden');
+                }
+                this.tabBarOverflow.doRefresh();
             }
         }
     } finally {

--- a/war/src/main/js/widgets/config/tabbar.js
+++ b/war/src/main/js/widgets/config/tabbar.js
@@ -136,16 +136,9 @@ exports.nowrap = function(configTableMetadata, tabBarFrame) {
     var configWidgets = configTableMetadata.configWidgets;
 
     if (!configWidgets.hasClass('nowrap')) {
-        var $ = jQD.getJQuery();
-
         configWidgets.addClass('nowrap');
-
-        var taboverflow =
-            $('<div class="taboverflow">' +
-                '<span class="icon">&#x25BE;&#9776;</span>' +
-                '<span class="count">9+</span>' +
-              '</div>');
-        tabBarFrame.append(taboverflow);
+        var TabBarOverflow = require('../tabs/TabBarOverflow');
+        new TabBarOverflow(tabBarFrame);
     }
 };
 

--- a/war/src/main/js/widgets/config/tabbar.js
+++ b/war/src/main/js/widgets/config/tabbar.js
@@ -98,18 +98,18 @@ exports.addTabs = function(configTable, options) {
         section.setActivator(tab);
     }
 
-    var tabs = $('<div class="form-config tabBarFrame"></div>');
+    var tabBarFrame = $('<div class="form-config tabBarFrame"></div>');
     var noTabs = $('<div class="noTabs" title="Remove configuration tabs and revert to the &quot;classic&quot; configuration view">Remove tabs</div>');
 
-    configTableMetadata.configWidgets.append(tabs);
+    configTableMetadata.configWidgets.append(tabBarFrame);
     configTableMetadata.configWidgets.prepend(noTabs);
-    tabs.append(tabBar);
+    tabBarFrame.append(tabBar);
 
-    tabs.mouseenter(function() {
-        tabs.addClass('mouse-over');
+    tabBarFrame.mouseenter(function() {
+        tabBarFrame.addClass('mouse-over');
     });
-    tabs.mouseleave(function() {
-        tabs.removeClass('mouse-over');
+    tabBarFrame.mouseleave(function() {
+        tabBarFrame.removeClass('mouse-over');
     });
     configTableMetadata.deactivator = noTabs;
 
@@ -121,7 +121,7 @@ exports.addTabs = function(configTable, options) {
     }
 
     if (configTable.hasClass('nowrap')) {
-        exports.nowrap(configTableMetadata);
+        exports.nowrap(configTableMetadata, tabBarFrame);
     }
 
     return configTableMetadata;
@@ -130,12 +130,22 @@ exports.addTabs = function(configTable, options) {
 /**
  * Apply non-wrapping of the tabs in the tabBar.
  * @param configTableMetadata The ConfigTableMetaData instance containing the tabBar containing the tabs.
+ * @param tabBarFrame The tabBar frame.
  */
-exports.nowrap = function(configTableMetadata) {
+exports.nowrap = function(configTableMetadata, tabBarFrame) {
     var configWidgets = configTableMetadata.configWidgets;
 
     if (!configWidgets.hasClass('nowrap')) {
+        var $ = jQD.getJQuery();
+
         configWidgets.addClass('nowrap');
+
+        var taboverflow =
+            $('<div class="taboverflow">' +
+                '<span class="icon">&#x25BE;&#9776;</span>' +
+                '<span class="count">9+</span>' +
+              '</div>');
+        tabBarFrame.append(taboverflow);
     }
 };
 

--- a/war/src/main/js/widgets/config/tabbar.js
+++ b/war/src/main/js/widgets/config/tabbar.js
@@ -120,7 +120,23 @@ exports.addTabs = function(configTable, options) {
         configTableMetadata.trackSectionVisibility();
     }
 
+    if (configTable.hasClass('nowrap')) {
+        exports.nowrap(configTableMetadata);
+    }
+
     return configTableMetadata;
+};
+
+/**
+ * Apply non-wrapping of the tabs in the tabBar.
+ * @param configTableMetadata The ConfigTableMetaData instance containing the tabBar containing the tabs.
+ */
+exports.nowrap = function(configTableMetadata) {
+    var configWidgets = configTableMetadata.configWidgets;
+
+    if (!configWidgets.hasClass('nowrap')) {
+        configWidgets.addClass('nowrap');
+    }
 };
 
 exports.addTabsActivator = function(configTable) {

--- a/war/src/main/js/widgets/config/tabbar.js
+++ b/war/src/main/js/widgets/config/tabbar.js
@@ -138,7 +138,13 @@ exports.nowrap = function(configTableMetadata, tabBarFrame) {
     if (!configWidgets.hasClass('nowrap')) {
         configWidgets.addClass('nowrap');
         var TabBarOverflow = require('../tabs/TabBarOverflow');
-        new TabBarOverflow(tabBarFrame);
+        var tabs = [];
+
+        for (var i = 0; i < configTableMetadata.sections.length; i++) {
+            tabs.push(configTableMetadata.sections[i].activator);
+        }
+
+        configTableMetadata.tabBarOverflow = new TabBarOverflow(tabBarFrame, tabs);
     }
 };
 

--- a/war/src/main/js/widgets/config/tabbar.less
+++ b/war/src/main/js/widgets/config/tabbar.less
@@ -46,8 +46,8 @@
     display:none;
   }
 
-  .form-config.tabBarFrame {
-    position: relative;
+  .tabBarFrame {
+    background-color: inherit;
     border-bottom: solid 1px @solid-border;
 
     .config-section-activators {
@@ -92,6 +92,26 @@
   }
 
 }
+
+.jenkins-config-widgets.nowrap {
+  position: relative;
+
+  .tabBarFrame {
+    position: absolute;
+    left: 0;
+    right: 0;
+
+    .tabBar {
+      overflow-x: hidden !important;
+      white-space: nowrap !important;
+      .tab {
+        display: inline-block !important;
+        float: none !important;
+      }
+    }
+  }
+}
+
 #jenkins{
   .jenkins-config {
     border:1px solid @solid-border;

--- a/war/src/main/js/widgets/config/tabbar.less
+++ b/war/src/main/js/widgets/config/tabbar.less
@@ -68,7 +68,8 @@
         text-decoration: none;
       }
       .tab:hover {
-        background:#bbb; color:@brightest;
+        background:#bbb;
+        color:@brightest;
       }
       .tab.active {
         background: @bright;
@@ -104,12 +105,39 @@
     .tabBar {
       overflow-x: hidden;
       white-space: nowrap;
-      margin-right: 40px;
+      margin-right: 54px;
 
       .tab {
         display: inline-block;
         float: none;
       }
+    }
+
+    .taboverflow {
+      cursor: pointer;
+      width: 44px;
+      position: absolute;
+      top: 7px;
+      right: 5px;
+      border:1px solid @solid-border;
+      .border-radius(5px);
+      padding: 3px 3px;
+      font-size: 0.9em;
+      text-align: center;
+
+      .icon {
+        float: left;
+        width: 18px;
+      }
+      .count {
+        float: right;
+        width: 18px;
+      }
+    }
+
+    .taboverflow:hover {
+      background:#bbb;
+      color:@brightest;
     }
   }
 }

--- a/war/src/main/js/widgets/config/tabbar.less
+++ b/war/src/main/js/widgets/config/tabbar.less
@@ -1,3 +1,5 @@
+@import "../tabs/tabbar-overflow";
+
 /*
  * Tab bar specific rules.
  */
@@ -96,50 +98,7 @@
 
 .jenkins-config-widgets.nowrap {
   position: relative;
-
-  .tabBarFrame {
-    position: absolute;
-    left: 0;
-    right: 0;
-
-    .tabBar {
-      overflow-x: hidden;
-      white-space: nowrap;
-      margin-right: 54px;
-
-      .tab {
-        display: inline-block;
-        float: none;
-      }
-    }
-
-    .taboverflow {
-      cursor: pointer;
-      width: 44px;
-      position: absolute;
-      top: 7px;
-      right: 5px;
-      border:1px solid @solid-border;
-      .border-radius(5px);
-      padding: 3px 3px;
-      font-size: 0.9em;
-      text-align: center;
-
-      .icon {
-        float: left;
-        width: 18px;
-      }
-      .count {
-        float: right;
-        width: 18px;
-      }
-    }
-
-    .taboverflow:hover {
-      background:#bbb;
-      color:@brightest;
-    }
-  }
+  .tabBarOverflow();
 }
 
 #jenkins{

--- a/war/src/main/js/widgets/config/tabbar.less
+++ b/war/src/main/js/widgets/config/tabbar.less
@@ -102,11 +102,13 @@
     right: 0;
 
     .tabBar {
-      overflow-x: hidden !important;
-      white-space: nowrap !important;
+      overflow-x: hidden;
+      white-space: nowrap;
+      margin-right: 40px;
+
       .tab {
-        display: inline-block !important;
-        float: none !important;
+        display: inline-block;
+        float: none;
       }
     }
   }

--- a/war/src/main/js/widgets/tabs/TabBarOverflow.js
+++ b/war/src/main/js/widgets/tabs/TabBarOverflow.js
@@ -40,12 +40,22 @@ function TabBarOverflow(tabBarFrame, tabs) {
         }
     });
 
+    var mouseInPopover = false;
+    taboverflowPopup.mouseenter(function() {
+        mouseInPopover = true;
+    });
+    taboverflowPopup.mouseleave(function() {
+        mouseInPopover = false;
+    });
+
     var win = $(windowHandle.getWindow());
     win.on('resize.jenkins.taboverflow', function() {
         tabOverflow.doRefresh();
     });
     win.on('scroll.jenkins.taboverflow', function() {
-        tabOverflow.hideDropdown();
+        if (!mouseInPopover) {
+            tabOverflow.hideDropdown();
+        }
     });
 
     function trackOverflow() {

--- a/war/src/main/js/widgets/tabs/TabBarOverflow.js
+++ b/war/src/main/js/widgets/tabs/TabBarOverflow.js
@@ -3,12 +3,12 @@ var windowHandle = require('window-handle');
 
 module.exports = TabBarOverflow;
 
-function TabBarOverflow(tabBarFrame) {
+function TabBarOverflow(tabBarFrame, tabs) {
     var $ = jQD.getJQuery();
 
     this.tabBarFrame = tabBarFrame;
     this.tabBar = $('.tabBar', tabBarFrame);
-    this.tabs = $('.tab', this.tabBar);
+    this.tabs = tabs;
 
     // Add the taboverflow button to the tabBar frame.
     // We will make this visible as needed.
@@ -17,16 +17,54 @@ function TabBarOverflow(tabBarFrame) {
             '<span class="icon">&#x25BE;&#9776;</span>' +
           '</div>');
     var taboverflowCount = $('<span class="count"></span>');
-    var taboverflowPopup = $('<div class="taboverflow-popup"></div>');
+    var taboverflowPopup = $('<div class="taboverflow-popup hidden"></div>');
     taboverflowBtn.append(taboverflowCount);
     tabBarFrame.append(taboverflowBtn);
     tabBarFrame.append(taboverflowPopup);
 
-    taboverflowCount.text('9+');
+    this.taboverflowCount = taboverflowCount;
+    this.taboverflowPopup = taboverflowPopup;
+    this.setTabCount();
+    this.setDropdownContent();
 
-    var win = $(windowHandle.getWindow());
-    var tover = this;
-    win.resize(function() {
-        console.log('*** ' + tover.tabBar.width());
+    // Show and hide the dropdown.
+    taboverflowBtn.click(function() {
+        if (taboverflowPopup.hasClass('hidden')) {
+            taboverflowPopup.removeClass('hidden');
+        } else {
+            taboverflowPopup.addClass('hidden');
+        }
     });
 }
+
+TabBarOverflow.prototype.setTabCount = function() {
+    if (this.tabs.length > 9) {
+        this.taboverflowCount.text('9+');
+    } else {
+        this.taboverflowCount.text(this.tabs.length);
+    }
+};
+
+TabBarOverflow.prototype.setDropdownContent = function() {
+    var $ = jQD.getJQuery();
+    var tabOverflow = this;
+
+    tabOverflow.taboverflowPopup.empty();
+    function addDropTab(tab) {
+        var dropTab = $('<div class="drop-tab">');
+        dropTab.text(tab.text());
+        tabOverflow.taboverflowPopup.append(dropTab);
+        dropTab.click(function() {
+            tabOverflow.taboverflowPopup.addClass('hidden');
+            tab.click();
+        });
+    }
+
+    for (var i = 0; i < this.tabs.length; i++) {
+        addDropTab(this.tabs[i]);
+    }
+};
+
+TabBarOverflow.prototype.trackTabVisibility = function() {
+    // TODO
+};

--- a/war/src/main/js/widgets/tabs/TabBarOverflow.js
+++ b/war/src/main/js/widgets/tabs/TabBarOverflow.js
@@ -41,7 +41,7 @@ function TabBarOverflow(tabBarFrame, tabs) {
     });
 
     var win = $(windowHandle.getWindow());
-    win.resize(function() {
+    win.on('resize.jenkins.taboverflow', function() {
         tabOverflow.doRefresh();
     });
 

--- a/war/src/main/js/widgets/tabs/TabBarOverflow.js
+++ b/war/src/main/js/widgets/tabs/TabBarOverflow.js
@@ -109,24 +109,24 @@ TabBarOverflow.prototype.onTabActivate = function(activatedTab, refresh) {
     // the supplied tab). We stop showing tabs once we show a tab that overflows the tabBar.
 
     // Hide them all..
-    for (var i = 0; i < this.tabs.length; i++) {
-        $(this.tabs[i]).removeClass('taboverflow-tab-visible');
+    for (var i1 = 0; i1 < this.tabs.length; i1++) {
+        $(this.tabs[i1]).removeClass('taboverflow-tab-visible');
     }
 
     // Start showing tabs, starting from the tab that was just activated...
     var addTabs = false;
     var addedCount = 0;
     var activeTabIdx = 0;
-    for (var i = 0; i < this.tabs.length; i++) {
-        var tab = this.tabs[i];
-        if (tab === activatedTab) {
+    for (var i2 = 0; i2 < this.tabs.length; i2++) {
+        var tabForward = this.tabs[i2];
+        if (tabForward === activatedTab) {
             addTabs = true;
-            activeTabIdx = i;
+            activeTabIdx = i2;
         }
         if (addTabs) {
-            $(tab).addClass('taboverflow-tab-visible');
+            $(tabForward).addClass('taboverflow-tab-visible');
             if (this.isOverflown()) {
-                $(tab).removeClass('taboverflow-tab-visible');
+                $(tabForward).removeClass('taboverflow-tab-visible');
                 break;
             }
             addedCount++;
@@ -136,11 +136,11 @@ TabBarOverflow.prototype.onTabActivate = function(activatedTab, refresh) {
     if (!this.isOverflown() && activeTabIdx > 0) {
         // There's room for more tabs. If there are tabs before the "active"
         // tab, then lets show some of those too.
-        for (var i = activeTabIdx - 1; i >= 0 ; i--) {
-            var tab = this.tabs[i];
-            $(tab).addClass('taboverflow-tab-visible');
+        for (var i3 = activeTabIdx - 1; i3 >= 0 ; i3--) {
+            var tabBack = this.tabs[i3];
+            $(tabBack).addClass('taboverflow-tab-visible');
             if (this.isOverflown()) {
-                $(tab).removeClass('taboverflow-tab-visible');
+                $(tabBack).removeClass('taboverflow-tab-visible');
                 break;
             }
             addedCount++;

--- a/war/src/main/js/widgets/tabs/TabBarOverflow.js
+++ b/war/src/main/js/widgets/tabs/TabBarOverflow.js
@@ -1,0 +1,32 @@
+var jQD = require('jquery-detached');
+var windowHandle = require('window-handle');
+
+module.exports = TabBarOverflow;
+
+function TabBarOverflow(tabBarFrame) {
+    var $ = jQD.getJQuery();
+
+    this.tabBarFrame = tabBarFrame;
+    this.tabBar = $('.tabBar', tabBarFrame);
+    this.tabs = $('.tab', this.tabBar);
+
+    // Add the taboverflow button to the tabBar frame.
+    // We will make this visible as needed.
+    var taboverflowBtn =
+        $('<div class="taboverflow-btn">' +
+            '<span class="icon">&#x25BE;&#9776;</span>' +
+          '</div>');
+    var taboverflowCount = $('<span class="count"></span>');
+    var taboverflowPopup = $('<div class="taboverflow-popup"></div>');
+    taboverflowBtn.append(taboverflowCount);
+    tabBarFrame.append(taboverflowBtn);
+    tabBarFrame.append(taboverflowPopup);
+
+    taboverflowCount.text('9+');
+
+    var win = $(windowHandle.getWindow());
+    var tover = this;
+    win.resize(function() {
+        console.log('*** ' + tover.tabBar.width());
+    });
+}

--- a/war/src/main/js/widgets/tabs/TabBarOverflow.js
+++ b/war/src/main/js/widgets/tabs/TabBarOverflow.js
@@ -90,6 +90,27 @@ TabBarOverflow.prototype.isOverflown = function() {
     return (this.tabBar.width() > this.tabBarFrame.width());
 };
 
+TabBarOverflow.prototype.tabIndex = function(tab) {
+    for (var i = 0; i < this.tabs.length; i++) {
+        if (this.tabs[i] === tab) {
+            return i;
+        }
+    }
+    throw 'Unknown tab.';
+};
+
+TabBarOverflow.prototype.hideAllTabs = function() {
+    var $ = jQD.getJQuery();
+    for (var i = 0; i < this.tabs.length; i++) {
+        $(this.tabs[i]).removeClass('taboverflow-tab-visible');
+    }
+};
+
+TabBarOverflow.prototype.visibleTabCount = function() {
+    var $ = jQD.getJQuery();
+    return $('.taboverflow-tab-visible', this.tabBar).size();
+};
+
 TabBarOverflow.prototype.onTabActivate = function(activatedTab, refresh) {
     // We need to check if this table is visible to the user and if not,
     // we need to make it visible.
@@ -101,53 +122,41 @@ TabBarOverflow.prototype.onTabActivate = function(activatedTab, refresh) {
         }
     }
 
-    var $ = jQD.getJQuery();
-
     // Ok, the tab that's just been activated is not visible to the user. So,
     // we make it (and local sibling tabs) visible by hiding other tabs before it.
     // We start by hiding all tabs. Then, we start showing tabs (starting from
     // the supplied tab). We stop showing tabs once we show a tab that overflows the tabBar.
 
+    var $ = jQD.getJQuery();
+
     // Hide them all..
-    for (var i1 = 0; i1 < this.tabs.length; i1++) {
-        $(this.tabs[i1]).removeClass('taboverflow-tab-visible');
-    }
+    this.hideAllTabs();
 
     // Start showing tabs, starting from the tab that was just activated...
-    var addTabs = false;
-    var addedCount = 0;
-    var activeTabIdx = 0;
-    for (var i2 = 0; i2 < this.tabs.length; i2++) {
-        var tabForward = this.tabs[i2];
-        if (tabForward === activatedTab) {
-            addTabs = true;
-            activeTabIdx = i2;
-        }
-        if (addTabs) {
-            $(tabForward).addClass('taboverflow-tab-visible');
-            if (this.isOverflown()) {
-                $(tabForward).removeClass('taboverflow-tab-visible');
-                break;
-            }
-            addedCount++;
+    var activeTabIdx = this.tabIndex(activatedTab);
+    for (var i1 = activeTabIdx; i1 < this.tabs.length; i1++) {
+        var tabForward = this.tabs[i1];
+        $(tabForward).addClass('taboverflow-tab-visible');
+        if (this.isOverflown()) {
+            $(tabForward).removeClass('taboverflow-tab-visible');
+            break;
         }
     }
 
     if (!this.isOverflown() && activeTabIdx > 0) {
         // There's room for more tabs. If there are tabs before the "active"
         // tab, then lets show some of those too.
-        for (var i3 = activeTabIdx - 1; i3 >= 0 ; i3--) {
-            var tabBack = this.tabs[i3];
+        for (var i2 = activeTabIdx - 1; i2 >= 0 ; i2--) {
+            var tabBack = this.tabs[i2];
             $(tabBack).addClass('taboverflow-tab-visible');
             if (this.isOverflown()) {
                 $(tabBack).removeClass('taboverflow-tab-visible');
                 break;
             }
-            addedCount++;
         }
     }
 
-    if (addedCount < this.tabs.length) {
+    if (this.visibleTabCount() < this.tabs.length) {
         this.taboverflowBtn.show();
     } else {
         this.taboverflowBtn.hide();

--- a/war/src/main/js/widgets/tabs/TabBarOverflow.js
+++ b/war/src/main/js/widgets/tabs/TabBarOverflow.js
@@ -111,6 +111,31 @@ TabBarOverflow.prototype.visibleTabCount = function() {
     return $('.taboverflow-tab-visible', this.tabBar).size();
 };
 
+TabBarOverflow.prototype.fillForward = function(fromTabIndex) {
+    var $ = jQD.getJQuery();
+    for (var i = fromTabIndex; i < this.tabs.length; i++) {
+        var tabForward = this.tabs[i];
+        $(tabForward).addClass('taboverflow-tab-visible');
+        if (this.isOverflown()) {
+            $(tabForward).removeClass('taboverflow-tab-visible');
+            return true;
+        }
+    }
+    return false;
+};
+
+TabBarOverflow.prototype.fillBackward = function(fromTabIndex) {
+    for (var i = fromTabIndex - 1; i >= 0 ; i--) {
+        var tabBack = this.tabs[i];
+        $(tabBack).addClass('taboverflow-tab-visible');
+        if (this.isOverflown()) {
+            $(tabBack).removeClass('taboverflow-tab-visible');
+            return true;
+        }
+    }
+    return false;
+};
+
 TabBarOverflow.prototype.onTabActivate = function(activatedTab, refresh) {
     // We need to check if this table is visible to the user and if not,
     // we need to make it visible.
@@ -134,26 +159,12 @@ TabBarOverflow.prototype.onTabActivate = function(activatedTab, refresh) {
 
     // Start showing tabs, starting from the tab that was just activated...
     var activeTabIdx = this.tabIndex(activatedTab);
-    for (var i1 = activeTabIdx; i1 < this.tabs.length; i1++) {
-        var tabForward = this.tabs[i1];
-        $(tabForward).addClass('taboverflow-tab-visible');
-        if (this.isOverflown()) {
-            $(tabForward).removeClass('taboverflow-tab-visible');
-            break;
-        }
-    }
+    var isFull = this.fillForward(activeTabIdx);
 
-    if (!this.isOverflown() && activeTabIdx > 0) {
-        // There's room for more tabs. If there are tabs before the "active"
-        // tab, then lets show some of those too.
-        for (var i2 = activeTabIdx - 1; i2 >= 0 ; i2--) {
-            var tabBack = this.tabs[i2];
-            $(tabBack).addClass('taboverflow-tab-visible');
-            if (this.isOverflown()) {
-                $(tabBack).removeClass('taboverflow-tab-visible');
-                break;
-            }
-        }
+    // If there's room for more tabs and there are tabs before the "active"
+    // tab, then lets show some of those too.
+    if (!isFull && activeTabIdx > 0) {
+        this.fillBackward(activeTabIdx);
     }
 
     if (this.visibleTabCount() < this.tabs.length) {

--- a/war/src/main/js/widgets/tabs/TabBarOverflow.js
+++ b/war/src/main/js/widgets/tabs/TabBarOverflow.js
@@ -44,6 +44,9 @@ function TabBarOverflow(tabBarFrame, tabs) {
     win.on('resize.jenkins.taboverflow', function() {
         tabOverflow.doRefresh();
     });
+    win.on('scroll.jenkins.taboverflow', function() {
+        tabOverflow.hideDropdown();
+    });
 
     function trackOverflow() {
         try {
@@ -88,10 +91,17 @@ TabBarOverflow.prototype.setDropdownContent = function() {
     var tabOverflow = this;
 
     tabOverflow.taboverflowPopup.empty();
-    function addDropTab(tab) {
+    function addDropTab(tabIndex) {
+        var tab = tabOverflow.tabs[tabIndex];
         if (tabOverflow.isTabShowable(tab)) {
             var dropTab = $('<div class="drop-tab">');
-            dropTab.text(tab.text());
+            if (tabOverflow.isTabVisible(tabIndex)) {
+                dropTab.addClass('visible');
+                dropTab.append('<span class="eye">&#x1f441;</span>');
+                dropTab.append(tab.text());
+            } else {
+                dropTab.text(tab.text());
+            }
             tabOverflow.taboverflowPopup.append(dropTab);
             dropTab.click(function() {
                 tabOverflow.hideDropdown();
@@ -100,8 +110,8 @@ TabBarOverflow.prototype.setDropdownContent = function() {
         }
     }
 
-    for (var i = 0; i < this.tabs.length; i++) {
-        addDropTab(this.tabs[i]);
+    for (var i = 0; i < tabOverflow.tabs.length; i++) {
+        addDropTab(i);
     }
 };
 
@@ -194,6 +204,7 @@ TabBarOverflow.prototype.slideForward = function(toTabIndex) {
 };
 
 TabBarOverflow.prototype.fillBackward = function(fromTabIndex) {
+    var $ = jQD.getJQuery();
     for (var i = fromTabIndex; i >= 0 ; i--) {
         var tab = this.tabs[i];
 
@@ -221,8 +232,16 @@ TabBarOverflow.prototype.slideBackward = function(toTabIndex) {
     this.fillForward(toTabIndex);
 };
 
+TabBarOverflow.prototype.isTabVisible = function(tab) {
+    var tabIndex = tab;
+    if (typeof tab === 'object') {
+        tabIndex = this.tabIndex(tab);
+    }
+    return (tabIndex >= this.visibleStartIndex && tabIndex <= this.visibleEndIndex);
+};
+
 TabBarOverflow.prototype.isActiveTabVisible = function() {
-    return (this.activeTabIndex >= this.visibleStartIndex && this.activeTabIndex <= this.visibleEndIndex);
+    return this.isTabVisible(this.activeTabIndex);
 };
 
 TabBarOverflow.prototype.onTabActivate = function(activatedTab) {

--- a/war/src/main/js/widgets/tabs/TabBarOverflow.js
+++ b/war/src/main/js/widgets/tabs/TabBarOverflow.js
@@ -22,17 +22,25 @@ function TabBarOverflow(tabBarFrame, tabs) {
     tabBarFrame.append(taboverflowBtn);
     tabBarFrame.append(taboverflowPopup);
 
+    this.taboverflowBtn = taboverflowBtn;
     this.taboverflowCount = taboverflowCount;
     this.taboverflowPopup = taboverflowPopup;
     this.setTabCount();
-    this.setDropdownContent();
 
     // Show and hide the dropdown.
+    var tabOverflow = this;
     taboverflowBtn.click(function() {
         if (taboverflowPopup.hasClass('hidden')) {
-            taboverflowPopup.removeClass('hidden');
+            tabOverflow.showDropdown();
         } else {
-            taboverflowPopup.addClass('hidden');
+            tabOverflow.hideDropdown();
+        }
+    });
+
+    var win = $(windowHandle.getWindow());
+    win.resize(function() {
+        if (tabOverflow.activeTab) {
+            tabOverflow.onTabActivate(tabOverflow.activeTab, true);
         }
     });
 }
@@ -45,6 +53,15 @@ TabBarOverflow.prototype.setTabCount = function() {
     }
 };
 
+TabBarOverflow.prototype.showDropdown = function() {
+    this.setDropdownContent();
+    this.taboverflowPopup.removeClass('hidden');
+};
+
+TabBarOverflow.prototype.hideDropdown = function() {
+    this.taboverflowPopup.addClass('hidden');
+};
+
 TabBarOverflow.prototype.setDropdownContent = function() {
     var $ = jQD.getJQuery();
     var tabOverflow = this;
@@ -55,7 +72,7 @@ TabBarOverflow.prototype.setDropdownContent = function() {
         dropTab.text(tab.text());
         tabOverflow.taboverflowPopup.append(dropTab);
         dropTab.click(function() {
-            tabOverflow.taboverflowPopup.addClass('hidden');
+            tabOverflow.hideDropdown();
             tab.click();
         });
     }
@@ -65,6 +82,76 @@ TabBarOverflow.prototype.setDropdownContent = function() {
     }
 };
 
-TabBarOverflow.prototype.trackTabVisibility = function() {
-    // TODO
+TabBarOverflow.prototype.trackTabVisibility = function(tabVisibleChecker) {
+    this.tabVisibleChecker = tabVisibleChecker;
+};
+
+TabBarOverflow.prototype.isOverflown = function() {
+    return (this.tabBar.width() > this.tabBarFrame.width());
+};
+
+TabBarOverflow.prototype.onTabActivate = function(activatedTab, refresh) {
+    // We need to check if this table is visible to the user and if not,
+    // we need to make it visible.
+
+    if (refresh === undefined || refresh === false) {
+        if (!this.isOverflown() && activatedTab.hasClass('taboverflow-tab-visible')) {
+            // This tab is already visible.
+            return;
+        }
+    }
+
+    var $ = jQD.getJQuery();
+
+    // Ok, the tab that's just been activated is not visible to the user. So,
+    // we make it (and local sibling tabs) visible by hiding other tabs before it.
+    // We start by hiding all tabs. Then, we start showing tabs (starting from
+    // the supplied tab). We stop showing tabs once we show a tab that overflows the tabBar.
+
+    // Hide them all..
+    for (var i = 0; i < this.tabs.length; i++) {
+        $(this.tabs[i]).removeClass('taboverflow-tab-visible');
+    }
+
+    // Start showing tabs, starting from the tab that was just activated...
+    var addTabs = false;
+    var addedCount = 0;
+    var activeTabIdx = 0;
+    for (var i = 0; i < this.tabs.length; i++) {
+        var tab = this.tabs[i];
+        if (tab === activatedTab) {
+            addTabs = true;
+            activeTabIdx = i;
+        }
+        if (addTabs) {
+            $(tab).addClass('taboverflow-tab-visible');
+            if (this.isOverflown()) {
+                $(tab).removeClass('taboverflow-tab-visible');
+                break;
+            }
+            addedCount++;
+        }
+    }
+
+    if (!this.isOverflown() && activeTabIdx > 0) {
+        // There's room for more tabs. If there are tabs before the "active"
+        // tab, then lets show some of those too.
+        for (var i = activeTabIdx - 1; i >= 0 ; i--) {
+            var tab = this.tabs[i];
+            $(tab).addClass('taboverflow-tab-visible');
+            if (this.isOverflown()) {
+                $(tab).removeClass('taboverflow-tab-visible');
+                break;
+            }
+            addedCount++;
+        }
+    }
+
+    if (addedCount < this.tabs.length) {
+        this.taboverflowBtn.show();
+    } else {
+        this.taboverflowBtn.hide();
+    }
+
+    this.activeTab = activatedTab;
 };

--- a/war/src/main/js/widgets/tabs/tabbar-overflow.less
+++ b/war/src/main/js/widgets/tabs/tabbar-overflow.less
@@ -1,0 +1,47 @@
+// Tabbar Overflow mixin.
+.tabBarOverflow() {
+  .tabBarFrame {
+    position: absolute;
+    left: 0;
+    right: 0;
+
+    .tabBar {
+      overflow-x: hidden;
+      white-space: nowrap;
+      margin-right: 54px;
+
+      .tab {
+        display: inline-block;
+        float: none;
+      }
+    }
+
+    .taboverflow-btn {
+      cursor: pointer;
+      width: 44px;
+      position: absolute;
+      top: 7px;
+      right: 5px;
+      border:1px solid @solid-border;
+      .border-radius(5px);
+      padding: 3px 3px;
+      font-size: 0.9em;
+      color: #999;
+      text-align: center;
+
+      .icon {
+        float: left;
+        width: 18px;
+      }
+      .count {
+        float: right;
+        width: 18px;
+      }
+    }
+
+    .taboverflow-btn:hover {
+      background:#bbb;
+      color:@brightest;
+    }
+  }
+}

--- a/war/src/main/js/widgets/tabs/tabbar-overflow.less
+++ b/war/src/main/js/widgets/tabs/tabbar-overflow.less
@@ -39,9 +39,32 @@
       }
     }
 
-    .taboverflow-btn:hover {
+    .taboverflow-btn:hover, .drop-tab:hover {
       background:#bbb;
       color:@brightest;
+      cursor: pointer;
+    }
+
+    .taboverflow-popup {
+      padding: 5px 10px;
+      overflow-y: auto;
+      background-color: @brightest;
+      max-width: 200px;
+      max-height: 250px;
+      position: absolute;
+      top: 35px;
+      right: 5px;
+
+      border:1px solid @solid-border;
+      .border-radius(5px);
+
+      .drop-tab {
+        padding: 5px;
+        .border-radius(2px);
+        overflow-x: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
     }
   }
 }

--- a/war/src/main/js/widgets/tabs/tabbar-overflow.less
+++ b/war/src/main/js/widgets/tabs/tabbar-overflow.less
@@ -54,7 +54,7 @@
       padding: 5px 10px;
       overflow-y: auto;
       background-color: @brightest;
-      max-width: 200px;
+      max-width: 250px;
       max-height: 250px;
       position: absolute;
       top: 35px;
@@ -69,6 +69,13 @@
         overflow-x: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+      }
+
+      .drop-tab.visible {
+        opacity: 0.5;
+        .eye {
+          margin-right: 5px;
+        }
       }
     }
   }

--- a/war/src/main/js/widgets/tabs/tabbar-overflow.less
+++ b/war/src/main/js/widgets/tabs/tabbar-overflow.less
@@ -4,15 +4,20 @@
     position: absolute;
     left: 0;
     right: 0;
+    padding-top: 5px;
+    padding-right: 54px;
 
     .tabBar {
+      display: inline;
       overflow-x: hidden;
       white-space: nowrap;
-      margin-right: 54px;
 
       .tab {
-        display: inline-block;
+        display: none;
         float: none;
+      }
+      .tab.taboverflow-tab-visible {
+        display: inline-block;
       }
     }
 


### PR DESCRIPTION
Today, config page scrollspy is kinda horrible if used on the system config with lots of plugins installed. It results in tab overflow where there can be 5+ rows of tabs. Looks a bit silly + is eating up a lot of space.

These changes introduce a dropdown box for when tabs overflow.

VIDEO: https://youtu.be/h25-8Hu1VLs (shows the current state at the start, followed by how things would look with these changes) 

@jenkinsci/code-reviewers 

Still have tests to do, but will leave those until we decide if we want this or not.
