### PR TITLE
[JENKINS-32027] Jobs with very long configuration cause script errors....

### DIFF
--- a/core/src/main/resources/lib/form/textarea/textarea.js
+++ b/core/src/main/resources/lib/form/textarea/textarea.js
@@ -2,13 +2,13 @@ Behaviour.specify("TEXTAREA.codemirror", 'textarea', 0, function(e) {
         //ensure, that textarea is visible, when obtaining its height, see JENKINS-25455
         function getTextareaHeight() {
             var p = e.parentNode.parentNode; //first parent is CodeMirror div, second is actual element which needs to be visible
-            var display = p.style.display; 
+            var display = p.style.display;
             p.style.display = "";
             var h = e.clientHeight;
             p.style.display = display;
             return h;
         }
-        
+
         var h = e.clientHeight || getTextareaHeight();
         var config = e.getAttribute("codemirror-config");
         config += (config ? ", " : " ") + "onBlur: function(editor){editor.save()}";
@@ -27,16 +27,10 @@ Behaviour.specify("TEXTAREA.codemirror", 'textarea', 0, function(e) {
 
         // the form needs to be populated before the "Apply" button
         if(e.up('form')) { // Protect against undefined element
-    		Element.on(e.up('form'),"jenkins:apply", function() {
-			e.value = codemirror.getValue()
-		})
+            Element.on(e.up('form'),"jenkins:apply", function() {
+                e.value = codemirror.getValue()
+            })
         }
-		
-        //refresh CM when there are some layout updates
-        function refreshCM() {
-            codemirror.refresh();
-        }
-        layoutUpdateCallback.add(refreshCM);
     });
 
 Behaviour.specify("DIV.textarea-preview-container", 'textarea', 100, function (e) {


### PR DESCRIPTION
This PR removes some code from the commit e9aeaf11b7171aed80381e8f66c5fb7056960141 of the PR #1460 (JENKINS-25455). That code seems like end up in a crazy refresh/re-layout cycle that can result in long page reload times (or even never ends the page load), depending on the job configuration (for example a massive use of Conditional Steps). The bug was introduced in Jenkins 1.598 so it affects all higher versions.

From my point of view that code is no longer necessary due to the bug reported in JENKINS-25455 is resolved just upgrading the groovy-plugin to a recent version. I have tested it.

@reviewbybees
