### PR TITLE
[FIXED JENKINS-36232] NPE during SCM polling

### DIFF
--- a/core/src/main/java/jenkins/triggers/SCMTriggerItem.java
+++ b/core/src/main/java/jenkins/triggers/SCMTriggerItem.java
@@ -121,7 +121,7 @@ public interface SCMTriggerItem {
             }
             @Override public PollingResult poll(TaskListener listener) {
                 SCMDecisionHandler veto = SCMDecisionHandler.firstShouldPollVeto(asItem());
-                if (!veto.shouldPoll(asItem())) {
+                if (veto != null && !veto.shouldPoll(asItem())) {
                     listener.getLogger().println(Messages.SCMTriggerItem_PollingVetoed(veto));
                     return PollingResult.NO_CHANGES;
                 }

--- a/core/src/test/java/jenkins/triggers/SCMTriggerItemTest.java
+++ b/core/src/test/java/jenkins/triggers/SCMTriggerItemTest.java
@@ -1,0 +1,38 @@
+package jenkins.triggers;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import hudson.model.Item;
+import hudson.model.SCMedItem;
+import hudson.model.TaskListener;
+import jenkins.scm.SCMDecisionHandler;
+
+@SuppressWarnings("deprecation")
+@RunWith(PowerMockRunner.class)
+public class SCMTriggerItemTest {
+
+    @Test
+    @PrepareForTest(SCMDecisionHandler.class)
+    public void noVetoDelegatesPollingToAnSCMedItem() {
+        // given
+        PowerMockito.mockStatic(SCMDecisionHandler.class);
+        PowerMockito.when(SCMDecisionHandler.firstShouldPollVeto(any(Item.class))).thenReturn(null);
+        SCMedItem scMedItem = Mockito.mock(SCMedItem.class);
+        TaskListener listener = Mockito.mock(TaskListener.class);
+
+        // when
+        SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(scMedItem).poll(listener);
+
+        // then
+        verify(scMedItem).poll(listener);
+    }
+
+}

--- a/core/src/test/java/jenkins/triggers/SCMTriggerItemTest.java
+++ b/core/src/test/java/jenkins/triggers/SCMTriggerItemTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.Issue;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -20,6 +21,7 @@ import jenkins.scm.SCMDecisionHandler;
 public class SCMTriggerItemTest {
 
     @Test
+    @Issue("JENKINS-36232")
     @PrepareForTest(SCMDecisionHandler.class)
     public void noVetoDelegatesPollingToAnSCMedItem() {
         // given


### PR DESCRIPTION
see [JENKINS-36232](https://issues.jenkins-ci.org/browse/JENKINS-36232) - a NullPointerException introduced in commit 5a2a265fde4bc41210bb40da9cc9522a3bd43f88 / PR #2418 causes the polling e.g. from a git hook to fail.

Added a null check like it is done in the other places SCMDecisionHandler.shouldPoll() is used.
