### PR TITLE
[JENKINS-39805] - Update SSHD module to 1.8

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -134,7 +134,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
-      <version>1.7</version>
+      <version>1.8</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>


### PR DESCRIPTION
The fix disables some obsolete Ciphers as per [JENKINS-39805](https://issues.jenkins-ci.org/browse/JENKINS-39805):  AES128CBC, TripleDESCBC, and BlowfishCBC

All changes: https://github.com/jenkinsci/sshd-module/compare/sshd-1.7...sshd-1.8

@jenkinsci/code-reviewers, @chillum, @ydubreuil, @aheritier