### PR TITLE
[FIXED JENKINS-31487] - Job status not updated in web UI during build

### DIFF
--- a/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
@@ -77,6 +77,6 @@ public class BuildHistoryWidget<T> extends HistoryWidget<Task,T> {
         historyPageFilter.add(baseList, getQueuedItems());
         historyPageFilter.widget = this;
 
-        return historyPageFilter;
+        return updateFirstTransientBuildKey(historyPageFilter);
     }
 }

--- a/core/src/main/java/hudson/widgets/HistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/HistoryWidget.java
@@ -114,6 +114,20 @@ public class HistoryWidget<O extends ModelObject,T> extends Widget {
         return firstTransientBuildKey;
     }
 
+    /**
+     * Calculates the first transient build record. Everything >= this will be discarded when AJAX call is made.
+     *
+     * @param historyPageFilter
+     *      The history page filter containing the list of builds.
+     * @return
+     *      The history page filter that was passed in.
+     */
+    @SuppressWarnings("unchecked")
+    protected HistoryPageFilter updateFirstTransientBuildKey(HistoryPageFilter historyPageFilter) {
+        updateFirstTransientBuildKey(historyPageFilter.runs);
+        return historyPageFilter;
+    }
+
     private Iterable<HistoryPageEntry<T>> updateFirstTransientBuildKey(Iterable<HistoryPageEntry<T>> source) {
         String key=null;
         for (HistoryPageEntry<T> t : source) {
@@ -166,7 +180,7 @@ public class HistoryWidget<O extends ModelObject,T> extends Widget {
 
         historyPageFilter.add(baseList);
         historyPageFilter.widget = this;
-        return historyPageFilter;
+        return updateFirstTransientBuildKey(historyPageFilter);
     }
 
     protected HistoryPageFilter<T> newPageFilter() {
@@ -238,7 +252,6 @@ public class HistoryWidget<O extends ModelObject,T> extends Widget {
         }
 
         HistoryPageFilter page = getHistoryPageFilter();
-        updateFirstTransientBuildKey(page.runs);
         req.getView(page,"ajaxBuildHistory.jelly").forward(req,rsp);
     }
 

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -119,6 +119,6 @@ THE SOFTWARE.
   </l:pane>
   </div>
   <script defer="true">
-      updateBuildHistory("${it.baseUrl}/buildHistory/ajax",${it.owner.nextBuildNumber});
+    updateBuildHistory("${it.baseUrl}/buildHistory/ajax", ${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber});
   </script>
 </j:jelly>


### PR DESCRIPTION
There were two issues preventing the build history from updating properly:
1) The next build number being fetched wasn't taking into account running builds, so any builds already running when the page is refreshed would be ignored. The fix was to use nextBuildNumberToFetch if it is available (which is the case if there are running builds) and to fall back to the next build otherwise.
2) The first transient build key (used to clear out builds from the history that are being updated) wasn't being set when the page first loads. This was fixed by making getHistoryPageFilter calculate the value so that it happens in all cases rather than just during the ajax call.

https://issues.jenkins-ci.org/browse/JENKINS-31487
