### PR TITLE
[JENKINS-32936] Support for multiple layouts in Jelly Layout tag

### DIFF
--- a/core/src/main/resources/hudson/AboutJenkins/index.jelly
+++ b/core/src/main/resources/hudson/AboutJenkins/index.jelly
@@ -25,44 +25,47 @@ THE SOFTWARE.
 <!-- 3rd party license acknowledgements and  -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-  <l:layout title="${%about(app.VERSION)}" norefresh="true">
-    <l:main-panel>
-      <h1 version="${app.VERSION}">${%about(app.VERSION)}</h1>
-      <p>
-        ${%blurb}
-      </p>
 
-      <p>
-        ${%dependencies}
-      </p>
-      <j:set var="uri" value="${it.licensesURL}"/>
-      <j:choose>
-          <j:when test="${uri != null}">
+  <l:layout norefresh="true" type="one-column" title="${%about(app.VERSION)}">
+
+    <l:main-panel>
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-md-24">
+          <h1 version="${app.VERSION}">${%about(app.VERSION)}</h1>
+          <p>${%blurb}</p>
+          <p>${%dependencies}</p>
+          <j:set var="uri" value="${it.licensesURL}"/>
+          <j:choose>
+            <j:when test="${uri != null}">
               <t:thirdPartyLicenses>
-                  <j:include uri="${uri}"/>
+                <j:include uri="${uri}"/>
               </t:thirdPartyLicenses>
-          </j:when>
-          <j:otherwise>
+            </j:when>
+            <j:otherwise>
               <p>${%No information recorded}</p>
-          </j:otherwise>
-      </j:choose>
-      <p>${%plugin.dependencies}</p>
-      <ul>
-          <j:forEach var="p" items="${app.pluginManager.plugins}"> <!-- TODO sort -->
-              <li>
-                  <a href="${rootURL}/pluginManager/plugin/${p.shortName}/thirdPartyLicenses">
-                      <j:choose>
-                          <j:when test="${p.active}">
-                              ${p.displayName}
-                          </j:when>
-                          <j:otherwise>
-                              <strike>${p.displayName}</strike>
-                          </j:otherwise>
-                      </j:choose>
-                  </a>
-              </li>
-          </j:forEach>
-      </ul>
+            </j:otherwise>
+          </j:choose>
+          <p>${%plugin.dependencies}</p>
+          <ul>
+            <j:forEach var="p" items="${app.pluginManager.plugins}"> <!-- TODO sort -->
+            <li>
+              <a href="${rootURL}/pluginManager/plugin/${p.shortName}/thirdPartyLicenses">
+                <j:choose>
+                  <j:when test="${p.active}">
+                    ${p.displayName}
+                  </j:when>
+                  <j:otherwise>
+                    <strike>${p.displayName}</strike>
+                  </j:otherwise>
+                </j:choose>
+              </a>
+            </li>
+            </j:forEach>
+          </ul>
+        </div>
+      </div>
+    </div>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -27,41 +27,51 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName} Config" type="one-column" norefresh="true" permission="${it.EXTENDED_READ}">
+
+  <l:layout norefresh="true" type="one-column" permission="${it.EXTENDED_READ}" title="${it.displayName} Config">
+
+    <l:js src="jsbundles/config-scrollspy.js" />
+    <l:css src="jsbundles/config-scrollspy.css" />
+
     <l:main-panel>
-      <l:js src="jsbundles/config-scrollspy.js" />
-      <l:css src="jsbundles/config-scrollspy.css" />
+    <div class="container">
+      <div class="row">
+        <div class="col-md-offset-2 col-md-20">
 
-      <div class="behavior-loading">${%LOADING}</div>
-      <f:form method="post" action="configSubmit" name="config" tableClass="config-table scrollspy">
-        <j:set var="descriptor" value="${it.descriptor}" />
-        <j:set var="instance" value="${it}" />
+          <div class="behavior-loading">${%LOADING}</div>
 
