### PR TITLE
[JENKINS-33936] [JENKINS-33937] add links to wiki for plugins during setup

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1006,6 +1006,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             pluginInfo.put("bundled", plugin.isBundled);
             pluginInfo.put("deleted", plugin.isDeleted());
             pluginInfo.put("downgradable", plugin.isDowngradable());
+            pluginInfo.put("website", plugin.getUrl());
             List<Dependency> dependencies = plugin.getDependencies();
             if (dependencies != null && !dependencies.isEmpty()) {
                 Map<String, String> dependencyMap = new HashMap<>();
@@ -1030,6 +1031,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 pluginInfo.put("excerpt", plugin.excerpt);
                 pluginInfo.put("site", site.getId());
                 pluginInfo.put("dependencies", plugin.dependencies);
+                pluginInfo.put("website", plugin.wiki);
                 response.add(pluginInfo);
             }
         }

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -50,4 +50,5 @@ installWizard_configureProxy_save=Save and Continue
 installWizard_skipPluginInstallations=Skip Plugin Installations
 installWizard_installIncomplete_dependenciesLabel=Dependencies
 installWizard_installingConsole_dependencyIndicatorNote=** - required dependency
+installWizard_websiteLinkLabel=Website
 installWizard_retry=Retry

--- a/war/src/main/js/templates/pluginSelectionPanel.hbs
+++ b/war/src/main/js/templates/pluginSelectionPanel.hbs
@@ -40,6 +40,7 @@
 						<span class="title">
 							<input type="checkbox" id="chk-{{plugin.name}}" name="{{plugin.name}}" value="{{searchTerm}}" {{#inSelectedPlugins plugin.name}}checked="checked"{{/inSelectedPlugins}}/>
 							{{plugin.title}}
+							<a href="{{plugin.website}}" target="_blank">{{../../translations.installWizard_websiteLinkLabel}}</a>
 						</span>
 						<span class="description">
 							{{{plugin.excerpt}}}
@@ -47,9 +48,9 @@
 						{{#hasDependencies plugin.name}}
 							<div class="dep-list">
 								{{#eachDependency ../plugin.name}}
-								<span class="dep badge">
+								<a class="dep badge" href="{{website}}" target="_blank">
 								{{title}}
-								</span>
+								</a>
 								{{/eachDependency}}
 							</div>
 						{{/hasDependencies}}

--- a/war/src/main/less/pluginSetupWizard.less
+++ b/war/src/main/less/pluginSetupWizard.less
@@ -432,6 +432,10 @@
 						.badge {
 							padding: 4px 8px;
 							margin: 5px 3px 0 0;
+							
+							&:hover, &:active, &:focus {
+								color: #fff;
+							}
 						}
 					}
 						


### PR DESCRIPTION
Setup wizard needs to add links to the wiki for plugins.

This fixes:
https://issues.jenkins-ci.org/browse/JENKINS-33936
https://issues.jenkins-ci.org/browse/JENKINS-33937

@reviewbybees
