### PR TITLE
Remove API restriction on UserDetailsCache

### DIFF
--- a/core/src/main/java/jenkins/security/UserDetailsCache.java
+++ b/core/src/main/java/jenkins/security/UserDetailsCache.java
@@ -50,7 +50,6 @@ import static com.google.common.cache.CacheBuilder.newBuilder;
  * @since TODO
  */
 @Extension
-@Restricted(NoExternalUse.class) //TODO Keep for LTS, Remove when in weekly
 public final class UserDetailsCache {
 
     private static final String SYS_PROP_NAME = UserDetailsCache.class.getName() + ".EXPIRE_AFTER_WRITE_SEC";


### PR DESCRIPTION
Followup to #2446 to remove the API restriction
so that the first fix can potentially be picked
for LTS while this stays in the weekly release.
