### PR TITLE
Fixed an JSHint error

### DIFF
--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -215,7 +215,7 @@ var createPluginSetupWizard = function(appendTarget) {
 				// add Jenkins version
 				if(translations.installWizard_jenkinsVersionTitle) { // wait until translations available
 					var $modalFooter = $container.find('.modal-footer');
-					if($modalFooter.length == 0) {
+					if($modalFooter.length === 0) {
 						$modalFooter = $('<div class="modal-footer"></div>').appendTo($container);
 					}
 					$modalFooter.prepend('<div class="jenkins-version">'+translations.installWizard_jenkinsVersionTitle+' '+$('body').attr('data-version')+'</div>');


### PR DESCRIPTION
```
[INFO] [12:12:04] LESS CSS pre-processing completed to 'src/main/webapp/jsbundles'.
[INFO] src/main/js/pluginSetupWizardGui.js: line 218, col 46, Expected '===' and instead saw '=='.
[INFO] 
[INFO] 1 error
[ERROR] 
[ERROR] events.js:141
[ERROR]       throw er; // Unhandled 'error' event
[ERROR]       ^
[ERROR] Error: JSHint failed for: src/main/js/pluginSetupWizardGui.js
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
```

When you run `com.github.eirslett:frontend-maven-plugin:0.0.23:gulp` on `org.jenkins-ci.main:jenkins-war`.

@reviewbybees especially @kzantow 
