### PR TITLE
[JENKINS-38370] Start defining APIs that are for the master JVM only

### DIFF
--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -46,6 +46,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import jenkins.util.io.OnMaster;
 
 /**
  * Retains the known extension instances for the given type 'T'.
@@ -68,7 +69,7 @@ import javax.annotation.Nonnull;
  * @see jenkins.model.Jenkins#getExtensionList(Class)
  * @see jenkins.model.Jenkins#getDescriptorList(Class)
  */
-public class ExtensionList<T> extends AbstractList<T> {
+public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
     /**
      * @deprecated as of 1.417
      *      Use {@link #jenkins}

--- a/core/src/main/java/hudson/ExtensionPoint.java
+++ b/core/src/main/java/hudson/ExtensionPoint.java
@@ -29,6 +29,7 @@ import static java.lang.annotation.ElementType.TYPE;
 import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Target;
+import jenkins.util.io.OnMaster;
 
 /**
  * Marker interface that designates extensible components
@@ -47,7 +48,7 @@ import java.lang.annotation.Target;
  * @see Plugin
  * @see Extension
  */
-public interface ExtensionPoint {
+public interface ExtensionPoint extends OnMaster {
     /**
      * Used by designers of extension points (direct subtypes of {@link ExtensionPoint}) to indicate that
      * the legacy instances are scoped to {@link Jenkins} instance. By default, legacy instances are

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -39,6 +39,7 @@ import hudson.views.ListViewColumn;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
+import jenkins.util.io.OnMaster;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.*;
@@ -125,7 +126,7 @@ import javax.annotation.Nonnull;
  * @author Kohsuke Kawaguchi
  * @see Describable
  */
-public abstract class Descriptor<T extends Describable<T>> implements Saveable {
+public abstract class Descriptor<T extends Describable<T>> implements Saveable, OnMaster {
     /**
      * The class being described by this descriptor.
      */

--- a/core/src/main/java/hudson/model/Item.java
+++ b/core/src/main/java/hudson/model/Item.java
@@ -27,6 +27,7 @@ package hudson.model;
 import hudson.Functions;
 import jenkins.util.SystemProperties;
 import hudson.security.PermissionScope;
+import jenkins.util.io.OnMaster;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
@@ -67,7 +68,7 @@ import hudson.util.Secret;
  * @see Items
  * @see ItemVisitor
  */
-public interface Item extends PersistenceRoot, SearchableModelObject, AccessControlled {
+public interface Item extends PersistenceRoot, SearchableModelObject, AccessControlled, OnMaster {
     /**
      * Gets the parent that contains this item.
      */

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -128,7 +128,7 @@ import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
  * @author Kohsuke Kawaguchi
  */
 public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, RunT>>
-        extends AbstractItem implements ExtensionPoint, StaplerOverridable, ModelObjectWithChildren, OnMaster {
+        extends AbstractItem implements ExtensionPoint, StaplerOverridable, ModelObjectWithChildren {
 
     private static final Logger LOGGER = Logger.getLogger(Job.class.getName());
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -212,6 +212,7 @@ import jenkins.slaves.WorkspaceLocator;
 import jenkins.util.JenkinsJVM;
 import jenkins.util.Timer;
 import jenkins.util.io.FileBoolean;
+import jenkins.util.io.OnMaster;
 import jenkins.util.xml.XMLUtils;
 import net.jcip.annotations.GuardedBy;
 import net.sf.json.JSONObject;
@@ -323,7 +324,7 @@ import org.kohsuke.stapler.WebMethod;
 @ExportedBean
 public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLevelItemGroup, StaplerProxy, StaplerFallback,
         ModifiableViewGroup, AccessControlled, DescriptorByNameOwner,
-        ModelObjectWithContextMenu, ModelObjectWithChildren {
+        ModelObjectWithContextMenu, ModelObjectWithChildren, OnMaster {
     private transient final Queue queue;
 
     /**

--- a/core/src/main/java/jenkins/util/io/OnMaster.java
+++ b/core/src/main/java/jenkins/util/io/OnMaster.java
@@ -16,4 +16,36 @@ package jenkins.util.io;
  * @since 1.475
  */
 public interface OnMaster {
+// TODO uncomment once we can have a delegating ClassFilter, also add SystemProperty to toggle feature
+//    @Extension
+//    @Restricted(NoExternalUse.class)
+//    class ChannelConfiguratorImpl extends ChannelConfigurator {
+//        @Override
+//        public void onChannelBuilding(ChannelBuilder builder, @Nullable Object context) {
+//            if (context instanceof SlaveComputer) {
+//                builder.withClassFilter(new ClassFilterImpl(builder.getClassFilter(), OnMaster.class.getName, ...));
+//            }
+//        }
+//    }
+//
+//    @Restricted(NoExternalUse.class)
+//    class ClassFilterImpl extends ClassFilter {
+//        private final ClassFilter delegate;
+//        private final Set<String> blacklist;
+//
+//        public ClassFilterImpl(ClassFilter delegate, String... blacklist) {
+//            this.blacklist = new HashSet<>(blacklist);
+//            this.delegate = delegate;
+//        }
+//
+//        @Override
+//        protected boolean isBlacklisted(String name) {
+//            return blacklist.contains(name) || delegate.isBlacklisted(name);
+//        }
+//
+//        @Override
+//        protected boolean isBlacklisted(Class c) {
+//            return c.getAnnotation(MasterJVMOnly.class) != null || delegate.isBlacklisted(c);
+//        }
+//    }
 }


### PR DESCRIPTION
See [JENKINS-38370](https://issues.jenkins-ci.org/browse/JENKINS-38370)

This PR only introduces the annotation. Commented code in the annotation shows one potential path to implementing the enforcement, but that path is not currently available due to the current API contract of `ClassFilter` (additionally I need to check if `ClassFilter` applies only to classes coming from the agent and not to classes received by the agent)

I have identified a couple of classes that are clearly `MasterJVMOnly` there are likely more such classes in core... plugins will also want to use this annotation, e.g. `CredentialsProvider` is intended to be `MasterJVMOnly`
