### PR TITLE
[JENKINS-25416][JENKINS-28790] - Fix the parametersReferencedFromPropertiesShouldRetainBackslashes() test

### DIFF
--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -222,7 +222,9 @@ public class MavenTest {
         final Entry envVar = new Entry("GLOBAL_PATH", "D:\\Jenkins");
 
         FreeStyleProject project = j.createFreeStyleProject();
-        project.getBuildersList().add(new Maven("--help",null,null,properties,null));
+        // This test implements legacy behavior, when Build Variables are injected by default
+        project.getBuildersList().add(new Maven("--help", null, null, properties, null,
+                false, null, null, true));
         project.addProperty(new ParametersDefinitionProperty(parameter));
         j.jenkins.getNodeProperties().replaceBy(Collections.singleton(
                 new EnvironmentVariablesNodeProperty(envVar)


### PR DESCRIPTION
The test fails after https://github.com/jenkinsci/jenkins/pull/1976/commits/84ee34f2df620f1280022f1678b81e5c27dfc330 , so the PR builder is broken now. Needs a fix ASAP

@olivergondza @jenkinsci/code-reviewers 
@reviewbybees
