### PR TITLE
[FIXED JENKINS-37616] Make Cloud.PROVISION independent from Jenkins.ADMINISTER

### DIFF
--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -28,6 +28,7 @@ import hudson.Extension;
 import hudson.DescriptorExtensionList;
 import hudson.model.Computer;
 import hudson.model.Slave;
+import hudson.security.PermissionScope;
 import hudson.slaves.NodeProvisioner.PlannedNode;
 import hudson.model.Describable;
 import jenkins.model.Jenkins;
@@ -42,6 +43,7 @@ import hudson.util.DescriptorList;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Collection;
+import java.util.concurrent.Future;
 
 /**
  * Creates {@link Node}s to dynamically expand/shrink the agents attached to Hudson.
@@ -175,10 +177,14 @@ public abstract class Cloud extends AbstractModelObject implements ExtensionPoin
         return Jenkins.getInstance().<Cloud,Descriptor<Cloud>>getDescriptorList(Cloud.class);
     }
 
+    private static final PermissionScope PERMISSION_SCOPE = new PermissionScope(Cloud.class);
+
     /**
      * Permission constant to control mutation operations on {@link Cloud}.
      *
      * This includes provisioning a new node, as well as removing it.
      */
-    public static final Permission PROVISION = Jenkins.ADMINISTER;
+    public static final Permission PROVISION = new Permission(
+            Computer.PERMISSIONS, "Provision", Messages._Cloud_ProvisionPermission_Description(), Jenkins.ADMINISTER, PERMISSION_SCOPE
+    );
 }

--- a/core/src/main/resources/hudson/slaves/Messages.properties
+++ b/core/src/main/resources/hudson/slaves/Messages.properties
@@ -41,3 +41,4 @@ NodeDescripter.CheckName.Mandatory=Name is mandatory
 ComputerLauncher.NoJavaFound=Java version {0} was found but 1.6 or later is needed.
 ComputerLauncher.JavaVersionResult={0} -version returned {1}.
 ComputerLauncher.UknownJavaVersion=Couldn\u2019t figure out the Java version of {0}
+Cloud.ProvisionPermission.Description=Provision new nodes

--- a/core/src/test/java/hudson/slaves/CloudTest.java
+++ b/core/src/test/java/hudson/slaves/CloudTest.java
@@ -1,0 +1,26 @@
+package hudson.slaves;
+
+import static org.junit.Assert.*;
+
+import hudson.model.Computer;
+import hudson.security.Permission;
+import hudson.security.SidACL;
+import jenkins.model.Jenkins;
+import org.acegisecurity.acls.sid.Sid;
+import org.junit.Test;
+
+public class CloudTest {
+
+    @Test
+    public void provisionPermissionShouldBeIndependentFromAdminister() throws Exception {
+        SidACL acl = new SidACL() {
+            @Override protected Boolean hasPermission(Sid p, Permission permission) {
+                return permission == Cloud.PROVISION;
+            }
+        };
+
+        assertTrue(acl.hasPermission(Jenkins.ANONYMOUS, Cloud.PROVISION));
+        assertFalse(acl.hasPermission(Jenkins.ANONYMOUS, Jenkins.ADMINISTER));
+        assertEquals(Cloud.PROVISION, Computer.PERMISSIONS.find("Provision"));
+    }
+}


### PR DESCRIPTION
[JENKINS-37616](https://issues.jenkins-ci.org/browse/JENKINS-37616)
