### PR TITLE
Use the latest version

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -300,7 +300,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>ssh-slaves</artifactId>
-                  <version>1.9</version>
+                  <version>1.10</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
In particular, this will install Java7 when build agents don't have any
Java. 1.9 tries to install Java6 which is no good.
