### PR TITLE
[WiP] make build log always use master’s encoding

### DIFF
--- a/core/src/main/java/hudson/Proc.java
+++ b/core/src/main/java/hudson/Proc.java
@@ -166,7 +166,7 @@ public abstract class Proc {
             latch.countDown();
         }
     }
-    
+
     /**
      * Locally launched process.
      */
@@ -211,7 +211,7 @@ public abstract class Proc {
         public LocalProc(String[] cmd,String[] env,InputStream in,OutputStream out,OutputStream err,File workDir) throws IOException {
             this( calcName(cmd),
                   stderr(environment(new ProcessBuilder(cmd),env).directory(workDir), err==null || err== SELFPUMP_OUTPUT),
-                  in, out, err );
+                  in, out, err);
         }
 
         private static ProcessBuilder stderr(ProcessBuilder pb, boolean redirectError) {
@@ -231,7 +231,7 @@ public abstract class Proc {
             return pb;
         }
 
-        private LocalProc( String name, ProcessBuilder procBuilder, InputStream in, OutputStream out, OutputStream err ) throws IOException {
+        private LocalProc( String name, ProcessBuilder procBuilder, InputStream in, OutputStream out, OutputStream err) throws IOException {
             Logger.getLogger(Proc.class.getName()).log(Level.FINE, "Running: {0}", name);
             this.name = name;
             this.out = out;

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1012,7 +1012,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     /**
      * Called by {@link Executor} to kill excessive executors from this computer.
      */
-    /*package*/ void removeExecutor(final Executor e) {
+    protected void removeExecutor(final Executor e) {
         final Runnable task = new Runnable() {
             @Override
             public void run() {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1695,13 +1695,6 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
             try {
                 try {
-                    Computer computer = Computer.currentComputer();
-                    Charset charset = null;
-                    if (computer != null) {
-                        charset = computer.getDefaultCharset();
-                        this.charset = charset.name();
-                    }
-
                     // don't do buffering so that what's written to the listener
                     // gets reflected to the file immediately, which can then be
                     // served to the browser immediately
@@ -1721,7 +1714,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                         }
                     }
 
-                    listener = new StreamBuildListener(logger,charset);
+                    listener = new StreamBuildListener(logger);
 
                     listener.started(getCauses());
 

--- a/core/src/main/java/hudson/model/StreamBuildListener.java
+++ b/core/src/main/java/hudson/model/StreamBuildListener.java
@@ -40,10 +40,13 @@ import java.util.List;
  * @author Kohsuke Kawaguchi
  */
 public class StreamBuildListener extends StreamTaskListener implements BuildListener {
+
+    /** @deprecated charset is forced to UTF-8 */
     public StreamBuildListener(OutputStream out, Charset charset) {
         super(out, charset);
     }
 
+    /** @deprecated charset is forced to UTF-8 */
     public StreamBuildListener(File out, Charset charset) throws IOException {
         super(out, charset);
     }
@@ -52,12 +55,6 @@ public class StreamBuildListener extends StreamTaskListener implements BuildList
         super(w);
     }
 
-    /**
-     * @deprecated as of 1.349
-     *      The caller should use {@link #StreamBuildListener(OutputStream, Charset)} to pass in
-     *      the charset and output stream separately, so that this class can handle encoding correctly.
-     */
-    @Deprecated
     public StreamBuildListener(PrintStream w) {
         super(w);
     }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -212,6 +212,10 @@ public class SlaveComputer extends Computer {
         return super.getIcon();
     }
 
+    protected TaskListener getListener() {
+        return taskListener;
+    }
+
     /**
      * @deprecated since 2008-05-20.
      */


### PR DESCRIPTION
Jenkins used to rely on build node's encoding as it pipe remote processes output as-is in log file.
This PR is about converting external process output from build node local encoding into master’s encoding. As a result, all logs on master use local platform encoding, and as a side-effet (considering my primary goal to implement [one-shot-executor](https://github.com/jenkinsci/one-shot-executor-plugin/)) we don't need to check build computer for encoding to create build log, so can postpone actual computer launch.
