### PR TITLE
Annotate and document the AsynchronousExecution#getExecutor() method

### DIFF
--- a/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
+++ b/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
@@ -32,6 +32,7 @@ import hudson.model.ResourceActivity;
 import hudson.model.ResourceController;
 import hudson.model.ResourceList;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -93,13 +94,16 @@ public abstract class AsynchronousExecution extends RuntimeException {
 
     /**
      * Obtains the associated executor.
+     * @return Associated Executor. May be {@code null} if {@link #setExecutor(hudson.model.Executor)} 
+     * has not been called yet.
      */
+    @CheckForNull
     public synchronized final Executor getExecutor() {
         return executor;
     }
 
     @Restricted(NoExternalUse.class)
-    public synchronized final void setExecutor(Executor executor) {
+    public synchronized final void setExecutor(@Nonnull Executor executor) {
         assert this.executor==null;
 
         this.executor = executor;


### PR DESCRIPTION
Just a minor fix for the Javadoc issue I've noticed during the implementation of other feature
