### PR TITLE
[FIXED JENKINS-21485] AdministrativeMonitor for plugins that have failed

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -26,6 +26,7 @@ package hudson;
 
 import com.google.common.collect.ImmutableSet;
 import hudson.PluginManager.PluginInstanceStore;
+import hudson.model.AdministrativeMonitor;
 import hudson.model.Api;
 import hudson.model.ModelObject;
 import jenkins.YesNoMaybe;
@@ -53,6 +54,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.LogFactory;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -555,6 +558,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
                 LOGGER.warning(shortName + " doesn't declare required core version.");
             } else {
                 if (Jenkins.getVersion().isOlderThan(new VersionNumber(requiredCoreVersion))) {
+                    NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_OutdatedCoreVersion(shortName, requiredCoreVersion));
                     throw new IOException(shortName + " requires a more recent core version (" + requiredCoreVersion + ") than the current (" + Jenkins.getVersion() + ").");
                 }
             }
@@ -567,13 +571,16 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
             PluginWrapper dependency = parent.getPlugin(d.shortName);
             if (dependency == null) {
                 missingDependencies.add(d.toString());
+                NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_MissingDependency(shortName, dependency.getLongName()));
             } else {
                 if (dependency.isActive()) {
                     if (ENABLE_PLUGIN_DEPENDENCIES_VERSION_CHECK && dependency.getVersionNumber().isOlderThan(new VersionNumber(d.version))) {
                         obsoleteDependencies.add(dependency.getShortName() + "(" + dependency.getVersion() + " < " + d.version + ")");
+                        NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_ObsoleteDependency(shortName, dependency.getLongName(), d.version));
                     }
                 } else {
                     disabledDependencies.add(d.toString());
+                    NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_DisabledDependency(shortName, dependency.getLongName()));
                 }
 
             }
@@ -584,6 +591,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
             if (dependency != null && dependency.isActive()) {
                 if (ENABLE_PLUGIN_DEPENDENCIES_VERSION_CHECK && dependency.getVersionNumber().isOlderThan(new VersionNumber(d.version))) {
                     obsoleteDependencies.add(dependency.getShortName() + "(" + dependency.getVersion() + " < " + d.version + ")");
+                    NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_ObsoleteDependency(shortName, dependency.getLongName(), d.version));
                 } else {
                     dependencies.add(d);
                 }
@@ -726,6 +734,38 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
         VersionNumber me = getVersionNumber();
 
         return me.isOlderThan(you);
+    }
+
+    @Extension
+    public final static PluginWrapperAdministrativeMonitor NOTICE = new PluginWrapperAdministrativeMonitor();
+
+    /**
+     * Administrative Monitor for failed plugins
+     */
+    public static final class PluginWrapperAdministrativeMonitor extends AdministrativeMonitor {
+        public final List<String> pluginError = new ArrayList<>();
+
+        void addErrorMessage(String error) {
+            pluginError.add(error);
+        }
+
+        public boolean isActivated() {
+            return !pluginError.isEmpty();
+        }
+
+        /**
+         * Depending on whether the user said "dismiss" or "correct", send him to the right place.
+         */
+        public void doAct(StaplerRequest req, StaplerResponse rsp) throws IOException {
+            if(req.hasParameter("correct")) {
+                rsp.sendRedirect(req.getContextPath()+"/pluginManager");
+
+            }
+        }
+
+        public static PluginWrapperAdministrativeMonitor get() {
+            return AdministrativeMonitor.all().get(PluginWrapperAdministrativeMonitor.class);
+        }
     }
 
 //

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -558,8 +558,8 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
                 LOGGER.warning(shortName + " doesn't declare required core version.");
             } else {
                 if (Jenkins.getVersion().isOlderThan(new VersionNumber(requiredCoreVersion))) {
-                    NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_OutdatedCoreVersion(shortName, requiredCoreVersion));
-                    throw new IOException(shortName + " requires a more recent core version (" + requiredCoreVersion + ") than the current (" + Jenkins.getVersion() + ").");
+                    NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_OutdatedCoreVersion(getLongName(), requiredCoreVersion));
+                    throw new IOException(getLongName() + " requires a more recent core version (" + requiredCoreVersion + ") than the current (" + Jenkins.getVersion() + ").");
                 }
             }
         }
