### PR TITLE
[FIXED JENKINS-33999] Update remoting to 2.57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>2.56</version>
+        <version>2.57</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This picks up the new remoting with the upstream fix for [JENKINS-33999](https://issues.jenkins-ci.org/browse/JENKINS-33999)
which allows spring Exceptions past the class blacklist

[diff link for remoting](https://github.com/jenkinsci/remoting/compare/remoting-2.56...remoting-2.57)
@reviewbybees
