### PR TITLE
Remove use of '>' which cause javadoc errors

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -28,9 +28,9 @@ THE SOFTWARE.
     Outer most tag for creating a heterogeneous list, where the user can choose arbitrary number of
     arbitrary items from the given list of descriptors, and configure them independently.
 
-    The submission can be data-bound into List&lt;T> where T is the common base type for the describable instances.
+    The submission can be data-bound into List&lt;T&gt; where T is the common base type for the describable instances.
 
-    For databinding use, please use &lt;f:repeatableHeteroProperty />
+    For databinding use, please use &lt;f:repeatableHeteroProperty /&gt;
     
     <st:attribute name="name" use="required">
       form name that receives an array for all the items in the heterogeneous list.


### PR DESCRIPTION
Tested with Java 8 and "mvn javadoc:test-javadoc".  Eliminates errors in other plugins such as multiple-scms-plugin,
such as:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.8:jar (attach-javadocs) on project multiple-scms: MavenReportException: Error while creating archive:
[ERROR] Exit code: 1 - target/checkout/target/generated-sources/taglib-interface/org/jenkinsci/plugins/multiplescms/FormsTagLib.java:21: error: bad use of '>'
[ERROR] *     The submission can be data-bound into List&lt;T> where T is the common base type for the describable instances.
[ERROR]
[ERROR] target/checkout/target/generated-sources/taglib-interface/org/jenkinsci/plugins/multiplescms/FormsTagLib.java:23: error: bad use of '>'
```
