### PR TITLE
HTML/XML attribute values are to be surrounded by quotes

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -59,7 +59,7 @@ Upcoming changes</a>
   <li class=>
 </ul>
 </div><!--=TRUNK-END=-->
-<h3><a name=v2.17>What's new in 2.17</a> (2016/08/05)</h3>
+<h3><a name="v2.17">What's new in 2.17</a> (2016/08/05)</h3>
 <ul class=image>
   <li class="major bug">
     Don't load all builds to display the paginated build history widget.
@@ -71,7 +71,7 @@ Upcoming changes</a>
     Internal: Invoke FindBugs during core build.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36715">issue 36715</a>)
 </ul>
-<h3><a name=v2.16>What's new in 2.16</a> (2016/07/31)</h3>
+<h3><a name="v2.16">What's new in 2.16</a> (2016/07/31)</h3>
 <ul class=image>
   <li class="major bug">
     Fix plugin dependency resolution. Jenkins will now refuse to load plugins with unsatisfied dependencies, which resulted in difficult to diagnose problems. <strong>This may result in errors on startup if your instance has an invalid plugin configuration.</strong>, check the Jenkins log for details.
@@ -116,7 +116,7 @@ Upcoming changes</a>
     Internal: Fix the default value handling of <tt>ArtifactArchiver.excludes</tt>.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29922">issue 29922</a>)
 </ul>
-<h3><a name=v2.15>What's new in 2.15</a> (2016/07/24)</h3>
+<h3><a name="v2.15">What's new in 2.15</a> (2016/07/24)</h3>
 <ul class=image>
   <li class="major bug">
     Tell browsers not to cache or try to autocomplete forms in Jenkins to prevent problems due to invalid data in form submissions.
@@ -138,7 +138,7 @@ Upcoming changes</a>
     Internal: Extract the CLI command <tt>offline-node</tt> from core.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34468">issue 34468</a>)
 </ul>
-<h3><a name=v2.14>What's new in 2.14</a> (2016/07/17)</h3>
+<h3><a name="v2.14">What's new in 2.14</a> (2016/07/17)</h3>
 <ul class=image>
   <li class=rfe>
     Minor optimization in calculation of recent build stability health report.
@@ -171,7 +171,7 @@ Upcoming changes</a>
     Developer API: Usage of <code>ItemCategory#MIN_TOSHOW</code> in external plugins is now restricted.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36593">issue 36593</a>)
 </ul>
-<h3><a name=v2.13>What's new in 2.13</a> (2016/07/10)</h3>
+<h3><a name="v2.13">What's new in 2.13</a> (2016/07/10)</h3>
 <ul class=image>
   <li class=bug>
     <code>IllegalStateException</code> under certain conditions when reloading configuration from disk while jobs are in the queue.
@@ -183,7 +183,7 @@ Upcoming changes</a>
     Make setup wizard installation panel usable on small screens.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34668">issue 34668</a>)
 </ul>
-<h3><a name=v2.12>What's new in 2.12</a> (2016/07/05)</h3>
+<h3><a name="v2.12">What's new in 2.12</a> (2016/07/05)</h3>
 <ul class=image>
   <li class=rfe>
     Enable the <code>DescriptorVisibilityFilter</code>s for ComputerLauncher, RetentionStrategy and NodeProperty.
@@ -220,14 +220,14 @@ Upcoming changes</a>
     Internal API: Make <code>BulkChange</code> auto-closeable.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2428">PR #2428</a>)
 </ul>
-<h3><a name=v2.11>What's new in 2.11</a> (2016/06/26)</h3>
+<h3><a name="v2.11">What's new in 2.11</a> (2016/06/26)</h3>
 <ul class=image>
   <li class=rfe>
     Provide an extension point for SCM decisions such as whether to poll a specific job's backing
     repository for changes.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36123">issue 36123</a>)
 </ul>
-<h3><a name=v2.10>What's new in 2.10</a> (2016/06/19)</h3>
+<h3><a name="v2.10">What's new in 2.10</a> (2016/06/19)</h3>
 <ul class=image>
   <li class=rfe>
     Better exception message if a <code>SecurityRealm</code> returns null when loading a user.
@@ -239,7 +239,7 @@ Upcoming changes</a>
     Internal: It was impossible to build Jenkins on 32-bit Linux machine.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-36052">issue 36052, regression from 2.0</a>)
 </ul>
-<h3><a name=v2.9>What's new in 2.9</a> (2016/06/13)</h3>
+<h3><a name="v2.9">What's new in 2.9</a> (2016/06/13)</h3>
 <ul class=image>
   <li class=bug>
     Always send usage statistics over HTTPs to the new usage.jenkins.io hostname.
@@ -275,7 +275,7 @@ Upcoming changes</a>
     API: Make it easier for <code>UpdateSite</code>s to tweak the </code>InstallationJob</code>.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-35402">issue 35402</a>)
 </ul>
-<h3><a name=v2.8>What's new in 2.8</a> (2016/06/05)</h3>
+<h3><a name="v2.8">What's new in 2.8</a> (2016/06/05)</h3>
 <ul class=image>
   <li class=bug>
     Explicitly declare compatibility of Windows build agent service with .NET Framework 4.
@@ -304,7 +304,7 @@ Upcoming changes</a>
     to the proxy validation logic.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1955">PR #1955</a>)
 </ul>
-<h3><a name=v2.7>What's new in 2.7</a> (2016/05/29)</h3>
+<h3><a name="v2.7">What's new in 2.7</a> (2016/05/29)</h3>
 <ul class=image>
   
   <li class="bug">
@@ -336,7 +336,7 @@ Upcoming changes</a>
     Internal: NodeJS build was malfunctional on Win x64.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-35201">issue 35201</a>)
 </ul>
-<h3><a name=v2.6>What's new in 2.6</a> (2016/05/22)</h3>
+<h3><a name="v2.6">What's new in 2.6</a> (2016/05/22)</h3>
 <ul class=image>
   <li class="major rfe">
     Adapt the Setup Wizard GUI to provide a similar user experience when upgrading Jenkins. 
@@ -383,7 +383,7 @@ Upcoming changes</a>
     Internal: CLI command <code>connect-node</code> was extracted from the core to CLI. 
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-31417">issue 31417</a>)
 </ul>
-<h3><a name=v2.5>What's new in 2.5</a> (2016/05/16)</h3>
+<h3><a name="v2.5">What's new in 2.5</a> (2016/05/16)</h3>
 <ul class=image>
   <li class="major bug">
     Do not throw exceptions if <code>Jenkins.getInstance()</code> returns <code>null</code> instance.
@@ -395,7 +395,7 @@ Upcoming changes</a>
     behavior change.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34857">issue 34857</a>)
 </ul>
-<h3><a name=v2.4>What's new in 2.4</a> (2016/05/15)</h3>
+<h3><a name="v2.4">What's new in 2.4</a> (2016/05/15)</h3>
 <ul class=image>
   <li class=rfe>
     Internal/build: <code>jenkins-ui</code> (NPM module) is private, used only internally.
@@ -507,13 +507,13 @@ Upcoming changes</a>
     (Controlled by <a href="https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties">PROTOCOL_CLASS_NAME.disabled</a>)
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-34819">issue 34819</a>)
 </ul>
