### PR TITLE
[FIXED JENKINS-39531] Warning the use of a custom workspace

### DIFF
--- a/core/src/main/resources/hudson/model/Job/index.jelly
+++ b/core/src/main/resources/hudson/model/Job/index.jelly
@@ -28,6 +28,11 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <h1 class="job-index-headline page-headline">${it.pronoun} <l:breakable value="${it.displayName}"/></h1>
+      <j:if test="${it.customWorkspace!=null}">
+          <div class="warning">
+            <p>${%Workspace}: ${it.customWorkspace}</p>
+          </div>
+      </j:if>
       <j:if test="${(it.fullName!=it.fullDisplayName) and (it.class.name!='hudson.matrix.MatrixConfiguration')}"> <!-- TODO rather check for TopLevelItem (how to do this from Jelly?) -->
         <j:choose>
           <j:when test="${it.parent!=app}">

--- a/core/src/main/resources/hudson/model/Job/index_es.properties
+++ b/core/src/main/resources/hudson/model/Job/index_es.properties
@@ -22,3 +22,4 @@
 
 Disable\ Project=Desactivar el proyecto
 Project\ name=Nombre del Proyecto
+Workspace=Zona de Trabajo


### PR DESCRIPTION
Very small improvement in order to warn the use of a custom workspace in the main view of a job.