### PR TITLE
Fix groovy test class declaration

### DIFF
--- a/test/src/test/groovy/hudson/model/AbstractProjectTest.groovy
+++ b/test/src/test/groovy/hudson/model/AbstractProjectTest.groovy
@@ -611,7 +611,7 @@ public class AbstractProjectTest extends HudsonTestCase {
 
     }
 
-    static class MockBuildTriggerThrowsNPEOnStart<Item> extends Trigger {
+    static class MockBuildTriggerThrowsNPEOnStart extends Trigger<Item> {
         @Override
         public void start(hudson.model.Item project, boolean newInstance) { throw new NullPointerException(); }
 


### PR DESCRIPTION
Not sure why this started to fail to compile when running tests from IDEA, but it is clearly wrong. The reported problem is that `start` did not override parent method despite annotated as such (because one of the arguments is of the type that is omitted from superclass declaration).
