### PR TITLE
[JENKINS-26940] Print message when installer isn't applicable

### DIFF
--- a/core/src/main/java/hudson/tools/InstallerTranslator.java
+++ b/core/src/main/java/hudson/tools/InstallerTranslator.java
@@ -69,6 +69,11 @@ public class InstallerTranslator extends ToolLocationTranslator {
                 } finally {
                     semaphore.release();
                 }
+            } else {
+                log.getLogger().println(Messages.CannotBeInstalled(
+                        installer.getDescriptor().getDisplayName(),
+                        tool.getName(),
+                        node.getDisplayName()));
             }
         }
         return null;

--- a/core/src/main/java/hudson/tools/InstallerTranslator.java
+++ b/core/src/main/java/hudson/tools/InstallerTranslator.java
@@ -28,6 +28,7 @@ import hudson.Extension;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.Semaphore;
@@ -50,6 +51,9 @@ public class InstallerTranslator extends ToolLocationTranslator {
         if (isp == null) {
             return null;
         }
+
+        ArrayList<String> inapplicableInstallersMessages = new ArrayList<String>();
+
         for (ToolInstaller installer : isp.installers) {
             if (installer.appliesTo(node)) {
                 Semaphore semaphore;
@@ -70,11 +74,14 @@ public class InstallerTranslator extends ToolLocationTranslator {
                     semaphore.release();
                 }
             } else {
-                log.getLogger().println(Messages.CannotBeInstalled(
+                inapplicableInstallersMessages.add(Messages.CannotBeInstalled(
                         installer.getDescriptor().getDisplayName(),
                         tool.getName(),
                         node.getDisplayName()));
             }
+        }
+        for (String message : inapplicableInstallersMessages) {
+            log.getLogger().println(message);
         }
         return null;
     }

--- a/core/src/main/resources/hudson/tools/Messages.properties
+++ b/core/src/main/resources/hudson/tools/Messages.properties
@@ -37,3 +37,4 @@ JDKInstaller.DescriptorImpl.displayName=Install from java.sun.com
 JDKInstaller.DescriptorImpl.doCheckId=Define JDK ID
 JDKInstaller.DescriptorImpl.doCheckAcceptLicense=You must agree to the license to download the JDK.
 ToolDescriptor.NotADirectory={0} is not a directory on the Jenkins master (but perhaps it exists on some agents)
+CannotBeInstalled=Installer "{0}" cannot be used to install "{1}" on the node "{2}"


### PR DESCRIPTION
Example:

```
[Gradle] - Launching build.
Installer "Extract *.zip/*.tar.gz" cannot be used to install "Gradle 2" on the node "Jenkins"
[Gradle] - [ERROR] Can't retrieve the Gradle executable.
```

It seems that users occasionally wonder why their installers "don't work". I'd also print the label expression to be extra helpful, but this may be misleading as `isApplicable(…)` can be overridden.
