### PR TITLE
[JENKINS-34755] Migrate to SystemProperties and restrict access to the engine

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -43,6 +43,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
+import jenkins.util.SystemProperties;
 import jenkins.util.VirtualFile;
 import org.apache.commons.io.IOUtils;
 import org.apache.tools.zip.ZipEntry;
@@ -311,11 +312,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
             // pseudo file name to let the Stapler set text/plain
             rsp.serveFile(req, in, lastModified, -1, length, "plain.txt");
         } else {
-            String csp = System.getProperty(DirectoryBrowserSupport.class.getName() + ".CSP");
-            if (csp == null) {
-                // default value unless overridden with system property
-                csp = DEFAULT_CSP_VALUE;
-            }
+            String csp = SystemProperties.getString(DirectoryBrowserSupport.class.getName() + ".CSP", DEFAULT_CSP_VALUE);
             if (!csp.trim().equals("")) {
                 // allow users to prevent sending this header by setting empty system property
                 for (String header : new String[]{"Content-Security-Policy", "X-WebKit-CSP", "X-Content-Security-Policy"}) {

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -53,6 +53,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import jenkins.util.SystemProperties;
 
 /**
  * Records the parameter values used for a build.
@@ -302,7 +303,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
 
     private boolean isSafeParameter(String name) {
         if (safeParameters == null) {
-            String paramNames = System.getProperty(SAFE_PARAMETERS_SYSTEM_PROPERTY_NAME);
+            String paramNames = SystemProperties.getString(SAFE_PARAMETERS_SYSTEM_PROPERTY_NAME);
             if (paramNames != null) {
                 safeParameters = Arrays.asList(paramNames.split(","));
             } else {

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -1025,7 +1025,8 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     @Restricted(NoExternalUse.class)
     public static class UserIDCanonicalIdResolver extends User.CanonicalIdResolver {
 
-        private static /* not final */ boolean SECURITY_243_FULL_DEFENSE = Boolean.parseBoolean(System.getProperty(User.class.getName() + ".SECURITY_243_FULL_DEFENSE", "true"));
+        private static /* not final */ boolean SECURITY_243_FULL_DEFENSE = 
+                SystemProperties.getBoolean(User.class.getName() + ".SECURITY_243_FULL_DEFENSE", true);
 
         private static final ThreadLocal<Boolean> resolving = new ThreadLocal<Boolean>() {
             @Override

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -53,6 +53,7 @@ import hudson.model.UpdateCenter.InstallationJob;
 import hudson.model.UpdateCenter.UpdateCenterJob;
 import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 import jenkins.util.xml.XMLUtils;
 
 /**
@@ -84,7 +85,7 @@ public class InstallUtil {
         }
         
         // Support a 3-state flag for running or disabling the setup wizard
-        String shouldRunFlag = System.getProperty("jenkins.install.runSetupWizard");
+        String shouldRunFlag = SystemProperties.getString("jenkins.install.runSetupWizard");
         boolean shouldRun = "true".equalsIgnoreCase(shouldRunFlag);
         boolean shouldNotRun = "false".equalsIgnoreCase(shouldRunFlag);
         

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -30,6 +30,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletContext;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Centralizes calls to {@link System#getProperty()} and related calls.
@@ -58,6 +60,8 @@ import org.apache.commons.lang.StringUtils;
  * @author Johannes Ernst
  * @since TODO
  */
+//TODO: Define a correct design of this engine later. Should be accessible in libs (remoting, stapler) and Jenkins modules too
+@Restricted(NoExternalUse.class)
 public class SystemProperties {
     /**
      * The ServletContext to get the "init" parameters from.

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -24,6 +24,7 @@
 package jenkins.util;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.EnvVars;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -120,12 +121,11 @@ public class SystemProperties {
      * @param      key   the name of the system property.
      * @param      def   a default value.
      * @return     the string value of the system property,
-     *             or {@code null} if there is no property with that key.
+     *             or {@code null} if the the property is missing and the default value is {@code null}.
      *
      * @exception  NullPointerException if {@code key} is {@code null}.
      * @exception  IllegalArgumentException if {@code key} is empty.
      */
-    @CheckForNull
     public static String getString(String key, @CheckForNull String def) {
         String value = System.getProperty(key); // keep passing on any exceptions
         if (value != null) {
@@ -215,11 +215,13 @@ public class SystemProperties {
       * 
       * This behaves just like <code>Integer.getInteger(String,Integer)</code>, except that it
       * also consults the <code>ServletContext</code>'s "init" parameters. If neither exist,
-      * return the default value.
+      * return the default value. 
       * 
       * @param   name property name.
       * @param   def   a default value.
       * @return  the {@code Integer} value of the property.
+      *          If the property is missing, return the default value.
+      *          Result may be {@code null} only if the default value is {@code null}.
       */
     public static Integer getInteger(String name, Integer def) {
         String v = getString(name);


### PR DESCRIPTION
Finalizes https://github.com/jenkinsci/jenkins/pull/2337
- [x] Do not require null checks in methods with default values
- [x] Migrate the newly created properties to SystemProperties
- [x] Restrict the access to SystemProperties to the Jenkins core only

If https://github.com/jenkinsci/jenkins/pull/2332 and https://github.com/jenkinsci/jenkins/pull/2323 address SystemProperties in their files, the entire core will be covered.

@jenkinsci/code-reviewers @reviewbybees
