### PR TITLE
remove node workspaces when job deleted

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -46,7 +46,9 @@ import hudson.search.SearchIndexBuilder;
 import hudson.search.SearchItem;
 import hudson.search.SearchItems;
 import hudson.security.ACL;
+import hudson.slaves.WorkspaceList;
 import hudson.tasks.LogRotator;
+import hudson.triggers.SafeTimerTask;
 import hudson.util.AlternativeUiTextProvider;
 import hudson.util.ChartUtil;
 import hudson.util.ColorPalette;
@@ -69,6 +71,7 @@ import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
 import jenkins.model.ProjectNamingStrategy;
 import jenkins.security.HexStringConfidentialKey;
+import jenkins.util.Timer;
 import jenkins.util.io.OnMaster;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
@@ -100,6 +103,8 @@ import java.io.*;
 import java.net.URLEncoder;
 import java.util.*;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
@@ -160,6 +165,8 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      */
     private transient Integer cachedBuildHealthReportsBuildNumber = null;
     private transient List<HealthReport> cachedBuildHealthReports = null;
+
+    private Logger logger = Logger.getLogger(Job.class.getName());
 
     boolean keepDependencies;
 
@@ -689,10 +696,26 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     public void delete() throws IOException, InterruptedException {
         super.delete();
         Util.deleteRecursive(getBuildDir());
+        scheduleNodeCleanup();
+    }
+
+    /**
+     * There may be a bit of work in cleaning up node workspaces.
+     * This can be scheduled to run in the background.
+     */
+    private void scheduleNodeCleanup() {
         if (this instanceof TopLevelItem) {
-            cleanupWorkspaces((TopLevelItem) this);
+            final TopLevelItem toDelete = (TopLevelItem) this;
+            ScheduledExecutorService ex = Timer.get();
+            ex.schedule(new SafeTimerTask() {
+                                @Override
+                                protected void doRun() throws Exception {
+                                    cleanupWorkspaces(toDelete);
+                                }},
+                                0, TimeUnit.SECONDS);
         }
     }
+
 
     /**
      * Clean out workspaces for attached agents (best efforts, as they may not always be online)
@@ -703,16 +726,16 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         List<Node> nodes = new ArrayList<>();
         nodes.add(j);
         nodes.addAll(j.getNodes());
-        Logger log = Logger.getLogger(Job.class.getName());
         for (Node node : nodes) {
             FilePath ws = node.getWorkspaceFor(item);
             if (ws != null) {
                 try {
                             ws.deleteRecursive();
+                            WorkspaceList.tempDir(ws).deleteRecursive();
                         } catch (IOException e) {
-                            log.log(Level.FINE, "Unable to clean out workspace for deleted job", e);
+                            logger.log(Level.FINE, "Unable to clean out workspace for deleted job", e);
                         } catch (InterruptedException e) {
-                            log.log(Level.FINE, "Unable to clean out workspace for deleted job", e);
+                            logger.log(Level.FINE, "Unable to clean out workspace for deleted job", e);
                         }
                 }
         }
@@ -1279,7 +1302,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
                 FormApply.success(".").generateResponse(req, rsp, null);
             }
         } catch (JSONException e) {
-            Logger.getLogger(Job.class.getName()).log(Level.WARNING, "failed to parse " + json, e);
+            logger.log(Level.WARNING, "failed to parse " + json, e);
             sendError(e, req, rsp);
         }
     }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -26,8 +26,14 @@ package hudson.model;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
-import hudson.*;
 
+import hudson.BulkChange;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.ExtensionPoint;
+import hudson.FilePath;
+import hudson.PermalinkList;
+import hudson.Util;
 import hudson.cli.declarative.CLIResolver;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Fingerprint.Range;

--- a/test/src/test/java/hudson/slaves/CleanupWorkspaceTest.java
+++ b/test/src/test/java/hudson/slaves/CleanupWorkspaceTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010, InfraDNA, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.slaves;
+
+import hudson.model.*;
+import hudson.model.Messages;
+import hudson.model.Queue.BuildableItem;
+import hudson.model.Queue.Task;
+import hudson.model.queue.CauseOfBlockage;
+import jenkins.model.Jenkins;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class CleanupWorkspaceTest extends HudsonTestCase {
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        // Set master executor count to zero to force all jobs to slaves
+        jenkins.setNumExecutors(0);
+    }
+
+    public void testCleanupOnDelete() throws Exception {
+        Slave slave = createSlave();
+        FreeStyleProject project = createFreeStyleProject();
+
+        Future<FreeStyleBuild> build = project.scheduleBuild2(0);
+        assertBuildStatus(Result.SUCCESS, build.get(20, TimeUnit.SECONDS));
+
+        assertTrue(slave.getWorkspaceFor(project).exists());
+        project.delete();
+
+        //after deleting workspaces should be gone:
+        assertFalse(slave.getWorkspaceFor(project).exists());
+    }
+
+}

--- a/test/src/test/java/hudson/slaves/CleanupWorkspaceTest.java
+++ b/test/src/test/java/hudson/slaves/CleanupWorkspaceTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2010, InfraDNA, Inc.
+ * Copyright (c) 2016, Michael Neale, CloudBees Inc
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,17 +25,10 @@
 package hudson.slaves;
 
 import hudson.model.*;
-import hudson.model.Messages;
-import hudson.model.Queue.BuildableItem;
-import hudson.model.Queue.Task;
-import hudson.model.queue.CauseOfBlockage;
-import jenkins.model.Jenkins;
 import org.jvnet.hudson.test.HudsonTestCase;
 
-import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class CleanupWorkspaceTest extends HudsonTestCase {
     @Override
@@ -57,6 +50,7 @@ public class CleanupWorkspaceTest extends HudsonTestCase {
         project.delete();
 
         //after deleting workspaces should be gone:
+        Thread.sleep(500);
         assertFalse(slave.getWorkspaceFor(project).exists());
     }
 


### PR DESCRIPTION
As per https://issues.jenkins-ci.org/browse/JENKINS-34781 - cleaning up workspaces is important when you use multibranch style plugins, and git flow 

(not ready to merge yet, but has a test, ready for discussion). Main downside is potentially slowing down the Job.delete() call (who isn't in a rush to delete their stuff!)

cc @jglick
