### PR TITLE
[FIX JENKINS-35263] displaying codeMirror as table to fix page sizing

### DIFF
--- a/core/src/main/resources/lib/form/textarea/textarea.css
+++ b/core/src/main/resources/lib/form/textarea/textarea.css
@@ -1,0 +1,5 @@
+td.setting-main .CodeMirror {
+  display: table;
+  table-layout: fixed;
+  width: 100%;
+}


### PR DESCRIPTION
td.setting-main .CodeMirror {
display: table;
table-layout: fixed;
width: 100%;
}

Setting as suggested by Dmitry Medvedev
https://issues.jenkins-ci.org/browse/JENKINS-27367

@jenkinsci/code-reviewers @daniel-beck @recena 
