### PR TITLE
Improve GlobalConfiguration Javadoc and default configure override

### DIFF
--- a/core/src/main/java/jenkins/model/DownloadSettings.java
+++ b/core/src/main/java/jenkins/model/DownloadSettings.java
@@ -36,13 +36,11 @@ import hudson.util.FormValidation;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import net.sf.json.JSONObject;
 import org.acegisecurity.AccessDeniedException;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Lets user configure how metadata files should be downloaded.
@@ -61,11 +59,6 @@ public final class DownloadSettings extends GlobalConfiguration {
     
     public DownloadSettings() {
         load();
-    }
-
-    @Override public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        req.bindJSON(this, json);
-        return true;
     }
 
     public boolean isUseBrowser() {

--- a/core/src/main/java/jenkins/model/GlobalConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalConfiguration.java
@@ -4,6 +4,8 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Convenient base class for extensions that contributes to the system configuration page but nothing
@@ -12,8 +14,8 @@ import hudson.model.Descriptor;
  * <p>
  * All {@link Descriptor}s are capable of contributing fragment to the system config page. If you are
  * implementing other extension points that need to expose some global configuration, you can do so
- * with <tt>global.groovy</tt> or <tt>global.jelly</tt> from your {@link Descriptor} instance. However
- * each <tt>global.*</tt> file will appear as its own section in the global configuration page.
+ * with {@code global.groovy} or {@code global.jelly} from your {@link Descriptor} instance. However
+ * each {@code global.*} file will appear as its own section in the global configuration page.
  * 
  * <p>
  * An option to present a single section for your plugin in the Jenkins global configuration page is
@@ -21,14 +23,20 @@ import hudson.model.Descriptor;
  * properties defined in your GlobalConfiguration subclass, here are two possibilities:
  * <ul><li>@{@link javax.inject.Inject} into your other {@link hudson.Extension}s (so this does <i>not</i> work
  * for classes not annotated with {@link hudson.Extension})</li>
- * <li>access it via a call to <code>GlobalConfiguration.all().get(&lt;your GlobalConfiguration subclass&gt;.class)
- * </code></li></ul>
+ * <li>access it via a call to {@code GlobalConfiguration.all().get(<your GlobalConfiguration subclass>.class)}</li></ul>
+ *
+ * <p>
+ * While an implementation might store its actual configuration data in various ways,
+ * meaning {@link #configure(StaplerRequest, JSONObject)} must be overridden,
+ * in the normal case you would simply define persistable fields with getters and setters.
+ * The {@code config} view would use data-bound controls like {@code f:entry}.
+ * Then make sure your constructor calls {@link #load} and your setters call {@link #save}.
  *
  * <h2>Views</h2>
  * <p>
- * Subtypes of this class should define a <tt>config.groovy</tt> file or <tt>config.jelly</tt> file
+ * Subtypes of this class should define a {@code config.groovy} file or {@code config.jelly} file
  * that gets pulled into the system configuration page.
- * 
+ * Typically its contents should be wrapped in an {@code f:section}.
  *
  * @author Kohsuke Kawaguchi
  * @since 1.425
@@ -45,6 +53,17 @@ public abstract class GlobalConfiguration extends Descriptor<GlobalConfiguration
     @Override
     public String getGlobalConfigPage() {
         return getConfigPage();
+    }
+
+    /**
+     * By default, calls {@link StaplerRequest#bindJSON(Object, JSONObject)},
+     * appropriate when your implementation has getters and setters for all fields.
+     * <p>{@inheritDoc}
+     */
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        return true;
     }
 
     /**

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -5,10 +5,8 @@ import hudson.Util;
 import hudson.XmlFile;
 import hudson.util.FormValidation;
 import hudson.util.XStream2;
-import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
 
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
@@ -145,12 +143,6 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Failed to set secure cookie flag", e);
         }
-    }
-
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        req.bindJSON(this,json);
-        return true;
     }
 
     /**

--- a/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java
+++ b/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java
@@ -4,10 +4,8 @@ import hudson.Extension;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.tools.ToolConfigurationCategory;
-import net.sf.json.JSONObject;
 
 import org.jenkinsci.Symbol;
-import org.kohsuke.stapler.StaplerRequest;
 
 //as close as it gets to the global Maven Project configuration
 @Extension(ordinal = 50) @Symbol("maven")
@@ -22,12 +20,6 @@ public class GlobalMavenConfig extends GlobalConfiguration {
     @Override
     public ToolConfigurationCategory getCategory() {
         return GlobalConfigurationCategory.get(ToolConfigurationCategory.class);
-    }
-
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        req.bindJSON(this, json);
-        return true;
     }
 
     public void setGlobalSettingsProvider(GlobalSettingsProvider globalSettingsProvider) {


### PR DESCRIPTION
I found that many `GlobalConfiguration` subtypes, especially the newer implementations in plugins that are not constrained by legacy settings storage issues, followed a simple usage pattern. Unfortunately the Javadoc did not describe this, and the default `configure` method is empty, whereas in most cases you just want it to call your setters with regular databinding.

@reviewbybees
