### PR TITLE
JENKINS-35206 - fix potential NPE due to corrupt Jenkins.InstallState

### DIFF
--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -93,10 +93,6 @@ public class InstallUtil {
      * Proceed to the state following the provided one
      */
     public static void proceedToNextStateFrom(InstallState prior) {
-        InstallState current = Jenkins.getInstance().getInstallState();
-        if (!current.equals(prior)) {
-            if (Main.isDevelopmentMode) LOGGER.warning("Transitioning state from: " + prior + ", but current is: " + current);
-        }
         InstallState next = getNextInstallState(prior);
         if (Main.isDevelopmentMode) LOGGER.info("Install state tranisitioning from: " + prior + " to: " + next);
         if (next != null) {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -953,6 +953,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @Nonnull
     @Restricted(NoExternalUse.class)
     public InstallState getInstallState() {
+        if (installState == null || installState.name() == null) {
+            return InstallState.UNKNOWN;
+        }
         return installState;
     }
 


### PR DESCRIPTION
Somehow `Jenkins.installState` was being corrupted; add some additional checking for this case and just return `InstallState.UNKNOWN`.

@reviewbybees esp. @oleg-nenashev 
