### PR TITLE
[JENKINS-36629] Optimization for recent build stability calculation

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1159,7 +1159,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             if (runs instanceof RunMap) {
                 RunMap<RunT> runMap = (RunMap<RunT>) runs;
                 for (int index = i.getNumber(); index > u.getNumber() && totalCount < 5; index--) {
-                    if (runMap.diskContains(index)) {
+                    if (runMap.runExists(index)) {
                         totalCount++;
                     }
                 }

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -293,14 +293,14 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
     }
 
     /**
-     * Checks if the disk index contains the specified build number.
+     * Checks if the the specified build exists.
      *
      * @param number the build number to probe.
-     * @return {@code true} if there is an on disk entry for the corresponding number, note that this does not mean that
-     * the corresponding build record will load.
-     * @since 2.14
+     * @return {@code true} if there is an run for the corresponding number, note that this does not mean that
+     * the corresponding record will load.
+     * @since FIXME
      */
-    public boolean diskContains(int number) {
+    public boolean runExists(int number) {
         return numberOnDisk.contains(number);
     }
 

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -41,10 +41,11 @@ import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
-
-import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.*;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.ASC;
+import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.DESC;
 
 /**
  * {@link SortedMap} that keeps build records by their build numbers, in the descending order
@@ -289,6 +290,18 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
 
     public R get(int n) {
         return getByNumber(n);
+    }
+
+    /**
+     * Checks if the disk index contains the specified build number.
+     *
+     * @param number the build number to probe.
+     * @return {@code true} if there is an on disk entry for the corresponding number, note that this does not mean that
+     * the corresponding build record will load.
+     * @since 2.14
+     */
+    public boolean diskContains(int number) {
+        return numberOnDisk.contains(number);
     }
 
     /**

--- a/test/src/test/java/hudson/model/FreeStyleProjectTest.java
+++ b/test/src/test/java/hudson/model/FreeStyleProjectTest.java
@@ -23,8 +23,13 @@
  */
 package hudson.model;
 
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
@@ -34,8 +39,11 @@ import hudson.tasks.Builder;
 import hudson.tasks.Shell;
 import java.io.ByteArrayInputStream;
 
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
@@ -125,5 +133,27 @@ public class FreeStyleProjectTest {
         assertEquals("echo hello",((Shell)builders.get(0)).getCommand().trim());
         assertTrue(builders.get(0)!=shell);
         System.out.println(project.getConfigFile().asString());
+    }
+
+    @Test
+    @Issue("JENKINS-36629")
+    public void buildStabilityReports() throws Exception {
+        for (int i = 0; i <= 32; i++) {
+            FreeStyleProject p = j.createFreeStyleProject(String.format("Pattern-%s", Integer.toBinaryString(i)));
+            int expectedFails = 0;
+            for (int j = 32; j >= 1; j = j / 2) {
+                p.getBuildersList().clear();
+                if ((i & j) == j) {
+                    p.getBuildersList().add(new FailureBuilder());
+                    if (j <= 16) {
+                        expectedFails++;
+                    }
+                }
+                p.scheduleBuild2(0).get();
+            }
+            HealthReport health = p.getBuildHealth();
+
+            assertThat(String.format("Pattern %s score", Integer.toBinaryString(i)), health.getScore(), is(100*(5-expectedFails)/5));
+        }
     }
 }


### PR DESCRIPTION
[JENKINS-36629](https://issues.jenkins-ci.org/browse/JENKINS-36629)

Should at most load two builds into memory for the recently stable case. 

In the non-recently stable case we just pre-load the most recently stable one and skip loading any intermediary successful ones.

<table>
<tr>
<th>Probability of job failing</th><th>Expected number of jobs loaded</th>
</tr>
<tr><td>50%</td><td>4.56</td></tr>
<tr><td>40%</td><td>4.29</td></tr>
<tr><td>30%</td><td>3.92</td></tr>
<tr><td>20%</td><td>3.44</td></tr>
<tr><td>10%</td><td>2.80</td></tr>
<tr><td>5%</td><td>2.43</td></tr>
<tr><td>2%</td><td>2.17</td></tr>
<tr><td>1%</td><td>2.09</td></tr>
</table>


This compares with the previous implementation which would be expected to always load 5 jobs in the event that there were at least 5 jobs in the build history

@reviewbybees @jenkinsci/code-reviewers 
