### PR TITLE
[JENKINS-36441] - Provide a bundling mechanism for plugins being unbundled from the core

### DIFF
--- a/core/src/main/java/hudson/LocalPluginManager.java
+++ b/core/src/main/java/hudson/LocalPluginManager.java
@@ -33,6 +33,8 @@ import javax.servlet.ServletContext;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -42,9 +44,12 @@ import java.util.logging.Logger;
  */
 public class LocalPluginManager extends PluginManager {
     
+    private final static Set<String> REQUIRED_PLUGINS_ARTIFACT_IDS;
     private final static Set<String> ENFORCED_VERSION_PLUGIN_ARTIFACT_IDS;
     
     static {
+        REQUIRED_PLUGINS_ARTIFACT_IDS = new HashSet<>(SystemProperties.getStringList(
+                LocalPluginManager.class.getName() + ".requiredPluginArtifactIDs"));
         ENFORCED_VERSION_PLUGIN_ARTIFACT_IDS = new HashSet<>(SystemProperties.getStringList(
                 LocalPluginManager.class.getName() + ".enforcedVersionPluginArtifactIDs"));
     }
@@ -99,5 +104,10 @@ public class LocalPluginManager extends PluginManager {
         return ENFORCED_VERSION_PLUGIN_ARTIFACT_IDS;
     }
 
+    @Override
+    public Set<String> getRequiredPluginArtifactIDs() {
+        return REQUIRED_PLUGINS_ARTIFACT_IDS;
+    }
+    
     private static final Logger LOGGER = Logger.getLogger(LocalPluginManager.class.getName());
 }

