### PR TITLE
[JENKINS-34601] Fix help file for node name attribute

### DIFF
--- a/core/src/main/resources/hudson/model/ComputerSet/_new.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/_new.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly"/>
     <l:main-panel>
       <f:form method="post" action="doCreateItem" name="config">
-        <f:entry title="${%Name}" help="/help/system-config/master-slave/name.html">
+        <f:entry title="${%Name}" help="${requestScope.descriptor.getHelpFile('name')}">
           <f:textbox name="name" value="${request.getParameter('name')}" clazz="required" checkMessage="${%Name is mandatory}"/>
         </f:entry>
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-34601

@jenkinsci/code-reviewers 

Fixes the help file link

<img width="1055" alt="capture d ecran 2016-05-04 a 11 19 06" src="https://cloud.githubusercontent.com/assets/171459/15024524/110bc5d0-11ea-11e6-9974-a04c5270a153.png">
