### PR TITLE
[JENKINS-37874] - Print warnings if Jenkins startup/reload do not reach the COMPLETED state

### DIFF
--- a/core/src/main/java/jenkins/diagnostics/CompletedInitializationMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/CompletedInitializationMonitor.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.diagnostics;
+
+import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.model.AdministrativeMonitor;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Performs monitoring of {@link Jenkins} {@link InitMilestone} status.
+ *
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+@Restricted(NoExternalUse.class)
+@Extension @Symbol("completedInitialization")
+public class CompletedInitializationMonitor extends AdministrativeMonitor {
+    @Override
+    public boolean isActivated() {
+        final Jenkins instance = Jenkins.getInstance();
+        // Safe to check in such way, because monitors are being checked in UI only.
+        // So Jenkins class construction and initialization must be always finished by the call of this extension.
+        return instance.getInitLevel() != InitMilestone.COMPLETED;
+    }
+}

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -911,10 +911,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             // Ensure we reached the final initialization state. Log the error otherwise
             if (initLevel != InitMilestone.COMPLETED) {
                 LOGGER.log(SEVERE, "Jenkins initialization has not reached the COMPLETED initialization milestone after the startup. " +
-                                "Current state: {0}." +
-                                "It is likely an issue with the Initialization task graph." +
-                                "Example: usage of @Initializer(after = InitMilestone.COMPLETED) in a plugin (JENKINS-37759)." +
-                                "Please create a bug in Jenkins bugtracker.",
+                                "Current state: {0}. " +
+                                "It may cause undefined incorrect behavior in Jenkins plugin relying on this state. " +
+                                "It is likely an issue with the Initialization task graph. " +
+                                "Example: usage of @Initializer(after = InitMilestone.COMPLETED) in a plugin (JENKINS-37759). " +
+                                "Please create a bug in Jenkins bugtracker. ",
                         initLevel);
             }
 
@@ -3854,9 +3855,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         // Ensure we reached the final initialization state. Log the error otherwise
         if (initLevel != InitMilestone.COMPLETED) {
             LOGGER.log(SEVERE, "Jenkins initialization has not reached the COMPLETED initialization milestone after the configuration reload. " +
-                            "Current state: {0}." +
-                            "It is likely an issue with the Initialization task graph." +
-                            "Example: usage of @Initializer(after = InitMilestone.COMPLETED) in a plugin (JENKINS-37759)." +
+                            "Current state: {0}. " +
+                            "It may cause undefined incorrect behavior in Jenkins plugin relying on this state. " +
+                            "It is likely an issue with the Initialization task graph. " +
+                            "Example: usage of @Initializer(after = InitMilestone.COMPLETED) in a plugin (JENKINS-37759). " +
                             "Please create a bug in Jenkins bugtracker.",
                     initLevel);
         }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -908,6 +908,17 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     InitMilestone.ordering()        // forced ordering among key milestones
             );
 
+            // Ensure we reached the final initialization state. Log the error otherwise
+            if (initLevel != InitMilestone.COMPLETED) {
+                LOGGER.log(SEVERE, "Jenkins initialization has not reached the COMPLETED initialization milestone after the startup. " +
+                                "Current state: {0}." +
+                                "It is likely an issue with the Initialization task graph." +
+                                "Example: usage of @Initializer(after = InitMilestone.COMPLETED) in a plugin (JENKINS-37759)." +
+                                "Please create a bug in Jenkins bugtracker.",
+                        initLevel);
+            }
+
+
             if(KILL_AFTER_LOAD)
                 System.exit(0);
 
@@ -3839,6 +3850,17 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public void reload() throws IOException, InterruptedException, ReactorException {
         queue.save();
         executeReactor(null, loadTasks());
+
+        // Ensure we reached the final initialization state. Log the error otherwise
+        if (initLevel != InitMilestone.COMPLETED) {
+            LOGGER.log(SEVERE, "Jenkins initialization has not reached the COMPLETED initialization milestone after the configuration reload. " +
+                            "Current state: {0}." +
+                            "It is likely an issue with the Initialization task graph." +
+                            "Example: usage of @Initializer(after = InitMilestone.COMPLETED) in a plugin (JENKINS-37759)." +
+                            "Please create a bug in Jenkins bugtracker.",
+                    initLevel);
+        }
+
         User.reload();
         queue.load();
         servletContext.setAttribute("app", this);

--- a/core/src/main/resources/jenkins/diagnostics/CompletedInitializationMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/CompletedInitializationMonitor/message.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <div class="warning">
+      <b>${%Warning!}</b>
+      ${%blurb(app.initLevel)}
+      ${%Example: usage of} <code>@Initializer(after = InitMilestone.COMPLETED)</code> ${%in a plugin}
+      (<a href="https://issues.jenkins-ci.org/browse/JENKINS-37759">JENKINS-37759</a>).
+      ${%Please} <a href="https://wiki.jenkins-ci.org/display/JENKINS/How+to+report+an+issue">${%report a bug}</a> ${%in the Jenkins bugtracker}.
+      <!--TODO: Nice2have: cause diagnostics-->
+  </div>
+</j:jelly>

--- a/core/src/main/resources/jenkins/diagnostics/CompletedInitializationMonitor/message.properties
+++ b/core/src/main/resources/jenkins/diagnostics/CompletedInitializationMonitor/message.properties
@@ -1,0 +1,6 @@
+blurb= Jenkins initialization has not reached the COMPLETED initialization milestone after the configuration reload. \
+    Current state is: \"{0}\". \
+    Such invalid state may cause undefined incorrect behavior of Jenkins plugins. \
+    It is likely an issue with the jenkins initialization or reloading task graph.
+
+


### PR DESCRIPTION
- [x] - Add SEVERE log messages in Jenkins constructor and reload() method
- [x] - Add Administrative monitor

https://issues.jenkins-ci.org/browse/JENKINS-37874 and https://issues.jenkins-ci.org/browse/JENKINS-37759

The fix is verified agains extreme-notification-1.2 (related fix - https://github.com/jenkinsci/extreme-notification-plugin/pull/5)

<img width="1006" alt="screen shot 2016-09-01 at 00 15 22" src="https://cloud.githubusercontent.com/assets/3000480/18148503/4132b716-6fda-11e6-97cb-4e1020956219.png">

<img width="1090" alt="screen shot 2016-09-01 at 00 16 09" src="https://cloud.githubusercontent.com/assets/3000480/18148507/450a3bca-6fda-11e6-9400-1b309d518b7e.png">

@reviewbybees
