### PR TITLE
[JENKINS-35333] New job popup

### DIFF
--- a/core/src/main/resources/hudson/model/View/popup.jelly
+++ b/core/src/main/resources/hudson/model/View/popup.jelly
@@ -1,0 +1,40 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+  <div class="remodal new-job-popup" data-remodal-id="newjob" id="add-item-panel">
+    <form method="post" action="createItem" name="createItem" id="createItem">
+      <div class="header">
+        <div class="add-item-name">
+          <label for="name">${%ItemName.label}</label>
+          <input name="name" id="name" type="text" tabindex="0" />
+          <div class="input-help">&#187; ${%ItemName.help}</div>
+          <div id="itemname-required" class="input-validation-message input-message-disabled">&#187; ${%ItemName.validation.required}</div>
+          <div id="itemname-invalid" class="input-validation-message input-message-disabled"></div>
+          <div id="itemtype-required" class="input-validation-message input-message-disabled">&#187; ${%ItemType.validation.required}</div>
+        </div>
+      </div>
+
+      <div class="categories flat" role="radiogroup" aria-labelledby="Items" />
+
+      <j:if test="${!empty(app.itemMap)}">
+        <div class="item-copy">
+          <p class="description">${%CopyOption.description}:</p>
+          <div class="add-item-copy">
+            <input type="radio" name="mode" value="copy" />
+            <div class="icon">
+              <img src="${resURL}/images/48x48/copy.png" />
+            </div>
+            <label>${%CopyOption.label}</label>
+            <j:set var="descriptor" value="${it.descriptor}" />
+            <s:textbox id="from" name="from" placeholder="${%CopyOption.placeholder}" field="copyNewItemFrom"/>
+          </div>
+        </div>
+      </j:if>
+
+      <div class="footer">
+        <div class="btn-decorator">
+          <button type="submit" id="ok-button">OK</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</j:jelly>

--- a/core/src/main/resources/hudson/model/View/popup.jelly
+++ b/core/src/main/resources/hudson/model/View/popup.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <div class="remodal new-job-popup" data-remodal-id="newjob" id="add-item-panel">
-    <form method="post" action="createItem" name="createItem" id="createItem">
+    <form method="post" action="${rootURL}/${it.viewUrl}createItem" name="createItem" id="createItem">
       <div class="header">
         <div class="add-item-name">
           <label for="name">${%ItemName.label}</label>

--- a/core/src/main/resources/hudson/model/View/popup.jelly
+++ b/core/src/main/resources/hudson/model/View/popup.jelly
@@ -13,7 +13,7 @@
         </div>
       </div>
 
-      <div class="categories flat" role="radiogroup" aria-labelledby="Items" />
+      <div id="items" class="categories flat" role="radiogroup" aria-labelledby="Items" />
 
       <j:if test="${!empty(app.itemMap)}">
         <div class="item-copy">

--- a/core/src/main/resources/hudson/model/View/popup.properties
+++ b/core/src/main/resources/hudson/model/View/popup.properties
@@ -1,0 +1,9 @@
+JobName={0} name
+ItemName.help=Required field
+ItemName.label=Enter an item name
+ItemName.validation.required=This field cannot be empty, please enter a valid name
+ItemType.validation.required=Please select an item type
+CopyOption.placeholder=Type to autocomplete
+CopyOption.description=if you want to create a new item from other existing, you can use this option
+CopyOption.label=Copy from
+CopyExisting=Copy existing {0}

--- a/core/src/main/resources/hudson/model/View/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/View/sidepanel.jelly
@@ -33,6 +33,10 @@ THE SOFTWARE.
     <link rel="alternate" title="Jenkins:${it.viewName} (all builds) (RSS 2.0)" href="${rootURL}/${it.url}rssAll?flavor=rss20" type="application/rss+xml" />
     <link rel="alternate" title="Jenkins:${it.viewName} (failed builds)" href="${rootURL}/${it.url}rssFailed" type="application/rss+xml" />
     <link rel="alternate" title="Jenkins:${it.viewName} (failed builds) (RSS 2.0)" href="${rootURL}/${it.url}rssFailed?flavor=rss20" type="application/rss+xml" />
