### PR TITLE
JENKINS-35981 Allow Setup wizard to work on Tomcat 8

### DIFF
--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -484,8 +484,12 @@ public class SetupWizard extends PageDecorator {
         public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
             // Force root requests to the setup wizard
             if (request instanceof HttpServletRequest) {
-                HttpServletRequest req = (HttpServletRequest)request;
-                if((req.getContextPath() + "/").equals(req.getRequestURI())) {
+                HttpServletRequest req = (HttpServletRequest) request;
+                String requestURI = req.getRequestURI();
+                if (requestURI.equals(req.getContextPath()) && !requestURI.endsWith("/")) {
+                    ((HttpServletResponse) response).sendRedirect(req.getContextPath() + "/");
+                    return;
+                } else if (req.getRequestURI().equals(req.getContextPath() + "/")) {
                     Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
                     chain.doFilter(new HttpServletRequestWrapper(req) {
                         public String getRequestURI() {


### PR DESCRIPTION
On Tomcat 8 the setup wizard is unable to get past the initial admin password screen when opening Jenkins using http://localhost/jenkins. This is because FORCE_SETUP_WIZARD_FILTER only allows requests that are made to http://localhost/jenkins/.
This change just simply makes sure that the user always accesses jenkins/, and hence everything work well.
My attempts of trying to extend the logic so both URLs are accepted were futile, because Tomcat appears to create JSESSIONID cookies for /jenkins/ path, which then also does not seem to work when accessing /jenkins...

https://issues.jenkins-ci.org/browse/JENKINS-35981
