### PR TITLE
[JENKINS-36592] Prevent NPE in BlockedBecauseOfBuildInProgress#getDescription() 

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1105,7 +1105,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      */
     @Deprecated
     public static class BecauseOfBuildInProgress extends BlockedBecauseOfBuildInProgress {
-        public BecauseOfBuildInProgress(AbstractBuild<?, ?> build) {
+        public BecauseOfBuildInProgress(@Nonnull AbstractBuild<?, ?> build) {
             super(build);
         }
     }
@@ -1146,7 +1146,15 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     public CauseOfBlockage getCauseOfBlockage() {
         // Block builds until they are done with post-production
         if (isLogUpdated() && !isConcurrentBuild()) {
-            return new BlockedBecauseOfBuildInProgress(getLastBuild());
+            final R lastBuild = getLastBuild();
+            if (lastBuild != null) {
+                return new BlockedBecauseOfBuildInProgress(lastBuild);
+            } else {
+                // The build has been lost during the execution
+                // It may happen in the case of the quick deletion of build after isLogUpdated() call 
+                // or API implemetation glisthes in the plugins. Anyway, we should let the code go then
+                LOGGER.log(Level.FINEST, "Previous build instance has been during the non-concurrent cause creation. The build is not blocked anymore");
+            }
         }
         if (blockBuildWhenDownstreamBuilding()) {
             AbstractProject<?,?> bup = getBuildingDownstream();

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1150,9 +1150,10 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             if (lastBuild != null) {
                 return new BlockedBecauseOfBuildInProgress(lastBuild);
             } else {
-                // The build has been likely deleted after the isLogUpdated() the after isLogUpdated() call 
-                // or API implemetation glitсhes in a plugin. Anyway, we should let the code go then
-                LOGGER.log(Level.FINE, "Previous build instance has been during the non-concurrent cause creation. The build is not blocked anymore");
+                // The build has been likely deleted after the isLogUpdated() call.
+                // Another cause may be an API implemetation glitсh in the implementation for AbstractProject. 
+                // Anyway, we should let the code go then.
+                LOGGER.log(Level.FINE, "The last build has been deleted during the non-concurrent cause creation. The build is not blocked anymore");
             }
         }
         if (blockBuildWhenDownstreamBuilding()) {

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1150,10 +1150,9 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             if (lastBuild != null) {
                 return new BlockedBecauseOfBuildInProgress(lastBuild);
             } else {
-                // The build has been lost during the execution
-                // It may happen in the case of the quick deletion of build after isLogUpdated() call 
-                // or API implemetation glisthes in the plugins. Anyway, we should let the code go then
-                LOGGER.log(Level.FINEST, "Previous build instance has been during the non-concurrent cause creation. The build is not blocked anymore");
+                // The build has been likely deleted after the isLogUpdated() the after isLogUpdated() call 
+                // or API implemetation glitсhes in a plugin. Anyway, we should let the code go then
+                LOGGER.log(Level.FINE, "Previous build instance has been during the non-concurrent cause creation. The build is not blocked anymore");
             }
         }
         if (blockBuildWhenDownstreamBuilding()) {

--- a/core/src/main/java/jenkins/model/BlockedBecauseOfBuildInProgress.java
+++ b/core/src/main/java/jenkins/model/BlockedBecauseOfBuildInProgress.java
@@ -28,6 +28,7 @@ import hudson.model.Executor;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.queue.CauseOfBlockage;
+import javax.annotation.Nonnull;
 
 /**
  * Indicates that a new build is blocked because the previous build is already in progress.
@@ -36,9 +37,14 @@ import hudson.model.queue.CauseOfBlockage;
  */
 public class BlockedBecauseOfBuildInProgress extends CauseOfBlockage {
     
+    @Nonnull
     private final Run<?, ?> build;
 
-    public BlockedBecauseOfBuildInProgress(Run<?, ?> build) {
+    /**
+     * Creates a cause for the specified build.
+     * @param build Build, which is already in progress
+     */
+    public BlockedBecauseOfBuildInProgress(@Nonnull Run<?, ?> build) {
         this.build = build;
     }
 


### PR DESCRIPTION
It may happen due to the race condition.

1) AbstractProject#getCauseOfBlockage() checks for non-concurrent running build in order to generate a cause of blockage
2) If the getCauseOfBlockage() happens in the context not synced with queue, after isLogUpdated() && !isConcurrentBuild() there may be a context switch. 
3) Build may complete and get deleted before we actually call getLastBuild() in the code
4) If it happens, BlockedBecauseOfBuildInProgress may get null in the constructor
5) Then, BlockedBecauseOfBuildInProgress#getDescription() will start throwing NPEs

https://issues.jenkins-ci.org/browse/JENKINS-36592

@reviewbybees
