### PR TITLE
Do not use '_' as an identifier

### DIFF
--- a/core/src/test/java/hudson/BulkChangeTest.java
+++ b/core/src/test/java/hudson/BulkChangeTest.java
@@ -98,10 +98,10 @@ public class BulkChangeTest {
     @Test
     public void nestedBulkChange() throws Exception {
         Point pt = new Point();
-        Point _ = new Point();
+        Point pt2 = new Point();
         BulkChange bc1 = new BulkChange(pt);
         try {
-            BulkChange bc2 = new BulkChange(_);
+            BulkChange bc2 = new BulkChange(pt2);
             try {
                 BulkChange bc3 = new BulkChange(pt);
                 try {


### PR DESCRIPTION
Eliminates Java 8 warnings:
  (use of '_' as an identifier might not be supported in releases after Java SE 8)
