### PR TITLE
Pick up a new windows slave installer module

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -56,7 +56,9 @@ Upcoming changes</a>
 <!-- Record your changes in the trunk here. -->
 <div id="trunk" style="display:none"><!--=TRUNK-BEGIN=-->
 <ul class=image>
-  <li class=>
+  <li class=bug>
+    Improved .NET compatibility with modern Windows build agent installation
+    (<a href="https://github.com/jenkinsci/windows-slave-installer-module/pull/3">PR #3</a>)
 </ul>
 </div><!--=TRUNK-END=-->
 <h3><a name=v2.7>What's new in 2.7</a> (2016/05/29)</h3>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>windows-slave-installer</artifactId>
-      <version>1.5.1</version>
+      <version>1.6</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
See https://github.com/jenkinsci/windows-slave-installer-module/pull/3

And I remind folks that this is 2016 which is kind of overdue to address compatibility with Windows Server 2012!
