### PR TITLE
[FIXED JENKINS-36594] - CauseOfInterruption.UserInterruption#getUser() should not create new users

### DIFF
--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -8,6 +8,7 @@ import org.jenkinsci.Symbol;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 
 /**
  * {@link HyperlinkNote} that links to a {@linkplain ModelObject model object},
@@ -26,7 +27,7 @@ public class ModelHyperlinkNote extends HyperlinkNote {
         return " class='model-link'";
     }
 
-    public static String encodeTo(User u) {
+    public static String encodeTo(@Nonnull User u) {
         return encodeTo(u,u.getDisplayName());
     }
 

--- a/core/src/main/java/jenkins/model/CauseOfInterruption.java
+++ b/core/src/main/java/jenkins/model/CauseOfInterruption.java
@@ -31,6 +31,8 @@ import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import java.io.Serializable;
+import java.util.Collections;
+import javax.annotation.CheckForNull;
 
 /**
  * Records why an {@linkplain Executor#interrupt() executor is interrupted}.
@@ -82,8 +84,9 @@ public abstract class CauseOfInterruption implements Serializable {
             this.user = userId;
         }
 
+        @CheckForNull
         public User getUser() {
-            return User.get(user);
+            return User.get(user, false, Collections.emptyMap());
         }
 
         public String getShortDescription() {
@@ -92,8 +95,10 @@ public abstract class CauseOfInterruption implements Serializable {
 
         @Override
         public void print(TaskListener listener) {
+            final User userInstance = getUser();
             listener.getLogger().println(
-                Messages.CauseOfInterruption_ShortDescription(ModelHyperlinkNote.encodeTo(getUser())));
+                Messages.CauseOfInterruption_ShortDescription(
+                        userInstance != null ? ModelHyperlinkNote.encodeTo(userInstance) : null));
         }
 
         @Override

--- a/core/src/main/java/jenkins/model/CauseOfInterruption.java
+++ b/core/src/main/java/jenkins/model/CauseOfInterruption.java
@@ -98,7 +98,7 @@ public abstract class CauseOfInterruption implements Serializable {
             final User userInstance = getUser();
             listener.getLogger().println(
                 Messages.CauseOfInterruption_ShortDescription(
-                        userInstance != null ? ModelHyperlinkNote.encodeTo(userInstance) : null));
+                        userInstance != null ? ModelHyperlinkNote.encodeTo(userInstance) : user));
         }
 
         @Override


### PR DESCRIPTION
Just a minor bug, which may potentially happen due to the race condition if a task gets interrupted  with SYSTEM authentication.
- UserInterruption#getUser() uses User.get(String), which creates users on demand.
- When we create CauseOfInterruption.UserInterruption, we expect it exists
- BUT: the user may be deleted from parallel thread by the time we call UserInterruption#print, which invokes getUser()
- In such case the recently deleted user may be recreated

https://issues.jenkins-ci.org/browse/JENKINS-36594

@reviewbybees
