### PR TITLE
[JENKINS-34854] - Migrate missing settings to SystemProperties

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
 import jenkins.util.JenkinsJVM;
+import jenkins.util.SystemProperties;
 import org.apache.commons.httpclient.Credentials;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
@@ -79,7 +80,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
      * Holds a default TCP connect timeout set on all connections returned from this class,
      * note this is value is in milliseconds, it's passed directly to {@link URLConnection#setConnectTimeout(int)}
      */
-    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = Integer.getInteger("hudson.ProxyConfiguration.DEFAULT_CONNECT_TIMEOUT_MILLIS", 20 * 1000);
+    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = SystemProperties.getInteger("hudson.ProxyConfiguration.DEFAULT_CONNECT_TIMEOUT_MILLIS", 20 * 1000);
     
     public final String name;
     public final int port;

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1654,7 +1654,7 @@ public class Util {
      * give up, thus improving build reliability.
      */
     @Restricted(value = NoExternalUse.class)
-    static int DELETION_MAX = Math.max(1, Integer.getInteger(Util.class.getName() + ".maxFileDeletionRetries", 3).intValue());
+    static int DELETION_MAX = Math.max(1, SystemProperties.getInteger(Util.class.getName() + ".maxFileDeletionRetries", 3).intValue());
 
     /**
      * The time (in milliseconds) that we will wait between attempts to
@@ -1666,7 +1666,7 @@ public class Util {
      * between attempts.
      */
     @Restricted(value = NoExternalUse.class)
-    static int WAIT_BETWEEN_DELETION_RETRIES = Integer.getInteger(Util.class.getName() + ".deletionRetryWait", 100).intValue();
+    static int WAIT_BETWEEN_DELETION_RETRIES = SystemProperties.getInteger(Util.class.getName() + ".deletionRetryWait", 100).intValue();
 
     /**
      * If this flag is set to true then we will request a garbage collection
@@ -1690,5 +1690,5 @@ public class Util {
      * unless you can tolerate the performance impact.
      */
     @Restricted(value = NoExternalUse.class)
-    static boolean GC_AFTER_FAILED_DELETE = Boolean.getBoolean(Util.class.getName() + ".performGCOnFailedDelete");
+    static boolean GC_AFTER_FAILED_DELETE = SystemProperties.getBoolean(Util.class.getName() + ".performGCOnFailedDelete");
 }

--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 
 /**
  * {@link AperiodicWork} that takes a long time to run. Similar to {@link AsyncPeriodicWork}, see {@link AsyncPeriodicWork} for
@@ -48,7 +49,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      *
      * @since 1.651
      */
