### PR TITLE
[JENKINS-33950] dependencies may be installed multiple times

### DIFF
--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/row.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/row.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <tr id="row${it.id}">
-    <td style="vertical-align: top; padding-right:1em">${it.name} <j:if test="${it.detail != null}">(${it.detail})</j:if></td>
+    <td style="vertical-align: top; padding-right:1em">${it.name}</td>
     <j:set var="status" value="${it.status}" /><!-- so that two reference to this variable resolve to the same value. -->
     <td id="status${status.id}" style="vertical-align:middle">
       <st:include it="${status}" page="status.jelly" />

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/row.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/row.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <tr id="row${it.id}">
-    <td style="vertical-align: top; padding-right:1em">${it.name}</td>
+    <td style="vertical-align: top; padding-right:1em">${it.name} <j:if test="${it.detail != null}">(${it.detail})</j:if></td>
     <j:set var="status" value="${it.status}" /><!-- so that two reference to this variable resolve to the same value. -->
     <td id="status${status.id}" style="vertical-align:middle">
       <st:include it="${status}" page="status.jelly" />


### PR DESCRIPTION
When installing multiple plugins (e.g. during the setup wizard, but also reproducible through the plugin manager) plugins may not be properly determined to be installed and may get installed multiple times, resulting in unnecssary restart required indicators. These installations happen in parallel based on downloaded plugin metadata, so it's not known until installation time whether another previously installed plugin ended up requiring the same thing. This fixes the main issue of Jenkins indicating it requires a restart, but doesn't prevent multiple concurrent downloads.

This fixes: https://issues.jenkins-ci.org/browse/JENKINS-33950

[Link for reviewers](2258/files?w=1)

@reviewbybees
