### PR TITLE
Minimize readResolve visibility

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -204,7 +204,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
         SaveableListener.fireOnChange(this, config);
     }
 
-    public Object readResolve() {
+    private Object readResolve() {
         if (secretPassword == null)
             // backward compatibility : get scrambled password and store it encrypted
             secretPassword = Secret.fromString(Scrambler.descramble(password));

--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -47,6 +47,8 @@ import net.sf.json.JSONObject;
 
 import org.acegisecurity.AccessDeniedException;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
@@ -87,6 +89,7 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
         this(null);
     }
 
+    @Restricted(NoExternalUse.class)
     public Object readResolve() {
         if (views == null)
             // this shouldn't happen, but an error in 1.319 meant the last view could be deleted

--- a/core/src/main/java/hudson/scm/NullChangeLogParser.java
+++ b/core/src/main/java/hudson/scm/NullChangeLogParser.java
@@ -41,7 +41,7 @@ public class NullChangeLogParser extends ChangeLogParser {
         return ChangeLogSet.createEmpty(build);
     }
     
-    private Object readResolve() {
+    protected Object readResolve() {
         return INSTANCE;
     }
 }

--- a/core/src/main/java/hudson/scm/NullChangeLogParser.java
+++ b/core/src/main/java/hudson/scm/NullChangeLogParser.java
@@ -41,7 +41,7 @@ public class NullChangeLogParser extends ChangeLogParser {
         return ChangeLogSet.createEmpty(build);
     }
     
-    public Object readResolve() {
+    private Object readResolve() {
         return INSTANCE;
     }
 }

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -141,9 +141,9 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
     }
 
     // Backwards compatibility for older builds
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
             justification = "Null checks in readResolve are valid since we deserialize and upgrade objects")
-    public Object readResolve() {
+    protected Object readResolve() {
         if (allowEmptyArchive == null) {
             this.allowEmptyArchive = SystemProperties.getBoolean(ArtifactArchiver.class.getName()+".warnOnEmpty");
         }

--- a/core/src/main/java/jenkins/install/InstallState.java
+++ b/core/src/main/java/jenkins/install/InstallState.java
@@ -221,7 +221,7 @@ public class InstallState implements ExtensionPoint {
      * {@code <installState class="jenkins.install.InstallState$CreateAdminUser" resolves-to="jenkins.install.InstallState">}
      * @see #UNUSED_INNER_CLASSES
      */
-    public Object readResolve() {
+    protected Object readResolve() {
         // If we get invalid state from the configuration, fallback to unknown
         if (StringUtils.isBlank(name)) {
             LOGGER.log(Level.WARNING, "Read install state with blank name: ''{0}''. It will be ignored", name);

--- a/test/src/test/java/hudson/model/RunMapTest.java
+++ b/test/src/test/java/hudson/model/RunMapTest.java
@@ -98,7 +98,7 @@ public class RunMapTest {
     }
 
     public static class BombAction extends InvisibleAction {
-        public Object readResolve() {
+        private Object readResolve() {
             bombed = true;
             throw new NullPointerException();
         }

--- a/test/src/test/java/hudson/triggers/TriggerTest.java
+++ b/test/src/test/java/hudson/triggers/TriggerTest.java
@@ -71,7 +71,7 @@ public class TriggerTest {
 
         // Override Trigger#readResolve so this one is not called
         @Override
-        public Object readResolve() {
+        protected Object readResolve() {
             return this;
         }
 

--- a/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -100,7 +100,7 @@ public class RobustReflectionConverterTest {
             return ACCEPT_KEYWORD.equals(keyword);
         }
         
-        public Object readResolve() throws Exception {
+        private Object readResolve() throws Exception {
             if (!ACL.SYSTEM.equals(Jenkins.getAuthentication())) {
                 // called via REST / CLI with authentication
                 if (!isAcceptable()) {


### PR DESCRIPTION
I don't think plugin code should ever be calling `readResolve`, and since it doesn't need to be public to work, I'm restricting it as much as possible.

One is called by tests, so I `@Restricted` it. Another overrides the parent class's `protected … readResolve`, so I've kept that the same. The others are now `private`.

I'm actually not positive this is a good idea, I'm counting on @jenkinsci/code-reviewers to be more knowledgeable about this than I am.
