### PR TITLE
Deprecating Computer.cliOnline()

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -523,6 +523,10 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         setTemporarilyOffline(true, new ByCLI(cause));
     }
 
+    /**
+     * Deprecated - implementation of CLI command "online-node" moved to {@link hudson.cli.OnlineNodeCommand}.
+     */
+    @Deprecated
     public void cliOnline() throws ExecutionException, InterruptedException {
         checkPermission(CONNECT);
         setTemporarilyOffline(false, null);


### PR DESCRIPTION
Functionality was moved to OnlineNodeCommand class already

As discussed in PR #2295, these methods don't have other usage nowadays thus deprecating
