### PR TITLE
[JENKINS-27299] refactor disable out of AbstractProject (alternate)

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -25,7 +25,6 @@ package hudson.cli;
 
 import hudson.Util;
 import hudson.console.ModelHyperlinkNote;
-import hudson.model.AbstractProject;
 import hudson.model.Cause.UserIdCause;
 import hudson.model.CauseAction;
 import hudson.model.Job;
@@ -157,7 +156,7 @@ public class BuildCommand extends CLICommand {
 
         if (!job.isBuildable()) {
             String msg = Messages.BuildCommand_CLICause_CannotBuildUnknownReasons(job.getFullDisplayName());
-            if (job instanceof AbstractProject<?, ?> && ((AbstractProject<?, ?>)job).isDisabled()) {
+            if (job.isDisabled()) {
                 msg = Messages.BuildCommand_CLICause_CannotBuildDisabled(job.getFullDisplayName());
             } else if (job.isHoldOffBuildUntilSave()){
                 msg = Messages.BuildCommand_CLICause_CannotBuildConfigNotSaved(job.getFullDisplayName());
@@ -167,7 +166,7 @@ public class BuildCommand extends CLICommand {
 
         Queue.Item item = ParameterizedJobMixIn.scheduleBuild2(job, 0, new CauseAction(new CLICause(Jenkins.getAuthentication().getName())), a);
         QueueTaskFuture<? extends Run<?,?>> f = item != null ? (QueueTaskFuture)item.getFuture() : null;
-        
+
         if (wait || sync || follow) {
             if (f == null) {
                 throw new IllegalStateException(BUILD_SCHEDULING_REFUSED);

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -683,6 +683,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         save();
     }
 
+    @Override
     public boolean isDisabled() {
         return disabled;
     }
@@ -729,20 +730,14 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         return this instanceof TopLevelItem;
     }
 
+    @Override
     public void disable() throws IOException {
         makeDisabled(true);
     }
 
+    @Override
     public void enable() throws IOException {
         makeDisabled(false);
-    }
-
-    @Override
-    public BallColor getIconColor() {
-        if(isDisabled())
-            return isBuilding() ? BallColor.DISABLED_ANIME : BallColor.DISABLED;
-        else
-            return super.getIconColor();
     }
 
     /**

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1070,6 +1070,57 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     /**
+     * The following methods should be overriden by Jobs that support being disabled:
+     * - supportsDisable() - override to return true
+     * - isDisabled()
+     * - disable()
+     * - enable()
+     *
+     * The default behavior for jobs that do not override these methods is isDisabled() always returns false,
+     * and enable()/disable() should not be called (they throw exceptions). enable()/disable() should only be
+     * called if supportsDisable() returns true.
+     *
+     * @since TODO
+     */
+    public boolean supportsDisable() {
+        return false;
+    }
+
+    /**
+     * Returns true if the job is currently disabled. Returns false if the job is not disabled, or does not
+     * support being disabled.
+     *
+     * @since TODO
+     */
+    public boolean isDisabled() {
+        return false;
+    }
+
+    /**
+     * Subclasses should implement this class if they support enable/disable semantics. Callers should check
+     * supportsDisable() before calling this method.
+     *
+     * Transitions this job to the disabled state. If the job is already disabled this method silently does nothing.
+     *
+     * @since TODO
+     */
+    public void disable() throws IOException {
+        throw new IllegalStateException("does not support disable/enable");
+    }
+
+    /**
+     * Subclasses should implement this class if they support enable/disable semantics. Callers should check
+     * supportsDisable() before calling this method.
+     *
+     * Transitions this job to the enabled state. If the job is already enabled this method silently does nothing.
+     *
+     * @since TODO
+     */
+    public void enable() throws IOException {
+        throw new IllegalStateException("does not support disable/enable");
+    }
+
+    /**
      * Used as the color of the status ball for the project.
      */
     @Exported(visibility = 2, name = "color")
@@ -1078,10 +1129,13 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         while (lastBuild != null && lastBuild.hasntStartedYet())
             lastBuild = lastBuild.getPreviousBuild();
 
-        if (lastBuild != null)
+        if(isDisabled()) {
+            return isBuilding() ? BallColor.DISABLED_ANIME : BallColor.DISABLED;
+        } else if (lastBuild != null) {
             return lastBuild.getIconColor();
-        else
+        } else {
             return BallColor.NOTBUILT;
+        }
     }
 
     /**

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1071,11 +1071,14 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * The following methods should be overriden by Jobs that support being disabled:
-     * - supportsDisable() - override to return true
-     * - isDisabled()
-     * - disable()
-     * - enable()
+     * <p><ul>
+     * <li>supportsDisable() - override to return true</li>
+     * <li>isDisabled()</li>
+     * <li>disable()</li>
+     * <li>enable()</li>
+     * </ul>
      *
+     * <p>
      * The default behavior for jobs that do not override these methods is isDisabled() always returns false,
      * and enable()/disable() should not be called (they throw exceptions). enable()/disable() should only be
      * called if supportsDisable() returns true.
@@ -1105,7 +1108,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      * @since TODO
      */
     public void disable() throws IOException {
-        throw new IllegalStateException("does not support disable/enable");
+        throw new IOException("does not support disable/enable");
     }
 
     /**
@@ -1117,7 +1120,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      * @since TODO
      */
     public void enable() throws IOException {
-        throw new IllegalStateException("does not support disable/enable");
+        throw new IOException("does not support disable/enable");
     }
 
     /**

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -47,6 +47,7 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.servlet.ServletException;
+
 import jenkins.model.Jenkins;
 
 import net.sf.json.JSONObject;
@@ -195,8 +196,8 @@ public class ListView extends View implements DirectlyModifiableView {
         for (TopLevelItem item : candidates) {
             if (!names.contains(item.getRelativeNameFrom(getOwnerItemGroup()))) continue;
             // Add if no status filter or filter matches enabled/disabled status:
-            if(statusFilter == null || !(item instanceof AbstractProject)
-                              || ((AbstractProject)item).isDisabled() ^ statusFilter)
+            if(statusFilter == null || !(item instanceof Job<?, ?>)
+                              || ((Job<?, ?>) item).isDisabled() ^ statusFilter)
                 items.add(item);
         }
 


### PR DESCRIPTION
This is an alternative implementation of https://github.com/jenkinsci/jenkins/pull/2543 that would let plugins add support for disable to their jobs without bumping their minimum Jenkins version. I've copied over the relevant description to this new pull request.

My ultimate goal is to make it so that when I use the "Disable removed jobs" feature of the Job DSL plugin it works with Pipeline jobs. Today it does not work because a) pipeline jobs do not support disable at all, and b) the Job DSL plugin is doing the disable via AbstractProject.disable().

To fix this I think I need 3 updates:
- This one to Jenkins core moves the disable-related methods from AbstractProject to Job<?,?> . Leaving the ones in AbstractProject as overrides. The default methods in Job<?,?> do nothing (isDisabled() always returns false, trying to disable a job throws an exception). Jobs subclasses that override these methods can support disable, and plugins that want to check the disabled/enabled status of a job can use Job.isDisabled()/disable() now instead of AbstractProject.isDisabled()/disable() (after checking Job.supportsDisable()).
- An update to workflow-job-plugin to override supportsDisabled()/isDisabled()/disable() (without adding @Override to the new methods, this way the plugin doesn't need to bump it's minimum Jenkins version). jenkinsci/workflow-job-plugin#23
- An update to the Job DSL plugin to use Job.disable() instead of AbstractProject.disable().

I did some manual testing of this diff + the change to workflow-job-plugin described above. I was able to confirm that the Build button goes away, trying to build via directly inputting the URL fails with the same error as Freestyle jobs, disabling via the UI appears to work correctly, and cron and SCM triggers are ignored correctly when the job is disabled.

There would be a few issues with this, for example plugins that explicitly check for AbstractProject.isDisabled() would not notice disabled pipeline jobs. Also, when using a Jenkins core version that doesn't have the modifications to ListView.java and BuildCommand.java here Jenkins core would not properly identify disabled Pipeline jobs.
