### PR TITLE
[FIX JENKINS-39700] Don't fail when no parameters property for job

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1231,8 +1231,6 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             DescribableList<JobProperty<?>, JobPropertyDescriptor> t = new DescribableList<JobProperty<?>, JobPropertyDescriptor>(NOOP,getAllProperties());
             JSONObject jsonProperties = json.optJSONObject("properties");
             if (jsonProperties != null) {
-            	//This handles the situation when Parameterized build checkbox is checked but no parameters are selected. User will be redirected to an error page with proper error message.
-            	Job.checkForEmptyParameters(jsonProperties);
               t.rebuild(req,jsonProperties,JobPropertyDescriptor.getPropertyDescriptors(Job.this.getClass()));
             } else {
               t.clear();
@@ -1537,18 +1535,4 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     private final static HexStringConfidentialKey SERVER_COOKIE = new HexStringConfidentialKey(Job.class,"serverCookie",16);
-    
-    /**
-     * This handles the situation when Parameterized build checkbox is checked 
-     * but no parameters are selected. User will be redirected to an error page
-     * with proper error message.
-     * @param jsonProperties
-     * @throws FormException 
-     */
-    private static void checkForEmptyParameters(JSONObject jsonProperties) throws FormException{
-        JSONObject parameterDefinitionProperty = jsonProperties.getJSONObject("hudson-model-ParametersDefinitionProperty");
-        if ((parameterDefinitionProperty.getBoolean("specified") == true)&& !parameterDefinitionProperty.has("parameterDefinitions")) {
-		    throw new FormException(Messages.Hudson_NoParamsSpecified(),"parameterDefinitions");
-        }
-    }
 }


### PR DESCRIPTION
Likely fallout from `OptionalJobProperty` introduction in 1.637 (!) a year ago. External monitor job sure is popular.

@jglick says in JENKINS-33991 that there's no guarantee that a `ParametersDefinitionProperty` if present also has at least one parameter, so just rip out this likely obsolete check.