-        <j:if test="${it.isNameEditable()}">
-          <f:entry title="${%name(it.pronoun)}">
-            <f:textbox name="name" value="${it.name}" />
-          </f:entry>
-        </j:if>
-        <f:entry title="${%Description}" help="${app.markupFormatter.helpUrl}">
-          <f:textarea name="description" value="${it.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>
-        </f:entry>
+          <f:form method="post" action="configSubmit" name="config" tableClass="config-table scrollspy">
+            <j:set var="descriptor" value="${it.descriptor}" />
+            <j:set var="instance" value="${it}" />
 
-        <f:descriptorList field="properties" descriptors="${h.getJobPropertyDescriptors(it)}" forceRowSet="true"/>
+            <j:if test="${it.isNameEditable()}">
+              <f:entry title="${%name(it.pronoun)}">
+                <f:textbox name="name" value="${it.name}" />
+              </f:entry>
+            </j:if>
+            <f:entry title="${%Description}" help="${app.markupFormatter.helpUrl}">
+              <f:textarea name="description" value="${it.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>
+            </f:entry>
 
-        <!-- additional entries from derived classes -->
-        <st:include page="configure-entries.jelly" />
+            <f:descriptorList field="properties" descriptors="${h.getJobPropertyDescriptors(it)}" forceRowSet="true"/>
 
-        <j:if test="${h.hasPermission(it,it.CONFIGURE)}">
-          <f:bottomButtonBar>
-            <!--<input type="button" name="StructureTest" value="Test" onclick="buildFormTree(this.form)" />-->
-            <f:submit value="${%Save}"/>
-            <f:apply value="${%Apply}"/>
-          </f:bottomButtonBar>
-        </j:if>
-      </f:form>
-      <j:if test="${h.hasPermission(it,it.CONFIGURE)}">
-        <st:adjunct includes="lib.form.confirm" />
-      </j:if>
+            <!-- additional entries from derived classes -->
+            <st:include page="configure-entries.jelly" />
+
+            <j:if test="${h.hasPermission(it,it.CONFIGURE)}">
+              <f:bottomButtonBar>
+                <!--<input type="button" name="StructureTest" value="Test" onclick="buildFormTree(this.form)" />-->
+                <f:submit value="${%Save}"/>
+                <f:apply value="${%Apply}"/>
+              </f:bottomButtonBar>
+            </j:if>
+          </f:form>
+          <j:if test="${h.hasPermission(it,it.CONFIGURE)}">
+            <st:adjunct includes="lib.form.confirm" />
+          </j:if>
+        </div>
+      </div>
+    </div>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.displayName} Config" cssclass="main-panel-only" norefresh="true" permission="${it.EXTENDED_READ}">
+  <l:layout title="${it.displayName} Config" type="one-column" norefresh="true" permission="${it.EXTENDED_READ}">
     <l:main-panel>
       <l:js src="jsbundles/config-scrollspy.js" />
       <l:css src="jsbundles/config-scrollspy.css" />

--- a/core/src/main/resources/hudson/model/View/newJob.jelly
+++ b/core/src/main/resources/hudson/model/View/newJob.jelly
@@ -47,7 +47,8 @@ THE SOFTWARE.
               </div>
             </div>
 
-            <div class="categories flat" role="radiogroup" aria-labelledby="Items"/>
+            <div class="categories flat" role="radiogroup" aria-labelledby="Items" />
+
             <j:if test="${!empty(app.itemMap)}">
               <div class="item-copy">
                 <p class="description">${%CopyOption.description}:</p>
@@ -62,7 +63,6 @@ THE SOFTWARE.
                 </div>
               </div>
             </j:if>
-            </div>
 
             <div class="footer">
               <div class="btn-decorator">

--- a/core/src/main/resources/hudson/model/View/newJob.jelly
+++ b/core/src/main/resources/hudson/model/View/newJob.jelly
@@ -32,44 +32,47 @@ THE SOFTWARE.
     <l:css src="jsbundles/add-item.css" />
 
     <l:main-panel>
