### PR TITLE
Ensure that Jenkins 2.0 Jenkinsfile uses correct packaging branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ properties([[$class: 'jenkins.model.BuildDiscarderProperty', strategy: [$class: 
                                                                         numToKeepStr: '50',
                                                                         artifactNumToKeepStr: '20']]])
 
-String packagingBranch = (binding.hasVariable('packagingBranch')) ? packagingBranch : 'master'
+String packagingBranch = (binding.hasVariable('packagingBranch')) ? packagingBranch : 'jenkins-2.0'
 
 timestampedNode('java') {
 


### PR DESCRIPTION
Ensures we use packaging that has taken up: https://github.com/jenkinsci/packaging/pull/51

Which includes fix for: [JENKINS-33776](https://issues.jenkins-ci.org/browse/JENKINS-33776).
Also allows for packaging with RC versions that include hyphens. 

The packaging branch jenkins-2.0 still needs to exist until LTS releases of pre-Jenkins 2.0 code are done (since the loss of AJP functionality in any pre-Jenkins 2 package would be considered a major regression).  Why?  Simply merging that to the packaging master would unexpectedly remove AJP support for any packages distributed after the merge.  Shifting the legacy master to a separate branch would require updating every single job that could distribute pre-Jenkins 2 code.
