### PR TITLE
BuildProcess: Update animal-sniffer-maven-plugin from 1.9 to 1.15.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,7 @@ THE SOFTWARE.
         <plugin>
 	        <groupId>org.codehaus.mojo</groupId>
 	        <artifactId>animal-sniffer-maven-plugin</artifactId>
-	        <version>1.9</version>
+	        <version>1.15</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
When I bundle a custom library into Jenkins WAR, I sometimes get into an <code>IllegalArgumentException</code> being thrown from animal-sniffer-maven-plugin during the build. 

```
[ERROR] Failed to execute goal org.codehaus.mojo:animal-sniffer-maven-plugin:1.9:check (default) on project jenkins-my-war: Execution default of goal org.codehaus.mojo:animal-sniffer-maven-plugin:1.9:check failed. IllegalArgumentException -> [Help 1]
```

Such issues happens in other projects, and the common solution is to upgrade animal-sniffer-maven-plugin (e.g. [ISPN-4433](https://issues.jboss.org/browse/ISPN-4433)). I propose to do the same