-      <div id="add-item-panel" style="display: none;">
-        <form method="post" action="createItem" name="createItem" id="createItem">
-          <div class="header">
-            <div class="add-item-name">
-              <label for="name">${%ItemName.label}</label>
-              <input name="name" id="name" type="text" />
-              <div class="input-help">&#187; ${%ItemName.help}</div>
-              <div id="itemname-required" class="input-validation-message input-message-disabled">&#187; ${%ItemName.validation.required}</div>
-              <div id="itemname-invalid" class="input-validation-message input-message-disabled"></div>
-              <div id="itemtype-required" class="input-validation-message input-message-disabled">&#187; ${%ItemType.validation.required}</div>
-            </div>
-          </div>
-
-          <div class="categories flat" />
-
-          <j:if test="${!empty(app.itemMap)}">
-            <div class="item-copy">
-              <p class="description">${%CopyOption.description}:</p>
-              <div class="add-item-copy">
-                <input type="radio" name="mode" value="copy" />
-                <div class="icon">
-                  <img src="${resURL}/images/48x48/copy.png" />
-                </div>
-                <label>${%CopyOption.label}</label>
-                <j:set var="descriptor" value="${it.descriptor}" />
-                <s:textbox id="from" name="from" placeholder="${%CopyOption.placeholder}" field="copyNewItemFrom"/>
+    <div class="container" id="add-item-panel" style="display: none;">
+      <div class="row">
+        <div class="col-md-offset-2 col-md-20">
+          <form method="post" action="createItem" name="createItem" id="createItem">
+            <div class="header">
+              <div class="add-item-name">
+                <label for="name">${%ItemName.label}</label>
+                <input name="name" id="name" type="text" />
+                <div class="input-help">&#187; ${%ItemName.help}</div>
+                <div id="itemname-required" class="input-validation-message input-message-disabled">&#187; ${%ItemName.validation.required}</div>
+                <div id="itemname-invalid" class="input-validation-message input-message-disabled"></div>
+                <div id="itemtype-required" class="input-validation-message input-message-disabled">&#187; ${%ItemType.validation.required}</div>
               </div>
             </div>
-          </j:if>
 
-          <div class="footer">
-            <div class="btn-decorator">
-              <button type="submit" id="ok-button">OK</button>
+            <div class="categories flat" />
+
+            <j:if test="${!empty(app.itemMap)}">
+              <div class="item-copy">
+                <p class="description">${%CopyOption.description}:</p>
+                <div class="add-item-copy">
+                  <input type="radio" name="mode" value="copy" />
+                  <div class="icon">
+                    <img src="${resURL}/images/48x48/copy.png" />
+                  </div>
+                  <label>${%CopyOption.label}</label>
+                  <j:set var="descriptor" value="${it.descriptor}" />
+                  <s:textbox id="from" name="from" placeholder="${%CopyOption.placeholder}" field="copyNewItemFrom"/>
+                </div>
+              </div>
+            </j:if>
+
+            <div class="footer">
+              <div class="btn-decorator">
+                <button type="submit" id="ok-button">OK</button>
+              </div>
             </div>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
-
+    </div>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/View/newJob.jelly
+++ b/core/src/main/resources/hudson/model/View/newJob.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:getStatic var="permission" className="hudson.model.Item" field="CREATE"/>
 
-  <l:layout norefresh="true" cssclass="main-panel-only" permission="${permission}" title="${%NewJob(it.newPronoun)}">
+  <l:layout norefresh="true" type="one-column" permission="${permission}" title="${%NewJob(it.newPronoun)}">
 
     <l:js src="jsbundles/add-item.js" />
     <l:css src="jsbundles/add-item.css" />

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -37,23 +37,23 @@ THE SOFTWARE.
       If non-null and not "false", auto refresh is disabled on this page.
       This is necessary for pages that include forms.
     </st:attribute>
