### PR TITLE
[FIXED JENKINS-25164] Add JOB_BASE_NAME env var

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -369,6 +369,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         env.put("JENKINS_SERVER_COOKIE",SERVER_COOKIE.get());
         env.put("HUDSON_SERVER_COOKIE",SERVER_COOKIE.get()); // Legacy compatibility
         env.put("JOB_NAME",getFullName());
+        env.put("SHORT_JOB_NAME",getName());
         return env;
     }
 

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -369,7 +369,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         env.put("JENKINS_SERVER_COOKIE",SERVER_COOKIE.get());
         env.put("HUDSON_SERVER_COOKIE",SERVER_COOKIE.get()); // Legacy compatibility
         env.put("JOB_NAME",getFullName());
-        env.put("LEAF_JOB_NAME", getName());
+        env.put("JOB_BASE_NAME", getName());
         return env;
     }
 

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -369,7 +369,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         env.put("JENKINS_SERVER_COOKIE",SERVER_COOKIE.get());
         env.put("HUDSON_SERVER_COOKIE",SERVER_COOKIE.get()); // Legacy compatibility
         env.put("JOB_NAME",getFullName());
-        env.put("SHORT_JOB_NAME",getName());
+        env.put("LEAF_JOB_NAME", getName());
         return env;
     }
 

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
@@ -3,7 +3,7 @@ package jenkins.model.CoreEnvironmentContributor;
 def l = namespace(lib.JenkinsTagLib)
 
 // also advertises those contributed by Run.getCharacteristicEnvVars()
-["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME", "LEAF_JOB_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
+["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME", "JOB_BASE_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
@@ -3,7 +3,7 @@ package jenkins.model.CoreEnvironmentContributor;
 def l = namespace(lib.JenkinsTagLib)
 
 // also advertises those contributed by Run.getCharacteristicEnvVars()
-["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
+["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME", "SHORT_JOB_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
@@ -3,7 +3,7 @@ package jenkins.model.CoreEnvironmentContributor;
 def l = namespace(lib.JenkinsTagLib)
 
 // also advertises those contributed by Run.getCharacteristicEnvVars()
-["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME", "SHORT_JOB_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
+["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME", "LEAF_JOB_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
@@ -1,7 +1,8 @@
 BUILD_NUMBER.blurb=The current build number, such as "153"
 BUILD_ID.blurb=The current build ID, identical to BUILD_NUMBER for builds created in 1.597+, but a YYYY-MM-DD_hh-mm-ss timestamp for older builds
 BUILD_DISPLAY_NAME.blurb=The display name of the current build, which is something like "#153" by default.
-JOB_NAME.blurb=Name of the project of this build, such as "foo" or "foo/bar". (To strip off folder paths from a Bourne shell script, try: <tt>$'{'JOB_NAME##*/}</tt>)
+JOB_NAME.blurb=Name of the project of this build, such as "foo" or "foo/bar". (To strip off folder paths from a Bourne shell script, use env var: <tt>SHORT_JOB_NAME</tt>)
+SHORT_JOB_NAME.blurb=Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".
 BUILD_TAG.blurb=String of "jenkins-<i>$'{'JOB_NAME}</i>-<i>$'{'BUILD_NUMBER}</i>". Convenient to put into a resource file, a jar file, etc for easier identification.
 EXECUTOR_NUMBER.blurb=\
   The unique number that identifies the current executor \

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
@@ -2,7 +2,7 @@ BUILD_NUMBER.blurb=The current build number, such as "153"
 BUILD_ID.blurb=The current build ID, identical to BUILD_NUMBER for builds created in 1.597+, but a YYYY-MM-DD_hh-mm-ss timestamp for older builds
 BUILD_DISPLAY_NAME.blurb=The display name of the current build, which is something like "#153" by default.
 JOB_NAME.blurb=Name of the project of this build, such as "foo" or "foo/bar".
-SHORT_JOB_NAME.blurb=Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".
+LEAF_JOB_NAME.blurb=Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".
 BUILD_TAG.blurb=String of "jenkins-<i>$'{'JOB_NAME}</i>-<i>$'{'BUILD_NUMBER}</i>". Convenient to put into a resource file, a jar file, etc for easier identification.
 EXECUTOR_NUMBER.blurb=\
   The unique number that identifies the current executor \

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
@@ -1,7 +1,7 @@
 BUILD_NUMBER.blurb=The current build number, such as "153"
 BUILD_ID.blurb=The current build ID, identical to BUILD_NUMBER for builds created in 1.597+, but a YYYY-MM-DD_hh-mm-ss timestamp for older builds
 BUILD_DISPLAY_NAME.blurb=The display name of the current build, which is something like "#153" by default.
-JOB_NAME.blurb=Name of the project of this build, such as "foo" or "foo/bar". (To strip off folder paths from a Bourne shell script, use env var: <tt>SHORT_JOB_NAME</tt>)
+JOB_NAME.blurb=Name of the project of this build, such as "foo" or "foo/bar".
 SHORT_JOB_NAME.blurb=Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".
 BUILD_TAG.blurb=String of "jenkins-<i>$'{'JOB_NAME}</i>-<i>$'{'BUILD_NUMBER}</i>". Convenient to put into a resource file, a jar file, etc for easier identification.
 EXECUTOR_NUMBER.blurb=\

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
@@ -2,7 +2,7 @@ BUILD_NUMBER.blurb=The current build number, such as "153"
 BUILD_ID.blurb=The current build ID, identical to BUILD_NUMBER for builds created in 1.597+, but a YYYY-MM-DD_hh-mm-ss timestamp for older builds
 BUILD_DISPLAY_NAME.blurb=The display name of the current build, which is something like "#153" by default.
 JOB_NAME.blurb=Name of the project of this build, such as "foo" or "foo/bar".
-LEAF_JOB_NAME.blurb=Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".
+JOB_BASE_NAME.blurb=Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".
 BUILD_TAG.blurb=String of "jenkins-<i>$'{'JOB_NAME}</i>-<i>$'{'BUILD_NUMBER}</i>". Convenient to put into a resource file, a jar file, etc for easier identification.
 EXECUTOR_NUMBER.blurb=\
   The unique number that identifies the current executor \


### PR DESCRIPTION
As per [JENKINS-25164](https://issues.jenkins-ci.org/browse/JENKINS-25164) it sounds like a good idea to have a `$SHORT_JOB_NAME` stripping off the path related to folders.

https://issues.jenkins-ci.org/browse/JENKINS-25164

@reviewbybees
