### PR TITLE
[FIXED JENKINS-36539] - OK button disabled if project type chosen first

### DIFF
--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -107,7 +107,6 @@ $.when(getItems()).done(function(data) {
           btn.removeClass('disabled');
           btn.prop('disabled', false);
         }
-        btn.focus();
       } else {
         if (!btn.hasClass('disabled')) {
           btn.addClass('disabled');
@@ -234,7 +233,7 @@ $.when(getItems()).done(function(data) {
     $("#add-item-panel").find("#name").focus();
 
     // Init NameField
-    $('input[name="name"]', '#createItem').blur(function() {
+    $('input[name="name"]', '#createItem').on("blur input", function() {
       if (!isItemNameEmpty()) {
         var itemName = $('input[name="name"]', '#createItem').val();
         $.get("checkJobName", { value: itemName }).done(function(data) {


### PR DESCRIPTION
These changes allow a user to first select an item type, and then enter in an item name afterwards. By having the code that enables (but doesn't put into focus) the 'OK' button once an 'input' event is triggered, a user can select the type first & then choose a name. Of course, if a user chooses, it's still possible to type in a name & then choose a type (although one downside to this change appears to be that the 'OK' button isn't in focus after choosing a type).

Initially, this caused an issue where each time the user entered a new character into the <input> element (thus triggering the 'input' event), the 'OK' button would be brought back into focus. As a result, I decided to remove the call to the focus() function inside enableSubmit();

The original ticket is [JENKINS-36539](https://issues.jenkins-ci.org/browse/JENKINS-36539)
