### PR TITLE
Changelog: Add the 2.29 release notice

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -60,7 +60,13 @@ Upcoming changes</a>
 </ul>
 </div><!--=TRUNK-END=-->
 <h3><a name=v2.29>What's new in 2.29</a> (2016/11/06)</h3>
-<ul class=image>
+<p>
+  <b class="color:red">Warning!</b> This release is not recommended for use due to 
+  <a href="https://issues.jenkins-ci.org/browse/JENKINS-39535">issue 39555</a>
+  and <a href="https://issues.jenkins-ci.org/browse/JENKINS-39535">issue 39414</a>.
+  We are working on the out-of-order release (<a href="https://groups.google.com/forum/#!topic/jenkinsci-dev/kceM9T8NEdg">discussion</a>).
+</p>
+<ul class=image>  
   <li class="rfe">
     Performance: Optimize log retrieval logic for large log files.
     (<a href="https://issues.jenkins-ci.org/browse/JENKINS-39535">issue 39535</a>)

--- a/changelog.html
+++ b/changelog.html
@@ -63,7 +63,7 @@ Upcoming changes</a>
 <p>
   <b class="color:red">Warning!</b> This release is not recommended for use due to 
   <a href="https://issues.jenkins-ci.org/browse/JENKINS-39535">issue 39555</a>
-  and <a href="https://issues.jenkins-ci.org/browse/JENKINS-39535">issue 39414</a>.
+  and <a href="https://issues.jenkins-ci.org/browse/JENKINS-39414">issue 39414</a>.
   We are working on the out-of-order release (<a href="https://groups.google.com/forum/#!topic/jenkinsci-dev/kceM9T8NEdg">discussion</a>).
 </p>
 <ul class=image>  


### PR DESCRIPTION
Just adds a notice to the changelog, but not to the top download popup. 
Hopefully it's enough for a while.

CC @daniel-beck @rtyler 