### PR TITLE
Introduce a URLFactory for generating URLs for notifications

### DIFF
--- a/core/src/main/java/jenkins/model/URLFactory.java
+++ b/core/src/main/java/jenkins/model/URLFactory.java
@@ -1,0 +1,51 @@
+package jenkins.model;
+
+import com.google.common.collect.Iterables;
+import hudson.ExtensionPoint;
+import hudson.model.Item;
+import hudson.model.Run;
+
+/**
+ * Generates URLs for well known UI locations for use in notifications (e.g. mailer, HipChat, Slack, IRC, etc)
+ * Extensible to allow plugins to override common URLs (e.g. Blue Ocean or another future secondary UI)
+ */
+public abstract class URLFactory implements ExtensionPoint {
+
+    private static final ClassicURLFactory CLASSIC_URL_FACTORY = new ClassicURLFactory();
+
+    /**
+     * Returns the first {@link URLFactory} found
+     * TODO: provide an administration option to allow administrator to choose the implementation.
+     * @return URLFactory
+     */
+    public static URLFactory get() {
+        return Iterables.getFirst(Jenkins.getInstance().getExtensionList(URLFactory.class), CLASSIC_URL_FACTORY);
+    }
+
+    /** Fully qualified URL for a Run */
+    public abstract String getRunURL(Run<?, ?> run);
+
+    /** Fully qualified URL for a page that displays changes for a project. */
+    public abstract String getChangesURL(Run<?, ?> run);
+
+    /** Fully qualified URL for a projects home */
+    public abstract String getProjectURL(Item project);
+
+    /** URL Factory for the Classical Jenkins UI */
+    static class ClassicURLFactory extends URLFactory {
+        @Override
+        public String getRunURL(Run<?, ?> run) {
+            return JenkinsLocationConfiguration.get().getUrl() + run.getUrl();
+        }
+
+        @Override
+        public String getChangesURL(Run<?, ?> run) {
+            return getProjectURL(run.getParent()) + "changes";
+        }
+
+        @Override
+        public String getProjectURL(Item project) {
+            return JenkinsLocationConfiguration.get().getUrl() + project.getUrl();
+        }
+    }
+}

--- a/core/src/main/java/jenkins/model/URLFactory.java
+++ b/core/src/main/java/jenkins/model/URLFactory.java
@@ -35,7 +35,7 @@ public abstract class URLFactory implements ExtensionPoint {
     static class ClassicURLFactory extends URLFactory {
         @Override
         public String getRunURL(Run<?, ?> run) {
-            return JenkinsLocationConfiguration.get().getUrl() + run.getUrl();
+            return getRoot() + run.getUrl();
         }
 
         @Override
@@ -45,7 +45,15 @@ public abstract class URLFactory implements ExtensionPoint {
 
         @Override
         public String getProjectURL(Item project) {
-            return JenkinsLocationConfiguration.get().getUrl() + project.getUrl();
+            return getRoot() + project.getUrl();
+        }
+
+        static String getRoot() {
+            String root = Jenkins.getInstance().getRootUrl();
+            if (root.endsWith("/")) {
+                root = root.substring(0, root.length() - 1);
+            }
+            return root;
         }
     }
 }


### PR DESCRIPTION
`URLFactory` introduces a way to generate URLs for well known UI locations for use in notifications (e.g. mailer, HipChat, Slack, IRC, etc). 

It is implemented as an extension point so plugins like `blueocean-plugin` that provide alternative user interfaces can override the URLs sent in notifications.

Here is the extension point in use https://github.com/jenkinsci/blueocean-plugin/pull/425 
I converted `mailer` as an example https://github.com/jenkinsci/mailer-plugin/pull/29 and `hipchat` https://github.com/jenkinsci/hipchat-plugin/pull/82 

@jenkinsci/code-reviewers 
