### PR TITLE
[JENKINS-36052] Add support for jenkins compilation on 32 bit linux

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -597,6 +597,14 @@ THE SOFTWARE.
       </properties>
     </profile>
     <profile>
+      <id>node-classifier-linux-32</id>
+      <activation><os><family>Linux</family><arch>i386</arch></os></activation>
+      <properties>
+        <node.download.file>node-v${node.version}-linux-x86.tar.gz</node.download.file>
+        <node.download.classifier />
+      </properties>
+    </profile>
+    <profile>
       <id>node-classifier-mac</id>
       <activation><os><family>mac</family></os></activation>
       <properties>


### PR DESCRIPTION
Jenkins needs to download nodejs to compile. The version is selected according to the architecture and the OS of the machine.

There is currently no entry for Linux 32 bits, and so the build fails. 

```
[WARNING] Could not get content
java.lang.IllegalArgumentException: Illegal character in path at index 32: https://nodejs.org/dist/v4.0.0/${node.download.file}
...
[ERROR] Failed to execute goal com.googlecode.maven-download-plugin:download-maven-plugin:1.2.1:wget (get-node) on project jenkins-war: IO Error: Could not get content -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.googlecode.maven-download-plugin:download-maven-plugin:1.2.1:wget (get-node) on project jenkins-war: IO Error
```

You can access the full log here: http://dufour.tk/~quentin/logs/mvnlogs4.log

I've already submitted [a PR for the plugin-pom repository](https://github.com/jenkinsci/plugin-pom/pull/28) which had the same problem. 

I've also opened [an issue on JIRA](https://issues.jenkins-ci.org/browse/JENKINS-36052), addressing the problem of architectures and OS officially supported by jenkins.

There is also 2 more files which could be updated : 
- https://github.com/jenkinsci/js-builder/blob/master/res/sample_extract_pom.xml
- https://github.com/jenkinsci/js-libs/blob/master/js-module-base/pom.xml
