### PR TITLE
[FIX JENKINS-31611] Restrict access to plugin pages

### DIFF
--- a/core/src/main/resources/hudson/PluginWrapper/thirdPartyLicenses.jelly
+++ b/core/src/main/resources/hudson/PluginWrapper/thirdPartyLicenses.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <!-- 3rd party license acknowledgements and  -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-  <l:layout title="${%about(it.longName)}">
+  <l:layout title="${%about(it.longName)}" permission="${app.ADMINISTER}">
     <l:main-panel>
       <h1>${%about(it.longName+' '+it.version)}</h1>
 

--- a/core/src/main/resources/hudson/PluginWrapper/uninstall.groovy
+++ b/core/src/main/resources/hudson/PluginWrapper/uninstall.groovy
@@ -1,9 +1,11 @@
 package hudson.PluginWrapper
 
+import jenkins.model.Jenkins
+
 def l = namespace(lib.LayoutTagLib)
 def f = namespace(lib.FormTagLib)
 
-l.layout {
+l.layout(permission: Jenkins.ADMINISTER) {
     def title = _("title", my.shortName)
     l.header(title:title)
     l.main_panel {


### PR DESCRIPTION
Access to the form isn't a problem, as the action is protected. Still, let's prevent access unless authorized.

@reviewbybees
