### PR TITLE
[JENKINS-36757] don't quote a paramaterized message.

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1450,7 +1450,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                         }
                     });
                 } else {
-                    LOGGER.log(WARNING, "Update site '{0}' does not declare the connection check URL. "
+                    LOGGER.log(WARNING, "Update site ''{0}'' does not declare the connection check URL. "
                             + "Skipping the network availability check.", site.getId());
                     connectionStates.put(ConnectionStatus.INTERNET, ConnectionStatus.SKIPPED);
                 }

--- a/core/src/main/java/jenkins/install/InstallState.java
+++ b/core/src/main/java/jenkins/install/InstallState.java
@@ -173,13 +173,13 @@ public class InstallState implements ExtensionPoint {
     public Object readResolve() {
         // If we get invalid state from the configuration, fallback to unknown
         if (StringUtils.isBlank(name)) {
-            LOGGER.log(Level.WARNING, "Read install state with blank name: '{0}'. It will be ignored", name);
+            LOGGER.log(Level.WARNING, "Read install state with blank name: ''{0}''. It will be ignored", name);
             return UNKNOWN;
         }
         
         InstallState state = InstallState.valueOf(name);
         if (state == null) {
-            LOGGER.log(Level.WARNING, "Cannot locate an extension point for the state '{0}'. It will be ignored", name);
+            LOGGER.log(Level.WARNING, "Cannot locate an extension point for the state ''{0}''. It will be ignored", name);
             return UNKNOWN;
         }
         

--- a/core/src/main/resources/lib/hudson/project/configurable_pt_BR.properties
+++ b/core/src/main/resources/lib/hudson/project/configurable_pt_BR.properties
@@ -24,4 +24,4 @@ Build\ scheduled=build agendada
 delete=Excluir {0}
 Configure=Configurar
 View\ Configuration= Configurar a view
-delete.confirm=Quer mesmo remover {0} '{1}'?
+delete.confirm=Quer mesmo remover {0} ''{1}''?


### PR DESCRIPTION
'{0}' is the literal string {0} in a message format - if you want to quote
the parameter then you need to use double single quotes ''{0}''

@reviewbybees 
[JENKINS-36757](https://issues.jenkins-ci.org/browse/JENKINS-36757)
