### PR TITLE
[FIXED JENKINS-38512] - "LinkageError: Failed to resolve null" when extensionpoint is an interface

### DIFF
--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -481,7 +481,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                     c.getMethods();
                     c.getFields();
                     LOGGER.log(Level.FINER, "{0} looks OK", c);
-                    while (c != Object.class) {
+                    while (c != null && c != Object.class) {
                         c.getGenericSuperclass();
                         c = c.getSuperclass();
                     }


### PR DESCRIPTION
assuming we define `public interface Foo extends ExtensionPoint { ... }`
and later declare some `@Extension public static final foo WILL_FAIL = new Foo() { ... };`
jenkins fails to load with "LinkageError: Failed to resolve null"
