### PR TITLE
Use the appropriate 'Gear' icon on the Plugin Manager page

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/sidepanel.groovy
+++ b/core/src/main/resources/hudson/PluginManager/sidepanel.groovy
@@ -28,7 +28,7 @@ l.header()
 l.side_panel {
     l.tasks {
         l.task(icon:"icon-up icon-md", href:rootURL+'/', title:_("Back to Dashboard"))
-        l.task(icon:"icon-setting icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"), permission:app.ADMINISTER, it:app)
+        l.task(icon:"icon-gear2 icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"), permission:app.ADMINISTER, it:app)
         if (!app.updateCenter.jobs.isEmpty()) {
             l.task(icon:"icon-plugin icon-md", href:"${rootURL}/updateCenter/", title:_("Update Center"))
         }


### PR DESCRIPTION
This has annoyed me for long enough

_Before_
![manage-jenkins-old](https://cloud.githubusercontent.com/assets/26594/18292753/bb2e8a0a-7443-11e6-857c-b354af0160c0.png)

_After_
![manage-jenkins-new](https://cloud.githubusercontent.com/assets/26594/18292757/c10c57ea-7443-11e6-9556-79196336ab3e.png)

Fixes [JENKINS-34250](https://issues.jenkins-ci.org/browse/JENKINS-34250)