+
+    <l:css src="jsbundles/remodal.css" />
+    <l:js src="jsbundles/add-item.js" />
+    <l:css src="jsbundles/add-item.css" />
   </l:header>
   <l:side-panel>
     <l:tasks>
@@ -40,8 +44,10 @@ THE SOFTWARE.
 
       <st:include page="tasks-new.jelly" it="${it.owner}" optional="true">
         <!-- made overridable for ViewGroup that doesn't allow modifications -->
-        <l:task href="${rootURL}/${it.viewUrl}newJob" icon="icon-new-package icon-md" it="${app}" permission="${it.itemCreatePermission}" title="${%NewJob(it.newPronoun)}"/>
+        <l:task href="#newjob" icon="icon-new-package icon-md" it="${app}" permission="${it.itemCreatePermission}" title="${%NewJob(it.newPronoun)}"/>
       </st:include>
+
+      <st:include page="popup.jelly" optional="true" />
 
       <j:choose>
         <j:when test="${it.class.name=='hudson.model.AllView'}">

--- a/war/package.json
+++ b/war/package.json
@@ -21,6 +21,7 @@
     "gulp-less": "^3.1.0"
   },
   "dependencies": {
+    "remodal-detached": "^1.0.7-v4",
     "bootstrap-detached": "^3.3.5-v1",
     "jenkins-js-modules": "^1.5.0",
     "jquery-detached": "^2.1.4-v2",

--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -1,5 +1,6 @@
 // Initialize all modules by requiring them. Also makes sure they get bundled (see gulpfile.js).
 var $ = require('jquery-detached').getJQuery();
+var $remodal = require('remodal-detached').getRemodal();
 
 var getItems = function() {
   var d = $.Deferred();

--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -1,6 +1,6 @@
 // Initialize all modules by requiring them. Also makes sure they get bundled (see gulpfile.js).
 var $ = require('jquery-detached').getJQuery();
-var $remodal = require('remodal-detached').getRemodal();
+require('remodal-detached').getRemodal();
 
 var getItems = function() {
   var d = $.Deferred();

--- a/war/src/main/js/add-item.less
+++ b/war/src/main/js/add-item.less
@@ -10,4 +10,5 @@
  * Widget styles
  */
 @import "widgets/config/tabbar";
+@import "widgets/add/remodal";
 @import "widgets/add/addform";

--- a/war/src/main/js/widgets/add/addform.less
+++ b/war/src/main/js/widgets/add/addform.less
@@ -357,3 +357,9 @@
     }
   }
 }
+
+.new-job-popup {
+  max-width: 800px;
+  padding: 0;
+  text-align: left;
+}

