### PR TITLE
[JENKINS-38514] Retain CauseOfBlockage from JobOffer

### DIFF
--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -399,7 +399,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         }
 
         if (!isAcceptingTasks()) {
-            return CauseOfBlockage.fromMessage(Messages._Node_BecauseNodeIsNotAcceptingTasks(getDisplayName()));
+            return new CauseOfBlockage.BecauseNodeIsNotAcceptingTasks(this);
         }
 
         // Looks like we can take the task

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -372,7 +372,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
     public CauseOfBlockage canTake(Queue.BuildableItem item) {
         Label l = item.getAssignedLabel();
         if(l!=null && !l.contains(this))
-            return CauseOfBlockage.fromMessage(Messages._Node_LabelMissing(getNodeName(),l));   // the task needs to be executed on label that this node doesn't have.
+            return CauseOfBlockage.fromMessage(Messages._Node_LabelMissing(getDisplayName(), l));   // the task needs to be executed on label that this node doesn't have.
 
         if(l==null && getMode()== Mode.EXCLUSIVE) {
             // flyweight tasks need to get executed somewhere, if every node
@@ -381,14 +381,14 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
                             || Jenkins.getInstance().getNumExecutors() < 1
                             || Jenkins.getInstance().getMode() == Mode.EXCLUSIVE)
             )) {
-                return CauseOfBlockage.fromMessage(Messages._Node_BecauseNodeIsReserved(getNodeName()));   // this node is reserved for tasks that are tied to it
+                return CauseOfBlockage.fromMessage(Messages._Node_BecauseNodeIsReserved(getDisplayName()));   // this node is reserved for tasks that are tied to it
             }
         }
 
         Authentication identity = item.authenticate();
         if (!getACL().hasPermission(identity,Computer.BUILD)) {
             // doesn't have a permission
-            return CauseOfBlockage.fromMessage(Messages._Node_LackingBuildPermission(identity.getName(),getNodeName()));
+            return CauseOfBlockage.fromMessage(Messages._Node_LackingBuildPermission(identity.getName(), getDisplayName()));
         }
 
         // Check each NodeProperty to see whether they object to this node
