### PR TITLE
call RunListener before Computer.defaultCharset has been determined

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1004,7 +1004,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     /**
      * Called by {@link Executor} to kill excessive executors from this computer.
      */
-    /*package*/ void removeExecutor(final Executor e) {
+    protected void removeExecutor(final Executor e) {
         final Runnable task = new Runnable() {
             @Override
             public void run() {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1692,12 +1692,6 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
             try {
                 try {
-                    Computer computer = Computer.currentComputer();
-                    Charset charset = null;
-                    if (computer != null) {
-                        charset = computer.getDefaultCharset();
-                        this.charset = charset.name();
-                    }
 
                     // don't do buffering so that what's written to the listener
                     // gets reflected to the file immediately, which can then be
@@ -1718,6 +1712,17 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                         }
                     }
 
+                    listener = new StreamBuildListener(logger);
+
+                    RunListener.fireStarted(this,listener);
+
+                    Computer computer = Computer.currentComputer();
+                    Charset charset = null;
+                    if (computer != null) {
+                        charset = computer.getDefaultCharset();
+                        this.charset = charset.name();
+                    }
+
                     listener = new StreamBuildListener(logger,charset);
 
                     listener.started(getCauses());
@@ -1730,8 +1735,6 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                         }
                         listener.getLogger().println(Messages.Run_running_as_(name));
                     }
-
-                    RunListener.fireStarted(this,listener);
 
                     updateSymlinks(listener);
 


### PR DESCRIPTION
Alternative to https://github.com/jenkinsci/jenkins/pull/2045
This PR do change the way BuildListener is created. Listener is first created without consideration for conputer.defaultCharset, and Listener are notified. Then a new BuildListener is created with same outputstream but charset set to match computer encoding. Most code only relies on `Listener.getLogger` so won't get impacted. But this has a huge impact on one-shot-executor design as we can delay the launch of the computer, so can share Listener between Run and ComputerLauncher.

see sample usage on https://github.com/jenkinsci/one-shot-executor-plugin/commit/5c6c166cccbf7dc0d322108dbee327a8ab1b680c
