### PR TITLE
[FIXED ENKINS-33601] Change 'Skip' text in setup wizard

### DIFF
--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -38,7 +38,7 @@ installWizard_installIncomplete_banner=Resume Installation
 installWizard_installIncomplete_message=Jenkins was restarted during installation and some plugins didn't seem to get installed.
 installWizard_installIncomplete_resumeInstallationButtonLabel=Resume
 installWizard_saveFirstUser=Save and Finish
-installWizard_skipFirstUser=Skip
+installWizard_skipFirstUser=Continue as admin
 installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
 You've skipped creating an admin user. To log in, use the username: 'admin' and \
 the security token you used to access the setup wizard.\


### PR DESCRIPTION
Change the label from 'Skip' to 'Continue as admin', for clarity, which is actually what happens if you don't create an alternate first admin user during the setup wizard.

![image](https://cloud.githubusercontent.com/assets/3009477/14251694/34a2d4c0-fa52-11e5-9ddb-52433b033619.png)

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-33601

@reviewbybees