--- a/core/src/main/java/hudson/LocalPluginManager.java
+++ b/core/src/main/java/hudson/LocalPluginManager.java
@@ -41,6 +41,14 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 public class LocalPluginManager extends PluginManager {
+    
+    private final static Set<String> ENFORCED_VERSION_PLUGIN_ARTIFACT_IDS;
+    
+    static {
+        ENFORCED_VERSION_PLUGIN_ARTIFACT_IDS = new HashSet<>(SystemProperties.getStringList(
+                LocalPluginManager.class.getName() + ".enforcedVersionPluginArtifactIDs"));
+    }
+    
     /**
      * Creates a new LocalPluginManager
      * @param context Servlet context. Provided for compatibility as {@code Jenkins.getInstance().servletContext} should be used.
@@ -84,6 +92,11 @@ public class LocalPluginManager extends PluginManager {
         } finally {
             loadDetachedPlugins();
         }
+    }
+
+    @Override
+    public Set<String> getEnforcedVersionPluginArtifactIDs() {
+        return ENFORCED_VERSION_PLUGIN_ARTIFACT_IDS;
     }
 
     private static final Logger LOGGER = Logger.getLogger(LocalPluginManager.class.getName());

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -905,20 +905,20 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         // normalization first, if the old file exists.
         rename(new File(rootDir,legacyName),file);
         
-        String pluginName = fileName.replace(".jpi", "");
+        String pluginArtifactId = fileName.replace(".jpi", "");
         
         // Copy if there is no file in the destination
         boolean shouldBeCopied = false;
         if (!file.exists()) {
             shouldBeCopied = true;
         } else {
-            boolean isVersionEnforced = getEnforcedVersionPluginArtifactIDs().contains(pluginName);
+            boolean isVersionEnforced = getEnforcedVersionPluginArtifactIDs().contains(pluginArtifactId);
             if (isVersionEnforced && file.lastModified() != lastModified) {
-                LOGGER.log(Level.INFO, "Version of bundled plugin {0} is enforced. The current version will be overriden", pluginName);
+                LOGGER.log(Level.INFO, "Version of bundled plugin {0} is enforced. The current version will be overriden", pluginArtifactId);
                 shouldBeCopied = true;
             }
             if (!isVersionEnforced && file.lastModified() < lastModified) {
-                LOGGER.log(Level.INFO, "PluginManager file defines a newer version of the plugin {0}. It will be upgraded", pluginName);
+                LOGGER.log(Level.INFO, "PluginManager file defines a newer version of the plugin {0}. It will be upgraded", pluginArtifactId);
                 shouldBeCopied = true;
             }
         }
@@ -928,7 +928,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             FileUtils.copyURLToFile(src, file);
             file.setLastModified(src.openConnection().getLastModified());
         } else {
-            LOGGER.log(Level.INFO, "Plugin {0} has been already installed && does not need an upgrade/downgrade. Skipping it", pluginName);
+            LOGGER.log(Level.INFO, "Plugin {0} has been already installed && does not need an upgrade/downgrade. Skipping it", pluginArtifactId);
         }
 
         // Plugin pinning has been deprecated.
@@ -984,17 +984,17 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             LOGGER.log(Level.WARNING, "Got empty plugin file name from the plugin path: {0}. Cannot install", url);
             return null;
         }
-        String pluginName = fileName.replace(".hpi", "").replace(".jpi", "");
+        String pluginArtifactId = fileName.replace(".hpi", "").replace(".jpi", "");
         
         // Check if it should be copied
         if (copiedPlugins.contains(url)) {
             // Ignore. Already copied.
             LOGGER.log(Level.INFO, "Skipping installation of {0} plugin {1}, because it has been already installed",
-                    new Object[] {pluginType, pluginName});
+                    new Object[] {pluginType, pluginArtifactId});
             return null;
         }
         final Set<String> requiredPluginArtifactIDs = getRequiredPluginArtifactIDs();
-        if (!requiredPluginArtifactIDs.contains(pluginName) && !shouldBeInstalled) {
+        if (!requiredPluginArtifactIDs.contains(pluginArtifactId) && !shouldBeInstalled) {
             // Is not a plugin, which is required for the installation. 
             // Let Plugin manager to make a decision regarding it.
             final CopyResult notRequiredInstallResult = handleNotRequiredBundledPlugin(url, fileName, pluginType);
@@ -1006,7 +1006,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         
         // Finally install the bundled plugin
         LOGGER.log(Level.INFO, "Installing the bundled {1} plugin {0} to Jenkins", 
-                new Object[] {pluginName, pluginType});
+                new Object[] {pluginArtifactId, pluginType});
         
         try {
             names.add(fileName);
@@ -1024,7 +1024,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      * Extensions can alter the behavior for such plugins.
      * @param url URL of the plugin file to be handled.
      * @param fileName Plugin file name
-     * @param pluginType plugin type String
+     * @param pluginType Plugin type String
      * @return Result of the custom plugin handling.
      *         {@code null} If the plugin should be installed
      * @since TODO
@@ -1033,9 +1033,9 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     protected CopyResult handleNotRequiredBundledPlugin(@Nonnull URL url, @Nonnull String fileName, 
             @Nonnull String pluginType) {
         // Default behavior - skip the plugin installation
-        String pluginName = fileName.replace(".hpi", "").replace(".jpi", "");
+        String pluginArtifactId = fileName.replace(".hpi", "").replace(".jpi", "");
         LOGGER.log(Level.INFO, "Skipping installation of the {0} bundled {1} plugin, because it is not a required plugin", 
-                new Object[] {pluginType, pluginName});
+                new Object[] {pluginType, pluginArtifactId});
         return new CopyResult(url, fileName, false);
     }
     

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -993,7 +993,8 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     new Object[] {pluginType, pluginName});
             return null;
         }
-        if (!shouldBeInstalled) {
+        final Set<String> requiredPluginArtifactIDs = getRequiredPluginArtifactIDs();
+        if (!requiredPluginArtifactIDs.contains(pluginName) && !shouldBeInstalled) {
             // Is not a plugin, which is required for the installation. 
             // Let Plugin manager to make a decision regarding it.
             final CopyResult notRequiredInstallResult = handleNotRequiredBundledPlugin(url, fileName, pluginType);
@@ -1036,6 +1037,16 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         LOGGER.log(Level.INFO, "Skipping installation of the {0} bundled {1} plugin, because it is not a required plugin", 
                 new Object[] {pluginType, pluginName});
         return new CopyResult(url, fileName, false);
+    }
+    
+    /**
+     * Gets set of plugins, which must be installed during the Jenkins instance startup.
+     * @return Set of plugin artifact IDs, 
+     * @since TODO
+     */
+    @Nonnull
+    public Set<String> getRequiredPluginArtifactIDs() {
+        return Collections.emptySet();
     }
     
     /**

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -24,8 +24,12 @@
 package jenkins.util;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.EnvVars;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletContext;
@@ -293,6 +297,30 @@ public class SystemProperties implements ServletContextListener {
             }
         }
         return def;
+    }
+    
+    /**
+     * Gets list of strings from the comma-separated system property string.
+     * Escaping of commas is not supported by the current implementation.
+     * @param propertyName property name
+     * @return List of strings. Returns empty list if the property is not defined or empty.
+     * @since TODO
+     */
+    @NonNull
+    public static List<String> getStringList(@NonNull String propertyName) {
+        final String rawString = SystemProperties.getString(propertyName);
+        if (rawString == null) {
+            return Collections.emptyList();
+        }
+        
+        final String[] values = rawString.split(",");
+        final List<String> res = new ArrayList<>(values.length);
+        for (String value : values) {
+            if (StringUtils.isNotBlank(value)) {
+                res.add(value);
+            }
+        }
+        return res;
     }
 
     @CheckForNull


### PR DESCRIPTION
This PR should allow to safely unbundle particular Jenkins core functionality to a plugin and then reference this unbundled plugin from Jenkins WAR (dependency + System Property definition). Otherwise there is no way to safely unbundle something without a new major Jenkins version.
- [x] Support copying of bundled plugins from WAR into Jenkins instance. The engine honors .disabled flags and previous plugin versions (they won't be overriden by default => user can upgrade plugins)
- [x] Allow specifying required and enforced plugin dependencies for plugins bundled into the WAR file
- [x] Allow altering the behavior of PluginManager for bundled, but not required plugins
- [ ] Write tests
- [ ] Provide example (Bouncy castle API plugin?)

https://issues.jenkins-ci.org/browse/JENKINS-36441

@reviewbybees @alobato @andresrc
