### PR TITLE
Add missing Javadoc @throws tags

### DIFF
--- a/core/src/test/java/hudson/BulkChangeTest.java
+++ b/core/src/test/java/hudson/BulkChangeTest.java
@@ -69,6 +69,8 @@ public class BulkChangeTest {
 
     /**
      * If there is no BulkChange, we should see two saves.
+     *
+     * @throws Exception test failure
      */
     @Test
     public void noBulkChange() throws Exception {
@@ -79,6 +81,8 @@ public class BulkChangeTest {
 
     /**
      * With a {@link BulkChange}, this will become just one save.
+     *
+     * @throws Exception test failure
      */
     @Test
     public void bulkChange() throws Exception {
@@ -94,6 +98,8 @@ public class BulkChangeTest {
 
     /**
      * {@link BulkChange}s can be nested.
+     *
+     * @throws Exception test failure
      */
     @Test
     public void nestedBulkChange() throws Exception {

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -87,6 +87,8 @@ public class FilePathTest {
     /**
      * An attempt to reproduce the file descriptor leak.
      * If this operation leaks a file descriptor, 2500 should be enough, I think.
+     *
+     * @throws Exception test failure
      */
     // TODO: this test is much too slow to be a traditional unit test. Should be extracted into some stress test
     // which is no part of the default test harness?
@@ -115,6 +117,8 @@ public class FilePathTest {
      * seeing the right byte count at the end.
      *
      * Also see JENKINS-7897
+     *
+     * @throws Exception test failure
      */
     @Issue("JENKINS-7871")
     @Test public void noRaceConditionInCopyTo() throws Exception {
@@ -435,6 +439,9 @@ public class FilePathTest {
      * Tests that permissions are kept when using {@link FilePath#copyToWithPermission(FilePath)}.
      * Also tries to check that a problem with setting the last-modified date on Windows doesn't fail the whole copy
      * - well at least when running this test on a Windows OS. See JENKINS-11073
+     *
+     * @throws IOException test failure
+     * @throws InterruptedException test failure
      */
     @Test public void copyToWithPermission() throws IOException, InterruptedException {
         File tmp = temp.getRoot();

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -527,6 +527,8 @@ public class UtilTest {
     /**
      * Compute 'known-correct' digests and see if I still get them when computed concurrently
      * to another digest.
+     *
+     * @throws InterruptedException test failure
      */
     @Issue("JENKINS-10346")
     @Test

--- a/core/src/test/java/hudson/scheduler/CronTabDayOfWeekLocaleTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabDayOfWeekLocaleTest.java
@@ -48,6 +48,8 @@ public class CronTabDayOfWeekLocaleTest {
     /**
      * This unit test is an slight adaptation of the unit test found in
      * HUDSON-8656.
+     *
+     * @throws Exception test failure
      */
     @Test
     @Url("http://issues.hudson-ci.org/browse/HUDSON-8656")

--- a/core/src/test/java/hudson/scheduler/CronTabTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabTest.java
@@ -92,6 +92,8 @@ public class CronTabTest {
 
     /**
      * Verifies that HUDSON-8656 never crops up again.
+     *
+     * @throws ANTLRException test failure
      */
     @Url("http://issues.hudson-ci.org/browse/HUDSON-8656")
     @Test
@@ -114,6 +116,8 @@ public class CronTabTest {
 
     /**
      * Verifies that HUDSON-8656 never crops up again.
+     *
+     * @throws ANTLRException test failure
      */
     @Url("http://issues.hudson-ci.org/browse/HUDSON-8656")
     @Test

--- a/core/src/test/java/hudson/util/CopyOnWriteMapTest.java
+++ b/core/src/test/java/hudson/util/CopyOnWriteMapTest.java
@@ -41,6 +41,8 @@ public class CopyOnWriteMapTest {
 
     /**
      * Verify that serialization form of CopyOnWriteMap.Hash and HashMap are the same.
+     *
+     * @throws Exception test failure
      */
     @Test public void hashSerialization() throws Exception {
         HashData td = new HashData();
@@ -83,6 +85,8 @@ public class CopyOnWriteMapTest {
     /**
      * Verify that an empty CopyOnWriteMap.Tree can be serialized,
      * and that serialization form is the same as a standard TreeMap.
+     *
+     * @throws Exception test failure
      */
     @Test public void treeSerialization() throws Exception {
         TreeData td = new TreeData();

--- a/core/src/test/java/hudson/util/io/TarArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/TarArchiverTest.java
@@ -48,6 +48,8 @@ public class TarArchiverTest {
 
     /**
      * Makes sure that permissions are properly stored in the tar file.
+     *
+     * @throws Exception test failure
      */
     @Issue("JENKINS-9397")
     @Test public void permission() throws Exception {

--- a/core/src/test/java/jenkins/RemotingJarSignatureTest.java
+++ b/core/src/test/java/jenkins/RemotingJarSignatureTest.java
@@ -19,6 +19,8 @@ import org.apache.commons.io.IOUtils;
 public class RemotingJarSignatureTest {
     /**
      * Makes sure that the remoting jar is properly signed.
+     *
+     * @throws Exception test failure
      */
     @Test
     public void testSignature() throws Exception {

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -228,6 +228,8 @@ public class AbstractLazyLoadRunMapTest {
 
     /**
      * If load fails, search needs to gracefully handle it
+     *
+     * @throws IOException test failure
      */
     @Test
     public void unloadableData() throws IOException {

--- a/core/src/test/java/jenkins/model/lazy/FakeMapBuilder.java
+++ b/core/src/test/java/jenkins/model/lazy/FakeMapBuilder.java
@@ -56,6 +56,8 @@ public class FakeMapBuilder implements TestRule {
     /**
      * Adds a build record under the givn ID but make it unloadable,
      * which will cause a failure when a load is attempted on this build ID.
+     *
+     * @throws IOException test failure
      */
     public FakeMapBuilder addUnloadable(int n) throws IOException {
         File build = new File(dir, Integer.toString(n));

--- a/core/src/test/java/jenkins/util/MarkFindingOutputStreamTest.java
+++ b/core/src/test/java/jenkins/util/MarkFindingOutputStreamTest.java
@@ -39,6 +39,8 @@ public class MarkFindingOutputStreamTest {
 
     /**
      * If a stream closes without completing a match, the partial match should be sent to the output.
+     *
+     * @throws IOException test failure
      */
     @Test
     public void closeInTheMiddle() throws IOException {

--- a/core/src/test/java/jenkins/util/TimerTest.java
+++ b/core/src/test/java/jenkins/util/TimerTest.java
@@ -14,6 +14,8 @@ public class TimerTest {
     /**
      * Launch two tasks which can only complete
      * by running doRun() concurrently.
+     *
+     * @throws InterruptedException test failure
      */
     @Test
     @Issue("JENKINS-19622")

--- a/core/src/test/java/jenkins/util/xstream/XStreamDOMTest.java
+++ b/core/src/test/java/jenkins/util/xstream/XStreamDOMTest.java
@@ -175,6 +175,8 @@ public class XStreamDOMTest {
     /**
      * Regardless of how we read XML into XStreamDOM, XStreamDOM should retain the raw XML infoset,
      * which means escaped names.
+     *
+     * @throws Exception test failure
      */
     @Test
     public void escapeHandling() throws Exception {

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -60,6 +60,8 @@ public class HistoryPageFilterTest {
 
     /**
      * Latest/top page where total number of items less than the max page size.
+     *
+     * @throws IOException test failure
      */
     @Test
     public void test_latest_partial_page() throws IOException {
@@ -89,6 +91,8 @@ public class HistoryPageFilterTest {
 
     /**
      * Latest/top page where total number of items greater than the max page size.
+     *
+     * @throws IOException test failure
      */
     @Test
     public void test_latest_longer_list() throws IOException {
@@ -113,6 +117,8 @@ public class HistoryPageFilterTest {
     /**
      * Test olderThan (page down) when set to id greater than newest (should never happen). Should be same as not
      * specifying newerThan/olderThan.
+     *
+     * @throws IOException test failure
      */
     @Test
     public void test_olderThan_gt_newest() throws IOException {
@@ -133,6 +139,8 @@ public class HistoryPageFilterTest {
     /**
      * Test olderThan (page down) when set to id less than the oldest (should never happen). Should just give an
      * empty list of builds.
+     *
+     * @throws IOException test failure
      */
     @Test
     public void test_olderThan_lt_oldest() throws IOException {
@@ -150,6 +158,8 @@ public class HistoryPageFilterTest {
     /**
      * Test olderThan (page down) when set to an id close to the oldest in the list (where
      * there's less than a full page older than the supplied olderThan arg).
+     *
+     * @throws IOException test failure
      */
     @Test
     public void test_olderThan_leaving_part_page() throws IOException {
@@ -171,6 +181,8 @@ public class HistoryPageFilterTest {
 
     /**
      * Test olderThan (page down) when set to an id in the middle. Should be a page up and a page down.
+     *
+     * @throws IOException test failure
      */
     @Test
     public void test_olderThan_mid_page() throws IOException {
@@ -190,6 +202,8 @@ public class HistoryPageFilterTest {
 
     /**
      * Test newerThan (page up) when set to id greater than newest (should never happen). Should be an empty list.
+     *
+     * @throws IOException test failure
      */
     @Test
     public void test_newerThan_gt_newest() throws IOException {
@@ -207,6 +221,8 @@ public class HistoryPageFilterTest {
     /**
      * Test newerThan (page up) when set to id less than the oldest (should never happen). Should give the oldest
      * set of builds.
+     *
+     * @throws IOException test failure
      */
     @Test
     public void test_newerThan_lt_oldest() throws IOException {
@@ -226,6 +242,8 @@ public class HistoryPageFilterTest {
 
     /**
      * Test newerThan (page up) mid range nearer the oldest build in the list.
+     *
+     * @throws IOException test failure
      */
     @Test
     public void test_newerThan_near_oldest() throws IOException {
@@ -247,6 +265,8 @@ public class HistoryPageFilterTest {
      * Test newerThan (page up) mid range nearer the newest build in the list. This works a little different
      * in that it will put the 2 builds newer than newerThan on the page and then fill the remaining slots on the
      * page with builds equal to and older i.e. it return the newest/latest builds.
+     *
+     * @throws IOException test failure
      */
     @Test
     public void test_newerThan_near_newest() throws IOException {

--- a/core/src/test/java/jenkins/xml/XMLUtilsTest.java
+++ b/core/src/test/java/jenkins/xml/XMLUtilsTest.java
@@ -107,6 +107,10 @@ public class XMLUtilsTest {
     /**
      * Tests getValue() directly. Tests the parse methods too (indirectly - yeah, a purest would have
      * tests for each).
+     *
+     * @throws XPathExpressionException test failure
+     * @throws SAXException test failure
+     * @throws IOException test failure
      */
     @Test
     public void testGetValue() throws XPathExpressionException, SAXException, IOException {


### PR DESCRIPTION
Eliminates Javadoc warnings with Java 8 with "mvn javadoc:test-javadoc", such as:

```
[ERROR] jenkins/core/src/test/java/jenkins/RemotingJarSignatureTest.java:24: warning: no @throws for java.lang.Exception
[ERROR] public void testSignature() throws Exception {
```