@@ -399,7 +399,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         }
 
         if (!isAcceptingTasks()) {
-            return CauseOfBlockage.fromMessage(Messages._Node_BecauseNodeIsNotAcceptingTasks(getNodeName()));
+            return CauseOfBlockage.fromMessage(Messages._Node_BecauseNodeIsNotAcceptingTasks(getDisplayName()));
         }
 
         // Looks like we can take the task

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -291,7 +291,7 @@ public class Queue extends ResourceController implements Saveable {
             if (executor.getOwner().isOffline()) {
                 return new CauseOfBlockage.BecauseNodeIsOffline(node);
             }
-            if (!executor.getOwner().isAcceptingTasks()) {
+            if (!executor.getOwner().isAcceptingTasks()) { // Node.canTake (above) does not consider RetentionStrategy.isAcceptingTasks
                 return new CauseOfBlockage.BecauseNodeIsNotAcceptingTasks(node);
             }
             return null;
@@ -2536,13 +2536,13 @@ public class Queue extends ResourceController implements Saveable {
                     if (nodes.size() != 1)      return new BecauseLabelIsOffline(label);
                     else                        return new BecauseNodeIsOffline(nodes.iterator().next());
                 } else {
-                    if (transientCausesOfBlockage != null) {
+                    if (transientCausesOfBlockage != null && label.getIdleExecutors() > 0) {
                         return new CompositeCauseOfBlockage(transientCausesOfBlockage);
                     }
                     if (nodes.size() != 1)      return new BecauseLabelIsBusy(label);
                     else                        return new BecauseNodeIsBusy(nodes.iterator().next());
                 }
-            } else if (transientCausesOfBlockage != null) {
+            } else if (transientCausesOfBlockage != null && new ComputerSet().getIdleExecutors() > 0) {
                 return new CompositeCauseOfBlockage(transientCausesOfBlockage);
             } else {
                 return CauseOfBlockage.createNeedsMoreExecutor(Messages._Queue_WaitingForNextAvailableExecutor());

--- a/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
+++ b/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
@@ -1,6 +1,7 @@
 package hudson.model.queue;
 
 import hudson.console.ModelHyperlinkNote;
+import hudson.model.Computer;
 import hudson.model.Queue.Task;
 import hudson.model.Node;
 import hudson.model.Messages;
@@ -101,6 +102,33 @@ public abstract class CauseOfBlockage {
             listener.getLogger().println(
                 Messages.Queue_NodeOffline(ModelHyperlinkNote.encodeTo(node)));
         }
+    }
+
+    /**
+     * Build is blocked because a node (or its retention strategy) is not accepting tasks.
+     * @since FIXME
+     */
+    public static final class BecauseNodeIsNotAcceptingTasks extends CauseOfBlockage implements NeedsMoreExecutor {
+
+        public final Node node;
+
+        public BecauseNodeIsNotAcceptingTasks(Node node) {
+            this.node = node;
+        }
+
+        @Override
+        public String getShortDescription() {
+            Computer computer = node.toComputer();
+            String name = computer != null ? computer.getDisplayName() : node.getDisplayName();
+            return Messages.Queue_node_not_accepting_tasks(name);
+        }
+
+        @Override
+        public void print(TaskListener listener) {
+            listener.getLogger().println(
+                Messages.Queue_node_not_accepting_tasks(ModelHyperlinkNote.encodeTo(node)));
+        }
+
     }
 
     /**

--- a/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
+++ b/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
@@ -8,6 +8,7 @@ import hudson.model.Messages;
 import hudson.model.Label;
 import hudson.model.TaskListener;
 import hudson.slaves.Cloud;
+import javax.annotation.Nonnull;
 import org.jvnet.localizer.Localizable;
 
 /**
@@ -43,8 +44,10 @@ public abstract class CauseOfBlockage {
     /**
      * Obtains a simple implementation backed by {@link Localizable}.
      */
-    public static CauseOfBlockage fromMessage(final Localizable l) {
+    public static CauseOfBlockage fromMessage(@Nonnull final Localizable l) {
+        l.getKey(); // null check
         return new CauseOfBlockage() {
+            @Override
             public String getShortDescription() {
                 return l.toString();
             }
@@ -120,13 +123,13 @@ public abstract class CauseOfBlockage {
         public String getShortDescription() {
             Computer computer = node.toComputer();
             String name = computer != null ? computer.getDisplayName() : node.getDisplayName();
-            return Messages.Queue_node_not_accepting_tasks(name);
+            return Messages.Node_BecauseNodeIsNotAcceptingTasks(name);
         }
 
         @Override
         public void print(TaskListener listener) {
             listener.getLogger().println(
-                Messages.Queue_node_not_accepting_tasks(ModelHyperlinkNote.encodeTo(node)));
+                Messages.Node_BecauseNodeIsNotAcceptingTasks(ModelHyperlinkNote.encodeTo(node)));
         }
 
     }

--- a/core/src/main/java/jenkins/model/queue/CompositeCauseOfBlockage.java
+++ b/core/src/main/java/jenkins/model/queue/CompositeCauseOfBlockage.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model.queue;
+
+import hudson.model.TaskListener;
+import hudson.model.queue.CauseOfBlockage;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Represents the fact that there was at least one {@link hudson.model.Queue.JobOffer} which rejected a task.
+ */
+@Restricted(NoExternalUse.class)
+public class CompositeCauseOfBlockage extends CauseOfBlockage {
+
+    public final Map<String, CauseOfBlockage> uniqueReasons;
+
+    public CompositeCauseOfBlockage(List<CauseOfBlockage> delegates) {
+        uniqueReasons = new TreeMap<>();
+        for (CauseOfBlockage delegate : delegates) {
+            uniqueReasons.put(delegate.getShortDescription(), delegate);
+        }
+    }
+
+    @Override
+    public String getShortDescription() {
+        return StringUtils.join(uniqueReasons.keySet(), "; ");
+    }
+
+    @Override
+    public void print(TaskListener listener) {
+        for (CauseOfBlockage delegate : uniqueReasons.values()) {
+            delegate.print(listener);
+        }
+    }
+
+}

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -196,7 +196,6 @@ Queue.WaitingForNextAvailableExecutorOn=Waiting for next available executor on {
 Queue.init=Restoring the build queue
 Queue.node_has_been_removed_from_configuration={0} has been removed from configuration
 Queue.executor_slot_already_in_use=Executor slot already in use
-Queue.node_not_accepting_tasks={0} is not accepting tasks
 
 ResultTrend.Aborted=Aborted
 ResultTrend.Failure=Failure

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -335,7 +335,7 @@ PasswordParameterDefinition.DisplayName=Password Parameter
 Node.BecauseNodeIsReserved={0} is reserved for jobs with matching label expression
 Node.BecauseNodeIsNotAcceptingTasks={0} is not accepting tasks
 Node.LabelMissing={0} doesn\u2019t have label {1}
-Node.LackingBuildPermission={0} doesn\u2019t have a permission to run on {1}
+Node.LackingBuildPermission={0} lacks permission to run on {1}
 Node.Mode.NORMAL=Use this node as much as possible
 Node.Mode.EXCLUSIVE=Only build jobs with label expressions matching this node
 

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -194,6 +194,9 @@ Queue.Unknown=???
 Queue.WaitingForNextAvailableExecutor=Waiting for next available executor
 Queue.WaitingForNextAvailableExecutorOn=Waiting for next available executor on {0}
 Queue.init=Restoring the build queue
+Queue.node_has_been_removed_from_configuration={0} has been removed from configuration
+Queue.executor_slot_already_in_use=Executor slot already in use
+Queue.node_not_accepting_tasks={0} is not accepting tasks
 
 ResultTrend.Aborted=Aborted
 ResultTrend.Failure=Failure

--- a/core/src/main/resources/jenkins/model/queue/CompositeCauseOfBlockage/summary.jelly
+++ b/core/src/main/resources/jenkins/model/queue/CompositeCauseOfBlockage/summary.jelly
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    <j:forEach var="delegate" items="${it.uniqueReasons.values()}" indexVar="index">
+        <j:if test="${index > 0}">; <wbr/></j:if>
+        <st:include it="${delegate}" page="summary"/>
+    </j:forEach>
+</j:jelly>

--- a/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
+++ b/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
@@ -1,12 +1,18 @@
 package hudson.model.queue;
 
 import hudson.model.FreeStyleProject;
+import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.Queue.Item;
+import hudson.model.TaskListener;
+import hudson.util.StreamTaskListener;
+import java.io.StringWriter;
 import java.util.logging.Level;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
@@ -41,6 +47,42 @@ public class QueueTaskDispatcherTest {
                 @Override
                 public String getShortDescription() {
                     return "blocked by canRun";
+                }
+            };
+        }
+    }
+
+    @Issue("JENKINS-38514")
+    @Test
+    public void canTakeBlockageIsDisplayed() throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject();
+        r.jenkins.getQueue().schedule(project);
+        Queue.Item item;
+        while (true) {
+            item = r.jenkins.getQueue().getItem(project);
+            if (item.isBuildable()) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        CauseOfBlockage cob = item.getCauseOfBlockage();
+        assertNotNull(cob);
+        assertThat(cob.getShortDescription(), containsString("blocked by canTake"));
+        StringWriter w = new StringWriter();
+        TaskListener l = new StreamTaskListener(w);
+        cob.print(l);
+        l.getLogger().flush();
+        assertThat(w.toString(), containsString("blocked by canTake"));
+    }
+
+    @TestExtension("canTakeBlockageIsDisplayed")
+    public static class AnotherQueueTaskDispatcher extends QueueTaskDispatcher {
+        @Override
+        public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
+            return new CauseOfBlockage() {
+                @Override
+                public String getShortDescription() {
+                    return "blocked by canTake";
                 }
             };
         }

--- a/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
+++ b/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
@@ -1,28 +1,39 @@
 package hudson.model.queue;
 
 import hudson.model.FreeStyleProject;
+import hudson.model.Queue;
 import hudson.model.Queue.Item;
-
-import org.jvnet.hudson.test.HudsonTestCase;
+import java.util.logging.Level;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
 
-public class QueueTaskDispatcherTest extends HudsonTestCase {
+public class QueueTaskDispatcherTest {
 
-    @SuppressWarnings("deprecation")
-    public void testCanRunBlockageIsDisplayed() throws Exception {
-        FreeStyleProject project = createFreeStyleProject();
-        jenkins.getQueue().schedule(project);
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
-        Item item = jenkins.getQueue().getItem(project);
+    @Rule
+    public LoggerRule logging = new LoggerRule().record(Queue.class, Level.ALL);
+
+    @Test
+    public void canRunBlockageIsDisplayed() throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject();
+        r.jenkins.getQueue().schedule(project);
+
+        Item item = r.jenkins.getQueue().getItem(project);
         for (int i = 0; i < 4 * 60 && !item.isBlocked(); i++) {
             Thread.sleep(250);
-            item = jenkins.getQueue().getItem(project);
+            item = r.jenkins.getQueue().getItem(project);
         }
         assertTrue("Not blocked after 60 seconds", item.isBlocked());
         assertEquals("Expected CauseOfBlockage to be returned", "blocked by canRun", item.getWhy());
     }
 
-    @TestExtension
+    @TestExtension("canRunBlockageIsDisplayed")
     public static class MyQueueTaskDispatcher extends QueueTaskDispatcher {
         @Override
         public CauseOfBlockage canRun(Item item) {
@@ -34,4 +45,5 @@ public class QueueTaskDispatcherTest extends HudsonTestCase {
             };
         }
     }
+
 }


### PR DESCRIPTION
[JENKINS-38514](https://issues.jenkins-ci.org/browse/JENKINS-38514)

Interactively tested in two scenarios:
* A `QueueTaskDispatcher.canTake` implementation in `cloudbees-folders-plus` which conditionally blocks execution of a given project on a given node. Previously just claimed that the assigned label had no free executors, which was manifestly untrue. Now shows a composite status including the plugin-supplied rejection message. (Also notes that other nodes lack the label. Ideally this part would be suppressed as secondary, though I could not think of a good way to distinguish those cases.)
* An `authorize-project` setup in which a project is by default run as `anonymous`, who lacks `Computer.BUILD`. Previously claimed that the project was waiting for an available executor; now shows that the anonymous user lacks permission on each node. (Again the display is overly verbose since there is no API to express that the anonymous user lacks permissions to build on *any* node.)

@reviewbybees