-    <st:attribute name="cssclass">
-      A css class name to include in the body element.
-    </st:attribute>
     <st:attribute name="css" deprecated="true">
       specify path that starts from "/" for loading additional CSS stylesheet.
-      path is interprted as relative to the context root. e.g.,
+      path is interpreted as relative to the context root. e.g.,
 
       {noformat}&lt;l:layout css="/plugin/mysuperplugin/css/myneatstyle.css">{noformat}
 
       This was originally added to allow plugins to load their stylesheets, but
-      *the use of thie attribute is discouraged now.*
+      *the use of the attribute is discouraged now.*
       plugins should now do so by inserting &lt;style> elements and/or &lt;script> elements
       in &lt;l:header/> tag.
     </st:attribute>
     <st:attribute name="permission">
       If given, this page is only made available to users that has the specified permission.
       (The permission will be checked against the "it" object.)
+    </st:attribute>
+    <st:attribute name="type" use="optional">
+      Available values: two-column (by default) or one-column (full-width size).
     </st:attribute>
   </st:documentation>
 <st:setHeader name="Expires" value="0" />
@@ -69,18 +69,21 @@ ${h.initPageVariables(context)}
   this also allows us to configure HttpSessionContextIntegrationFilter not to create sessions,
   which I suspect can end up creating sessions for wrong resource types (such as static resources.)
 -->
+<j:if test="${attrs.type==null}">
+  <j:set var="layoutType" value="two-column"/>
+</j:if>
 <j:set var="isMSIE" value="${userAgent.contains('MSIE')}"/>
 <j:set var="_" value="${request.getSession()}"/>
 <j:set var="_" value="${h.configureAutoRefresh(request, response, attrs.norefresh!=null and !attrs.norefresh.equals(false))}"/>
-  <j:set var="extensionsAvailable" value="${h.extensionsAvailable}"/>
-  <j:if test="${request.servletPath=='/' || request.servletPath==''}">
-    ${h.advertiseHeaders(response)}
-    <j:if test="${extensionsAvailable}">
-      <j:forEach var="pd" items="${h.pageDecorators}">
-        <st:include it="${pd}" page="httpHeaders.jelly" optional="true"/>
-      </j:forEach>
-    </j:if>
+<j:set var="extensionsAvailable" value="${h.extensionsAvailable}"/>
+<j:if test="${request.servletPath=='/' || request.servletPath==''}">
+  ${h.advertiseHeaders(response)}
+  <j:if test="${extensionsAvailable}">
+    <j:forEach var="pd" items="${h.pageDecorators}">
+      <st:include it="${pd}" page="httpHeaders.jelly" optional="true"/>
+    </j:forEach>
   </j:if>
+</j:if>
 <x:doctype name="html" />
 <html>
   <head data-rooturl="${rootURL}" data-resurl="${resURL}" resURL="${resURL}">
@@ -91,6 +94,7 @@ ${h.initPageVariables(context)}
     </j:if>
 
     <title>${h.appendIfNotNull(title, ' [Jenkins]', 'Jenkins')}</title>
+    <link rel="stylesheet" href="${resURL}/css/layout-common.css" type="text/css" />
     <link rel="stylesheet" href="${resURL}/css/style.css" type="text/css" />
     <link rel="stylesheet" href="${resURL}/css/color.css" type="text/css" />
     <link rel="stylesheet" href="${resURL}/css/responsive-grid.css" type="text/css" />
@@ -107,8 +111,7 @@ ${h.initPageVariables(context)}
     <script src="${resURL}/scripts/behavior.js" type="text/javascript"/>
 
     <!-- we include our own prototype.js, so don't let stapler pull in another. -->
-    <st:adjunct assumes="org.kohsuke.stapler.framework.prototype.prototype"
-                includes="org.kohsuke.stapler.bind"/>
+    <st:adjunct assumes="org.kohsuke.stapler.framework.prototype.prototype" includes="org.kohsuke.stapler.bind"/>
 
     <!-- To use the debug version of YUI, set the system property 'debug.YUI' to true -->
     <j:set var="yuiSuffix" value="${h.yuiSuffix}" />
