### PR TITLE
[FIX JENKINS-26438] Allow to keep forever with custom build discarder

### DIFF
--- a/core/src/main/resources/hudson/model/Run/logKeep.jelly
+++ b/core/src/main/resources/hudson/model/Run/logKeep.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <j:if test="${it.parent.logRotator!=null and it.canToggleLogKeep()}">
+  <j:if test="${it.parent.buildDiscarder!=null and it.canToggleLogKeep()}">
     <form method="get" action="toggleLogKeep" style="margin-top:1em">
       <j:if test="${it.keepLog and h.hasPermission(it,it.DELETE)}">
         <f:submit value="${%Don't keep this build forever}"  />


### PR DESCRIPTION
`getLogRotator` is `null` when the configured `BuildDiscarder` is not a `LogRotator` instance.

Javadoc in `BuildDiscarder` and `Run` indicate that `keepLog` should be considered by any `BuildDiscarder`.
