### PR TITLE
[FIX JENKINS-38301] Add configuration for disabling admin monitors

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1950,6 +1950,11 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @Extension @Symbol("pluginCycleDependencies")
     public static final class PluginCycleDependenciesMonitor extends AdministrativeMonitor {
 
+        @Override
+        public String getDisplayName() {
+            return Messages.PluginManager_PluginCycleDependenciesMonitor_DisplayName();
+        }
+
         private transient volatile boolean isActive = false;
 
         private transient volatile List<PluginWrapper> pluginsWithCycle;
@@ -2007,6 +2012,11 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
         public boolean isActivated() {
             return !pluginsToBeUpdated.isEmpty();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.PluginManager_PluginUpdateMonitor_DisplayName();
         }
 
         /**

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -748,6 +748,11 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
             return !plugins.isEmpty();
         }
 
+        @Override
+        public String getDisplayName() {
+            return Messages.PluginWrapper_PluginWrapperAdministrativeMonitor_DisplayName();
+        }
+
         public Collection<PluginWrapper> getPlugins() {
             return plugins.values();
         }

--- a/core/src/main/java/hudson/diagnosis/NullIdDescriptorMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/NullIdDescriptorMonitor.java
@@ -50,6 +50,11 @@ import static hudson.init.InitMilestone.EXTENSIONS_AUGMENTED;
 @Extension @Symbol("nullId")
 public class NullIdDescriptorMonitor extends AdministrativeMonitor {
 
+    @Override
+    public String getDisplayName() {
+        return Messages.NullIdDescriptorMonitor_DisplayName();
+    }
+
     private final List<Descriptor> problems = new ArrayList<Descriptor>();
 
     @Override

--- a/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
@@ -93,5 +93,10 @@ public class ReverseProxySetupMonitor extends AdministrativeMonitor {
             return new HttpRedirect("https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+says+my+reverse+proxy+setup+is+broken");
         }
     }
+
+    @Override
+    public String getDisplayName() {
+        return Messages.ReverseProxySetupMonitor_DisplayName();
+    }
 }
 

--- a/core/src/main/java/hudson/diagnosis/TooManyJobsButNoView.java
+++ b/core/src/main/java/hudson/diagnosis/TooManyJobsButNoView.java
@@ -42,6 +42,12 @@ import java.io.IOException;
  */
 @Extension @Symbol("tooManyJobsButNoView")
 public class TooManyJobsButNoView extends AdministrativeMonitor {
+
+    @Override
+    public String getDisplayName() {
+        return Messages.TooManyJobsButNoView_DisplayName();
+    }
+
     public boolean isActivated() {
         Jenkins h = Jenkins.getInstance();
         return h.getViews().size()==1 && h.getItemMap().size()> THRESHOLD;

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -986,6 +986,12 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      */
     @Extension @Symbol("coreUpdate")
     public static final class CoreUpdateMonitor extends AdministrativeMonitor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.UpdateCenter_CoreUpdateMonitor_DisplayName();
+        }
+
         public boolean isActivated() {
             Data data = getData();
             return data!=null && data.hasCoreUpdates();

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -349,6 +349,12 @@ public class SCMTrigger extends Trigger<Item> {
 
     @Extension
     public static final class AdministrativeMonitorImpl extends AdministrativeMonitor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.SCMTrigger_AdministrativeMonitorImpl_DisplayName();
+        }
+
         private boolean on;
 
         public boolean isActivated() {

--- a/core/src/main/java/jenkins/diagnostics/SecurityIsOffMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/SecurityIsOffMonitor.java
@@ -20,6 +20,12 @@ import java.io.IOException;
  */
 @Extension @Symbol("securityIsOff")
 public class SecurityIsOffMonitor extends AdministrativeMonitor {
+
+    @Override
+    public String getDisplayName() {
+        return Messages.SecurityIsOffMonitor_DisplayName();
+    }
+
     @Override
     public boolean isActivated() {
         return !Jenkins.getInstance().isUseSecurity();

--- a/core/src/main/java/jenkins/model/DownloadSettings.java
+++ b/core/src/main/java/jenkins/model/DownloadSettings.java
@@ -138,6 +138,11 @@ public final class DownloadSettings extends GlobalConfiguration {
 
     @Extension public static final class Warning extends AdministrativeMonitor {
 
+        @Override
+        public String getDisplayName() {
+            return Messages.DownloadSettings_Warning_DisplayName();
+        }
+
         @Override public boolean isActivated() {
             return DownloadSettings.get().isUseBrowser();
         }

--- a/core/src/main/java/jenkins/security/s2m/AdminCallableMonitor.java
+++ b/core/src/main/java/jenkins/security/s2m/AdminCallableMonitor.java
@@ -39,7 +39,7 @@ public class AdminCallableMonitor extends AdministrativeMonitor {
 
     @Override
     public String getDisplayName() {
-        return "Agent \u2192 Master Access Control";
+        return Messages.AdminCallableMonitor_DisplayName();
     }
 
     // bind this to URL

--- a/core/src/main/java/jenkins/security/s2m/MasterKillSwitchWarning.java
+++ b/core/src/main/java/jenkins/security/s2m/MasterKillSwitchWarning.java
@@ -28,6 +28,11 @@ public class MasterKillSwitchWarning extends AdministrativeMonitor {
         return rule.getMasterKillSwitch() && config.isRelevant();
     }
 
+    @Override
+    public String getDisplayName() {
+        return Messages.MasterKillSwitchWarning_DisplayName();
+    }
+
     public HttpResponse doAct(@QueryParameter String dismiss) throws IOException {
         if(dismiss!=null) {
             disable(true);

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -61,6 +61,8 @@ PluginManager.UploadPluginsPermission.Description=\
 PluginManager.ConfigureUpdateCenterPermission.Description=\
   The "configure update center" permission allows a user to \
   configure update sites and proxy settings.
+PluginManager.PluginCycleDependenciesMonitor.DisplayName=Cyclic Dependencies Detector
+PluginManager.PluginUpdateMonitor.DisplayName=Invalid Plugin Configuration
 
 AboutJenkins.DisplayName=About Jenkins
 AboutJenkins.Description=See the version and license information.
@@ -80,4 +82,7 @@ PluginWrapper.disabledAndObsolete={0} v{1} is disabled and older than required. 
 PluginWrapper.disabled={0} is disabled. To fix, enable it.
 PluginWrapper.obsolete={0} v{1} is older than required. To fix, install v{2} or later.
 PluginWrapper.obsoleteCore=You must update Jenkins from v{0} to v{1} or later to run this plugin.
+PluginWrapper.PluginWrapperAdministrativeMonitor.DisplayName=Plugins Failed To Load
+
 TcpSlaveAgentListener.PingAgentProtocol.displayName=Ping protocol
+

--- a/core/src/main/resources/hudson/diagnosis/Messages.properties
+++ b/core/src/main/resources/hudson/diagnosis/Messages.properties
@@ -3,3 +3,7 @@ MemoryUsageMonitor.TOTAL=Total
 OldDataMonitor.Description=Scrub configuration files to remove remnants from old plugins and earlier versions.
 OldDataMonitor.DisplayName=Manage Old Data
 HudsonHomeDiskUsageMonitor.DisplayName=Disk Usage Monitor
+
+NullIdDescriptorMonitor.DisplayName=Missing Descriptor ID
+ReverseProxySetupMonitor.DisplayName=Reverse Proxy Setup
+TooManyJobsButNoView.DisplayName=Too Many Jobs Not Organized in Views

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -272,6 +272,8 @@ UpdateCenter.Status.ConnectionFailed=\
   <span class=error>Failed to connect to {0}. \
   Perhaps you need to <a href="../pluginManager/advanced">configure HTTP proxy?</a></span>
 UpdateCenter.init=Initialing update center
+UpdateCenter.CoreUpdateMonitor.DisplayName=Jenkins Update Notification
+
 UpdateCenter.PluginCategory.android=Android Development
 UpdateCenter.PluginCategory.builder=Build Tools
 UpdateCenter.PluginCategory.buildwrapper=Build Wrappers

--- a/core/src/main/resources/hudson/node_monitors/Messages.properties
+++ b/core/src/main/resources/hudson/node_monitors/Messages.properties
@@ -32,3 +32,4 @@ SwapSpaceMonitor.DisplayName=Free Swap Space
 TemporarySpaceMonitor.DisplayName=Free Temp Space
 AbstractNodeMonitorDescriptor.NoDataYet=Not yet
 DiskSpaceMonitorDescriptor.DiskSpace.FreeSpaceTooLow=Disk space is too low. Only {0}GB left on {1}.
+MonitorMarkedNodeOffline.DisplayName=Node Marked Offline Due to Health Check

--- a/core/src/main/resources/hudson/triggers/Messages.properties
+++ b/core/src/main/resources/hudson/triggers/Messages.properties
@@ -30,3 +30,4 @@ TimerTrigger.no_schedules_so_will_never_run=No schedules so will never run
 TimerTrigger.TimerTriggerCause.ShortDescription=Started by timer
 TimerTrigger.would_last_have_run_at_would_next_run_at=Would last have run at {0}; would next run at {1}.
 Trigger.init=Initializing timer for triggers
+SCMTrigger.AdministrativeMonitorImpl.DisplayName=Too Many SCM Polling Threads

--- a/core/src/main/resources/jenkins/diagnostics/Messages.properties
+++ b/core/src/main/resources/jenkins/diagnostics/Messages.properties
@@ -1,0 +1,2 @@
+CompletedInitializationMonitor.DisplayName=Jenkins Initialization Monitor
+SecurityIsOffMonitor.DisplayName=Disabled Security

--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
@@ -21,36 +21,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package jenkins.diagnostics;
 
-import hudson.Extension;
-import hudson.init.InitMilestone;
-import hudson.model.AdministrativeMonitor;
-import jenkins.model.Jenkins;
-import org.jenkinsci.Symbol;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
+package jenkins.management.AdministrativeMonitorsConfiguration
 
-/**
- * Performs monitoring of {@link Jenkins} {@link InitMilestone} status.
- *
- * @author Oleg Nenashev
- * @since TODO
- */
-@Restricted(NoExternalUse.class)
-@Extension @Symbol("completedInitialization")
-public class CompletedInitializationMonitor extends AdministrativeMonitor {
+import hudson.model.AdministrativeMonitor
 
-    @Override
-    public String getDisplayName() {
-        return Messages.CompletedInitializationMonitor_DisplayName();
-    }
+f = namespace(lib.FormTagLib)
+st = namespace("jelly:stapler")
 
-    @Override
-    public boolean isActivated() {
-        final Jenkins instance = Jenkins.getInstance();
-        // Safe to check in such way, because monitors are being checked in UI only.
-        // So Jenkins class construction and initialization must be always finished by the call of this extension.
-        return instance.getInitLevel() != InitMilestone.COMPLETED;
+f.section(title: _("Administrative monitors configuration")) {
+    f.advanced(title: _("Administrative monitors")) {
+        f.entry(title: _("Enabled administrative monitors")) {
+            p(_("blurb"))
+            table(width: "100%") {
+                for (AdministrativeMonitor am : AdministrativeMonitor.all()) {
+                    f.block() {
+                        f.checkbox(name: "administrativeMonitor",
+                                title: am.displayName,
+                                checked: am.enabled,
+                                json: am.id);
+                    }
+                    tr() {
+                        td(colspan: "2");
+                        td(class: "setting-description") {
+                            st.include(from: am, page: "description", optional: true);
+                        }
+                        td();
+                    }
+                }
+            }
+        }
     }
 }

--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.properties
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.properties
@@ -1,0 +1,5 @@
+blurb = Administrative monitors are warnings shown to Jenkins administrators \
+  about the state of the Jenkins instance. It is generally strongly \
+  recommended to keep all administrative monitors enabled, but if you are \
+  not interested in specific warnings, uncheck them here to permanently \
+  hide them.

--- a/core/src/main/resources/jenkins/model/Messages.properties
+++ b/core/src/main/resources/jenkins/model/Messages.properties
@@ -68,3 +68,5 @@ ParameterizedJobMixIn.build_now=Build Now
 BlockedBecauseOfBuildInProgress.shortDescription=Build #{0} is already in progress{1}
 BlockedBecauseOfBuildInProgress.ETA=\ (ETA:{0})
 BuildDiscarderProperty.displayName=Discard old builds
+
+DownloadSettings.Warning.DisplayName=Browser-based metadata download

--- a/core/src/main/resources/jenkins/security/s2m/Messages.properties
+++ b/core/src/main/resources/jenkins/security/s2m/Messages.properties
@@ -1,0 +1,2 @@
+AdminCallableMonitor.DisplayName=Rejected Agent \u2192 Master Access Attempt
+MasterKillSwitchWarning.DisplayName=Disabled Agent \u2192 Master Access Control


### PR DESCRIPTION
Also add display name for all admin monitors in core.

Screenshots:

> <img width="639" alt="Screen shot 1" src="https://cloud.githubusercontent.com/assets/1831569/18604883/556407a2-7c38-11e6-81d0-9407c7fb1fa7.png">

---

> <img width="649" alt="screen shot 2" src="https://cloud.githubusercontent.com/assets/1831569/18604884/58bcd0aa-7c38-11e6-91c2-c8743f30c016.png">

@reviewbybees
