### PR TITLE
[FIX JENKINS-34669] Use adjunct to load plugin wizard .js

### DIFF
--- a/core/src/main/resources/jenkins/install/SetupWizard/index.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/index.jelly
@@ -2,7 +2,6 @@
 <l:html norefresh="true" title="${it.displayName}" xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:main-panel>
     <div class="plugin-setup-wizard-container"></div>
-    <script src="${resURL}/${j.installWizardPath}.js" type="text/javascript"/>
-    <link rel="stylesheet" href="${resURL}/${j.installWizardPath}.css" type="text/css" />
+    <st:adjunct includes="${j.installWizardPath}" />
   </l:main-panel>
 </l:html>

--- a/core/src/main/resources/lib/layout/html.jelly
+++ b/core/src/main/resources/lib/layout/html.jelly
@@ -157,8 +157,7 @@ ${h.initPageVariables(context)}
 
     <j:invokeStatic var="j" className="jenkins.model.Jenkins" method="getInstance" />
     <j:if test="${!j.installState.setupComplete}">
-      <script src="${resURL}/${j.installWizardPath}.js" type="text/javascript"/>
-      <link rel="stylesheet" href="${resURL}/${j.installWizardPath}.css" type="text/css" />
+      <st:adjunct includes="${j.installWizardPath}" />
     </j:if>
 
     <j:if test="${isMSIE}">

--- a/war/gulpfile.js
+++ b/war/gulpfile.js
@@ -23,7 +23,7 @@ builder.bundle('src/main/js/pluginSetupWizard.js')
     .withExternalModuleMapping('bootstrap', 'core-assets/bootstrap:bootstrap3', {addDefaultCSS: true})
     .withExternalModuleMapping('handlebars', 'core-assets/handlebars:handlebars3')
     .less('src/main/less/pluginSetupWizard.less')
-    .inDir('src/main/webapp/jsbundles');
+    .inDir('target/classes/org/jenkinsci/setup'); // bundle as an adjunct
 
 //
 // Bundle the Config Tab Bar.

--- a/war/src/main/webapp/WEB-INF/web.xml
+++ b/war/src/main/webapp/WEB-INF/web.xml
@@ -47,7 +47,7 @@ THE SOFTWARE.
 
   <context-param>
       <param-name>install-wizard-path</param-name>
-      <param-value>jsbundles/pluginSetupWizard</param-value>
+      <param-value>org.jenkinsci.setup.pluginSetupWizard</param-value>
   </context-param>
 
   <servlet-mapping>


### PR DESCRIPTION
See [JENKINS-34669](https://issues.jenkins-ci.org/browse/JENKINS-34669)

Haven't run a full build so lets make sure the PR builds it first.

@oleg-nenashev @kzantow 