-<h3><a name=v2.3>What's new in 2.3</a> (2016/05/11)</h3>
+<h3><a name="v2.3">What's new in 2.3</a> (2016/05/11)</h3>
 <ul class=image>
   <li class="major bug">
      <strong>Important security fixes</strong>
      (see the <a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-05-11">security advisory</a> for details and plugin compatibility issues)
 </ul>
-<h3><a name=v2.2>What's new in 2.2</a> (2016/05/08)</h3>
+<h3><a name="v2.2">What's new in 2.2</a> (2016/05/08)</h3>
 <ul class=image>
   <li class="rfe">
     Add symbol annotations on core.
@@ -550,7 +550,7 @@ Upcoming changes</a>
     Fix inline help for node name field.
   	(<a href="https://issues.jenkins-ci.org/browse/JENKINS-34601">issue 34601</a>)
 </ul>
-<h3><a name=v2.1>What's new in 2.1</a> (2016/05/01)</h3>
+<h3><a name="v2.1">What's new in 2.1</a> (2016/05/01)</h3>
 <ul class=image>
   <li class="major bug">
   	Enable disabled dependencies during plugin installations.
@@ -624,7 +624,7 @@ Upcoming changes</a>
 </ul>
 
 
-<h3><a name=v2.0>What's new in 2.0</a> (2016/04/20)</h3>
+<h3><a name="v2.0">What's new in 2.0</a> (2016/04/20)</h3>
 <div style="margin: 10px; padding: 10px; background-color: #FFFFCE;">
   <strong>More detailed information about the new features in Jenkins 2.0 <a href="/2.0/">on the overview page</a>.</strong>
 </div>
@@ -675,7 +675,7 @@ Upcoming changes</a>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-33942">issue 33942</a>)
 
 </ul>
-<h3><a name=v1.656>What's new in 1.656</a> (2016/04/03)</h3>
+<h3><a name="v1.656">What's new in 1.656</a> (2016/04/03)</h3>
 <ul class=image>
   <li class="bug">
     Advertise the correct JNLP port when using the system property override.
@@ -696,7 +696,7 @@ Upcoming changes</a>
     Core development: Prevent leaking threads due to <tt>NioChannelSelector</tt>.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2176">pull 2176</a>)
 </ul>
-<h3><a name=v1.655>What's new in 1.655</a> (2016/03/27)</h3>
+<h3><a name="v1.655">What's new in 1.655</a> (2016/03/27)</h3>
 <ul class=image>
   <li class="major bug">
     Downgrade Stapler to 1.239 to fix remote API issues.
@@ -721,7 +721,7 @@ Upcoming changes</a>
     Core Development:  Add the <tt>.mvn</tt> directory and set default <tt>-Xmx</tt> value.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2162">pull 2162</a>)
 </ul>
-<h3><a name=v1.654>What's new in 1.654</a> (2016/03/21)</h3>
+<h3><a name="v1.654">What's new in 1.654</a> (2016/03/21)</h3>
 <ul class=image>
   <li class="bug">
     Improve logging and error message when JNLP is already in use.
@@ -748,7 +748,7 @@ Upcoming changes</a>
     Do not specifically require .NET framework 2.0 since 4.0 will do as well.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21484">issue 21484</a>)
 </ul>
-<h3><a name=v1.653>What's new in 1.653</a> (2016/03/13)</h3>
+<h3><a name="v1.653">What's new in 1.653</a> (2016/03/13)</h3>
 <ul class=image>
   <li class="major rfe">
     Support encrypted communication between master and JNLP slaves.
@@ -762,7 +762,7 @@ Upcoming changes</a>
   <li class="rfe">
     Developer API: <tt>Jenkins.getInstance()</tt> cannot be <tt>null</tt> anymore. Introduced <tt>Jenkins.getInstanceOrNull()</tt>.
 </ul>
-<h3><a name=v1.652>What's new in 1.652</a> (2016/03/06)</h3>
+<h3><a name="v1.652">What's new in 1.652</a> (2016/03/06)</h3>
 <ul class=image>
   <li class="bug">
     Under some conditions Jenkins startup could fail because of incorrectly linked extensions; now recovering more gracefully.
@@ -771,7 +771,7 @@ Upcoming changes</a>
     Developer API: Add <tt>WorkspaceList.tempDir(…)</tt>.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27152">issue 27152</a>)
 </ul>
-<h3><a name=v1.651>What's new in 1.651</a> (2016/02/28)</h3>
+<h3><a name="v1.651">What's new in 1.651</a> (2016/02/28)</h3>
 <ul class=image>
   <li class="rfe">
     Move periodic task log files from <code>JENKINS_HOME/*.log</code> to <code>JENKINS_HOME/logs/tasks/*.log</code> and rotate them periodically rather than overwrite every execution.
@@ -780,13 +780,13 @@ Upcoming changes</a>
     Fix documentation of proxy configuration.
     (<a href="https://github.com/jenkinsci/jenkins/pull/2060">pull 2060</a>)
 </ul>
-<h3><a name=v1.650>What's new in 1.650</a> (2016/02/24)</h3>
+<h3><a name="v1.650">What's new in 1.650</a> (2016/02/24)</h3>
 <ul class=image>
    <li class="major bug">
      <strong>Important security fixes</strong>
      (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-02-24">security advisory</a>)
 </ul>
-<h3><a name=v1.649>What's new in 1.649</a> (2016/02/21)</h3>
+<h3><a name="v1.649">What's new in 1.649</a> (2016/02/21)</h3>
 <ul class=image>
   <li class="rfe">
     Allow changing the directory used for the extraction of plugin archives via the <code>--pluginroot</code> CLI option (also controllable via the <code>hudson.PluginManager.workDir</code> system property / context parameter. Also document the <code>--webroot</code> CLI parameter in <code>java -jar jenkins.war --help</code>
@@ -802,7 +802,7 @@ Upcoming changes</a>
     (<a href="https://github.com/jenkinsci/jenkins/pull/2041">pull 2041</a>,
     <a href="https://github.com/jenkinsci/jenkins/pull/2044">pull 2044</a>)
 </ul>
-<h3><a name=v1.648>What's new in 1.648</a> (2016/02/17)</h3>
+<h3><a name="v1.648">What's new in 1.648</a> (2016/02/17)</h3>
 <ul class=image>
   <li class="rfe">
     Improved Czech and Polish translation.
@@ -813,13 +813,13 @@ Upcoming changes</a>
     Generate new instance identity file when the existing one is found to be corrupt.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29240">issue 29240</a>)
 </ul>
-<h3><a name=v1.647>What's new in 1.647</a> (2016/02/04)</h3>
+<h3><a name="v1.647">What's new in 1.647</a> (2016/02/04)</h3>
 <ul class=image>
   <li class="bug">
     Retrieve tool installer metadata from all update sites.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-32328">issue 32328</a>)
 </ul>
-<h3><a name=v1.646>What's new in 1.646</a> (2016/01/25)</h3>
+<h3><a name="v1.646">What's new in 1.646</a> (2016/01/25)</h3>
 <ul class=image>
   <li class="major rfe">
     The official parent POM for plugins is now hosted in the <code>plugin-pom</code> repository, starting with version 2.0.
@@ -834,7 +834,7 @@ Upcoming changes</a>
     Added missing translations for Polish language.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1986">pull 1986</a>)
 </ul>
-<h3><a name=v1.645>What's new in 1.645</a> (2016/01/18)</h3>
+<h3><a name="v1.645">What's new in 1.645</a> (2016/01/18)</h3>
 <ul class=image>
   <li class="bug">
     Cleanup of CLI error handling and return codes.
@@ -858,7 +858,7 @@ Upcoming changes</a>
     Pass <tt>$it</tt> to contents of <tt>dropdownDescriptorSelector</tt>.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19565">issue 19565</a>)
 </ul>
-<h3><a name=v1.644>What's new in 1.644</a> (2016/01/10)</h3>
+<h3><a name="v1.644">What's new in 1.644</a> (2016/01/10)</h3>
 <ul class=image>
   <li class="rfe">
     API changes: Add a reusable implementation of <code>IdleOfflineCause</code> class.
@@ -876,7 +876,7 @@ Upcoming changes</a>
     The Windows service wrapper now specifies the <code>--webroot</code> argument to extract the war file into <code>%BASE%</code>.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1951">pull 1951</a>)
 </ul>
-<h3><a name=v1.643>What's new in 1.643</a> (2015/12/20)</h3>
+<h3><a name="v1.643">What's new in 1.643</a> (2015/12/20)</h3>
 <ul class=image>
   <li class="bug">
     Fix when multiple clouds are set up and provisioning of a node is denied.
@@ -888,19 +888,19 @@ Upcoming changes</a>
     Allow specifying the default TCP slave agent listener port via system property.
     (<a href="https://github.com/jenkinsci/jenkins/commit/653fbdb65024b1b528e21f682172885f7111bba9">commit 653fbdb</a>)
 </ul>
-<h3><a name=v1.642>What's new in 1.642</a> (2015/12/13)</h3>
+<h3><a name="v1.642">What's new in 1.642</a> (2015/12/13)</h3>
 <ul class=image>
   <li class="major bug">
     Various kinds of settings could not be saved since 1.640.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-31954">issue 31954</a>)
 </ul>
-<h3><a name=v1.641>What's new in 1.641</a> (2015/12/09)</h3>
+<h3><a name="v1.641">What's new in 1.641</a> (2015/12/09)</h3>
 <ul class=image>
    <li class="major bug">
      <strong>Important security fixes</strong>
      (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-12-09">security advisory</a>)
 </ul>
-<h3><a name=v1.640>What's new in 1.640</a> (2015/12/07)</h3>
+<h3><a name="v1.640">What's new in 1.640</a> (2015/12/07)</h3>
 <ul class=image>
   <li class="rfe">
     Added support of default values in the <code>enum.jelly</code> form element.
@@ -926,7 +926,7 @@ Upcoming changes</a>
     API changes: Deprecate subclassing of <code>hudson.Plugin</code>.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1940">PR 1940</a>)
 </ul>
-<h3><a name=v1.639>What's new in 1.639</a> (2015/11/29)</h3>
+<h3><a name="v1.639">What's new in 1.639</a> (2015/11/29)</h3>
 <ul class=image>
   <li class="major bug">
     “Discard old builds” setting would be lost if resaving job configuration as of 1.637 without rechecking the box.
@@ -938,13 +938,13 @@ Upcoming changes</a>
     Multiple workspace browser features broken on Windows masters since 1.634.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-31015">issue 31015</a>)
 </ul>
-<h3><a name=v1.638>What's new in 1.638</a> (2015/11/11)</h3>
+<h3><a name="v1.638">What's new in 1.638</a> (2015/11/11)</h3>
 <ul class=image>
   <li class="major bug">
     <strong>Important security fixes</strong>
     (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-11-11">security advisory</a>)
 </ul>
-<h3><a name=v1.637>What's new in 1.637</a> (2015/11/08)</h3>
+<h3><a name="v1.637">What's new in 1.637</a> (2015/11/08)</h3>
 <ul class=image>
   <li class="bug">
     Remove useless warnings about a JDK named <em>null</em>.
@@ -953,13 +953,13 @@ Upcoming changes</a>
     New <tt>OptionalJobProperty</tt> class to simplify <tt>JobProperty</tt> creation.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1888">pull 1888</a>)
 </ul>
-<h3><a name=v1.636>What's new in 1.636</a> (2015/11/01)</h3>
+<h3><a name="v1.636">What's new in 1.636</a> (2015/11/01)</h3>
 <ul class=image>
   <li class="rfe">
     Add "lastCompletedBuild" job permalink.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26270">issue 26270</a>)
 </ul>
-<h3><a name=v1.635>What's new in 1.635</a> (2015/10/25)</h3>
+<h3><a name="v1.635">What's new in 1.635</a> (2015/10/25)</h3>
 <ul class=image>
   <li class="rfe">
     Make Node implement Saveable.
@@ -981,7 +981,7 @@ Upcoming changes</a>
     Update JNA library to 4.2.1 in order to integrate fixes for linux-ppc64 and linux-arm platforms.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-15792">issue 15792</a>)
 </ul>
-<h3><a name=v1.634>What's new in 1.634</a> (2015/10/18)</h3>
+<h3><a name="v1.634">What's new in 1.634</a> (2015/10/18)</h3>
 <ul class=image>
   <li class="major bug">
     Fix order of builds in new builds history widget introduced in 1.633.
@@ -1014,7 +1014,7 @@ Upcoming changes</a>
     Let a combobox display its drop-down when focused, so users can see candidates without entering a letter.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26278">issue 26278</a>)
 </ul>
-<h3><a name=v1.633>What's new in 1.633</a> (2015/10/11)</h3>
+<h3><a name="v1.633">What's new in 1.633</a> (2015/10/11)</h3>
 <ul class=image>
   <li class="rfe">
     Added safari pinned tab icon.
@@ -1045,7 +1045,7 @@ Upcoming changes</a>
     Build history pagination and search.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26445">issue 26445</a>)
 </ul>
-<h3><a name=v1.632>What's new in 1.632</a> (2015/10/05)</h3>
+<h3><a name="v1.632">What's new in 1.632</a> (2015/10/05)</h3>
 <ul class=image>
   <li class="bug">
     Optimize TagCloud size calculation.
@@ -1066,25 +1066,25 @@ Upcoming changes</a>
     Sidepanel controls with confirmation (<code>lib/layout/task</code>) did not assign the proper CSS style.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-30787">issue 30787</a>)
 </ul>
-<h3><a name=v1.631>What's new in 1.631</a> (2015/09/27)</h3>
+<h3><a name="v1.631">What's new in 1.631</a> (2015/09/27)</h3>
 <ul class=image>
   <li class=rfe>
     Add proper labels for plugin categories assigned to some plugins.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1758">PR 1758</a>)
 </ul>
-<h3><a name=v1.630>What's new in 1.630</a> (2015/09/20)</h3>
+<h3><a name="v1.630">What's new in 1.630</a> (2015/09/20)</h3>
 <ul class=image>
   <li class="bug">
     Make <tt>JenkinsRule</tt> useable on systems which don't support JNA
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29507">issue 29507</a>)
 </ul>
-<h3><a name=v1.629>What's new in 1.629</a> (2015/09/15)</h3>
+<h3><a name="v1.629">What's new in 1.629</a> (2015/09/15)</h3>
 <ul class=image>
   <li class="rfe">
     Old data monitor made Jenkins single-threaded for all saves.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-30139">issue 30139</a>)
 </ul>
-<h3><a name=v1.628>What's new in 1.628</a> (2015/09/06)</h3>
+<h3><a name="v1.628">What's new in 1.628</a> (2015/09/06)</h3>
 <ul class=image>
   <li class="rfe">
     Replaced all non java.util.logging logging libraries with slf4j interceptors.
@@ -1093,7 +1093,7 @@ Upcoming changes</a>
     Document <tt>allBuilds</tt> subtree in remote API for jobs.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1817">PR 1817</a>)
 </ul>
-<h3><a name=v1.627>What's new in 1.627</a> (2015/08/30)</h3>
+<h3><a name="v1.627">What's new in 1.627</a> (2015/08/30)</h3>
 <ul class=image>
   <li class="major bug">
     Race condition in triggers could cause various <code>NullPointerException</code>s.
@@ -1105,7 +1105,7 @@ Upcoming changes</a>
     Allow plugins to augment or replace the plugin manager UI.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1788">PR 1788</a>)
 </ul>
-<h3><a name=v1.626>What's new in 1.626</a> (2015/08/23)</h3>
+<h3><a name="v1.626">What's new in 1.626</a> (2015/08/23)</h3>
 <ul class=image>
   <li class="bug">
     RunIdMigrator fails to revert Matrix and Maven jobs.
@@ -1115,7 +1115,7 @@ Upcoming changes</a>
       (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29798">issue 29798</a>)
   <li class=>
 </ul>
-<h3><a name=v1.625>What's new in 1.625</a> (2015/08/17)</h3>
+<h3><a name="v1.625">What's new in 1.625</a> (2015/08/17)</h3>
 <ul class=image>
   <li class="major bug">
     Fixed a deadlock between the old data monitor and authorization strategies.
@@ -1127,15 +1127,15 @@ Upcoming changes</a>
     Do not display <em>No changes</em> if changelog is still being computed.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-2327">issue 2327</a>)
 </ul>
-<h3><a name=v1.624>What's new in 1.624</a> (2015/08/09)</h3>
+<h3><a name="v1.624">What's new in 1.624</a> (2015/08/09)</h3>
 <ul class=image>
   <li class=rfe>
     Allow more job types to use a custom &quot;Build Now&quot; text.
   (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26147">issue 26147</a>)
 </ul>
-<h3><a name=v1.623>What's new in 1.623</a> (2015/08/02)</h3>
+<h3><a name="v1.623">What's new in 1.623</a> (2015/08/02)</h3>
 <p><em>No notable changes in this release.</em></p>
-<h3><a name=v1.622>What's new in 1.622</a> (2015/07/27)</h3>
+<h3><a name="v1.622">What's new in 1.622</a> (2015/07/27)</h3>
 <ul class=image>
   <li class=rfe>
     Jenkins now support self-restart and daemonization in FreeBSD
@@ -1144,7 +1144,7 @@ Upcoming changes</a>
     Node provisioner may fail to correctly indicate that provisioning was finished.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29568">issue 29568</a>)
 </ul>
-<h3><a name=v1.621>What's new in 1.621</a> (2015/07/19)</h3>
+<h3><a name="v1.621">What's new in 1.621</a> (2015/07/19)</h3>
 <ul class=image>
   <li class=bug>
     Sort by 'Free Disk Space' is incorrect.
@@ -1159,13 +1159,13 @@ Upcoming changes</a>
     Don't run trigger for disabled/copied projects.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1617">PR 1617</a>)
 </ul>
-<h3><a name=v1.620>What's new in 1.620</a> (2015/07/12)</h3>
+<h3><a name="v1.620">What's new in 1.620</a> (2015/07/12)</h3>
 <ul class=image>
   <li class=bug>
     Display system info even when slave is temporarily offline.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-29300">issue 29300</a>)
 </ul>
-<h3><a name=v1.619>What's new in 1.619</a> (2015/07/05)</h3>
+<h3><a name="v1.619">What's new in 1.619</a> (2015/07/05)</h3>
 <ul class=image>
   <li class=bug>
     Update auto-installer metadata for newly installed plugins.
@@ -1174,7 +1174,7 @@ Upcoming changes</a>
     Allow plugins to veto process killing.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-9104">issue 9104</a>)
 </ul>
-<h3><a name=v1.618>What's new in 1.618</a> (2015/06/29)</h3>
+<h3><a name="v1.618">What's new in 1.618</a> (2015/06/29)</h3>
 <ul class=image>
   <li class=bug>
     Fix deadlock in hudson.model.Executor.
@@ -1208,7 +1208,7 @@ Upcoming changes</a>
     Always use earlier start time when merging two equivalent queue items.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-2180">issue 2180</a>)
 </ul>
-<h3><a name=v1.617>What's new in 1.617</a> (2015/06/07)</h3>
+<h3><a name="v1.617">What's new in 1.617</a> (2015/06/07)</h3>
 <ul class=image>
   <li class=bug>
     Regression in build-history causing ball to not open console
@@ -1221,13 +1221,13 @@ Upcoming changes</a>
     if Jenkins nodes has not been loaded yet
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28654">issue 28654</a>) 
 </ul>
-<h3><a name=v1.616>What's new in 1.616</a> (2015/05/31)</h3>
+<h3><a name="v1.616">What's new in 1.616</a> (2015/05/31)</h3>
 <ul class=image>
   <li class=bug>
     Job loading can be broken by <code>NullPointerException</code> in a build trigger
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27549">issue 27549</a>) 
 </ul>
-<h3><a name=v1.615>What's new in 1.615</a> (2015/05/25)</h3>
+<h3><a name="v1.615">What's new in 1.615</a> (2015/05/25)</h3>
 <ul class=image>
   <li class=bug>
     Improper calculation of queue length in <code>UnlabeledLoadStatistics</code>
@@ -1252,7 +1252,7 @@ Upcoming changes</a>
     Build History badges don't wrap
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28455">issue 28455</a>)
 </ul>
-<h3><a name=v1.614>What's new in 1.614</a> (2015/05/17)</h3>
+<h3><a name="v1.614">What's new in 1.614</a> (2015/05/17)</h3>
 <ul class=image>
   <li class=rfe>
     ExtensionList even listener.
@@ -1270,7 +1270,7 @@ Upcoming changes</a>
     Do not follow href after sending POST via l:task
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28437">issue 28437</a>)
 </ul>
-<h3><a name=v1.613>What's new in 1.613</a> (2015/05/10)</h3>
+<h3><a name="v1.613">What's new in 1.613</a> (2015/05/10)</h3>
 <ul class=image>
   <li class=bug>
     Update bundled LDAP plugin in order to restore missing help files
@@ -1279,7 +1279,7 @@ Upcoming changes</a>
     hudson.model.Run.getLog() throws IndexOutOfBoundsException when called with maxLines=0
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27441">issue 27441</a>)
 </ul>
-<h3><a name=v1.612>What's new in 1.612</a> (2015/05/03)</h3>
+<h3><a name="v1.612">What's new in 1.612</a> (2015/05/03)</h3>
 <ul class=image>
   <li class=rfe>
     <strong>Jenkins now requires Java 7</strong>.
@@ -1308,7 +1308,7 @@ Upcoming changes</a>
     configured JVM options.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28111">issue 28111</a>)
 </ul>
-<h3><a name=v1.611>What's new in 1.611</a> (2015/04/26)</h3>
+<h3><a name="v1.611">What's new in 1.611</a> (2015/04/26)</h3>
 <ul class=image>
   <li class=bug>
     <code>Descriptor.getId</code> fix in 1.610 introduced a regression affecting at least the Copy Artifacts plugin.
@@ -1328,7 +1328,7 @@ Upcoming changes</a>
     Correctly identify Channel listener onClose propagated exceptions
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-28062">issue 28062</a>
 </ul>
-<h3><a name=v1.610>What's new in 1.610</a> (2015/04/19)</h3>
+<h3><a name="v1.610">What's new in 1.610</a> (2015/04/19)</h3>
 <ul class=image>
   <li class=bug>
     Since 1.598 overrides of <code>Descriptor.getId</code> were not correctly handled by form binding, breaking at least the CloudBees Templates plugin.
@@ -1341,7 +1341,7 @@ Upcoming changes</a>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27708">issue 27708</a>,
     <a href="https://issues.jenkins-ci.org/browse/JENKINS-27871">issue 27871</a>)
 </ul>
-<h3><a name=v1.609>What's new in 1.609</a> (2015/04/12)</h3>
+<h3><a name="v1.609">What's new in 1.609</a> (2015/04/12)</h3>
 <ul class=image>
   <li class=bug>
     When concurrent builds are enabled, artifact retention policy may delete artifact being
@@ -1351,7 +1351,7 @@ Upcoming changes</a>
     Documentation for $BUILD_ID did not reflect current reality
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26520">issue 26520</a>)
 </ul>
-<h3><a name=v1.608>What's new in 1.608</a> (2015/04/05)</h3>
+<h3><a name="v1.608">What's new in 1.608</a> (2015/04/05)</h3>
 <ul class=image>
   <li class=bug>
     PeepholePermalink RunListenerImpl oncompleted should be triggered before downstream builds are triggered.
@@ -1372,7 +1372,7 @@ Upcoming changes</a>
     Starting this version, native packages are produced from <a href="https://github.com/jenkinsci/packaging">the new repository</a>.
     File issues related to installers and packages in the <code>packaging</code> component.
 </ul>
-<h3><a name=v1.607>What's new in 1.607</a> (2015/03/30)</h3>
+<h3><a name="v1.607">What's new in 1.607</a> (2015/03/30)</h3>
 <ul class=image>
   <li class=bug>
     JSONP served with the wrong MIME type and rejected by Chrome.
@@ -1419,7 +1419,7 @@ Upcoming changes</a>
     Build reports to be running for 45 yr and counting.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26777">issue 26777</a>)
 </ul>
-<h3><a name=v1.606>What's new in 1.606</a> (2015/03/23)</h3>
+<h3><a name="v1.606">What's new in 1.606</a> (2015/03/23)</h3>
 <ul class=image>
   <li class=bug>
     Jenkins CLI doesn't handle arguments with equal signs
@@ -1434,13 +1434,13 @@ Upcoming changes</a>
     Fixes to several security vulnerabilities.
     (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-03-23">advisory</a>)
 </ul>
-<h3><a name=v1.605>What's new in 1.605</a> (2015/03/16)</h3>
+<h3><a name="v1.605">What's new in 1.605</a> (2015/03/16)</h3>
 <ul class=image>
   <li class=bug>
     Integrate Stapler fix for queue item API always returning 404 Not Found since 1.601.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27256">issue 27256</a>)
 </ul>
-<h3><a name=v1.604>What's new in 1.604</a> (2015/03/15)</h3>
+<h3><a name="v1.604">What's new in 1.604</a> (2015/03/15)</h3>
 <ul class=image>
   <li class=rfe>
     Added a switch (<tt>-Dhudson.model.User.allowNonExistentUserToLogin=true</tt>) to let users login even when the record is not found in the backend security realm.
@@ -1455,13 +1455,13 @@ Upcoming changes</a>
     Show displayName in build remote API.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26723">issue 26723</a>)
 </ul>
-<h3><a name=v1.602>What's new in 1.602</a> (2015/03/08)</h3>
+<h3><a name="v1.602">What's new in 1.602</a> (2015/03/08)</h3>
 <ul class=image>
   <li class="rfe">
     Show Check Now button also on Available and Updates tabs of plugin manager.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1593">PR 1593</a>)
 </ul>
-<h3><a name=v1.601>What's new in 1.601</a> (2015/03/03)</h3>
+<h3><a name="v1.601">What's new in 1.601</a> (2015/03/03)</h3>
 <ul class=image>
   <li class="major bug">
     Regression with environment variables in 1.600.
@@ -1479,7 +1479,7 @@ Upcoming changes</a>
     Map Queue.Item.id onto Run
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-27096">issue 27096</a>)
 </ul>
-<h3><a name=v1.600>What's new in 1.600</a> (2015/02/28)</h3>
+<h3><a name="v1.600">What's new in 1.600</a> (2015/02/28)</h3>
 <ul class=image>
   <li class="major bug">
     Fixes to multiple security vulnerabilities.
@@ -1499,7 +1499,7 @@ Upcoming changes</a>
     Maven build step fail to launch mvn process when special chars are present in build variables.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26684">issue 26684</a>)
 </ul>
-<h3><a name=v1.599>What's new in 1.599</a> (2015/02/16)</h3>
+<h3><a name="v1.599">What's new in 1.599</a> (2015/02/16)</h3>
 <ul class=image>
   <li class=bug>
     Errors in some Maven builds since 1.598.
@@ -1523,7 +1523,7 @@ Upcoming changes</a>
     Allow OldDataMonitor to discard promoted-build-plugin Promotions
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-26718">issue 26718</a>)
 </ul>
-<h3><a name=v1.598>What's new in 1.598</a> (2015/01/25)</h3>
+<h3><a name="v1.598">What's new in 1.598</a> (2015/01/25)</h3>
 <ul class=image>
   <li class=bug>
     FutureImpl does not cancel its start future.
@@ -1569,7 +1569,7 @@ Upcoming changes</a>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25455">issue 25455</a>,
      <a href="https://issues.jenkins-ci.org/browse/JENKINS-23151">issue 23151</a>)
 </ul>
-<h3><a name=v1.597>What's new in 1.597</a> (2015/01/19)</h3>
+<h3><a name="v1.597">What's new in 1.597</a> (2015/01/19)</h3>
 <ul class=image>
   <li class='major rfe'>
     <b><tt>JENKINS_HOME</tt> layout change</b>: builds are now keyed by build numbers and not timestamps.
@@ -1598,7 +1598,7 @@ Upcoming changes</a>
     Add range check for H(X-Y) syntax.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25897">issue 25897</a>)
 </ul>
-<h3><a name=v1.596>What's new in 1.596</a> (2015/01/04)</h3>
+<h3><a name="v1.596">What's new in 1.596</a> (2015/01/04)</h3>
 <ul class=image>
   <li class=bug>
     Build page was broken in Hungarian localization while building.
@@ -1607,7 +1607,7 @@ Upcoming changes</a>
     Allow breaking label and node lists.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25989">issue 25989</a>)
 </ul>
-<h3><a name=v1.595>What's new in 1.595</a> (2014/12/21)</h3>
+<h3><a name="v1.595">What's new in 1.595</a> (2014/12/21)</h3>
 <ul class=image>
   <li class=bug>
     Spurious warnings in the log after deleting builds.
@@ -1620,7 +1620,7 @@ Upcoming changes</a>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25499">issue 25499</a>,
      <a href="https://issues.jenkins-ci.org/browse/JENKINS-25498">issue 25498</a>)
 </ul>
-<h3><a name=v1.594>What's new in 1.594</a> (2014/12/14)</h3>
+<h3><a name="v1.594">What's new in 1.594</a> (2014/12/14)</h3>
 <ul class=image>
   <li class=bug>
     After recent Java security updates, Jenkins would not gracefully recover from a deleted <code>secrets/master.key</code>.
@@ -1629,7 +1629,7 @@ Upcoming changes</a>
     <i>Restrict where this project can be run</i> regressed in 1.589 when using the ClearCase plugin.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25533">issue 25533</a>)
 </ul>
-<h3><a name=v1.593>What's new in 1.593</a> (2014/12/07)</h3>
+<h3><a name="v1.593">What's new in 1.593</a> (2014/12/07)</h3>
 <ul class=image>
   <li class=rfe>
     Dynamic Single/Multi line Build History layout.
@@ -1638,19 +1638,19 @@ Upcoming changes</a>
      <a href="https://issues.jenkins-ci.org/browse/JENKINS-24687">issue 24687</a>,
      <a href="https://issues.jenkins-ci.org/browse/JENKINS-24589">issue 24589</a>)
 </ul>
-<h3><a name=v1.592>What's new in 1.592</a> (2014/11/30)</h3>
+<h3><a name="v1.592">What's new in 1.592</a> (2014/11/30)</h3>
 <ul class=image>
   <li class=bug>
     Performance problems on large workspaces associated with validating file include patterns.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25759">issue 25759</a>)
 </ul>
-<h3><a name=v1.591>What's new in 1.591</a> (2014/11/25)</h3>
+<h3><a name="v1.591">What's new in 1.591</a> (2014/11/25)</h3>
 <ul class=image>
   <li class=bug>
     Always use forward slashes in path separators during in ZIP archives generated by Directory Browser
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22514">issue 22514</a>)
 </ul>
-<h3><a name=v1.590>What's new in 1.590</a> (2014/11/16)</h3>
+<h3><a name="v1.590">What's new in 1.590</a> (2014/11/16)</h3>
 <ul class=image>
   <li class=bug>
     Basic Authentication in combination with Session is broken
@@ -1671,7 +1671,7 @@ Upcoming changes</a>
     API method to get non-null <code>Jenkins</code> instance with internal validation
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23339">issue 23339</a>)
 </ul>
-<h3><a name=v1.589>What's new in 1.589</a> (2014/11/09)</h3>
+<h3><a name="v1.589">What's new in 1.589</a> (2014/11/09)</h3>
 <ul class=image>
   <li class=bug>
     JNA error in <code>WindowsInstallerLink.doDoInstall</code>.
@@ -1680,7 +1680,7 @@ Upcoming changes</a>
     Restore compatibility of label assignment for some plugins.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25372">issue 25372</a>)
 </ul>
-<h3><a name=v1.588>What's new in 1.588</a> (2014/11/02)</h3>
+<h3><a name="v1.588">What's new in 1.588</a> (2014/11/02)</h3>
 <ul class=image>
   <li class=bug>
     Unnecessarily slow startup time with a massive number of jobs.
@@ -1689,7 +1689,7 @@ Upcoming changes</a>
     Custom workspace option did not work under some conditions.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25221">issue 25221</a>)
 </ul>
-<h3><a name=v1.587>What's new in 1.587</a> (2014/10/29)</h3>
+<h3><a name="v1.587">What's new in 1.587</a> (2014/10/29)</h3>
 <ul class=image>
   <li class=bug>
     Queue didn't always leave a trail for cancelled items properly
@@ -1701,7 +1701,7 @@ Upcoming changes</a>
     Introduced slave-to-master security mechanism to defend a master from slaves.
     (<a href="http://jenkins-ci.org/security-144">SECURITY-144</a>)
 </ul>
-<h3><a name=v1.586>What's new in 1.586</a> (2014/10/26)</h3>
+<h3><a name="v1.586">What's new in 1.586</a> (2014/10/26)</h3>
 <ul class=image>
   <li class=rfe>
     Bumping up JNA to 4.10. This is potentially a breaking change for plugins that depend on JNA 3.x
@@ -1717,7 +1717,7 @@ Upcoming changes</a>
     Existing <code>FileParameter</code>s should be handled as different values to avoid merging of queued builds
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19017">issue 19017</a>)
 </ul>
-<h3><a name=v1.585>What's new in 1.585</a> (2014/10/19)</h3>
+<h3><a name="v1.585">What's new in 1.585</a> (2014/10/19)</h3>
 <ul class=image>
   <li class=bug>
     Build health computed repeatedly for a single Weather column cell.
@@ -1758,7 +1758,7 @@ Upcoming changes</a>
     Incorporated a fix for "Poodle" (CVE-2014-3566) vulnerability in the HTTPS connector of "java -jar jenkins.war"
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-25169">issue 25169</a>)
 </ul>
-<h3><a name=v1.584>What's new in 1.584</a> (2014/10/12)</h3>
+<h3><a name="v1.584">What's new in 1.584</a> (2014/10/12)</h3>
 <ul class=image>
   <li class=rfe>
     Diagnostic thread names are now available while requests are still in filters
@@ -1776,13 +1776,13 @@ Upcoming changes</a>
     Do not consider port in use error to be a successful start of Jenkins on Debian.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24966">issue 24966</a>)
 </ul>
-<h3><a name=v1.583>What's new in 1.583</a> (2014/10/01)</h3>
+<h3><a name="v1.583">What's new in 1.583</a> (2014/10/01)</h3>
 <ul class=image>
   <li class='major bug'>
     Fixes to multiple security vulnerabilities.
     (<a href="https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2014-10-01">security advisory</a>)
 </ul>
-<h3><a name=v1.582>What's new in 1.582</a> (2014/09/28)</h3>
+<h3><a name="v1.582">What's new in 1.582</a> (2014/09/28)</h3>
 <ul class=image>
   <li class=bug>
     Channel reader thread can end up consuming 100% CPU.
@@ -1814,7 +1814,7 @@ Upcoming changes</a>
     handle job move when buildDir is configured to a custom location.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24825">issue 24825</a>)
 </ul>
-<h3><a name=v1.581>What's new in 1.581</a> (2014/09/21)</h3>
+<h3><a name="v1.581">What's new in 1.581</a> (2014/09/21)</h3>
 <ul class=image>
   <li class=rfe>
     Use slightly larger Jenkins head icon.
@@ -1829,7 +1829,7 @@ Upcoming changes</a>
     Wrong Hebrew localization resulted in broken console output since 1.539.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24614">issue 24614</a>)
 </ul>
-<h3><a name=v1.580>What's new in 1.580</a> (2014/09/14)</h3>
+<h3><a name="v1.580">What's new in 1.580</a> (2014/09/14)</h3>
 <ul class=image>
   <li class=bug>
     Health reports saved to disk before 1.576 showed no weather icon since that version.
@@ -1841,7 +1841,7 @@ Upcoming changes</a>
     Add editable descriptions for label atoms.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-6153">issue 6153</a>)
 </ul>
-<h3><a name=v1.579>What's new in 1.579</a> (2014/09/06)</h3>
+<h3><a name="v1.579">What's new in 1.579</a> (2014/09/06)</h3>
 <ul class=image>
   <li class=bug>
     <code>ConcurrentModificationException</code> in <code>RunListProgressiveRendering</code>.
@@ -1862,7 +1862,7 @@ Upcoming changes</a>
     Debian package now sets umask to 027 by default for better default privacy. See <tt>/etc/default/jenkins</tt> to change this.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24514">issue 24514</a>)
 </ul>
-<h3><a name=v1.578>What's new in 1.578</a> (2014/08/31)</h3>
+<h3><a name="v1.578">What's new in 1.578</a> (2014/08/31)</h3>
 <ul class=image>
   <li class=rfe>
     Added 'no-store' to the 'Cache-Control' header to avoid accidental information leak through local cache backup
@@ -1874,7 +1874,7 @@ Upcoming changes</a>
     Use absolute links for computer sidepanel items so they don't break as easily.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23963">issue 23963</a>)
 </ul>
-<h3><a name=v1.577>What's new in 1.577</a> (2014/08/24)</h3>
+<h3><a name="v1.577">What's new in 1.577</a> (2014/08/24)</h3>
 <ul class=image>
   <li class="major bug">
     Failure to migrate legacy user records in 1.576 properly broke Jenkins, resulted in NullPointerExceptions.
@@ -1915,7 +1915,7 @@ Upcoming changes</a>
     Properly consider busy executors when reducing a node's executor count.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24095">issue 24095</a>)
 </ul>
-<h3><a name=v1.576>What's new in 1.576</a> (2014/08/18)</h3>
+<h3><a name="v1.576">What's new in 1.576</a> (2014/08/18)</h3>
 <ul class=image>
   <li class="bug">
     Worked around "incompatible InnerClasses attribute" bug in IBM J9 VM
@@ -1955,7 +1955,7 @@ Upcoming changes</a>
     Modernize tabBar and bigtable.  Makes the project view look better.  Same for Plugin Manager.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-24030">issue 24030</a>)
 </ul>
-<h3><a name=v1.575>What's new in 1.575</a> (2014/08/10)</h3>
+<h3><a name="v1.575">What's new in 1.575</a> (2014/08/10)</h3>
 <ul class=image>
   <li class="rfe">
     Move option to fingerprint artifacts to Archive the Artifacts, Advanced options.
@@ -2000,7 +2000,7 @@ Upcoming changes</a>
     Restrict access to SCM trigger status page to administrators.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1327">pull 1282</a>)
 </ul>
-<h3><a name=v1.574>What's new in 1.574</a> (2014/07/27)</h3>
+<h3><a name="v1.574">What's new in 1.574</a> (2014/07/27)</h3>
 <ul class=image>
   <li class="rfe">
     UI redesign: Use Helvetica as default font
@@ -2013,7 +2013,7 @@ Upcoming changes</a>
     Use native encoding for filenames in downloaded ZIPs.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20663">issue 20663</a>)
 </ul>
-<h3><a name=v1.573>What's new in 1.573</a> (2014/07/20)</h3>
+<h3><a name="v1.573">What's new in 1.573</a> (2014/07/20)</h3>
 <ul class=image>
   <li class="rfe">
     UI redesign: Changed element alignment, removed sidebar link underlines
@@ -2029,7 +2029,7 @@ Upcoming changes</a>
     Fixed unnecessary eager loading of build records in certain code path.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18065">issue 18065</a>)
 </ul>
-<h3><a name=v1.572>What's new in 1.572</a> (2014/07/13)</h3>
+<h3><a name="v1.572">What's new in 1.572</a> (2014/07/13)</h3>
 <ul class=image>
   <li class="major rfe">
     UI redesign: Changed header, made layout &lt;div&gt;-based and responsive
@@ -2041,7 +2041,7 @@ Upcoming changes</a>
     Do not offer automatic upgrade if war parent directory is not writable
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23683">issue 23683</a>)
 </ul>
-<h3><a name=v1.571>What's new in 1.571</a> (2014/07/07)</h3>
+<h3><a name="v1.571">What's new in 1.571</a> (2014/07/07)</h3>
 <ul class=image>
   <li class=bug>
     <code>IllegalArgumentException</code> from <code>AbstractProject.getEnvironment</code> when trying to get environment variables from an offline slave.
@@ -2053,7 +2053,7 @@ Upcoming changes</a>
     Master computer is not notified using ComputerListener
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23481">issue 23481</a>)
 </ul>
-<h3><a name=v1.570>What's new in 1.570</a> (2014/06/29)</h3>
+<h3><a name="v1.570">What's new in 1.570</a> (2014/06/29)</h3>
 <ul class=image>
   <li class=rfe>
     Add CLI commands to add jobs to and remove jobs from views (add-job-to-view, remove-job-from-view).
@@ -2083,7 +2083,7 @@ Upcoming changes</a>
     Fixed <code>NullPointerException</code> when &quot;properties&quot; element is missing in a job's configuration submission by JSON
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-23437">issue 23437</a>)
 </ul>
-<h3><a name=v1.569>What's new in 1.569</a> (2014/06/23)</h3>
+<h3><a name="v1.569">What's new in 1.569</a> (2014/06/23)</h3>
 <ul class=image>
   <li class=rfe>
     Jenkins can now kill Win32 processes from Win64 JVMs.
@@ -2101,7 +2101,7 @@ Upcoming changes</a>
     When Jenkins had a lot of jobs, submitting a view configuration change could overload the web server, even if few of the jobs were selected.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20327">issue 20327</a>)
 </ul>
-<h3><a name=v1.568>What's new in 1.568</a> (2014/06/15)</h3>
+<h3><a name="v1.568">What's new in 1.568</a> (2014/06/15)</h3>
 <ul class=image>
   <li class=bug>
     Fixed JNLP connection handling problem
@@ -2125,7 +2125,7 @@ Upcoming changes</a>
     API changes allowing to create nested launchers (<code>DecoratedLauncher</code>)
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19454">issue 19454</a>)
 </ul>
-<h3><a name=v1.567>What's new in 1.567</a> (2014/06/09)</h3>
+<h3><a name="v1.567">What's new in 1.567</a> (2014/06/09)</h3>
 <ul class=image>
   <li class="bug">
     Fixed a reference counting bug in the remoting layer.
@@ -2189,7 +2189,7 @@ Upcoming changes</a>
     Added an option to archive artifacts only when the build is successful
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22699">issue 22699</a>)
 </ul>
-<h3><a name=v1.566>What's new in 1.566</a> (2014/06/01)</h3>
+<h3><a name="v1.566">What's new in 1.566</a> (2014/06/01)</h3>
 <ul class=image>
   <li class="rfe">
     Configurable case sensitivity mode for user IDs.
@@ -2204,7 +2204,7 @@ Upcoming changes</a>
     Jenkins cannot restart Windows service
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22685">issue 22685</a>)
 </ul>
-<h3><a name=v1.565>What's new in 1.565</a> (2014/05/26)</h3>
+<h3><a name="v1.565">What's new in 1.565</a> (2014/05/26)</h3>
 <ul class=image>
   <li class="bug">
     Misleading error message trying to dynamically update a plugin (which is impossible) on an NFS filesystem.
@@ -2224,7 +2224,7 @@ Upcoming changes</a>
     Fixed localization of build environment variable help.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22867">issue 22867</a>)
 </ul>
-<h3><a name=v1.564>What's new in 1.564</a> (2014/05/19)</h3>
+<h3><a name="v1.564">What's new in 1.564</a> (2014/05/19)</h3>
 <ul class=image>
   <li class="rfe">
     Improve list view performance on large instances with folders.
@@ -2237,7 +2237,7 @@ Upcoming changes</a>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22879">issue 22879</a>,
     <a href="https://issues.jenkins-ci.org/browse/JENKINS-22798">issue 22798</a>)
 </ul>
-<h3><a name=v1.563>What's new in 1.563</a> (2014/05/11)</h3>
+<h3><a name="v1.563">What's new in 1.563</a> (2014/05/11)</h3>
 <ul class=image>
   <li class="major bug">
     Memory exhaustion in remoting channel since 1.560.
@@ -2258,7 +2258,7 @@ Upcoming changes</a>
     Again show proper display names for build parameters.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22755">issue 22755</a>)
 </ul>
-<h3><a name=v1.562>What's new in 1.562</a> (2014/05/03)</h3>
+<h3><a name="v1.562">What's new in 1.562</a> (2014/05/03)</h3>
 <ul class=image>
   <li class=bug>
     Next build link was not reliably available from a previous build after starting a new one.
@@ -2279,7 +2279,7 @@ Upcoming changes</a>
     Add links to nodes on thread dump page for easier navigation.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22672">issue 22672</a>)
 </ul>
-<h3><a name=v1.561>What's new in 1.561</a> (2014/04/27)</h3>
+<h3><a name="v1.561">What's new in 1.561</a> (2014/04/27)</h3>
 <ul class=image>
   <li class=bug>
     Fixed a corner case handling of tool installation.
@@ -2358,7 +2358,7 @@ Upcoming changes</a>
     Return queue item location when triggering buildWithParameters.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-13546">issue 13546</a>)
 </ul>
-<h3><a name=v1.560>What's new in 1.560</a> (2014/04/20)</h3>
+<h3><a name="v1.560">What's new in 1.560</a> (2014/04/20)</h3>
 <ul class=image>
   <li class='major rfe'>
     Enforcing build trigger authentication at runtime by checking authentication associated with a build, rather than at configuration time.
@@ -2401,7 +2401,7 @@ Upcoming changes</a>
     Remotely triggered builds now show correct IP address through proxy.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18008">issue 18008</a>)
 </ul>
-<h3><a name=v1.559>What's new in 1.559</a> (2014/04/13)</h3>
+<h3><a name="v1.559">What's new in 1.559</a> (2014/04/13)</h3>
 <ul class=image>
   <li class=rfe>
     Slaves connected via Java Web Start now restart themselves when a connection to Jenkins is lost.
@@ -2413,7 +2413,7 @@ Upcoming changes</a>
     Faster rendering of views containing many items.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-18364">issue 18364</a>)
 </ul>
-<h3><a name=v1.558>What's new in 1.558</a> (2014/04/06)</h3>
+<h3><a name="v1.558">What's new in 1.558</a> (2014/04/06)</h3>
 <ul class=image>
   <li class=rfe>
     Cron-style trigger configuration will now display expected prior and subsequent run times.
@@ -2445,7 +2445,7 @@ Upcoming changes</a>
     Fixed NPE executing <tt>Pipe.EOF</tt> with <tt>ProxyWriter</tt>
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-20769">issue 20769</a>)
 </ul>
-<h3><a name=v1.557>What's new in 1.557</a> (2014/03/31)</h3>
+<h3><a name="v1.557">What's new in 1.557</a> (2014/03/31)</h3>
 <ul class=image>
   <li class=bug>
     Fixed <tt>ArrayIndexOutOfBoundsException</tt> in XStream with Oracle JDK8 release version
@@ -2472,7 +2472,7 @@ Upcoming changes</a>
     Allow JDK8 (and other versions) to be downloaded by JDKInstaller correctly.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-22347">issue 22347</a>)
 </ul>
-<h3><a name=v1.556>What's new in 1.556</a> (2014/03/23)</h3>
+<h3><a name="v1.556">What's new in 1.556</a> (2014/03/23)</h3>
 <ul class=image>
   <li class=rfe>
     Access through API token and SSH key login now fully retains group memberships.
@@ -2483,7 +2483,7 @@ Upcoming changes</a>
   <li class=rfe>
     Job can be reloaded individually from disk with "job/FOO/reload" URL or "reload-job" CLI command
 </ul>
-<h3><a name=v1.555>What's new in 1.555</a> (2014/03/16)</h3>
+<h3><a name="v1.555">What's new in 1.555</a> (2014/03/16)</h3>
 <ul class=image>
   <li class=bug>
     Jenkins should recover gracefully from a failure to process "remember me" cookie
@@ -2492,7 +2492,7 @@ Upcoming changes</a>
     Fixed Up link in matrix projects
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21773">issue 21773</a>)
 </ul>
-<h3><a name=v1.554>What's new in 1.554</a> (2014/03/09)</h3>
+<h3><a name="v1.554">What's new in 1.554</a> (2014/03/09)</h3>
 <ul class=image>
   <li class=bug>
     Archiving of symlinks as artifacts did not work in some cases.
@@ -2501,7 +2501,7 @@ Upcoming changes</a>
     Slow rendering of directories with many entries in remote workspaces.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21780">issue 21780</a>)
 </ul>
-<h3><a name=v1.553>What's new in 1.553</a> (2014/03/02)</h3>
+<h3><a name="v1.553">What's new in 1.553</a> (2014/03/02)</h3>
 <ul class=image>
   <li class=bug>
     Build history widget only showed the last day of builds.
@@ -2527,7 +2527,7 @@ Upcoming changes</a>
     Fix autocompletion for items in folders.
     (<a href="https://github.com/jenkinsci/jenkins/pull/1124">pull request 1124</a>)
 </ul>
-<h3><a name=v1.552>What's new in 1.552</a> (2014/02/24)</h3>
+<h3><a name="v1.552">What's new in 1.552</a> (2014/02/24)</h3>
 <ul class=image>
   <li class=bug>
     Fixed handling of default JENKINS_HOME when storing CLI credentials
@@ -2544,7 +2544,7 @@ Upcoming changes</a>
   <li class=rfe>
     Improve detection of broken reverse proxy setups.
 </ul>
-<h3><a name=v1.551>What's new in 1.551</a> (2014/02/14)</h3>
+<h3><a name="v1.551">What's new in 1.551</a> (2014/02/14)</h3>
 <ul class=image>
   <li class='major bug'>
     Valentine's day security release that contains more than a dozen security fixes.
@@ -2588,7 +2588,7 @@ Upcoming changes</a>
   <li class=bug>
     "java -jar jenkins.war" should use unique session cookie for users who run multiple Jenkins on the same host.
 </ul>
-<h3><a name=v1.550>What's new in 1.550</a> (2014/02/09)</h3>
+<h3><a name="v1.550">What's new in 1.550</a> (2014/02/09)</h3>
 <ul class=image>
   <li class=bug>
     Report number of all jobs as part of usage statistics
@@ -2597,7 +2597,7 @@ Upcoming changes</a>
     Replace description in error dialog instead of appending
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21457">issue 21457</a>)
 </ul>
-<h3><a name=v1.549>What's new in 1.549</a> (2014/01/25)</h3>
+<h3><a name="v1.549">What's new in 1.549</a> (2014/01/25)</h3>
 <ul class=image>
   <li class=bug>
     Removing the "keep this build forever" lock on a build should require the DELETE permission.
@@ -2615,7 +2615,7 @@ Upcoming changes</a>
     Allow more specific loggers to reduce log level.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21386">issue 21386</a>)
 </ul>
-<h3><a name=v1.548>What's new in 1.548</a> (2014/01/20)</h3>
+<h3><a name="v1.548">What's new in 1.548</a> (2014/01/20)</h3>
 <ul class=image>
   <li class=rfe>
     API for adding actions to a wide class of model objects at once.
@@ -2641,7 +2641,7 @@ Upcoming changes</a>
     Option to hold lazy-loaded build references strongly, weakly, and more.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-19400">issue 19400</a>)
 </ul>
-<h3><a name=v1.547>What's new in 1.547</a> (2014/01/12)</h3>
+<h3><a name="v1.547">What's new in 1.547</a> (2014/01/12)</h3>
 <ul class=image>
   <li class=rfe>
     Split Windows slave functionality into its own plugin.
@@ -2652,7 +2652,7 @@ Upcoming changes</a>
     Fixed Trend Graph NPE when there isn't any builds
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-21239">issue 21239</a>)
 </ul>
-<h3><a name=v1.546>What's new in 1.546</a> (2014/01/06)</h3>
+<h3><a name="v1.546">What's new in 1.546</a> (2014/01/06)</h3>
 <ul class=image>
   <li class="major bug">
     Builds disappear after renaming a job.


### PR DESCRIPTION
It's not proper HTML, if attribute values are not surrounded by quotes as in 

`<a name=v2.11>`

Now the HTML is a little cleaner (at least):

`<a name="v2.11">`

I actually extract the (new) entries using an XPath expression using xmlstarlet:

`html/body/div/div/div/h3/a`

But my toolchain complains about the missing surrounding quotes.
