### PR TITLE
[JENKINS-38340] fix UpdateCenter download error

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1188,7 +1188,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                         URL redirectUrl = new URL(httpConn.getHeaderField("location"));
                         conn = connect(job, redirectUrl);
                     } finally {
-                        Util.closeAndLogFailures(httpConn.getInputStream(), LOGGER, job.getDestination().getName(), src.toString());;
+                        Util.closeAndLogFailures(httpConn.getInputStream(), LOGGER, job.getDestination().getName(), src.toString());
                     }
                 }
             }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1183,10 +1183,13 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 HttpURLConnection httpConn = (HttpURLConnection) conn;
                 if (httpConn.getResponseCode() == HttpURLConnection.HTTP_MOVED_TEMP 
                     || httpConn.getResponseCode() == HttpURLConnection.HTTP_MOVED_PERM) {
-                    // 302, 301
-                    // TODO maybe need resolve recursive redirect
-                    conn = connect(job, new URL(httpConn.getHeaderField("location")));
-                    IOUtils.closeQuietly(httpConn.getInputStream());
+                    // TODO maybe need to resolve recursive redirect
+                    try {
+                        URL redirectUrl = new URL(httpConn.getHeaderField("location"));
+                        conn = connect(job, redirectUrl);
+                    } finally {
+                        Util.closeAndLogFailures(httpConn.getInputStream(), LOGGER, job.getDestination().getName(), src.toString());;
+                    }
                 }
             }
             return conn;


### PR DESCRIPTION
fix UpdateCenter download from http url error when response http status code is 301 or 302

Jira issue is [#JENKINS-38340](https://issues.jenkins-ci.org/browse/JENKINS-38340)
