### PR TITLE
[JENKINS-26700] Support symlinks in ZIP.

### DIFF
--- a/core/src/main/java/hudson/util/IOUtils.java
+++ b/core/src/main/java/hudson/util/IOUtils.java
@@ -129,6 +129,16 @@ public class IOUtils {
     }
 
     /**
+     * Gets the mode of a file/directory/symlink, if appropriate.
+     * @return a file mode, or -1 if not on Unix
+     * @throws PosixException if the file/link could not be statted, NOT for a broken symlink!
+     */
+    public static int lmode(File f) throws PosixException {
+        if(Functions.isWindows())   return -1;
+        return PosixAPI.jnr().lstat(f.getPath()).mode();
+    }
+
+    /**
      * Read the first line of the given stream, close it, and return that line.
      *
      * @param encoding

--- a/core/src/main/java/hudson/util/io/TarArchiver.java
+++ b/core/src/main/java/hudson/util/io/TarArchiver.java
@@ -59,7 +59,7 @@ final class TarArchiver extends Archiver {
     public void visitSymlink(File link, String target, String relativePath) throws IOException {
         TarArchiveEntry e = new TarArchiveEntry(relativePath, TarConstants.LF_SYMLINK);
         try {
-            int mode = IOUtils.mode(link);
+            int mode = IOUtils.lmode(link);
             if (mode != -1) {
                 e.setMode(mode);
             }


### PR DESCRIPTION
apache-compress is in core-dependencies already.

Note:
While browsing code looking for usage of IOUtils.mode(), I also found a bug in TarArchiver (which is fixed here as well):
It was using the wrong file mode on symlinks (Instead of using the symlink's mode it used the target's mode).