### PR TITLE
Fix [JENKINS-34281] by running shutdown as system user (now against master)

### DIFF
--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -27,6 +27,7 @@ import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider
 import com.thoughtworks.xstream.core.JVM;
 import com.trilead.ssh2.util.IOUtils;
 import hudson.model.Hudson;
+import hudson.security.ACL;
 import hudson.util.BootFailure;
 import jenkins.model.Jenkins;
 import hudson.util.HudsonIsLoading;
@@ -244,7 +245,7 @@ public class WebAppMain implements ServletContextListener {
             };
             initThread.start();
         } catch (BootFailure e) {
-            e.publish(context,home);
+            e.publish(context, home);
         } catch (Error | RuntimeException e) {
             LOGGER.log(SEVERE, "Failed to initialize Jenkins",e);
             throw e;
@@ -364,19 +365,24 @@ public class WebAppMain implements ServletContextListener {
 
     public void contextDestroyed(ServletContextEvent event) {
         try {
-            terminated = true;
-            Jenkins instance = Jenkins.getInstanceOrNull();
-            if(instance!=null)
-                instance.cleanUp();
-            Thread t = initThread;
-            if (t != null && t.isAlive()) {
-                LOGGER.log(Level.INFO, "Shutting down a Jenkins instance that was still starting up", new Throwable("reason"));
-                t.interrupt();
-            }
+            ACL.impersonate(ACL.SYSTEM, new Runnable() {
+                @Override
+                public void run() {
+                    terminated = true;
+                    Jenkins instance = Jenkins.getInstanceOrNull();
+                    if (instance != null)
+                        instance.cleanUp();
+                    Thread t = initThread;
+                    if (t != null && t.isAlive()) {
+                        LOGGER.log(Level.INFO, "Shutting down a Jenkins instance that was still starting up", new Throwable("reason"));
+                        t.interrupt();
+                    }
 
-            // Logger is in the system classloader, so if we don't do this
-            // the whole web app will never be undepoyed.
-            Logger.getLogger("").removeHandler(handler);
+                    // Logger is in the system classloader, so if we don't do this
+                    // the whole web app will never be undepoyed.
+                    Logger.getLogger("").removeHandler(handler);
+                }
+            });
         } finally {
             JenkinsJVMAccess._setJenkinsJVM(false);
         }


### PR DESCRIPTION
Replicates #2276 but basing against master for 2.1, not 2.0 branch, and does not include the likely-unneeded ACL.impersonate(ACL.SYSTEM) call before System.exit(0). 

Summary for those that didn't see the previous:
Fixes [JENKINS-34281](https://issues.jenkins-ci.org/browse/JENKINS-34281).   

**Too long; Didn't read summary:** Jenkins wasn't running some forms of shutdown as the system user, and when we removed anonymous read access as part of the secure-out-of-the-box PR (https://github.com/jenkinsci/jenkins/pull/2042/files#diff-f65b8a70854ca1cc6c12397eee54d279R62) then it could no longer see build items to persist them.

**Details:**
- Build queue was not persisted on shutdown, when doing a new Jenkins 2.0 install with setup wizard.  The file was made, but no Items (builds) were included. Result: disappearing builds. 
- Build queue was not persisted because when saving the queue, it lists the items to save with Queue queue.getItems(), which returned an empty list
- getItems() returns an empty list, because items are only returned when permissions make them readable, and during shutdown it did not have permissions to read them (permission check failed)
- During shutdown, read permissions were not present because secure-out-of-the-box removed anonymous read access that allowed it to work before. 
- Solution: run shutdown correctly as system user, which has full permissions

Replicates the key bit of dad9b04422d572003c83f0fc4543060a70971cc0 in a fresh, clean commit (avoiding conflicts on cherry-pick). 
