### PR TITLE
Change to new spelling rules in german

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractItem/help-slaveAffinity_de.html.lang,slave_rename
+++ b/core/src/main/resources/hudson/model/AbstractItem/help-slaveAffinity_de.html.lang,slave_rename
@@ -2,10 +2,10 @@
   Manchmal kann ein Projekt nur auf einem bestimmten Agent-Knoten (oder
   Master-Knoten) erfolgreich gebaut werden.
   
-  In diesem Fall sollte diese Option angewählt werden, so daß Jenkins
+  In diesem Fall sollte diese Option angewählt werden, so dass Jenkins
   das Projekt stets nur auf diesem bestimmten Knoten baut.
   
-  In allen anderen Fällen sollten Sie diese Option abwählen, so daß Jenkins
+  In allen anderen Fällen sollten Sie diese Option abwählen, so dass Jenkins
   Builds auf allen verfügbaren Knoten planen kann - was in kürzeren
   Durchlaufzeiten resultieren kann.
 

--- a/core/src/main/resources/hudson/model/Messages_de.properties
+++ b/core/src/main/resources/hudson/model/Messages_de.properties
@@ -199,13 +199,13 @@ Run.Summary.BrokenSince=Defekt seit Build {0}
 Run.Summary.Unknown=Ergebnis unbekannt
 
 Slave.Network.Mounted.File.System.Warning=\
-  Sind Sie sicher, da\u00df Sie ein Netzlaufwerk als Stammverzeichnis verwenden m\u00f6chen? \
-  Hinweis: Dieses Verzeichnis mu\u00df nicht vom Master-Knoten aus sichtbar sein.
+  Sind Sie sicher, dass Sie ein Netzlaufwerk als Stammverzeichnis verwenden m\u00f6chen? \
+  Hinweis: Dieses Verzeichnis muss nicht vom Master-Knoten aus sichtbar sein.
 Slave.Remote.Director.Mandatory=Ein Stammverzeichnis muss angegeben werden.
 
 UpdateCenter.DownloadButNotActivated=Erfolgreich heruntergeladen. Wird beim n\u00e4chsten Neustart aktiviert.
 UpdateCenter.n_a=(nicht verf\u00fcgbar)
-View.MissingMode=Ein Ansichtstyp mu\u00df angegeben werden.
+View.MissingMode=Ein Ansichtstyp muss angegeben werden.
 View.Permissions.Title=Ansichten
 View.CreatePermission.Description=\
   Dieses Recht erlaubt, neue Ansichten anzulegen.

--- a/core/src/main/resources/hudson/security/AuthorizationStrategy/Unsecured/help_de.html
+++ b/core/src/main/resources/hudson/security/AuthorizationStrategy/Unsecured/help_de.html
@@ -5,6 +5,6 @@
   Dies ist praktikabel in Situationen, in denen Sie Jenkins in einer 
   vertrauenswürdigen Umgebung (z.B. einem Firmenintranet) betreiben und Sie
   Authentifizierung nur für personalisierte Anzeigen benötigen. In diesem
-  Modus muß sich ein Anwender für kleine, schnelle Änderungen in Jenkins nicht
+  Modus muss sich ein Anwender für kleine, schnelle Änderungen in Jenkins nicht
   jedesmal explizit anmelden.
 </div>

--- a/core/src/main/resources/hudson/security/Messages_de.properties
+++ b/core/src/main/resources/hudson/security/Messages_de.properties
@@ -55,10 +55,10 @@ UserDetailsServiceProxy.UnableToQuery=Benutzerinformationen konnten nicht abgefr
 
 PAMSecurityRealm.DisplayName=Unix Benutzer-/Gruppenverzeichnis
 PAMSecurityRealm.ReadPermission=Jenkins ben\u00f6tigt Leserechte f\u00fcr /etc/shadow
-PAMSecurityRealm.BelongToGroup={0} mu\u00df zu Gruppe {1} geh\u00f6ren, um /etc/shadow lesen zu k\u00f6nnen.
+PAMSecurityRealm.BelongToGroup={0} muss zu Gruppe {1} geh\u00f6ren, um /etc/shadow lesen zu k\u00f6nnen.
 PAMSecurityRealm.RunAsUserOrBelongToGroupAndChmod=\
-  Entweder mu\u00df Jenkins als {0} ausgef\u00fchrt werden, oder {1} mu\u00df zu Gruppe {2} geh\u00f6ren und \
-  ''chmod g+r /etc/shadow'' mu\u00df ausgef\u00fchrt werden, damit Jenkins /etc/shadow lesen kann.
+  Entweder muss Jenkins als {0} ausgef\u00fchrt werden, oder {1} muss zu Gruppe {2} geh\u00f6ren und \
+  ''chmod g+r /etc/shadow'' muss ausgef\u00fchrt werden, damit Jenkins /etc/shadow lesen kann.
 PAMSecurityRealm.Success=Erfolgreich
 PAMSecurityRealm.User=Benutzer ''{0}''
 PAMSecurityRealm.CurrentUser=Aktueller Benutzer

