### PR TITLE
Ensure Jenkins uses jenkins-2.0 packaging in JenkinsFile, to avoid [JENKINS-33776]. Jenkins! (v2.0)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ properties([[$class: 'jenkins.model.BuildDiscarderProperty', strategy: [$class: 
                                                                         numToKeepStr: '50',
                                                                         artifactNumToKeepStr: '20']]])
 
-String packagingBranch = (binding.hasVariable('packagingBranch')) ? packagingBranch : 'master'
+String packagingBranch = (binding.hasVariable('packagingBranch')) ? packagingBranch : 'jenkins-2.0'
 
 timestampedNode('java') {
 


### PR DESCRIPTION
Ensures we use packaging that has taken up: https://github.com/jenkinsci/packaging/pull/51

Which includes fix for: [JENKINS-33776](https://issues.jenkins-ci.org/browse/JENKINS-33776).

Fixed the merge base.
