### PR TITLE
[FIXED JENKINS-39232] - DefaultJnlpSlaveReceiver should not reject connections from non-JNLP launchers

### DIFF
--- a/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
+++ b/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
@@ -59,7 +59,7 @@ public class DefaultJnlpSlaveReceiver extends JnlpAgentReceiver {
             // We cannot just rely on the launcher type
             // TODO: Harden checks by provising new APIs in Launcher
             LOGGER.log(Level.FINE, "Received connection request to JNLP agent {0}. "
-                    + "This slave's launcher is instance of the {1} class, which does not extend {2}. "
+                    + "This agent's launcher is instance of the {1} class, which does not extend {2}. "
                     + "Accepting the connection request (JENKINS-39232).",
                     new Object[] {clientName, launcher.getClass(), JNLPLauncher.class});
         }

--- a/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
+++ b/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
@@ -7,6 +7,7 @@ import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Slave;
 import hudson.remoting.Channel;
+import hudson.slaves.ComputerLauncher;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
 import java.io.OutputStream;
@@ -47,9 +48,20 @@ public class DefaultJnlpSlaveReceiver extends JnlpAgentReceiver {
     public void afterProperties(@NonNull JnlpConnectionState event) {
         String clientName = event.getProperty(JnlpConnectionState.CLIENT_NAME_KEY);
         SlaveComputer computer = (SlaveComputer) Jenkins.getInstance().getComputer(clientName);
-        if (computer == null || !(computer.getLauncher() instanceof JNLPLauncher)) {
-            event.reject(new ConnectionRefusalException(String.format("%s is not a JNLP agent", clientName)));
+        if (computer == null) {
+            event.reject(new ConnectionRefusalException(String.format("%s is not a registered JNLP agent", clientName)));
             return;
+        }
+        
+        final ComputerLauncher launcher = computer.getLauncher();
+        if (!(launcher instanceof JNLPLauncher) && LOGGER.isLoggable(Level.FINE)) {
+            // We do not interrupt the connection, because there are corner cases mentioned in JENKINS-39232
+            // We cannot just rely on the launcher type
+            // TODO: Harden checks by provising new APIs in Launcher
+            LOGGER.log(Level.FINE, "Received connection request to JNLP agent {0}. "
+                    + "This slave's launcher is instance of the {1} class, which does not extend {2}. "
+                    + "Accepting the connection request (JENKINS-39232).",
+                    new Object[] {clientName, launcher.getClass(), JNLPLauncher.class});
         }
         Channel ch = computer.getChannel();
         if (ch != null) {


### PR DESCRIPTION
In 2.27 we released Remoting 3. It required some patches in the core. 

There was also compatibility check hardening: https://github.com/jenkinsci/jenkins/blob/71cbe0cc7c601c04509faa618b23194335288fee/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java#L50-L53
From what I see the code does not process `ComputerLauncherFilter` or `DelegatingComputerLauncher` correctly, and it causes failures of plugins like Slave Setup Plugin (https://github.com/jenkinsci/slave-setup-plugin/blob/ba1a93e0d1a4a150c1cd1cda87a29930a2d60773/src/main/java/org/jenkinsci/plugins/slave_setup/SetupSlaveLauncher.java#L23). 

It also breaks plugins like VSphere plugin, which use JNLP, but declare there own Launcher, which nests the JNLP one: https://github.com/jenkinsci/vsphere-cloud-plugin/blob/dd3f70f41b06ac2ab3e02996f924a73f15850911/src/main/java/org/jenkinsci/plugins/vSphereCloudLauncher.java#L31

https://issues.jenkins-ci.org/browse/JENKINS-39232

@reviewbybees @jenkinsci/code-reviewers @stephenc 
