### PR TITLE
[FIXED JENKINS-36922] Upgrade to instance-identity-module 2.0

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -99,7 +99,13 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>1.5.1</version>
+      <version>2.0</version>
+    </dependency>
+    <dependency>
+      <!-- TODO remove once bouncycastle-api plugin bundles bouncycastle -->
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.54</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
- We migrate the bcpkix dependency from instance-identity to the war's WEB-INF/lib so that the net effect is zero and we are still not exposiing the bcpkix as a transitive dependency of jenkins-core

@jenkinsci/code-reviewers @reviewbybees

See [JENKINS-36922](https://issues.jenkins-ci.org/browse/JENKINS-36922)
