### PR TITLE
Update annotation-indexer from 1.7 to 1.11

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -195,7 +195,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.7</version>
+      <version>1.11</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
Diff: https://github.com/jenkinsci/lib-annotation-indexer/compare/e90dade9a07b04b64ac1b08d539d30ad69ddf7a8...2eec43c72b3cd040d2057e6bbbf639f5e030453e

Major changes:
- 1.11 - [JENKINS-32978] support latest source version to avoid compile time warnings with JDK7
- 1.10 - Get ready for JDK 9
- 1.10 - Be tolerant against line separators on different operating systems
- 1.9 - Support of third-party annotations
- 1.8 - Annotation processor can be intercepted

CC @kohsuke @olivergondza @daspilker who made changes there
