### PR TITLE
Make sure Security218BlackBoxTest cleans up threads it starts

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -25,6 +25,7 @@ package hudson.cli;
 
 import hudson.cli.client.Messages;
 import hudson.remoting.Channel;
+import hudson.remoting.NamingThreadFactory;
 import hudson.remoting.PingThread;
 import hudson.remoting.Pipe;
 import hudson.remoting.RemoteInputStream;
@@ -80,7 +81,7 @@ import static java.util.logging.Level.*;
  * 
  * @author Kohsuke Kawaguchi
  */
-public class CLI {
+public class CLI implements AutoCloseable {
     private final ExecutorService pool;
     private final Channel channel;
     private final CliEntryPoint entryPoint;
@@ -121,7 +122,7 @@ public class CLI {
         if(!url.endsWith("/"))  url+='/';
 
         ownsPool = exec==null;
-        pool = exec!=null ? exec : Executors.newCachedThreadPool();
+        pool = exec!=null ? exec : Executors.newCachedThreadPool(new NamingThreadFactory(Executors.defaultThreadFactory(), "CLI.pool"));
 
         Channel _channel;
         try {

--- a/test/src/test/java/hudson/cli/CLIActionTest.java
+++ b/test/src/test/java/hudson/cli/CLIActionTest.java
@@ -65,10 +65,10 @@ public class CLIActionTest {
     @Test
     public void security218_take2() throws Exception {
         pool = Executors.newCachedThreadPool();
-        try {
+        try (CLI cli = new CLI(j.getURL())) {
             List/*<String>*/ commands = new ArrayList();
             commands.add(new Security218());
-            new CLI(j.getURL()).execute(commands);
+            cli.execute(commands);
             fail("Expected the call to be rejected");
         } catch (Exception e) {
             assertThat(Functions.printThrowable(e), containsString("Rejected: " + Security218.class.getName()));

--- a/test/src/test/java/hudson/model/ComputerSetTest.java
+++ b/test/src/test/java/hudson/model/ComputerSetTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 
@@ -70,16 +69,13 @@ public class ComputerSetTest {
     public void nodeOfflineCli() throws Exception {
         DumbSlave s = j.createSlave();
 
-        CLI cli = new CLI(j.getURL());
-        try {
+        try (CLI cli = new CLI(j.getURL())) {
             assertTrue(cli.execute("wait-node-offline","xxx")!=0);
             assertTrue(cli.execute("wait-node-online",s.getNodeName())==0);
 
             s.toComputer().disconnect().get();
 
             assertTrue(cli.execute("wait-node-offline",s.getNodeName())==0);
-        } finally {
-            cli.close();
         }
     }
 

--- a/test/src/test/java/hudson/model/listeners/ItemListenerTest.java
+++ b/test/src/test/java/hudson/model/listeners/ItemListenerTest.java
@@ -66,8 +66,7 @@ public class ItemListenerTest {
     public void onCreatedViaCLI() throws Exception {
         ByteArrayOutputStream buf = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(buf);
-        CLI cli = new CLI(j.getURL());
-        try {
+        try (CLI cli = new CLI(j.getURL())) {
             cli.execute(Arrays.asList("create-job", "testJob"),
                     new ByteArrayInputStream(("<project><actions/><builders/><publishers/>"
                             + "<buildWrappers/></project>").getBytes()),
@@ -75,8 +74,6 @@ public class ItemListenerTest {
             out.flush();
             assertNotNull("job should be created: " + buf, j.jenkins.getItem("testJob"));
             assertEquals("onCreated event should be triggered: " + buf, "C", events.toString());
-        } finally {
-            cli.close();
         }
     }
 }

--- a/test/src/test/java/hudson/security/CliAuthenticationTest.java
+++ b/test/src/test/java/hudson/security/CliAuthenticationTest.java
@@ -43,22 +43,16 @@ public class CliAuthenticationTest {
     }
 
     private int command(String... args) throws Exception {
-        CLI cli = new CLI(j.getURL());
-        try {
+        try (CLI cli = new CLI(j.getURL())) {
             return cli.execute(args);
-        } finally {
-            cli.close();
         }
     }
 
     private String commandAndOutput(String... args) throws Exception {
-        CLI cli = new CLI(j.getURL());
-        try {
+        try (CLI cli = new CLI(j.getURL())) {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             cli.execute(Arrays.asList(args), new NullInputStream(0), baos, baos);
             return baos.toString();
-        } finally {
-            cli.close();
         }
     }
 

--- a/test/src/test/java/jenkins/security/Security218BlackBoxTest.java
+++ b/test/src/test/java/jenkins/security/Security218BlackBoxTest.java
@@ -73,7 +73,6 @@ public class Security218BlackBoxTest {
         closables = new ArrayList<>();
     }
 
-    @SuppressWarnings("deprecation") // SocketInputStream.read ignores Thread.interrupt
     @AfterClass public static void shutdownExecutors() throws Exception {
         for (AutoCloseable c : closables) {
             c.close();

--- a/test/src/test/java/jenkins/security/Security218BlackBoxTest.java
+++ b/test/src/test/java/jenkins/security/Security218BlackBoxTest.java
@@ -29,6 +29,7 @@ import hudson.cli.CLI;
 import hudson.cli.CliPort;
 import hudson.remoting.BinarySafeStream;
 import hudson.util.DaemonThreadFactory;
+import hudson.util.NamingThreadFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -40,13 +41,17 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import jenkins.security.security218.ysoserial.payloads.CommonsCollections1;
 import jenkins.security.security218.ysoserial.util.Serializables;
+import org.junit.AfterClass;
 import static org.junit.Assert.*;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -60,7 +65,23 @@ public class Security218BlackBoxTest {
         assertTrue("$JENKINS_URL and $JENKINS_HOME must both be defined together", (overrideURL == null) == (overrideHome == null));
     }
 
-    private static final ExecutorService executors = Executors.newCachedThreadPool(new DaemonThreadFactory());
+    private static ExecutorService executors;
+    private static List<AutoCloseable> closables;
+
+    @BeforeClass public static void startExecutors() throws Exception {
+        executors = Executors.newCachedThreadPool(new NamingThreadFactory(new DaemonThreadFactory(), "Security218BlackBoxTest.executors"));
+        closables = new ArrayList<>();
+    }
+
+    @SuppressWarnings("deprecation") // SocketInputStream.read ignores Thread.interrupt
+    @AfterClass public static void shutdownExecutors() throws Exception {
+        for (AutoCloseable c : closables) {
+            c.close();
+        }
+        closables = null;
+        executors.shutdownNow();
+        executors.awaitTermination(5, TimeUnit.MINUTES); // >3m test timeout, so we will get a failure + thread dump if this does not work
+    }
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
@@ -81,18 +102,25 @@ public class Security218BlackBoxTest {
         for (int round = 0; round < 2; round++) {
             final int _round = round;
             final ServerSocket proxySocket = new ServerSocket(0);
+            closables.add(proxySocket);
             executors.submit(new Runnable() {
                 @Override
                 public void run() {
                     try {
                         Socket proxy = proxySocket.accept();
+                        closables.add(proxy);
                         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                         String host = conn.getHeaderField("X-Jenkins-CLI-Host");
                         Socket real = new Socket(host == null ? url.getHost() : host, conn.getHeaderFieldInt("X-Jenkins-CLI-Port", -1));
+                        closables.add(real);
                         final InputStream realIS = real.getInputStream();
+                        closables.add(realIS);
                         final OutputStream realOS = real.getOutputStream();
+                        closables.add(realOS);
                         final InputStream proxyIS = proxy.getInputStream();
+                        closables.add(proxyIS);
                         final OutputStream proxyOS = proxy.getOutputStream();
+                        closables.add(proxyOS);
                         executors.submit(new Runnable() {
                             @Override
                             public void run() {
@@ -248,12 +276,14 @@ public class Security218BlackBoxTest {
                         // Bypassing _main because it does nothing interesting here.
                         // Hardcoding CLI protocol version 1 (CliProtocol) because it is easier to sniff.
                         try {
-                            new CLI(r.getURL()) {
+                            CLI cli = new CLI(r.getURL()) {
                                 @Override
                                 protected CliPort getCliTcpPort(String url) throws IOException {
                                     return new CliPort(new InetSocketAddress(proxySocket.getInetAddress(), proxySocket.getLocalPort()), /* ignore identity */ null, 1);
                                 }
-                            }.execute("help");
+                            };
+                            closables.add(cli);
+                            cli.execute("help");
                         } catch (Exception x) {
                             x.printStackTrace();
                         }

--- a/test/src/test/java/jenkins/security/Security218CliTest.java
+++ b/test/src/test/java/jenkins/security/Security218CliTest.java
@@ -32,7 +32,6 @@ import java.io.File;
 import java.io.PrintStream;
 import jenkins.security.security218.Payload;
 import org.jenkinsci.remoting.RoleChecker;
-import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;
@@ -176,11 +175,13 @@ public class Security218CliTest {
         
         // Bypassing _main because it does nothing interesting here.
         // Hardcoding CLI protocol version 1 (CliProtocol) because it is easier to sniff.
-        int exitCode = new CLI(r.getURL()).execute("send-payload",
-                payload.toString(), "mv " + file.getAbsolutePath() + " " + moved.getAbsolutePath());
-        assertEquals("Unexpected result code.", expectedResultCode, exitCode);
-        assertTrue("Payload should not invoke the move operation " + file, !moved.exists());
-        file.delete();
+        try (CLI cli = new CLI(r.getURL())) {
+            int exitCode = cli.execute("send-payload",
+                    payload.toString(), "mv " + file.getAbsolutePath() + " " + moved.getAbsolutePath());
+            assertEquals("Unexpected result code.", expectedResultCode, exitCode);
+            assertTrue("Payload should not invoke the move operation " + file, !moved.exists());
+            file.delete();
+        }
     }
     
     @TestExtension()


### PR DESCRIPTION
While looking at the thread dump for a flaked test (`AbstractProjectTest.testConfiguringBlockBuildWhenUpstreamBuildingRoundtrip`, not that it really matters), I noticed that there were a lot of threads started by `Security218BlackBoxTest` in another test run blocked in `SocketInputStream.read`.

Currently we reuse JVMs between test suites, forking only as many as concurrency requires, so it is important to clean up static state between runs. `jenkins.util.Timer` does this correctly, though `FilePath.localPool` and `Computer.threadPoolForRemoting` still do not—a topic for a future fix.

Retrofitting `CLI` to be `AutoCloseable` as well, and naming some more thread factories to make it easier to diagnose thread leaks.

@reviewbybees