### PR TITLE
[JENKINS-32148] - Add :hover to all stripped table rows

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -462,6 +462,9 @@ table.stripped-even tr:nth-child(even) {
 table.stripped-odd tr:nth-child(odd) {
   background: #fbfbfb;
 }
+table.stripped tr:hover, table.stripped-even tr:hover, table.stripped-odd tr:hover {
+  background: #e8e8e8 !important;
+}
 
 div.pane-header {
   font-weight: bold;
@@ -1021,7 +1024,7 @@ table.parameters > tbody:hover {
   padding: 3px 4px 3px 4px;
 }
 
-.build-row:hover, .build-row.model-link-active {
+.build-row.model-link-active {
   background: #e8e8e8 !important;
 }
 


### PR DESCRIPTION
If a table is being styled with `stripped` in order to visually better separate the rows it makes sense to also apply an `on-hover` style to highlight the row under the mouse cursor.

First I wanted to address this on a per-plugin base (jenkinsci/junit-plugin#55) but the suggestion there makes sense to address it globally.
