### PR TITLE
Present stacktrace when throwable attached to Descriptor.FormException

### DIFF
--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -1144,7 +1144,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
                         .generateResponse(req, rsp, node);
             } else {
                 // for now, we can't really use the field name that caused the problem.
-                new Failure(getMessage()).generateResponse(req,rsp,node);
+                new Failure(getMessage()).generateResponse(req,rsp,node,getCause());
             }
         }
     }

--- a/core/src/main/java/hudson/model/Failure.java
+++ b/core/src/main/java/hudson/model/Failure.java
@@ -28,6 +28,7 @@ import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+import javax.annotation.Nullable;
 import javax.servlet.ServletException;
 import java.io.IOException;
 
@@ -52,6 +53,13 @@ public class Failure extends RuntimeException implements HttpResponse {
     public Failure(String message, boolean pre) {
         super(message);
         this.pre = pre;
+    }
+
+    public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node, @Nullable Throwable throwable) throws IOException, ServletException {
+        if (throwable != null) {
+            req.setAttribute("exception", throwable);
+        }
+        generateResponse(req, rsp, node);
     }
 
     public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {

--- a/core/src/main/java/hudson/model/Failure.java
+++ b/core/src/main/java/hudson/model/Failure.java
@@ -28,7 +28,7 @@ import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import javax.annotation.Nullable;
+import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 import java.io.IOException;
 
@@ -55,7 +55,7 @@ public class Failure extends RuntimeException implements HttpResponse {
         this.pre = pre;
     }
 
-    public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node, @Nullable Throwable throwable) throws IOException, ServletException {
+    public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node, @CheckForNull Throwable throwable) throws IOException, ServletException {
         if (throwable != null) {
             req.setAttribute("exception", throwable);
         }


### PR DESCRIPTION
Form submission can yield  an error screen showing nothing but `javax.servlet.ServletException: java.lang.NullPointerException` presuming it needs no further explanation as it delegate to `hudson.model.Failure`.

This change makes sure then when there is a cause in `FormException`, its stacktrace is presented to the user.
