### PR TITLE
[FIXED JENKINS-37559] - Fix ProcessTree.java on Solaris with 64-bit JVM

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -25,6 +25,9 @@ package hudson.util;
 
 import com.sun.jna.Memory;
 import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+import com.sun.jna.LastErrorException;
 import com.sun.jna.ptr.IntByReference;
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -752,8 +755,28 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
     /**
      * Implementation for Solaris that uses <tt>/proc</tt>.
      *
-     * Amazingly, this single code works for both 32bit and 64bit Solaris, despite the fact
-     * that does a lot of pointer manipulation and what not.
+     * /proc/PID/psinfo contains a psinfo_t struct. We use it to determine where the
+     *     process arguments and environment are located in PID's address space.
+     *     Note that the psinfo_t struct is different (different sized elements) for 32-bit
+     *     vs 64-bit processes and the kernel will provide the version of the struct that
+     *     matches the _reader_ (this Java process) regardless of whether PID is a
+     *     32-bit or 64-bit process.
+     *
+     *     Note that this means that if PID is a 64-bit process, then a 32-bit Java
+     *     process can not get meaningful values for envp and argv out of the psinfo_t. The
+     *     values will have been truncated to 32-bits.
+     *
+     * /proc/PID/as contains the address space of the process we are inspecting. We can
+     *     follow the envp and argv pointers from psinfo_t to find the environment variables
+     *     and process arguments. When following pointers in this address space we need to
+     *     make sure to use 32-bit or 64-bit pointers depending on what sized pointers
+     *     PID uses, regardless of what size pointers the Java process uses.
+     *
+     *     Note that the size of a 64-bit address space is larger than Long.MAX_VALUE (because
+     *     longs are signed). So normal Java utilities like RandomAccessFile and FileChannel
+     *     (which use signed longs as offsets) are not able to read from the end of the address
+     *     space, where envp and argv will be. Therefore we need to use LIBC.pread() directly.
+     *     when accessing this file.
      */
     static class Solaris extends ProcfsUnix {
         protected OSProcess createProcess(final int pid) throws IOException {
@@ -761,15 +784,23 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         }
 
         private class SolarisProcess extends UnixProcess {
+            private static final byte PR_MODEL_ILP32 = 1;
+            private static final byte PR_MODEL_LP64 = 2;
+
+            /*
+             * True if target process is 64-bit (Java process may be different).
+             */
+            private final boolean b64;
+
             private final int ppid;
             /**
-                 * Address of the environment vector. Even on 64bit Solaris this is still 32bit pointer.
+             * Address of the environment vector.
              */
-            private final int envp;
+            private final long envp;
             /**
-                 * Similarly, address of the arguments vector.
+             * Similarly, address of the arguments vector.
              */
-            private final int argp;
+            private final long argp;
             private final int argc;
             private EnvVars envVars;
             private List<String> arguments;
@@ -821,10 +852,23 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                         throw new IOException("psinfo PID mismatch");   // sanity check
                     ppid = adjust(psinfo.readInt());
 
-                    psinfo.seek(188);  // now jump to pr_argc
-                    argc = adjust(psinfo.readInt());
-                    argp = adjust(psinfo.readInt());
-                    envp = adjust(psinfo.readInt());
+                    /*
+                     * Read the remainder of psinfo_t differently depending on whether the
+                     * Java process is 32-bit or 64-bit.
+                     */
+                    if (Pointer.SIZE == 8) {
+                        psinfo.seek(236);  // offset of pr_argc
+                        argc = adjust(psinfo.readInt());
+                        argp = adjustL(psinfo.readLong());
+                        envp = adjustL(psinfo.readLong());
+                        b64 = (psinfo.readByte() == PR_MODEL_LP64);
+                    } else {
+                        psinfo.seek(188);  // offset of pr_argc
+                        argc = adjust(psinfo.readInt());
+                        argp = to64(adjust(psinfo.readInt()));
+                        envp = to64(adjust(psinfo.readInt()));
+                        b64 = (psinfo.readByte() == PR_MODEL_LP64);
+                    }
                 } finally {
                     psinfo.close();
                 }
@@ -842,23 +886,28 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     return arguments;
 
                 arguments = new ArrayList<String>(argc);
+		if (argc == 0) {
+		    return arguments;
+		}
 
+                int psize = b64 ? 8 : 4;
+                Memory m = new Memory(psize);
                 try {
-                    RandomAccessFile as = new RandomAccessFile(getFile("as"),"r");
                     if(LOGGER.isLoggable(FINER))
                         LOGGER.finer("Reading "+getFile("as"));
+                    int fd = LIBC.open(getFile("as").getAbsolutePath(), 0);
                     try {
                         for( int n=0; n<argc; n++ ) {
                             // read a pointer to one entry
-                            as.seek(to64(argp+n*4));
-                            int p = adjust(as.readInt());
+                            LIBC.pread(fd, m, new NativeLong(psize), new NativeLong(argp+n*psize));
+                            long addr = b64 ? m.getLong(0) : m.getInt(0);
 
-                            arguments.add(readLine(as, p, "argv["+ n +"]"));
+                            arguments.add(readLine(fd, addr, "argv["+ n +"]"));
                         }
                     } finally {
-                        as.close();
+                        LIBC.close(fd);
                     }
-                } catch (IOException e) {
+                } catch (IOException | LastErrorException e) {
                     // failed to read. this can happen under normal circumstances (most notably permission denied)
                     // so don't report this as an error.
                 }
@@ -872,44 +921,51 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     return envVars;
                 envVars = new EnvVars();
 
+		if (envp == 0) {
+		    return envVars;
+		}
+
+                int psize = b64 ? 8 : 4;
+                Memory m = new Memory(psize);
                 try {
-                    RandomAccessFile as = new RandomAccessFile(getFile("as"),"r");
                     if(LOGGER.isLoggable(FINER))
                         LOGGER.finer("Reading "+getFile("as"));
+                    int fd = LIBC.open(getFile("as").getAbsolutePath(), 0);
                     try {
                         for( int n=0; ; n++ ) {
                             // read a pointer to one entry
-                            as.seek(to64(envp+n*4));
-                            int p = adjust(as.readInt());
-                            if(p==0)
-                                break;  // completed the walk
+                            LIBC.pread(fd, m, new NativeLong(psize), new NativeLong(envp+n*psize));
+                            long addr = b64 ? m.getLong(0) : m.getInt(0);
+                            if (addr == 0) // completed the walk
+                                break;
 
                             // now read the null-terminated string
-                            envVars.addLine(readLine(as, p, "env["+ n +"]"));
+                            envVars.addLine(readLine(fd, addr, "env["+ n +"]"));
                         }
                     } finally {
-                        as.close();
+                        LIBC.close(fd);
                     }
-                } catch (IOException e) {
+                } catch (IOException | LastErrorException e) {
                     // failed to read. this can happen under normal circumstances (most notably permission denied)
                     // so don't report this as an error.
                 }
-
                 return envVars;
             }
 
