### PR TITLE
Display delete button only when build is not locked

### DIFF
--- a/core/src/main/resources/hudson/model/Run/confirmDelete.jelly
+++ b/core/src/main/resources/hudson/model/Run/confirmDelete.jelly
@@ -24,20 +24,23 @@ THE SOFTWARE.
 
 <!-- Confirm deletion of the build/run -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.fullDisplayName}" norefresh="true">
-		<st:include page="sidepanel.jelly" />
-		<l:main-panel>
+    <st:include page="sidepanel.jelly"/>
+    <l:main-panel>
       <j:set var="msg" value="${it.whyKeepLog}"/>
       <j:if test="${msg!=null}">
-		    <p class="warning">${%Warning}: ${msg}</p>
-		  </j:if>
+        <p class="warning">${%Warning}: ${msg}</p>
+      </j:if>
 
-		    <form method="post" action="doDelete">
-		      ${%Are you sure about deleting the build?}
-		      <f:submit value="${%Yes}" />
-		    </form>
+      <j:if test="${msg==null}">
+        <form method="post" action="doDelete">
+          ${%Are you sure about deleting the build?}
+          <f:submit value="${%Yes}"/>
+        </form>
+      </j:if>
 
-		</l:main-panel>
-	</l:layout>
+    </l:main-panel>
+  </l:layout>
 </j:jelly>


### PR DESCRIPTION
Partially reverting changes introduced in https://github.com/jenkinsci/jenkins/commit/818ae76af82e8cb3f25cfbb83d42812c80809bab -- there is no need to display delete button when `whyKeepLog != null` as the delete will fail anyway. 

see https://issues.jenkins-ci.org/browse/JENKINS-26281

At the same time I fixed the formatting as it was a bit of a mess.

Diff: https://github.com/jenkinsci/jenkins/pull/2483/files?w=1
