### PR TITLE
[FIX JENKINS-39433] Make URI encoding check into admin monitor

### DIFF
--- a/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
@@ -1,0 +1,42 @@
+package jenkins.diagnostics;
+
+import hudson.Extension;
+import hudson.model.*;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+
+import static hudson.Util.fixEmpty;
+
+@Restricted(NoExternalUse.class)
+@Extension
+public class URICheckEncodingMonitor extends AdministrativeMonitor {
+
+    public boolean isCheckEnabled() {
+        return !"ISO-8859-1".equalsIgnoreCase(System.getProperty("file.encoding"));
+    }
+
+    @Override
+    public boolean isActivated() {
+        return true;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Messages.URICheckEncodingMonitor_DisplayName();
+    }
+
+    public FormValidation doCheckURIEncoding(StaplerRequest request) throws IOException {
+        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        // expected is non-ASCII String
+        final String expected = "\u57f7\u4e8b";
+        final String value = fixEmpty(request.getParameter("value"));
+        if (!expected.equals(value))
+            return FormValidation.warningWithMarkup(hudson.model.Messages.Hudson_NotUsesUTF8ToDecodeURL());
+        return FormValidation.ok();
+    }
+}

--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
@@ -31,6 +31,7 @@ import hudson.model.PageDecorator;
 import hudson.util.HttpResponses;
 import hudson.util.HudsonIsLoading;
 import hudson.util.HudsonIsRestarting;
+import jenkins.diagnostics.URICheckEncodingMonitor;
 import jenkins.model.Jenkins;
 import net.sf.json.JSON;
 import net.sf.json.JSONObject;
@@ -81,6 +82,10 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
         for (AdministrativeMonitor am : ams) {
             if (am instanceof ReverseProxySetupMonitor) {
                 // TODO make reverse proxy monitor work when shown on any URL
+                continue;
+            }
+            if (am instanceof URICheckEncodingMonitor) {
+                // TODO make URI encoding monitor work when shown on any URL
                 continue;
             }
             if (am.isEnabled() && am.isActivated()) {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -33,31 +33,11 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.thoughtworks.xstream.XStream;
-import hudson.BulkChange;
-import hudson.DNSMultiCast;
-import hudson.DescriptorExtensionList;
-import hudson.Extension;
-import hudson.ExtensionComponent;
-import hudson.ExtensionFinder;
-import hudson.ExtensionList;
-import hudson.ExtensionPoint;
-import hudson.FilePath;
-import hudson.Functions;
-import hudson.Launcher;
+import hudson.*;
 import hudson.Launcher.LocalLauncher;
-import hudson.Lookup;
-import hudson.Main;
-import hudson.Plugin;
-import hudson.PluginManager;
-import hudson.PluginWrapper;
-import hudson.ProxyConfiguration;
 import jenkins.AgentProtocol;
+import jenkins.diagnostics.URICheckEncodingMonitor;
 import jenkins.util.SystemProperties;
-import hudson.TcpSlaveAgentListener;
-import hudson.UDPBroadcastThread;
-import hudson.Util;
-import hudson.WebAppMain;
-import hudson.XmlFile;
 import hudson.cli.declarative.CLIMethod;
 import hudson.cli.declarative.CLIResolver;
 import hudson.init.InitMilestone;
@@ -4454,20 +4434,21 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Checks if container uses UTF-8 to decode URLs. See
      * http://wiki.jenkins-ci.org/display/JENKINS/Tomcat#Tomcat-i18n
      */
+    @Restricted(NoExternalUse.class)
+    @RestrictedSince("since TODO")
+    @Deprecated
     public FormValidation doCheckURIEncoding(StaplerRequest request) throws IOException {
-        // expected is non-ASCII String
-        final String expected = "\u57f7\u4e8b";
-        final String value = fixEmpty(request.getParameter("value"));
-        if (!expected.equals(value))
-            return FormValidation.warningWithMarkup(Messages.Hudson_NotUsesUTF8ToDecodeURL());
-        return FormValidation.ok();
+        return ExtensionList.lookup(URICheckEncodingMonitor.class).get(0).doCheckURIEncoding(request);
     }
 
     /**
      * Does not check when system default encoding is "ISO-8859-1".
      */
+    @Restricted(NoExternalUse.class)
+    @RestrictedSince("since TODO")
+    @Deprecated
     public static boolean isCheckURIEncodingEnabled() {
-        return !"ISO-8859-1".equalsIgnoreCase(System.getProperty("file.encoding"));
+        return ExtensionList.lookup(URICheckEncodingMonitor.class).get(0).isCheckEnabled();
     }
 
     /**

--- a/core/src/main/resources/jenkins/diagnostics/Messages.properties
+++ b/core/src/main/resources/jenkins/diagnostics/Messages.properties
@@ -1,2 +1,3 @@
 CompletedInitializationMonitor.DisplayName=Jenkins Initialization Monitor
 SecurityIsOffMonitor.DisplayName=Disabled Security
+URICheckEncodingMonitor.DisplayName=Check URI Encoding

--- a/core/src/main/resources/jenkins/diagnostics/URICheckEncodingMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/URICheckEncodingMonitor/message.jelly
@@ -1,0 +1,16 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <j:if test="${it.checkEnabled}">
+        <script>
+            var url="${rootURL}/${it.url}/checkURIEncoding";
+            var params = {value : '\u57f7\u4e8b'};
+            var checkAjax = new Ajax.Updater(
+                'message', url,
+                {
+                    method: 'get', parameters: params
+                }
+            );
+        </script>
+        <span id="message"></span>
+    </j:if>
+</j:jelly>

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -59,19 +59,6 @@ THE SOFTWARE.
   </j:if>
   <l:main-panel>
     <h1>${%Manage Jenkins}</h1>
-    <j:if test="${it.checkURIEncodingEnabled}">
-      <script>
-        var url='checkURIEncoding';
-        var params= {value : '\u57f7\u4e8b'};
-        var checkAjax=new Ajax.Updater(
-          'message', url,
-          {
-            method: 'get', parameters: params
-          }
-        );
-      </script>
-      <span id="message"></span>
-    </j:if>
 
     <j:forEach var="am" items="${app.administrativeMonitors}">
       <j:if test="${am.isActivated() and am.isEnabled()}">


### PR DESCRIPTION
Basically move the code into an administrative monitor.

Tested manually that sending a different string than expected results in a warning, and that the deprecated code still works as expected despite being obsolete.

The original request in JENKINS-39433 was to be able to disable the check, but the implementation was a hack anyway. Now it's an admin monitor, and can be disabled in Configure System as a side effect.