-            private String readLine(RandomAccessFile as, int p, String prefix) throws IOException {
+            private String readLine(int fd, long addr, String prefix) throws IOException {
                 if(LOGGER.isLoggable(FINEST))
-                    LOGGER.finest("Reading "+prefix+" at "+p);
+                    LOGGER.finest("Reading "+prefix+" at "+addr);
 
-                as.seek(to64(p));
+                Memory m = new Memory(1);
+                byte ch = 1;
                 ByteArrayOutputStream buf = new ByteArrayOutputStream();
-                int ch,i=0;
-                while((ch=as.read())>0) {
-                    if((++i)%100==0 && LOGGER.isLoggable(FINEST))
-                        LOGGER.finest(prefix +" is so far "+buf.toString());
-
+                while(true) {
+                    LIBC.pread(fd, m, new NativeLong(1), new NativeLong(addr));
+                    ch = m.getByte(0);
+                    if (ch == 0)
+                        break;
                     buf.write(ch);
+                    addr++;
                 }
                 String line = buf.toString();
                 if(LOGGER.isLoggable(FINEST))
@@ -936,6 +992,13 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 return i;
         }
 
+        public static long adjustL(long i) {
+            if(IS_LITTLE_ENDIAN) {
+                return Long.reverseBytes(i);
+            } else {
+                return i;
+            }
+        }
     }
 
     /**

--- a/core/src/main/java/hudson/util/jna/GNUCLibrary.java
+++ b/core/src/main/java/hudson/util/jna/GNUCLibrary.java
@@ -29,6 +29,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.Native;
 import com.sun.jna.Memory;
 import com.sun.jna.NativeLong;
+import com.sun.jna.LastErrorException;
 import com.sun.jna.ptr.IntByReference;
 import jnr.posix.POSIX;
 import org.jvnet.libpam.impl.CLibrary.passwd;
@@ -74,8 +75,10 @@ public interface GNUCLibrary extends Library {
     int chown(String fileName, int uid, int gid);
     int chmod(String fileName, int i);
 
+    int open(String pathname, int flags) throws LastErrorException;
     int dup(int old);
     int dup2(int old, int _new);
+    long pread(int fd, Memory buffer, NativeLong size, NativeLong offset) throws LastErrorException;
     int close(int fd);
 
     // see http://www.gnu.org/s/libc/manual/html_node/Renaming-Files.html


### PR DESCRIPTION
This is my first attempt at submitting a pull request, so please let me know if there's anything different I should be doing. This diff should fix an issue with ProcessTree.kill on Solaris machines that are using a 64-bit JDK.

**The issue**
I could not get pipeline jobs to abort properly on Solaris machines. Whenever I tried to abort a pipeline job that was running a shell script on a solaris machine the console would say "Sending interrupt signal to process", but debugging on the actual system did not show the slave processes getting any signals.

Adding some debugging info to the Jenkins code I noticed that the mechanism to identify and kill spawned processes [via an environment variable](https://wiki.jenkins-ci.org/display/JENKINS/ProcessTreeKiller) Relies on very OS-specific logic in ProcessTree.java to list the environment variables of processes. On Solaris this logic assumes the data it gets out of /proc/{pid}/psinfo contains 32-bit pointers. This is only true as long as the process reading the data out of /proc/{pid}/psinfo is a 32-bit process (i.e. the Java process running slave.jar). If the Java process is 64-bit it will get a 64-bit psinfo_t struct out of /proc/{pid}/psinfo. This results in all of the pointer arithmetic in ProcessTree.java being wrong for 64-bit JVM processes.

There is also some complication around whether the target process (whose environment variables we are trying to read) is 32-bit or 64-bit. I have tried to include descriptive commends in my diff to explain when we are doing 32-bit or 64-bit arithmetic.

I also ended up needing to use LIBC.pread directly because in all of my testing envp pointed to an offset in /proc/{pid}/as that cannot be represented in a Java long (because Java long is signed), which appears to mean none of Java's standard IO libraries can read the data from the offset (gives negative offset seek errors).

**Testing**
I started slave.jar with both 32-bit JVM (Java 7) and 64-bit JVM (Java 8) on a Solaris box. I had both run a pipeline script that started long-running 32 and 64-bit processes, then aborted the jobs and made sure all of them signaled the correct processes (except 32-bit JVM signaling 64-bit subprocess, which falls back to doing nothing).
