### PR TITLE
[FIXED JENKINS-37731] Change symbol and constructor for SCMTrigger.

### DIFF
--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -137,7 +137,7 @@ public class SCMTrigger extends Trigger<Item> {
      * @param ignorePostCommitHooks
      *     True if we should ignore post commit hooks, false otherwise.
      *
-     * @since 2.21
+     * @since 2.22
      */
     @DataBoundSetter
     public void setIgnorePostCommitHooks(boolean ignorePostCommitHooks) {

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -76,6 +76,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -97,17 +98,29 @@ import static java.util.logging.Level.WARNING;
 public class SCMTrigger extends Trigger<Item> {
     
     private boolean ignorePostCommitHooks;
-    
-    public SCMTrigger(String scmpoll_spec) throws ANTLRException {
-        this(scmpoll_spec, false);
-    }
-    
+
     @DataBoundConstructor
+    public SCMTrigger(String scmpoll_spec) throws ANTLRException {
+        super(scmpoll_spec);
+    }
+
+    /**
+     * Backwards-compatibility constructor.
+     *
+     * @param scmpoll_spec
+     *     The spec to poll with.
+     * @param ignorePostCommitHooks
+     *     Whether to ignore post commit hooks.
+     * @throws ANTLRException
+     *
+     * @deprecated since 2.21
+     */
+    @Deprecated
     public SCMTrigger(String scmpoll_spec, boolean ignorePostCommitHooks) throws ANTLRException {
         super(scmpoll_spec);
         this.ignorePostCommitHooks = ignorePostCommitHooks;
     }
-    
+
     /**
      * This trigger wants to ignore post-commit hooks.
      * <p>
@@ -117,6 +130,23 @@ public class SCMTrigger extends Trigger<Item> {
      */
     public boolean isIgnorePostCommitHooks() {
         return this.ignorePostCommitHooks;
+    }
+
+    /**
+     * Data-bound setter for ignoring post commit hooks.
+     *
+     * @param ignorePostCommitHooks
+     *     True if we should ignore post commit hooks, false otherwise.
+     *
+     * @since 2.21
+     */
+    @DataBoundSetter
+    public void setIgnorePostCommitHooks(boolean ignorePostCommitHooks) {
+        this.ignorePostCommitHooks = ignorePostCommitHooks;
+    }
+
+    public String getScmpoll_spec() {
+        return super.getSpec();
     }
 
     @Override
@@ -178,7 +208,7 @@ public class SCMTrigger extends Trigger<Item> {
         return new File(job.getRootDir(),"scm-polling.log");
     }
 
-    @Extension @Symbol("scm")
+    @Extension @Symbol("pollScm")
     public static class DescriptorImpl extends TriggerDescriptor {
 
         private static ThreadFactory threadFactory() {

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -111,7 +111,6 @@ public class SCMTrigger extends Trigger<Item> {
      *     The spec to poll with.
      * @param ignorePostCommitHooks
      *     Whether to ignore post commit hooks.
-     * @throws ANTLRException
      *
      * @deprecated since 2.21
      */
@@ -208,7 +207,7 @@ public class SCMTrigger extends Trigger<Item> {
         return new File(job.getRootDir(),"scm-polling.log");
     }
 
-    @Extension @Symbol("pollScm")
+    @Extension @Symbol("pollSCM")
     public static class DescriptorImpl extends TriggerDescriptor {
 
         private static ThreadFactory threadFactory() {

--- a/core/src/main/resources/hudson/triggers/SCMTrigger/config.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/config.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Schedule}" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
-    <f:textarea name="scmpoll_spec" checkUrl="'${rootURL}/trigger/TimerTrigger/check?value='+encodeURIComponent(this.value)" value="${instance.spec}"/>
+    <f:textarea field="scmpoll_spec" checkUrl="'${rootURL}/trigger/TimerTrigger/check?value='+encodeURIComponent(this.value)"/>
   </f:entry>
   <f:entry field="ignorePostCommitHooks" title="${%Ignore post-commit hooks}">
     <f:checkbox />


### PR DESCRIPTION
[JENKINS-37731](https://issues.jenkins-ci.org/browse/JENKINS-37731)

Using "scm" as the @Symbol led to collisions with the "scm" global
variable in Pipeline, so that had to go. Changed it to "pollScm". Also
moved the @DataBoundConstructor to the single-parameter constructor,
deprecated the two-parameter constructor, created a @DataBoundSetter
for ignorePostCommitHooks, and added a getter for "scmpoll_spec" to
fix snippet generator and general syntactic goodness.

So now, with this, it's possible to do:

``` groovy
properties([
  pipelineTriggers([
    pollScm('@daily')
  ])
])
```

Tada.

Tests for the snippet generator and job property stuff will be landing
in a separate PR for workflow-multibranch.

cc @jenkinsci/code-reviewers @reviewbybees @jglick @oleg-nenashev @daniel-beck 
