### PR TITLE
Fix href tags

### DIFF
--- a/core/src/main/java/hudson/search/SearchResult.java
+++ b/core/src/main/java/hudson/search/SearchResult.java
@@ -3,7 +3,7 @@ package hudson.search;
 import java.util.List;
 
 /**
- * @author <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public interface SearchResult extends List<SuggestedItem> {
 

--- a/core/src/test/java/hudson/model/ItemsTest.java
+++ b/core/src/test/java/hudson/model/ItemsTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ItemsTest {
 


### PR DESCRIPTION
Eliminates errors with Java 8 and "mvn javadoc:test-javadoc" such as:

```
[ERROR] jenkins/core/src/test/java/hudson/model/ItemsTest.java:12: error: unknown attribute: hef
[ERROR] * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
```
