### PR TITLE
[JENKINS-37561, CID-1205051] - Prevent resource leak in AntClassLoader#findClassInComponents()

### DIFF
--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -1352,31 +1352,25 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
         throws ClassNotFoundException {
         // we need to search the components of the path to see if
         // we can find the class we want.
-        InputStream stream = null;
         String classFilename = getClassFilename(name);
-        try {
-            Enumeration e = pathComponents.elements();
-            while (e.hasMoreElements()) {
-                File pathComponent = (File) e.nextElement();
-                try {
-                    stream = getResourceStream(pathComponent, classFilename);
-                    if (stream != null) {
-                        log("Loaded from " + pathComponent + " "
-                            + classFilename, Project.MSG_DEBUG);
-                        return getClassFromStream(stream, name, pathComponent);
-                    }
-                } catch (SecurityException se) {
-                    throw se;
-                } catch (IOException ioe) {
-                    // ioe.printStackTrace();
-                    log("Exception reading component " + pathComponent + " (reason: "
-                            + ioe.getMessage() + ")", Project.MSG_VERBOSE);
+        Enumeration e = pathComponents.elements();
+        while (e.hasMoreElements()) {
+            File pathComponent = (File) e.nextElement();
+            try (final InputStream stream = getResourceStream(pathComponent, classFilename)) {
+                if (stream != null) {
+                    log("Loaded from " + pathComponent + " "
+                        + classFilename, Project.MSG_DEBUG);
+                    return getClassFromStream(stream, name, pathComponent);
                 }
+            } catch (SecurityException se) {
+                throw se;
+            } catch (IOException ioe) {
+                // ioe.printStackTrace();
+                log("Exception reading component " + pathComponent + " (reason: "
+                        + ioe.getMessage() + ")", Project.MSG_VERBOSE);
             }
-            throw new ClassNotFoundException(name);
-        } finally {
-            FileUtils.close(stream);
         }
+        throw new ClassNotFoundException(name);
     }
 
     /**


### PR DESCRIPTION
It has been originally reported by Coverity in https://scan5.coverity.com/reports.htm#v36021/p10292/fileInstanceId=97573616&defectInstanceId=28155759&mergedDefectId=1205051. It happens on Exceptional paths only, but actually I see 31 runaway handlers on my jenkins-2.18 instance (maybe happens due to plugin dynamic load failure)

The issue happens, because finally block is misplaced. It handles only the last stream in this cycle.

@reviewbybees @jenkinsci/code-reviewers 
