### PR TITLE
Support Execute Shell on IBM z/OS mainframe slaves.

### DIFF
--- a/core/src/main/java/hudson/tasks/CommandInterpreter.java
+++ b/core/src/main/java/hudson/tasks/CommandInterpreter.java
@@ -158,7 +158,7 @@ public abstract class CommandInterpreter extends Builder {
      * Creates a script file in a temporary name in the specified directory.
      */
     public FilePath createScriptFile(@Nonnull FilePath dir) throws IOException, InterruptedException {
-        return dir.createTextTempFile("hudson", getFileExtension(), getContents(), false);
+        return dir.createScriptTempFile("hudson", getFileExtension(), getContents(), false);
     }
 
     public abstract String[] buildCommandLine(FilePath script);


### PR DESCRIPTION
Currently slave will start with file.encoding=ISO-8859-1.
Ant builds run successfully, however shell execution fails as the
generated command file needs to be in IBM-1047 (ebcdic).

This change clones the createTextTempFile method as createScriptTempFile
which writes the file in the encoding specified by sun.jnu.encoding
(defaulting to file.encoding if property not set). 
CommandInterpreter has been updated to use this cloned method.

After this fix, 
z/OS slaves are usable for both Ant execution and execute shell build steps.

**Note: this fix potentially affects execute shell on all platforms.**