### PR TITLE
[FIXED JENKINS-34668] - setup wizard installing panel unusable on small screens

### DIFF
--- a/war/src/main/less/pluginSetupWizard.less
+++ b/war/src/main/less/pluginSetupWizard.less
@@ -52,7 +52,7 @@
         animation-iteration-count: infinite;
         animation-timing-function: linear;
     }
-
+    
     .no-spin() {
         -webkit-animation-name: none;
         -moz-animation-name: none;
@@ -123,7 +123,7 @@
 
           @media screen and (max-width: 992px) {
             padding:5%;
-            height:20%;
+            height: 20%;
             max-height: 20%;
         h1{
           font-size:24px;
@@ -559,7 +559,7 @@
        width: 100%;
        position: relative;
        max-height: 40%;
-       height:40%;
+       height: 40%;
        top: 0;
     }
 
@@ -614,9 +614,9 @@
         @media screen and (max-width: 992px) {
            width: 100%;
            position: relative;
-           height:40%;
-           max-height:40%;
-	       top: 0;
+           height: 40%;
+           max-height: 40%;
+           top: 0;
         }
         &.success-panel {
             bottom: 0;

--- a/war/src/main/less/pluginSetupWizard.less
+++ b/war/src/main/less/pluginSetupWizard.less
@@ -123,6 +123,8 @@
 
           @media screen and (max-width: 992px) {
             padding:5%;
+            height:20%;
+            max-height: 20%;
         h1{
           font-size:24px;
         }
@@ -555,8 +557,10 @@
     
      @media screen and (max-width: 992px) {
        width: 100%;
-       position:static;
-       max-height:33%;
+       position: relative;
+       max-height: 40%;
+       height:40%;
+       top: 0;
     }
 
         .selected {
@@ -609,8 +613,10 @@
 
         @media screen and (max-width: 992px) {
            width: 100%;
-           position:static;
-           max-height:33%;
+           position: relative;
+           height:40%;
+           max-height:40%;
+	       top: 0;
         }
         &.success-panel {
             bottom: 0;


### PR DESCRIPTION
Portions of the UI were styled incorrectly on small screens during setup wizard plugin installation.

This addresses: https://issues.jenkins-ci.org/browse/JENKINS-34668

And looks like:

![image](https://cloud.githubusercontent.com/assets/3009477/15896013/427e7a08-2d5c-11e6-95ae-aa689664d3a6.png)
