### PR TITLE
[JENKINS-21486] Fixing optional PluginWrapper.Dependency version resolution

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -209,10 +209,10 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
             if(idx==-1)
                 throw new IllegalArgumentException("Illegal dependency specifier "+s);
             this.shortName = s.substring(0,idx);
-            this.version = s.substring(idx+1);
-            
+            String version = s.substring(idx+1);
+
             boolean isOptional = false;
-            String[] osgiProperties = s.split(";");
+            String[] osgiProperties = version.split("[;]");
             for (int i = 1; i < osgiProperties.length; i++) {
                 String osgiProperty = osgiProperties[i].trim();
                 if (osgiProperty.equalsIgnoreCase("resolution:=optional")) {
@@ -220,6 +220,11 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
                 }
             }
             this.optional = isOptional;
+            if (isOptional) {
+                this.version = osgiProperties[0];
+            } else {
+                this.version = version;
+            }
         }
 
         @Override

--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -1,0 +1,26 @@
+package hudson;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PluginWrapperTest {
+
+    @Test
+    public void dependencyTest() {
+        String version = "plugin:0.0.2";
+        PluginWrapper.Dependency dependency = new PluginWrapper.Dependency(version);
+        assertEquals("plugin", dependency.shortName);
+        assertEquals("0.0.2", dependency.version);
+        assertEquals(false, dependency.optional);
+    }
+
+    @Test
+    public void optionalDependencyTest() {
+        String version = "plugin:0.0.2;resolution:=optional";
+        PluginWrapper.Dependency dependency = new PluginWrapper.Dependency(version);
+        assertEquals("plugin", dependency.shortName);
+        assertEquals("0.0.2", dependency.version);
+        assertEquals(true, dependency.optional);
+    }
+}


### PR DESCRIPTION
Without it version of optional dependency is set to "X.Y;resolution:=optional" which causes problems when using hudson.util.VersionNumber comparison methods.

Fix created by @Vlatombe: https://github.com/jenkinsci/jenkins/commit/d57db1b1f2e30917c337eabdc0c204a832fb8d0a (https://github.com/jenkinsci/jenkins/pull/2172)

Reverted by #2236.

@reviewbybees esp. @Vlatombe @daniel-beck 
