### PR TITLE
JENKINS-34708 - UpdateCenter.EnableJob not properly setting status

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1528,12 +1528,14 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                         }
                     }
                 }
-                status = new Success();
             } catch(Throwable e) {
                 LOGGER.log(Level.SEVERE, "An unexpected error occurred while attempting to enable " + plugin.getDisplayName(), e);
                 error = e;
                 requiresRestart = true;
                 status = new Failure(e);
+            }
+            if(status instanceof Pending) {
+                status = new Success();
             }
         }
     }


### PR DESCRIPTION
This corrects an issue during the installation / upgrade where plugin enable jobs are not properly setting the status, resulting in the setup wizard appearing to hang indefinitely.

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-34708

@reviewbybees
