### PR TITLE
FIXED JENKINS-36282 - "Export as plain XML" option doesn´t export jobs inside folders

### DIFF
--- a/core/src/main/java/hudson/model/AllView.java
+++ b/core/src/main/java/hudson/model/AllView.java
@@ -80,6 +80,11 @@ public class AllView extends View {
     }
 
     @Override
+    public Collection<TopLevelItem> getAllItems() {
+        return Items.getAllItems(getOwnerItemGroup(), TopLevelItem.class);
+    }
+
+    @Override
     public String getPostConstructLandingPage() {
         return ""; // there's no configuration page
     }

--- a/core/src/main/resources/hudson/model/View/cc.xml.jelly
+++ b/core/src/main/resources/hudson/model/View/cc.xml.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
   <j:new var="h" className="hudson.Functions" />
 
   <Projects>
-    <j:forEach var="p" items="${it.items}">
+    <j:forEach var="p" items="${it.allItems}">
       <j:set var="lb" value="${p.lastCompletedBuild}"/>
       <j:if test="${lb!=null}">
         <Project  name="${p.displayName}"


### PR DESCRIPTION
Adding a new method to obtain all items in `hudson.model.AllView.java` and using it in `cc.xml.jelly`

More info in [JENKINS-36282](https://issues.jenkins-ci.org/browse/JENKINS-36282)

@reviewbybees
