### PR TITLE
Re-introduce a reference to the setup administrator password in the logs

### DIFF
--- a/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
@@ -18,7 +18,7 @@
                     <p>
                         ${%jenkins.install.findSecurityTokenMessage(it.initialAdminPasswordFile)}
                     </p>
-                    <p>${%Please copy the password and paste it below.}</p>
+                    <p>${%Please copy the password from either location and paste it below.}</p>
                     <j:if test="${error}">
                         <div class="alert alert-danger">
                           <strong>${%ERROR:} </strong>

--- a/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.properties
+++ b/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.properties
@@ -1,2 +1,2 @@
 jenkins.install.findSecurityTokenMessage=To ensure Jenkins is securely set up by the administrator, \
-a password has been generated and written to the file on the Jenkins server here: <br/><small><code>{0}</code></small>
+a password has been written to the log (<small><a href="https://jenkins.io/redirect/find-jenkins-logs" target="_blank">not sure where to find it?</a></small>) and this file on the server: <p><small><code>{0}</code></small></p>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -41,7 +41,7 @@ installWizard_saveFirstUser=Save and Finish
 installWizard_skipFirstUser=Continue as admin
 installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
 You've skipped creating an admin user. To log in, use the username: 'admin' and \
-the security token you used to access the setup wizard.\
+the administrator password you used to access the setup wizard.\
 </div>
 installWizard_addFirstUser_title=Getting Started
 installWizard_configureProxy_label=Configure Proxy


### PR DESCRIPTION
This makes if possible for users without access to file-systems, like those
running Jenkins masters in Docker containers (unmapped jenkins_home) to still be
able to successfully use Jenkins 2.0

This commit also fixes an errant reference to "security token" which we no
longer use in the beginning of the Getting Started wizard, opting instead for
"administrator password"
