### PR TITLE
Generate a dump of OOM + temporarily disable OldDataMonitorTest.memory

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -201,7 +201,7 @@ THE SOFTWARE.
         <artifactId>maven-surefire-plugin</artifactId>
         <!-- version specified in grandparent pom -->
         <configuration>
-          <argLine>${jacocoSurefireArgs} -Dfile.encoding=UTF-8 -Xmx1g -XX:MaxPermSize=128m</argLine>
+          <argLine>${jacocoSurefireArgs} -Dfile.encoding=UTF-8 -Xmx1g -XX:MaxPermSize=128m -XX:+HeapDumpOnOutOfMemoryError</argLine>
           <systemPropertyVariables>
               <!-- use AntClassLoader that supports predictable file handle release -->
               <hudson.ClassicPluginStrategy.useAntClassLoader>true</hudson.ClassicPluginStrategy.useAntClassLoader>

--- a/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
@@ -88,7 +88,7 @@ public class OldDataMonitorTest {
     }
 
     @Issue("JENKINS-19544")
-    @Ignore
+    @Ignore("Disabled while diagnosing a random OOM issue") // FIXME enable and remove -XX:+HeapDumpOnOutOfMemoryError
     @Test public void memory() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject("p");
         FreeStyleBuild b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));

--- a/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
@@ -88,6 +88,7 @@ public class OldDataMonitorTest {
     }
 
     @Issue("JENKINS-19544")
+    @Ignore
     @Test public void memory() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject("p");
         FreeStyleBuild b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));


### PR DESCRIPTION
Generate a dump on OOM + temporarily disable `OldDataMonitorTest.memory` (diagnosing an elusive OOM happening randomly mostly in CI).

@jenkinsci/code-reviewers esp. @daniel-beck @jglick 
@reviewbybees