@@ -571,16 +571,16 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
             PluginWrapper dependency = parent.getPlugin(d.shortName);
             if (dependency == null) {
                 missingDependencies.add(d.toString());
-                NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_MissingDependency(shortName, dependency.getLongName()));
+                NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_MissingDependency(getLongName(), d.shortName));
             } else {
                 if (dependency.isActive()) {
                     if (ENABLE_PLUGIN_DEPENDENCIES_VERSION_CHECK && dependency.getVersionNumber().isOlderThan(new VersionNumber(d.version))) {
                         obsoleteDependencies.add(dependency.getShortName() + "(" + dependency.getVersion() + " < " + d.version + ")");
-                        NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_ObsoleteDependency(shortName, dependency.getLongName(), d.version));
+                        NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_ObsoleteDependency(getLongName(), dependency.getLongName(), d.version));
                     }
                 } else {
                     disabledDependencies.add(d.toString());
-                    NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_DisabledDependency(shortName, dependency.getLongName()));
+                    NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_DisabledDependency(getLongName(), dependency.getLongName()));
                 }
 
             }
@@ -591,7 +591,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
             if (dependency != null && dependency.isActive()) {
                 if (ENABLE_PLUGIN_DEPENDENCIES_VERSION_CHECK && dependency.getVersionNumber().isOlderThan(new VersionNumber(d.version))) {
                     obsoleteDependencies.add(dependency.getShortName() + "(" + dependency.getVersion() + " < " + d.version + ")");
-                    NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_ObsoleteDependency(shortName, dependency.getLongName(), d.version));
+                    NOTICE.addErrorMessage(Messages.PluginWrapper_admonitor_ObsoleteDependency(getLongName(), dependency.getLongName(), d.version));
                 } else {
                     dependencies.add(d);
                 }

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -71,3 +71,8 @@ ProxyConfiguration.FailedToConnect=Failed to connect to {0} (code {1}).
 ProxyConfiguration.Success=Success
 
 Functions.NoExceptionDetails=No Exception details
+
+PluginWrapper.admonitor.OutdatedCoreVersion=Plugin {0} requires Jenkins {1} or later
+PluginWrapper.admonitor.MissingDependency=Plugin {0} doesn\u2019t have installed the required dependency {1}.
+PluginWrapper.admonitor.DisabledDependency=Plugin {0} has disabled the required dependency {1}
+PluginWrapper.admonitor.ObsoleteDependency=Plugin {0} requires {1} {2} or later

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -73,6 +73,6 @@ ProxyConfiguration.Success=Success
 Functions.NoExceptionDetails=No Exception details
 
 PluginWrapper.admonitor.OutdatedCoreVersion=Plugin {0} requires Jenkins {1} or later
-PluginWrapper.admonitor.MissingDependency=Plugin {0} doesn\u2019t have installed the required dependency {1}.
-PluginWrapper.admonitor.DisabledDependency=Plugin {0} has disabled the required dependency {1}
+PluginWrapper.admonitor.MissingDependency=Plugin {0} requires the missing plugin {1}
+PluginWrapper.admonitor.DisabledDependency=Plugin {0} depends on the disabled {1}
 PluginWrapper.admonitor.ObsoleteDependency=Plugin {0} requires {1} {2} or later

--- a/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/message.jelly
@@ -1,0 +1,15 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <div class="error">
+        <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
+            <div style="float:right">
+                <f:submit name="correct" value="${%Correct}"/>
+            </div>
+        </form>
+        <ul>
+            <j:forEach items="${it.pluginError}" var="pluginError">
+                <li>${pluginError}</li>
+            </j:forEach>
+        </ul>
+    </div>
+</j:jelly>


### PR DESCRIPTION
This PR substitute #2098 in case we keep @Vlatombe's PR #2172. 

Notice that I needed to do:

```
public final static PluginWrapperAdministrativeMonitor NOTICE = new PluginWrapperAdministrativeMonitor();
```

because it looks like the Extensions are not leaded at this point.

CC @jglick @daniel-beck @Vlatombe 

@reviewbybees
