### PR TITLE
[JENKINS-34137] setup wizard: better handling of the close button

### DIFF
--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -207,7 +207,7 @@ var createPluginSetupWizard = function(appendTarget) {
 				decorate($container);
 				
 				var $modalHeader = $container.find('.modal-header');
-				if($modalHeader.length > 0) {
+				if($modalHeader.length > 0 && $modalHeader.is('.closeable')) {
 					$modalHeader.prepend(
 						'<button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button>');
 				}
@@ -815,7 +815,7 @@ var createPluginSetupWizard = function(appendTarget) {
 		'.plugin-select-recommended': function() { selectedPluginNames = pluginManager.recommendedPluginNames(); refreshPluginSelectionPanel(); },
 		'.plugin-show-selected': toggleSelectedSearch,
 		'.select-category': selectCategory,
-		'.close': closeInstaller,
+		'.close': skipFirstUser,
 		'.resume-installation': resumeInstallation,
 		'.install-done-restart': restartJenkins,
 		'.save-first-user:not([disabled])': saveFirstUser,

--- a/war/src/main/js/templates/pluginSelectionPanel.hbs
+++ b/war/src/main/js/templates/pluginSelectionPanel.hbs
@@ -1,4 +1,4 @@
-<div class="modal-header">
+<div class="modal-header closeable">
 	<h4 class="modal-title">{{translations.installWizard_installCustom_title}}</h4>
 </div>
 <div class="modal-body plugin-selector">

--- a/war/src/main/js/templates/welcomePanel.hbs
+++ b/war/src/main/js/templates/welcomePanel.hbs
@@ -1,4 +1,4 @@
-<div class="modal-header">
+<div class="modal-header closeable">
 	<h4 class="modal-title">{{translations.installWizard_welcomePanel_title}}</h4>
 </div>
 <div class="modal-body">


### PR DESCRIPTION
Fix some issues with the close button: don't allow while plugins installing or in certain other places, close now directs to setup complete panel, with message about skipping admin user creation.

This fixes: https://issues.jenkins-ci.org/browse/JENKINS-34137

@reviewbybees
