### PR TITLE
[FIXED JENKINS-34710] - PluginWrapper should not throw IOException if somebody enables the enabled plugin

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -440,6 +440,10 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      * Enables this plugin next time Jenkins runs.
      */
     public void enable() throws IOException {
+        if (!disableFile.exists()) {
+            LOGGER.log(Level.FINEST, "Plugin {0} has been already enabled. Skipping the enable() operation", getShortName());
+            return;
+        }
         if(!disableFile.delete())
             throw new IOException("Failed to delete "+disableFile);
     }


### PR DESCRIPTION
The issue happens on my custom Jenkins 2.2-based WAR file with custom update center. I get severe errors in the log, because Jenkins tries to enable the enabled plugin and gets into a SEVERE error in such case.

https://issues.jenkins-ci.org/browse/JENKINS-34710

@reviewbybees
