### PR TITLE
[JENKINS-39883] Remove obsolete property from slave-agent.jnlp file

### DIFF
--- a/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
@@ -57,7 +57,6 @@ THE SOFTWARE.
           </j:otherwise>
         </j:choose>
         <jar href="${rootURL}jnlpJars/remoting.jar"/>
-        <property name="hudson.showWindowsServiceInstallLink" value="true" />
       </resources>
 
       <application-desc main-class="hudson.remoting.jnlp.Main">


### PR DESCRIPTION
This was removed in https://github.com/jenkinsci/windows-slave-installer-module/commit/9f763ed72e6319a192f233e7a95fae8a22e7fbe5#diff-c29e6014aed86dde6086c07b90099f26L55

No other occurrence: https://github.com/search?q=org%3Ajenkinsci+showWindowsServiceInstallLink&type=Code