### PR TITLE
Update XStream drive to improve performance in xml serilization/deserialization

### DIFF
--- a/core/src/main/java/hudson/XmlFile.java
+++ b/core/src/main/java/hudson/XmlFile.java
@@ -28,7 +28,7 @@ import com.thoughtworks.xstream.XStreamException;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.StreamException;
-import com.thoughtworks.xstream.io.xml.XppDriver;
+import com.thoughtworks.xstream.io.xml.Xpp3Driver;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.Descriptor;
 import hudson.util.AtomicFileWriter;
@@ -307,7 +307,7 @@ public final class XmlFile {
 
     private static final SAXParserFactory JAXP = SAXParserFactory.newInstance();
 
-    private static final XppDriver DEFAULT_DRIVER = new XppDriver();
+    private static final Xpp3Driver DEFAULT_DRIVER = new Xpp3Driver();
 
     static {
         JAXP.setNamespaceAware(true);

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -26,7 +26,7 @@ package hudson.model;
 
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.io.StreamException;
-import com.thoughtworks.xstream.io.xml.XppDriver;
+import com.thoughtworks.xstream.io.xml.Xpp3Driver;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.ExtensionPoint;
@@ -1168,7 +1168,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
             // Do not allow overwriting view name as it might collide with another
             // view in same ViewGroup and might not satisfy Jenkins.checkGoodName.
             String oldname = name;
-            Jenkins.XSTREAM.unmarshal(new XppDriver().createReader(in), this);
+            Jenkins.XSTREAM.unmarshal(new Xpp3Driver().createReader(in), this);
             name = oldname;
         } catch (StreamException e) {
             throw new IOException("Unable to read",e);

--- a/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
+++ b/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
@@ -35,7 +35,7 @@ import com.thoughtworks.xstream.io.xml.AbstractXmlReader;
 import com.thoughtworks.xstream.io.xml.AbstractXmlWriter;
 import com.thoughtworks.xstream.io.xml.DocumentReader;
 import com.thoughtworks.xstream.io.xml.XmlFriendlyReplacer;
-import com.thoughtworks.xstream.io.xml.XppDriver;
+import com.thoughtworks.xstream.io.xml.Xpp3Driver;
 import hudson.Util;
 import hudson.util.VariableResolver;
 
@@ -241,11 +241,11 @@ public class XStreamDOM {
      * Writes this {@link XStreamDOM} into {@link OutputStream}.
      */
     public void writeTo(OutputStream os) {
-        writeTo(new XppDriver().createWriter(os));
+        writeTo(new Xpp3Driver().createWriter(os));
     }
 
     public void writeTo(Writer w) {
-        writeTo(new XppDriver().createWriter(w));
+        writeTo(new Xpp3Driver().createWriter(w));
     }
 
     public void writeTo(HierarchicalStreamWriter w) {
@@ -262,11 +262,11 @@ public class XStreamDOM {
     }
 
     public static XStreamDOM from(InputStream in) {
-        return from(new XppDriver().createReader(in));
+        return from(new Xpp3Driver().createReader(in));
     }
 
     public static XStreamDOM from(Reader in) {
-        return from(new XppDriver().createReader(in));
+        return from(new Xpp3Driver().createReader(in));
     }
 
     public static XStreamDOM from(HierarchicalStreamReader in) {


### PR DESCRIPTION
According XStream FAQ (http://x-stream.github.io/faq.html#Scalability):

> XStream is a generalizing library, it inspects and handles your types on
> the fly. Therefore it will normally be slower than a piece of optimised
> Java code generated out of a schema. However, it is possible to increase
> the performance anyway:
> - Write custom converters for those of your types that occur very often in
>   your XML.
> - Keep a configured XStream instance for multiple usage. Creation and
>   initialization is quite expensive compared to the overhead of Stream
>   when calling marshall or unmarshal.
> - Use Xpp3 or StAX parsers.

So, I decided to move from old Xpp to new Xpp3.
