### PR TITLE
[FIXED JENKINS-40286] - Delegate JnlpMac computation to SlaveComputers if possible

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -665,7 +665,7 @@ public class SlaveComputer extends Computer {
 
     @WebMethod(name="slave-agent.jnlp")
     public HttpResponse doSlaveAgentJnlp(StaplerRequest req, StaplerResponse res) throws IOException, ServletException {
-        return new EncryptedSlaveAgentJnlpFile(this, "slave-agent.jnlp.jelly", getName(), CONNECT);
+        return new EncryptedSlaveAgentJnlpFile(this, "slave-agent.jnlp.jelly", CONNECT);
     }
 
     @Override

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -665,7 +665,7 @@ public class SlaveComputer extends Computer {
 
     @WebMethod(name="slave-agent.jnlp")
     public HttpResponse doSlaveAgentJnlp(StaplerRequest req, StaplerResponse res) throws IOException, ServletException {
-        return new EncryptedSlaveAgentJnlpFile(this, "slave-agent.jnlp.jelly", CONNECT);
+        return new EncryptedSlaveAgentJnlpFile(this, "slave-agent.jnlp.jelly", getName(), CONNECT);
     }
 
     @Override

--- a/core/src/main/java/jenkins/slaves/EncryptedSlaveAgentJnlpFile.java
+++ b/core/src/main/java/jenkins/slaves/EncryptedSlaveAgentJnlpFile.java
@@ -4,6 +4,7 @@ import hudson.security.AccessControlled;
 import hudson.security.Permission;
 import hudson.slaves.SlaveComputer;
 import hudson.util.Secret;
+import hudson.Util;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.ResponseImpl;
 import org.kohsuke.stapler.StaplerRequest;
@@ -35,27 +36,23 @@ import java.security.SecureRandom;
  */
 public class EncryptedSlaveAgentJnlpFile implements HttpResponse {
     /**
-     * The object that owns the Jelly view that renders JNLP file.
-     * For example {@link SlaveComputer}.
+     * The object that owns the Jelly view that renders JNLP file this is always 
+     * some type of {@link SlaveComputer}.
      */
-    private final AccessControlled it;
+    private final SlaveComputer it;
     /**
      * Name of the view that renders JNLP file that belongs to {@link #it}.
      */
     private final String viewName;
-    /**
-     * Name of the agent, which is used to determine secret HMAC code.
-     */
-    private final String slaveName;
+
     /**
      * Permission that allows plain text access. Checked against {@link #it}.
      */
     private final Permission connectPermission;
 
-    public EncryptedSlaveAgentJnlpFile(AccessControlled it, String viewName, String slaveName, Permission connectPermission) {
+    public EncryptedSlaveAgentJnlpFile(SlaveComputer it, String viewName, Permission connectPermission) {
         this.it = it;
         this.viewName = viewName;
-        this.slaveName = slaveName;
         this.connectPermission = connectPermission;
     }
 
@@ -77,7 +74,7 @@ public class EncryptedSlaveAgentJnlpFile implements HttpResponse {
             byte[] iv = new byte[128/8];
             new SecureRandom().nextBytes(iv);
 
-            byte[] jnlpMac = JnlpSlaveAgentProtocol.SLAVE_SECRET.mac(slaveName.getBytes("UTF-8"));
+            byte[] jnlpMac = Util.fromHexString(it.getJnlpMac());
             SecretKey key = new SecretKeySpec(jnlpMac, 0, /* export restrictions */ 128 / 8, "AES");
             byte[] encrypted;
             try {


### PR DESCRIPTION
This change centralizes the jnlpMac generation and makes it simpler for plugin developers extending SlaveComputer to change how the encryption key is generated.

https://issues.jenkins-ci.org/browse/JENKINS-40286