### PR TITLE
[JENKINS-23271] - Prevent early deallocation of the Proc instance by GC in ProcStarter#join()

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -167,14 +167,6 @@ public abstract class Launcher {
         protected boolean reverseStdin, reverseStdout, reverseStderr;
 
         /**
-         * Just an instance holder for {@link #join()}, which creates a temporary {@link Proc} instance.
-         * Usage of {@code volatile} should prevent preliminary deallocation of the process object during the {@link Proc#join()} call.
-         */
-        @CheckForNull
-        @GuardedBy("this")
-        private volatile Proc procHolderForJoin;
-
-        /**
          * Passes a white-space separated single-string command (like "cat abc def") and parse them
          * as a command argument. This method also handles quotes.
          */
@@ -393,24 +385,23 @@ public abstract class Launcher {
 
         /**
          * Starts the process and waits for its completion.
-         * This method stores internal context and hence it is synchronized
          * @return Return code of the invoked process
          * @throws IOException Operation error (e.g. remote call failure)
          * @throws InterruptedException The process has been interrupted
          */
-        public synchronized int join() throws IOException, InterruptedException {
+        public int join() throws IOException, InterruptedException {
             // The logging around procHolderForJoin prevents the preliminary object deallocation we saw in JENKINS-23271
-            try {
-                procHolderForJoin = start();
-                LOGGER.log(Level.FINER, "Started the process {0}", procHolderForJoin);
-                final int returnCode = procHolderForJoin.join();
-                if (LOGGER.isLoggable(Level.FINER)) {
-                    LOGGER.log(Level.FINER, "Process {0} has finished with the return code {1}", new Object[] {procHolderForJoin, returnCode});
-                }
-                return returnCode;
-            } finally {
-                procHolderForJoin = null;
+            final Proc procHolderForJoin = start();
+            LOGGER.log(Level.FINER, "Started the process {0}", procHolderForJoin);
+            final int returnCode = procHolderForJoin.join();
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.log(Level.FINER, "Process {0} has finished with the return code {1}", new Object[] {procHolderForJoin, returnCode});
             }
+            if (procHolderForJoin.isAlive()) { // Should never happen but this forces Proc to not be removed and early GC by escape analysis
+                assert false : "Process not finished after call to join() completed";
+                LOGGER.log(Level.WARNING, "Process not finished after call to join() completed");
+            }
+            return returnCode;
         }
 
         /**

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -393,15 +393,18 @@ public abstract class Launcher {
             // The logging around procHolderForJoin prevents the preliminary object deallocation we saw in JENKINS-23271
             final Proc procHolderForJoin = start();
             LOGGER.log(Level.FINER, "Started the process {0}", procHolderForJoin);
-            final int returnCode = procHolderForJoin.join();
-            if (LOGGER.isLoggable(Level.FINER)) {
-                LOGGER.log(Level.FINER, "Process {0} has finished with the return code {1}", new Object[] {procHolderForJoin, returnCode});
+            try {
+                final int returnCode = procHolderForJoin.join();
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.log(Level.FINER, "Process {0} has finished with the return code {1}", new Object[]{procHolderForJoin, returnCode});
+                }
+                return returnCode;
+            } finally {
+                if (procHolderForJoin.isAlive()) { // Should never happen but this forces Proc to not be removed and early GC by escape analysis
+                    assert false : "Process not finished after call to join() completed";
+                    LOGGER.log(Level.WARNING, "Process not finished after call to join() completed");
+                }
             }
-            if (procHolderForJoin.isAlive()) { // Should never happen but this forces Proc to not be removed and early GC by escape analysis
-                assert false : "Process not finished after call to join() completed";
-                LOGGER.log(Level.WARNING, "Process not finished after call to join() completed");
-            }
-            return returnCode;
         }
 
         /**

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -401,7 +401,6 @@ public abstract class Launcher {
                 return returnCode;
             } finally {
                 if (procHolderForJoin.isAlive()) { // Should never happen but this forces Proc to not be removed and early GC by escape analysis
-                    assert false : "Process not finished after call to join() completed";
                     LOGGER.log(Level.WARNING, "Process not finished after call to join() completed");
                 }
             }


### PR DESCRIPTION
Just realized I have not proposed a hackish fix for [JENKINS-23271](https://issues.jenkins-ci.org/browse/JENKINS-23271) yet. It was implemented a while ago, but seems to be still actual. Have not tested it with the latest core BTW.

It is a hackish way, which likely prevents a preliminary deallocation of the spawned `RemoteProc` instance, which we see in JENKINS-23271. Proc instance was not actually required in the original code since we were creating and using `RemoteInvocationHandler` wrapper only, and the theory discussed with @stephenc was that object gets removed by Java8 garbage collector before we get into join().

This fix enforces the persistency of `ProcStarter#start()` result by adding logging and the enforced volatile field (maybe the last one is not really required, but JIT compiler in Java implementations may be smart enough to skip unused loggers)

This is a pretty old fix from August, which has been soak tested on my instance for several weeks (mid-August => Jenkins World). On the reference instance (just a small Jenkins 2.7.1 instance with 4 agents and very frequent builds with `CommandInterpreter steps`) I saw 2 failures over the period. On the fixed instance - 0. It does not proof anything, but at least the fix was soak tested a bit.

@reviewbybees @stephenc 