--- a/war/src/main/js/widgets/add/remodal.less
+++ b/war/src/main/js/widgets/add/remodal.less
@@ -1,0 +1,408 @@
+/*
+ *  Remodal - v1.0.7
+ *  Responsive, lightweight, fast, synchronized with CSS animations, fully customizable modal window plugin with declarative configuration and hash tracking.
+ *  http://vodkabears.github.io/remodal/
+ *
+ *  Made by Ilya Makarov
+ *  Under MIT License
+ */
+
+/* ==========================================================================
+   Remodal's necessary styles
+   ========================================================================== */
+
+/* Hide scroll bar */
+
+html.remodal-is-locked {
+  overflow: hidden;
+
+  -ms-touch-action: none;
+  touch-action: none;
+}
+
+/* Anti FOUC */
+
+.remodal,
+[data-remodal-id] {
+  display: none;
+}
+
+/* Necessary styles of the overlay */
+
+.remodal-overlay {
+  position: fixed;
+  z-index: 9999;
+  top: -5000px;
+  right: -5000px;
+  bottom: -5000px;
+  left: -5000px;
+
+  display: none;
+}
+
+/* Necessary styles of the wrapper */
+
+.remodal-wrapper {
+  position: fixed;
+  z-index: 10000;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  display: none;
+  overflow: auto;
+
+  text-align: center;
+
+  -webkit-overflow-scrolling: touch;
+}
+
+.remodal-wrapper:after {
+  display: inline-block;
+
+  height: 100%;
+  margin-left: -0.05em;
+
+  content: "";
+}
+
+/* Fix iPad, iPhone glitches */
+
+.remodal-overlay,
+.remodal-wrapper {
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+}
+
+/* Necessary styles of the modal dialog */
+
+.remodal {
+  position: relative;
+
+  outline: none;
+
+  -webkit-text-size-adjust: 100%;
+  -moz-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+.remodal-is-initialized {
+  /* Disable Anti-FOUC */
+  display: inline-block;
+}
+
+
+/*
+ *  Remodal - v1.0.7
+ *  Responsive, lightweight, fast, synchronized with CSS animations, fully customizable modal window plugin with declarative configuration and hash tracking.
+ *  http://vodkabears.github.io/remodal/
+ *
+ *  Made by Ilya Makarov
+ *  Under MIT License
+ */
+
+/* ==========================================================================
+   Remodal's default mobile first theme
+   ========================================================================== */
+
+/* Default theme styles for the background */
+
+.remodal-bg.remodal-is-opening,
+.remodal-bg.remodal-is-opened {
+  -webkit-filter: blur(3px);
+  filter: blur(3px);
+}
+
+/* Default theme styles of the overlay */
+
+.remodal-overlay {
+  background: rgba(43, 46, 56, 0.9);
+}
+
+.remodal-overlay.remodal-is-opening,
+.remodal-overlay.remodal-is-closing {
+  -webkit-animation-duration: 0.3s;
+  animation-duration: 0.3s;
+  -webkit-animation-fill-mode: forwards;
+  animation-fill-mode: forwards;
+}
+
+.remodal-overlay.remodal-is-opening {
+  -webkit-animation-name: remodal-overlay-opening-keyframes;
+  animation-name: remodal-overlay-opening-keyframes;
+}
+
+.remodal-overlay.remodal-is-closing {
+  -webkit-animation-name: remodal-overlay-closing-keyframes;
+  animation-name: remodal-overlay-closing-keyframes;
+}
+
+/* Default theme styles of the wrapper */
+
+.remodal-wrapper {
+  padding: 10px 10px 0;
+}
+
+/* Default theme styles of the modal dialog */
+
+.remodal {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  margin-bottom: 10px;
+  padding: 35px;
+
+  -webkit-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
+
+  color: #2b2e38;
+  background: #fff;
+}
+
+.remodal.remodal-is-opening,
+.remodal.remodal-is-closing {
+  -webkit-animation-duration: 0.3s;
+  animation-duration: 0.3s;
+  -webkit-animation-fill-mode: forwards;
+  animation-fill-mode: forwards;
+}
+
+.remodal.remodal-is-opening {
+  -webkit-animation-name: remodal-opening-keyframes;
+  animation-name: remodal-opening-keyframes;
+}
+
+.remodal.remodal-is-closing {
+  -webkit-animation-name: remodal-closing-keyframes;
+  animation-name: remodal-closing-keyframes;
+}
+
+/* Vertical align of the modal dialog */
+
+.remodal,
+.remodal-wrapper:after {
+  vertical-align: middle;
+}
+
+/* Close button */
+
+.remodal-close {
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  display: block;
+  overflow: visible;
+
+  width: 35px;
+  height: 35px;
+  margin: 0;
+  padding: 0;
+
+  cursor: pointer;
+  -webkit-transition: color 0.2s;
+  transition: color 0.2s;
+  text-decoration: none;
+
+  color: #95979c;
+  border: 0;
+  outline: 0;
+  background: transparent;
+}
+
+.remodal-close:hover,
+.remodal-close:focus {
+  color: #2b2e38;
+}
+
+.remodal-close:before {
+  font-family: Arial, "Helvetica CY", "Nimbus Sans L", sans-serif !important;
+  font-size: 25px;
+  line-height: 35px;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  display: block;
+
+  width: 35px;
+
+  content: "\00d7";
+  text-align: center;
+}
+
+/* Dialog buttons */
+
+.remodal-confirm,
+.remodal-cancel {
+  font: inherit;
+
+  display: inline-block;
+  overflow: visible;
+
+  min-width: 110px;
+  margin: 0;
+  padding: 12px 0;
+
+  cursor: pointer;
+  -webkit-transition: background 0.2s;
+  transition: background 0.2s;
+  text-align: center;
+  vertical-align: middle;
+  text-decoration: none;
+
+  border: 0;
+  outline: 0;
+}
+
+.remodal-confirm {
+  color: #fff;
+  background: #81c784;
+}
+
+.remodal-confirm:hover,
+.remodal-confirm:focus {
+  background: #66bb6a;
+}
+
+.remodal-cancel {
+  color: #fff;
+  background: #e57373;
+}
+
+.remodal-cancel:hover,
+.remodal-cancel:focus {
+  background: #ef5350;
+}
+
+/* Remove inner padding and border in Firefox 4+ for the button tag. */
+
+.remodal-confirm::-moz-focus-inner,
+.remodal-cancel::-moz-focus-inner,
+.remodal-close::-moz-focus-inner {
+  padding: 0;
+
+  border: 0;
+}
+
+/* Keyframes
+   ========================================================================== */
+
+@-webkit-keyframes remodal-opening-keyframes {
+  from {
+    -webkit-transform: scale(1.05);
+    transform: scale(1.05);
+
+    opacity: 0;
+  }
+  to {
+    -webkit-transform: none;
+    transform: none;
+
+    opacity: 1;
+  }
+}
+
+@keyframes remodal-opening-keyframes {
+  from {
+    -webkit-transform: scale(1.05);
+    transform: scale(1.05);
+
+    opacity: 0;
+  }
+  to {
+    -webkit-transform: none;
+    transform: none;
+
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes remodal-closing-keyframes {
+  from {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+
+    opacity: 1;
+  }
+  to {
+    -webkit-transform: scale(0.95);
+    transform: scale(0.95);
+
+    opacity: 0;
+  }
+}
+
+@keyframes remodal-closing-keyframes {
+  from {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+
+    opacity: 1;
+  }
+  to {
+    -webkit-transform: scale(0.95);
+    transform: scale(0.95);
+
+    opacity: 0;
+  }
+}
+
+@-webkit-keyframes remodal-overlay-opening-keyframes {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes remodal-overlay-opening-keyframes {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes remodal-overlay-closing-keyframes {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes remodal-overlay-closing-keyframes {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+/* Media queries
+   ========================================================================== */
+
+@media only screen and (min-width: 641px) {
+  .remodal {
+    max-width: 700px;
+  }
+}
+
+/* IE8
+   ========================================================================== */
+
+.lt-ie9 .remodal-overlay {
+  background: #2b2e38;
+}
+
+.lt-ie9 .remodal {
+  width: 700px;
+}


### PR DESCRIPTION
This Pull Request implements the ability to create a new job in a popup dialog window directly from home page. 
The change uses [remodal](https://github.com/VodkaBears/Remodal) library which uses css in an added file and required js from npm module.
The interface of the popup is taken from existing newJob.jelly structure and placed into a popup.
You can see the demonstration of the change in the GIF below.

![popup](https://cloud.githubusercontent.com/assets/9495022/16226459/96210800-37bc-11e6-810d-cd12dc7175f2.gif)
