### PR TITLE
 [JENKINS-34751] use patched version of Groovy 2.4.6

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <staplerFork>true</staplerFork>
     <stapler.version>1.243</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
-    <groovy.version>2.4.6</groovy.version>
+    <groovy.version>2.4.6-jenkins-1</groovy.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
contains fixes for [GROOVY-7761](https://issues.apache.org/jira/browse/GROOVY-7761) and [GROOVY-7826](https://issues.apache.org/jira/browse/GROOVY-7826), see https://github.com/jenkinsci/groovy/compare/GROOVY_2_4_6...GROOVY_2_4_6-jenkins-1

dev list thread:
https://groups.google.com/forum/?fromgroups#!topic/jenkinsci-dev/KPagVUko3hg

[JENKINS-34751](https://issues.jenkins-ci.org/browse/JENKINS-34751)
