### PR TITLE
[JENKINS-23365] Better diagnostics and robustness

### DIFF
--- a/core/src/main/java/hudson/scm/ChangeLogAnnotator.java
+++ b/core/src/main/java/hudson/scm/ChangeLogAnnotator.java
@@ -33,6 +33,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.scm.ChangeLogSet.Entry;
 import hudson.util.CopyOnWriteList;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -81,7 +82,7 @@ public abstract class ChangeLogAnnotator implements ExtensionPoint {
         if (build instanceof AbstractBuild && Util.isOverridden(ChangeLogAnnotator.class, getClass(), "annotate", AbstractBuild.class, Entry.class, MarkupText.class)) {
             annotate((AbstractBuild) build, change, text);
         } else {
-            throw new AbstractMethodError("You must override the newer overload of annotate");
+            Logger.getLogger(ChangeLogAnnotator.class.getName()).log(Level.WARNING, "You must override the newer overload of annotate from {0}", getClass().getName());
         }
     }
 


### PR DESCRIPTION
Follows up #1257.

```
…    SEVERE  hudson.scm.ChangeLogSet$Entry#getMsgAnnotated: ChangeLogAnnotator org.marvelution.jenkins.plugins.jira.scm.JIRAChangeLogAnnotator@… failed to annotate message '…'; You must override the newer overload of annotate
… [id=…]    WARNING h.ExpressionFactory2$JexlExpression#evaluate: Caught exception evaluating: cs.commentAnnotated in /…/job/…/…/changes. Reason: java.lang.reflect.InvocationTargetExceptionjava.lang.reflect.InvocationTargetException
    at …
Caused by: java.lang.AbstractMethodError: You must override the newer overload of annotate
    at hudson.scm.ChangeLogAnnotator.annotate(ChangeLogAnnotator.java:85)
    at hudson.plugins.git.GitChangeSet.getCommentAnnotated(GitChangeSet.java:477)
    ... 173 more
```

@reviewbybees
