### PR TITLE
[JENKINS-34438] Activate JSHint through js-builder

### DIFF
--- a/war/gulpfile.js
+++ b/war/gulpfile.js
@@ -1,6 +1,3 @@
-var gulp = require('gulp');
-var jshint = require('gulp-jshint');
-
 //
 // See https://github.com/tfennelly/jenkins-js-builder
 //
@@ -26,13 +23,13 @@ builder.bundle('src/main/js/pluginSetupWizard.js')
     .inDir('src/main/webapp/jsbundles');
 
 //
-//Bundle the Upgrade Wizard.
+// Bundle the Upgrade Wizard.
 //
 builder.bundle('src/main/js/upgradeWizard.js')
- .withExternalModuleMapping('jquery-detached', 'core-assets/jquery-detached:jquery2')
- .withExternalModuleMapping('bootstrap', 'core-assets/bootstrap:bootstrap3')
- .withExternalModuleMapping('handlebars', 'core-assets/handlebars:handlebars3')
- .inDir('src/main/webapp/jsbundles');
+    .withExternalModuleMapping('jquery-detached', 'core-assets/jquery-detached:jquery2')
+    .withExternalModuleMapping('bootstrap', 'core-assets/bootstrap:bootstrap3')
+    .withExternalModuleMapping('handlebars', 'core-assets/handlebars:handlebars3')
+    .inDir('src/main/webapp/jsbundles');
 
 //
 // Bundle the Config Tab Bar.
@@ -56,13 +53,3 @@ builder.bundle('src/main/js/add-item.js')
     .withExternalModuleMapping('jquery-detached', 'core-assets/jquery-detached:jquery2')
     .less('src/main/js/add-item.less')
     .inDir('src/main/webapp/jsbundles');
-
-//
-// JSHint, a JavaScript Code Quality Tool
-//
-gulp.task('lint', function() {
-    return gulp.src('src/main/js/**/*.js')
-        .pipe(jshint())
-        .pipe(jshint.reporter('default'))
-        .pipe(jshint.reporter('fail'));
-});

--- a/war/package.json
+++ b/war/package.json
@@ -16,8 +16,6 @@
     "jenkins-handlebars-rt": "^1.0.1",
     "jenkins-js-builder": "0.0.40",
     "jenkins-js-test": "^1.0.0",
-    "jshint": "^2.9.2",
-    "gulp-jshint": "^2.0.0",
     "gulp-less": "^3.1.0"
   },
   "dependencies": {

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -630,7 +630,11 @@ THE SOFTWARE.
     </profile>
     <profile>
       <id>node-download</id>
-      <activation><file><exists>package.json</exists></file></activation>
+      <activation>
+        <file>
+          <exists>package.json</exists>
+        </file>
+      </activation>
       <build>
         <plugins>
           <plugin>
@@ -736,7 +740,7 @@ THE SOFTWARE.
                   <goal>gulp</goal>
                 </goals>
                 <configuration>
-                  <arguments>lint bundle</arguments>
+                  <arguments>jshint bundle</arguments>
                 </configuration>
               </execution>
 


### PR DESCRIPTION
This is a follow-up of https://github.com/jenkinsci/jenkins/pull/2289

Downstream of https://github.com/jenkinsci/jenkins/pull/2368

With this PR we use JSHint through `js-builder` and its configuration provided by [default](https://github.com/jenkinsci/js-builder/blob/master/res/default.jshintrc.json).

@reviewbybees esp. @tfennelly 
