### PR TITLE
[FIX JENKINS-34857] Revert "Switch Jenkins.getInstance() to @Nonnull"

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -756,17 +756,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @throws IllegalStateException {@link Jenkins} has not been started, or was already shut down
      */
     @CLIResolver
-    @Nonnull
+    @Nullable // TODO replace with non-null once Jenkins 2.0+
     public static Jenkins getInstance() {
-        Jenkins instance = HOLDER.getInstance();
-        if (instance == null) {
-            if(!Boolean.getBoolean(Jenkins.class.getName()+".disableExceptionOnNullInstance")) {
-                // TODO: remove that second block around 2.20 (that is: ~20 versions to battle test it)
-                // See https://github.com/jenkinsci/jenkins/pull/2297#issuecomment-216710150
-                throw new IllegalStateException("Jenkins has not been started, or was already shut down");
-            }
-        }
-        return instance;
+        // TODO throw an IllegalStateException in Jenkins 2.0+
+        return HOLDER.getInstance();
     }
 
     /**


### PR DESCRIPTION
Reverts jenkinsci/jenkins#2297

At least the Subversion plugin seems to have some paths receiving a null `jenkins.model.Jenkins` instance. 2.4 has been released only 14 hours ago by @kohsuke and already that issue report.

We just discussed with @oleg-nenashev on IRC and think this would be safer to roll back the change and possibly release a 2.5 now before more users start upgrading to 2.4.

Currently, only the Subversion plugin seems to trigger that. But it's too early to conclude it's an exception :-/.
