### PR TITLE
Force ordering between GPG and jarsigner

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -558,7 +558,7 @@ THE SOFTWARE.
             <executions>
               <execution>
                 <id>signWar</id>
-                <phase>verify</phase>
+                <phase>pre-integration-test</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>


### PR DESCRIPTION
jarsigner adds signatures by updating the file itself, so we have
to run it before GPG plugin signs the bit, which happens in the 'verify'
phase.

The 'pre-integration-test' phase happens right after the 'package'
phase and before the 'verify' phase, so this is adequate.

See: https://groups.google.com/forum/#!msg/jenkinsci-users/POk8TOcwOM8/i5wn2a0MMwAJ
