### PR TITLE
[JENKINS-39465] - Fix the AgentProtocol settings persistency handling

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1022,10 +1022,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
         if (disabledAgentProtocols == null && _disabledAgentProtocols != null) {
             disabledAgentProtocols = Arrays.asList(_disabledAgentProtocols);
+            _disabledAgentProtocols = null;
         }
         if (enabledAgentProtocols == null && _enabledAgentProtocols != null) {
             enabledAgentProtocols = Arrays.asList(_enabledAgentProtocols);
+            _enabledAgentProtocols = null;
         }
+        // Invalidate the protocols cache after the reload
+        agentProtocols = null;
         return this;
     }
     

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -617,6 +617,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @CheckForNull
     private List<String> disabledAgentProtocols;
+    /**
+     * @deprecated Just a temporary buffer for XSTream migration code from JENKINS-39465, do not use
+     */
+    @Deprecated
+    private transient String[] _disabledAgentProtocols;
 
     /**
      * The TCP agent protocols that are {@link AgentProtocol#isOptIn()} and explicitly enabled.
@@ -626,6 +631,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @CheckForNull
     private List<String> enabledAgentProtocols;
+    /**
+     * @deprecated Just a temporary buffer for XSTream migration code from JENKINS-39465, do not use
+     */
+    @Deprecated
+    private transient String[] _enabledAgentProtocols;
 
     /**
      * The TCP agent protocols that are enabled. Built from {@link #disabledAgentProtocols} and
@@ -1009,6 +1019,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
         if (SLAVE_AGENT_PORT_ENFORCE) {
             slaveAgentPort = getSlaveAgentPortInitialValue(slaveAgentPort);
+        }
+        if (disabledAgentProtocols == null && _disabledAgentProtocols != null) {
+            disabledAgentProtocols = Arrays.asList(_disabledAgentProtocols);
+        }
+        if (enabledAgentProtocols == null && _enabledAgentProtocols != null) {
+            enabledAgentProtocols = Arrays.asList(_enabledAgentProtocols);
         }
         return this;
     }
@@ -5027,8 +5043,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             // for backward compatibility with <1.75, recognize the tag name "view" as well.
             XSTREAM.alias("view", ListView.class);
             XSTREAM.alias("listView", ListView.class);
-            XSTREAM.addImplicitCollection(Jenkins.class, "disabledAgentProtocols", "disabledAgentProtocol", String.class);
-            XSTREAM.addImplicitCollection(Jenkins.class, "enabledAgentProtocols", "enabledAgentProtocol", String.class);
+            XSTREAM.addImplicitArray(Jenkins.class, "_disabledAgentProtocols", "disabledAgentProtocol");
+            XSTREAM.addImplicitArray(Jenkins.class, "_enabledAgentProtocols", "enabledAgentProtocol");
             XSTREAM2.addCriticalField(Jenkins.class, "securityRealm");
             XSTREAM2.addCriticalField(Jenkins.class, "authorizationStrategy");
             // this seems to be necessary to force registration of converter early enough

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -584,7 +584,6 @@ public class JenkinsTest {
         final Set<String> agentProtocolsBeforeReload = j.jenkins.getAgentProtocols();
         j.jenkins.reload();
         
-        // TODO: Smells like a bug, but maybe it's a default behavior
         assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == j.jenkins.getAgentProtocols());
         assertThat("We should have disabled two protocols", 
                 j.jenkins.getAgentProtocols().size(), equalTo(defaultProtocols.size() - 2));

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -25,7 +25,10 @@ package jenkins.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -75,6 +78,12 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import org.junit.Assume;
 
 /**
  * @author kingfai
@@ -470,5 +479,124 @@ public class JenkinsTest {
         public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
             throw new IOException("Something happened (the listener always throws this exception)");
         }
+    }
+    
+    // TODO: When unmarshalling Jenkins file, the AgentProtocols container does not get replaced
+    // Could it be a bug? XStream behavior analysis says "no", but who knows... Ideally the cache should be invalidated
+    
+    @Test
+    @Issue("JENKINS-39465")
+    public void agentProtocols_singleEnable_roundtrip() throws Exception {
+        final Set<String> defaultProtocols = Collections.unmodifiableSet(j.jenkins.getAgentProtocols());
+        Assume.assumeThat("We assume that JNLP3-connect is disabled", 
+                defaultProtocols, not(hasItem("JNLP3-connect")));
+        
+        final Set<String> newProtocols = new HashSet<>(defaultProtocols);
+        newProtocols.add("JNLP3-connect");
+        j.jenkins.setAgentProtocols(newProtocols);
+        j.jenkins.save();
+        final Set<String> agentProtocolsBeforeReload = j.jenkins.getAgentProtocols();
+        assertThat("JNLP3-connect must be enabled before the roundtrip", 
+                j.jenkins.getAgentProtocols(), hasItem("JNLP3-connect"));
+        
+        j.jenkins.reload();
+        
+        final Set<String> reloadedProtocols = j.jenkins.getAgentProtocols();
+        // TODO: restore
+        // assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == reloadedProtocols);
+        assertThat("We should have additional enabled protocol", 
+                reloadedProtocols.size(), equalTo(defaultProtocols.size() + 1));
+        assertThat("JNLP3-connect must be enabled after the roundtrip", 
+                reloadedProtocols, hasItem("JNLP3-connect"));
+    }
+    
+    @Test
+    @Issue("JENKINS-39465")
+    public void agentProtocols_multipleDisable_roundtrip() throws Exception {
+        final Set<String> defaultProtocols = Collections.unmodifiableSet(j.jenkins.getAgentProtocols());
+        Assume.assumeThat("At least one protocol is enabled", defaultProtocols.size(), greaterThan(0));
+        
+        final String protocolToDisable = defaultProtocols.iterator().next();
+        
+        final Set<String> newProtocols = new HashSet<>(defaultProtocols);
+        newProtocols.remove(protocolToDisable);
+        j.jenkins.setAgentProtocols(newProtocols);
+        j.jenkins.save();
+        assertThat(protocolToDisable + " must be disabled before the roundtrip", 
+                j.jenkins.getAgentProtocols(), not(hasItem(protocolToDisable)));
+        final Set<String> agentProtocolsBeforeReload = j.jenkins.getAgentProtocols();
+        j.jenkins.reload();
+        
+        // TODO: restore
+        // assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == j.jenkins.getAgentProtocols());
+        assertThat("We should have disabled one protocol", 
+                j.jenkins.getAgentProtocols().size(), equalTo(defaultProtocols.size() - 1));
+        assertThat(protocolToDisable + " must be disabled after the roundtrip", 
+                j.jenkins.getAgentProtocols(), not(hasItem(protocolToDisable)));
+    }
+    
+    @Test
+    @Issue("JENKINS-39465")
+    public void agentProtocols_multipleEnable_roundtrip() throws Exception {
+        final Set<String> defaultProtocols = Collections.unmodifiableSet(j.jenkins.getAgentProtocols());
+        Assume.assumeThat("We assume that JNLP3-connect is disabled", 
+                defaultProtocols, not(hasItem("JNLP3-connect")));
+        Assume.assumeThat("We assume that JNLP4-connect is disabled", 
+                defaultProtocols, not(hasItem("JNLP4-connect")));
+        
+        final Set<String> newProtocols = new HashSet<>(defaultProtocols);
+        newProtocols.add("JNLP3-connect");
+        newProtocols.add("JNLP4-connect");
+        j.jenkins.setAgentProtocols(newProtocols);
+        j.jenkins.save();
+        final Set<String> agentProtocolsBeforeReload = j.jenkins.getAgentProtocols();
+        assertThat("JNLP3-connect must be enabled before the roundtrip", 
+                j.jenkins.getAgentProtocols(), hasItem("JNLP3-connect"));
+        assertThat("JNLP4-connect must be enabled before the roundtrip", 
+                j.jenkins.getAgentProtocols(), hasItem("JNLP4-connect"));
+        
+        j.jenkins.reload();
+        
+        final Set<String> reloadedProtocols = j.jenkins.getAgentProtocols();
+        // TODO: restore
+        // assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == reloadedProtocols);
+        assertThat("We should have two additional enabled protocols", 
+                reloadedProtocols.size(), equalTo(defaultProtocols.size() + 2));
+        assertThat("JNLP3-connect must be enabled after the roundtrip", 
+                reloadedProtocols, hasItem("JNLP3-connect"));
+        assertThat("JNLP3-connect must be enabled after the roundtrip", 
+                reloadedProtocols, hasItem("JNLP4-connect"));
+    }
+    
+    @Test
+    @Issue("JENKINS-39465")
+    public void agentProtocols_singleDisable_roundtrip() throws Exception {
+        final Set<String> defaultProtocols = Collections.unmodifiableSet(j.jenkins.getAgentProtocols());
+        Assume.assumeThat("At least two protocol should be enabled", defaultProtocols.size(), greaterThan(1));
+        
+        Iterator<String> iterator = defaultProtocols.iterator();
+        final String protocolToDisable1 = iterator.next();
+        final String protocolToDisable2 = iterator.next();
+        
+        final Set<String> newProtocols = new HashSet<>(defaultProtocols);
+        newProtocols.remove(protocolToDisable1);
+        newProtocols.remove(protocolToDisable2);
+        j.jenkins.setAgentProtocols(newProtocols);
+        j.jenkins.save();
+        assertThat(protocolToDisable1 + " must be disabled before the roundtrip", 
+                j.jenkins.getAgentProtocols(), not(hasItem(protocolToDisable1)));
+        assertThat(protocolToDisable2 + " must be disabled before the roundtrip", 
+                j.jenkins.getAgentProtocols(), not(hasItem(protocolToDisable2)));
+        final Set<String> agentProtocolsBeforeReload = j.jenkins.getAgentProtocols();
+        j.jenkins.reload();
+        
+        // TODO: Smells like a bug, but maybe it's a default behavior
+        // assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == j.jenkins.getAgentProtocols());
+        assertThat("We should have disabled two protocols", 
+                j.jenkins.getAgentProtocols().size(), equalTo(defaultProtocols.size() - 2));
+        assertThat(protocolToDisable1 + " must be disaabled after the roundtrip", 
+                j.jenkins.getAgentProtocols(), not(hasItem(protocolToDisable1)));
+        assertThat(protocolToDisable2 + " must be disaabled after the roundtrip", 
+                j.jenkins.getAgentProtocols(), not(hasItem(protocolToDisable2)));
     }
 }

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -481,9 +481,6 @@ public class JenkinsTest {
         }
     }
     
-    // TODO: When unmarshalling Jenkins file, the AgentProtocols container does not get replaced
-    // Could it be a bug? XStream behavior analysis says "no", but who knows... Ideally the cache should be invalidated
-    
     @Test
     @Issue("JENKINS-39465")
     public void agentProtocols_singleEnable_roundtrip() throws Exception {
@@ -502,8 +499,7 @@ public class JenkinsTest {
         j.jenkins.reload();
         
         final Set<String> reloadedProtocols = j.jenkins.getAgentProtocols();
-        // TODO: restore
-        // assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == reloadedProtocols);
+        assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == reloadedProtocols);
         assertThat("We should have additional enabled protocol", 
                 reloadedProtocols.size(), equalTo(defaultProtocols.size() + 1));
         assertThat("JNLP3-connect must be enabled after the roundtrip", 
@@ -527,8 +523,7 @@ public class JenkinsTest {
         final Set<String> agentProtocolsBeforeReload = j.jenkins.getAgentProtocols();
         j.jenkins.reload();
         
-        // TODO: restore
-        // assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == j.jenkins.getAgentProtocols());
+        assertFalse("The protocol list must have been really refreshed", agentProtocolsBeforeReload == j.jenkins.getAgentProtocols());
         assertThat("We should have disabled one protocol", 
                 j.jenkins.getAgentProtocols().size(), equalTo(defaultProtocols.size() - 1));
         assertThat(protocolToDisable + " must be disabled after the roundtrip", 
@@ -558,8 +553,7 @@ public class JenkinsTest {
         j.jenkins.reload();
         
         final Set<String> reloadedProtocols = j.jenkins.getAgentProtocols();
-        // TODO: restore
-        // assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == reloadedProtocols);
+        assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == reloadedProtocols);
         assertThat("We should have two additional enabled protocols", 
                 reloadedProtocols.size(), equalTo(defaultProtocols.size() + 2));
         assertThat("JNLP3-connect must be enabled after the roundtrip", 
@@ -591,7 +585,7 @@ public class JenkinsTest {
         j.jenkins.reload();
         
         // TODO: Smells like a bug, but maybe it's a default behavior
-        // assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == j.jenkins.getAgentProtocols());
+        assertFalse("The protocol list must have been really reloaded", agentProtocolsBeforeReload == j.jenkins.getAgentProtocols());
         assertThat("We should have disabled two protocols", 
                 j.jenkins.getAgentProtocols().size(), equalTo(defaultProtocols.size() - 2));
         assertThat(protocolToDisable1 + " must be disaabled after the roundtrip", 


### PR DESCRIPTION
Well, everybody likes XStream magic...

- [x] Fix XStream serialization/deserializaation (See Data Format Notes below)
 * Users may have to reconfigure their Settings to make them persistent. Seems to be fine since the original configuration is vroken. Needs to be changelogged in any case
- [x] Invalidate `agentProtocols` cache on the configuration reload 
- [x] Add some functional tests for single and multiple protocol redefinition

### Data Format Notes

Due to whatever reason, without a definition of an array recipient field the data goes to the disk in the following way:

```
<enabledAgentProtocol>JNLP3-connect</enabledAgentProtocol>
<enabledAgentProtocol>JNLP4-connect</enabledAgentProtocol>
```

It is supposed to processed by Implicit array correctly thanks to `addImplicitCollection()`, but it does not actually happen. With the fix the data is being stored in another format:

```
  <enabledAgentProtocols>
    <string>JNLP3-connect</string>
    <string>JNLP4-connect</string>
  </enabledAgentProtocols>
```

This data now works correctly and gets deserialized correctly. readResolve() just adds a fallback for the case when Implicit array handling starts behaving correctly (?).

https://issues.jenkins-ci.org/browse/JENKINS-39465

@reviewbybees, esp. @stephenc 