### PR TITLE
[JENKINS-13190] AuthorizationStrategyOverride

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -495,7 +495,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      * Returns the {@link ACL} for this object.
      */
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.getInstance().getOverriddenAuthorizationStrategy().getACL(this);
     }
 
     /**

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -320,7 +320,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.getInstance().getOverriddenAuthorizationStrategy().getACL(this);
     }
 
     public void checkPermission(Permission permission) {

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1529,7 +1529,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      */
     @Override
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.getInstance().getOverriddenAuthorizationStrategy().getACL(this);
     }
 
     public BuildTimelineWidget getTimeline() {

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -457,7 +457,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
     }
 
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.getInstance().getOverriddenAuthorizationStrategy().getACL(this);
     }
 
     public final void checkPermission(Permission permission) {

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -867,7 +867,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     }
 
     public ACL getACL() {
-        final ACL base = Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        final ACL base = Jenkins.getInstance().getOverriddenAuthorizationStrategy().getACL(this);
         // always allow a non-anonymous user full control of himself.
         return new ACL() {
             public boolean hasPermission(Authentication a, Permission permission) {

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -584,7 +584,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
      * Returns the {@link ACL} for this object.
      */
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.getInstance().getOverriddenAuthorizationStrategy().getACL(this);
     }
 
     public void checkPermission(Permission p) {

--- a/core/src/main/java/hudson/security/AuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/AuthorizationStrategy.java
@@ -68,6 +68,11 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * for all the other model objects eventually delegate.
      * <p>
      * IOW, this ACL will have the ultimate say on the access control.
+     *
+     * <p>
+     * Plugins may define this method
+     * but should not call this method directly,
+     * and should call {@link Jenkins#getACL()} instead.
      */
     public abstract @Nonnull ACL getRootACL();
 
@@ -80,6 +85,17 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
     	return getACL((Job)project);
     }
 
+    /**
+     * Returns the instance of {@link ACL} for a job.
+     *
+     * <p>
+     * Plugins may define this method
+     * but should not call this method directly,
+     * and should call {@link Job#getACL()} instead.
+     *
+     * @param project job
+     * @return ACL for the job.
+     */
     public @Nonnull ACL getACL(@Nonnull Job<?,?> project) {
     	return getRootACL();
     }
@@ -91,6 +107,11 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * <p>
      * The default implementation makes the view visible if any of the items are visible
      * or the view is configurable.
+     *
+     * <p>
+     * Plugins may define this method
+     * but should not call this method directly,
+     * and should call {@link View#getACL()} instead.
      *
      * @since 1.220
      */
@@ -117,6 +138,11 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * <p>
      * The default implementation returns {@link #getRootACL()}.
      *
+     * <p>
+     * Plugins may define this method
+     * but should not call this method directly,
+     * and should call {@link AbstractItem#getACL()} instead.
+     * 
      * @since 1.220
      */
     public @Nonnull ACL getACL(@Nonnull AbstractItem item) {
@@ -129,6 +155,11 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      *
      * <p>
      * The default implementation returns {@link #getRootACL()}.
+     *
+     * <p>
+     * Plugins may define this method
+     * but should not call this method directly,
+     * and should call {@link User#getACL()} instead.
      *
      * @since 1.221
      */
@@ -143,6 +174,11 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * <p>
      * The default implementation delegates to {@link #getACL(Node)}
      *
+     * <p>
+     * Plugins may define this method
+     * but should not call this method directly,
+     * and should call {@link Computer#getACL()} instead.
+     *
      * @since 1.220
      */
     public @Nonnull ACL getACL(@Nonnull Computer computer) {
@@ -156,12 +192,32 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * <p>
      * The default implementation returns {@link #getRootACL()}.
      *
+     * <p>
+     * Plugins may define this method
+     * but should not call this method directly,
+     * and should call {@link Cloud#getACL()} instead.
+     *
      * @since 1.252
      */
     public @Nonnull ACL getACL(@Nonnull Cloud cloud) {
         return getRootACL();
     }
 
+    /**
+     * Implementation can choose to provide different ACL for different {@link Node}s.
+     * This can be used as a basis for more fine-grained access control.
+     *
+     * <p>
+     * The default implementation returns {@link #getRootACL()}.
+     *
+     * <p>
+     * Plugins may define this method
+     * but should not call this method directly,
+     * and should call {@link Node#getACL()} instead.
+     *
+     * @param node
+     * @return
+     */
     public @Nonnull ACL getACL(@Nonnull Node node) {
         return getRootACL();
     }

--- a/core/src/main/java/hudson/security/AuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/AuthorizationStrategy.java
@@ -93,8 +93,8 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * but should not call this method directly,
      * and should call {@link Job#getACL()} instead.
      *
-     * @param project job
-     * @return ACL for the job.
+     * @param project a job to test access controls
+     * @return access controls for the job
      */
     public @Nonnull ACL getACL(@Nonnull Job<?,?> project) {
     	return getRootACL();
@@ -112,6 +112,9 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * Plugins may define this method
      * but should not call this method directly,
      * and should call {@link View#getACL()} instead.
+     *
+     * @param item a view to test access controls
+     * @return access controls for the view
      *
      * @since 1.220
      */
@@ -143,6 +146,9 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * but should not call this method directly,
      * and should call {@link AbstractItem#getACL()} instead.
      * 
+     * @param item an item to test access controls
+     * @return access controls for the item
+     *
      * @since 1.220
      */
     public @Nonnull ACL getACL(@Nonnull AbstractItem item) {
@@ -160,6 +166,9 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * Plugins may define this method
      * but should not call this method directly,
      * and should call {@link User#getACL()} instead.
+     *
+     * @param user a user to test access controls
+     * @return access controls for the user
      *
      * @since 1.221
      */
@@ -179,6 +188,9 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * but should not call this method directly,
      * and should call {@link Computer#getACL()} instead.
      *
+     * @param computer a computer to test access controls
+     * @return access controls for the computer
+     *
      * @since 1.220
      */
     public @Nonnull ACL getACL(@Nonnull Computer computer) {
@@ -196,6 +208,9 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * Plugins may define this method
      * but should not call this method directly,
      * and should call {@link Cloud#getACL()} instead.
+     *
+     * @param cloud an cloud to test access controls
+     * @return access controls for the cloud
      *
      * @since 1.252
      */
@@ -215,8 +230,8 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
      * but should not call this method directly,
      * and should call {@link Node#getACL()} instead.
      *
-     * @param node
-     * @return
+     * @param node a node to test access controls
+     * @return access controls for the node
      */
     public @Nonnull ACL getACL(@Nonnull Node node) {
         return getRootACL();

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -104,7 +104,7 @@ public abstract class Cloud extends AbstractModelObject implements ExtensionPoin
     }
 
     public ACL getACL() {
-        return Jenkins.getInstance().getAuthorizationStrategy().getACL(this);
+        return Jenkins.getInstance().getOverriddenAuthorizationStrategy().getACL(this);
     }
 
     public final void checkPermission(Permission permission) {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -207,6 +207,7 @@ import jenkins.security.ConfidentialKey;
 import jenkins.security.ConfidentialStore;
 import jenkins.security.SecurityListener;
 import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.OverriddenAuthorizationStrategy;
 import jenkins.slaves.WorkspaceLocator;
 import jenkins.util.JenkinsJVM;
 import jenkins.util.Timer;
@@ -384,6 +385,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *
      * Never null.
      */
+    @Nonnull
     private volatile AuthorizationStrategy authorizationStrategy = AuthorizationStrategy.UNSECURED;
 
     /**
@@ -2426,15 +2428,40 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @Override
     public ACL getACL() {
-        return authorizationStrategy.getRootACL();
+        return getOverriddenAuthorizationStrategy().getRootACL();
     }
 
     /**
+     * {@link AuthorizationStrategy} configured in Global Security page.
+     *
+     * Use {@code getACL()} methods provided by items to get {@link ACL}s
+     * (e.g. {@link #getACL()}, {@link Job#getACL()}).
+     *
      * @return
      *      never null.
      */
+    @Nonnull
     public AuthorizationStrategy getAuthorizationStrategy() {
         return authorizationStrategy;
+    }
+
+    /**
+     * {@link AuthorizationStrategy} extended with extensions.
+     *
+     * This method is used by Jenkins internally and you never need to use this.
+     * You should use {@link #getAuthorizationStrategy()} to access the {@link AuthorizationStrategy}
+     * configured in Global Security page.
+     * And you should get {@link ACL}s with {@code getACL()} provided by target items,
+     * like {@link #getACL()}, {@link Job#getACL()} and so on.
+     *
+     * @return never {@code null}
+     * @since TODO
+     */
+    @Nonnull
+    public AuthorizationStrategy getOverriddenAuthorizationStrategy() {
+        return new OverriddenAuthorizationStrategy(
+            getAuthorizationStrategy()
+        );
     }
 
     /**

--- a/core/src/main/java/jenkins/security/AuthorizationStrategyDenyOverride.java
+++ b/core/src/main/java/jenkins/security/AuthorizationStrategyDenyOverride.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import org.acegisecurity.Authentication;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractItem;
+import hudson.model.Computer;
+import hudson.model.Job;
+import hudson.model.Node;
+import hudson.model.User;
+import hudson.model.View;
+import hudson.security.ACL;
+import hudson.security.Permission;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
+
+/**
+ * Extension point to override {@link ACL} to deny permissions.
+ *
+ * This extension is automatically enabled when installed.
+ *
+ * @param <T> target type.
+ *     This can be {@link Jenkins}, {@link Job}, {@link View}, {@link AbstractItem},
+ *     {@link User}, {@link Computer}, {@link Cloud} or {@link Node}.
+ *
+ * @since TODO
+ */
+public abstract class AuthorizationStrategyDenyOverride<T> extends AuthorizationStrategyOverrideBase<T> implements ExtensionPoint {
+    /**
+     * {@inheritDoc}
+     */
+    public final Boolean hasPermission(
+        @Nonnull T item,
+        @Nonnull Authentication a,
+        @Nonnull Permission p
+    ) {
+        if (deny(item, a, p)) {
+            return false;
+        }
+        return null;
+    }
+
+    /**
+     * Test whether to deny the permission.
+     *
+     * @param item target object.
+     * @param a authentication to test the permission
+     * @param p permission to test
+     * @return {@code true} to deny the permission. {@code false} otherwise.
+     */
+    public abstract boolean deny(
+        @Nonnull T item,
+        @Nonnull Authentication a,
+        @Nonnull Permission p
+    );
+
+    /**
+     * @return all registered {@link AuthorizationStrategyDenyOverride}
+     */
+    public static List<AuthorizationStrategyDenyOverride<?>> all() {
+        Jenkins j = Jenkins.getInstanceOrNull();
+        if (j == null) {
+            return Collections.emptyList();
+        }
+        // cast
+        // ExtensionList<AuthorizationStrategyDenyOverride>
+        // to
+        // List<AuthorizationStrategyDenyOverride<?>>
+        @SuppressWarnings("rawtypes")
+        List<AuthorizationStrategyDenyOverride<?>> lst = Lists.transform(
+                j.getExtensionList(AuthorizationStrategyDenyOverride.class),
+                new Function<AuthorizationStrategyDenyOverride, AuthorizationStrategyDenyOverride<?>>() {
+                    @Override
+                    public AuthorizationStrategyDenyOverride<?> apply(AuthorizationStrategyDenyOverride item) {
+                        return item;
+                    }
+                }
+        );
+        return lst;
+    }
+}

--- a/core/src/main/java/jenkins/security/AuthorizationStrategyOverride.java
+++ b/core/src/main/java/jenkins/security/AuthorizationStrategyOverride.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractItem;
+import hudson.model.Computer;
+import hudson.model.Describable;
+import hudson.model.Job;
+import hudson.model.Node;
+import hudson.model.User;
+import hudson.model.View;
+import hudson.security.ACL;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
+
+/**
+ * Extension point to override {@link ACL}.
+ *
+ * Administrators should configure explicitly
+ * to enable this extension.
+ *
+ * @param <T> target type.
+ *     This can be {@link Jenkins}, {@link Job}, {@link View}, {@link AbstractItem},
+ *     {@link User}, {@link Computer}, {@link Cloud} or {@link Node}.
+ *
+ * @see AuthorizationStrategyOverrideConfiguration
+ * @since TODO
+ */
+public abstract class AuthorizationStrategyOverride<T>
+    extends AuthorizationStrategyOverrideBase<T>
+    implements Describable<AuthorizationStrategyOverride<?>>, ExtensionPoint
+{
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthorizationStrategyOverrideDescriptor getDescriptor() {
+        return (AuthorizationStrategyOverrideDescriptor)Jenkins.getInstance().getDescriptorOrDie(getClass());
+    }
+}

--- a/core/src/main/java/jenkins/security/AuthorizationStrategyOverrideBase.java
+++ b/core/src/main/java/jenkins/security/AuthorizationStrategyOverrideBase.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import javax.annotation.Nonnull;
+
+import org.acegisecurity.Authentication;
+
+import hudson.model.AbstractItem;
+import hudson.model.Computer;
+import hudson.model.Job;
+import hudson.model.Node;
+import hudson.model.User;
+import hudson.model.View;
+import hudson.security.ACL;
+import hudson.security.Permission;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
+
+/**
+ * Overrides {@link ACL}.
+ *
+ * You don't derive classes from this class directly.
+ * Use {@link AuthorizationStrategyOverride} or {@link AuthorizationStrategyDenyOverride}
+ * as extension points.
+ *
+ * @param <T> target type.
+ *     This can be {@link Jenkins}, {@link Job}, {@link View}, {@link AbstractItem},
+ *     {@link User}, {@link Computer}, {@link Cloud} or {@link Node}.
+ *
+ * @since TODO
+ */
+public abstract class AuthorizationStrategyOverrideBase<T> {
+    /**
+     * Test the permission.
+     *
+     * This becomes the final result of the permission
+     * if you return non-null.
+     *
+     * @param item target object.
+     * @param a authentication to test the permission
+     * @param p permission to test
+     * @return {@code true} or {@code false} to override the permission. {@code null} otherwise.
+     */
+    public abstract Boolean hasPermission(
+        @Nonnull T item,
+        @Nonnull Authentication a,
+        @Nonnull Permission p
+    );
+}

--- a/core/src/main/java/jenkins/security/AuthorizationStrategyOverrideConfiguration.java
+++ b/core/src/main/java/jenkins/security/AuthorizationStrategyOverrideConfiguration.java
@@ -1,0 +1,169 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.Symbol;
+import org.jvnet.tiger_types.Types;
+import org.kohsuke.stapler.StaplerRequest;
+
+import com.google.inject.Injector;
+
+import hudson.Extension;
+import hudson.util.DescribableList;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+
+/**
+ * Configuration for {@link AuthorizationStrategyOverride}.
+ *
+ * @since TODO
+ */
+@Extension @Symbol("authorizationStrategyOverride")
+public class AuthorizationStrategyOverrideConfiguration extends GlobalConfiguration {
+    private final DescribableList<AuthorizationStrategyOverride<?>, AuthorizationStrategyOverrideDescriptor> overrides
+        = new DescribableList<AuthorizationStrategyOverride<?>, AuthorizationStrategyOverrideDescriptor>(this);
+
+    public AuthorizationStrategyOverrideConfiguration() {
+        load();
+    }
+
+    private Object readResolve() {
+        overrides.setOwner(this);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalConfigurationCategory getCategory() {
+        return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
+    }
+
+    /**
+     * @return the list of configured {@link AuthorizationStrategyOverride}
+     */
+    public DescribableList<AuthorizationStrategyOverride<?>, AuthorizationStrategyOverrideDescriptor> getOverrides() {
+        return overrides;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        try {
+            overrides.rebuildHetero(
+                    req,
+                    json,
+                    AuthorizationStrategyOverrideDescriptor.all(),
+                    "overrides"
+            );
+            return true;
+        } catch (IOException e) {
+            throw new FormException(e, "overrides");
+        }
+    }
+
+    /**
+     * @return the singleton instance. never {@code null}
+     * @throws IllegalStateException {@link Jenkins} has not been started, or was already shut down
+     */
+    @Nonnull
+    public static AuthorizationStrategyOverrideConfiguration get() {
+        return Jenkins.getInstance().getInjector().getInstance(AuthorizationStrategyOverrideConfiguration.class);
+    }
+
+    /**
+     * @return the singleton instance. may be null if {@link Jenkins} has not been started, or was already shut down.
+     */
+    @CheckForNull
+    public static AuthorizationStrategyOverrideConfiguration getOrNull() {
+        Jenkins j = Jenkins.getInstanceOrNull();
+        if (j == null) {
+            return null;
+        }
+        Injector i = j.getInjector();
+        if (i == null) {
+            return null;
+        }
+        return i.getInstance(AuthorizationStrategyOverrideConfiguration.class);
+    }
+
+    /**
+     * Returns the list of enabled {@link AuthorizationStrategyOverrideBase}.
+     *
+     * includes all available {@link AuthorizationStrategyDenyOverride}
+     * and all enabled {@link AuthorizationStrategyOverride}.
+     *
+     * @return the list of {@link AuthorizationStrategyOverrideBase}
+     */
+    public static List<AuthorizationStrategyOverrideBase<?>> enables() {
+        List<AuthorizationStrategyOverrideBase<?>> lst = new ArrayList<>();
+        lst.addAll(AuthorizationStrategyDenyOverride.all());
+
+        AuthorizationStrategyOverrideConfiguration conf = AuthorizationStrategyOverrideConfiguration.getOrNull();
+        if (conf != null) {
+            lst.addAll(conf.getOverrides());
+        }
+        return lst;
+    }
+
+    /**
+     * Returns the list of enabled {@link AuthorizationStrategyOverrideBase} targeting a specific type.
+     *
+     * @param klazz a type to test ACL.
+     * @return the list of {@link AuthorizationStrategyOverrideBase}
+     */
+    public static <T> List<AuthorizationStrategyOverrideBase<? super T>> enables(Class<T> klazz) {
+        List<AuthorizationStrategyOverrideBase<? super T>> lst = new ArrayList<>();
+        for (AuthorizationStrategyOverrideBase<?> d: enables()) {
+            Type p = Types.getBaseClass(d.getClass(), AuthorizationStrategyOverrideBase.class);
+            if (!(p instanceof ParameterizedType)) {
+                continue;
+            }
+            ParameterizedType pt = (ParameterizedType)p;
+            Class<?> targetType = Types.erasure(Types.getTypeArgument(pt, 0));
+            if (!targetType.isAssignableFrom(klazz)) {
+                continue;
+            }
+            @SuppressWarnings("unchecked")
+            AuthorizationStrategyOverrideBase<? super T> decorator = (AuthorizationStrategyOverrideBase<? super T>)d;
+            lst.add(decorator);
+        }
+        return lst;
+    }
+}

--- a/core/src/main/java/jenkins/security/AuthorizationStrategyOverrideDescriptor.java
+++ b/core/src/main/java/jenkins/security/AuthorizationStrategyOverrideDescriptor.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import java.util.Collections;
+import java.util.List;
+
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+/**
+ * Descriptor for {@link AuthorizationStrategyOverride}
+ *
+ * @since TODO
+ */
+public abstract class AuthorizationStrategyOverrideDescriptor extends Descriptor<AuthorizationStrategyOverride<?>> {
+    /**
+     * @return all registered {@link AuthorizationStrategyOverrideDescriptor}
+     */
+    @SuppressWarnings("unchecked")
+    public static List<AuthorizationStrategyOverrideDescriptor> all() {
+        Jenkins j = Jenkins.getInstanceOrNull();
+        if (j == null) {
+            return Collections.emptyList();
+        }
+        return (List<AuthorizationStrategyOverrideDescriptor>)j.getDescriptorList(AuthorizationStrategyOverride.class);
+    }
+}

--- a/core/src/main/java/jenkins/security/OverriddenAuthorizationStrategy.java
+++ b/core/src/main/java/jenkins/security/OverriddenAuthorizationStrategy.java
@@ -1,0 +1,172 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import java.util.Collection;
+
+import javax.annotation.Nonnull;
+
+import org.acegisecurity.Authentication;
+
+import hudson.model.AbstractItem;
+import hudson.model.AbstractProject;
+import hudson.model.Computer;
+import hudson.model.Job;
+import hudson.model.Node;
+import hudson.model.User;
+import hudson.model.View;
+import hudson.security.ACL;
+import hudson.security.AuthorizationStrategy;
+import hudson.security.Permission;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
+
+/**
+ * {@link AuthorizationStrategy} overriding another {@link AuthorizationStrategy}
+ * with {@link AuthorizationStrategyOverrideBase}.
+ *
+ * @since TODO
+ */
+public class OverriddenAuthorizationStrategy extends AuthorizationStrategy {
+    private final AuthorizationStrategy baseStrategy;
+
+    /**
+     * Creates a new instance wrapping another {@link AuthorizationStrategy}.
+     *
+     * @param baseStrategy a strategy to override.
+     */
+    public OverriddenAuthorizationStrategy(@Nonnull AuthorizationStrategy baseStrategy) {
+        this.baseStrategy = baseStrategy;
+    }
+
+    /**
+     * @return wrapped {@link AuthorizationStrategy}
+     */
+    @Nonnull
+    public AuthorizationStrategy getBaseStrategy() {
+        return baseStrategy;
+    }
+
+    @Nonnull
+    private <T> ACL overrideACL(@Nonnull final ACL baseAcl, @Nonnull final T item, @Nonnull final Class<T> klazz) {
+        return new ACL() {
+            @Override
+            public boolean hasPermission(@Nonnull Authentication a, @Nonnull Permission p) {
+                for (AuthorizationStrategyOverrideBase<? super T> d: AuthorizationStrategyOverrideConfiguration.enables(klazz)) {
+                    Boolean permission = d.hasPermission(item, a, p);
+                    if (permission != null) {
+                        return permission.booleanValue();
+                    }
+                }
+                return baseAcl.hasPermission(a, p);
+            }
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<String> getGroups() {
+        return getBaseStrategy().getGroups();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ACL getRootACL() {
+        Jenkins j = Jenkins.getInstanceOrNull();
+        if (j == null) {
+            return getBaseStrategy().getRootACL();
+        }
+        return overrideACL(getBaseStrategy().getRootACL(), j, Jenkins.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("deprecation")
+    @Override
+    public @Nonnull ACL getACL(@Nonnull AbstractProject<?,?> project) {
+        return overrideACL(getBaseStrategy().getACL(project), project, AbstractProject.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @Nonnull ACL getACL(@Nonnull Job<?,?> project) {
+        return overrideACL(getBaseStrategy().getACL(project), project, Job.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @Nonnull ACL getACL(@Nonnull View item) {
+        return overrideACL(getBaseStrategy().getACL(item), item, View.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @Nonnull ACL getACL(@Nonnull AbstractItem item) {
+        return overrideACL(getBaseStrategy().getACL(item), item, AbstractItem.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @Nonnull ACL getACL(@Nonnull User user) {
+        return overrideACL(getBaseStrategy().getACL(user), user, User.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @Nonnull ACL getACL(@Nonnull Computer computer) {
+        return overrideACL(getBaseStrategy().getACL(computer), computer, Computer.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @Nonnull ACL getACL(@Nonnull Cloud cloud) {
+        return overrideACL(getBaseStrategy().getACL(cloud), cloud, Cloud.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @Nonnull ACL getACL(@Nonnull Node node) {
+        return overrideACL(getBaseStrategy().getACL(node), node, Node.class);
+    }
+}

--- a/core/src/main/resources/jenkins/security/AuthorizationStrategyOverride/config.groovy
+++ b/core/src/main/resources/jenkins/security/AuthorizationStrategyOverride/config.groovy
@@ -1,0 +1,1 @@
+// the default is empty configuration

--- a/core/src/main/resources/jenkins/security/AuthorizationStrategyOverrideConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/security/AuthorizationStrategyOverrideConfiguration/config.groovy
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.security.AuthorizationStrategyOverrideConfiguration;
+
+import jenkins.security.AuthorizationStrategyOverrideDescriptor;
+
+f=namespace(lib.FormTagLib)
+
+if (!AuthorizationStrategyOverrideDescriptor.all().empty) {
+    f.section(title:_("Overriding authorization")) {
+        f.block() {
+            f.repeatableHeteroProperty(field:"overrides",hasHeader:true)
+        }
+    }
+}

--- a/test/src/test/java/jenkins/security/AuthorizationStrategyDenyOverrideTest.java
+++ b/test/src/test/java/jenkins/security/AuthorizationStrategyDenyOverrideTest.java
@@ -29,6 +29,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Collections;
+
 import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
@@ -37,17 +39,23 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockFolder;
+import org.jvnet.hudson.test.MockQueueItemAuthenticator;
 import org.jvnet.hudson.test.TestExtension;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 
 import hudson.model.AbstractItem;
 import hudson.model.Computer;
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.ListView;
 import hudson.model.Node;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
 import hudson.model.User;
 import hudson.model.View;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
@@ -80,6 +88,7 @@ public class AuthorizationStrategyDenyOverrideTest {
         auth.add(Jenkins.READ, "developer");
         auth.add(Item.READ, "developer");
         auth.add(Item.CONFIGURE, "developer");
+        auth.add(Item.BUILD, "developer");
         auth.add(View.READ, "developer");
         auth.add(View.CONFIGURE, "developer");
         auth.add(Computer.BUILD, "developer");
@@ -426,14 +435,45 @@ public class AuthorizationStrategyDenyOverrideTest {
 
     @Test
     public void testNode() throws Exception {
-        DumbSlave slave = j.createOnlineSlave();
+        j.jenkins.setNumExecutors(0);
+        DumbSlave slave1 = j.createOnlineSlave();
+        DumbSlave slave2 = j.createOnlineSlave();
 
-        assertTrue(slave.getACL().hasPermission(User.get("developer").impersonate(), Computer.BUILD));
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(
+            // a parameter not to builds merged in the queue.
+            new StringParameterDefinition("UNIQUE", "")
+        ));
+        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(
+            new MockQueueItemAuthenticator(Collections.singletonMap(
+                p.getFullName(),
+                User.get("developer").impersonate()
+            ))
+        );
+
         TestDenyNode deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyNode.class);
         deny.user = "developer";
         deny.permission = Computer.BUILD.getId();
-        deny.node = slave.getNodeName();
-        assertFalse(slave.getACL().hasPermission(User.get("developer").impersonate(), Computer.BUILD));
+        deny.node = slave1.getNodeName();
+
+        final int NUM_BUILDS = 10;
+
+        for (int i = 0; i < NUM_BUILDS; ++i) {
+            p.scheduleBuild2(
+                0,
+                new ParametersAction(
+                    new StringParameterValue("UNIQUE", Integer.toString(i))
+                )
+            );
+        }
+        j.waitUntilNoActivity();
+        int buildnum = 0;
+        for (FreeStyleBuild b = p.getLastBuild(); b != null; b = b.getPreviousBuild()) {
+            j.assertBuildStatusSuccess(b);
+            assertEquals(slave2, b.getBuiltOn());
+            ++buildnum;
+        }
+        assertEquals(NUM_BUILDS, buildnum);
     }
 
     /**

--- a/test/src/test/java/jenkins/security/AuthorizationStrategyDenyOverrideTest.java
+++ b/test/src/test/java/jenkins/security/AuthorizationStrategyDenyOverrideTest.java
@@ -373,7 +373,7 @@ public class AuthorizationStrategyDenyOverrideTest {
             if (!permission.equals(p.getId())) {
                 return false;
             }
-            if (!cloud.equals(item.getDisplayName())) {
+            if (!cloud.equals(item.name)) {
                 return false;
             }
             if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
@@ -391,7 +391,7 @@ public class AuthorizationStrategyDenyOverrideTest {
         TestDenyCloud deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyCloud.class);
         deny.user = "developer";
         deny.permission = Cloud.PROVISION.getId();
-        deny.cloud = c.getDisplayName();
+        deny.cloud = c.name;
         assertFalse(c.getACL().hasPermission(User.get("developer").impersonate(), Cloud.PROVISION));
     }
 

--- a/test/src/test/java/jenkins/security/AuthorizationStrategyDenyOverrideTest.java
+++ b/test/src/test/java/jenkins/security/AuthorizationStrategyDenyOverrideTest.java
@@ -1,0 +1,547 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.acegisecurity.Authentication;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockFolder;
+import org.jvnet.hudson.test.TestExtension;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+
+import hudson.model.AbstractItem;
+import hudson.model.Computer;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.ListView;
+import hudson.model.Node;
+import hudson.model.User;
+import hudson.model.View;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.Permission;
+import hudson.slaves.Cloud;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.DummyCloudImpl;
+import jenkins.model.Jenkins;
+
+/**
+ * Tests for {@link AuthorizationStrategyDenyOverride}
+ *
+ * Tests in integrated ways as possible.
+ */
+public class AuthorizationStrategyDenyOverrideTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    /**
+     * Setups basic securities.
+     * Sets up following users:
+     * * admin     Administrator
+     * * developer Can configure any items.
+     */
+    @Before
+    public void enableSecurity() {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        GlobalMatrixAuthorizationStrategy auth = new GlobalMatrixAuthorizationStrategy();
+        auth.add(Jenkins.ADMINISTER, "admin");
+        auth.add(Jenkins.READ, "developer");
+        auth.add(Item.READ, "developer");
+        auth.add(Item.CONFIGURE, "developer");
+        auth.add(View.READ, "developer");
+        auth.add(View.CONFIGURE, "developer");
+        auth.add(Computer.BUILD, "developer");
+        auth.add(Cloud.PROVISION, "developer");
+        j.jenkins.setAuthorizationStrategy(auth);
+    }
+
+    /**
+     * Denies the specified permission of the specified user.
+     */
+    @TestExtension
+    public static class TestDenyJenkins extends AuthorizationStrategyDenyOverride<Jenkins> {
+        public String user = null;
+        public String permission = null;
+
+        @Override
+        public boolean deny(Jenkins item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission)) {
+                return false;
+            }
+            if (!permission.equals(p.getId())) {
+                return false;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return false;
+            }
+            // deny!
+            return true;
+        }
+    }
+
+    @Test
+    public void testJenkins() throws Exception {
+        WebClient wc = j.createWebClient().login("developer");
+        wc.goTo("");
+
+        TestDenyJenkins deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyJenkins.class);
+        deny.user = "developer";
+        deny.permission = Jenkins.READ.getId();
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.goTo("");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Denies the specified permission to the specified job of the specified user.
+     */
+    @TestExtension
+    public static class TestDenyJob extends AuthorizationStrategyDenyOverride<Job<?, ?>> {
+        public String user = null;
+        public String permission = null;
+        public String job = null;
+
+        @Override
+        public boolean deny(Job<?, ?> item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(job)) {
+                return false;
+            }
+            if (!permission.equals(p.getId())) {
+                return false;
+            }
+            if (!job.equals(item.getFullName())) {
+                return false;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return false;
+            }
+            // deny!
+            return true;
+        }
+    }
+
+    @Test
+    public void testJob() throws Exception {
+        WebClient wc = j.createWebClient().login("developer");
+        FreeStyleProject p = j.createFreeStyleProject();
+        wc.getPage(p, "configure");
+        TestDenyJob deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyJob.class);
+        deny.user = "developer";
+        deny.permission = Job.EXTENDED_READ.getId();
+        deny.job = p.getFullName();
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Denies the specified permission to the specified view of the specified user.
+     */
+    @TestExtension
+    public static class TestDenyView extends AuthorizationStrategyDenyOverride<View> {
+        public String user = null;
+        public String permission = null;
+        public String view = null;
+
+        @Override
+        public boolean deny(View item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(view)) {
+                return false;
+            }
+            if (!permission.equals(p.getId())) {
+                return false;
+            }
+            if (!view.equals(item.getViewName())) {
+                return false;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return false;
+            }
+            // deny!
+            return true;
+        }
+    }
+
+    @Test
+    public void testView() throws Exception {
+        WebClient wc = j.createWebClient().login("developer");
+        View v = new ListView("testView");
+        j.jenkins.addView(v);
+        wc.getPage(v, "configure");
+        TestDenyView deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyView.class);
+        deny.user = "developer";
+        deny.permission = View.CONFIGURE.getId();
+        deny.view = v.getViewName();
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(v, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Denies the specified permission to the specified item of the specified user.
+     */
+    @TestExtension
+    public static class TestDenyAbstractItem extends AuthorizationStrategyDenyOverride<AbstractItem> {
+        public String user = null;
+        public String permission = null;
+        public String itemName = null;
+
+        @Override
+        public boolean deny(AbstractItem item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(itemName)) {
+                return false;
+            }
+            if (!permission.equals(p.getId())) {
+                return false;
+            }
+            if (!itemName.equals(item.getFullName())) {
+                return false;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return false;
+            }
+            // deny!
+            return true;
+        }
+    }
+
+    @Test
+    public void testAbstractItem() throws Exception {
+        // MockFolder doesn't provide GUI,
+        // and cannot test in an integrated way.
+        MockFolder f = j.createFolder("testFolder");
+        assertTrue(f.getACL().hasPermission(User.get("developer").impersonate(), Item.CONFIGURE));
+        TestDenyAbstractItem deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyAbstractItem.class);
+        deny.user = "developer";
+        deny.permission = Item.CONFIGURE.getId();
+        deny.itemName = f.getFullName();
+        assertFalse(f.getACL().hasPermission(User.get("developer").impersonate(), Item.CONFIGURE));
+    }
+
+    /**
+     * Denies the specified permission to the specified user of the specified user.
+     */
+    @TestExtension
+    public static class TestDenyUser extends AuthorizationStrategyDenyOverride<User> {
+        public String user = null;
+        public String permission = null;
+        public String targetUser = null;
+
+        @Override
+        public boolean deny(User item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(targetUser)) {
+                return false;
+            }
+            if (!permission.equals(p.getId())) {
+                return false;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(targetUser, item.getId())) {
+                return false;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return false;
+            }
+            // deny!
+            return true;
+        }
+    }
+
+    @Test
+    public void testUser() throws Exception {
+        WebClient wc = j.createWebClient().login("admin");
+        User u = User.get("test");
+        wc.goTo(u.getUrl() + "/configure");
+        TestDenyUser deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyUser.class);
+        deny.user = "admin";
+        deny.permission = Jenkins.ADMINISTER.getId();
+        deny.targetUser = "test";
+
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.goTo(u.getUrl() + "/configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Denies the specified permission to the specified computer of the specified user.
+     */
+    @TestExtension
+    public static class TestDenyComputer extends AuthorizationStrategyDenyOverride<Computer> {
+        public String user = null;
+        public String permission = null;
+        public String computer = null;
+
+        @Override
+        public boolean deny(Computer item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(computer)) {
+                return false;
+            }
+            if (!permission.equals(p.getId())) {
+                return false;
+            }
+            if (!computer.equals(item.getName())) {
+                return false;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return false;
+            }
+            // deny!
+            return true;
+        }
+    }
+
+    @Test
+    public void testComputer() throws Exception {
+        DumbSlave slave = j.createOnlineSlave();
+
+        WebClient wc = j.createWebClient().login("developer");
+        wc.getPage(slave, "configure");
+        TestDenyComputer deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyComputer.class);
+        deny.user = "developer";
+        deny.permission = Computer.CONFIGURE.getId();
+        deny.computer = slave.getNodeName();
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(slave, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Denies the specified permission to the specified item of the specified user.
+     */
+    @TestExtension
+    public static class TestDenyCloud extends AuthorizationStrategyDenyOverride<Cloud> {
+        public String user = null;
+        public String permission = null;
+        public String cloud = null;
+
+        @Override
+        public boolean deny(Cloud item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(cloud)) {
+                return false;
+            }
+            if (!permission.equals(p.getId())) {
+                return false;
+            }
+            if (!cloud.equals(item.getDisplayName())) {
+                return false;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return false;
+            }
+            // deny!
+            return true;
+        }
+    }
+
+    @Test
+    public void testCloud() throws Exception {
+        Cloud c = new DummyCloudImpl(j, 0);
+        assertTrue(c.getACL().hasPermission(User.get("developer").impersonate(), Cloud.PROVISION));
+        TestDenyCloud deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyCloud.class);
+        deny.user = "developer";
+        deny.permission = Cloud.PROVISION.getId();
+        deny.cloud = c.getDisplayName();
+        assertFalse(c.getACL().hasPermission(User.get("developer").impersonate(), Cloud.PROVISION));
+    }
+
+
+    /**
+     * Denies the specified permission to the specified node of the specified user.
+     */
+    @TestExtension
+    public static class TestDenyNode extends AuthorizationStrategyDenyOverride<Node> {
+        public String user = null;
+        public String permission = null;
+        public String node = null;
+
+        @Override
+        public boolean deny(Node item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(node)) {
+                return false;
+            }
+            if (!permission.equals(p.getId())) {
+                return false;
+            }
+            if (!node.equals(item.getNodeName())) {
+                return false;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return false;
+            }
+            // deny!
+            return true;
+        }
+    }
+
+    @Test
+    public void testNode() throws Exception {
+        DumbSlave slave = j.createOnlineSlave();
+
+        assertTrue(slave.getACL().hasPermission(User.get("developer").impersonate(), Computer.BUILD));
+        TestDenyNode deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyNode.class);
+        deny.user = "developer";
+        deny.permission = Computer.BUILD.getId();
+        deny.node = slave.getNodeName();
+        assertFalse(slave.getACL().hasPermission(User.get("developer").impersonate(), Computer.BUILD));
+    }
+
+    /**
+     * Test that can deny even permissions of administrators.
+     *
+     * @throws Exception test fails.
+     */
+    @Test
+    public void testOverrideEvenAdminister() throws Exception {
+        WebClient wc = j.createWebClient().login("admin");
+        FreeStyleProject p = j.createFreeStyleProject();
+        wc.getPage(p, "configure");
+        TestDenyJob deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyJob.class);
+        deny.user = "admin";
+        deny.permission = Job.EXTENDED_READ.getId();
+        deny.job = p.getFullName();
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    @Test
+    public void testAbstractItemAffectsJob() throws Exception {
+        WebClient wc = j.createWebClient().login("developer");
+        FreeStyleProject p = j.createFreeStyleProject();
+        wc.getPage(p, "configure");
+        TestDenyAbstractItem deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyAbstractItem.class);
+        deny.user = "developer";
+        deny.permission = Job.EXTENDED_READ.getId();
+        deny.itemName = p.getFullName();
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * {@link GlobalMatrixAuthorizationStrategy} inherits Jenkins permissions
+     * to Job permissions.
+     * But the permission overriding mechanism affects only Jenkins permissions,
+     * not Job permissions
+     *
+     * @throws Exception test failed
+     */
+    @Test
+    public void testJenkinsPermissionIsNotInherited() throws Exception {
+        WebClient wc = j.createWebClient().login("developer");
+        FreeStyleProject p = j.createFreeStyleProject();
+        wc.getPage(p, "configure");
+        TestDenyJenkins deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyJenkins.class);
+        deny.user = "developer";
+        deny.permission = Job.EXTENDED_READ.getId();
+        wc.getPage(p, "configure");
+    }
+
+    /**
+     * Denies the specified permission to the specified free style project of the specified user.
+     *
+     * Unfortunately, this doesn't work.
+     */
+    @TestExtension
+    public static class TestDenyFreeStyleProject extends AuthorizationStrategyDenyOverride<FreeStyleProject> {
+        public String user = null;
+        public String permission = null;
+        public String project = null;
+
+        @Override
+        public boolean deny(FreeStyleProject item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(project)) {
+                return false;
+            }
+            if (!permission.equals(p.getId())) {
+                return false;
+            }
+            if (!project.equals(item.getFullName())) {
+                return false;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return false;
+            }
+            // deny!
+            return true;
+        }
+    }
+
+    /**
+     * AuthorizationStrategyDenyOverride with specific classes
+     * like AuthorizationStrategyDenyOverride<FreeStyleProject>
+     * doesn't work.
+     *
+     * @throws Exception test fails
+     */
+    @Test
+    public void testSpecificClassOverrideDontWork() throws Exception {
+        WebClient wc = j.createWebClient().login("developer");
+        FreeStyleProject p = j.createFreeStyleProject();
+        wc.getPage(p, "configure");
+        TestDenyFreeStyleProject deny = j.jenkins.getExtensionList(AuthorizationStrategyDenyOverride.class).get(TestDenyFreeStyleProject.class);
+        deny.user = "developer";
+        deny.permission = Job.EXTENDED_READ.getId();
+        deny.project = p.getFullName();
+        wc.getPage(p, "configure");
+    }
+}

--- a/test/src/test/java/jenkins/security/AuthorizationStrategyOverrideConfigurationTest.java
+++ b/test/src/test/java/jenkins/security/AuthorizationStrategyOverrideConfigurationTest.java
@@ -1,0 +1,139 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.acegisecurity.Authentication;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.HudsonPrivateSecurityRealm;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+
+/**
+ * Tests for {@link AuthorizationStrategyOverrideConfiguration}
+ */
+public class AuthorizationStrategyOverrideConfigurationTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    /**
+     * Setups basic securities.
+     * Sets up following users:
+     * * admin     Administrator
+     */
+    @Before
+    public void enableSecurity() throws Exception {
+        // To use the configuration page in tests,
+        // JenkinsRule#createDummySecurityRealm() isn't applicable.
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(
+            false,      // allowSignup
+            false,      // enableCaptcha
+            null        // captchaSupport
+        );
+        realm.createAccount("admin", "admin");
+        realm.createAccount("developer", "developer");
+        j.jenkins.setSecurityRealm(realm);
+        GlobalMatrixAuthorizationStrategy auth = new GlobalMatrixAuthorizationStrategy();
+        auth.add(Jenkins.ADMINISTER, "admin");
+        j.jenkins.setAuthorizationStrategy(auth);
+    }
+
+    private void configRoundTripGlobalSecurity() throws Exception {
+        j.submit(j.createWebClient().login("admin").goTo("configureSecurity").getFormByName("config"));
+    }
+
+    /**
+     * AuthorizationStrategyOverride to test configurations.
+     */
+    public static class TestConfigureAuthorizationStrategyOverride extends AuthorizationStrategyOverride<Jenkins> {
+        private final String field;
+
+        @DataBoundConstructor
+        public TestConfigureAuthorizationStrategyOverride(String field) {
+            this.field = field;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        @Override
+        public Boolean hasPermission(Jenkins item, Authentication a, Permission p) {
+            // do nothing
+            return null;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizationStrategyOverrideDescriptor {
+        }
+
+    }
+
+    @Test
+    public void testConfigurationDisabled() throws Exception {
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().clear();
+        configRoundTripGlobalSecurity();
+        assertEquals(
+            Collections.emptyList(),
+            AuthorizationStrategyOverrideConfiguration.get().getOverrides()
+        );
+    }
+
+    @Test
+    public void testConfigurationEnabled() throws Exception {
+        TestConfigureAuthorizationStrategyOverride expect1 =
+            new TestConfigureAuthorizationStrategyOverride("test value1");
+        TestConfigureAuthorizationStrategyOverride expect2 =
+            new TestConfigureAuthorizationStrategyOverride("test value2");
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().clear();
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().add(expect1);
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().add(expect2);
+        configRoundTripGlobalSecurity();
+        j.assertEqualDataBoundBeans(
+            Arrays.asList(expect1, expect2),
+            AuthorizationStrategyOverrideConfiguration.get().getOverrides()
+        );
+        // assert they are newly configured ones.
+        assertNotSame(expect1, AuthorizationStrategyOverrideConfiguration.get().getOverrides().get(0));
+        assertNotSame(expect2, AuthorizationStrategyOverrideConfiguration.get().getOverrides().get(1));
+        // ensure that is is saved
+        j.assertEqualDataBoundBeans(
+                Arrays.asList(expect1, expect2),
+                new AuthorizationStrategyOverrideConfiguration().getOverrides()
+            );
+    }
+}

--- a/test/src/test/java/jenkins/security/AuthorizationStrategyOverrideTest.java
+++ b/test/src/test/java/jenkins/security/AuthorizationStrategyOverrideTest.java
@@ -1,0 +1,813 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.acegisecurity.Authentication;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockFolder;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+
+import hudson.model.AbstractItem;
+import hudson.model.Computer;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.ListView;
+import hudson.model.Node;
+import hudson.model.User;
+import hudson.model.View;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.Permission;
+import hudson.slaves.Cloud;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.DummyCloudImpl;
+import jenkins.model.Jenkins;
+
+/**
+ * Tests for {@link AuthorizationStrategyOverride} and {@link AuthorizationStrategyOverrideConfiguration}
+ */
+public class AuthorizationStrategyOverrideTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    /**
+     * Setups basic securities.
+     * Sets up following users:
+     * * admin          Administrator
+     * * developer      Can configure any items.
+     * * user           Can read any items.
+     */
+    @Before
+    public void enableSecurity() {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        GlobalMatrixAuthorizationStrategy auth = new GlobalMatrixAuthorizationStrategy();
+        auth.add(Jenkins.ADMINISTER, "admin");
+        auth.add(Jenkins.READ, "developer");
+        auth.add(Item.READ, "developer");
+        auth.add(Item.CONFIGURE, "developer");
+        auth.add(View.READ, "developer");
+        auth.add(View.CONFIGURE, "developer");
+        auth.add(Computer.BUILD, "developer");
+        auth.add(Cloud.PROVISION, "developer");
+        auth.add(Jenkins.READ, "user");
+        auth.add(Item.READ, "user");
+        auth.add(View.READ, "user");
+        j.jenkins.setAuthorizationStrategy(auth);
+    }
+
+    /**
+     * Allows or denies the specified permission of the specified user.
+     */
+    public static class TestOverrideJenkins extends AuthorizationStrategyOverride<Jenkins> {
+        private final String user;
+        private final String permission;
+        private final boolean result;
+
+        @DataBoundConstructor
+        public TestOverrideJenkins(String user, String permission, boolean result) {
+            this.user = user;
+            this.permission = permission;
+            this.result = result;
+        }
+
+        @Override
+        public Boolean hasPermission(Jenkins item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission)) {
+                return null;
+            }
+            if (!permission.equals(p.getId())) {
+                return null;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return null;
+            }
+            // decide the permission
+            return result;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizationStrategyOverrideDescriptor {
+        }
+    }
+
+    @Test
+    public void testJenkinsAllow() throws Exception {
+        WebClient wc = j.createWebClient().login("user");
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.goTo("configure");
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideJenkins("user", Jenkins.ADMINISTER.getId(), true));
+        wc.getOptions().setPrintContentOnFailingStatusCode(true);
+        wc.goTo("configure");
+    }
+
+    @Test
+    public void testJenkinsDeny() throws Exception {
+        WebClient wc = j.createWebClient().login("admin");
+        wc.goTo("configure");
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideJenkins("admin", Jenkins.ADMINISTER.getId(), false));
+
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.goTo("configure");
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Allows or denies the specified permission to the specified job of the specified user.
+     */
+    public static class TestOverrideJob extends AuthorizationStrategyOverride<Job<?, ?>> {
+        private final String user;
+        private final String job;
+        private final String permission;
+        private final boolean result;
+
+        @DataBoundConstructor
+        public TestOverrideJob(String user, String job, String permission, boolean result) {
+            this.user = user;
+            this.job = job;
+            this.permission = permission;
+            this.result = result;
+        }
+
+        @Override
+        public Boolean hasPermission(Job<?, ?> item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(job)) {
+                return null;
+            }
+            if (!permission.equals(p.getId())) {
+                return null;
+            }
+            if (!job.equals(item.getFullName())) {
+                return null;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return null;
+            }
+            // decide the permission
+            return result;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizationStrategyOverrideDescriptor {
+        }
+    }
+
+    @Test
+    public void testJobAllow() throws Exception {
+        WebClient wc = j.createWebClient().login("user");
+        FreeStyleProject p = j.createFreeStyleProject();
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideJob("user", p.getFullName(), Job.EXTENDED_READ.getId(), true));
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideJob("user", p.getFullName(), Job.CONFIGURE.getId(), true));
+
+        wc.getOptions().setPrintContentOnFailingStatusCode(true);
+        wc.getPage(p, "configure");
+    }
+
+    @Test
+    public void testJobDeny() throws Exception {
+        WebClient wc = j.createWebClient().login("developer");
+        FreeStyleProject p = j.createFreeStyleProject();
+        wc.getPage(p, "configure");
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideJob("developer", p.getFullName(), Job.EXTENDED_READ.getId(), false));
+
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Allows or denies the specified permission to the specified view of the specified user.
+     */
+    public static class TestOverrideView extends AuthorizationStrategyOverride<View> {
+        private final String user;
+        private final String view;
+        private final String permission;
+        private final boolean result;
+
+        @DataBoundConstructor
+        public TestOverrideView(String user, String view, String permission, boolean result) {
+            this.user = user;
+            this.view = view;
+            this.permission = permission;
+            this.result = result;
+        }
+
+        @Override
+        public Boolean hasPermission(View item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(view)) {
+                return null;
+            }
+            if (!permission.equals(p.getId())) {
+                return null;
+            }
+            if (!view.equals(item.getViewName())) {
+                return null;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return null;
+            }
+            // decide the permission
+            return result;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizationStrategyOverrideDescriptor {
+        }
+    }
+
+    @Test
+    public void testViewAllow() throws Exception {
+        WebClient wc = j.createWebClient().login("user");
+        View v = new ListView("testView");
+        j.jenkins.addView(v);
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(v, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideView("user", v.getViewName(), View.CONFIGURE.getId(), true));
+
+        wc.getOptions().setPrintContentOnFailingStatusCode(true);
+        wc.getPage(v, "configure");
+    }
+
+    @Test
+    public void testViewDeny() throws Exception {
+        WebClient wc = j.createWebClient().login("developer");
+        View v = new ListView("testView");
+        j.jenkins.addView(v);
+        wc.getPage(v, "configure");
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideView("developer", v.getViewName(), View.CONFIGURE.getId(), false));
+
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(v, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Allows or denies the specified permission to the specified item of the specified user.
+     */
+    public static class TestOverrideAbstractItem extends AuthorizationStrategyOverride<AbstractItem> {
+        private final String user;
+        private final String itemName;
+        private final String permission;
+        private final boolean result;
+
+        @DataBoundConstructor
+        public TestOverrideAbstractItem(String user, String itemName, String permission, boolean result) {
+            this.user = user;
+            this.itemName = itemName;
+            this.permission = permission;
+            this.result = result;
+        }
+
+        @Override
+        public Boolean hasPermission(AbstractItem item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(itemName)) {
+                return null;
+            }
+            if (!permission.equals(p.getId())) {
+                return null;
+            }
+            if (!itemName.equals(item.getFullName())) {
+                return null;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return null;
+            }
+            // decide the permission
+            return result;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizationStrategyOverrideDescriptor {
+        }
+    }
+
+    @Test
+    public void testAbstractItemAllow() throws Exception {
+        // MockFolder doesn't provide GUI,
+        // and cannot test in an integrated way.
+        MockFolder f = j.createFolder("testFolder");
+        assertFalse(f.getACL().hasPermission(User.get("user").impersonate(), Item.CONFIGURE));
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideAbstractItem("user", f.getFullName(), Item.CONFIGURE.getId(), true));
+
+        assertTrue(f.getACL().hasPermission(User.get("user").impersonate(), Item.CONFIGURE));
+    }
+
+    @Test
+    public void testAbstractItemDeny() throws Exception {
+        // MockFolder doesn't provide GUI,
+        // and cannot test in an integrated way.
+        MockFolder f = j.createFolder("testFolder");
+        assertTrue(f.getACL().hasPermission(User.get("developer").impersonate(), Item.CONFIGURE));
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideAbstractItem("developer", f.getFullName(), Item.CONFIGURE.getId(), false));
+
+        assertFalse(f.getACL().hasPermission(User.get("developer").impersonate(), Item.CONFIGURE));
+    }
+
+    /**
+     * Allows or denies the specified permission to the specified user of the specified user.
+     */
+    public static class TestOverrideUser extends AuthorizationStrategyOverride<User> {
+        private final String user;
+        private final String targetUser;
+        private final String permission;
+        private final boolean result;
+
+        @DataBoundConstructor
+        public TestOverrideUser(String user, String targetUser, String permission, boolean result) {
+            this.user = user;
+            this.targetUser = targetUser;
+            this.permission = permission;
+            this.result = result;
+        }
+
+        @Override
+        public Boolean hasPermission(User item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(targetUser)) {
+                return null;
+            }
+            if (!permission.equals(p.getId())) {
+                return null;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(targetUser, item.getId())) {
+                return null;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return null;
+            }
+            // decide the permission
+            return result;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizationStrategyOverrideDescriptor {
+        }
+    }
+
+    @Test
+    public void testUserAllow() throws Exception {
+        WebClient wc = j.createWebClient().login("user");
+        User u = User.get("test");
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.goTo(u.getUrl() + "/configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideUser("user", "test", Jenkins.ADMINISTER.getId(), true));
+
+        wc.getOptions().setPrintContentOnFailingStatusCode(true);
+        wc.goTo(u.getUrl() + "/configure");
+    }
+
+    @Test
+    public void testUserDeny() throws Exception {
+        WebClient wc = j.createWebClient().login("admin");
+        User u = User.get("test");
+        wc.goTo(u.getUrl() + "/configure");
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideUser("admin", "test", Jenkins.ADMINISTER.getId(), false));
+
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.goTo(u.getUrl() + "/configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Allows or denies the specified permission to the specified computer of the specified user.
+     */
+    public static class TestOverrideComputer extends AuthorizationStrategyOverride<Computer> {
+        private final String user;
+        private final String computer;
+        private final String permission;
+        private final boolean result;
+
+        @DataBoundConstructor
+        public TestOverrideComputer(String user, String computer, String permission, boolean result) {
+            this.user = user;
+            this.computer = computer;
+            this.permission = permission;
+            this.result = result;
+        }
+
+        @Override
+        public Boolean hasPermission(Computer item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(computer)) {
+                return null;
+            }
+            if (!permission.equals(p.getId())) {
+                return null;
+            }
+            if (!computer.equals(item.getName())) {
+                return null;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return null;
+            }
+            // decide the permission
+            return result;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizationStrategyOverrideDescriptor {
+        }
+    }
+
+    @Test
+    public void testComputerAllow() throws Exception {
+        DumbSlave slave = j.createOnlineSlave();
+
+        WebClient wc = j.createWebClient().login("user");
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(slave, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideComputer("user", slave.getNodeName(), Computer.CONFIGURE.getId(), true));
+
+        wc.getOptions().setPrintContentOnFailingStatusCode(true);
+        wc.getPage(slave, "configure");
+    }
+
+    @Test
+    public void testComputerDeny() throws Exception {
+        DumbSlave slave = j.createOnlineSlave();
+
+        WebClient wc = j.createWebClient().login("developer");
+        wc.getPage(slave, "configure");
+
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideComputer("developer", slave.getNodeName(), Computer.CONFIGURE.getId(), false));
+
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(slave, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Allows or denies the specified permission to the specified item of the specified user.
+     */
+    public static class TestOverrideCloud extends AuthorizationStrategyOverride<Cloud> {
+        private final String user;
+        private final String cloud;
+        private final String permission;
+        private final boolean result;
+
+        @DataBoundConstructor
+        public TestOverrideCloud(String user, String cloud, String permission, boolean result) {
+            this.user = user;
+            this.cloud = cloud;
+            this.permission = permission;
+            this.result = result;
+        }
+
+        @Override
+        public Boolean hasPermission(Cloud item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(cloud)) {
+                return null;
+            }
+            if (!permission.equals(p.getId())) {
+                return null;
+            }
+            if (!cloud.equals(item.name)) {
+                return null;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return null;
+            }
+            // decide the permission
+            return result;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizationStrategyOverrideDescriptor {
+        }
+    }
+
+    @Test
+    public void testCloudAllow() throws Exception {
+        Cloud c = new DummyCloudImpl(j, 0);
+        assertFalse(c.getACL().hasPermission(User.get("user").impersonate(), Cloud.PROVISION));
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideCloud("user", c.name, Cloud.PROVISION.getId(), true));
+        assertTrue(c.getACL().hasPermission(User.get("user").impersonate(), Cloud.PROVISION));
+    }
+
+    @Test
+    public void testCloudDeny() throws Exception {
+        Cloud c = new DummyCloudImpl(j, 0);
+        assertTrue(c.getACL().hasPermission(User.get("developer").impersonate(), Cloud.PROVISION));
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideCloud("developer", c.name, Cloud.PROVISION.getId(), false));
+        assertFalse(c.getACL().hasPermission(User.get("developer").impersonate(), Cloud.PROVISION));
+    }
+
+    /**
+     * Allows or denies the specified permission to the specified node of the specified user.
+     */
+    public static class TestOverrideNode extends AuthorizationStrategyOverride<Node> {
+        private final String user;
+        private final String node;
+        private final String permission;
+        private final boolean result;
+
+        @DataBoundConstructor
+        public TestOverrideNode(String user, String node, String permission, boolean result) {
+            this.user = user;
+            this.node = node;
+            this.permission = permission;
+            this.result = result;
+        }
+
+        @Override
+        public Boolean hasPermission(Node item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(node)) {
+                return null;
+            }
+            if (!permission.equals(p.getId())) {
+                return null;
+            }
+            if (!node.equals(item.getNodeName())) {
+                return null;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return null;
+            }
+            // decide the result
+            return result;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizationStrategyOverrideDescriptor {
+        }
+    }
+
+    @Test
+    public void testNodeAllow() throws Exception {
+        DumbSlave slave = j.createOnlineSlave();
+
+        assertFalse(slave.getACL().hasPermission(User.get("user").impersonate(), Computer.BUILD));
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideNode("user", slave.getNodeName(), Computer.BUILD.getId(), true));
+        assertTrue(slave.getACL().hasPermission(User.get("user").impersonate(), Computer.BUILD));
+    }
+
+    @Test
+    public void testNodeDeny() throws Exception {
+        DumbSlave slave = j.createOnlineSlave();
+
+        assertTrue(slave.getACL().hasPermission(User.get("developer").impersonate(), Computer.BUILD));
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideNode("developer", slave.getNodeName(), Computer.BUILD.getId(), false));
+        assertFalse(slave.getACL().hasPermission(User.get("developer").impersonate(), Computer.BUILD));
+    }
+
+    /**
+     * Test that can deny even permissions of administrators.
+     *
+     * @throws Exception test fails.
+     */
+    @Test
+    public void testOverrideEvenAdminister() throws Exception {
+        WebClient wc = j.createWebClient().login("admin");
+        FreeStyleProject p = j.createFreeStyleProject();
+        wc.getPage(p, "configure");
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideJob("admin", p.getFullName(), Job.EXTENDED_READ.getId(), false));
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    @Test
+    public void testAbstractItemAffectsJob() throws Exception {
+        WebClient wc = j.createWebClient().login("user");
+        FreeStyleProject p = j.createFreeStyleProject();
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideAbstractItem("user", p.getFullName(), Job.EXTENDED_READ.getId(), true));
+        wc.getOptions().setPrintContentOnFailingStatusCode(true);
+        wc.getPage(p, "configure");
+    }
+
+    /**
+     * {@link GlobalMatrixAuthorizationStrategy} inherits Jenkins permissions
+     * to Job permissions.
+     * But the permission overriding mechanism affects only Jenkins permissions,
+     * not Job permissions
+     *
+     * @throws Exception test failed
+     */
+    @Test
+    public void testJenkinsPermissionIsNotInherited() throws Exception {
+        WebClient wc = j.createWebClient().login("user");
+        FreeStyleProject p = j.createFreeStyleProject();
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideJenkins("user", Job.EXTENDED_READ.getId(), true));
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    /**
+     * Denies the specified permission to the specified free style project of the specified user.
+     *
+     * Unfortunately, this doesn't work.
+     */
+    public static class TestOverrideFreeStyleProject extends AuthorizationStrategyOverride<FreeStyleProject> {
+        private final  String user;
+        private final  String project;
+        private final  String permission;
+        private final boolean result;
+
+        @DataBoundConstructor
+        public TestOverrideFreeStyleProject(String user, String project, String permission, boolean result) {
+            this.user = user;
+            this.project = project;
+            this.permission = permission;
+            this.result = result;
+        }
+
+        @Override
+        public Boolean hasPermission(FreeStyleProject item, Authentication a, Permission p) {
+            if (StringUtils.isEmpty(user) || StringUtils.isEmpty(permission) || StringUtils.isEmpty(project)) {
+                return null;
+            }
+            if (!permission.equals(p.getId())) {
+                return null;
+            }
+            if (!project.equals(item.getFullName())) {
+                return null;
+            }
+            if (!Jenkins.getInstance().getSecurityRealm().getUserIdStrategy().equals(user, a.getName())) {
+                return null;
+            }
+            // decide the permission
+            return result;
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends AuthorizationStrategyOverrideDescriptor {
+        }
+    }
+
+    /**
+     * AuthorizationStrategyDenyOverride with specific classes
+     * like AuthorizationStrategyDenyOverride<FreeStyleProject>
+     * doesn't work.
+     *
+     * @throws Exception test fails
+     */
+    @Test
+    public void testSpecificClassOverrideDontWork() throws Exception {
+        WebClient wc = j.createWebClient().login("user");
+        FreeStyleProject p = j.createFreeStyleProject();
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideFreeStyleProject("user", p.getFullName(), Job.EXTENDED_READ.getId(), true));
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+
+    @Test
+    public void testEvaluationOrder() throws Exception {
+        WebClient wc = j.createWebClient().login("user");
+        FreeStyleProject p = j.createFreeStyleProject();
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideFreeStyleProject("user", p.getFullName(), Job.EXTENDED_READ.getId(), false));
+        AuthorizationStrategyOverrideConfiguration.get().getOverrides().
+            add(new TestOverrideFreeStyleProject("user", p.getFullName(), Job.EXTENDED_READ.getId(), true));
+        try {
+            wc.getOptions().setPrintContentOnFailingStatusCode(false);
+            wc.getPage(p, "configure");
+            fail();
+        } catch(FailingHttpStatusCodeException e) {
+            assertEquals(403, e.getStatusCode());
+        }
+    }
+}

--- a/test/src/test/resources/jenkins/security/AuthorizationStrategyOverrideConfigurationTest/TestConfigureAuthorizationStrategyOverride/config.jelly
+++ b/test/src/test/resources/jenkins/security/AuthorizationStrategyOverrideConfigurationTest/TestConfigureAuthorizationStrategyOverride/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry field="field">
+    <f:textbox />
+  </f:entry>
+</j:jelly>


### PR DESCRIPTION
[JENKINS-13190](https://issues.jenkins-ci.org/browse/JENKINS-13190)
Introduce new following extension points to allow plugins to override ACLs:
- `AuthorizationStrategyOverride<T>`
  - Allow or deny specific permissions of specific items.
  - For security reasons, administrators need to configure them in the global security configuration page explicitly if they want to enable them.
    - I believe permissions should be allowed only when administrators explicitly want that as that can easily cause security vulnerabilities.
- `AuthorizationStrategyDenyOverride<T>`
  - Deny specific permissions of specific items.
  - They are enabled when plugins with them are installed. No need to configure them explicitly.
    - I believe denying permissions doesn't cause security vulnerabilities.

Otherwise, plugins that want to provide their own additional ACL rules have to implement `AuthorizationStrategy` that alternates existing strategies like [matrix-auth](https://wiki.jenkins-ci.org/display/JENKINS/Matrix+Authorization+Strategy+Plugin) or [role-strategy](https://wiki.jenkins-ci.org/display/JENKINS/Role+Strategy+Plugin) and it is apparently unreasonable.

This replaces #412:
- Require explicit configurations to allow permissions.
- Allow override permissions for specific items (e.g. a specific project)

Use case:
- I want this feature for [JENKINS-35081 
  Separate authorization configuration page (authorize-project plugin)](https://issues.jenkins-ci.org/browse/JENKINS-35081)
  - I want to provide a separate configuration page of authorize-project plugin so that the buildtime aithorization is determined in project configuration pages.
  - I want allow only users configured in 
    the authorization configuration page to configure the project.

Outline of the change:
- Add `Jenkins#getOverriddenAuthorizationStrategy()` which returns `OverridingAuthorizationStrategy` wrapping `Jenkins#getAuthorizationStrategy()`.
- `OverridingAuthorizationStrategy` injects overriding ACLs.
  - It enumerates `AuthorizationStrategyOverride<T>` and `AuthorizationStrategyDenyOverride<T>` where `T` matches required types (`Jenkins`, `Job`, `Computer`, and so on) and test the permission and return an overridden value if exists.
- `getACL` methods like `Jenkins#getACL()`, `Job#getACL()`, `Computer#getACL()` and so on now calls `Jenkins#getOverriddenAuthorizationStrategy()`.

Known issues and notes:
- Overriding permissions doesn't take effects for plugins using `AuthorizationStrategy#getACL(...)` directly.
  - Plugins should use methods like `AbstractItem#getACL()` instead (I updated javadocs to describe so).
  - As far as I checked roughly, following plugins look use `AuthorizationStrategy#getACL(...)`:
    - gitlab-auth-plugin
    - pubsub-light-module
    - support-core-plugin
- I worry that this might performance issues as it uses Java reflections to list and filter registered instances of `AuthorizationStrategyOverride`.
  - Is there appropriate way to cache the results? I'm not sure when to invalidate the caches.
- `T` of `AuthorizationStrategyOverride<T>` should be `Jenkins`, `Job`, `AbstractItem`, `Computer`, `User`, `Cloud`, `Node` and their supertypes.
  - More specific types, e.g. `FreeStyleProject` isn't applicable.
  - This is a limitation to take advantage of Java generics and have it easy for developers implement sub classes of `AuthorizationStrategyOverride`.
  - Please let me know if there're better ways for Java generics.

A screenshot of the Configure Global Secury page:

![authorizationstrategyoverride](https://cloud.githubusercontent.com/assets/3115961/17157641/b04b0cfa-53cb-11e6-8477-ae13f5d3ce4e.png)
