### PR TITLE
[FIXED JENKINS-34880] do not show warnings if tool installer is in at least 1 update site

### DIFF
--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -403,7 +403,7 @@ public class DownloadService extends PageDecorator {
                     jsonString = loadJSONHTML(new URL(site + ".html?id=" + URLEncoder.encode(getId(), "UTF-8") + "&version=" + URLEncoder.encode(Jenkins.VERSION, "UTF-8")));
                     toolInstallerMetadataExists = true;
                 } catch (Exception e) {
-                    LOGGER.log(Level.WARNING, "Could not load json from " + site, e );
+                    LOGGER.log(Level.FINE, "Could not load json from " + site, e );
                     continue;
                 }
                 JSONObject o = JSONObject.fromObject(jsonString);


### PR DESCRIPTION
I think we should keep those logs but I have reduced the level to FINE. Also the download of metadata does not look like failing if a tool installer is missing in 1 update site: if there is 1 update site containing the tool installer json entries, these will be retrieved, regardless the position of the update site in the list, as long as the json file for that tool installer has the default schema (id, name, url) which is the case for the most including [gradle](http://ftp.nluug.nl/programming/jenkins/updates/updates/hudson.plugins.gradle.GradleInstaller.json). if the tool installer does not have the default schema only the installers of the first updates site in the list will be taken into account (default implementation). See https://github.com/jenkinsci/jenkins/pull/2050 and https://github.com/jenkinsci/jenkins/pull/1972
