### PR TITLE
[JENKINS-40281] Do not try to mutate the result of getActions(Class)

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -480,6 +480,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     public @Nonnull List<BuildBadgeAction> getBadgeActions() {
         List<BuildBadgeAction> r = getActions(BuildBadgeAction.class);
         if(isKeepLog()) {
+            r = new ArrayList<>(r);
             r.add(new KeepLogBuildBadge());
         }
         return r;

--- a/test/src/test/java/hudson/model/RunTest.java
+++ b/test/src/test/java/hudson/model/RunTest.java
@@ -26,6 +26,8 @@ package hudson.model;
 import java.net.HttpURLConnection;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -57,6 +59,18 @@ public class RunTest  {
         });
         j.assertBuildStatusSuccess(j.createFreeStyleProject("stuff").scheduleBuild2(0));
         j.createWebClient().assertFails("job/stuff/1/nonexistent", HttpURLConnection.HTTP_NOT_FOUND);
+    }
+
+    @Issue("JENKINS-40281")
+    @Test public void getBadgeActions() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        FreeStyleBuild b = j.buildAndAssertSuccess(p);
+        assertEquals(0, b.getBadgeActions().size());
+        assertTrue(b.canToggleLogKeep());
+        b.keepLog();
+        List<BuildBadgeAction> badgeActions = b.getBadgeActions();
+        assertEquals(1, badgeActions.size());
+        assertEquals(Run.KeepLogBuildBadge.class, badgeActions.get(0).getClass());
     }
 
 }


### PR DESCRIPTION
[JENKINS-40281](https://issues.jenkins-ci.org/browse/JENKINS-40281)

Amends #2582.

@reviewbybees