@@ -165,7 +168,7 @@ ${h.initPageVariables(context)}
     <script src="${resURL}/jsbundles/page-init.js" type="text/javascript"/>
 
   </head>
-  <body id="jenkins" class="yui-skin-sam jenkins-${h.version} ${attrs.cssclass}" data-version="${h.version}" data-model-type="${it.class.name}">
+  <body id="jenkins" class="yui-skin-sam jenkins-${h.version} ${layoutType}" data-version="${h.version}" data-model-type="${it.class.name}">
     <!-- for accessibility, skip the entire navigation bar and etc and go straight to the head of the content -->
     <a href="#skip2content" class="skiplink">Skip to content</a>
 
@@ -233,21 +236,23 @@ ${h.initPageVariables(context)}
     </div>
 
     <div id="page-body" class="clear">
-      <div id="side-panel">
-        <j:set var="mode" value="side-panel" />
-        <d:invokeBody />
-  
-        <!-- add YUI logger if debugging YUI -->
-        <j:if test="${h.yuiSuffix=='debug'}">
-        <div id="yui-logreader" style="margin-top:1em"/>
-          <script>
-            Behaviour.addLoadEvent(function(){
-              var logReader = new YAHOO.widget.LogReader("yui-logreader");
-              logReader.collapse();
-            });
-          </script>
-        </j:if>
-      </div>
+      <j:if test="${layoutType=='two-column'}">
+        <div id="side-panel">
+          <j:set var="mode" value="side-panel" />
+          <d:invokeBody />
+
+          <!-- add YUI logger if debugging YUI -->
+          <j:if test="${h.yuiSuffix=='debug'}">
+          <div id="yui-logreader" style="margin-top:1em"/>
+            <script>
+              Behaviour.addLoadEvent(function(){
+                var logReader = new YAHOO.widget.LogReader("yui-logreader");
+                logReader.collapse();
+              });
+            </script>
+          </j:if>
+        </div>
+      </j:if>
       <div id="main-panel">
          <j:set var="mode" value="main-panel" />
          <d:invokeBody/>

--- a/core/src/main/resources/lib/layout/side-panel.jelly
+++ b/core/src/main/resources/lib/layout/side-panel.jelly
@@ -23,8 +23,13 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:s="jelly:stapler" xmlns:d="jelly:define">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+  <st:documentation>
+    Generates a left side content as part of a Jenkins page. Typically known as two-column or left-side +  main-content layouts
+  </st:documentation>
+
   <j:if test="${mode=='side-panel'}">
     <d:invokeBody />
   </j:if>
+
 </j:jelly>

--- a/core/src/main/resources/lib/layout/taglib
+++ b/core/src/main/resources/lib/layout/taglib
@@ -1,1 +1,1 @@
-Tag library that defines the basic layout of Hudson pages.
+Tag library that defines the basic layouts of Jenkins pages.

--- a/war/src/main/webapp/css/layout-common.css
+++ b/war/src/main/webapp/css/layout-common.css
@@ -32,7 +32,7 @@ body {
   padding: 0 0 40px 0;
 }
 
-/* ---------- header ---------- */
+/* --------------- header --------------- */
 
 #header {
   background-color: #000000;
@@ -73,7 +73,7 @@ body {
   background-color: #f6faf2;
 }
 
-/* ---------------------------- */
+/* -------------------------------------- */
 
 #page-body.clear:after {
   clear: both;
@@ -91,11 +91,11 @@ body {
   padding: 15px 15px 40px 15px;
 }
 
-body.left-side #main-panel {
+body.two-column #main-panel {
   margin-left: 320px;
 }
 
