### PR TITLE
[JENKINS-18435] Tell browsers not to cache or try to autocomplete forms

### DIFF
--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -46,7 +46,7 @@ THE SOFTWARE.
 
             <j:if test="${it.isNameEditable()}">
               <f:entry title="${%name(it.pronoun)}">
-                <f:textbox name="name" value="${it.name}" />
+                <f:textbox name="name" value="${it.name}" autocomplete="on"/>
               </f:entry>
             </j:if>
             <f:entry title="${%Description}" help="${app.markupFormatter.helpUrl}">

--- a/core/src/main/resources/hudson/model/View/configure.jelly
+++ b/core/src/main/resources/hudson/model/View/configure.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
 
       <f:form method="post" action="configSubmit" name="viewConfig">
         <f:entry title="${%Name}">
-          <f:textbox name="name" value="${it.viewName}" />
+          <f:textbox name="name" value="${it.viewName}" autocomplete="on"/>
         </f:entry>
         <f:entry title="${%Description}" help="/help/view-config/description.html">
           <f:textarea name="description" field="description" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>

--- a/core/src/main/resources/lib/form/form.jelly
+++ b/core/src/main/resources/lib/form/form.jelly
@@ -48,8 +48,12 @@ THE SOFTWARE.
     <st:attribute name="tableClass">
       Optional class attribute for &lt;table> that is created in the form.
     </st:attribute>
+    <st:attribute name="autocomplete">
+      Optional attribute for allowing browsers to perform auto complete or pre-fill the form from history.
+      Default: false
+    </st:attribute>
   </st:documentation>
-  <form action="${action}" method="${method}" enctype="${attrs.enctype}" name="${name}" target="${attrs.target}">
+  <form action="${action}" method="${method}" enctype="${attrs.enctype}" name="${name}" target="${attrs.target}" autocomplete="${attrs.autocomplete==true?'on':'off'}">
     <table width="100%" class="${attrs.tableClass}">
       <d:invokeBody/>
     </table>

--- a/test/src/test/java/lib/form/FormTest.java
+++ b/test/src/test/java/lib/form/FormTest.java
@@ -1,0 +1,111 @@
+package lib.form;
+
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlInput;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.model.RootAction;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for lib/form.jelly.
+ */
+public class FormTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-18435")
+    public void autocompleteOffByDefault() throws IOException, SAXException {
+        HtmlPage page = j.createWebClient().goTo("autocompleteOffByDefault");
+        HtmlForm form = page.getFormByName("config");
+        String autocomplete = form.getAttribute("autocomplete");
+        assertNotNull(autocomplete);
+        assertEquals("off", autocomplete);
+    }
+
+    @Test
+    @Issue("JENKINS-18435")
+    public void autocompleteOnWhenTrue() throws IOException, SAXException {
+        HtmlPage page = j.createWebClient().goTo("autocompleteOnWhenTrue");
+        HtmlForm form = page.getFormByName("config");
+        String autocomplete = form.getAttribute("autocomplete");
+        assertNotNull(autocomplete);
+        assertEquals("on", autocomplete);
+    }
+
+    @Test
+    @Issue("JENKINS-18435")
+    public void inputsCanSetAutocomplete() throws IOException, SAXException {
+        HtmlPage page = j.createWebClient().goTo("inputsCanSetAutocomplete");
+        HtmlForm form = page.getFormByName("config");
+        HtmlInput a = form.getInputByName("a");
+        String autocomplete = a.getAttribute("autocomplete");
+        assertNotNull(autocomplete);
+        assertEquals("on", autocomplete);
+    }
+
+    @TestExtension("autocompleteOffByDefault")
+    public static class AutocompleteOffByDefault implements RootAction {
+        @Override
+        public String getIconFileName() {
+            return "gear2.png";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "AutocompleteOffByDefault";
+        }
+
+        @Override
+        public String getUrlName() {
+            return "autocompleteOffByDefault";
+        }
+    }
+
+    @TestExtension("autocompleteOnWhenTrue")
+    public static class AutocompleteOnWhenTrue implements RootAction {
+        @Override
+        public String getIconFileName() {
+            return "gear2.png";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "AutocompleteOnWhenTrue";
+        }
+
+        @Override
+        public String getUrlName() {
+            return "autocompleteOnWhenTrue";
+        }
+    }
+
+    @TestExtension("inputsCanSetAutocomplete")
+    public static class InputsCanSetAutocomplete implements RootAction {
+        @Override
+        public String getIconFileName() {
+            return "gear2.png";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "InputsCanSetAutocomplete";
+        }
+
+        @Override
+        public String getUrlName() {
+            return "inputsCanSetAutocomplete";
+        }
+    }
+}

--- a/test/src/test/resources/lib/form/FormTest/AutocompleteOffByDefault/index.jelly
+++ b/test/src/test/resources/lib/form/FormTest/AutocompleteOffByDefault/index.jelly
@@ -1,0 +1,37 @@
+<!--
+The MIT License
+
+Copyright (c) 2016, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+    <l:layout title="Testing the autocomplete attribute of form">
+        <l:main-panel>
+            <f:form method="post" name="config" action="doIt">
+                <f:entry title="a">
+                    <f:textbox name="a" value="avalue" />
+                </f:entry>
+                <f:submit value="submit" />
+            </f:form>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/test/src/test/resources/lib/form/FormTest/AutocompleteOnWhenTrue/index.jelly
+++ b/test/src/test/resources/lib/form/FormTest/AutocompleteOnWhenTrue/index.jelly
@@ -1,0 +1,37 @@
+<!--
+The MIT License
+
+Copyright (c) 2016, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+    <l:layout title="Testing the autocomplete attribute of form">
+        <l:main-panel>
+            <f:form method="post" name="config" action="doIt" autocomplete="${true}">
+                <f:entry title="a">
+                    <f:textbox name="a" value="avalue" />
+                </f:entry>
+                <f:submit value="submit" />
+            </f:form>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/test/src/test/resources/lib/form/FormTest/InputsCanSetAutocomplete/index.jelly
+++ b/test/src/test/resources/lib/form/FormTest/InputsCanSetAutocomplete/index.jelly
@@ -1,0 +1,37 @@
+<!--
+The MIT License
+
+Copyright (c) 2016, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+    <l:layout title="Testing the autocomplete attribute of form">
+        <l:main-panel>
+            <f:form method="post" name="config" action="doIt">
+                <f:entry title="a">
+                    <f:textbox name="a" value="avalue" autocomplete="on"/>
+                </f:entry>
+                <f:submit value="submit" />
+            </f:form>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>


### PR DESCRIPTION
Setting autocomplete to "off" will tell browsers not to try to autofill
forms during history navigation. Since this seems to be a prominent
problem in Jenkins I feel it is best to have it default to "off" and let
individual inputs or pages opt-in to enable it instead
to indicate they can handle it.
The standard login page does not seem to use the taglib form tag
so it is not affected, even so, all modern browsers ignores
the autocomplete attribute on username and password fields anyway.

Example article mentioning this: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

@reviewbybees
@jenkinsci/code-reviewers 
