### PR TITLE
[JENKINS-34494] enable required plugins during plugin installs

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1404,7 +1404,42 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
 
 
     }
-
+    
+    /**
+     * Enables a required plugin, provides feedback in the update center
+     */
+    public class EnableJob extends UpdateCenterJob {
+        private final Plugin plugin;
+        
+        public EnableJob(UpdateSite site, @Nonnull Plugin plugin) {
+            super(site);
+            this.plugin = plugin;
+        }
+        
+        public Plugin getPlugin() {
+            return plugin;
+        }
+        
+        @Override
+        public void run() {
+            try {
+                plugin.getInstalled().enable();
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "Failed to enable " + plugin.getDisplayName(), e);
+                error = e;
+            }
+        }
+    }
+    
+    /**
+     * A no-op, e.g. this plugin is already installed
+     */
+    public class NoOpJob extends EnableJob {
+        public NoOpJob(UpdateSite site, @Nonnull Plugin plugin) {
+            super(site, plugin);
+        }
+    }
+    
     /**
      * Base class for a job that downloads a file from the Jenkins project.
      */

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -861,12 +861,12 @@ public class UpdateSite {
             if(pw != null) { // JENKINS-34494 - check for this plugin being disabled
                 Future<UpdateCenterJob> enableJob = null;
                 if(!pw.isEnabled()) {
-                    UpdateCenter.EnableJob job = uc.new EnableJob(UpdateSite.this, this);
+                    UpdateCenter.EnableJob job = uc.new EnableJob(UpdateSite.this, null, this, dynamicLoad);
                     job.setCorrelationId(correlationId);
                     enableJob = uc.addJob(job);
                 }
                 if(pw.getVersionNumber().equals(new VersionNumber(version))) {
-                    return enableJob != null ? enableJob : uc.addJob(uc.new NoOpJob(UpdateSite.this, this));
+                    return enableJob != null ? enableJob : uc.addJob(uc.new NoOpJob(UpdateSite.this, null, this));
                 }
             }
             UpdateCenter.InstallationJob job = uc.new InstallationJob(this, UpdateSite.this, Jenkins.getAuthentication(), dynamicLoad);

--- a/core/src/main/resources/hudson/model/UpdateCenter/EnableJob/row.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/EnableJob/row.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <tr id="row${it.id}">
     <td style="vertical-align: top; padding-right:1em">${it.plugin.displayName}</td>
     <td style="vertical-align:middle">
-      <l:icon class="icon-yellow icon-md"/> ${%Enabled}
+      <l:icon class="icon-${it.error!=null?'yellow':'blue'} icon-md"/> ${%Enabled Dependency}
     </td>
   </tr>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/EnableJob/row.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/EnableJob/row.jelly
@@ -1,0 +1,33 @@
+<!--
+The MIT License
+
+Copyright (c) 2016, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <tr id="row${it.id}">
+    <td style="vertical-align: top; padding-right:1em">${it.plugin.displayName}</td>
+    <td style="vertical-align:middle">
+      <l:icon class="icon-yellow icon-md"/> ${%Enabled}
+    </td>
+  </tr>
+</j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/NoOpJob/row.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/NoOpJob/row.jelly
@@ -1,0 +1,33 @@
+<!--
+The MIT License
+
+Copyright (c) 2016, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <tr id="row${it.id}">
+    <td style="vertical-align: top; padding-right:1em">${it.plugin.displayName}</td>
+    <td style="vertical-align:middle">
+      <l:icon class="icon-yellow icon-md"/> ${%Already Installed}
+    </td>
+  </tr>
+</j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/NoOpJob/row.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/NoOpJob/row.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <tr id="row${it.id}">
     <td style="vertical-align: top; padding-right:1em">${it.plugin.displayName}</td>
     <td style="vertical-align:middle">
-      <l:icon class="icon-yellow icon-md"/> ${%Already Installed}
+      <l:icon class="icon-${it.error!=null?'yellow':'blue'} icon-md"/> ${%Already Installed}
     </td>
   </tr>
 </j:jelly>


### PR DESCRIPTION
During plugin installs, particularly noticed when upgrading to Jenkins 2, required dependencies which are  disabled are left as such, causing issues running newly installed plugins or worse.

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-34494
