### PR TITLE
[FIXED JENKINS-38650] - Cleanup spelling in CLi commands + Javadoc updates

### DIFF
--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -125,6 +125,13 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
     public transient PrintStream stdout,stderr;
 
     /**
+     * Shared text, which is reported back to CLI if an error happens in commands 
+     * taking lists of parameters.
+     * @since TODO
+     */
+    static final String CLI_ERROR_TEXT = "Error occurred while performing this command, see previous stderr output.";
+    
+    /**
      * Connected to stdin of the CLI agent.
      *
      * <p>

--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -129,7 +129,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
      * taking lists of parameters.
      * @since TODO
      */
-    static final String CLI_ERROR_TEXT = "Error occurred while performing this command, see previous stderr output.";
+    static final String CLI_LISTPARAM_SUMMARY_ERROR_TEXT = "Error occurred while performing this command, see previous stderr output.";
     
     /**
      * Connected to stdin of the CLI agent.

--- a/core/src/main/java/hudson/cli/CancelQuietDownCommand.java
+++ b/core/src/main/java/hudson/cli/CancelQuietDownCommand.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
  * Cancel previous quiet down Jenkins - preparation for a restart
  *
  * @author pjanouse
- * @since TODO
+ * @since 2.14
  */
 @Extension
 public class CancelQuietDownCommand extends CLICommand {

--- a/core/src/main/java/hudson/cli/ClearQueueCommand.java
+++ b/core/src/main/java/hudson/cli/ClearQueueCommand.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
  * Clears the build queue
  *
  * @author pjanouse
- * @since TODO
+ * @since 1.654
  */
 @Extension
 public class ClearQueueCommand extends CLICommand {

--- a/core/src/main/java/hudson/cli/ConnectNodeCommand.java
+++ b/core/src/main/java/hudson/cli/ConnectNodeCommand.java
@@ -97,7 +97,7 @@ public class ConnectNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException(CLI_ERROR_TEXT);
+            throw new AbortException(CLI_LISTPARAM_SUMMARY_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/ConnectNodeCommand.java
+++ b/core/src/main/java/hudson/cli/ConnectNodeCommand.java
@@ -37,13 +37,14 @@ import java.util.List;
 import java.util.logging.Logger;
 
 /**
+ * Reconnect to a node or nodes.
  * @author pjanouse
- * @since TODO
+ * @since 2.6
  */
 @Extension
 public class ConnectNodeCommand extends CLICommand {
 
-    @Argument(metaVar="NAME", usage="Slave name, or empty string for master; comama-separated list is supported", required=true, multiValued=true)
+    @Argument(metaVar="NAME", usage="Slave name, or empty string for master; comma-separated list is supported", required=true, multiValued=true)
     private List<String> nodes;
 
     @Option(name="-f", usage="Cancel any currently pending connect operation and retry from scratch")
@@ -96,7 +97,7 @@ public class ConnectNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occured while performing this command, see previous stderr output.");
+            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/ConnectNodeCommand.java
+++ b/core/src/main/java/hudson/cli/ConnectNodeCommand.java
@@ -97,7 +97,7 @@ public class ConnectNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
+            throw new AbortException(CLI_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DeleteJobCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteJobCommand.java
@@ -84,7 +84,7 @@ public class DeleteJobCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException(CLI_ERROR_TEXT);
+            throw new AbortException(CLI_LISTPARAM_SUMMARY_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DeleteJobCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteJobCommand.java
@@ -84,7 +84,7 @@ public class DeleteJobCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
+            throw new AbortException(CLI_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DeleteJobCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteJobCommand.java
@@ -34,8 +34,9 @@ import java.util.HashSet;
 import java.util.logging.Logger;
 
 /**
+ * CLI command, which deletes a job or multiple jobs.
  * @author pjanouse
- * @since TODO
+ * @since 1.649
  */
 @Extension
 public class DeleteJobCommand extends CLICommand {
@@ -83,7 +84,7 @@ public class DeleteJobCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occured while performing this command, see previous stderr output.");
+            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DeleteNodeCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteNodeCommand.java
@@ -34,13 +34,14 @@ import java.util.List;
 import java.util.logging.Logger;
 
 /**
+ * CLI command, which deletes Jenkins nodes.
  * @author pjanouse
- * @since TODO
+ * @since 1.618
  */
 @Extension
 public class DeleteNodeCommand extends CLICommand {
 
-    @Argument(usage="Nodes name to delete", required=true, multiValued=true)
+    @Argument(usage="Names of nodes to delete", required=true, multiValued=true)
     private List<String> nodes;
 
     @Override
@@ -82,7 +83,7 @@ public class DeleteNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occured while performing this command, see previous stderr output.");
+            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DeleteNodeCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteNodeCommand.java
@@ -83,7 +83,7 @@ public class DeleteNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
+            throw new AbortException(CLI_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DeleteNodeCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteNodeCommand.java
@@ -83,7 +83,7 @@ public class DeleteNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException(CLI_ERROR_TEXT);
+            throw new AbortException(CLI_LISTPARAM_SUMMARY_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DeleteViewCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteViewCommand.java
@@ -95,7 +95,7 @@ public class DeleteViewCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException(CLI_ERROR_TEXT);
+            throw new AbortException(CLI_LISTPARAM_SUMMARY_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DeleteViewCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteViewCommand.java
@@ -95,7 +95,7 @@ public class DeleteViewCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occured while performing this command, see previous stderr output.");
+            throw new AbortException(CLI_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DisconnectNodeCommand.java
+++ b/core/src/main/java/hudson/cli/DisconnectNodeCommand.java
@@ -37,12 +37,13 @@ import java.util.List;
 import java.util.logging.Logger;
 
 /**
+ * CLI Command, which disconnects nodes.
  * @author pjanouse
- * @since TODO
+ * @since 2.14
  */
 @Extension
 public class DisconnectNodeCommand extends CLICommand {
-    @Argument(metaVar = "NAME", usage = "Slave name, or empty string for master; comama-separated list is supported", required = true, multiValued = true)
+    @Argument(metaVar = "NAME", usage = "Slave name, or empty string for master; comma-separated list is supported", required = true, multiValued = true)
     private List<String> nodes;
 
     @Option(name = "-m", usage = "Record the reason about why you are disconnecting this node")
@@ -94,7 +95,7 @@ public class DisconnectNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occured while performing this command, see previous stderr output.");
+            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DisconnectNodeCommand.java
+++ b/core/src/main/java/hudson/cli/DisconnectNodeCommand.java
@@ -95,7 +95,7 @@ public class DisconnectNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException(CLI_ERROR_TEXT);
+            throw new AbortException(CLI_LISTPARAM_SUMMARY_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/DisconnectNodeCommand.java
+++ b/core/src/main/java/hudson/cli/DisconnectNodeCommand.java
@@ -95,7 +95,7 @@ public class DisconnectNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
+            throw new AbortException(CLI_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/OfflineNodeCommand.java
+++ b/core/src/main/java/hudson/cli/OfflineNodeCommand.java
@@ -89,7 +89,7 @@ public class OfflineNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
+            throw new AbortException(CLI_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/OfflineNodeCommand.java
+++ b/core/src/main/java/hudson/cli/OfflineNodeCommand.java
@@ -89,7 +89,7 @@ public class OfflineNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException(CLI_ERROR_TEXT);
+            throw new AbortException(CLI_LISTPARAM_SUMMARY_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/OfflineNodeCommand.java
+++ b/core/src/main/java/hudson/cli/OfflineNodeCommand.java
@@ -39,8 +39,9 @@ import java.util.HashSet;
 import java.util.List;
 
 /**
+ * CLI Command, which puts the Jenkins node offline.
  * @author pjanouse
- * @since TODO
+ * @since 2.15
  */
 @Extension
 public class OfflineNodeCommand extends CLICommand {
@@ -88,7 +89,7 @@ public class OfflineNodeCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occured while performing this command, see previous stderr output.");
+            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/OnlineNodeCommand.java
+++ b/core/src/main/java/hudson/cli/OnlineNodeCommand.java
@@ -87,7 +87,7 @@ public class OnlineNodeCommand extends CLICommand {
         }
 
         if (errorOccurred){
-            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
+            throw new AbortException(CLI_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/OnlineNodeCommand.java
+++ b/core/src/main/java/hudson/cli/OnlineNodeCommand.java
@@ -87,7 +87,7 @@ public class OnlineNodeCommand extends CLICommand {
         }
 
         if (errorOccurred){
-            throw new AbortException(CLI_ERROR_TEXT);
+            throw new AbortException(CLI_LISTPARAM_SUMMARY_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/OnlineNodeCommand.java
+++ b/core/src/main/java/hudson/cli/OnlineNodeCommand.java
@@ -37,8 +37,9 @@ import java.util.HashSet;
 import java.util.List;
 
 /**
+ * CLI Command, which moves the node to the online state.
  * @author pjanouse
- * @since TODO
+ * @since 1.642
  */
 @Extension
 public class OnlineNodeCommand extends CLICommand {
@@ -86,7 +87,7 @@ public class OnlineNodeCommand extends CLICommand {
         }
 
         if (errorOccurred){
-            throw new AbortException("Error occured while performing this command, see previous stderr output.");
+            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/QuietDownCommand.java
+++ b/core/src/main/java/hudson/cli/QuietDownCommand.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
  * Quiet down Jenkins - preparation for a restart
  *
  * @author pjanouse
- * @since TODO
+ * @since 2.14
  */
 @Extension
 public class QuietDownCommand extends CLICommand {

--- a/core/src/main/java/hudson/cli/ReloadConfigurationCommand.java
+++ b/core/src/main/java/hudson/cli/ReloadConfigurationCommand.java
@@ -28,10 +28,10 @@ import hudson.Extension;
 import jenkins.model.Jenkins;
 
 /**
- * Reload everything from file system
+ * Reload everything from the file system.
  *
  * @author pjanouse
- * @since TODO
+ * @since 2.4
  */
 @Extension
 public class ReloadConfigurationCommand extends CLICommand {

--- a/core/src/main/java/hudson/cli/ReloadJobCommand.java
+++ b/core/src/main/java/hudson/cli/ReloadJobCommand.java
@@ -38,8 +38,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * Reloads job from the disk.
  * @author pjanouse
- * @since TODO
+ * @since 1.633
  */
 @Extension
 public class ReloadJobCommand extends CLICommand {
@@ -100,7 +101,7 @@ public class ReloadJobCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occured while performing this command, see previous stderr output.");
+            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/ReloadJobCommand.java
+++ b/core/src/main/java/hudson/cli/ReloadJobCommand.java
@@ -101,7 +101,7 @@ public class ReloadJobCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException("Error occurred while performing this command, see previous stderr output.");
+            throw new AbortException(CLI_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/ReloadJobCommand.java
+++ b/core/src/main/java/hudson/cli/ReloadJobCommand.java
@@ -101,7 +101,7 @@ public class ReloadJobCommand extends CLICommand {
         }
 
         if (errorOccurred) {
-            throw new AbortException(CLI_ERROR_TEXT);
+            throw new AbortException(CLI_LISTPARAM_SUMMARY_ERROR_TEXT);
         }
         return 0;
     }

--- a/core/src/main/java/hudson/cli/WaitNodeOfflineCommand.java
+++ b/core/src/main/java/hudson/cli/WaitNodeOfflineCommand.java
@@ -28,8 +28,9 @@ import hudson.model.Node;
 import org.kohsuke.args4j.Argument;
 
 /**
+ * CLI command, which waits till the node switches to the offline state.
  * @author pjanouse
- * @since TODO
+ * @since 2.16
  */
 @Extension
 public class WaitNodeOfflineCommand extends CLICommand {

--- a/core/src/main/java/hudson/cli/WaitNodeOnlineCommand.java
+++ b/core/src/main/java/hudson/cli/WaitNodeOnlineCommand.java
@@ -28,8 +28,9 @@ import hudson.model.Node;
 import org.kohsuke.args4j.Argument;
 
 /**
+ * CLI command, which waits till the node switches to the online state.
  * @author pjanouse
- * @since TODO
+ * @since 2.16
  */
 @Extension
 public class WaitNodeOnlineCommand extends CLICommand {

--- a/test/src/test/java/hudson/cli/ConnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConnectNodeCommandTest.java
@@ -64,7 +64,7 @@ public class ConnectNodeCommandTest {
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: user is missing the Agent/Connect permission"));
-        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT)));
     }
 
     @Test public void connectNodeShouldFailIfNodeDoesNotExist() throws Exception {
@@ -74,7 +74,7 @@ public class ConnectNodeCommandTest {
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: No such agent \"never_created\" exists."));
-        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT)));
     }
 
     @Test public void connectNodeShouldSucceed() throws Exception {
@@ -156,7 +156,7 @@ public class ConnectNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
         assertThat(slave1.toComputer().isOnline(), equalTo(true));
         assertThat(slave2.toComputer().isOnline(), equalTo(true));
     }

--- a/test/src/test/java/hudson/cli/ConnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConnectNodeCommandTest.java
@@ -64,7 +64,7 @@ public class ConnectNodeCommandTest {
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: user is missing the Agent/Connect permission"));
-        assertThat(result.stderr(), not(containsString("ERROR: Error occured while performing this command, see previous stderr output.")));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
     }
 
     @Test public void connectNodeShouldFailIfNodeDoesNotExist() throws Exception {
@@ -74,7 +74,7 @@ public class ConnectNodeCommandTest {
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: No such agent \"never_created\" exists."));
-        assertThat(result.stderr(), not(containsString("ERROR: Error occured while performing this command, see previous stderr output.")));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
     }
 
     @Test public void connectNodeShouldSucceed() throws Exception {
@@ -156,7 +156,7 @@ public class ConnectNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
         assertThat(slave1.toComputer().isOnline(), equalTo(true));
         assertThat(slave2.toComputer().isOnline(), equalTo(true));
     }

--- a/test/src/test/java/hudson/cli/DeleteJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteJobCommandTest.java
@@ -131,7 +131,7 @@ public class DeleteJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getItem("aProject1"), nullValue());
         assertThat(j.jenkins.getItem("aProject2"), nullValue());
@@ -150,7 +150,7 @@ public class DeleteJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getItem("aProject1"), nullValue());
         assertThat(j.jenkins.getItem("aProject2"), nullValue());
@@ -169,7 +169,7 @@ public class DeleteJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getItem("aProject1"), nullValue());
         assertThat(j.jenkins.getItem("aProject2"), nullValue());
@@ -189,7 +189,7 @@ public class DeleteJobCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created1: No such job 'never_created1'"));
         assertThat(result.stderr(), containsString("never_created2: No such job 'never_created2'"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getItem("aProject1"), nullValue());
         assertThat(j.jenkins.getItem("aProject2"), nullValue());

--- a/test/src/test/java/hudson/cli/DeleteJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteJobCommandTest.java
@@ -131,7 +131,7 @@ public class DeleteJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getItem("aProject1"), nullValue());
         assertThat(j.jenkins.getItem("aProject2"), nullValue());
@@ -150,7 +150,7 @@ public class DeleteJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getItem("aProject1"), nullValue());
         assertThat(j.jenkins.getItem("aProject2"), nullValue());
@@ -169,7 +169,7 @@ public class DeleteJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getItem("aProject1"), nullValue());
         assertThat(j.jenkins.getItem("aProject2"), nullValue());
@@ -189,7 +189,7 @@ public class DeleteJobCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created1: No such job 'never_created1'"));
         assertThat(result.stderr(), containsString("never_created2: No such job 'never_created2'"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getItem("aProject1"), nullValue());
         assertThat(j.jenkins.getItem("aProject2"), nullValue());

--- a/test/src/test/java/hudson/cli/DeleteNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteNodeCommandTest.java
@@ -118,7 +118,7 @@ public class DeleteNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such node 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aNode1"), nullValue());
         assertThat(j.jenkins.getView("aNode2"), nullValue());
@@ -137,7 +137,7 @@ public class DeleteNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such node 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aNode1"), nullValue());
         assertThat(j.jenkins.getView("aNode2"), nullValue());
@@ -156,7 +156,7 @@ public class DeleteNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such node 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aNode1"), nullValue());
         assertThat(j.jenkins.getView("aNode2"), nullValue());
@@ -176,7 +176,7 @@ public class DeleteNodeCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created1: No such node 'never_created1'"));
         assertThat(result.stderr(), containsString("never_created2: No such node 'never_created2'"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aNode1"), nullValue());
         assertThat(j.jenkins.getView("aNode2"), nullValue());

--- a/test/src/test/java/hudson/cli/DeleteNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteNodeCommandTest.java
@@ -118,7 +118,7 @@ public class DeleteNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such node 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aNode1"), nullValue());
         assertThat(j.jenkins.getView("aNode2"), nullValue());
@@ -137,7 +137,7 @@ public class DeleteNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such node 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aNode1"), nullValue());
         assertThat(j.jenkins.getView("aNode2"), nullValue());
@@ -156,7 +156,7 @@ public class DeleteNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such node 'never_created'"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aNode1"), nullValue());
         assertThat(j.jenkins.getView("aNode2"), nullValue());
@@ -176,7 +176,7 @@ public class DeleteNodeCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created1: No such node 'never_created1'"));
         assertThat(result.stderr(), containsString("never_created2: No such node 'never_created2'"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aNode1"), nullValue());
         assertThat(j.jenkins.getView("aNode2"), nullValue());

--- a/test/src/test/java/hudson/cli/DeleteViewCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteViewCommandTest.java
@@ -175,7 +175,7 @@ public class DeleteViewCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No view named never_created inside view Jenkins"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aView1"), nullValue());
         assertThat(j.jenkins.getView("aView2"), nullValue());
@@ -194,7 +194,7 @@ public class DeleteViewCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No view named never_created inside view Jenkins"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aView1"), nullValue());
         assertThat(j.jenkins.getView("aView2"), nullValue());
@@ -213,7 +213,7 @@ public class DeleteViewCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No view named never_created inside view Jenkins"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aView1"), nullValue());
         assertThat(j.jenkins.getView("aView2"), nullValue());
@@ -233,7 +233,7 @@ public class DeleteViewCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created1: No view named never_created1 inside view Jenkins"));
         assertThat(result.stderr(), containsString("never_created2: No view named never_created2 inside view Jenkins"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aView1"), nullValue());
         assertThat(j.jenkins.getView("aView2"), nullValue());
@@ -267,7 +267,7 @@ public class DeleteViewCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("All: Jenkins does not allow to delete 'All' view"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aView1"), nullValue());
         assertThat(j.jenkins.getView("aView2"), nullValue());

--- a/test/src/test/java/hudson/cli/DeleteViewCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteViewCommandTest.java
@@ -175,7 +175,7 @@ public class DeleteViewCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No view named never_created inside view Jenkins"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aView1"), nullValue());
         assertThat(j.jenkins.getView("aView2"), nullValue());
@@ -194,7 +194,7 @@ public class DeleteViewCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No view named never_created inside view Jenkins"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aView1"), nullValue());
         assertThat(j.jenkins.getView("aView2"), nullValue());
@@ -213,7 +213,7 @@ public class DeleteViewCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No view named never_created inside view Jenkins"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aView1"), nullValue());
         assertThat(j.jenkins.getView("aView2"), nullValue());
@@ -233,7 +233,7 @@ public class DeleteViewCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created1: No view named never_created1 inside view Jenkins"));
         assertThat(result.stderr(), containsString("never_created2: No view named never_created2 inside view Jenkins"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aView1"), nullValue());
         assertThat(j.jenkins.getView("aView2"), nullValue());
@@ -267,7 +267,7 @@ public class DeleteViewCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("All: Jenkins does not allow to delete 'All' view"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(j.jenkins.getView("aView1"), nullValue());
         assertThat(j.jenkins.getView("aView2"), nullValue());

--- a/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
@@ -68,7 +68,7 @@ public class DisconnectNodeCommandTest {
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: user is missing the Agent/Disconnect permission"));
-        assertThat(result.stderr(), not(containsString("ERROR: Error occured while performing this command, see previous stderr output.")));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class DisconnectNodeCommandTest {
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: No such agent \"never_created\" exists."));
-        assertThat(result.stderr(), not(containsString("ERROR: Error occured while performing this command, see previous stderr output.")));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
     }
 
     @Test
@@ -233,7 +233,7 @@ public class DisconnectNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
         assertThat(slave1.toComputer().isOffline(), equalTo(true));
         assertThat(slave1.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
         assertThat(((OfflineCause.ByCLI) slave1.toComputer().getOfflineCause()).message, equalTo("aCause"));

--- a/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
@@ -68,7 +68,7 @@ public class DisconnectNodeCommandTest {
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: user is missing the Agent/Disconnect permission"));
-        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT)));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class DisconnectNodeCommandTest {
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: No such agent \"never_created\" exists."));
-        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT)));
     }
 
     @Test
@@ -233,7 +233,7 @@ public class DisconnectNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
         assertThat(slave1.toComputer().isOffline(), equalTo(true));
         assertThat(slave1.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
         assertThat(((OfflineCause.ByCLI) slave1.toComputer().getOfflineCause()).message, equalTo("aCause"));

--- a/test/src/test/java/hudson/cli/OfflineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OfflineNodeCommandTest.java
@@ -74,7 +74,7 @@ public class OfflineNodeCommandTest {
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: user is missing the Agent/Disconnect permission"));
-        assertThat(result.stderr(), not(containsString("ERROR: Error occured while performing this command, see previous stderr output.")));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class OfflineNodeCommandTest {
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: No such agent \"never_created\" exists."));
-        assertThat(result.stderr(), not(containsString("ERROR: Error occured while performing this command, see previous stderr output.")));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
     }
 
     @Test
@@ -371,7 +371,7 @@ public class OfflineNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
         assertThat(slave1.toComputer().isOffline(), equalTo(true));
         assertThat(slave1.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
         assertThat(((OfflineCause.ByCLI) slave1.toComputer().getOfflineCause()).message, equalTo(null));
@@ -397,7 +397,7 @@ public class OfflineNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
         assertThat(slave1.toComputer().isOffline(), equalTo(true));
         assertThat(slave1.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
         assertThat(((OfflineCause.ByCLI) slave1.toComputer().getOfflineCause()).message, equalTo("aCause"));

--- a/test/src/test/java/hudson/cli/OfflineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OfflineNodeCommandTest.java
@@ -74,7 +74,7 @@ public class OfflineNodeCommandTest {
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: user is missing the Agent/Disconnect permission"));
-        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT)));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class OfflineNodeCommandTest {
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: No such agent \"never_created\" exists."));
-        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT)));
+        assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT)));
     }
 
     @Test
