### PR TITLE
[FIXED JENKINS-37523] - wrong message for duplicate item name during create

### DIFF
--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -176,7 +176,6 @@ $.when(getItems()).done(function(data) {
 
         setFieldValidationStatus('items', true);
         if (!getFieldValidationStatus('name')) {
-          activateValidationMessage('#itemname-required', '.add-item-name');
           $('input[name="name"][type="text"]', '#createItem').focus();
         } else {
           if (getFormValidationStatus()) {


### PR DESCRIPTION
During new item creation, if you enter a duplicate item name, the message was being overridden by an incorrect message about the name being required.

This addresses: [JENKINS-37523](https://issues.jenkins-ci.org/browse/JENKINS-37523)

@jenkinsci/code-reviewers & @reviewbybees esp. @jtnord @recena
