### PR TITLE
[JENKINS-38370] - ExtensionPoints may be used on agents

### DIFF
--- a/core/src/main/java/hudson/ExtensionPoint.java
+++ b/core/src/main/java/hudson/ExtensionPoint.java
@@ -48,7 +48,7 @@ import jenkins.util.io.OnMaster;
  * @see Plugin
  * @see Extension
  */
-public interface ExtensionPoint extends OnMaster {
+public interface ExtensionPoint {
     /**
      * Used by designers of extension points (direct subtypes of {@link ExtensionPoint}) to indicate that
      * the legacy instances are scoped to {@link Jenkins} instance. By default, legacy instances are


### PR DESCRIPTION
It's a follow up to https://github.com/jenkinsci/jenkins/pull/2556

Some extension points are being executed on slaves (e.g. https://github.com/jenkinsci/cygwin-process-killer-plugin/blob/master/src/main/java/com/synopsys/arc/jenkinsci/plugins/cygwinprocesskiller/CygwinProcessKiller.java - ProcessKiller EP gets propagated).

@reviewbybees @jenkinsci/code-reviewers ASAP please. Otherwise we may have to introduce binary incompatibility in 2.29
