### PR TITLE
[JENKINS-34629] jenkins-ui (NPM module) is private, used only internally

### DIFF
--- a/war/package.json
+++ b/war/package.json
@@ -3,6 +3,12 @@
   "version": "1.0.0",
   "description": "Jenkins User Interface",
   "license": "MIT",
+  "author": {
+    "name": "Tom Fennelly",
+    "email": "tom.fennelly@gmail.com",
+    "url": "https://github.com/tfennelly"
+  },
+  "private": true,
   "devDependencies": {
     "gulp": "^3.9.0",
     "handlebars": "^3.0.3",


### PR DESCRIPTION
[JENKINS-34629](https://issues.jenkins-ci.org/browse/JENKINS-34629)

Result of `frontend-maven-plugin:1.0:npm` after this PR is:

```
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building Jenkins war 2.2-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- frontend-maven-plugin:1.0:npm (default-cli) @ jenkins-war ---
[INFO] Running 'npm install' in /Users/recena/Development/projects/jenkins/war
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.474 s
[INFO] Finished at: 2016-05-05T22:07:37+02:00
[INFO] Final Memory: 10M/309M
[INFO] ------------------------------------------------------------------------

Process finished with exit code 0
```

@reviewbybees especially @tfennelly 
