### PR TITLE
[FIXED JENKINS-44417] - Fix Warning image size to support retina display

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -847,6 +847,7 @@ LABEL.attach-previous {
     min-height: 16px;
     line-height: 16px;
     background-image: url( "../images/16x16/warning.png" );
+    background-size: 16px 16px;
     background-position: left center;
     background-repeat: no-repeat;
 }


### PR DESCRIPTION
### Changelog Entry

* bug, "Fix Warning image size to correctly show it on Retina display displays"

https://issues.jenkins-ci.org/browse/JENKINS-44417