--- a/core/src/main/resources/hudson/tools/AbstractCommandInstaller/help_de.html
+++ b/core/src/main/resources/hudson/tools/AbstractCommandInstaller/help_de.html
@@ -1,6 +1,6 @@
 <p>
     Startet ein Shell-Kommando Ihrer Wahl, um das Hilfsprogramm zu installieren.
-    Unter Ubuntu könnte das beispielsweise so aussehen (unter der Annahme, daß
+    Unter Ubuntu könnte das beispielsweise so aussehen (unter der Annahme, dass
     der Jenkins-Benutzer in <code>/etc/sudoers</code> gelistet ist):
     
 </p>

--- a/core/src/main/resources/hudson/triggers/SCMTrigger/help_de.html
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/help_de.html
@@ -5,7 +5,7 @@
   <p>
   Bedenken Sie, dass dies für das Versionsverwaltungssystem CVS eine äußerst
   ressourcenintensive Operation darstellt, da Jenkins bei jeder Abfrage den 
-  kompletten Arbeitsbereich überprüfen und mit dem CVS-Server abgleichen muß.
+  kompletten Arbeitsbereich überprüfen und mit dem CVS-Server abgleichen muss.
   Ziehen Sie daher alternativ einen "Push"-Auslöser in Betracht, wie er in 
   <a href="https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project">diesem Dokument</a> beschrieben
   wird.

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv_de.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv_de.properties
@@ -8,7 +8,7 @@ BUILD_TAG.blurb=Eine Zeichenkette in der Form "jenkins-<i>$'{'JOB_NAME}</i>-<i>$
 EXECUTOR_NUMBER.blurb=Die laufende Nummer des Build-Prozessors, der den aktuellen Build ausf\u00FChrt \
                               (aus den Build-Prozessoren desselben Rechners). \
                               Dies ist die Nummer, die Sie auch im Build-Prozessor Status sehen - \
-                              mit der Ausnahme, da\u00DF bei der Umgebungsvariable die Z\u00E4hlung bei 0 und nicht \
+                              mit der Ausnahme, dass bei der Umgebungsvariable die Z\u00E4hlung bei 0 und nicht \
                               bei 1 beginnt.
 NODE_LABELS.blurb=Durch Leerzeichen getrennte Liste von Labels, die dem Knoten zugeordnet sind.
 WORKSPACE.blurb=Der absolute Pfad zum Arbeitsbereich.

--- a/core/src/main/resources/jenkins/model/GlobalQuietPeriodConfiguration/help-quietPeriod_de.html
+++ b/core/src/main/resources/jenkins/model/GlobalQuietPeriodConfiguration/help-quietPeriod_de.html
@@ -11,7 +11,7 @@
     <li>
       Ihr Programmierstil es erfordert, eine logische Änderung in mehreren
       CVS/SVN-Operationen durchzuführen. Eine verlängerte Ruheperiode verhindert
-      in diesem Falle, daß Jenkins einen Build verfrüht startet und einen Fehlschlag
+      in diesem Falle, dass Jenkins einen Build verfrüht startet und einen Fehlschlag
       meldet. 
     </li>
     <li>

--- a/core/src/main/resources/jenkins/triggers/ReverseBuildTrigger/help_de.html
+++ b/core/src/main/resources/jenkins/triggers/ReverseBuildTrigger/help_de.html
@@ -1,6 +1,6 @@
 <div>
   <p>
-    Richtet einen Build-Auslöser ein, so daß immer dann, wenn ein anderes
+    Richtet einen Build-Auslöser ein, so dass immer dann, wenn ein anderes
     Projekt erfolgreich gebaut wurde, ein neuer Build dieses Projekts
     geplant wird. Dies ist beispielsweise sehr praktisch, um ausführliche
     Tests an einen erfolgreichen Build anzuschließen.

--- a/war/src/main/webapp/help/project-config/custom-workspace_de.html
+++ b/war/src/main/webapp/help/project-config/custom-workspace_de.html
@@ -7,14 +7,14 @@
 
   <p>
   In einer solchen Situation verwenden Sie beispielsweise "festverdrahtete" Dateipfade und 
-  der Code muß daher an einer bestimmten Stelle im Dateisystem gebaut werden.
+  der Code muss daher an einer bestimmten Stelle im Dateisystem gebaut werden.
   Zweifellos ist dies kein Idealfall eines Builds, aber diese Option erlaubt es Ihnen,
   auch in einer solchen Situation weiterzukommmen. 
   <p>
   In einer anderen Situation verwenden Sie ein Projekt nicht um einen
   Software-Build auszuführen, sondern um eine Batch-Aufgabe auszuführen, z.B. als Cron-Ersatz.
   In diesem Fall können Sie diese Option verwenden, um ein relevantes Verzeichnis als 
-  Arbeitsverzeichnis einzustellen, so daß Anwender Dateien in diesem Verzeichnis über
+  Arbeitsverzeichnis einzustellen, so dass Anwender Dateien in diesem Verzeichnis über
   die Weboberfläche von Jenkins abrufen können und relevante Kommandos einfacher 
   gestartet werden können.
 
@@ -24,7 +24,7 @@
   Knoten zur Ausführung vorsehen. Manchmal ist dies wünschenswert,
   manchmal nicht. Darüberhinaus können Sie auch mehrere Projekte
   auf das gleiche Arbeitsverzeichnis verweisen. In diesem Fall müssen Sie
-  dafür sorgen, daß die gleichzeitige Ausführung dieser Jobs keine unerwünschten
+  dafür sorgen, dass die gleichzeitige Ausführung dieser Jobs keine unerwünschten
   gegenseitigen Beeinträchtigungen herbeiführt.
   
   <p>

--- a/war/src/main/webapp/help/project-config/description_de.html
+++ b/war/src/main/webapp/help/project-config/description_de.html
@@ -1,5 +1,5 @@
 <div>
-  Diese Beschreibung wird zu Beginn der Projektseite angezeigt, so daß
+  Diese Beschreibung wird zu Beginn der Projektseite angezeigt, so dass
   Anwender nachlesen können, um was es in diesem Job geht.
   Sie können hier auch alle HTML-Tags verwenden.
 </div>

--- a/war/src/main/webapp/help/scm-browsers/list_de.html
+++ b/war/src/main/webapp/help/scm-browsers/list_de.html
@@ -3,7 +3,7 @@
   Repository-Browser.
   
   In der Einstellung "Auto" versucht Jenkins, den Repository-Browser aus anderen
-  Jobs abzuleiten. Dazu muß das SCM des vorliegenden Jobs von einem Repository-Browser
+  Jobs abzuleiten. Dazu muss das SCM des vorliegenden Jobs von einem Repository-Browser
   unterstützt werden und ein anderer Job existieren, dessen Verbindung zu einem
   solchen Repository-Browser bereits vollständig konfiguriert wurde. 
 </div>

--- a/war/src/main/webapp/help/system-config/master-slave/demand/idleDelay_de.html
+++ b/war/src/main/webapp/help/system-config/master-slave/demand/idleDelay_de.html
@@ -1,4 +1,4 @@
 <div>
-    Anzahl der Minuten, die dieser Slave inaktiv gewesen sein muß, bevor er
+    Anzahl der Minuten, die dieser Slave inaktiv gewesen sein muss, bevor er
     offline geschaltet wird.
 </div>

--- a/war/src/main/webapp/help/system-config/master-slave/demand/inDemandDelay_de.html
+++ b/war/src/main/webapp/help/system-config/master-slave/demand/inDemandDelay_de.html
@@ -1,4 +1,4 @@
 <div>
-    Anzahl der Minuten, die ein geplanter Job mindestens gewartet haben muß,
+    Anzahl der Minuten, die ein geplanter Job mindestens gewartet haben muss,
     bevor versucht wird, diesen Slave-Knoten zu starten.
 </div>

--- a/war/src/main/webapp/help/tasks/fingerprint/keepDependencies_de.html
+++ b/war/src/main/webapp/help/tasks/fingerprint/keepDependencies_de.html
@@ -6,8 +6,8 @@
   <p>
   Wenn Ihr Job von einem anderen Job innerhalb Jenkins' abhängt und Sie 
   gelegentlich Ihren Arbeitsbereich markieren ("taggen"), ist es meist sehr
-  praktisch oder sogar notwendig, daß Sie auch Ihre Abhängigkeiten innerhalb
-  von Jenkins markieren. Das Problem dabei ist aber, daß durch die Log-Rotation eventuell
+  praktisch oder sogar notwendig, dass Sie auch Ihre Abhängigkeiten innerhalb
+  von Jenkins markieren. Das Problem dabei ist aber, dass durch die Log-Rotation eventuell
   ein Build, von dem Ihr Projekt abhängt, bereits verworfen wurde (etwa wenn
   in Ihren Abhängigkeiten in letzter Zeit sehr viele neue Builds stattfanden).
   Wenn dies geschieht, sind Sie nicht mehr in der Lage, zuverlässig Ihre
@@ -15,6 +15,6 @@
 
   <p>
   Diese Funktion löst das Problem durch "Sperrung" der Builds, von denen Ihr
-  Projekt abhängt. Dadurch wird garantiert, daß Sie immer Ihre kompletten
+  Projekt abhängt. Dadurch wird garantiert, dass Sie immer Ihre kompletten
   Abhängigkeiten markieren können.
 </div>


### PR DESCRIPTION
Changed every occurence of 'muß' to 'muss' and 'daß' to 'dass' because it's no longer
correct.
