### PR TITLE
JENKINS-37282 ignore exceptions when including summaries

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -107,7 +107,9 @@ THE SOFTWARE.
 
         <!-- give actions a chance to contribute summary item -->
         <j:forEach var="a" items="${it.allActions}">
-          <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
+          <j:catch var="exceptionVariable">
+            <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
+          </j:catch>
         </j:forEach>
       </table>
 

--- a/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -110,6 +110,9 @@ THE SOFTWARE.
           <j:catch var="exceptionVariable">
             <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
           </j:catch>
+          <j:if test="${exceptionVariable != null}">
+            Exception for ${a}: ${exceptionVariable}
+          </j:if>
         </j:forEach>
       </table>
 


### PR DESCRIPTION
Apologies for the simplistic fix to JENKINS-37282 but I must admit to not knowing much about Apache Jelly and this at least means that the pages appear ok, even if they may mask some detail that cannot be displayed.
