### PR TITLE
Annotate localizer generated Messages classes with NoExternalUse

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -25,6 +25,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+        <groupId>org.kohsuke</groupId>
+        <artifactId>access-modifier-annotation</artifactId>
+        <version>1.7</version>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.4</version>
@@ -42,7 +47,7 @@
     <dependency>
       <groupId>org.jvnet.localizer</groupId>
       <artifactId>localizer</artifactId>
-      <version>1.23</version>
+      <version>1.24</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
@@ -88,6 +93,7 @@
             <configuration>
               <fileMask>Messages.properties</fileMask>
               <outputDirectory>target/generated-sources/localizer</outputDirectory>
+              <accessModifierAnnotations>true</accessModifierAnnotations>
             </configuration>
           </execution>
         </executions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -212,7 +212,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jvnet.localizer</groupId>
       <artifactId>localizer</artifactId>
-      <version>1.23</version>
+      <version>1.24</version>
     </dependency>
     <dependency>
       <groupId>antlr</groupId>
@@ -697,6 +697,7 @@ THE SOFTWARE.
             <configuration>
               <fileMask>Messages.properties</fileMask>
               <outputDirectory>target/generated-sources/localizer</outputDirectory>
+              <accessModifierAnnotations>true</accessModifierAnnotations>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.jvnet.localizer</groupId>
           <artifactId>maven-localizer-plugin</artifactId>
-          <version>1.23</version>
+          <version>1.24</version>
           <configuration>
             <outputEncoding>UTF-8</outputEncoding>
           </configuration>


### PR DESCRIPTION
Also update to localizer 1.24 which adds support for this.

Using another component's `Messages` is brittle and always risky, so let's make sure anyone with a recent enough core dependency and using the access-modifier-checker gets an error during build.

This will not break plugins at runtime, just make sure they don't reuse core `Messages` during build. In time, reuse should fade as core dependencies get updated.