-@media (max-width: 750px) {
+@media (max-width: 970px) {
   body.two-column #side-panel {
     width: 100%;
     float: none;
@@ -117,8 +117,7 @@ body.left-side #main-panel {
   }
 }
 
-
-/* ---------- footer ---------- */
+/* --------------- footer --------------- */
 
 footer {
   padding: 11px 0;
@@ -139,4 +138,4 @@ footer span {
   line-height: 14px;
 }
 
-/* ---------------------------- */
+/* -------------------------------------- */

--- a/war/src/main/webapp/css/layout-common.css
+++ b/war/src/main/webapp/css/layout-common.css
@@ -1,0 +1,142 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+html {
+  position: relative;
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 0 0 40px 0;
+}
+
+/* ---------- header ---------- */
+
+#header {
+  background-color: #000000;
+  height: 40px;
+}
+
+#header div {
+  display: inline-block;
+  height: inherit;
+}
+
+#header .logo {
+  margin-left: 16px;
+}
+
+#jenkins-home-link {
+  position: absolute;
+  height: 40px;
+}
+
+#jenkins-head-icon {
+  position: absolute;
+  bottom: 0px;
+}
+
+#jenkins-name-icon {
+  position: absolute;
+  bottom: 3px;
+  left: 32px;
+}
+
+#header .searchbox, #header .login {
+  float: right;
+  padding: 6px 11px;
+}
+
+#breadcrumbBar, #footer-container, .top-sticker-inner {
+  background-color: #f6faf2;
+}
+
+/* ---------------------------- */
+
+#page-body.clear:after {
+  clear: both;
+  content: "";
+  display: table;
+}
+
+#side-panel {
+  padding: 15px 15px 40px 15px;
+  float: left;
+  width: 320px;
+}
+
+#main-panel {
+  padding: 15px 15px 40px 15px;
+}
+
+body.left-side #main-panel {
+  margin-left: 320px;
+}
+
+@media (max-width: 750px) {
+  body.two-column #side-panel {
+    width: 100%;
+    float: none;
+    padding-bottom: 20px;
+  }
+
+  body.two-column #main-panel {
+    margin-left: 0;
+  }
+}
+
+@media (min-width: 1170px) {
+  body.two-column #side-panel {
+    width: 360px;
+  }
+
+  body.two-column #main-panel {
+    margin-left: 360px;
+  }
+}
+
+
+/* ---------- footer ---------- */
+
+footer {
+  padding: 11px 0;
+  background-color: #f6faf2;
+  border-top: 1px solid #d3d7cf;
+  border-bottom: 1px solid #f6faf2;
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  clear: both;
+  font-size: 12px;
+  text-align: right;
+}
+
+footer span {
+  margin-left: 15px;
+  line-height: 14px;
+}
+
+/* ---------------------------- */

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1853,24 +1853,6 @@ table#legend-table td {
     border-color: #faebcc;
 }
 
