### PR TITLE
Stop storing three identical copies of remoting.jar in jenkins.war

### DIFF
--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -32,6 +32,8 @@ import hudson.Launcher.RemoteLauncher;
 import hudson.Util;
 import hudson.model.Descriptor.FormException;
 import hudson.remoting.Callable;
+import hudson.remoting.Channel;
+import hudson.remoting.Which;
 import hudson.slaves.CommandLauncher;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.DumbSlave;
@@ -373,7 +375,7 @@ public abstract class Slave extends Node implements Serializable {
             return res.openConnection();
         }
 
-        public URL getURL() throws MalformedURLException {
+        public URL getURL() throws IOException {
             String name = fileName;
             
             // Prevent the access to war contents & prevent the folder escaping (SECURITY-195)
@@ -383,6 +385,8 @@ public abstract class Slave extends Node implements Serializable {
             
             if (name.equals("hudson-cli.jar"))  {
                 name="jenkins-cli.jar";
+            } else if (name.equals("slave.jar") || name.equals("remoting.jar")) {
+                name = "lib/" + Which.jarFile(Channel.class).getName();
             }
             
             URL res = Jenkins.getInstance().servletContext.getResource("/WEB-INF/" + name);

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -249,18 +249,6 @@ THE SOFTWARE.
                 <!-- dependencies that goes to unusual locations -->
                 <artifactItem>
                   <groupId>${project.groupId}</groupId>
-                  <artifactId>remoting</artifactId>
-                  <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF</outputDirectory>
-                  <destFileName>remoting.jar</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>remoting</artifactId>
-                  <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF</outputDirectory>
-                  <destFileName>slave.jar</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>${project.groupId}</groupId>
                   <artifactId>cli</artifactId>
                   <classifier>jar-with-dependencies</classifier>
                   <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF</outputDirectory>


### PR DESCRIPTION
Should reduce the download size, and eliminate a source of confusion.

@reviewbybees