### PR TITLE
Update BUILD_TAG description to mention the replacement of slashes with dashes

### DIFF
--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
@@ -3,7 +3,7 @@ BUILD_ID.blurb=The current build ID, identical to BUILD_NUMBER for builds create
 BUILD_DISPLAY_NAME.blurb=The display name of the current build, which is something like "#153" by default.
 JOB_NAME.blurb=Name of the project of this build, such as "foo" or "foo/bar".
 JOB_BASE_NAME.blurb=Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".
-BUILD_TAG.blurb=String of "jenkins-<i>$'{'JOB_NAME}</i>-<i>$'{'BUILD_NUMBER}</i>". Convenient to put into a resource file, a jar file, etc for easier identification.
+BUILD_TAG.blurb=String of "jenkins-<i>$'{'JOB_NAME}</i>-<i>$'{'BUILD_NUMBER}</i>". All forward slashes ('/') in the JOB_NAME are replaced with dashes ('-'). Convenient to put into a resource file, a jar file, etc for easier identification.
 EXECUTOR_NUMBER.blurb=\
   The unique number that identifies the current executor \
   (among executors of the same machine) that\u2019s \


### PR DESCRIPTION
Divergence introduced with 117d69b8164872ba22f5ceb46b60f2cae23e29db.

This is relevant in many scenarios as these tags are primed to be used in character strings with varying levels of character restrictions. For example, forward slashes are disallowed in Docker image tags, so it is very interesting for a user to know that they can still rely on `BUILD_TAG` to construct them.

Note: Translations are not updated.
