### PR TITLE
[JENKINS-31618] Fixed NoSuchMethodException in loginLink.jelly

### DIFF
--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -515,8 +515,8 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
         if (from == null
                 && request != null
                 && request.getRequestURI() != null
-                && request.getRequestURI().equals("/loginError")
-                && request.getRequestURI().equals("/login")) {
+                && !request.getRequestURI().equals("/loginError")
+                && !request.getRequestURI().equals("/login")) {
 
                 from = request.getRequestURI();
         }

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -62,6 +62,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.Cookie;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -483,6 +484,44 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
      * Singleton constant that represents "no authentication."
      */
     public static final SecurityRealm NO_AUTHENTICATION = new None();
+
+    /**
+     * Perform a calculation where we should go back after sucessfull login
+     *
+     * @return Encoded URI where we should go back after sucessfull login or "/" if no way back
+     *
+     * @since TODO
+     */
+    public static String getFrom() {
+        String from = null;
+        final StaplerRequest request = Stapler.getCurrentRequest();
+
+        if (request.getSession(false) != null) {
+            from = (String) request.getSession().getAttribute("from");
+        }
+
+        if (from == null) {
+            from = request.getParameter("from");
+        }
+
+        final String requestURI = request.getRequestURI();
+        if (from == null && requestURI != null
+                && requestURI.compareTo("/loginError") != 0 && requestURI.compareTo("/login") != 0) {
+            from = requestURI;
+        }
+
+        if (from == null || from.trim().isEmpty()) {
+            from = "/";
+        }
+
+        try {
+            from = java.net.URLEncoder.encode(from, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            from = "/";
+        }
+
+        return from;
+    }
 
     private static class None extends SecurityRealm {
         public SecurityComponents createSecurityComponents() {

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -49,6 +49,8 @@ import org.acegisecurity.userdetails.UserDetailsService;
 import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -494,6 +496,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
      *
      * @since TODO
      */
+    @Restricted(DoNotUse.class)
     public static String getFrom() {
         String from = null, returnValue = null;
         final StaplerRequest request = Stapler.getCurrentRequest();
@@ -503,10 +506,8 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
         if (request != null
                 && request.getSession(false) != null) {
             from = (String) request.getSession().getAttribute("from");
-        } else {
-            if (request != null) {
-                from = request.getParameter("from");
-            }
+        } else if (request != null) {
+            from = request.getParameter("from");
         }
 
         // If entry point was not found, try to deduce it from the request URI
@@ -514,18 +515,18 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
         if (from == null
                 && request != null
                 && request.getRequestURI() != null
-                && request.getRequestURI().compareTo("/loginError") != 0
-                && request.getRequestURI().compareTo("/login") != 0) {
+                && request.getRequestURI().equals("/loginError")
+                && request.getRequestURI().equals("/login")) {
 
                 from = request.getRequestURI();
         }
 
         // If deduced entry point isn't deduced yet or the content is a blank value
         // use the root web point "/" as a fallback
-        from.trim();
         if (StringUtils.isBlank(from)) {
             from = "/";
         }
+        from.trim();
 
         // Encode the return value
         try {

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -489,9 +489,9 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
     public static final SecurityRealm NO_AUTHENTICATION = new None();
 
     /**
-     * Perform a calculation where we should go back after sucessfull login
+     * Perform a calculation where we should go back after successful login
      *
-     * @return Encoded URI where we should go back after sucessfull login
+     * @return Encoded URI where we should go back after successful login
      *         or "/" if no way back or an issue occurred
      *
      * @since TODO

--- a/core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
+++ b/core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
@@ -25,5 +25,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-  <a href="${rootURL}/${app.securityRealm.loginUrl}?from=${from}"><b>${%login}</b></a>
+  <a href="${rootURL}/${app.securityRealm.loginUrl}?from=${app.securityRealm.from}"><b>${%login}</b></a>
 </j:jelly>

--- a/core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
+++ b/core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
@@ -25,9 +25,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-  <j:invokeStatic var="from" className="java.net.URLEncoder" method="encode">
-    <j:arg value="${if (request.session.attribute('from')!=null) request.session.getAttribute('from');  else if (request.getParameter('from')!=null) request.getParameter('from'); else if (request.requestURI=='/loginError' || request.requestURI=='/login') '/'; else request.requestURI;}"/>
-    <j:arg value="UTF-8"/>
-  </j:invokeStatic>
   <a href="${rootURL}/${app.securityRealm.loginUrl}?from=${from}"><b>${%login}</b></a>
 </j:jelly>


### PR DESCRIPTION
The expression is modified to prevent return NULL value. When the expression evaluation
returns NULL value for the first argument, non-exists method URLEncoder.encode(Object,String)
is called instead of encode(String,String).

https://issues.jenkins-ci.org/browse/JENKINS-31618