-body.main-panel-only #side-panel {
-    width: 0 !important;
-    padding: 0 !important;
-    overflow: hidden !important;
-}
-body.main-panel-only #main-panel {
-    margin: 0 auto !important;
-    min-width: 100%;
-    padding: 2em 2em;
-    display: inline-block;
-    width: auto;
-}
-@media screen and (min-width: 1024px) {
-    body.main-panel-only #main-panel {
-        padding: 2em 10%;
-    }
-}
-
 /* see the Icon class for the definition of these CSS classes */
 .icon-sm {
     width: 16px;

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -22,100 +22,6 @@
  * THE SOFTWARE.
  */
 
-/* General page layout */
-
-html {
-  position: relative;
-  min-height: 100%;
-}
-
-body {
-  margin: 0;
-  padding: 0 0 40px 0;
-}
-
-#header {
-  background-color: #000000;
-  height: 40px;
-}
-
-#header div {
-  display: inline-block;
-  height: inherit;
-}
-#header .logo {
-  margin-left: 16px;
-}
-
-#jenkins-home-link {
-  position: absolute;
-  height: 40px;
-}
-
-#jenkins-head-icon {
-  position: absolute;
-  bottom: 0px;
-}
-#jenkins-name-icon {
-  position: absolute;
-  bottom: 3px;
-  left: 32px;
-}
-
-#header .searchbox, #header .login {
-  float: right;
-  padding: 6px 11px;
-}
-
-#breadcrumbBar, #footer-container, .top-sticker-inner {
-  background-color: #f6faf2;
-}
-
-#page-body.clear:after {
-  clear: both;
-  content: "";
-  display: table;
-}
-
-#side-panel {
-  padding: 15px 15px 40px 15px;
-  float: left;
-  width: 320px;
-}
-
-#main-panel {
-  padding: 15px 15px 40px 15px;
-  margin-left: 320px;
-}
-
-body#jenkins.j-hide-left #main-panel {
-  max-width:70em;
-  margin:0 auto;
-}
-
-@media (max-width: 750px) {
-  #side-panel {
-    width: 100%;
-    float: none;
-    padding-bottom: 20px;
-  }
-
-  #main-panel {
-    margin-left: 0;
-    width: 100%;
-  }
-}
-
-@media (min-width: 1170px) {
-  #side-panel {
-    width: 360px;
-  }
-
-  #main-panel {
-    margin-left: 360px;
-  }
-}
-
 /* task */
 
 #tasks {
@@ -133,28 +39,6 @@ body#jenkins.j-hide-left #main-panel {
 #buildQueue {
   margin-bottom: 20px;
 }
-
-/* footer */
-
-footer {
-  padding: 11px 0;
-  background-color: #f6faf2;
-  border-top: 1px solid #d3d7cf;
-  border-bottom: 1px solid #f6faf2;
-  width: 100%;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  clear: both;
-  font-size: 12px;
-  text-align: right;
-}
-
-footer span {
-  margin-left: 15px;
-  line-height: 14px;
-}
-
 
 /* Fonts etc */
 


### PR DESCRIPTION
[JENKINS-32936](https://issues.jenkins-ci.org/browse/JENKINS-32936) and [JENKINS-25488](https://issues.jenkins-ci.org/browse/JENKINS-25488)

Basically, this PR allows to use `<l:layout type="[two-column or one-column]">` in order to use a full-width size layout (main-content) or a two-column layout (left-side + main-content).

This PR is a follow up of #2029 but in this case agaisnt `master` (now 2.x):
- [x] Replace the solution introduced [here](https://github.com/jenkinsci/jenkins/commit/2cc9853ad664fe0c73ab0643b891603529de5e72)
- [x] Verify the solution proposes with three views: New item (`newJob.jelly`), Job configuration (`configuration.jelly`) and About (`AboutJenkins/index.jelly`)

Tested on Firefox and Chrome on Linux and Mac. Windows environment are welcome.

Part of these modifications were commented and reviewed by @KostyaSha, @kzantow, @tfennelly and @daniel-beck in its previous [PR](https://github.com/jenkinsci/jenkins/pull/2029)

Following some screenshots (1024x800px):

![captura el 2016-04-12 a las 12 48 12](https://cloud.githubusercontent.com/assets/1021745/14457774/4a7e2040-00ad-11e6-9573-26a05036761d.png)

![captura el 2016-04-12 a las 12 50 38](https://cloud.githubusercontent.com/assets/1021745/14457778/4e345466-00ad-11e6-95c3-5c9b4ea5be0d.png)

![captura el 2016-04-12 a las 12 50 55](https://cloud.githubusercontent.com/assets/1021745/14457779/509a741a-00ad-11e6-8fdd-b10e6f051894.png)

![captura el 2016-04-12 a las 12 52 31](https://cloud.githubusercontent.com/assets/1021745/14457798/75ecc22c-00ad-11e6-8960-6fecbcbf760b.png)

@reviewbybees

For reviewers [this](https://github.com/jenkinsci/jenkins/pull/2253/files?w=1)
