### PR TITLE
[FIXED JENKINS-37189] Only append `?uctest` to http/https update center URLs

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1042,7 +1042,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
          * @throws IOException if a connection to the update center server can't be established.
          */
         public void checkUpdateCenter(ConnectionCheckJob job, String updateCenterUrl) throws IOException {
-            testConnection(new URL(updateCenterUrl + "?uctest"));
+            if (updateCenterUrl.startsWith("http://") || updateCenterUrl.startsWith("https://")) {
+                testConnection(new URL(updateCenterUrl + (updateCenterUrl.indexOf('?') == -1 ? "?uctest" : "&uctest")));
+            } else {
+                testConnection(new URL(updateCenterUrl));
+            }
         }
 
         /**

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1042,11 +1042,23 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
          * @throws IOException if a connection to the update center server can't be established.
          */
         public void checkUpdateCenter(ConnectionCheckJob job, String updateCenterUrl) throws IOException {
+            testConnection(toUpdateCenterCheckUrl(updateCenterUrl));
+        }
+
+        /**
+         * Converts an update center URL into the URL to use for checking its connectivity.
+         * @param updateCenterUrl the URL to convert.
+         * @return the converted URL.
+         * @throws MalformedURLException if the supplied URL is malformed.
+         */
+        static URL toUpdateCenterCheckUrl(String updateCenterUrl) throws MalformedURLException {
+            URL url;
             if (updateCenterUrl.startsWith("http://") || updateCenterUrl.startsWith("https://")) {
-                testConnection(new URL(updateCenterUrl + (updateCenterUrl.indexOf('?') == -1 ? "?uctest" : "&uctest")));
+                url = new URL(updateCenterUrl + (updateCenterUrl.indexOf('?') == -1 ? "?uctest" : "&uctest"));
             } else {
-                testConnection(new URL(updateCenterUrl));
+                url = new URL(updateCenterUrl);
             }
+            return url;
         }
 
         /**

--- a/core/src/test/java/hudson/model/UpdateCenterTest.java
+++ b/core/src/test/java/hudson/model/UpdateCenterTest.java
@@ -1,0 +1,44 @@
+package hudson.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class UpdateCenterTest {
+
+    @Test
+    public void toUpdateCenterCheckUrl_http_noQuery() throws Exception {
+        assertThat(UpdateCenter.UpdateCenterConfiguration.toUpdateCenterCheckUrl(
+                "http://updates.jenkins-ci.org/update-center.json").toExternalForm(),
+                is("http://updates.jenkins-ci.org/update-center.json?uctest"));
+    }
+
+    @Test
+    public void toUpdateCenterCheckUrl_https_noQuery() throws Exception {
+        assertThat(UpdateCenter.UpdateCenterConfiguration.toUpdateCenterCheckUrl(
+                "https://updates.jenkins-ci.org/update-center.json").toExternalForm(),
+                is("https://updates.jenkins-ci.org/update-center.json?uctest"));
+    }
+
+    @Test
+    public void toUpdateCenterCheckUrl_http_query() throws Exception {
+        assertThat(UpdateCenter.UpdateCenterConfiguration.toUpdateCenterCheckUrl(
+                "http://updates.jenkins-ci.org/update-center.json?version=2.7").toExternalForm(),
+                is("http://updates.jenkins-ci.org/update-center.json?version=2.7&uctest"));
+    }
+
+    @Test
+    public void toUpdateCenterCheckUrl_https_query() throws Exception {
+        assertThat(UpdateCenter.UpdateCenterConfiguration.toUpdateCenterCheckUrl(
+                "https://updates.jenkins-ci.org/update-center.json?version=2.7").toExternalForm(),
+                is("https://updates.jenkins-ci.org/update-center.json?version=2.7&uctest"));
+    }
+
+    @Test
+    public void toUpdateCenterCheckUrl_file() throws Exception {
+        assertThat(UpdateCenter.UpdateCenterConfiguration.toUpdateCenterCheckUrl(
+                "file://./foo.jar!update-center.json").toExternalForm(),
+                is("file://./foo.jar!update-center.json"));
+    }
+}


### PR DESCRIPTION
- Also fixes to append `&uctest` if the update center URL already contains a query fragment

@jenkinsci/code-reviewers @reviewbybees

@olivergondza can we get an exemption so that this can be included in the backports for 2.7.3?
