### PR TITLE
[FIXED JENKINS-37041] Ensure that detached plugins are always at least their minimum version

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -401,6 +401,16 @@ public class ClassicPluginStrategy implements PluginStrategy {
         public VersionNumber getSplitWhen() {
             return splitWhen;
         }
+
+        /**
+         * Gets the minimum required version for the current version of Jenkins.
+         *
+         * @return the minimum required version for the current version of Jenkins.
+         * @sice 2.16
+         */
+        public VersionNumber getRequireVersion() {
+            return new VersionNumber(requireVersion);
+        }
     }
 
     private static final List<DetachedPlugin> DETACHED_LIST = Collections.unmodifiableList(Arrays.asList(

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -57,17 +57,13 @@ import java.io.FileInputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
 import java.net.URL;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
@@ -277,7 +273,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
             }
             // some earlier versions of maven-hpi-plugin apparently puts "null" as a literal in Hudson-Version. watch out for them.
             if (jenkinsVersion == null || jenkinsVersion.equals("null") || new VersionNumber(jenkinsVersion).compareTo(detached.splitWhen) <= 0) {
-                out.add(new PluginWrapper.Dependency(detached.shortName + ':' + detached.requireVersion));
+                out.add(new PluginWrapper.Dependency(detached.shortName + ':' + detached.requiredVersion));
                 LOGGER.log(Level.FINE, "adding implicit dependency {0} → {1} because of {2}", new Object[] {pluginName, detached.shortName, jenkinsVersion});
             }
         }
@@ -378,12 +374,12 @@ public class ClassicPluginStrategy implements PluginStrategy {
          * be "1.123.*" (because 1.124 will be the first version that doesn't include the removed code.)
          */
         private final VersionNumber splitWhen;
-        private final String requireVersion;
+        private final String requiredVersion;
 
-        private DetachedPlugin(String shortName, String splitWhen, String requireVersion) {
+        private DetachedPlugin(String shortName, String splitWhen, String requiredVersion) {
             this.shortName = shortName;
             this.splitWhen = new VersionNumber(splitWhen);
-            this.requireVersion = requireVersion;
+            this.requiredVersion = requiredVersion;
         }
 
         /**
@@ -408,8 +404,8 @@ public class ClassicPluginStrategy implements PluginStrategy {
          * @return the minimum required version for the current version of Jenkins.
          * @sice 2.16
          */
-        public VersionNumber getRequireVersion() {
-            return new VersionNumber(requireVersion);
+        public VersionNumber getRequiredVersion() {
+            return new VersionNumber(requiredVersion);
         }
     }
 

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -716,6 +716,34 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     new Object[] {lastExecVersion, Jenkins.VERSION, loadedDetached});
 
             InstallUtil.saveLastExecVersion();
+        } else {
+            final Set<ClassicPluginStrategy.DetachedPlugin> forceUpgrade = new HashSet<>();
+            for (ClassicPluginStrategy.DetachedPlugin p : ClassicPluginStrategy.getDetachedPlugins()) {
+                VersionNumber installedVersion = getPluginVersion(rootDir, p.getShortName());
+                VersionNumber requireVersion = p.getRequireVersion();
+                if (installedVersion != null && installedVersion.isOlderThan(requireVersion)) {
+                    LOGGER.log(Level.WARNING,
+                            "Detached plugin {0} found at version {1}, required minimum version is {2}",
+                            new Object[]{p.getShortName(), installedVersion, requireVersion});
+                    forceUpgrade.add(p);
+                }
+            }
+            if (!forceUpgrade.isEmpty()) {
+                Set<String> loadedDetached = loadPluginsFromWar("/WEB-INF/detached-plugins", new FilenameFilter() {
+                    @Override
+                    public boolean accept(File dir, String name) {
+                        name = normalisePluginName(name);
+                        for (ClassicPluginStrategy.DetachedPlugin detachedPlugin : forceUpgrade) {
+                            if (detachedPlugin.getShortName().equals(name)) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    }
+                });
+                LOGGER.log(INFO, "Upgraded detached plugins (and dependencies): {0}",
+                        new Object[]{loadedDetached});
+            }
         }
     }
 

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -720,11 +720,11 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             final Set<ClassicPluginStrategy.DetachedPlugin> forceUpgrade = new HashSet<>();
             for (ClassicPluginStrategy.DetachedPlugin p : ClassicPluginStrategy.getDetachedPlugins()) {
                 VersionNumber installedVersion = getPluginVersion(rootDir, p.getShortName());
-                VersionNumber requireVersion = p.getRequireVersion();
-                if (installedVersion != null && installedVersion.isOlderThan(requireVersion)) {
+                VersionNumber requiredVersion = p.getRequiredVersion();
+                if (installedVersion != null && installedVersion.isOlderThan(requiredVersion)) {
                     LOGGER.log(Level.WARNING,
                             "Detached plugin {0} found at version {1}, required minimum version is {2}",
-                            new Object[]{p.getShortName(), installedVersion, requireVersion});
+                            new Object[]{p.getShortName(), installedVersion, requiredVersion});
                     forceUpgrade.add(p);
                 }
             }


### PR DESCRIPTION
See [JENKINS-37041](https://issues.jenkins-ci.org/browse/JENKINS-37041)

Ok, so here was the test scenario:
1. Upgrade Jenkins (this will upgrade the detached plugin)
2. Stop Jenkins
3. Overwrite the detached plugin with the older version
4. Start Jenkins
5. Watch as the world burns

With this fix, under my _(slightly contrived)_ test scenario I now get

```
INFO: Started initialization
Jul 28, 2016 4:07:38 PM hudson.PluginManager loadDetachedPlugins
WARNING: Detached plugin bouncycastle-api found at version 1.648.3, required minimum version is 2.16.0
...
INFO: Initializing Bouncy Castle security provider.
Jul 28, 2016 4:07:39 PM jenkins.bouncycastle.api.SecurityProviderInitializer addSecurityProvider
INFO: Bouncy Castle security provider initialized.
Jul 28, 2016 4:07:42 PM jenkins.InitReactorRunner$1 onAttained
```

So this fixed the only code path that I could find that remained whereby a plugin that has been detached would not get upgraded (namely if the admin mistakenly overwrites the detached plugin with an older version than the stated minimum version)

CRITICAL IMHO that this lands in 2.16

@reviewbybees @jenkinsci/code-reviewers 
