### PR TITLE
JENKINS-18349, JENKINS-15512,  Added Apache Ivy as a plugin to Jenkin…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -404,6 +404,11 @@ THE SOFTWARE.
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.ivy</groupId>
+      <artifactId>ivy</artifactId>
+      <version>2.4.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
       <version>${groovy.version}</version>


### PR DESCRIPTION
Adding Ivy as a dependency to Jenkins Core will allow @Grab annotations (part of core groovy) to work in the Jenkins Script console.

Example:

```
@Grab(group='org.codehaus.groovy.modules.http-builder', module='http-builder', version='0.7' )
def http = new groovyx.net.http.HTTPBuilder('http://www.codehaus.org')
println http
```

Before:

> java.lang.NoClassDefFoundError: org/apache/ivy/core/settings/IvySettings
>   at java.lang.Class.getDeclaredMethods0(Native Method)
>   at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
>   at java.lang.Class.privateGetPublicMethods(Class.java:2902)
>   at java.lang.Class.getMethods(Class.java:1615)
>   at java.beans.Introspector.getPublicDeclaredMethods(Introspector.java:1336)
>   at java.beans.Introspector.getTargetMethodInfo(Introspector.java:1197)

After:

> groovyx.net.http.HTTPBuilder@9cebc79
