### PR TITLE
Add newline after the text in userContent/readme.txt

### DIFF
--- a/core/src/main/java/hudson/init/impl/InitialUserContent.java
+++ b/core/src/main/java/hudson/init/impl/InitialUserContent.java
@@ -42,7 +42,7 @@ public class InitialUserContent {
         File userContentDir = new File(h.getRootDir(), "userContent");
         if(!userContentDir.exists()) {
             userContentDir.mkdirs();
-            FileUtils.writeStringToFile(new File(userContentDir,"readme.txt"), Messages.Hudson_USER_CONTENT_README());
+            FileUtils.writeStringToFile(new File(userContentDir,"readme.txt"), Messages.Hudson_USER_CONTENT_README() + "\n");
         }
     }
 }


### PR DESCRIPTION
This adds a newline after the text in `userContent/readme.txt` so that you can easily read it in the cmd line.
