### PR TITLE
Update MIT license link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@ THE SOFTWARE.
   <licenses>
     <license>
       <name>The MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <url>https://opensource.org/licenses/MIT</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
The former link is a dead link.
