### PR TITLE
[FIXED JENKINS-35641] - Always send usage statistics over HTTPs to the new usage.jenkins.io hostname

### DIFF
--- a/core/src/main/resources/hudson/model/UsageStatistics/footer.jelly
+++ b/core/src/main/resources/hudson/model/UsageStatistics/footer.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
   <j:if test="${it.due}">
     <script>
       Behaviour.addLoadEvent(function() {
-        loadScript("${app.isRootUrlSecure()?'https':'http'}://usage.jenkins-ci.org/usage-stats.js?${it.statData}");
+        loadScript("https://usage.jenkins.io/usage-stats.js?${it.statData}");
       });
     </script>
   </j:if>


### PR DESCRIPTION
References [INFRA-559](https://issues.jenkins-ci.org/browse/INFRA-559)

https://issues.jenkins-ci.org/browse/JENKINS-35641