@@ -371,7 +371,7 @@ public class OfflineNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
         assertThat(slave1.toComputer().isOffline(), equalTo(true));
         assertThat(slave1.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
         assertThat(((OfflineCause.ByCLI) slave1.toComputer().getOfflineCause()).message, equalTo(null));
@@ -397,7 +397,7 @@ public class OfflineNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
         assertThat(slave1.toComputer().isOffline(), equalTo(true));
         assertThat(slave1.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
         assertThat(((OfflineCause.ByCLI) slave1.toComputer().getOfflineCause()).message, equalTo("aCause"));

--- a/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
@@ -253,7 +253,7 @@ public class OnlineNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
         if (slave1.toComputer().isConnecting()) {
             System.out.println("Waiting until aNode1 going online is in progress...");
             slave1.toComputer().waitUntilOnline();

--- a/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
@@ -253,7 +253,7 @@ public class OnlineNodeCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
         if (slave1.toComputer().isConnecting()) {
             System.out.println("Waiting until aNode1 going online is in progress...");
             slave1.toComputer().waitUntilOnline();

--- a/test/src/test/java/hudson/cli/ReloadJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/ReloadJobCommandTest.java
@@ -181,7 +181,7 @@ public class ReloadJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job \u2018never_created\u2019 exists."));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
         assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
@@ -207,7 +207,7 @@ public class ReloadJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job \u2018never_created\u2019 exists."));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
         assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
@@ -233,7 +233,7 @@ public class ReloadJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job \u2018never_created\u2019 exists."));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
         assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
@@ -260,7 +260,7 @@ public class ReloadJobCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created1: No such job \u2018never_created1\u2019 exists."));
         assertThat(result.stderr(), containsString("never_created2: No such job \u2018never_created2\u2019 exists."));
-        assertThat(result.stderr(), containsString("ERROR: Error occured while performing this command, see previous stderr output."));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
 
         assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
         assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));

--- a/test/src/test/java/hudson/cli/ReloadJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/ReloadJobCommandTest.java
@@ -181,7 +181,7 @@ public class ReloadJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job \u2018never_created\u2019 exists."));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
         assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
@@ -207,7 +207,7 @@ public class ReloadJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job \u2018never_created\u2019 exists."));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
         assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
@@ -233,7 +233,7 @@ public class ReloadJobCommandTest {
         assertThat(result, failedWith(5));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such job \u2018never_created\u2019 exists."));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
         assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
@@ -260,7 +260,7 @@ public class ReloadJobCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created1: No such job \u2018never_created1\u2019 exists."));
         assertThat(result.stderr(), containsString("never_created2: No such job \u2018never_created2\u2019 exists."));
-        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_ERROR_TEXT));
+        assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
         assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
         assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));


### PR DESCRIPTION
Also adds some javadoc and since definitions.

https://issues.jenkins-ci.org/browse/JENKINS-38650

@jenkinsci/code-reviewers @pjanouse
