### PR TITLE
Tests did not match naming pattern so were never being executed

### DIFF
--- a/test/src/test/java/hudson/model/Slave2Test.java
+++ b/test/src/test/java/hudson/model/Slave2Test.java
@@ -39,7 +39,7 @@ import org.jvnet.hudson.test.Issue;
  * has an index.
  * @author Oleg Nenashev
  */
-public class SlaveTest2 {
+public class Slave2Test {
     
     @Rule
     public JenkinsRule rule = new JenkinsRule();


### PR DESCRIPTION
Just a straightforward rename to a name that matches the inclusion rules

@jenkinsci/code-reviewers @reviewbybees @oleg-nenashev 
