### PR TITLE
Upgrade to stapler 1.243 and some testcase fix.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.239</stapler.version>
+    <stapler.version>1.241</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.6</groovy.version>
   </properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.241</stapler.version>
+    <stapler.version>1.243</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.6</groovy.version>
   </properties>

--- a/test/src/test/java/hudson/model/ApiTest.java
+++ b/test/src/test/java/hudson/model/ApiTest.java
@@ -23,17 +23,20 @@
  */
 package hudson.model;
 
-import static org.junit.Assert.*;
-
 import com.gargoylesoftware.htmlunit.Page;
-
-import java.io.File;
-import java.net.HttpURLConnection;
-
+import com.gargoylesoftware.htmlunit.WebResponse;
+import net.sf.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.net.HttpURLConnection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -53,8 +56,15 @@ public class ApiTest {
     @Test public void json() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject("p");
         JenkinsRule.WebClient wc = j.createWebClient();
-        assertEquals("{\"name\":\"p\"}", wc.goTo(p.getUrl() + "api/json?tree=name", "application/json").getWebResponse().getContentAsString());
-        assertEquals("wrap({\"name\":\"p\"})", wc.goTo(p.getUrl() + "api/json?tree=name&jsonp=wrap", "application/javascript").getWebResponse().getContentAsString());
+        WebResponse response = wc.goTo(p.getUrl() + "api/json?tree=name", "application/json").getWebResponse();
+        JSONObject json = JSONObject.fromObject(response.getContentAsString());
+        assertEquals("p", json.get("name"));
+
+        String s = wc.goTo(p.getUrl() + "api/json?tree=name&jsonp=wrap", "application/javascript").getWebResponse().getContentAsString();
+        assertTrue(s.startsWith("wrap("));
+        assertEquals(')', s.charAt(s.length()-1));
+        json = JSONObject.fromObject(s.substring("wrap(".length(), s.length() - 1));
+        assertEquals("p", json.get("name"));
     }
 
     @Test

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -68,6 +68,37 @@ import hudson.triggers.SCMTrigger.SCMTriggerCause;
 import hudson.triggers.TimerTrigger.TimerTriggerCause;
 import hudson.util.OneShotEvent;
 import hudson.util.XStream2;
+import jenkins.model.Jenkins;
+import jenkins.security.QueueItemAuthenticatorConfiguration;
+import jenkins.triggers.ReverseBuildTrigger;
+import org.acegisecurity.Authentication;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.acls.sid.PrincipalSid;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.apache.commons.fileupload.FileUploadException;
+import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.io.FileUtils;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockQueueItemAuthenticator;
+import org.jvnet.hudson.test.SequenceLock;
+import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -84,40 +115,9 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import jenkins.model.Jenkins;
-import jenkins.security.QueueItemAuthenticatorConfiguration;
-import jenkins.triggers.ReverseBuildTrigger;
-import org.acegisecurity.Authentication;
-import org.acegisecurity.GrantedAuthority;
-import org.acegisecurity.acls.sid.PrincipalSid;
-import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.io.FileUtils;
 
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.*;
-
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.MockQueueItemAuthenticator;
-import org.jvnet.hudson.test.SequenceLock;
-import org.jvnet.hudson.test.SleepBuilder;
-import org.jvnet.hudson.test.TestBuilder;
-import org.jvnet.hudson.test.TestExtension;
-import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -937,15 +937,15 @@ public class QueueTest {
         webClient.login("alice");
         XmlPage p2 = webClient.goToXml("queue/api/xml");
         //alice does not have permission on the project and will not see it in the queue.
-        assertEquals("<queue></queue>", p2.getContent());
-
+        assertTrue(p2.getByXPath("/queue/node()").isEmpty());
         webClient = r.createWebClient();
         webClient.login("james");
         XmlPage p3 = webClient.goToXml("queue/api/xml");
-        //james has DISCOVER permission on the project and will only be able to see the task name.
-        assertEquals("<queue><discoverableItem><task><name>project</name></task></discoverableItem></queue>",
-                p3.getContent());
 
+        //james has DISCOVER permission on the project and will only be able to see the task name.
+        List projects = p3.getByXPath("/queue/discoverableItem/task/name/text()");
+        assertEquals(1, projects.size());
+        assertEquals("project", projects.get(0).toString());
     }
 
     //we force the project not to be executed so that it stays in the queue

--- a/test/src/test/java/hudson/security/csrf/DefaultCrumbIssuerTest.java
+++ b/test/src/test/java/hudson/security/csrf/DefaultCrumbIssuerTest.java
@@ -8,8 +8,7 @@ package hudson.security.csrf;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import java.net.HttpURLConnection;
-import static org.junit.Assert.*;
+import net.sf.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,6 +16,10 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.recipes.PresetData;
+
+import java.net.HttpURLConnection;
+
+import static org.junit.Assert.*;
 
 /**
  *
@@ -126,7 +129,9 @@ public class DefaultCrumbIssuerTest {
     @Test public void apiJson() throws Exception {
         WebClient wc = r.createWebClient();
         String json = wc.goTo("crumbIssuer/api/json", "application/json").getWebResponse().getContentAsString();
-        assertTrue(json, json.matches("\\Q{\"crumb\":\"\\E[0-9a-f]+\\Q\",\"crumbRequestField\":\"" + r.jenkins.getCrumbIssuer().getCrumbRequestField() + "\"}\\E"));
+        JSONObject jsonObject = JSONObject.fromObject(json);
+        assertEquals(r.jenkins.getCrumbIssuer().getCrumbRequestField(),jsonObject.getString("crumbRequestField"));
+        assertTrue(jsonObject.getString("crumb").matches("[0-9a-f]+"));
         wc.assertFails("crumbIssuer/api/json?jsonp=hack", HttpURLConnection.HTTP_FORBIDDEN);
     }
 


### PR DESCRIPTION
I noticed couple of failing tests in https://github.com/jenkinsci/jenkins/pull/2265. 

Tests were failing because these tests ApiTest.json() were comparing fixed string json and Stapler 1.241 adds _class element to generated JSON with the name of ExportedBean class resulting in test failure. 

We should close https://github.com/jenkinsci/jenkins/pull/2265 and evaluate this PR to upgrade Stapler.
