### PR TITLE
[FIXED JENKINS-35402] Make it easier for update sites to tweak the InstallationJob

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -219,6 +219,20 @@ public class UpdateSite {
     }
 
     /**
+     * Extension point to allow implementations of {@link UpdateSite} to create a custom
+     * {@link UpdateCenter.InstallationJob}.
+     *
+     * @param plugin      the plugin to create the {@link UpdateCenter.InstallationJob} for.
+     * @param uc          the {@link UpdateCenter}.
+     * @param dynamicLoad {@code true} if the plugin should be attempted to be dynamically loaded.
+     * @return the {@link UpdateCenter.InstallationJob}.
+     * @since 2.9
+     */
+    protected UpdateCenter.InstallationJob createInstallationJob(Plugin plugin, UpdateCenter uc, boolean dynamicLoad) {
+        return uc.new InstallationJob(plugin, this, Jenkins.getAuthentication(), dynamicLoad);
+    }
+
+    /**
      * Verifies the signature in the update center data file.
      */
     private FormValidation verifySignature(JSONObject o) throws IOException {
@@ -872,7 +886,7 @@ public class UpdateSite {
                     return enableJob != null ? enableJob : uc.addJob(uc.new NoOpJob(UpdateSite.this, null, this));
                 }
             }
-            UpdateCenter.InstallationJob job = uc.new InstallationJob(this, UpdateSite.this, Jenkins.getAuthentication(), dynamicLoad);
+            UpdateCenter.InstallationJob job = createInstallationJob(this, uc, dynamicLoad);
             job.setCorrelationId(correlationId);
             return uc.addJob(job);
         }


### PR DESCRIPTION
See [JENKINS-35402](https://issues.jenkins-ci.org/browse/JENKINS-35402)

@jenkinsci/code-reviewers (FYI @reviewbybees)

This will allow a custom UpdateSite instance to customize the InstallationJob instance (e.g. to allow getURL() to use a custom protocol handler without requiring a global installation of the protocol handler)
