### PR TITLE
[FIXED JENKINS-38960] Deprecate getIconFilePathPattern and switch to IconSpec

### DIFF
--- a/core/src/main/java/hudson/model/FreeStyleProject.java
+++ b/core/src/main/java/hudson/model/FreeStyleProject.java
@@ -25,6 +25,8 @@ package hudson.model;
 
 import hudson.Extension;
 import jenkins.model.Jenkins;
+import org.jenkins.ui.icon.Icon;
+import org.jenkins.ui.icon.IconSet;
 import org.jenkinsci.Symbol;
 import jenkins.model.item_category.StandaloneProjectsCategory;
 import org.kohsuke.accmod.Restricted;
@@ -97,5 +99,16 @@ public class FreeStyleProject extends Project<FreeStyleProject,FreeStyleBuild> i
             return (Jenkins.RESOURCE_PATH + "/images/:size/freestyleproject.png").replaceFirst("^/", "");
         }
 
+        @Override
+        public String getIconClassName() {
+            return "icon-freestyle-project";
+        }
+
+        static {
+            IconSet.icons.addIcon(new Icon("icon-freestyle-project icon-sm", "16x16/freestyleproject.png", Icon.ICON_SMALL_STYLE));
+            IconSet.icons.addIcon(new Icon("icon-freestyle-project icon-md", "24x24/freestyleproject.png", Icon.ICON_MEDIUM_STYLE));
+            IconSet.icons.addIcon(new Icon("icon-freestyle-project icon-lg", "32x32/freestyleproject.png", Icon.ICON_LARGE_STYLE));
+            IconSet.icons.addIcon(new Icon("icon-freestyle-project icon-xlg", "48x48/freestyleproject.png", Icon.ICON_XLARGE_STYLE));
+        }
     }
 }

--- a/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
+++ b/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
@@ -195,6 +195,7 @@ public abstract class TopLevelItemDescriptor extends Descriptor<TopLevelItem> im
      * @deprecated prefer {@link #getIconClassName()}
      */
     @CheckForNull
+    @Deprecated
     public String getIconFilePathPattern() {
         return null;
     }
@@ -210,6 +211,7 @@ public abstract class TopLevelItemDescriptor extends Descriptor<TopLevelItem> im
      * @deprecated prefer {@link #getIconClassName()}
      */
     @CheckForNull
+    @Deprecated
     public String getIconFilePath(String size) {
         if (!StringUtils.isBlank(getIconFilePathPattern())) {
             return getIconFilePathPattern().replace(":size", size);

--- a/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
+++ b/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
@@ -219,7 +219,7 @@ public abstract class TopLevelItemDescriptor extends Descriptor<TopLevelItem> im
 
     /**
      * Get the Item's Icon class specification e.g. 'icon-notepad'.
-     * <p/>
+     * <p>
      * Note: do <strong>NOT</strong> include icon size specifications (such as 'icon-sm').
      *
      * @return The Icon class specification e.g. 'icon-notepad'.

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -1058,6 +1058,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
             metadata.put("displayName", descriptor.getDisplayName());
             metadata.put("description", descriptor.getDescription());
             metadata.put("iconFilePathPattern", descriptor.getIconFilePathPattern());
+            metadata.put("iconClassName", descriptor.getIconClassName());
 
             Category category = categories.getItem(ic.getId());
             if (category != null) {

--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -3,7 +3,7 @@ var $ = require('jquery-detached').getJQuery();
 
 var getItems = function() {
   var d = $.Deferred();
-  $.get('itemCategories?depth=3').done(
+  $.get('itemCategories?depth=3&iconStyle=icon-xlg').done(
     function(data){
       d.resolve(data);
     }
@@ -200,7 +200,10 @@ $.when(getItems()).done(function(data) {
 
     function drawIcon(elem) {
       var $icn;
-      if (elem.iconFilePathPattern) {
+      if (elem.iconClassName && elem.iconQualifiedUrl) {
+        $icn = $('<div class="icon">');
+        $(['<img class="', elem.iconClassName, ' icon-xlg" src="', elem.iconQualifiedUrl, '">'].join('')).appendTo($icn);
+      } else if (elem.iconFilePathPattern) {
         $icn = $('<div class="icon">');
         var iconFilePath = jRoot + '/' + elem.iconFilePathPattern.replace(":size", "48x48");
         $(['<img src="', iconFilePath, '">'].join('')).appendTo($icn);


### PR DESCRIPTION
See [JENKINS-38960](https://issues.jenkins-ci.org/browse/JENKINS-38960)

@jenkinsci/code-reviewers @reviewbybees 

/cc @michaelneale I'm wondering if BO is using the now deprecated information

/cc @recena You added the original method, I cannot find in jelly where it is used... and hints/tips as to where else I need to apply fix-up (already fixing some of the SCM-API usage)
