### PR TITLE
[FIXED JENKINS-36775] - No longer hard-code the icon for the executor panel

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -68,6 +68,8 @@ import jenkins.model.Jenkins;
 import jenkins.util.ContextResettingExecutorService;
 import jenkins.security.MasterToSlaveCallable;
 
+import org.jenkins.ui.icon.Icon;
+import org.jenkins.ui.icon.IconSet;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -718,6 +720,11 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         }
     }
 
+    /**
+     * Returns the icon for this computer.
+     * 
+     * @see #getIconClassName()
+     */
     @Exported
     public String getIcon() {
         if(isOffline())
@@ -726,6 +733,15 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             return "computer.png";
     }
 
+    /**
+     * Returns the class name that will be used to lookup the icon.
+     * 
+     * This class name will be added as a class tag to the html img tags where the icon should
+     * show up followed by a size specifier given by {@link Icon#toNormalizedIconSizeClass(String)}
+     * The conversion of class tag to src tag is registered through {@link IconSet#addIcon(Icon)}
+     * 
+     * @see #getIcon()
+     */
     @Exported
     public String getIconClassName() {
         if(isOffline())

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -722,6 +722,8 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
 
     /**
      * Returns the icon for this computer.
+     * 	 
+     * It is both the recommended and default implementation to serve different icons based on {@link #isOffline}
      * 
      * @see #getIconClassName()
      */
@@ -739,6 +741,8 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      * This class name will be added as a class tag to the html img tags where the icon should
      * show up followed by a size specifier given by {@link Icon#toNormalizedIconSizeClass(String)}
      * The conversion of class tag to src tag is registered through {@link IconSet#addIcon(Icon)}
+     * 
+     * It is both the recommended and default implementation to serve different icons based on {@link #isOffline}
      * 
      * @see #getIcon()
      */

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
   <d:taglib uri="local">
     <d:tag name="computerCaption">
 
-      <a href="${rootURL}/${c.url}" class="model-link inside"><l:icon class="icon-computer${c.offline?'-x':''} icon-sm" alt="${altText}"/><st:nbsp/>${title}</a>
+      <a href="${rootURL}/${c.url}" class="model-link inside"><l:icon class="${c.iconClassName} icon-sm" alt="${altText}"/><st:nbsp/>${title}</a>
       <j:if test="${c.offline}"> <st:nbsp/> (${%offline})</j:if>
       <j:if test="${!c.acceptingTasks}"> <st:nbsp/> (${%suspended})</j:if>
     </d:tag>


### PR DESCRIPTION
[JENKINS-36775](https://issues.jenkins-ci.org/browse/JENKINS-36775)
