### PR TITLE
[JENKINS-37332] - Prevent File descriptor leaks when reading manifests from JARs

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -974,7 +974,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         // See https://groups.google.com/d/msg/jenkinsci-dev/kRobm-cxFw8/6V66uhibAwAJ
     }
 
-    private static @CheckForNull Manifest parsePluginManifest(URL bundledJpi) {
+    /*package*/ static @CheckForNull Manifest parsePluginManifest(URL bundledJpi) {
         try {
             URLClassLoader cl = new URLClassLoader(new URL[]{bundledJpi});
             InputStream in=null;
@@ -996,8 +996,15 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         return null;
     }
     
+    /**
+     * Retrieves input stream for the Manifest url.
+     * The method intelligently handles the case of {@link JarURLConnection} pointing to files within JAR.
+     * @param url Url of the manifest file
+     * @return Input stream, which allows to retrieve manifest. This stream must be closed outside
+     * @throws IOException Operation error
+     */
     @Nonnull
-    private static InputStream getBundledJpiManifestStream(@Nonnull URL url) throws IOException {
+    /*package*/ static InputStream getBundledJpiManifestStream(@Nonnull URL url) throws IOException {
         URLConnection uc = url.openConnection();
         InputStream in = null;
         // Magic, which allows to avoid using stream generated for JarURLConnection.
@@ -1029,8 +1036,15 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         return in;
     }
     
+    /**
+     * Retrieves modification date of the specified file.
+     * The method intelligently handles the case of {@link JarURLConnection} pointing to files within JAR.
+     * @param url Url of the file
+     * @return Modification date
+     * @throws IOException Operation error
+     */
     @Nonnull
-    private static long getModificationDate(@Nonnull URL url) throws IOException {
+    /*package*/ static long getModificationDate(@Nonnull URL url) throws IOException {
         URLConnection uc = url.openConnection();
         
         // It prevents file desciptor leak if the URL references a file within JAR

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -982,7 +982,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     return manifest;
                 }
             } finally {
-                IOUtils.closeQuietly(in);
+                Util.closeAndLogFailures(in, LOGGER, PluginWrapper.MANIFEST_FILENAME, bundledJpi.toString());
                 if (cl instanceof Closeable)
                     ((Closeable)cl).close();
             }

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1619,6 +1619,28 @@ public class Util {
         p.load(new StringReader(properties));
         return p;
     }
+    
+    /**
+     * Closes the item and logs error to the log in the case of error.
+     * Logging will be performed on the {@code WARNING} level.
+     * @param toClose Item to close. Nothing will happen if it is {@code null}
+     * @param logger Logger, which receives the error
+     * @param closeableName Name of the closeable item
+     * @param closeableOwner String representation of the closeable holder
+     * @since TODO once merged to the master and un-restricted
+     */
+    @Restricted(NoExternalUse.class)
+    public static void closeAndLogFailures(@CheckForNull Closeable toClose, @Nonnull Logger logger, 
+            @Nonnull String closeableName, @Nonnull String closeableOwner) {
+        if (toClose == null) {
+            return;
+        }
+        try {
+            toClose.close();
+        } catch(IOException ex) {
+            logger.log(Level.WARNING, String.format("Failed to close %s of %s", closeableName, closeableOwner), ex);
+        }
+    }
 
     public static final FastDateFormat XS_DATETIME_FORMATTER = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss'Z'",new SimpleTimeZone(0,"GMT"));
 

--- a/core/src/test/java/hudson/PluginManagerTest.java
+++ b/core/src/test/java/hudson/PluginManagerTest.java
@@ -93,6 +93,13 @@ public class PluginManagerTest {
         assertThat("manifest should have been read from the sample", manifest, notNullValue());
         assertAttribute(manifest, "Created-By", "Apache Maven");
         assertAttribute(manifest, "Short-Name", "matrix-auth");
+        
+        // Multi-line entries
+        assertAttribute(manifest, "Specification-Title", "Offers matrix-based security authorization strategies (global and per-project).");
+        assertAttribute(manifest, "Url", "http://wiki.jenkins-ci.org/display/JENKINS/Matrix+Authorization+Strategy+Plugin");
+    
+        // Empty field
+        assertAttribute(manifest, "Plugin-Developers", null);
     }
     
     @Test
@@ -101,7 +108,7 @@ public class PluginManagerTest {
         URL url = toManifestUrl(jar);
         assertThat("Manifest last modified date should be equal to the file date", 
                 PluginManager.getModificationDate(url), 
-                equalTo(jar.lastModified()));    
+                equalTo(jar.lastModified()));
     }
     
     private static void assertAttribute(Manifest manifest, String attributeName, String value) throws AssertionError {
@@ -119,7 +126,9 @@ public class PluginManagerTest {
                 "Built-By: jglick\n" +
                 "Build-Jdk: 1.8.0_92\n" +
                 "Extension-Name: matrix-auth\n" +
-                "Specification-Title: Offers matrix-based security authorization strate\n" +
+                "Specification-Title: \n" +
+                " Offers matrix-based security \n" +
+                " authorization strate\n" +
                 " gies (global and per-project).\n" +
                 "Implementation-Title: matrix-auth\n" +
                 "Implementation-Version: 1.4\n" +

--- a/core/src/test/java/hudson/PluginManagerTest.java
+++ b/core/src/test/java/hudson/PluginManagerTest.java
@@ -24,17 +24,33 @@
 
 package hudson;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+import org.apache.commons.io.FileUtils;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
-
+ 
+/**
+ * Tests of {@link PluginManager}.
+ */
 public class PluginManagerTest {
 
     @Rule public TemporaryFolder tmp = new TemporaryFolder();
@@ -68,4 +84,77 @@ public class PluginManagerTest {
             assertThat(ex.getCause().getMessage(), containsString("Refusing to resolve entity with publicId(null) and systemId (file:///)"));
         }
     }
+    
+    @Test
+    public void shouldProperlyParseManifestFromJar() throws IOException {
+        File jar = createHpiWithManifest();
+        final Manifest manifest = PluginManager.parsePluginManifest(jar.toURI().toURL());
+        
+        assertThat("manifest should have been read from the sample", manifest, notNullValue());
+        assertAttribute(manifest, "Created-By", "Apache Maven");
+        assertAttribute(manifest, "Short-Name", "matrix-auth");
+    }
+    
+    @Test
+    public void shouldProperlyRetrieveModificationDate() throws IOException {
+        File jar = createHpiWithManifest();
+        URL url = toManifestUrl(jar);
+        assertThat("Manifest last modified date should be equal to the file date", 
+                PluginManager.getModificationDate(url), 
+                equalTo(jar.lastModified()));    
+    }
+    
+    private static void assertAttribute(Manifest manifest, String attributeName, String value) throws AssertionError {
+        Attributes attributes = manifest.getMainAttributes();
+        assertThat("Main attributes must not be empty", attributes, notNullValue());
+        assertThat("Attribute '" + attributeName + "' does not match the sample", 
+                attributes.getValue(attributeName), 
+                equalTo(value));
+        
+    }
+    
+    private static final String SAMPLE_MANIFEST_FILE = "Manifest-Version: 1.0\n" +
+                "Archiver-Version: Plexus Archiver\n" +
+                "Created-By: Apache Maven\n" +
+                "Built-By: jglick\n" +
+                "Build-Jdk: 1.8.0_92\n" +
+                "Extension-Name: matrix-auth\n" +
+                "Specification-Title: Offers matrix-based security authorization strate\n" +
+                " gies (global and per-project).\n" +
+                "Implementation-Title: matrix-auth\n" +
+                "Implementation-Version: 1.4\n" +
+                "Group-Id: org.jenkins-ci.plugins\n" +
+                "Short-Name: matrix-auth\n" +
+                "Long-Name: Matrix Authorization Strategy Plugin\n" +
+                "Url: http://wiki.jenkins-ci.org/display/JENKINS/Matrix+Authorization+S\n" +
+                " trategy+Plugin\n" +
+                "Plugin-Version: 1.4\n" +
+                "Hudson-Version: 1.609.1\n" +
+                "Jenkins-Version: 1.609.1\n" +
+                "Plugin-Dependencies: icon-shim:2.0.3,cloudbees-folder:5.2.2;resolution\n" +
+                " :=optional\n" +
+                "Plugin-Developers: ";
+    
+    private File createHpiWithManifest() throws IOException {
+        File newFolder = tmp.newFolder("myJar");
+        String manifestPath = "META-INF/MANIFEST.MF";
+        new File("META-INF").mkdir();
+        FileUtils.write(new File(newFolder, manifestPath), SAMPLE_MANIFEST_FILE);
+        
+        final File f = new File(tmp.getRoot(), "my.hpi");
+        try(ZipOutputStream out = new ZipOutputStream(new FileOutputStream(f))) {
+            ZipEntry e = new ZipEntry(manifestPath);
+            out.putNextEntry(e);
+            byte[] data = SAMPLE_MANIFEST_FILE.getBytes();
+            out.write(data, 0, data.length);
+            out.closeEntry();
+        }
+        return f;
+    }
+        
+    
+    private URL toManifestUrl(File jarFile) throws MalformedURLException {
+        final String manifestPath = "META-INF/MANIFEST.MF";
+        return new URL("jar:" + jarFile.toURI().toURL() + "!/" + manifestPath);
+    }  
 }


### PR DESCRIPTION
Fixes a critical regression introduced in 2.16. File Descriptor leak happens, because JarUrlConnection does not bother to automatically close underlying resource input streams when we access them. Good blog post about it: http://www.genevski.com/2010/04/javaneturl-and-jarurlconnection-may.html

Cause:
- Initially the unstable code has been introduced by https://github.com/jenkinsci/jenkins/commit/19f9b63d74693d4de6f6906e9896399d18b4107f
- then this code has been transiently used by @stephenc in https://github.com/jenkinsci/jenkins/commit/2a450e5ac2ecd83a54f05c83729852073601816e , which caused locking of detached plugins and their further update

Changes:
- [x] Prevent file descriptor leak when reading manifests
- [x] Prevent potential file descriptor leak if we load bundles from another JAR (corner-case)
- [x] Improve diagnostics of file close operations
- [x] Unit tests

https://issues.jenkins-ci.org/browse/JENKINS-37332

@reviewbybees @daniel-beck  @jenkinsci/code-reviewers 
