### PR TITLE
[JENKINS-31162] Wrong spacing in flat mode

### DIFF
--- a/war/src/main/js/widgets/add/addform.less
+++ b/war/src/main/js/widgets/add/addform.less
@@ -255,6 +255,7 @@
 
   .categories.flat {
     .category {
+      padding: 0 10px;
       border-bottom: none;
 
       .header {
@@ -263,11 +264,11 @@
     }
 
     .category:first-child {
-      padding-bottom: 0;
+      padding: 10px 10px 0 10px;
     }
 
     .category:last-child {
-      padding-top: 0;
+      padding: 0 10px 10px 10px;
     }
   }
 


### PR DESCRIPTION
This is a follow-up of https://github.com/jenkinsci/jenkins/pull/2117
### Before

![jenkins-31162-2_before](https://cloud.githubusercontent.com/assets/1021745/14760716/6dffe746-094b-11e6-82c0-174de922a5dc.png)
### After

![jenkins-31162-2_after](https://cloud.githubusercontent.com/assets/1021745/14760717/76b12094-094b-11e6-89fc-b3a722b45f88.png)

The current implementation allows to use a special mode named `flat`. This mode enables rendering all items without any representations of categories. If you don't use this model, you can see a hierarchal representation of items.

@reviewbybees
