### PR TITLE
[JENKINS-33244] better handling of failed plugins during setup wizard

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -36,6 +36,8 @@ import hudson.model.Failure;
 import hudson.model.ItemGroupMixIn;
 import hudson.model.UpdateCenter;
 import hudson.model.UpdateSite;
+import hudson.model.UpdateCenter.DownloadJob;
+import hudson.model.UpdateCenter.InstallationJob;
 import hudson.security.Permission;
 import hudson.security.PermissionScope;
 import hudson.util.CyclicGraphDetector;
@@ -1055,6 +1057,20 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
         return new HttpRedirect("./sites");
     }
+    
+    /**
+     * Called to progress status beyond installing plugins, e.g. if 
+     * there were failures that prevented installation from naturally proceeding
+     */
+    @RequirePOST
+    @Restricted(DoNotUse.class) // WebOnly
+    public void doInstallPluginsDone() {
+        Jenkins j = Jenkins.getInstance();
+        j.checkPermission(Jenkins.ADMINISTER);
+        if(InstallState.INITIAL_PLUGINS_INSTALLING.equals(j.getInstallState())) {
+            Jenkins.getInstance().setInstallState(InstallState.INITIAL_PLUGINS_INSTALLING.getNextState());
+        }
+    }
 
     /**
      * Performs the installation of the plugins.
@@ -1182,22 +1198,30 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             new Thread() {
                 @Override
                 public void run() {
+                    final boolean failures[] = { false };
                     INSTALLING: while (true) {
                         try {
-				updateCenter.persistInstallStatus();
+                            updateCenter.persistInstallStatus();
                             Thread.sleep(500);
+                            failures[0] = false;
                             for (Future<UpdateCenter.UpdateCenterJob> jobFuture : installJobs) {
                                 if(!jobFuture.isDone() && !jobFuture.isCancelled()) {
                                     continue INSTALLING;
                                 }
+                                UpdateCenter.UpdateCenterJob job = jobFuture.get();
+                                if(job instanceof InstallationJob && ((InstallationJob)job).status instanceof DownloadJob.Failure) {
+                                    failures[0] = true;
+                                }
                             }
-                        } catch (InterruptedException e) {
+                        } catch (Exception e) {
                             LOGGER.log(WARNING, "Unexpected error while waiting for initial plugin set to install.", e);
                         }
                         break;
                     }
-			updateCenter.persistInstallStatus();
-                    jenkins.setInstallState(InstallState.INITIAL_PLUGINS_INSTALLING.getNextState());
+                    updateCenter.persistInstallStatus();
+                    if(!failures[0]) {
+                        jenkins.setInstallState(InstallState.INITIAL_PLUGINS_INSTALLING.getNextState());
+                    }
                 }
             }.start();
         }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -136,6 +136,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     private static final String UPDATE_CENTER_URL = System.getProperty(UpdateCenter.class.getName()+".updateCenterUrl","http://updates.jenkins-ci.org/");
 
     /**
+     * Read timeout when downloading plugins, defaults to 1 minute
+     */
+    private static final int PLUGIN_DOWNLOAD_READ_TIMEOUT = Integer.getInteger(UpdateCenter.class.getName()+".pluginDownloadReadTimeoutSeconds", 60) * 1000;
+
+    /**
      * {@linkplain UpdateSite#getId() ID} of the default update site.
      * @since 1.483
      */
