### PR TITLE
[JENKINS-36871] Allow accessing instance identity from core

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -117,7 +117,7 @@ public final class TcpSlaveAgentListener extends Thread {
     @Nullable
     public String getIdentityPublicKey() {
         InstanceIdentityProvider<RSAPublicKey, RSAPrivateKey> provider =
-                InstanceIdentityProvider.get(RSAPrivateKey.class);
+                InstanceIdentityProvider.get(InstanceIdentityProvider.RSA);
         RSAPublicKey key = provider == null ? null : provider.getPublicKey();
         return key == null ? null : new String(Base64.encodeBase64(key.getEncoded()), Charset.forName("UTF-8"));
     }

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -23,6 +23,11 @@
  */
 package hudson;
 
+import java.nio.charset.Charset;
+import java.security.interfaces.RSAPublicKey;
+import java.security.interfaces.RSAPrivateKey;
+import javax.annotation.Nullable;
+import jenkins.model.identity.InstanceIdentityProvider;
 import jenkins.util.SystemProperties;
 import hudson.slaves.OfflineCause;
 import java.io.DataOutputStream;
@@ -44,6 +49,7 @@ import java.net.Socket;
 import java.nio.channels.ServerSocketChannel;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 
 /**
@@ -102,6 +108,20 @@ public final class TcpSlaveAgentListener extends Thread {
     public int getAdvertisedPort() {
         return CLI_PORT != null ? CLI_PORT : getPort();
     }
+
+    /**
+     * Gets the Base64 encoded public key that forms part of this instance's identity keypair.
+     * @return the Base64 encoded public key
+     * @since FIXME
+     */
+    @Nullable
+    public String getIdentityPublicKey() {
+        InstanceIdentityProvider<RSAPublicKey, RSAPrivateKey> provider =
+                InstanceIdentityProvider.get(RSAPrivateKey.class);
+        RSAPublicKey key = provider == null ? null : provider.getPublicKey();
+        return key == null ? null : new String(Base64.encodeBase64(key.getEncoded()), Charset.forName("UTF-8"));
+    }
+
 
     @Override
     public void run() {

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -116,9 +116,7 @@ public final class TcpSlaveAgentListener extends Thread {
      */
     @Nullable
     public String getIdentityPublicKey() {
-        InstanceIdentityProvider<RSAPublicKey, RSAPrivateKey> provider =
-                InstanceIdentityProvider.get(InstanceIdentityProvider.RSA);
-        RSAPublicKey key = provider == null ? null : provider.getPublicKey();
+        RSAPublicKey key = InstanceIdentityProvider.RSA.getPublicKey();
         return key == null ? null : new String(Base64.encodeBase64(key.getEncoded()), Charset.forName("UTF-8"));
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4796,7 +4796,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         "/signup",
         "/tcpSlaveAgentListener",
         "/federatedLoginService/",
-        "/securityRealm"
+        "/securityRealm",
+        "/instance-identity"
     );
 
     /**

--- a/core/src/main/java/jenkins/model/identity/IdentityRootAction.java
+++ b/core/src/main/java/jenkins/model/identity/IdentityRootAction.java
@@ -39,8 +39,7 @@ public class IdentityRootAction implements UnprotectedRootAction {
      */
     @Override
     public String getUrlName() {
-        return InstanceIdentityProvider.get(InstanceIdentityProvider.RSA) == null
-                ? null : "instance-identity";
+        return InstanceIdentityProvider.RSA.getKeyPair() == null ? null : "instance-identity";
     }
 
     /**
@@ -49,9 +48,7 @@ public class IdentityRootAction implements UnprotectedRootAction {
      * @return the PEM encoded public key.
      */
     public String getPublicKey() {
-        InstanceIdentityProvider<RSAPublicKey, RSAPrivateKey> provider =
-                InstanceIdentityProvider.get(InstanceIdentityProvider.RSA);
-        RSAPublicKey key = provider == null ? null : provider.getPublicKey();
+        RSAPublicKey key = InstanceIdentityProvider.RSA.getPublicKey();
         if (key == null) {
             return null;
         }
@@ -75,9 +72,7 @@ public class IdentityRootAction implements UnprotectedRootAction {
      * @return the fingerprint of the public key.
      */
     public String getFingerprint() {
-        InstanceIdentityProvider<RSAPublicKey, RSAPrivateKey> provider =
-                InstanceIdentityProvider.get(InstanceIdentityProvider.RSA);
-        RSAPublicKey key = provider == null ? null : provider.getPublicKey();
+        RSAPublicKey key = InstanceIdentityProvider.RSA.getPublicKey();
         if (key == null) {
             return null;
         }

--- a/core/src/main/java/jenkins/model/identity/IdentityRootAction.java
+++ b/core/src/main/java/jenkins/model/identity/IdentityRootAction.java
@@ -39,7 +39,8 @@ public class IdentityRootAction implements UnprotectedRootAction {
      */
     @Override
     public String getUrlName() {
-        return InstanceIdentityProvider.get(RSAPrivateKey.class) == null ? null : "instance-identity";
+        return InstanceIdentityProvider.get(InstanceIdentityProvider.RSA) == null
+                ? null : "instance-identity";
     }
 
     /**
@@ -49,7 +50,7 @@ public class IdentityRootAction implements UnprotectedRootAction {
      */
     public String getPublicKey() {
         InstanceIdentityProvider<RSAPublicKey, RSAPrivateKey> provider =
-                InstanceIdentityProvider.get(RSAPrivateKey.class);
+                InstanceIdentityProvider.get(InstanceIdentityProvider.RSA);
         RSAPublicKey key = provider == null ? null : provider.getPublicKey();
         if (key == null) {
             return null;
@@ -75,7 +76,7 @@ public class IdentityRootAction implements UnprotectedRootAction {
      */
     public String getFingerprint() {
         InstanceIdentityProvider<RSAPublicKey, RSAPrivateKey> provider =
-                InstanceIdentityProvider.get(RSAPrivateKey.class);
+                InstanceIdentityProvider.get(InstanceIdentityProvider.RSA);
         RSAPublicKey key = provider == null ? null : provider.getPublicKey();
         if (key == null) {
             return null;

--- a/core/src/main/java/jenkins/model/identity/IdentityRootAction.java
+++ b/core/src/main/java/jenkins/model/identity/IdentityRootAction.java
@@ -1,0 +1,81 @@
+package jenkins.model.identity;
+
+import hudson.Extension;
+import hudson.model.UnprotectedRootAction;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import org.apache.commons.codec.Charsets;
+import org.apache.commons.codec.binary.Base64;
+import org.jenkinsci.remoting.util.KeyUtils;
+
+/**
+ * A simple root action that exposes the public key to users so that they do not need to search for the
+ * {@code X-Instance-Identity} response header, also exposes the fingerprint of the public key so that people
+ * can verify a fingerprint of a master before connecting to it.
+ *
+ * @since FIXME
+ */
+@Extension
+public class IdentityRootAction implements UnprotectedRootAction {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getUrlName() {
+        return InstanceIdentityProvider.get(RSAPrivateKey.class) == null ? null : "instance-identity";
+    }
+
+    /**
+     * Returns the PEM encoded public key.
+     *
+     * @return the PEM encoded public key.
+     */
+    public String getPublicKey() {
+        InstanceIdentityProvider<RSAPublicKey, RSAPrivateKey> provider =
+                InstanceIdentityProvider.get(RSAPrivateKey.class);
+        RSAPublicKey key = provider == null ? null : provider.getPublicKey();
+        if (key == null) {
+            return null;
+        }
+        byte[] encoded = Base64.encodeBase64(key.getEncoded());
+        int index = 0;
+        StringBuilder buf = new StringBuilder(encoded.length + 20);
+        while (index < encoded.length) {
+            int len = Math.min(64, encoded.length - index);
+            if (index > 0) {
+                buf.append("\n");
+            }
+            buf.append(new String(encoded, index, len, Charsets.UTF_8));
+            index += len;
+        }
+        return String.format("-----BEGIN PUBLIC KEY-----%n%s%n-----END PUBLIC KEY-----%n", buf.toString());
+    }
+
+    /**
+     * Returns the fingerprint of the public key.
+     *
+     * @return the fingerprint of the public key.
+     */
+    public String getFingerprint() {
+        InstanceIdentityProvider<RSAPublicKey, RSAPrivateKey> provider =
+                InstanceIdentityProvider.get(RSAPrivateKey.class);
+        RSAPublicKey key = provider == null ? null : provider.getPublicKey();
+        return key == null ? null : KeyUtils.fingerprint(key);
+    }
+}

--- a/core/src/main/java/jenkins/model/identity/InstanceIdentityProvider.java
+++ b/core/src/main/java/jenkins/model/identity/InstanceIdentityProvider.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model.identity;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import javax.annotation.CheckForNull;
+
+/**
+ * A source of instance identity.
+ *
+ * @param <PUB>  the type of public key.
+ * @param <PRIV> the type of private key.
+ * @since FIXME
+ */
+public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV extends PrivateKey> implements
+        ExtensionPoint {
+    /**
+     * Gets the {@link KeyPair} that comprises the instance identity.
+     *
+     * @return the {@link KeyPair} that comprises the instance identity.
+     */
+    @CheckForNull
+    public abstract KeyPair getKeyPair();
+
+    /**
+     * Shortcut to {@link KeyPair#getPublic()}.
+     *
+     * @return the public key.
+     */
+    @CheckForNull
+    public PUB getPublicKey() {
+        KeyPair keyPair = getKeyPair();
+        return keyPair == null ? null : (PUB) keyPair.getPublic();
+    }
+
+    /**
+     * Shortcut to {@link KeyPair#getPrivate()}.
+     *
+     * @return the private key.
+     */
+    @CheckForNull
+    public PRIV getPrivateKey() {
+        KeyPair keyPair = getKeyPair();
+        return keyPair == null ? null : (PRIV) keyPair.getPublic();
+    }
+
+    /**
+     * Gets the self-signed {@link X509Certificate} that is associated with this identity. The certificate
+     * will must be currently valid. Repeated calls to this method may result in new certificates being generated.
+     *
+     * @return the certificate.
+     */
+    @CheckForNull
+    public abstract X509Certificate getCertificate();
+
+    /**
+     * Gets the provider of the required identity type.
+     *
+     * @param keyType the type of private key.
+     * @param <PUB>   the type of public key.
+     * @param <PRIV>  the type of private key.
+     * @return the provider or {@code null} if no provider of the specified type is available.
+     */
+    @CheckForNull
+    @SuppressWarnings("unchecked")
+    public static <PUB extends PublicKey, PRIV extends PrivateKey> InstanceIdentityProvider<PUB, PRIV> get(
+            Class<PRIV> keyType) {
+        for (InstanceIdentityProvider provider : ExtensionList.lookup(InstanceIdentityProvider.class)) {
+            KeyPair keyPair = provider.getKeyPair();
+            if (keyPair != null && keyType.isInstance(keyPair.getPrivate())) {
+                return (InstanceIdentityProvider<PUB, PRIV>) provider;
+            }
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/jenkins/model/identity/InstanceIdentityProvider.java
+++ b/core/src/main/java/jenkins/model/identity/InstanceIdentityProvider.java
@@ -35,6 +35,8 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
@@ -47,6 +49,11 @@ import javax.annotation.Nonnull;
  */
 public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV extends PrivateKey> implements
         ExtensionPoint {
+
+    /**
+     * Our logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(InstanceIdentityProvider.class.getName());
     /**
      * RSA keys.
      */
@@ -146,11 +153,23 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
         private static <PUB extends PublicKey, PRIV extends PrivateKey> InstanceIdentityProvider<PUB, PRIV> get(
                 @Nonnull KeyTypes<PUB, PRIV> type) {
             for (InstanceIdentityProvider provider : ExtensionList.lookup(InstanceIdentityProvider.class)) {
-                KeyPair keyPair = provider.getKeyPair();
-                if (keyPair != null
-                        && type.pubKeyType.isInstance(keyPair.getPublic())
-                        && type.privKeyType.isInstance(keyPair.getPrivate())) {
-                    return (InstanceIdentityProvider<PUB, PRIV>) provider;
+                try {
+                    KeyPair keyPair = provider.getKeyPair();
+                    if (keyPair != null
+                            && type.pubKeyType.isInstance(keyPair.getPublic())
+                            && type.privKeyType.isInstance(keyPair.getPrivate())) {
+                        return (InstanceIdentityProvider<PUB, PRIV>) provider;
+                    }
+                } catch (RuntimeException e) {
+                    LOGGER.log(Level.WARNING,
+                            "Instance identity provider " + provider + " propagated a runtime exception", e);
+                } catch (Error e) {
+                    LOGGER.log(Level.INFO,
+                            "Encountered an error while consulting instance identity provider " + provider, e);
+                    throw e;
+                } catch (Throwable e) {
+                    LOGGER.log(Level.SEVERE,
+                            "Instance identity provider " + provider + " propagated an uncaught exception", e);
                 }
             }
             return null;
@@ -185,7 +204,21 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
         @CheckForNull
         public KeyPair getKeyPair() {
             InstanceIdentityProvider<PUB, PRIV> provider = get(this);
-            return provider == null ? null : provider.getKeyPair();
+            try {
+                return provider == null ? null : provider.getKeyPair();
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING,
+                        "Instance identity provider " + provider + " propagated a runtime exception", e);
+                return null;
+            } catch (Error e) {
+                LOGGER.log(Level.INFO,
+                        "Encountered an error while consulting instance identity provider " + provider, e);
+                throw e;
+            } catch (Throwable e) {
+                LOGGER.log(Level.SEVERE,
+                        "Instance identity provider " + provider + " propagated an uncaught exception", e);
+                return null;
+            }
         }
 
         /**
@@ -196,7 +229,21 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
         @CheckForNull
         public PUB getPublicKey() {
             InstanceIdentityProvider<PUB, PRIV> provider = get(this);
-            return provider == null ? null : provider.getPublicKey();
+            try {
+                return provider == null ? null : provider.getPublicKey();
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING,
+                        "Instance identity provider " + provider + " propagated a runtime exception", e);
+                return null;
+            } catch (Error e) {
+                LOGGER.log(Level.INFO,
+                        "Encountered an error while consulting instance identity provider " + provider, e);
+                throw e;
+            } catch (Throwable e) {
+                LOGGER.log(Level.SEVERE,
+                        "Instance identity provider " + provider + " propagated an uncaught exception", e);
+                return null;
+            }
         }
 
         /**
@@ -207,7 +254,21 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
         @CheckForNull
         public PRIV getPrivateKey() {
             InstanceIdentityProvider<PUB, PRIV> provider = get(this);
-            return provider == null ? null : provider.getPrivateKey();
+            try {
+                return provider == null ? null : provider.getPrivateKey();
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING,
+                        "Instance identity provider " + provider + " propagated a runtime exception", e);
+                return null;
+            } catch (Error e) {
+                LOGGER.log(Level.INFO,
+                        "Encountered an error while consulting instance identity provider " + provider, e);
+                throw e;
+            } catch (Throwable e) {
+                LOGGER.log(Level.SEVERE,
+                        "Instance identity provider " + provider + " propagated an uncaught exception", e);
+                return null;
+            }
         }
 
         /**
@@ -219,7 +280,21 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
         @CheckForNull
         public X509Certificate getCertificate() {
             InstanceIdentityProvider<PUB, PRIV> provider = get(this);
-            return provider == null ? null : provider.getCertificate();
+            try {
+                return provider == null ? null : provider.getCertificate();
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING,
+                        "Instance identity provider " + provider + " propagated a runtime exception", e);
+                return null;
+            } catch (Error e) {
+                LOGGER.log(Level.INFO,
+                        "Encountered an error while consulting instance identity provider " + provider, e);
+                throw e;
+            } catch (Throwable e) {
+                LOGGER.log(Level.SEVERE,
+                        "Instance identity provider " + provider + " propagated an uncaught exception", e);
+                return null;
+            }
         }
     }
 

--- a/core/src/main/java/jenkins/model/identity/InstanceIdentityProvider.java
+++ b/core/src/main/java/jenkins/model/identity/InstanceIdentityProvider.java
@@ -30,6 +30,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 
 /**
  * A source of instance identity.
@@ -43,17 +44,21 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
     /**
      * Gets the {@link KeyPair} that comprises the instance identity.
      *
-     * @return the {@link KeyPair} that comprises the instance identity.
+     * @return the {@link KeyPair} that comprises the instance identity. {@code null} could technically be returned in
+     * the event that a keypair could not be generated, for example if the specific key type of this provider
+     * is not permitted at the required length by the JCA policy.
      */
-    @CheckForNull
+    @Nullable
     public abstract KeyPair getKeyPair();
 
     /**
      * Shortcut to {@link KeyPair#getPublic()}.
      *
-     * @return the public key.
+     * @return the public key. {@code null} could technically be returned in the event that a keypair could not be
+     * generated, for example if the specific key type of this provider is not permitted at the required length by
+     * the JCA policy.
      */
-    @CheckForNull
+    @Nullable
     public PUB getPublicKey() {
         KeyPair keyPair = getKeyPair();
         return keyPair == null ? null : (PUB) keyPair.getPublic();
@@ -62,21 +67,25 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
     /**
      * Shortcut to {@link KeyPair#getPrivate()}.
      *
-     * @return the private key.
+     * @return the private key. {@code null} could technically be returned in the event that a keypair could not be
+     * generated, for example if the specific key type of this provider is not permitted at the required length by
+     * the JCA policy.
      */
-    @CheckForNull
+    @Nullable
     public PRIV getPrivateKey() {
         KeyPair keyPair = getKeyPair();
-        return keyPair == null ? null : (PRIV) keyPair.getPublic();
+        return keyPair == null ? null : (PRIV) keyPair.getPrivate();
     }
 
     /**
      * Gets the self-signed {@link X509Certificate} that is associated with this identity. The certificate
      * will must be currently valid. Repeated calls to this method may result in new certificates being generated.
      *
-     * @return the certificate.
+     * @return the certificate. {@code null} could technically be returned in the event that a keypair could not be
+     * generated, for example if the specific key type of this provider is not permitted at the required length by
+     * the JCA policy.
      */
-    @CheckForNull
+    @Nullable
     public abstract X509Certificate getCertificate();
 
     /**

--- a/core/src/main/java/jenkins/model/identity/InstanceIdentityProvider.java
+++ b/core/src/main/java/jenkins/model/identity/InstanceIdentityProvider.java
@@ -71,7 +71,7 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
      * is not permitted at the required length by the JCA policy.
      */
     @CheckForNull
-    public abstract KeyPair getKeyPair();
+    protected abstract KeyPair getKeyPair();
 
     /**
      * Shortcut to {@link KeyPair#getPublic()}.
@@ -80,7 +80,7 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
      */
     @SuppressWarnings("unchecked")
     @CheckForNull
-    public PUB getPublicKey() {
+    protected PUB getPublicKey() {
         KeyPair keyPair = getKeyPair();
         return keyPair == null ? null : (PUB) keyPair.getPublic();
     }
@@ -92,7 +92,7 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
      */
     @SuppressWarnings("unchecked")
     @CheckForNull
-    public PRIV getPrivateKey() {
+    protected PRIV getPrivateKey() {
         KeyPair keyPair = getKeyPair();
         return keyPair == null ? null : (PRIV) keyPair.getPrivate();
     }
@@ -104,7 +104,7 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
      * @return the certificate. {@code null} if {@link #getKeyPair()} is {@code null}.
      */
     @CheckForNull
-    public abstract X509Certificate getCertificate();
+    protected abstract X509Certificate getCertificate();
 
     /**
      * Holds information about the paired keytypes that can be used to form the various identity keys.

--- a/core/src/main/java/jenkins/model/identity/InstanceIdentityProvider.java
+++ b/core/src/main/java/jenkins/model/identity/InstanceIdentityProvider.java
@@ -48,17 +48,15 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
      * the event that a keypair could not be generated, for example if the specific key type of this provider
      * is not permitted at the required length by the JCA policy.
      */
-    @Nullable
+    @CheckForNull
     public abstract KeyPair getKeyPair();
 
     /**
      * Shortcut to {@link KeyPair#getPublic()}.
      *
-     * @return the public key. {@code null} could technically be returned in the event that a keypair could not be
-     * generated, for example if the specific key type of this provider is not permitted at the required length by
-     * the JCA policy.
+     * @return the public key. {@code null} if {@link #getKeyPair()} is {@code null}.
      */
-    @Nullable
+    @CheckForNull
     public PUB getPublicKey() {
         KeyPair keyPair = getKeyPair();
         return keyPair == null ? null : (PUB) keyPair.getPublic();
@@ -67,11 +65,9 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
     /**
      * Shortcut to {@link KeyPair#getPrivate()}.
      *
-     * @return the private key. {@code null} could technically be returned in the event that a keypair could not be
-     * generated, for example if the specific key type of this provider is not permitted at the required length by
-     * the JCA policy.
+     * @return the private key. {@code null} if {@link #getKeyPair()} is {@code null}.
      */
-    @Nullable
+    @CheckForNull
     public PRIV getPrivateKey() {
         KeyPair keyPair = getKeyPair();
         return keyPair == null ? null : (PRIV) keyPair.getPrivate();
@@ -81,11 +77,9 @@ public abstract class InstanceIdentityProvider<PUB extends PublicKey, PRIV exten
      * Gets the self-signed {@link X509Certificate} that is associated with this identity. The certificate
      * will must be currently valid. Repeated calls to this method may result in new certificates being generated.
      *
-     * @return the certificate. {@code null} could technically be returned in the event that a keypair could not be
-     * generated, for example if the specific key type of this provider is not permitted at the required length by
-     * the JCA policy.
+     * @return the certificate. {@code null} if {@link #getKeyPair()} is {@code null}.
      */
-    @Nullable
+    @CheckForNull
     public abstract X509Certificate getCertificate();
 
     /**

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol3.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol3.java
@@ -39,8 +39,7 @@ public class JnlpSlaveAgentProtocol3 extends AgentProtocol {
 
     @Override
     public String getName() {
-        if (ENABLED)    return "JNLP3-connect";
-        else            return "JNLP3-disabled";
+        return ENABLED ? "JNLP3-connect" : null;
     }
 
     @Override

--- a/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
+++ b/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <st:contentType value="text/plain;charset=UTF-8"/>
   <!--
     Publicize the TCP port number for JNLP agents so that they know where to conenct.
     Keep the legacy header for better backward compatibility

--- a/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
+++ b/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
@@ -34,6 +34,8 @@ THE SOFTWARE.
     if the host name is overriden, advertise that as well
   -->
   <st:header name="X-Jenkins-JNLP-Host" value="${app.tcpSlaveAgentListener.CLI_HOST_NAME}" />
+  <!-- publish the instance identity so that agents can verify match from discovery -->
+  <st:header name="X-Instance-Identity" value="${app.tcpSlaveAgentListener.identityPublicKey}" />
 
   Jenkins
 </j:jelly>

--- a/core/src/main/resources/jenkins/model/identity/IdentityRootAction/index.jelly
+++ b/core/src/main/resources/jenkins/model/identity/IdentityRootAction/index.jelly
@@ -11,12 +11,12 @@
       </j:otherwise>
     </j:choose>
     <l:main-panel>
-      <h1><l:icon class="icon-help icon-xlg" tooltip="${%helpUrl}"/> ${%Instance Identity}</h1>
+      <h1><l:icon class="icon-help icon-xlg"/> ${%Instance Identity}</h1>
       <p>${%blurb}</p>
       <h2>${%Public Key}</h2>
-      <pre>${it.publicKey}</pre>
+      <pre id="key">${it.publicKey}</pre>
       <h2>${%Fingerprint}</h2>
-      <pre>${it.fingerprint}</pre>
+      <pre id="fingerprint">${it.fingerprint}</pre>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/jenkins/model/identity/IdentityRootAction/index.jelly
+++ b/core/src/main/resources/jenkins/model/identity/IdentityRootAction/index.jelly
@@ -1,0 +1,22 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:layout title="${%Instance Identity}">
+    <j:choose>
+      <j:when test="${app.hasPermission(app.READ)}">
+        <st:include page="sidepanel" it="${app}"/>
+      </j:when>
+      <j:otherwise>
+        <l:side-panel/>
+      </j:otherwise>
+    </j:choose>
+    <l:main-panel>
+      <h1><l:icon class="icon-help icon-xlg" tooltip="${%helpUrl}"/> ${%Instance Identity}</h1>
+      <p>${%blurb}</p>
+      <h2>${%Public Key}</h2>
+      <pre>${it.publicKey}</pre>
+      <h2>${%Fingerprint}</h2>
+      <pre>${it.fingerprint}</pre>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/core/src/main/resources/jenkins/model/identity/IdentityRootAction/index.properties
+++ b/core/src/main/resources/jenkins/model/identity/IdentityRootAction/index.properties
@@ -1,0 +1,3 @@
+blurb=Every Jenkins instance has a pair of public and private keys used to uniquely identify that Jenkins instance. \
+  The public key is published in the <code>X-Instance-Identity</code> header for web requests against the Jenkins UI. \
+  You can also find the key and the fingerprint of the key on this page.

--- a/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
+++ b/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
@@ -1,0 +1,70 @@
+package hudson;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.remoting.Base64;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import javax.annotation.Nullable;
+import jenkins.model.identity.InstanceIdentityProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class TcpSlaveAgentListenerTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void headers() throws Exception {
+        r.getInstance().setSlaveAgentPort(-1);
+        try {
+            r.createWebClient().goTo("tcpSlaveAgentListener");
+            fail("Should get 404");
+        } catch (FailingHttpStatusCodeException e) {
+            assertThat(e.getStatusCode(), is(404));
+        }
+        r.getInstance().setSlaveAgentPort(0);
+        Page p = r.createWebClient().goTo("tcpSlaveAgentListener", "text/plain");
+        assertThat(p.getWebResponse().getResponseHeaderValue("X-Instance-Identity"), notNullValue());
+    }
+
+    @TestExtension // TODO remove once instance-identity with provider impl embedded in war
+    public static class ProviderImpl extends InstanceIdentityProvider<RSAPublicKey,RSAPrivateKey> {
+
+        private final KeyPair keyPair;
+
+        public ProviderImpl() throws NoSuchAlgorithmException, InvalidKeySpecException {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(1024);
+            this.keyPair = generator.generateKeyPair();
+        }
+
+        @Nullable
+        @Override
+        public KeyPair getKeyPair() {
+            return keyPair;
+        }
+
+        @Nullable
+        @Override
+        public X509Certificate getCertificate() {
+            return null;
+        }
+    }
+}

--- a/test/src/test/java/jenkins/model/identity/IdentityRootActionTest.java
+++ b/test/src/test/java/jenkins/model/identity/IdentityRootActionTest.java
@@ -1,0 +1,57 @@
+package jenkins.model.identity;
+
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.ExtensionList;
+import hudson.model.UnprotectedRootAction;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import javax.annotation.Nullable;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class IdentityRootActionTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void ui() throws Exception {
+        HtmlPage p = r.createWebClient().goTo("instance-identity");
+        assertThat(p.getElementById("fingerprint").getTextContent(),
+                containsString(ExtensionList.lookup(UnprotectedRootAction.class).get(IdentityRootAction.class).getFingerprint()));
+    }
+
+    @TestExtension // TODO remove once instance-identity with provider impl embedded in war
+    public static class ProviderImpl extends InstanceIdentityProvider<RSAPublicKey,RSAPrivateKey> {
+
+        private final KeyPair keyPair;
+
+        public ProviderImpl() throws NoSuchAlgorithmException, InvalidKeySpecException {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(1024);
+            this.keyPair = generator.generateKeyPair();
+        }
+
+        @Nullable
+        @Override
+        public KeyPair getKeyPair() {
+            return keyPair;
+        }
+
+        @Nullable
+        @Override
+        public X509Certificate getCertificate() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
See [JENKINS-36871](https://issues.jenkins-ci.org/browse/JENKINS-36871) for the context.

The localized context of this change is as follows:
- We need to be able to allow users to easily view the instance identity's public key 
- We need to be able to access the instance identity's public/private keys and a self-signed certificate of them to enable TLS encryption of the JNLP connection via a TLS upgrade mechanism on the plaintext agent listener port

While the first could be handled entirely from within the Instance Identity module, the second would require supporting changes in core... and if we are making changes in core it is better to do the right changes in core.

We could just move the instance identity code directly into core... except that this would pull a hard dependency on either bouncycastle or a shaded bouncycastle into the core classpath... and we are [trying to remove bouncycastle from the core classpath](https://github.com/jenkinsci/jenkins/pull/2475) and adding a shaded one would only cause confusion for duck-typers.

Thus we expose the extension point in Jenkins core and then get instance identity to implement it... (there is some fun in how we get the coordinated releases out, but I am waiting on other PRs before I can get to that and add the changes to the pom.xml to pick up instance-identity 2.1 with the implemented provider)

@jenkinsci/code-reviewers @reviewbybees 
