### PR TITLE
[JENKINS-33596] disable UDP broadcast & jmDNS by default, make configurable

### DIFF
--- a/core/src/main/java/hudson/DNSMultiCast.java
+++ b/core/src/main/java/hudson/DNSMultiCast.java
@@ -1,10 +1,23 @@
 package hudson;
 
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
 import jenkins.model.Jenkins.MasterComputer;
+import net.sf.json.JSONObject;
 
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceInfo;
+
+import org.kohsuke.stapler.StaplerRequest;
+
+import com.google.inject.Injector;
+
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+
+import static java.util.logging.Level.SEVERE;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
@@ -20,11 +33,58 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 public class DNSMultiCast implements Closeable {
+    public static boolean disabled = Boolean.getBoolean(DNSMultiCast.class.getName()+".disabled");
+
+    private static final Logger LOGGER = Logger.getLogger(DNSMultiCast.class.getName());
+
+    private static transient DNSMultiCast dnsMultiCast;
+
+    /**
+     * Starts the DNS Multicast services, if enabled
+     */
+    @Initializer(after=InitMilestone.PLUGINS_PREPARED)
+    public static void startDnsMulticast() {
+        if(disabled) { // this will force disabling DNS
+            return;
+        }
+        if(dnsMultiCast == null) {
+            // check config for this feature being enabled
+            Jenkins jenkins = Jenkins.getInstance();
+            Injector injector = jenkins.getInjector();
+            GlobalDNSMultiCastConfiguration config = injector.getInstance(GlobalDNSMultiCastConfiguration.class);
+            if(config.isDnsMultiCastEnabled()) {
+                dnsMultiCast = new DNSMultiCast(jenkins);
+            }
+        }
+    }
+    
+    /**
+     * Stops the DNS Multicast services if running
+     */
+    @hudson.init.Terminator
+    public static void stopDnsMulticast() throws Exception {
+        if(dnsMultiCast!=null) {
+            LOGGER.log(Level.FINE, "Closing DNS Multicast service");
+            try {
+                dnsMultiCast.close();
+                dnsMultiCast = null;
+            } catch (OutOfMemoryError e) {
+                // we should just propagate this, no point trying to log
+                throw e;
+            } catch (LinkageError e) {
+                LOGGER.log(SEVERE, "Failed to close DNS Multicast service", e);
+                // safe to ignore and continue for this one
+            } catch (Exception e) {
+                LOGGER.log(SEVERE, "Failed to close DNS Multicast service", e);
+                // save for later
+                throw e;
+            }
+        }
+    }
+
     private JmDNS jmdns;
 
     public DNSMultiCast(final Jenkins jenkins) {
-        if (disabled)   return; // escape hatch
-        
         // the registerService call can be slow. run these asynchronously
         MasterComputer.threadPoolForRemoting.submit(new Callable<Object>() {
             public Object call() {
@@ -85,7 +145,44 @@ public class DNSMultiCast implements Closeable {
         }
     }
 
-    private static final Logger LOGGER = Logger.getLogger(DNSMultiCast.class.getName());
-
-    public static boolean disabled = Boolean.getBoolean(DNSMultiCast.class.getName()+".disabled");
+    @Extension(ordinal=196) // after GlobalCrumbIssuerConfiguration
+    public static class GlobalDNSMultiCastConfiguration extends GlobalConfiguration {
+        public GlobalDNSMultiCastConfiguration() {
+            load();
+        }
+        
+        // JENKINS-33596 - disable jmDNS by default
+        private boolean isDnsMultiCastEnabled = false;
+        
+        @Override
+        public GlobalConfigurationCategory getCategory() {
+            return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
+        }
+        
+        public boolean isDnsMultiCastEnabled() {
+            return isDnsMultiCastEnabled;
+        }
+        
+        public void setDnsMultiCastEnabled(boolean isDnsMultiCastEnabled) {
+            this.isDnsMultiCastEnabled = isDnsMultiCastEnabled;
+        }
+        
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+            // for compatibility reasons, the actual value is stored in Jenkins
+            if (json.getBoolean("dnsMultiCastEnabled")) {
+                isDnsMultiCastEnabled = true;
+                startDnsMulticast();
+            } else {
+                isDnsMultiCastEnabled = false;
+                try {
+                    stopDnsMulticast();
+                } catch (Exception e) {
+                    LOGGER.log(Level.SEVERE, "Unable to stop DNS Multicast Services: ", e);
+                }
+            }
+            save();
+            return true;
+        }
+    }
 }

--- a/core/src/main/java/hudson/DNSMultiCast.java
+++ b/core/src/main/java/hudson/DNSMultiCast.java
@@ -176,8 +176,11 @@ public class DNSMultiCast implements Closeable {
         
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+            Jenkins jenkins = Jenkins.getInstance();
+            jenkins.checkPermission(Jenkins.ADMINISTER);
+            
             // for compatibility reasons, the actual value is stored in Jenkins
-            if (json.getBoolean("dnsMultiCastEnabled")) {
+            if (json.get("dnsMultiCastEnabled") != null) {
                 isDnsMultiCastEnabled = true;
                 startDnsMulticast();
             } else {

--- a/core/src/main/resources/hudson/DNSMultiCast/GlobalDNSMultiCastConfiguration/config.jelly
+++ b/core/src/main/resources/hudson/DNSMultiCast/GlobalDNSMultiCastConfiguration/config.jelly
@@ -1,8 +1,4 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section title="${%Cluster Broadcast Messaging}">
-    <f:entry title="" field="dnsMultiCastEnabled">
-      <f:checkbox checked="${it.isDnsMultiCastEnabled()}" title="${%Enable DNS Multicast}" />
-    </f:entry>
-  </f:section>
+  <f:optionalBlock field="dnsMultiCastEnabled" checked="${it.isDnsMultiCastEnabled()}" title="${%Enable DNS Multicast}" />
 </j:jelly>

--- a/core/src/main/resources/hudson/DNSMultiCast/GlobalDNSMultiCastConfiguration/config.jelly
+++ b/core/src/main/resources/hudson/DNSMultiCast/GlobalDNSMultiCastConfiguration/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:section title="${%Cluster Broadcast Messaging}">
+    <f:entry title="" field="dnsMultiCastEnabled">
+      <f:checkbox checked="${it.isDnsMultiCastEnabled()}" title="${%Enable DNS Multicast}" />
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/core/src/main/resources/hudson/UDPBroadcastThread/UDPBroadcastThreadGlobalConfiguration/config.jelly
+++ b/core/src/main/resources/hudson/UDPBroadcastThread/UDPBroadcastThreadGlobalConfiguration/config.jelly
@@ -1,6 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="" field="udpBroadcastEnabled">
-    <f:checkbox checked="${it.isUdpBroadcastEnabled()}" title="${%Enable UDP Broadcast}" />
-  </f:entry>
+  <f:optionalBlock field="udpBroadcastEnabled" checked="${it.isUdpBroadcastEnabled()}" title="${%Enable UDP Broadcast}">
+    <f:entry title="${%UDP Broadcast Port}" field="udpBroadcastPort">
+      <f:number />
+    </f:entry>
+  </f:optionalBlock>
 </j:jelly>

--- a/core/src/main/resources/hudson/UDPBroadcastThread/UDPBroadcastThreadGlobalConfiguration/config.jelly
+++ b/core/src/main/resources/hudson/UDPBroadcastThread/UDPBroadcastThreadGlobalConfiguration/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="" field="udpBroadcastEnabled">
+    <f:checkbox checked="${it.isUdpBroadcastEnabled()}" title="${%Enable UDP Broadcast}" />
+  </f:entry>
+</j:jelly>


### PR DESCRIPTION
Moves configuration for jmDNS and UDP broadcast from `Jenkins` constructor to global security configuration items.

Addresses: https://issues.jenkins-ci.org/browse/JENKINS-33596

TODO:
- [ ] Ensure upgrading from prior versions results in these services being enabled as they were
