### PR TITLE
[FIXED JENKINS-37590] Better handling of null parameter definitions.

### DIFF
--- a/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
+++ b/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
@@ -70,18 +70,19 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
     private final List<ParameterDefinition> parameterDefinitions;
 
     @DataBoundConstructor
-    public ParametersDefinitionProperty(@Nonnull List<ParameterDefinition> parameterDefinitions) {
+    public ParametersDefinitionProperty(List<ParameterDefinition> parameterDefinitions) {
         if (parameterDefinitions == null) {
-            throw new NullPointerException("ParameterDefinitions is null when this is a not valid value");
+            parameterDefinitions = new ArrayList<>();
         }
         this.parameterDefinitions = parameterDefinitions;
     }
 
-    public ParametersDefinitionProperty(@Nonnull ParameterDefinition... parameterDefinitions) {
-        if (parameterDefinitions == null) {
-            throw new NullPointerException("ParameterDefinitions is null when this is a not valid value");
+    public ParametersDefinitionProperty(ParameterDefinition... parameterDefinitions) {
+        if (parameterDefinitions == null || (parameterDefinitions.length == 1 && parameterDefinitions[0] == null)) {
+            this.parameterDefinitions = new ArrayList<>();
+        } else {
+            this.parameterDefinitions = Arrays.asList(parameterDefinitions);
         }
-        this.parameterDefinitions = Arrays.asList(parameterDefinitions) ;
     }
 
     private Object readResolve() {

--- a/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
+++ b/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
@@ -70,14 +70,14 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
     private final List<ParameterDefinition> parameterDefinitions;
 
     @DataBoundConstructor
-    public ParametersDefinitionProperty(List<ParameterDefinition> parameterDefinitions) {
+    public ParametersDefinitionProperty(@CheckForNull List<ParameterDefinition> parameterDefinitions) {
         if (parameterDefinitions == null) {
             parameterDefinitions = new ArrayList<>();
         }
         this.parameterDefinitions = parameterDefinitions;
     }
 
-    public ParametersDefinitionProperty(ParameterDefinition... parameterDefinitions) {
+    public ParametersDefinitionProperty(@CheckForNull ParameterDefinition... parameterDefinitions) {
         if (parameterDefinitions == null || (parameterDefinitions.length == 1 && parameterDefinitions[0] == null)) {
             this.parameterDefinitions = new ArrayList<>();
         } else {

--- a/test/src/test/java/hudson/model/ParametersDefinitionPropertyTest.java
+++ b/test/src/test/java/hudson/model/ParametersDefinitionPropertyTest.java
@@ -24,6 +24,7 @@
 
 package hudson.model;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import net.sf.json.JSONObject;
@@ -43,6 +44,18 @@ public class ParametersDefinitionPropertyTest {
 
     @Rule
     public LoggerRule logs = new LoggerRule();
+
+    @Issue("JENKINS-37590")
+    @Test
+    public void nullArgToConstructor() throws Exception {
+        ParametersDefinitionProperty pdp = new ParametersDefinitionProperty((ParameterDefinition)null);
+        assertNotNull(pdp);
+        assertTrue(pdp.getParameterDefinitionNames().isEmpty());
+
+        ParametersDefinitionProperty nullList = new ParametersDefinitionProperty((List<ParameterDefinition>)null);
+        assertNotNull(nullList);
+        assertTrue(nullList.getParameterDefinitionNames().isEmpty());
+    }
 
     @Issue("JENKINS-31458")
     @Test


### PR DESCRIPTION
[JENKINS-37590](https://issues.jenkins-ci.org/browse/JENKINS-37590)

Rejecting null parameter definitions lists results in an error if you
try to save a job config with "This build is parameterized" checked
but no actual parameters specified. We should handle null better by
populating an empty list if needed instead.

cc @jenkinsci/code-reviewers @reviewbybees
