### PR TITLE
[FIXED JENKINS-36940] Remove trailing space from ES Hudson.DisplayName

### DIFF
--- a/core/src/main/resources/jenkins/model/Messages_es.properties
+++ b/core/src/main/resources/jenkins/model/Messages_es.properties
@@ -24,7 +24,7 @@ Hudson.BadPortNumber=N\u00famero erroneo de puerto {0}
 Hudson.Computer.Caption=Principal
 Hudson.Computer.DisplayName=principal
 Hudson.ControlCodeNotAllowed=El c\u00f3digo de control {0} no est\u00e1 permitido
-Hudson.DisplayName=Jenkins 
+Hudson.DisplayName=Jenkins
 Hudson.JobAlreadyExists=Una tarea con el nombre ''{0}'' ya existe
 Hudson.NoJavaInPath=No se encuentra el comando java en el ''PATH''. Quiz\u00e1s necesite configurar <a href=''{0}/configure''> JDKs</a>?
 Hudson.NoName=No se ha especificado un nombre


### PR DESCRIPTION
Noticed it while investigating https://groups.google.com/forum/#!topic/jenkinsci-dev/rwu5AzMilII

This is the only Hudson.DisplayName that has the trailing space.
