### PR TITLE
Fixed missing icon in script console

### DIFF
--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -26,12 +26,12 @@ THE SOFTWARE.
   Called from doScript() to display the execution result and the form.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout norefresh="true" permission="${h.RUN_SCRIPTS}">
     <st:include page="sidepanel.jelly" />
 
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/${it.icon}" width="48" height="48" alt=""/> ${%Script Console}</h1>
+      <h1><img src="${imagesURL}/48x48/notepad.png" width="48" height="48" alt=""/> ${%Script Console}</h1>
 
       <j:choose>
         <j:when test="${it.channel != null}">


### PR DESCRIPTION
The script console icon looks like this right now:  
![image](https://cloud.githubusercontent.com/assets/11491375/18033509/90109c5a-6d27-11e6-9075-143c16f9ade7.png)

This PR fixed this. I can't use `${it.iconFileName}`, cause `${it}` is a `hudson.model.Hudson` instance.
