### PR TITLE
[JENKINS-37549] Fixed color for ComboBoxList

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1160,8 +1160,8 @@ table.parameters > tbody:hover {
 .comboBoxList {
   border: 1px solid #000;
   overflow: visible;
-  color: MenuText;
-  background-color: Menu;
+  background-color: white;
+  color: black;
 }
 .comboBoxSelectedItem {
   background-color: Highlight;


### PR DESCRIPTION
UI changes to Jenkins 2 has made it hard to see anything with Gray background and White Text.
Style is in line with Selects and other form inputs.
[Checked git blame and the CSS rule is from 2006](https://github.com/jenkinsci/jenkins/commit/8a0dc230f44e84e5a7f7920cf9a31f09a54999ac) 😆

Here is it shown:
![screen shot 2016-08-17 at 18 13 58](https://cloud.githubusercontent.com/assets/1661688/17744091/7e6a135c-64a6-11e6-88fe-b9dabb22214b.png)

Here it is fixed:
![screen shot 2016-08-17 at 18 15 57](https://cloud.githubusercontent.com/assets/1661688/17744137/b8919f6e-64a6-11e6-9b87-31e85ba1b5b2.png)
