### PR TITLE
Upgrade stapler version to 1.241.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.239</stapler.version>
+    <stapler.version>1.241</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.6</groovy.version>
   </properties>


### PR DESCRIPTION
This PR updates the version of stapler to the latest released version (1.241). See [change log](https://github.com/stapler/stapler/compare/stapler-parent-1.239...stapler-parent-1.241) for more information.

@reviewbybees
