### PR TITLE
[FIXED JENKINS-34705] - Fix the infinite loop in InstallationWizard if the internet check is skipped

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -198,6 +198,12 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
          */
         PRECHECK,
         /**
+         * Connection status check has been skipped.
+         * As example, it may happen if there is no connection check URL defined for the site.
+         * @since TODO
+         */
+        SKIPPED,
+        /**
          * Connection status is being checked at this time.
          */
         CHECKING,
@@ -1377,6 +1383,10 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                             connectionStates.put(ConnectionStatus.INTERNET, ConnectionStatus.OK);
                         }
                     });
+                } else {
+                    LOGGER.log(WARNING, "Update site '{0}' does not declare the connection check URL. "
+                            + "Skipping the network availability check.", site.getId());
+                    connectionStates.put(ConnectionStatus.INTERNET, ConnectionStatus.SKIPPED);
                 }
 
                 connectionStates.put(ConnectionStatus.UPDATE_SITE, ConnectionStatus.CHECKING);

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -341,9 +341,11 @@ public class UpdateSite {
     }
 
     /**
-     * Returns an "always up" server for Internet connectivity testing, or null if we are going to skip the test.
+     * Gets a URL for the Internet connection check.
+     * @return  an "always up" server for Internet connectivity testing, or {@code null} if we are going to skip the test.
      */
     @Exported
+    @CheckForNull
     public String getConnectionCheckUrl() {
         Data dt = getData();
         if(dt==null)    return "http://www.google.com/";

--- a/war/src/main/js/util/jenkins.js
+++ b/war/src/main/js/util/jenkins.js
@@ -200,12 +200,17 @@ exports.testConnectivity = function(siteId, handler) {
 				handler(false, true, response.message);
 			}
 			
+			// Define statuses, which need additional check iteration via async job on the Jenkins master
+			// Statuses like "OK" or "SKIPPED" are considered as fine.
 			var uncheckedStatuses = ['PRECHECK', 'CHECKING', 'UNCHECKED'];
 			if(uncheckedStatuses.indexOf(response.data.updatesite) >= 0  || uncheckedStatuses.indexOf(response.data.internet) >= 0) {
 				setTimeout(testConnectivity, 100);
 			}
 			else {
-				if(response.status !== 'ok' || response.data.updatesite !== 'OK' || response.data.internet !== 'OK') {
+				// Update site should be always reachable, but we do not require the internet connection
+				// if it's explicitly skipped by the update center
+				if(response.status !== 'ok' || response.data.updatesite !== 'OK' || 
+							(response.data.internet !== 'OK' && response.data.internet !== 'SKIPPED')) {
 					// no connectivity, but not fatal
 					handler(false, false);
 				}


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-34705

UpdateSite in Jenkins can return null from getConnectionCheckUrl() in order to indicate that the connection check should be skipped.

In Jenkins 2.2 there is no special status for the "SKIPPED" connection check. UpdateCenter::doCheckConnection() returns <code>{"internet": "UNCHECKED"}</code> in such case.

When PluginSetupWizard.js::checkConnectivity() receives such UNCHECKED result, it tries to query Jenkins again with 100ms timeout. Actually it leads to the infinite loop, because Jenkins UpdateCenter returns "UNCHECKED" forever.

@reviewbybees @kzantow 
