### PR TITLE
[JENKINS-32340] Enable disabled dependencies

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -565,7 +565,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
         // make sure dependencies exist
         for (Dependency d : dependencies) {
             PluginWrapper dependency = parent.getPlugin(d.shortName);
-            if (dependency == null || !dependency.isActive()) {
+            if (dependency == null) {
                 missingDependencies.add(d.toString());
             } else {
                 if (dependency.isActive()) {

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -565,7 +565,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
         // make sure dependencies exist
         for (Dependency d : dependencies) {
             PluginWrapper dependency = parent.getPlugin(d.shortName);
-            if (dependency == null) {
+            if (dependency == null || !dependency.isActive()) {
                 missingDependencies.add(d.toString());
             } else {
                 if (dependency.isActive()) {

--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -173,6 +173,12 @@ Behaviour.specify("#filter-box", '_table', 0, function(e) {
         
         function setEnableWidgetStates() {
             for (var i = 0; i < pluginTRs.length; i++) {
+                var pluginMetadata = pluginTRs[i].jenkinsPluginMetadata;
+                if (pluginTRs[i].hasClassName('has-dependants-but-disabled')) {
+                    if (pluginMetadata.enableInput.checked) {
+                        pluginTRs[i].removeClassName('has-dependants-but-disabled');
+                        }
+                }
                 markAllDependantsDisabled(pluginTRs[i]);
                 markHasDisabledDependencies(pluginTRs[i]);
             }

--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -176,7 +176,7 @@ Behaviour.specify("#filter-box", '_table', 0, function(e) {
                 var pluginMetadata = pluginTRs[i].jenkinsPluginMetadata;
                 if (pluginTRs[i].hasClassName('has-dependants-but-disabled')) {
                     if (pluginMetadata.enableInput.checked) {
-                        pluginTRs[i].removeClassName('has-dependants-but-disabled');
+                            pluginTRs[i].removeClassName('has-dependants-but-disabled');
                         }
                 }
                 markAllDependantsDisabled(pluginTRs[i]);

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -68,7 +68,7 @@ THE SOFTWARE.
                 <th width="1">${%Uninstall}</th>
               </tr>
               <j:forEach var="p" items="${app.pluginManager.plugins}">
-                <tr class="plugin ${p.hasDependants()?'has-dependants':''} ${p.isDeleted()?'deleted':''}" data-plugin-id="${p.shortName}" data-plugin-name="${p.displayName}">
+                <tr class="plugin ${p.hasDependants()?'has-dependants':''} ${(p.hasDependants() &amp;&amp; !p.enabled)?'has-dependants-but-disabled':''} ${p.isDeleted()?'deleted':''}" data-plugin-id="${p.shortName}" data-plugin-name="${p.displayName}">
                   <j:set var="state" value="${p.enabled?'true':null}"/>
                   <td class="center pane enable" data="${state}">
                     <input type="checkbox" checked="${state}" onclick="flip(event)"

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1349,6 +1349,12 @@ TABLE.fingerprint-in-build TD {
   opacity: 0.2;
 }
 
+#plugins tr.has-dependants-but-disabled .enable input {
+  pointer-events: auto;
+  opacity: 1.0;
+  visibility: visible;
+}
+
 #plugins tr.has-disabled-dependency .enable input {
   opacity: 0.4;
 }


### PR DESCRIPTION
Created this PR due the urgency and don't want to cope with git conflicts due @Vlatombe PR #2172 which stepped #2002

It's not possible to enable disabled dependencies that should not have been disabled in the first place.
Steps to reproduce:

```
$ export JAVA_HOME=$HOME/DisabledDependencyHome
$ java -jar jenkins.war
$ touch $JENKINS_HOME/plugins/junit.jpi.disabled
$ java -jar jenkins.war
JUnit plugin cannot be enabled through the UI
```

@reviewbybees CC @tfennelly @daniel-beck @Vlatombe (since he didn't cover one of the cases - `|| !dependency.isActive()`)
