### PR TITLE
[JENKINS-37140,JENKINS-36991] - Upgrade remoting to 2.61

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>2.60</version>
+        <version>2.61</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Fixed issues:
- [JENKINS-37140](https://issues.jenkins-ci.org/browse/JENKINS-37140) -
  JNLP Slave connection issue with _JNLP3-connect_ protocol when the generated encrypted cookie contains a newline symbols.
  (https://github.com/jenkinsci/remoting/pull/95)
- [JENKINS-36991](https://issues.jenkins-ci.org/browse/JENKINS-36991) -
  Unable to load class when remote classloader gets interrupted.
  (https://github.com/jenkinsci/remoting/pull/94)

Enhancements:
- Improve diagnostics for Jar Cache write errors.
  (https://github.com/jenkinsci/remoting/pull/91)
