### PR TITLE
[JENKINS-33948] - Always display clicked scrollspy items as active

### DIFF
--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -104,7 +104,7 @@ var createPluginSetupWizard = function(appendTarget) {
 			return options.fn();
 		}
 	});
-
+	
 	// Include handlebars templates here - explicitly require them and they'll be available by hbsfy as part of the bundle process
 	var errorPanel = require('./templates/errorPanel.hbs');
 	var loadingPanel = require('./templates/loadingPanel.hbs');
@@ -165,6 +165,19 @@ var createPluginSetupWizard = function(appendTarget) {
 			html: true,
 			title: text
 		}).tooltip('show');
+	});
+	
+	// handle clicking links that might not get highlighted due to position on the page
+	$wizard.on('click', '.nav>li>a', function(){
+		var $li = $(this).parent();
+		var activateClicked = function() {
+			if(!$li.is('.active')) {
+				$li.parent().find('>li').removeClass('active');
+				$li.addClass('active');
+			}
+		};
+		setTimeout(activateClicked, 150); // this is the scroll time
+		setTimeout(activateClicked, 250); // this should combat timing issues
 	});
 
 	// localized messages


### PR DESCRIPTION
Display clicked scrollspy items as active, even if they would not normally be highlighted due to position at the bottom of the page.

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-33948
