### PR TITLE
[JENKINS-36732] Use start time instead of scheduled time in build history.

### DIFF
--- a/core/src/main/java/hudson/model/BuildTimelineWidget.java
+++ b/core/src/main/java/hudson/model/BuildTimelineWidget.java
@@ -62,8 +62,8 @@ public class BuildTimelineWidget {
         TimelineEventList result = new TimelineEventList();
         for (Run r : builds.byTimestamp(min,max)) {
             Event e = new Event();
-            e.start = r.getTime();
-            e.end   = new Date(r.timestamp+r.getDuration());
+            e.start = new Date(r.getStartTimeInMillis());
+            e.end   = new Date(r.getStartTimeInMillis()+r.getDuration());
             e.title = r.getFullDisplayName();
             // what to put in the description?
             // e.description = "Longish description of event "+r.getFullDisplayName();

--- a/core/src/main/java/jenkins/widgets/BuildListTable.java
+++ b/core/src/main/java/jenkins/widgets/BuildListTable.java
@@ -25,9 +25,13 @@
 package jenkins.widgets;
 
 import hudson.Functions;
+import hudson.Util;
 import hudson.model.BallColor;
 import hudson.model.Run;
 import net.sf.json.JSONObject;
+
+import java.util.Date;
+
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
@@ -45,6 +49,7 @@ public class BuildListTable extends RunListProgressiveRendering {
         element.put("displayName", build.getDisplayName());
         element.put("timestampString", build.getTimestampString());
         element.put("timestampString2", build.getTimestampString2());
+        element.put("timestampString3", Util.XS_DATETIME_FORMATTER.format(new Date(build.getStartTimeInMillis())));
         Run.Summary buildStatusSummary = build.getBuildStatusSummary();
         element.put("buildStatusSummaryWorse", buildStatusSummary.isWorse);
         element.put("buildStatusSummaryMessage", buildStatusSummary.message);

--- a/core/src/main/resources/lib/hudson/buildListTable.jelly
+++ b/core/src/main/resources/lib/hudson/buildListTable.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
                   insert('\u00A0').
                   insert(new Element('a', {href: '${rootURL}/' + e.url, 'class': 'model-link inside'}).
                       update(e.displayName.escapeHTML())));
-              tr.insert(new Element('td', {data: e.timestampString2, tooltip: '${%Click to center timeline on event}', onclick: 'javascript:tl.getBand(0).scrollToCenter(Timeline.DateTime.parseGregorianDateTime("' + e.timestampString2 + '"))'}).
+              tr.insert(new Element('td', {data: e.timestampString2, tooltip: '${%Click to center timeline on event}', onclick: 'javascript:tl.getBand(0).scrollToCenter(Timeline.DateTime.parseGregorianDateTime("' + e.timestampString3 + '"))'}).
                   update(e.timestampString.escapeHTML()));
               tr.insert(new Element('td', {style: e.buildStatusSummaryWorse ? 'color: red' : ''}).
                   update(e.buildStatusSummaryMessage.escapeHTML()));


### PR DESCRIPTION
[JENKINS-36732](https://issues.jenkins-ci.org/browse/JENKINS-36732)

There's a build
- scheduled at 10:00
- started at 11:00  (nodes were busy for long time)
- finished at 11:30

Before this fix, the build history displays the build during 10:00 - 10:30.
This fix displays the build during 11:00 - 11:30 correctly.

Before this fix:
![screen shot 2016-07-16 at 11 12 16](https://cloud.githubusercontent.com/assets/3115961/16892532/a6d3e95e-4b50-11e6-9ba1-e7827192bf02.png)

After this fix:
![screen shot 2016-07-16 at 12 20 46](https://cloud.githubusercontent.com/assets/3115961/16892533/b16096a6-4b50-11e6-99b9-0abb48961272.png)
