### PR TITLE
[JENKINS-29922] Correct the default value handling of ArtifactArchiver.excludes

### DIFF
--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
 
 import net.sf.json.JSONObject;
 import javax.annotation.Nonnull;
@@ -76,7 +77,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
     /**
      * Possibly null 'excludes' pattern as in Ant.
      */
-    private String excludes = "";
+    private String excludes;
 
     @Deprecated
     private Boolean latestOnly;
@@ -154,11 +155,11 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
         return artifacts;
     }
 
-    public String getExcludes() {
+    public @CheckForNull String getExcludes() {
         return excludes;
     }
 
-    @DataBoundSetter public final void setExcludes(String excludes) {
+    @DataBoundSetter public final void setExcludes(@CheckForNull String excludes) {
         this.excludes = Util.fixEmptyAndTrim(excludes);
     }
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -133,6 +133,12 @@ THE SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jvnet.mock-javamail</groupId>
       <artifactId>mock-javamail</artifactId>
       <version>1.7</version>


### PR DESCRIPTION
Noted in [JENKINS-29922](https://issues.jenkins-ci.org/browse/JENKINS-29922) that _Snippet Generator_ as of 2.7.1 will produce

``` groovy
archiveArtifacts artifacts: 'x', excludes: null
```

whereas

``` groovy
archiveArtifacts 'x'
```

would suffice.

Same applies to the older `$class`-based syntax, it is just more noticeable now, since I would like to push the stock `ArtifactArchiver` in place of the dedicated `archive` step.

@reviewbybees
