### PR TITLE
[FIX JENKINS-34857] Don't throw Exception when Jenkins.getInstance() yields null

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -760,7 +760,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public static Jenkins getInstance() {
         Jenkins instance = HOLDER.getInstance();
         if (instance == null) {
-            if(!Boolean.getBoolean(Jenkins.class.getName()+".disableExceptionOnNullInstance")) {
+            if(Boolean.getBoolean(Jenkins.class.getName()+".enableExceptionOnNullInstance")) {
                 // TODO: remove that second block around 2.20 (that is: ~20 versions to battle test it)
                 // See https://github.com/jenkinsci/jenkins/pull/2297#issuecomment-216710150
                 throw new IllegalStateException("Jenkins has not been started, or was already shut down");


### PR DESCRIPTION
Alternative approach to fixing JENKINS-34857. 

Could be preferred to #2354 

@stephenc WDYT?
