### PR TITLE
[FIXED JENKINS-35201] - NodeJS could not be built on Win x64

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -617,7 +617,7 @@ THE SOFTWARE.
       <activation><os><family>windows</family><arch>amd64</arch></os></activation>
       <properties>
         <node.download.file>win-x64/node.exe</node.download.file>
-        <node.download.classifier>/x64</node.download.classifier>
+        <node.download.classifier>/win-x64</node.download.classifier>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Since recent changes about NodeJS I could not built Jenkins on Windows x64. With this change the build success. Take a look and if no question, merge it
