### PR TITLE
[JENKINS-36476] Underprivileged users could not use the default value of a password parameter

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -154,6 +154,7 @@ import org.kohsuke.stapler.jelly.InternationalizedStringExpression.RawHtmlArgume
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import hudson.model.PasswordParameterDefinition;
 import hudson.util.RunList;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.CheckForNull;
@@ -1779,7 +1780,7 @@ public class Functions {
             }
             return ((Secret) o).getEncryptedValue();
         }
-        if (getIsUnitTest()) {
+        if (getIsUnitTest() && !o.equals(PasswordParameterDefinition.DEFAULT_VALUE)) {
             throw new SecurityException("attempted to render plaintext ‘" + o + "’ in password field; use a getter of type Secret instead");
         }
         return o.toString();

--- a/core/src/main/java/hudson/model/PasswordParameterDefinition.java
+++ b/core/src/main/java/hudson/model/PasswordParameterDefinition.java
@@ -31,6 +31,7 @@ import hudson.Extension;
 import hudson.util.Secret;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Parameter whose value is a {@link Secret} and is hidden from the UI.
@@ -39,6 +40,9 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
  * @since 1.319
  */
 public class PasswordParameterDefinition extends SimpleParameterDefinition {
+
+    @Restricted(NoExternalUse.class)
+    public static final String DEFAULT_VALUE = "<DEFAULT>";
 
     private Secret defaultValue;
 
@@ -66,7 +70,7 @@ public class PasswordParameterDefinition extends SimpleParameterDefinition {
     @Override
     public PasswordParameterValue createValue(StaplerRequest req, JSONObject jo) {
         PasswordParameterValue value = req.bindJSON(PasswordParameterValue.class, jo);
-        if (value.getValue().getPlainText().isEmpty()) {
+        if (value.getValue().getPlainText().equals(DEFAULT_VALUE)) {
             value = new PasswordParameterValue(getName(), getDefaultValue());
         }
         value.setDescription(getDescription());

--- a/core/src/main/java/hudson/model/PasswordParameterDefinition.java
+++ b/core/src/main/java/hudson/model/PasswordParameterDefinition.java
@@ -66,6 +66,9 @@ public class PasswordParameterDefinition extends SimpleParameterDefinition {
     @Override
     public PasswordParameterValue createValue(StaplerRequest req, JSONObject jo) {
         PasswordParameterValue value = req.bindJSON(PasswordParameterValue.class, jo);
+        if (value.getValue().getPlainText().isEmpty()) {
+            value = new PasswordParameterValue(getName(), getDefaultValue());
+        }
         value.setDescription(getDescription());
         return value;
     }

--- a/core/src/main/resources/hudson/model/PasswordParameterDefinition/index.jelly
+++ b/core/src/main/resources/hudson/model/PasswordParameterDefinition/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
 	<f:entry title="${it.name}" description="${it.formattedDescription}">
 		<div name="parameter">
 			<input type="hidden" name="name" value="${it.name}" />
-			<f:password name="value" value="${it.defaultValueAsSecret}" />
+			<f:password name="value"/>
 		</div>
 	</f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/PasswordParameterDefinition/index.jelly
+++ b/core/src/main/resources/hudson/model/PasswordParameterDefinition/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
 	<f:entry title="${it.name}" description="${it.formattedDescription}">
 		<div name="parameter">
 			<input type="hidden" name="name" value="${it.name}" />
-			<f:password name="value"/>
+			<f:password name="value" value="${it.DEFAULT_VALUE}"/>
 		</div>
 	</f:entry>
 </j:jelly>

--- a/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
@@ -58,7 +58,7 @@ public class PasswordParameterDefinitionTest {
         p.addProperty(new ParametersDefinitionProperty(new PasswordParameterDefinition("secret", "s3cr3t", "")));
         p.getBuildersList().add(new TestBuilder() {
             @Override public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-                listener.getLogger().println("I heard about a " + build.getEnvironment(listener).get("secret"));
+                listener.getLogger().println("I heard about a " + build.getEnvironment(listener).get("secret") + "!");
                 return true;
             }
         });
@@ -69,7 +69,7 @@ public class PasswordParameterDefinitionTest {
         j.waitUntilNoActivity();
         FreeStyleBuild b1 = p.getLastBuild();
         assertEquals(1, b1.getNumber());
-        j.assertLogContains("I heard about a s3cr3t", j.assertBuildStatusSuccess(b1));
+        j.assertLogContains("I heard about a s3cr3t!", j.assertBuildStatusSuccess(b1));
         // Another control case: anyone can enter a different value.
         HtmlForm form = wc.login("dev").getPage(p, "build?delay=0sec").getFormByName("parameters");
         HtmlPasswordInput input = form.getInputByName("value");
@@ -78,13 +78,22 @@ public class PasswordParameterDefinitionTest {
         j.waitUntilNoActivity();
         FreeStyleBuild b2 = p.getLastBuild();
         assertEquals(2, b2.getNumber());
-        j.assertLogContains("I heard about a rumor", j.assertBuildStatusSuccess(b2));
+        j.assertLogContains("I heard about a rumor!", j.assertBuildStatusSuccess(b2));
         // Test case: anyone can use default value.
         j.submit(wc.login("dev").getPage(p, "build?delay=0sec").getFormByName("parameters"));
         j.waitUntilNoActivity();
         FreeStyleBuild b3 = p.getLastBuild();
         assertEquals(3, b3.getNumber());
-        j.assertLogContains("I heard about a s3cr3t", j.assertBuildStatusSuccess(b3));
+        j.assertLogContains("I heard about a s3cr3t!", j.assertBuildStatusSuccess(b3));
+        // Another control case: blank values.
+        form = wc.login("dev").getPage(p, "build?delay=0sec").getFormByName("parameters");
+        input = form.getInputByName("value");
+        input.setText("");
+        j.submit(form);
+        j.waitUntilNoActivity();
+        FreeStyleBuild b4 = p.getLastBuild();
+        assertEquals(4, b4.getNumber());
+        j.assertLogContains("I heard about a !", j.assertBuildStatusSuccess(b4));
     }
 
 }

--- a/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
@@ -24,10 +24,18 @@
 
 package hudson.model;
 
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPasswordInput;
+import hudson.Launcher;
+import java.io.IOException;
+import jenkins.model.Jenkins;
 import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.TestBuilder;
 
 public class PasswordParameterDefinitionTest {
 
@@ -38,6 +46,45 @@ public class PasswordParameterDefinitionTest {
         p.addProperty(new ParametersDefinitionProperty(new PasswordParameterDefinition("p", "s3cr3t", "")));
         j.configRoundtrip(p);
         assertEquals("s3cr3t", ((PasswordParameterDefinition) p.getProperty(ParametersDefinitionProperty.class).getParameterDefinition("p")).getDefaultValue());
+    }
+
+    @Issue("JENKINS-36476")
+    @Test public void defaultValueAlwaysAvailable() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
+            grant(Jenkins.ADMINISTER).everywhere().to("admin").
+            grant(Jenkins.READ, Item.READ, Item.BUILD).everywhere().to("dev"));
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(new PasswordParameterDefinition("secret", "s3cr3t", "")));
+        p.getBuildersList().add(new TestBuilder() {
+            @Override public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                listener.getLogger().println("I heard about a " + build.getEnvironment(listener).get("secret"));
+                return true;
+            }
+        });
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.getOptions().setThrowExceptionOnFailingStatusCode(false); // ParametersDefinitionProperty/index.jelly sends a 405 but really it is OK
+        // Control case: admin can use default value.
+        j.submit(wc.login("admin").getPage(p, "build?delay=0sec").getFormByName("parameters"));
+        j.waitUntilNoActivity();
+        FreeStyleBuild b1 = p.getLastBuild();
+        assertEquals(1, b1.getNumber());
+        j.assertLogContains("I heard about a s3cr3t", j.assertBuildStatusSuccess(b1));
+        // Another control case: anyone can enter a different value.
+        HtmlForm form = wc.login("dev").getPage(p, "build?delay=0sec").getFormByName("parameters");
+        HtmlPasswordInput input = form.getInputByName("value");
+        input.setText("rumor");
+        j.submit(form);
+        j.waitUntilNoActivity();
+        FreeStyleBuild b2 = p.getLastBuild();
+        assertEquals(2, b2.getNumber());
+        j.assertLogContains("I heard about a rumor", j.assertBuildStatusSuccess(b2));
+        // Test case: anyone can use default value.
+        j.submit(wc.login("dev").getPage(p, "build?delay=0sec").getFormByName("parameters"));
+        j.waitUntilNoActivity();
+        FreeStyleBuild b3 = p.getLastBuild();
+        assertEquals(3, b3.getNumber());
+        j.assertLogContains("I heard about a s3cr3t", j.assertBuildStatusSuccess(b3));
     }
 
 }


### PR DESCRIPTION
[JENKINS-36476](https://issues.jenkins-ci.org/browse/JENKINS-36476)

Note that the current patch does not allow a job to deliberately interpret the empty string as a special value. To support that, it would be necessary to patch `Functions.getPasswordValue` to allow some special token like `"<DEFAULT>"` to be passed along in plain text without complaining.

@reviewbybees
