### PR TITLE
Wrong javascript invocation

### DIFF
--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -179,7 +179,7 @@ THE SOFTWARE.
               </l:confirmationLink>
             </j:when>
             <j:otherwise>
-              <a href="${href}" class="task-icon-link" onclick="${attrs.onclick ?: (post ? 'postRequest_' + id + '(this)' : null)}">
+              <a href="${href}" class="task-icon-link" onclick="${attrs.onclick ?: (post ? 'return postRequest_' + id + '(this)' : null)}">
                 <j:choose>
                   <j:when test="${iconMetadata != null}">
                     <l:icon class="${iconMetadata.classSpec}" style="width: 24px; height: 24px; margin: 2px;" />


### PR DESCRIPTION
`<task />` Jelly tag is generating a wrong `POST` request.

@jenkinsci/code-reviewers especially @olivergondza since he did that https://github.com/jenkinsci/jenkins/commit/baa192499a12ecd3fd819b14fcd9c33cd96433ef

@reviewbybees
