### PR TITLE
[JENKINS-34189] Prevent footer from overlapping with content

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -31,7 +31,7 @@ html {
 
 body {
   margin: 0;
-  padding: 0 0 40px 0;
+  padding: 0;
 }
 
 #header {
@@ -142,7 +142,7 @@ footer {
   border-top: 1px solid #d3d7cf;
   border-bottom: 1px solid #f6faf2;
   width: 100%;
-  position: absolute;
+  position: static;
   bottom: 0;
   left: 0;
   clear: both;


### PR DESCRIPTION
The footer CSS had `position: absolute` and had a variable height. Since the footer can contain error messages from plugins, the height would grow to cover up actual content (console logs, etc.).

This commit ensures the footer stays on the bottom of the screen, below all content, at all times.
