### PR TITLE
[JENKINS-20187] - Handle growing files when creating a tar file.

### DIFF
--- a/core/src/main/java/hudson/util/io/TarArchiver.java
+++ b/core/src/main/java/hudson/util/io/TarArchiver.java
@@ -33,8 +33,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -101,14 +99,15 @@ final class TarArchiver extends Archiver {
         try {
             if (!file.isDirectory()) {
                 // ensure we don't write more bytes than the declared when we created the entry
-                try (BoundedInputStream in = new BoundedInputStream(new FileInputStream(file), size)) {
+                
+                try (FileInputStream fin = new FileInputStream(file);
+                     BoundedInputStream in = new BoundedInputStream(fin, size)) {
                     int len;
                     while ((len = in.read(buf)) >= 0) {
                         tar.write(buf, 0, len);
                     }
                 } catch (IOException e) {// log the exception in any case
                     IOException ioE = new IOException("Error writing to tar file from: " + file, e);
-                    ioE.addSuppressed(e);
                     throw ioE;
                 }
             }

--- a/core/src/main/java/hudson/util/io/TarArchiver.java
+++ b/core/src/main/java/hudson/util/io/TarArchiver.java
@@ -33,10 +33,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarConstants;
 
-import static org.apache.tools.tar.TarConstants.LF_SYMLINK;
 
 /**
  * {@link FileVisitor} that creates a tar archive.
@@ -55,7 +58,7 @@ final class TarArchiver extends Archiver {
 
     @Override
     public void visitSymlink(File link, String target, String relativePath) throws IOException {
-        TarArchiveEntry e = new TarArchiveEntry(relativePath, LF_SYMLINK);
+        TarArchiveEntry e = new TarArchiveEntry(relativePath, TarConstants.LF_SYMLINK);
         try {
             int mode = IOUtils.mode(link);
             if (mode != -1) {
@@ -87,27 +90,46 @@ final class TarArchiver extends Archiver {
         int mode = IOUtils.mode(file);
         if (mode!=-1)   te.setMode(mode);
         te.setModTime(file.lastModified());
-        if(!file.isDirectory())
-            te.setSize(file.length());
-
-        tar.putArchiveEntry(te);
+        long size = 0;
 
         if (!file.isDirectory()) {
-            FileInputStream in = new FileInputStream(file);
-            try {
-                int len;
-                while((len=in.read(buf))>=0)
-                    tar.write(buf,0,len);
-            } finally {
-                in.close();
+            size = file.length();
+            te.setSize(size);
+        }
+        tar.putArchiveEntry(te);
+        try {
+            if (!file.isDirectory()) {
+                FileInputStream in = new FileInputStream(file);
+                try {
+                    int len;
+                    int read = 0;
+                    while ((len = in.read(buf)) >= 0) {
+                        if (len + read <= size) { // ensure we don't write more bytes than the declared when we created
+                                                  // the entry
+                            tar.write(buf, 0, len);
+                            read += len;
+                        } else {
+                            tar.write(buf, 0, (int) size - read);
+                            break;
+                        }
+                    }
+                } catch (IOException e) {// log the exception in any case
+                    LOGGER.log(Level.SEVERE, "Error writing to tar file from: " + file, e);
+                    throw e;
+                } finally {
+                    in.close();
+                }
             }
+        } finally { // always close the entry
+            tar.closeArchiveEntry();
         }
 
-        tar.closeArchiveEntry();
         entriesWritten++;
     }
 
     public void close() throws IOException {
         tar.close();
     }
+
+    private static final Logger LOGGER = Logger.getLogger(TarArchiver.class.getName());
 }


### PR DESCRIPTION
[JENKINS-20187](https://issues.jenkins-ci.org/browse/JENKINS-20187)

If the file grows while being included on the tar file (typical case of a log file), it will only be included the original size when the operation was started and included on the header of the tar entry.

Removed dependency from `org.apache.tools.tar.TarConstants` in favor of `org.apache.commons.compress.archivers.tar.TarConstants`

@reviewbybees esp @jglick @jtnord @amuniz
