### PR TITLE
[JENKINS-34674,JENKINS-34675] - Handling of the default update site ID

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -143,9 +143,10 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
 
     /**
      * {@linkplain UpdateSite#getId() ID} of the default update site.
-     * @since 1.483
+     * @since 1.483 - public property
+     * @since TODO - configurable via system property
      */
-    public static final String ID_DEFAULT = "default";
+    public static final String ID_DEFAULT = System.getProperty(UpdateCenter.class.getName()+".defaultUpdateSiteId", "default");
 
     @Restricted(NoExternalUse.class)
     public static final String ID_UPLOAD = "_upload";

--- a/test/src/test/java/hudson/model/UpdateCenterConnectionStatusTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterConnectionStatusTest.java
@@ -67,7 +67,7 @@ public class UpdateCenterConnectionStatusTest {
         JSONObject response = jenkinsRule.getJSON("updateCenter/connectionStatus?siteId=blahblah").getJSONObject();
 
         Assert.assertEquals("error", response.getString("status"));
-        Assert.assertEquals("Unknown site 'blahblah'.", response.getString("message"));
+        Assert.assertEquals("Cannot check connection status of the update site with ID='blahblah'. This update center cannot be resolved", response.getString("message"));
     }
 
     private UpdateSite updateSite = new UpdateSite(UpdateCenter.ID_DEFAULT, "http://xyz") {

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -894,7 +894,7 @@ var createPluginSetupWizard = function(appendTarget) {
 		jenkins.testConnectivity(siteId, handleGenericError(function(isConnected, isFatal, errorMessage) {
 			if(!isConnected) {
 				if (isFatal) { // We cannot continue, show error
-					setPanel(errorPanel, { errorMessage: 'Default update site connectivity check failed with fatal error: ' + errorMessage + '. Please create a bug in Jenkins JIRA.' });
+					setPanel(errorPanel, { errorMessage: 'Default update site connectivity check failed with fatal error: ' + errorMessage + '. If you see this issue for the custom Jenkins WAR bundle, consider setting the correct value of the hudson.model.UpdateCenter.defaultUpdateSiteId system property (requires Jenkins restart). Otherwise please create a bug in Jenkins JIRA.' });
 				} else { // The update center is offline, no problem
 					setPanel(offlinePanel);
 				}

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -889,9 +889,15 @@ var createPluginSetupWizard = function(appendTarget) {
 		translations = localizations;
 
 		// check for connectivity
-		jenkins.testConnectivity(handleGenericError(function(isConnected) {
+		//TODO: make the Update Center ID configurable
+		var siteId = 'default';
+		jenkins.testConnectivity(siteId, handleGenericError(function(isConnected, isFatal, errorMessage) {
 			if(!isConnected) {
-				setPanel(offlinePanel);
+				if (isFatal) { // We cannot continue, show error
+					setPanel(errorPanel, { errorMessage: 'Default update site connectivity check failed with fatal error: ' + errorMessage + '. Please create a bug in Jenkins JIRA.' });
+				} else { // The update center is offline, no problem
+					setPanel(offlinePanel);
+				}
 				return;
 			}
 

--- a/war/src/main/js/util/jenkins.js
+++ b/war/src/main/js/util/jenkins.js
@@ -192,18 +192,22 @@ exports.loadTranslations = function(bundleName, handler, onError) {
 /**
  * Runs a connectivity test, calls handler with a boolean whether there is sufficient connectivity to the internet
  */
-exports.testConnectivity = function(handler) {
+exports.testConnectivity = function(siteId, handler) {
 	// check the connectivity api
 	var testConnectivity = function() {
-		exports.get('/updateCenter/connectionStatus?siteId=default', function(response) {
+		exports.get('/updateCenter/connectionStatus?siteId=' + siteId, function(response) {
+			if(response.status !== 'ok') {
+				handler(false, true, response.message);
+			}
+			
 			var uncheckedStatuses = ['PRECHECK', 'CHECKING', 'UNCHECKED'];
 			if(uncheckedStatuses.indexOf(response.data.updatesite) >= 0  || uncheckedStatuses.indexOf(response.data.internet) >= 0) {
 				setTimeout(testConnectivity, 100);
 			}
 			else {
 				if(response.status !== 'ok' || response.data.updatesite !== 'OK' || response.data.internet !== 'OK') {
-					// no connectivity
-					handler(false);
+					// no connectivity, but not fatal
+					handler(false, false);
 				}
 				else {
 					handler(true);


### PR DESCRIPTION
- [x] - Properly annotate methods
- [x] - [JENKINS-34675](https://issues.jenkins-ci.org/browse/JENKINS-34675) - Prevent hanging of the InstallationWizard UI if the default Update Site ID cannot be resolved. In such case an error message will be displayed
- [x] - [JENKINS-34674](https://issues.jenkins-ci.org/browse/JENKINS-34674) - Add a system property, which allows specifying custom Update Center IDs

Error message example:
<img width="1000" alt="screen shot 2016-05-08 at 14 46 26" src="https://cloud.githubusercontent.com/assets/3000480/15097924/6f50ef1c-152d-11e6-9e2e-118fbc741459.png">

@reviewbybees @kzantow 
