### PR TITLE
Allow specifying custom AbortExceptions

### DIFF
--- a/core/src/main/java/hudson/AbortException.java
+++ b/core/src/main/java/hudson/AbortException.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  *
  * @author Kohsuke Kawaguchi
 */
-public final class AbortException extends IOException {
+public class AbortException extends IOException {
     public AbortException() {
     }
 


### PR DESCRIPTION
Workflow users may want to catch specific Exceptions without stracktrace in future.

Logically it shouldn't be final because it possible to make Exceptions with stacktraces and impossible without. WDYT?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jenkins/2288)

<!-- Reviewable:end -->
