### PR TITLE
[JENKINS-10912] Use setInterval in refreshPart

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1486,6 +1486,7 @@ function expandTextArea(button,id) {
 // refresh a part of the HTML specified by the given ID,
 // by using the contents fetched from the given URL.
 function refreshPart(id,url) {
+    var intervalID = null;
     var f = function() {
         if(isPageVisible()) {
             new Ajax.Request(url, {
@@ -1506,21 +1507,18 @@ function refreshPart(id,url) {
                     Behaviour.applySubtree(node);
                     layoutUpdateCallback.call();
 
-                    if(isRunAsTest) return;
-                    refreshPart(id,url);
+                    if (isRunAsTest && intervalID) {
+                        window.clearInterval(intervalID);
+                        intervalID = null;
+                    }
                 }
-            });    
-        } else {
-            // Reschedule
-            if(isRunAsTest) return;
-            refreshPart(id,url);
+            });
         }
-        
     };
     // if run as test, just do it once and do it now to make sure it's working,
     // but don't repeat.
     if(isRunAsTest) f();
-    else    window.setTimeout(f, 5000);
+    else intervalID = window.setInterval(f, 5000);
 }
 
 

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1494,6 +1494,8 @@ function refreshPart(id,url) {
                     var hist = $(id);
                     if (hist == null) {
                         console.log("There's no element that has ID of " + id);
+                        if (intervalID !== null)
+                            window.clearInterval(intervalID);
                         return;
                     }
                     var p = hist.up();

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1508,11 +1508,6 @@ function refreshPart(id,url) {
 
                     Behaviour.applySubtree(node);
                     layoutUpdateCallback.call();
-
-                    if (isRunAsTest && intervalID) {
-                        window.clearInterval(intervalID);
-                        intervalID = null;
-                    }
                 }
             });
         }


### PR DESCRIPTION
The current implementation of refreshPart creates a new closure every 5
seconds, which, in combination with XMLHttpRequest objects, results in a
significant memory leak in all major browsers. By using
window.setInterval to schedule periodic refreshes, only one closure per
id is created. Please see [issue 10912](https://issues.jenkins-ci.org/browse/JENKINS-34923) in the Jenkins tracker for
further details.

https://issues.jenkins-ci.org/browse/JENKINS-10912
