### PR TITLE
Update remoting to 2.60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>2.59</version>
+        <version>2.60</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Changes summary:

Fixed issues:
- [JENKINS-22722](https://issues.jenkins-ci.org/browse/JENKINS-22722) - 
  Make the channel reader tolerant against Socket timeouts. 
  (https://github.com/jenkinsci/remoting/pull/80)
- [JENKINS-32326](https://issues.jenkins-ci.org/browse/JENKINS-32326) - 
  Support no_proxy environment variable. 
  (https://github.com/jenkinsci/remoting/pull/84)
- [JENKINS-35190](https://issues.jenkins-ci.org/browse/JENKINS-35190)  - 
  Do not invoke PingFailureAnalyzer for agent=>master ping failures. 
  (https://github.com/jenkinsci/remoting/pull/85)
- [JENKINS-31256](https://issues.jenkins-ci.org/browse/JENKINS-31256) - 
  <code>hudson.Remoting.Engine#waitForServerToBack</code> now uses credentials for connection. 
  (https://github.com/jenkinsci/remoting/pull/87)
- [JENKINS-35494](https://issues.jenkins-ci.org/browse/JENKINS-35494) - 
  Fix FindBugs warnings in file management in <code>hudson.remoting.Launcher</code> (main executable class). 
  (https://github.com/jenkinsci/remoting/pull/88)

Enhancements:
- Ensure a message is logged if remoting fails to override the default <code>ClassFilter</code>. 
  (https://github.com/jenkinsci/remoting/pull/80)

@reviewbybees @jenkinsci/code-reviewers 
