### PR TITLE
[JENKINS-27299] refactor disable out of AbstractProject

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -25,7 +25,6 @@ package hudson.cli;
 
 import hudson.Util;
 import hudson.console.ModelHyperlinkNote;
-import hudson.model.AbstractProject;
 import hudson.model.Cause.UserIdCause;
 import hudson.model.CauseAction;
 import hudson.model.Job;
@@ -44,6 +43,7 @@ import hudson.model.queue.QueueTaskFuture;
 import hudson.util.EditDistance;
 import hudson.util.StreamTaskListener;
 
+import jenkins.model.DisableableJobMixIn;
 import jenkins.scm.SCMDecisionHandler;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
@@ -157,7 +157,7 @@ public class BuildCommand extends CLICommand {
 
         if (!job.isBuildable()) {
             String msg = Messages.BuildCommand_CLICause_CannotBuildUnknownReasons(job.getFullDisplayName());
-            if (job instanceof AbstractProject<?, ?> && ((AbstractProject<?, ?>)job).isDisabled()) {
+            if (DisableableJobMixIn.isDisabled(job)) {
                 msg = Messages.BuildCommand_CLICause_CannotBuildDisabled(job.getFullDisplayName());
             } else if (job.isHoldOffBuildUntilSave()){
                 msg = Messages.BuildCommand_CLICause_CannotBuildConfigNotSaved(job.getFullDisplayName());
@@ -167,7 +167,7 @@ public class BuildCommand extends CLICommand {
 
         Queue.Item item = ParameterizedJobMixIn.scheduleBuild2(job, 0, new CauseAction(new CLICause(Jenkins.getAuthentication().getName())), a);
         QueueTaskFuture<? extends Run<?,?>> f = item != null ? (QueueTaskFuture)item.getFuture() : null;
-        
+
         if (wait || sync || follow) {
             if (f == null) {
                 throw new IllegalStateException(BUILD_SCHEDULING_REFUSED);

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -110,6 +110,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.model.Uptime;
+import jenkins.model.DisableableJobMixIn;
 import jenkins.model.lazy.LazyBuildMixIn;
 import jenkins.scm.DefaultSCMCheckoutStrategyImpl;
 import jenkins.scm.SCMCheckoutStrategy;
@@ -143,7 +144,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  * @see AbstractBuild
  */
 @SuppressWarnings("rawtypes")
-public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends AbstractBuild<P,R>> extends Job<P,R> implements BuildableItem, LazyBuildMixIn.LazyLoadingJob<P,R>, ParameterizedJobMixIn.ParameterizedJob {
+public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends AbstractBuild<P,R>> extends Job<P,R> implements BuildableItem, LazyBuildMixIn.LazyLoadingJob<P,R>, ParameterizedJobMixIn.ParameterizedJob, DisableableJobMixIn.DisableableJob {
 
     /**
      * {@link SCM} associated with the project.
@@ -683,6 +684,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         save();
     }
 
+    @Override
     public boolean isDisabled() {
         return disabled;
     }
@@ -729,20 +731,14 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         return this instanceof TopLevelItem;
     }
 
+    @Override
     public void disable() throws IOException {
         makeDisabled(true);
     }
 
+    @Override
     public void enable() throws IOException {
         makeDisabled(false);
-    }
-
-    @Override
-    public BallColor getIconColor() {
-        if(isDisabled())
-            return isBuilding() ? BallColor.DISABLED_ANIME : BallColor.DISABLED;
-        else
-            return super.getIconColor();
     }
 
     /**

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -86,6 +86,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ProjectNamingStrategy;
 import jenkins.model.RunIdMigrator;
+import jenkins.model.DisableableJobMixIn;
 import jenkins.model.lazy.LazyBuildMixIn;
 import jenkins.security.HexStringConfidentialKey;
 import jenkins.util.io.OnMaster;
@@ -1078,10 +1079,13 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         while (lastBuild != null && lastBuild.hasntStartedYet())
             lastBuild = lastBuild.getPreviousBuild();
 
-        if (lastBuild != null)
+        if(DisableableJobMixIn.isDisabled(this)) {
+            return isBuilding() ? BallColor.DISABLED_ANIME : BallColor.DISABLED;
+        } else if (lastBuild != null) {
             return lastBuild.getIconColor();
-        else
+        } else {
             return BallColor.NOTBUILT;
+        }
     }
 
     /**

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -47,6 +47,8 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.servlet.ServletException;
+
+import jenkins.model.DisableableJobMixIn;
 import jenkins.model.Jenkins;
 
 import net.sf.json.JSONObject;
@@ -195,8 +197,8 @@ public class ListView extends View implements DirectlyModifiableView {
         for (TopLevelItem item : candidates) {
             if (!names.contains(item.getRelativeNameFrom(getOwnerItemGroup()))) continue;
             // Add if no status filter or filter matches enabled/disabled status:
-            if(statusFilter == null || !(item instanceof AbstractProject)
-                              || ((AbstractProject)item).isDisabled() ^ statusFilter)
+            if(statusFilter == null || !(item instanceof Job<?, ?>)
+                              || DisableableJobMixIn.isDisabled((Job<?, ?>) item) ^ statusFilter)
                 items.add(item);
         }
 

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -60,6 +60,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import jenkins.model.DependencyDeclarer;
+import jenkins.model.DisableableJobMixIn;
 import jenkins.model.Jenkins;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
 import jenkins.security.QueueItemAuthenticatorDescriptor;
@@ -247,7 +248,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
                 if (dep.shouldTriggerBuild(build, listener, buildActions)) {
                     AbstractProject p = dep.getDownstreamProject();
                     // Allow shouldTriggerBuild to return false first, in case it is skipping because of a lack of Item.READ/DISCOVER permission:
-                    if (p.isDisabled()) {
+                    if (DisableableJobMixIn.isDisabled(p)) {
                         logger.println(Messages.BuildTrigger_Disabled(ModelHyperlinkNote.encodeTo(p)));
                         continue;
                     }

--- a/core/src/main/java/jenkins/model/DisableableJobMixIn.java
+++ b/core/src/main/java/jenkins/model/DisableableJobMixIn.java
@@ -1,0 +1,63 @@
+package jenkins.model;
+
+import hudson.model.Job;
+import hudson.model.ParametersDefinitionProperty;
+
+import java.io.IOException;
+
+/**
+ * Allows a {@link Job} to declare that it is disableable without extending AbstractProject.
+ * Consumers who want to check or update the enabled/disabled state of jobs should use the
+ * static methods provided here.
+ *
+ * @since TODO
+ */
+public final class DisableableJobMixIn {
+
+    /**
+     * Returns true if the given Job implements DisableableJobMixIn and is disabled.
+     * Otherwise returns false.
+     */
+    public static boolean isDisabled(final Job<?,?> job) {
+        if (!(job instanceof DisableableJob)) {
+            return false;
+        }
+        return ((DisableableJob) job).isDisabled();
+    }
+
+    /**
+     * Puts the Job into an enabled state. Has no effect if the job is already enabled
+     * or does not implement DisableableJob (implying it is always enabled).
+     */
+    public static void enable(final Job<?,?> job) throws IOException {
+        if (job instanceof DisableableJob) {
+            ((DisableableJob) job).enable();
+        }
+    }
+
+    /**
+     * Puts the job into a disabled state if it supports it (implements DisableableJob).
+     * Has no effect if the job is already disabled, or does not implement DisableableJob.
+     */
+    public static void disableIfSupported(final Job<?,?> job) throws IOException {
+        if (job instanceof DisableableJob) {
+            ((DisableableJob) job).disable();
+        }
+    }
+
+    public interface DisableableJob {
+        boolean isDisabled();
+
+        /**
+	 * Should put the job into an enabled state. If the job is already enabled this
+	 * should be a no-op.
+	 */
+        void enable() throws IOException;
+
+	/**
+	 * Should put the job into a disabled state. If the job is already disabled this
+	 * should be a no-op.
+	 */
+        void disable() throws IOException;
+    }
+}


### PR DESCRIPTION
I'm not sure if this is the right approach to take, so I'm posting this in hopes that someone can point me in a better direction if this is wrong.

My ultimate goal is to make it so that when I use the "Disable removed jobs" feature of the Job DSL plugin it works with Pipeline jobs. Today it does not work because a) pipeline jobs do not support disable at all, and b) the Job DSL plugin is doing the disable via AbstractProject.disable().

To fix this I think I need 3 updates:
- This one to Jenkins core adds a non-AbstractProject-specific interface to check if a job is disabled and disable the job. In this case I implemented it as an optional interface the Job can implement (DisableableJobMixIn.DisableableJob).
- An update to workflow-job-plugin to implement the new interface and add all of the actual code to support disabling (I did not see an easy way to share disable code between WorkflowJob and AbstractProject related to disabling, most of it deals with the Configuration UI and persisting a boolean as part of the job config.xml) https://github.com/jenkinsci/workflow-job-plugin/pull/22
- An update to the Job DSL plugin to use DisableableJobMixIn.disableIfSupported() instead of AbstractProject.disable().

I did some manual testing of this diff + the change to workflow-job-plugin described above. I was able to confirm that the Build button goes away, trying to build via directly inputting the URL fails with the same error as Freestyle jobs, disabling via the UI appears to work correctly, and cron and SCM triggers are ignored correctly when the job is disabled.
