### PR TITLE
Update the detached version of Maven plugin to 2.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ THE SOFTWARE.
     <patch.tracker.serverId>jenkins-jira</patch.tracker.serverId>
 
     <slf4jVersion>1.7.7</slf4jVersion> <!-- < 1.6.x version didn't specify the license (MIT) -->
-    <maven-plugin.version>2.7.1</maven-plugin.version>
+    <maven-plugin.version>2.14</maven-plugin.version>
     <matrix-project.version>1.4.1</matrix-project.version>
     <sorcerer.version>0.11</sorcerer.version>
     <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -402,7 +402,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>junit</artifactId>
-                  <version>1.2-beta-4</version>
+                  <version>1.6</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
It's a follow-up to https://github.com/jenkinsci/jenkins/pull/2568
The plan was to bump the detached version, but we didn't do it in time

CC @reviewbybees @jenkinsci/code-reviewers @aheritier @KostyaSha