-    private static final long LOG_ROTATE_MINUTES = Long.getLong(AsyncAperiodicWork.class.getName() +
+    private static final long LOG_ROTATE_MINUTES = SystemProperties.getLong(AsyncAperiodicWork.class.getName() +
             ".logRotateMinutes", TimeUnit.DAYS.toMinutes(1));
     /**
      * The default file size after which to try and rotate the log file used by {@link #createListener()}.
@@ -59,7 +60,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      *
      * @since 1.651
      */
-    private static final long LOG_ROTATE_SIZE = Long.getLong(AsyncAperiodicWork.class.getName() + ".logRotateSize",
+    private static final long LOG_ROTATE_SIZE = SystemProperties.getLong(AsyncAperiodicWork.class.getName() + ".logRotateSize",
             -1L);
     /**
      * The number of milliseconds (since startup or previous rotation) after which to try and rotate the log file.
@@ -91,8 +92,8 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
     protected AsyncAperiodicWork(String name) {
         this.name = name;
         this.logRotateMillis = TimeUnit.MINUTES.toMillis(
-                Long.getLong(getClass().getName()+".logRotateMinutes", LOG_ROTATE_MINUTES));
-        this.logRotateSize = Long.getLong(getClass().getName() +".logRotateSize", LOG_ROTATE_SIZE);
+                SystemProperties.getLong(getClass().getName()+".logRotateMinutes", LOG_ROTATE_MINUTES));
+        this.logRotateSize = SystemProperties.getLong(getClass().getName() +".logRotateSize", LOG_ROTATE_SIZE);
     }
 
     /**

--- a/core/src/main/java/hudson/model/AsyncPeriodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncPeriodicWork.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 
 /**
  * {@link PeriodicWork} that takes a long time to run.
@@ -29,7 +30,7 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
      *
      * @since 1.651
      */
-    private static final long LOG_ROTATE_MINUTES = Long.getLong(AsyncPeriodicWork.class.getName() + ".logRotateMinutes",
+    private static final long LOG_ROTATE_MINUTES = SystemProperties.getLong(AsyncPeriodicWork.class.getName() + ".logRotateMinutes",
             TimeUnit.DAYS.toMinutes(1));
     /**
      * The default file size after which to try and rotate the log file used by {@link #createListener()}.
@@ -40,7 +41,7 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
      *
      * @since 1.651
      */
-    private static final long LOG_ROTATE_SIZE = Long.getLong(AsyncPeriodicWork.class.getName() + ".logRotateSize", -1L);
+    private static final long LOG_ROTATE_SIZE = SystemProperties.getLong(AsyncPeriodicWork.class.getName() + ".logRotateSize", -1L);
     /**
      * The number of milliseconds (since startup or previous rotation) after which to try and rotate the log file.
      *
@@ -71,8 +72,8 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
     protected AsyncPeriodicWork(String name) {
         this.name = name;
         this.logRotateMillis = TimeUnit.MINUTES.toMillis(
-                Long.getLong(getClass().getName() + ".logRotateMinutes", LOG_ROTATE_MINUTES));
-        this.logRotateSize = Long.getLong(getClass().getName() + ".logRotateSize", LOG_ROTATE_SIZE);
+                SystemProperties.getLong(getClass().getName() + ".logRotateMinutes", LOG_ROTATE_MINUTES));
+        this.logRotateSize = SystemProperties.getLong(getClass().getName() + ".logRotateSize", LOG_ROTATE_SIZE);
     }
 
     /**

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -489,7 +489,7 @@ public class DownloadService extends PageDecorator {
 
         private static final Logger LOGGER = Logger.getLogger(Downloadable.class.getName());
         private static final long DEFAULT_INTERVAL =
-                Long.getLong(Downloadable.class.getName()+".defaultInterval", DAYS.toMillis(1));
+                SystemProperties.getLong(Downloadable.class.getName()+".defaultInterval", DAYS.toMillis(1));
     }
 
     public static boolean neverUpdate = SystemProperties.getBoolean(DownloadService.class.getName()+".never");

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -267,7 +267,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
             return parameters;
         }
 
-        if (Boolean.getBoolean(KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME)) {
+        if (SystemProperties.getBoolean(KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME)) {
             return parameters;
         }
 

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -151,7 +151,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     /**
      * Read timeout when downloading plugins, defaults to 1 minute
      */
-    private static final int PLUGIN_DOWNLOAD_READ_TIMEOUT = Integer.getInteger(UpdateCenter.class.getName()+".pluginDownloadReadTimeoutSeconds", 60) * 1000;
+    private static final int PLUGIN_DOWNLOAD_READ_TIMEOUT = SystemProperties.getInteger(UpdateCenter.class.getName()+".pluginDownloadReadTimeoutSeconds", 60) * 1000;
 
     /**
      * {@linkplain UpdateSite#getId() ID} of the default update site.

--- a/core/src/main/java/hudson/slaves/CloudSlaveRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/CloudSlaveRetentionStrategy.java
@@ -9,6 +9,7 @@ import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.util.SystemProperties;
 
 /**
  * Default convenience implementation of {@link RetentionStrategy} for agents provisioned from {@link Cloud}.
@@ -71,7 +72,7 @@ public class CloudSlaveRetentionStrategy<T extends Computer> extends RetentionSt
     }
 
     // for debugging, it's convenient to be able to reduce this time
-    public static long TIMEOUT = Long.getLong(CloudSlaveRetentionStrategy.class.getName()+".timeout", TimeUnit2.MINUTES.toMillis(10));
+    public static long TIMEOUT = SystemProperties.getLong(CloudSlaveRetentionStrategy.class.getName()+".timeout", TimeUnit2.MINUTES.toMillis(10));
 
     private static final Logger LOGGER = Logger.getLogger(CloudSlaveRetentionStrategy.class.getName());
 }

--- a/core/src/main/java/hudson/slaves/ConnectionActivityMonitor.java
+++ b/core/src/main/java/hudson/slaves/ConnectionActivityMonitor.java
@@ -90,14 +90,14 @@ public class ConnectionActivityMonitor extends AsyncPeriodicWork {
     /**
      * Time till initial ping
      */
-    private static final long TIME_TILL_PING = Long.getLong(ConnectionActivityMonitor.class.getName()+".timeToPing",TimeUnit2.MINUTES.toMillis(3));
+    private static final long TIME_TILL_PING = SystemProperties.getLong(ConnectionActivityMonitor.class.getName()+".timeToPing",TimeUnit2.MINUTES.toMillis(3));
 
-    private static final long FREQUENCY = Long.getLong(ConnectionActivityMonitor.class.getName()+".frequency",TimeUnit2.SECONDS.toMillis(10));
+    private static final long FREQUENCY = SystemProperties.getLong(ConnectionActivityMonitor.class.getName()+".frequency",TimeUnit2.SECONDS.toMillis(10));
 
     /**
      * When do we abandon the effort and cut off?
      */
-    private static final long TIMEOUT = Long.getLong(ConnectionActivityMonitor.class.getName()+".timeToPing",TimeUnit2.MINUTES.toMillis(4));
+    private static final long TIMEOUT = SystemProperties.getLong(ConnectionActivityMonitor.class.getName()+".timeToPing",TimeUnit2.MINUTES.toMillis(4));
 
 
     // disabled by default until proven in the production

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -80,6 +80,7 @@ import org.kohsuke.stapler.StaplerResponse;
 
 import static java.util.logging.Level.*;
 import jenkins.model.RunAction2;
+import jenkins.util.SystemProperties;
 
 
 /**
@@ -664,5 +665,5 @@ public class SCMTrigger extends Trigger<Item> {
     /**
      * How long is too long for a polling activity to be in the queue?
      */
-    public static long STARVATION_THRESHOLD =Long.getLong(SCMTrigger.class.getName()+".starvationThreshold", TimeUnit2.HOURS.toMillis(1));
+    public static long STARVATION_THRESHOLD = SystemProperties.getLong(SCMTrigger.class.getName()+".starvationThreshold", TimeUnit2.HOURS.toMillis(1));
 }

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -95,7 +95,7 @@ public class InstallUtil {
                 return InstallState.TEST;
             }
             
-            if (Boolean.getBoolean("hudson.Main.development")) {
+            if (SystemProperties.getBoolean("hudson.Main.development")) {
                 return InstallState.DEVELOPMENT;
             }
         }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -595,7 +595,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * TCP agent port.
      * 0 for random, -1 to disable.
      */
-    private int slaveAgentPort = Integer.getInteger(Jenkins.class.getName()+".slaveAgentPort",0);
+    private int slaveAgentPort = SystemProperties.getInteger(Jenkins.class.getName()+".slaveAgentPort",0);
 
     /**
      * Whitespace-separated labels assigned to the master as a {@link Node}.
@@ -760,7 +760,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public static Jenkins getInstance() {
         Jenkins instance = HOLDER.getInstance();
         if (instance == null) {
-            if(Boolean.getBoolean(Jenkins.class.getName()+".enableExceptionOnNullInstance")) {
+            if(SystemProperties.getBoolean(Jenkins.class.getName()+".enableExceptionOnNullInstance")) {
                 // TODO: remove that second block around 2.20 (that is: ~20 versions to battle test it)
                 // See https://github.com/jenkinsci/jenkins/pull/2297#issuecomment-216710150
                 throw new IllegalStateException("Jenkins has not been started, or was already shut down");

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol3.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol3.java
@@ -22,6 +22,7 @@ import java.io.PrintWriter;
 import java.net.Socket;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.util.SystemProperties;
 
 /**
  * Master-side implementation for JNLP3-connect protocol.
@@ -127,8 +128,9 @@ public class JnlpSlaveAgentProtocol3 extends AgentProtocol {
 
     static {
         String propName = JnlpSlaveAgentProtocol3.class.getName() + ".enabled";
-        if (System.getProperties().containsKey(propName))
-            ENABLED = Boolean.getBoolean(propName);
+        String propertyString = SystemProperties.getString(propName);
+        if (propertyString != null)
+            ENABLED = SystemProperties.getBoolean(propName);
         else {
             byte hash = Util.fromHexString(Jenkins.getActiveInstance().getLegacyInstanceId())[0];
             ENABLED = (hash%10)==0;

--- a/core/src/main/java/jenkins/util/ProgressiveRendering.java
+++ b/core/src/main/java/jenkins/util/ProgressiveRendering.java
@@ -77,7 +77,7 @@ public abstract class ProgressiveRendering {
 
     private static final Logger LOG = Logger.getLogger(ProgressiveRendering.class.getName());
     /** May be set to a number of milliseconds to sleep in {@link #canceled}, useful for watching what are normally fast computations. */
-    private static final Long DEBUG_SLEEP = Long.getLong("jenkins.util.ProgressiveRendering.DEBUG_SLEEP");
+    private static final Long DEBUG_SLEEP = SystemProperties.getLong("jenkins.util.ProgressiveRendering.DEBUG_SLEEP");
     private static final int CANCELED = -1;
     private static final int ERROR = -2;
 

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -249,6 +249,51 @@ public class SystemProperties implements ServletContextListener {
         }
         return def;
     }
+    
+    /**
+      * Determines the long value of the system property with the
+      * specified name.
+      * 
+      * This behaves just like {@link Long#getLong(java.lang.String)}, except that it
+      * also consults the {@link ServletContext}'s "init" parameters.
+      * 
+      * @param   name property name.
+      * @return  the {@code Integer} value of the property.
+      */
+    @CheckForNull
+    public static Long getLong(String name) {
+        return getLong(name, null);
+    }
+    
+    /**
+      * Determines the integer value of the system property with the
+      * specified name, or a default value.
+      * 
+      * This behaves just like <code>Long.getLong(String,Integer)</code>, except that it
+      * also consults the <code>ServletContext</code>'s "init" parameters. If neither exist,
+      * return the default value. 
+      * 
+      * @param   name property name.
+      * @param   def   a default value.
+      * @return  the {@code Integer} value of the property.
+      *          If the property is missing, return the default value.
+      *          Result may be {@code null} only if the default value is {@code null}.
+      */
+    public static Long getLong(String name, Long def) {
+        String v = getString(name);
+       
+        if (v != null) {
+            try {
+                return Long.decode(v);
+            } catch (NumberFormatException e) {
+                // Ignore, fallback to default
+                if (LOGGER.isLoggable(Level.CONFIG)) {
+                    LOGGER.log(Level.CONFIG, "Property. Value is not integer: {0} => {1}", new Object[] {name, v});
+                }
+            }
+        }
+        return def;
+    }
 
     @CheckForNull
     private static String tryGetValueFromContext(String key) {

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -258,7 +258,7 @@ public class SystemProperties implements ServletContextListener {
       * also consults the {@link ServletContext}'s "init" parameters.
       * 
       * @param   name property name.
-      * @return  the {@code Integer} value of the property.
+      * @return  the {@code Long} value of the property.
       */
     @CheckForNull
     public static Long getLong(String name) {
@@ -269,13 +269,13 @@ public class SystemProperties implements ServletContextListener {
       * Determines the integer value of the system property with the
       * specified name, or a default value.
       * 
-      * This behaves just like <code>Long.getLong(String,Integer)</code>, except that it
+      * This behaves just like <code>Long.getLong(String,Long)</code>, except that it
       * also consults the <code>ServletContext</code>'s "init" parameters. If neither exist,
       * return the default value. 
       * 
       * @param   name property name.
       * @param   def   a default value.
-      * @return  the {@code Integer} value of the property.
+      * @return  the {@code Long} value of the property.
       *          If the property is missing, return the default value.
       *          Result may be {@code null} only if the default value is {@code null}.
       */
@@ -288,7 +288,7 @@ public class SystemProperties implements ServletContextListener {
             } catch (NumberFormatException e) {
                 // Ignore, fallback to default
                 if (LOGGER.isLoggable(Level.CONFIG)) {
-                    LOGGER.log(Level.CONFIG, "Property. Value is not integer: {0} => {1}", new Object[] {name, v});
+                    LOGGER.log(Level.CONFIG, "Property. Value is not long: {0} => {1}", new Object[] {name, v});
                 }
             }
         }


### PR DESCRIPTION
Follow-up to https://github.com/jenkinsci/jenkins/pull/2337
- [x] - Fix: Integer and Boolean settings have been forgotten
- [x] - Add: Long SystemProperties API
- [x] - Migration of Long settings to SystemProperties

I have not found properties of other type after the search.

https://issues.jenkins-ci.org/browse/JENKINS-34854

@reviewbybees
