### PR TITLE
[JENKINS-34748] - Plugin Manager builds incorrect list of plugin dependencies if they are nested

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -558,9 +558,10 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 }
 
                 if (dependencyURL != null) {
-                    dependencySet.add(dependencyURL);
                     // And transitive deps...
                     addDependencies(dependencyURL, fromPath, dependencySet);
+                    // And then add the current plugin 
+                    dependencySet.add(dependencyURL);
                 }
             }
         }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-34748

The issue has been introduced in https://github.com/jenkinsci/jenkins/commit/036a8e94ed37cf851f0cafb9cb12c21e3496ed7c . CC @tfennelly 

<code>PluginManager::addDependencies()</code> is supposed to recursively check the plugin dependency tree and to construct a list. But calls in <code>if (dependencyURL != null)</code> are misordered

Suppose we have pluginA depends on pluginB, which depends on pluginC...
1) We invoke addDependencies() for pluginB if pluginA is being loaded
2) We pass through the first iteration of the method and get into <code>if (dependencyURL != null)</code>
3) We add pluginB to the list and invoke addDependencies for children ([pluginC])
4) We enter second addDependencies() and exit on the first condition, because dependencySet already contains pluginB => we exit without adding pluginC to the dependency list

@jenkinsci/code-reviewers @reviewbybees
