### PR TITLE
[JENKINS-19445, JENKINS-34213, JENKINS-34808, JENKINS-34121] Bump remoting to 2.59

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>2.57</version>
+        <version>2.59</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This pull-request updates remoring in 1.651.x LTS baseline

Why upgrade instead of backporting:
- All changes in 2.58 may be considered as bugs
- Functional logic in JENKINS-19445, JENKINS-34808
- 2.59 change is critical due to known issues in the JNLP3 protocol

Cons: the change has been released in jenkins-2.54 on May 15, so 2 weeks of soaking have not passed yet

Changes:

2.58:
- [JENKINS-34213](https://issues.jenkins-ci.org/browse/JENKINS-34213) - Ensure that the unexporter cleans up whatever it can each sweep (https://github.com/jenkinsci/remoting/pull/81)
- [JENKINS-19445](https://issues.jenkins-ci.org/browse/JENKINS-19445) Force class load on UserRequest in order to prevent deadlock on windows nodes when using JNA and Subversion (https://github.com/jenkinsci/remoting/pull/82)
- [JENKINS-34808](https://issues.jenkins-ci.org/browse/JENKINS-34808) - Allow user to adjust socket timeout (https://github.com/jenkinsci/remoting/pull/68)

2.59:
- [JENKINS-34819](https://issues.jenkins-ci.org/browse/JENKINS-34819) - Allow disabling the remoting protocols individually. Works around issues like [JENKINS-34121](https://issues.jenkins-ci.org/browse/JENKINS-34121) (https://github.com/jenkinsci/remoting/pull/83)

@olivergondza @aheritier @stephenc @reviewbybees
