### PR TITLE
Use DirectoryStream paths in java 7 to traverse the users.

### DIFF
--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -424,8 +424,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
         if (!configFile.isFile() && !configFile.getParentFile().isDirectory()) {
             // check for legacy users and migrate if safe to do so.
 
-            try {
-                DirectoryStream<Path> legacy = getLegacyConfigFilesFor(id);
+            try (DirectoryStream<Path> legacy = getLegacyConfigFilesFor(id)){
                 if (legacy != null && legacy.iterator().hasNext()) {
                     for (Path legacyUserDir : legacy) {
                         final XmlFile legacyXml = new XmlFile(XSTREAM, legacyUserDir.resolve("config.xml").toFile());

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -425,7 +425,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
             // check for legacy users and migrate if safe to do so.
 
             try (DirectoryStream<Path> legacy = getLegacyConfigFilesFor(id)){
-                if (legacy != null && legacy.iterator().hasNext()) {
+                if (legacy.iterator().hasNext()) {
                     for (Path legacyUserDir : legacy) {
                         final XmlFile legacyXml = new XmlFile(XSTREAM, legacyUserDir.resolve("config.xml").toFile());
                         try {
@@ -437,8 +437,8 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
                                     try {
                                         Files.move(legacyUserDir, Paths.get(configFile.toURI()));
                                     } catch (IOException e) {
-                                        LOGGER.log(Level.WARNING, "Failed to migrate user record from {0} to {1}",
-                                                new Object[]{legacyUserDir, configFile.getParentFile()});
+                                        LOGGER.log(Level.WARNING, String.format("Failed to migrate user record from %s to %s",
+                                                legacyUserDir, configFile.getParentFile()), e);
                                     }
                                     break;
                                 }
@@ -447,13 +447,13 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
                                         new Object[]{ legacyUserDir, o });
                             }
                         } catch (IOException e) {
-                            LOGGER.log(Level.FINE, String.format("Exception trying to load user from {0}: {1}",
-                                    new Object[]{ legacyUserDir, e.getMessage() }), e);
+                            LOGGER.log(Level.FINE, String.format("Exception trying to load user from %s: %s",
+                                    legacyUserDir, e.getMessage()), e);
                         }
                     }
                 }
             } catch (IOException e) {
-                e.printStackTrace();
+                LOGGER.log(Level.WARNING, "Issue obtaining the directory stream for legacy users.", e);
             }
 
         }

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -65,6 +65,10 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.FileFilter;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -419,31 +423,40 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
         final File configFile = getConfigFileFor(id);
         if (!configFile.isFile() && !configFile.getParentFile().isDirectory()) {
             // check for legacy users and migrate if safe to do so.
-            File[] legacy = getLegacyConfigFilesFor(id);
-            if (legacy != null && legacy.length > 0) {
-                for (File legacyUserDir : legacy) {
-                    final XmlFile legacyXml = new XmlFile(XSTREAM, new File(legacyUserDir, "config.xml"));
-                    try {
-                        Object o = legacyXml.read();
-                        if (o instanceof User) {
-                            if (idStrategy().equals(id, legacyUserDir.getName()) && !idStrategy().filenameOf(legacyUserDir.getName())
-                                    .equals(legacyUserDir.getName())) {
-                                if (!legacyUserDir.renameTo(configFile.getParentFile())) {
-                                    LOGGER.log(Level.WARNING, "Failed to migrate user record from {0} to {1}",
-                                            new Object[]{legacyUserDir, configFile.getParentFile()});
+
+            try {
+                DirectoryStream<Path> legacy = getLegacyConfigFilesFor(id);
+                if (legacy != null && legacy.iterator().hasNext()) {
+                    for (Path legacyUserDir : legacy) {
+                        final XmlFile legacyXml = new XmlFile(XSTREAM, legacyUserDir.resolve("config.xml").toFile());
+                        try {
+                            Object o = legacyXml.read();
+                            if (o instanceof User) {
+                                String fileName = legacyUserDir.getFileName().toString();
+                                if (idStrategy().equals(id, fileName) && !idStrategy().filenameOf(fileName)
+                                        .equals(fileName)) {
+                                    try {
+                                        Files.move(legacyUserDir, Paths.get(configFile.toURI()));
+                                    } catch (IOException e) {
+                                        LOGGER.log(Level.WARNING, "Failed to migrate user record from {0} to {1}",
+                                                new Object[]{legacyUserDir, configFile.getParentFile()});
+                                    }
+                                    break;
                                 }
-                                break;
+                            } else {
+                                LOGGER.log(Level.FINE, "Unexpected object loaded from {0}: {1}",
+                                        new Object[]{ legacyUserDir, o });
                             }
-                        } else {
-                            LOGGER.log(Level.FINE, "Unexpected object loaded from {0}: {1}",
-                                    new Object[]{ legacyUserDir, o });
+                        } catch (IOException e) {
+                            LOGGER.log(Level.FINE, String.format("Exception trying to load user from {0}: {1}",
+                                    new Object[]{ legacyUserDir, e.getMessage() }), e);
                         }
-                    } catch (IOException e) {
-                        LOGGER.log(Level.FINE, String.format("Exception trying to load user from {0}: {1}",
-                                new Object[]{ legacyUserDir, e.getMessage() }), e);
                     }
                 }
+            } catch (IOException e) {
+                e.printStackTrace();
             }
+
         }
         if (u==null && (create || configFile.exists())) {
             User tmp = new User(id, fullName);
@@ -655,12 +668,11 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
         return new File(getRootDir(), idStrategy().filenameOf(id) +"/config.xml");
     }
 
-    private static final File[] getLegacyConfigFilesFor(final String id) {
-        return getRootDir().listFiles(new FileFilter() {
+    private static final DirectoryStream<Path> getLegacyConfigFilesFor(final String id) throws IOException {
+        return Files.newDirectoryStream(getRootDir().toPath(), new DirectoryStream.Filter<Path>() {
             @Override
-            public boolean accept(File pathname) {
-                return pathname.isDirectory() && new File(pathname, "config.xml").isFile() && idStrategy().equals(
-                        pathname.getName(), id);
+            public boolean accept(Path entry) throws IOException {
+                return Files.isDirectory(entry) && Files.exists(entry.resolve("config.xml")) && idStrategy().equals(entry.getFileName().toString(), id);
             }
         });
     }


### PR DESCRIPTION
With the move to Java 7 the nio2 library is made available for usage. The DirectoryStream api allows for a more effeicient method of walking the directory tree structure. This fixes a potential performance issue where there are several thousand users in the $JENKINS_HOME/users directory which are still on the legacy format for user ids. This uses the NIO2 methods for doing the tree walk and moving the directories into the correct locations.

@reviewbybees
