### PR TITLE
[WiP] [FIX JENKINS-35433] Add NPM package file to publish js module utils

### DIFF
--- a/war/src/main/js/util/package.json
+++ b/war/src/main/js/util/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "jenkins-js-utils",
+  "version": "0.5.0",
+  "description": "Jenkins JavaScript utilities for use with jenkins-js-modules",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github.com:jenkinsci/jenkins.git"
+  },
+  "keywords": [
+    "jenkins",
+    "js",
+    "modules",
+    "utils"
+  ],
+  "author": "Jenkins Contrubutors",
+  "license": "MIT"
+}


### PR DESCRIPTION
In order to reuse the js utils from other locations, need them published to NPM.

Addresses: https://issues.jenkins-ci.org/browse/JENKINS-35433
