### PR TITLE
[FIXED JENKINS-31791] Optimize BuildHistoryWidget

### DIFF
--- a/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
@@ -27,7 +27,6 @@ import jenkins.model.Jenkins;
 import hudson.model.Queue.Item;
 import hudson.model.Queue.Task;
 import jenkins.widgets.HistoryPageFilter;
-import org.apache.commons.collections.IteratorUtils;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -75,11 +74,7 @@ public class BuildHistoryWidget<T> extends HistoryWidget<Task,T> {
     public HistoryPageFilter getHistoryPageFilter() {
         final HistoryPageFilter<T> historyPageFilter = newPageFilter();
 
-        List<T> items = new LinkedList<T>();
-
-        items.addAll((Collection<? extends T>) getQueuedItems());
-        items.addAll(IteratorUtils.toList(baseList.iterator()));
-        historyPageFilter.add(items);
+        historyPageFilter.add(baseList, getQueuedItems());
         historyPageFilter.widget = this;
 
         return historyPageFilter;

--- a/core/src/main/java/hudson/widgets/HistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/HistoryWidget.java
@@ -30,7 +30,6 @@ import hudson.model.Run;
 
 import jenkins.widgets.HistoryPageEntry;
 import jenkins.widgets.HistoryPageFilter;
-import org.apache.commons.collections.IteratorUtils;
 import org.kohsuke.stapler.Header;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -89,7 +88,7 @@ public class HistoryWidget<O extends ModelObject,T> extends Widget {
      *      The parent model object that owns this widget.
      */
     public HistoryWidget(O owner, Iterable<T> baseList, Adapter<? super T> adapter) {
-	StaplerRequest currentRequest = Stapler.getCurrentRequest();
+        StaplerRequest currentRequest = Stapler.getCurrentRequest();
         this.adapter = adapter;
         this.baseList = baseList;
         this.baseUrl = Functions.getNearestAncestorUrl(currentRequest,owner);
@@ -148,15 +147,15 @@ public class HistoryWidget<O extends ModelObject,T> extends Widget {
         Iterator<T> iterator = historyItemList.iterator();
 
         if (!iterator.hasNext()) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         List<HistoryPageEntry<T>> pageEntries = new ArrayList<HistoryPageEntry<T>>();
         while (iterator.hasNext()) {
-	        pageEntries.add(new HistoryPageEntry<T>(iterator.next()));
+            pageEntries.add(new HistoryPageEntry<T>(iterator.next()));
         }
 
-	return pageEntries;
+        return pageEntries;
     }
 
     /**
@@ -165,7 +164,7 @@ public class HistoryWidget<O extends ModelObject,T> extends Widget {
     public HistoryPageFilter getHistoryPageFilter() {
         HistoryPageFilter<T> historyPageFilter = newPageFilter();
 
-        historyPageFilter.add(IteratorUtils.toList(baseList.iterator()));
+        historyPageFilter.add(baseList);
         historyPageFilter.widget = this;
         return historyPageFilter;
     }

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -23,6 +23,8 @@
  */
 package jenkins.widgets;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Run;
@@ -32,6 +34,8 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -101,85 +105,116 @@ public class HistoryPageFilter<T> {
     /**
      * Add build items to the History page.
      *
-     * @param items The items to be added. Assumes the list of items are in descending queue ID order i.e. newest first.
+     * @param runItems The items to be added. Assumes the items are in descending queue ID order i.e. newest first.
+     * @deprecated Replaced by add(Iterable&lt;T&gt;) as of version 2.15
      */
-    public void add(@Nonnull List<T> items) {
-        if (items.isEmpty()) {
+    @Deprecated
+    public void add(@Nonnull List<T> runItems) {
+        addInternal(runItems);
+    }
+
+    /**
+     * Add build items to the History page.
+     *
+     * @param runItems The items to be added. Assumes the items are in descending queue ID order i.e. newest first.
+     * @since 2.15
+     */
+    public void add(@Nonnull Iterable<T> runItems) {
+        addInternal(runItems);
+    }
+
+    /**
+     * Add run items and queued items to the History page.
+     *
+     * @param runItems The items to be added. Assumes the items are in descending queue ID order i.e. newest first.
+     * @param queueItems The queue items to be added. Queue items do not need to be sorted.
+     * @since 2.15
+     */
+    public void add(@Nonnull Iterable<T> runItems, @Nonnull List<Queue.Item> queueItems) {
+        sort(queueItems);
+        addInternal(Iterables.concat(queueItems, runItems));
+    }
+
+    /**
+     * Add items to the History page, internal implementation.
+     * @param items The items to be added.
+     * @param <ItemT> The type of items should either be T or Queue.Item.
+     */
+    private <ItemT> void addInternal(@Nonnull Iterable<ItemT> items) {
+        // Note that items can be a large lazily evaluated collection,
+        // so this method is optimized to only iterate through it as much as needed.
+
+        if (!items.iterator().hasNext()) {
             return;
         }
 
-        sort(items);
-
-        nextBuildNumber = getNextBuildNumber(items.get(0));
+        nextBuildNumber = getNextBuildNumber(items.iterator().next());
 
         if (newerThan == null && olderThan == null) {
             // Just return the first page of entries (newest)
-            for (T item : items) {
-                add(item);
+            Iterator<ItemT> iter = items.iterator();
+            while (iter.hasNext()) {
+                add(iter.next());
                 if (isFull()) {
                     break;
                 }
             }
-            hasDownPage = (items.size() > maxEntries);
+            hasDownPage = iter.hasNext();
         } else if (newerThan != null) {
             int toFillCount = getFillCount();
             if (toFillCount > 0) {
-                // Locate the point in the items list where the 'newerThan' build item is. Once located,
-                // add a max of 'getFillCount' build items before that build item.
-                long newestInList = HistoryPageEntry.getEntryId(items.get(0));
-                long oldestInList = HistoryPageEntry.getEntryId(items.get(items.size() - 1));
-                int newerThanIdx = -1;
+                // Walk through the items and keep track of the oldest
+                // 'toFillCount' items until we reach an item older than
+                // 'newerThan' or the end of the list.
+                LinkedList<ItemT> itemsToAdd = new LinkedList<>();
+                Iterator<ItemT> iter = items.iterator();
+                while (iter.hasNext()) {
+                    ItemT item = iter.next();
+                    if (HistoryPageEntry.getEntryId(item) > newerThan) {
+                        itemsToAdd.addLast(item);
 
-                if (newerThan > newestInList) {
-                    // Nothing newer
-                } else if (newerThan >= oldestInList) {
-                    // newerThan is within the range of items in the item list.
-                    // go through the list and locate the cut-off point.
-                    for (int i = 0; i < items.size(); i++) {
-                        T item = items.get(i);
-                        if (HistoryPageEntry.getEntryId(item) <= newerThan) {
-                            newerThanIdx = i;
-                            break;
-                        }
-                    }
-                } else if (newerThan < oldestInList) {
-                    newerThanIdx = items.size();
-                }
-
-                if (newerThanIdx != -1) {
-                    if (newerThanIdx <= maxEntries) {
-                        // If there's less than a full page of items newer than "newerThan", then it's ok to
-                        // fill the page with items older than "newerThan".
-                        int itemCountToAdd = Math.min(toFillCount, items.size());
-                        for (int i = 0; i < itemCountToAdd; i++) {
-                            add(items.get(i));
+                        // Discard an item off the front of the list if we have
+                        // to (which means we would be able to page up).
+                        if (itemsToAdd.size() > toFillCount) {
+                            itemsToAdd.removeFirst();
+                            hasUpPage = true;
                         }
                     } else {
-                        // There's more than a full page of items newer than "newerThan".
-                        for (int i = (newerThanIdx - toFillCount); i < newerThanIdx; i++) {
-                            add(items.get(i));
-                        }
-                        hasUpPage = true;
+                        break;
                     }
-                    // if there are items after the "newerThan" item, then we
-                    // can page down.
-                    hasDownPage = (items.size() > newerThanIdx + 1);
-                } else {
+                }
+                if (itemsToAdd.size() == 0) {
                     // All builds are older than newerThan ?
                     hasDownPage = true;
+                } else {
+                    // If there's less than a full page of items newer than
+                    // 'newerThan', then it's ok to fill the page with older items.
+                    if (itemsToAdd.size() < toFillCount) {
+                        // We have to restart the iterator and skip the items that we added (because
+                        // we may have popped an extra item off the iterator that did not get added).
+                        Iterator<ItemT> skippedIter = items.iterator();
+                        Iterators.skip(skippedIter, itemsToAdd.size());
+                        for (int i = itemsToAdd.size(); i < toFillCount && skippedIter.hasNext(); i++) {
+                            ItemT item = skippedIter.next();
+                            itemsToAdd.addLast(item);
+                        }
+                    }
+                    hasDownPage = iter.hasNext();
+                    for (Object item : itemsToAdd) {
+                        add(item);
+                    }
                 }
             }
         } else if (olderThan != null) {
-            for (int i = 0; i < items.size(); i++) {
-                T item = items.get(i);
+            Iterator<ItemT> iter = items.iterator();
+            while (iter.hasNext()) {
+                Object item = iter.next();
                 if (HistoryPageEntry.getEntryId(item) >= olderThan) {
                     hasUpPage = true;
                 } else {
                     add(item);
                     if (isFull()) {
-                        // This page is full but there may be more builds older
-                        // than the oldest on this page.
-                        hasDownPage = (i + 1 < items.size());
+                        hasDownPage = iter.hasNext();
                         break;
                     }
                 }
@@ -191,13 +226,13 @@ public class HistoryPageFilter<T> {
         return queueItems.size() + runs.size();
     }
 
-    private void sort(List<T> items) {
+    private void sort(List<? extends Object> items) {
         // Queue items can start building out of order with how they got added to the queue. Sorting them
         // before adding to the page. They'll still get displayed before the building items coz they end
         // up in a different list in HistoryPageFilter.
-        Collections.sort(items, new Comparator<T>() {
+        Collections.sort(items, new Comparator<Object>() {
             @Override
-            public int compare(T o1, T o2) {
+            public int compare(Object o1, Object o2) {
                 long o1QID = HistoryPageEntry.getEntryId(o1);
                 long o2QID = HistoryPageEntry.getEntryId(o2);
 
@@ -212,7 +247,7 @@ public class HistoryPageFilter<T> {
         });
     }
 
-    private long getNextBuildNumber(@Nonnull T entry) {
+    private long getNextBuildNumber(@Nonnull Object entry) {
         if (entry instanceof Queue.Item) {
             Queue.Task task = ((Queue.Item) entry).task;
             if (task instanceof Job) {
@@ -227,13 +262,19 @@ public class HistoryPageFilter<T> {
     }
 
     private void addQueueItem(Queue.Item item) {
-        HistoryPageEntry entry = new HistoryPageEntry(item);
+        HistoryPageEntry<Queue.Item> entry = new HistoryPageEntry<>(item);
         queueItems.add(entry);
         updateNewestOldest(entry.getEntryId());
     }
 
     private void addRun(Run run) {
-        HistoryPageEntry entry = new HistoryPageEntry(run);
+        HistoryPageEntry<Run> entry = new HistoryPageEntry<>(run);
+        // Assert that runs have been added in descending order
+        if (runs.size() > 0) {
+            if (entry.getEntryId() > runs.get(runs.size() - 1).getEntryId()) {
+                throw new IllegalStateException("Runs were out of order");
+            }
+        }
         runs.add(entry);
         updateNewestOldest(entry.getEntryId());
     }
@@ -243,7 +284,7 @@ public class HistoryPageFilter<T> {
         oldestOnPage = Math.min(oldestOnPage, entryId);
     }
 
-    private boolean add(T entry) {
+    private boolean add(Object entry) {
         // Purposely not calling isFull(). May need to add a greater number of entries
         // to the page initially, newerThan then cutting it back down to size using cutLeading()
         if (entry instanceof Queue.Item) {

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -117,7 +117,7 @@ public class HistoryPageFilter<T> {
      * Add build items to the History page.
      *
      * @param runItems The items to be added. Assumes the items are in descending queue ID order i.e. newest first.
-     * @since 2.15
+     * @since TODO
      */
     public void add(@Nonnull Iterable<T> runItems) {
         addInternal(runItems);
@@ -128,7 +128,7 @@ public class HistoryPageFilter<T> {
      *
      * @param runItems The items to be added. Assumes the items are in descending queue ID order i.e. newest first.
      * @param queueItems The queue items to be added. Queue items do not need to be sorted.
-     * @since 2.15
+     * @since TODO
      */
     public void add(@Nonnull Iterable<T> runItems, @Nonnull List<Queue.Item> queueItems) {
         sort(queueItems);

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -23,7 +23,12 @@
  */
 package jenkins.widgets;
 
-import hudson.model.*;
+import hudson.model.Job;
+import hudson.model.MockItem;
+import hudson.model.ModelObject;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.Run;
 import jenkins.widgets.HistoryPageEntry;
 import jenkins.widgets.HistoryPageFilter;
 import org.junit.Assert;

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -23,11 +23,7 @@
  */
 package jenkins.widgets;
 
-import hudson.model.Job;
-import hudson.model.MockItem;
-import hudson.model.ModelObject;
-import hudson.model.Result;
-import hudson.model.Run;
+import hudson.model.*;
 import jenkins.widgets.HistoryPageEntry;
 import jenkins.widgets.HistoryPageFilter;
 import org.junit.Assert;
@@ -49,7 +45,7 @@ public class HistoryPageFilterTest {
     @Test
     public void test_latest_empty_page() {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> itemList = new ArrayList<>();
 
         historyPageFilter.add(itemList);
         Assert.assertEquals(false, historyPageFilter.hasUpPage);
@@ -64,15 +60,10 @@ public class HistoryPageFilterTest {
     @Test
     public void test_latest_partial_page() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> runs = newRuns(1, 2);
+        List<Queue.Item> queueItems = newQueueItems(3, 4);
 
-        itemList.addAll(newRuns(1, 2));
-        itemList.addAll(newQueueItems(3, 4));
-
-        // want to make sure the list items are ordered by id in descending order
-        Assert.assertEquals(HistoryPageEntry.getEntryId(1), HistoryPageEntry.getEntryId(itemList.get(0)));
-        historyPageFilter.add(itemList);
-        Assert.assertEquals(4, HistoryPageEntry.getEntryId(itemList.get(0)));
+        historyPageFilter.add(runs, queueItems);
 
         Assert.assertEquals(false, historyPageFilter.hasUpPage);
         Assert.assertEquals(false, historyPageFilter.hasDownPage);
@@ -93,12 +84,10 @@ public class HistoryPageFilterTest {
     @Test
     public void test_latest_longer_list() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> runs = newRuns(1, 10);
+        List<Queue.Item> queueItems = newQueueItems(11, 12);
 
-        itemList.addAll(newRuns(1, 10));
-        itemList.addAll(newQueueItems(11, 12));
-
-        historyPageFilter.add(itemList);
+        historyPageFilter.add(runs, queueItems);
 
         Assert.assertEquals(false, historyPageFilter.hasUpPage);
         Assert.assertEquals(true, historyPageFilter.hasDownPage);
@@ -117,9 +106,8 @@ public class HistoryPageFilterTest {
     @Test
     public void test_olderThan_gt_newest() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, 11L);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> itemList = newRuns(1, 10);
 
-        itemList.addAll(newRuns(1, 10));
         historyPageFilter.add(itemList);
 
         Assert.assertEquals(false, historyPageFilter.hasUpPage);
@@ -137,9 +125,8 @@ public class HistoryPageFilterTest {
     @Test
     public void test_olderThan_lt_oldest() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, 0L);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> itemList = newRuns(1, 10);
 
-        itemList.addAll(newRuns(1, 10));
         historyPageFilter.add(itemList);
 
         Assert.assertEquals(true, historyPageFilter.hasUpPage);
@@ -154,9 +141,8 @@ public class HistoryPageFilterTest {
     @Test
     public void test_olderThan_leaving_part_page() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, 4L);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> itemList = newRuns(1, 10);
 
-        itemList.addAll(newRuns(1, 10));
         historyPageFilter.add(itemList);
 
         Assert.assertEquals(true, historyPageFilter.hasUpPage);
@@ -175,9 +161,8 @@ public class HistoryPageFilterTest {
     @Test
     public void test_olderThan_mid_page() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, 8L);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> itemList = newRuns(1, 10);
 
-        itemList.addAll(newRuns(1, 10));
         historyPageFilter.add(itemList);
 
         Assert.assertEquals(true, historyPageFilter.hasUpPage);
@@ -194,9 +179,8 @@ public class HistoryPageFilterTest {
     @Test
     public void test_newerThan_gt_newest() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, 11L, null);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> itemList = newRuns(1, 10);
 
-        itemList.addAll(newRuns(1, 10));
         historyPageFilter.add(itemList);
 
         Assert.assertEquals(false, historyPageFilter.hasUpPage);
@@ -211,9 +195,8 @@ public class HistoryPageFilterTest {
     @Test
     public void test_newerThan_lt_oldest() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, 0L, null);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> itemList = newRuns(1, 10);
 
-        itemList.addAll(newRuns(1, 10));
         historyPageFilter.add(itemList);
 
         Assert.assertEquals(true, historyPageFilter.hasUpPage);
@@ -230,9 +213,8 @@ public class HistoryPageFilterTest {
     @Test
     public void test_newerThan_near_oldest() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, 3L, null);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> itemList = newRuns(1, 10);
 
-        itemList.addAll(newRuns(1, 10));
         historyPageFilter.add(itemList);
 
         Assert.assertEquals(true, historyPageFilter.hasUpPage);
@@ -251,9 +233,8 @@ public class HistoryPageFilterTest {
     @Test
     public void test_newerThan_near_newest() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, 8L, null);
-        List<ModelObject> itemList = new ArrayList<ModelObject>();
+        List<ModelObject> itemList = newRuns(1, 10);
 
-        itemList.addAll(newRuns(1, 10));
         historyPageFilter.add(itemList);
 
         Assert.assertEquals(false, historyPageFilter.hasUpPage);
@@ -264,8 +245,51 @@ public class HistoryPageFilterTest {
         Assert.assertEquals(HistoryPageEntry.getEntryId(6), historyPageFilter.oldestOnPage);
     }
 
-    private List<ModelObject> newQueueItems(long startId, long endId) {
-        List<ModelObject> items = new ArrayList<ModelObject>();
+    /**
+     * Test newerThan (page up) mid range when there are queued builds that are new enough to
+     * not show up.
+     */
+    @Test
+    public void test_newerThan_doesntIncludeQueuedItems() throws IOException {
+        HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, 5L, null);
+        List<ModelObject> runs = newRuns(1, 10);
+        List<Queue.Item> queueItems = newQueueItems(11, 12);
+
+        historyPageFilter.add(runs, queueItems);
+
+        Assert.assertEquals(true, historyPageFilter.hasUpPage);
+        Assert.assertEquals(true, historyPageFilter.hasDownPage);
+        Assert.assertEquals(0, historyPageFilter.queueItems.size());
+        Assert.assertEquals(5, historyPageFilter.runs.size());
+
+        Assert.assertEquals(HistoryPageEntry.getEntryId(10), historyPageFilter.runs.get(0).getEntryId());
+        Assert.assertEquals(HistoryPageEntry.getEntryId(10), historyPageFilter.newestOnPage);
+        Assert.assertEquals(HistoryPageEntry.getEntryId(6), historyPageFilter.oldestOnPage);
+    }
+
+    /**
+     * Test that later items in the list that are not needed for display are not evaluated at all (for performance).
+     */
+    @Test
+    public void test_laterItemsNotEvaluated() throws IOException {
+        HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
+        List<ModelObject> itemList = newRuns(6, 10);
+        for (int queueId = 5; queueId >= 1; queueId--) {
+            itemList.add(new ExplodingMockRun(queueId));
+        }
+
+        historyPageFilter.add(itemList);
+
+        Assert.assertEquals(false, historyPageFilter.hasUpPage);
+        Assert.assertEquals(true, historyPageFilter.hasDownPage);
+        Assert.assertEquals(5, historyPageFilter.runs.size());
+
+        Assert.assertEquals(HistoryPageEntry.getEntryId(10), historyPageFilter.newestOnPage);
+        Assert.assertEquals(HistoryPageEntry.getEntryId(6), historyPageFilter.oldestOnPage);
+    }
+
+    private List<Queue.Item> newQueueItems(long startId, long endId) {
+        List<Queue.Item> items = new ArrayList<>();
         for (long queueId = startId; queueId <= endId; queueId++) {
             items.add(new MockItem(queueId));
         }
@@ -273,15 +297,16 @@ public class HistoryPageFilterTest {
     }
 
     private List<ModelObject> newRuns(long startId, long endId) throws IOException {
-        List<ModelObject> runs = new ArrayList<ModelObject>();
-        for (long queueId = startId; queueId <= endId; queueId++) {
+        // Runs should be in reverse order, newest first.
+        List<ModelObject> runs = new ArrayList<>();
+        for (long queueId = endId; queueId >= startId; queueId--) {
             runs.add(new MockRun(queueId));
         }
         return runs;
     }
 
     private HistoryPageFilter<ModelObject> newPage(int maxEntries, Long newerThan, Long olderThan) {
-        HistoryPageFilter<ModelObject> pageFilter = new HistoryPageFilter<ModelObject>(maxEntries);
+        HistoryPageFilter<ModelObject> pageFilter = new HistoryPageFilter<>(maxEntries);
         if (newerThan != null) {
             pageFilter.setNewerThan(HistoryPageEntry.getEntryId(newerThan));
         } else if (olderThan != null) {
@@ -322,6 +347,25 @@ public class HistoryPageFilterTest {
         @Override
         public int getNumber() {
             return (int) queueId;
+        }
+    }
+
+    // A version of MockRun that will throw an exception if getQueueId or getNumber is called
+    private static class ExplodingMockRun extends MockRun {
+        public ExplodingMockRun(long queueId) throws IOException {
+            super(queueId);
+        }
+
+        @Override
+        public long getQueueId() {
+            Assert.fail("Should not get called");
+            return super.getQueueId();
+        }
+
+        @Override
+        public int getNumber() {
+            Assert.fail("Should not get called");
+            return super.getNumber();
         }
     }
 }


### PR DESCRIPTION
Refactor HistoryPageFilter to lazily evaluate an iterable of previous runs, instead of instantiating a super long list of builds. Instantiating the whole list can be problematic with lots of historical builds especially if disk IO is slow.

This PR also contains a commit to ~~upgrade to~~ install Apache Commons Collections 4, which contains some useful new APIs (notably `IterableUtils`). I can yank this into a separate PR if that is easier.