@@ -1004,6 +1009,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             URLConnection con = null;
             try {
                 con = connect(job,src);
+                //JENKINS-34174 - set timeout for downloads, may hang indefinitely
+                // particularly noticeable during 2.0 install when downloading
+                // many plugins
+                con.setReadTimeout(PLUGIN_DOWNLOAD_READ_TIMEOUT);
+                
                 int total = con.getContentLength();
                 in = new CountingInputStream(con.getInputStream());
                 byte[] buf = new byte[8192];

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -50,4 +50,8 @@ installWizard_configureProxy_save=Save and Continue
 installWizard_skipPluginInstallations=Skip Plugin Installations
 installWizard_installIncomplete_dependenciesLabel=Dependencies
 installWizard_installingConsole_dependencyIndicatorNote=** - required dependency
+installWizard_pluginInstallFailure_title=Installation Failures
+installWizard_pluginInstallFailure_message=Some plugins failed to install properly, you may retry installing them or continue \
+with the failed plugins
+installWizard_continue=Continue
 installWizard_retry=Retry

--- a/war/src/main/js/api/pluginManager.js
+++ b/war/src/main/js/api/pluginManager.js
@@ -174,6 +174,20 @@ exports.isRestartRequired = function(handler) {
 };
 
 /**
+ * Skip failed plugins, continue
+ */
+exports.installPluginsDone = function(handler) {
+	jenkins.post('/pluginManager/installPluginsDone', {}, function() {
+		handler();
+	}, {
+		timeout: pluginManagerErrorTimeoutMillis,
+		error: function(xhr, textStatus, errorThrown) {
+			handler.call({ isError: true, message: errorThrown });
+		}
+	});
+}
+
+/**
  * Restart Jenkins
  */
 exports.restartJenkins = function(handler) {

--- a/war/src/main/js/templates/successPanel.hbs
+++ b/war/src/main/js/templates/successPanel.hbs
@@ -1,26 +1,35 @@
 <div class="modal-header">
-	<h4 class="modal-title">{{translations.installWizard_pluginsInstalled_title}}</h4>
+    <h4 class="modal-title">{{translations.installWizard_welcomePanel_title}}</h4>
 </div>
 <div class="modal-body">
-	<div class="jumbotron welcome-panel success-panel">
-		<h1>{{translations.installWizard_pluginsInstalled_banner}}</h1>
+    <div class="jumbotron welcome-panel success-panel">
+        <h1>{{translations.installWizard_pluginInstallFailure_title}}</h1>
 
-		{{#if restartRequired}}
-		<p>{{translations.installWizard_installComplete_message}} {{translations.installWizard_installComplete_restartRequiredMessage}}</p>
-		<button type="button" class="btn btn-primary install-done-restart">
-			{{translations.installWizard_installComplete_restartLabel}}
-		</button>
-		{{else}}
-		<p>{{translations.installWizard_installComplete_message}}</p>
-		<button type="button" class="btn btn-primary install-done">
-			{{translations.installWizard_installComplete_finishButtonLabel}}
-		</button>
-		{{/if}}
-	</div>
+        {{#if failedPlugins}}
+        <p>{{translations.installWizard_pluginInstallFailure_message}}</p>
+        <button type="button" class="btn btn-primary retry-failed-plugins">
+            {{translations.installWizard_retry}}
+        </button>
+        {{/if}}
+    </div>
 
-	<div class="selected-plugin-progress success-panel">
-		{{#each installingPlugins}}
-		<div class="selected-plugin {{installStatus}}" data-name="{{id name}}">{{title}}</div>
-		{{/each}}
-	</div>
+    <div class="selected-plugin-progress success-panel">
+        {{#each installingPlugins}}
+        <div class="selected-plugin {{installStatus}}" data-name="{{id name}}">{{title}}</div>
+        {{/each}}
+    </div>
+</div>
+<div class="modal-footer">
+	{{#if failedPlugins}}
+    <button type="button" class="btn btn-link continue-with-failed-plugins">
+        {{translations.installWizard_continue}}
+    </button>
+    <button type="button" class="btn btn-primary retry-failed-plugins">
+        {{translations.installWizard_retry}}
+    </button>
+    {{else}}
+    <button type="button" class="btn btn-primary continue-with-failed-plugins">
+        {{translations.installWizard_continue}}
+    </button>
+    {{/if}}
 </div>


### PR DESCRIPTION
This change provides a 'retry' option during installation to attempt to reinstall plugins which failed to install and/or download during the initial setup.

![image](https://cloud.githubusercontent.com/assets/3009477/14724908/f80d9232-07e6-11e6-8998-ef82d51fac74.png)

This addresses:
https://issues.jenkins-ci.org/browse/JENKINS-33244
https://issues.jenkins-ci.org/browse/JENKINS-34174
