### PR TITLE
[JENKINS-23271] - Prohibit automatic unexporting of RemoteProcess objects to prevent Intermittent ObjectId issue

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -1147,7 +1147,7 @@ public abstract class Launcher {
 
             final Proc p = ps.start();
 
-            return Channel.current().export(RemoteProcess.class,new RemoteProcess() {
+            return Channel.current().exportAsyncObject(RemoteProcess.class,new RemoteProcess() {
                 public int join() throws InterruptedException, IOException {
                     try {
                         return p.join();

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>2.61</version>
+        <version>2.61-SNAPSHOT</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Follow-up fix of https://github.com/jenkinsci/remoting/pull/99

https://issues.jenkins-ci.org/browse/JENKINS-23271

@reviewbybees
