### PR TITLE
[FIXED JENKINS-36043] - Fixed NPE when no "scm" JSON object is null

### DIFF
--- a/core/src/main/java/hudson/scm/SCMS.java
+++ b/core/src/main/java/hudson/scm/SCMS.java
@@ -57,6 +57,7 @@ public class SCMS {
     @SuppressWarnings("deprecation")
     public static SCM parseSCM(StaplerRequest req, AbstractProject target) throws FormException, ServletException {
         SCM scm = req.bindJSON(SCM.class, req.getSubmittedForm().getJSONObject("scm"));
+        if(scm==null)   return new NullSCM();
         scm.getDescriptor().generation++;
         return scm;
     }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-36043
