### PR TITLE
[JENKINS-34858] - Listed Parameters should reflect what was used when the build ran

### DIFF
--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -111,7 +111,9 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
      */
     public ParametersAction(List<ParameterValue> parameters, Collection<String> additionalSafeParameters) {
         this(parameters);
-        safeParameters.addAll(additionalSafeParameters);
+        if (additionalSafeParameters != null) {
+            safeParameters.addAll(additionalSafeParameters);
+        }
     }
     
     public ParametersAction(ParameterValue... parameters) {
@@ -244,9 +246,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
             }
         }
 
-        ParametersAction parametersAction = new ParametersAction(combinedParameters);
-        parametersAction.safeParameters = this.safeParameters;
-        return parametersAction;
+        return new ParametersAction(combinedParameters, this.safeParameters);
     }
 
     /*
@@ -257,14 +257,12 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
     @Nonnull
     public ParametersAction merge(@CheckForNull ParametersAction overrides) {
         if (overrides == null) {
-            ParametersAction parametersAction = new ParametersAction(parameters);
-            parametersAction.safeParameters = this.safeParameters;
+            ParametersAction parametersAction = new ParametersAction(parameters, this.safeParameters);
             return parametersAction;
         }
         ParametersAction parametersAction = createUpdated(overrides.parameters);
         Set<String> safe = new TreeSet<>();
-        if (parametersAction.safeParameters != null) {
-            //loadSafeParameters() should have been called by createUpdated
+        if (parametersAction.safeParameters != null && this.safeParameters != null) {
             safe.addAll(this.safeParameters);
         }
         if (overrides.safeParameters != null) {
@@ -277,6 +275,9 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
     private Object readResolve() {
         if (build != null)
             OldDataMonitor.report(build, "1.283");
+        if (safeParameters == null) {
+            safeParameters = Collections.emptySet();
+        }
         return this;
     }
 

--- a/test/src/test/java/hudson/model/ParametersActionTest2.java
+++ b/test/src/test/java/hudson/model/ParametersActionTest2.java
@@ -160,12 +160,15 @@ public class ParametersActionTest2 {
                 new StringParameterDefinition("bar", "bar"))));
 
         try {
-            ParametersAction action = new TestParametersAction(
-                    new StringParameterValue("foo", "baz"),
-                    new StringParameterValue("bar", "bar"),
-                    new StringParameterValue("whitelisted1", "x"),
-                    new StringParameterValue("whitelisted2", "y"),
-                    new StringParameterValue("whitelisted3", "y"));
+            ParametersAction action = new ParametersAction(
+                    Arrays.<ParameterValue>asList(
+                        new StringParameterValue("foo", "baz"),
+                        new StringParameterValue("bar", "bar"),
+                        new StringParameterValue("whitelisted1", "x"),
+                        new StringParameterValue("whitelisted2", "y"),
+                        new StringParameterValue("whitelisted3", "y")
+                                                 ),
+                    Arrays.asList("whitelisted1", "whitelisted2"));
             FreeStyleBuild build = j.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause(), action));
 
             assertTrue("whitelisted1 parameter is listed in getParameters",
@@ -286,16 +289,6 @@ public class ParametersActionTest2 {
         return false;
     }
 
-    public static class TestParametersAction extends ParametersAction {
-        public TestParametersAction(ParameterValue... parameters) {
-            super(parameters);
-        }
-
-        @Override
-        protected Collection<String> getAdditionalSafeParameters() {
-            return Arrays.asList("whitelisted1", "whitelisted2");
-        }
-    }
 
     public static class ParametersCheckBuilder extends Builder {
 


### PR DESCRIPTION
… the build ran

And provided a way for plugins to define safe parameters by extending ParametersAction

@jenkinsci/code-reviewers 
@reviewbybees
@oleg-nenashev @daniel-beck @amuniz 
