### PR TITLE
[FIXED JENKINS-40362] - Update SSHD Core from 0.8.0 to 0.14.0

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -134,7 +134,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
-      <version>1.8</version>
+      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>


### PR DESCRIPTION
Effectively it picks only https://github.com/jenkinsci/sshd-module/pull/8 from @GLundh

In this PR the SSHD Core is being upgraded from a pretty old 0.8.0 to "only" 2-year old 0.14.0. There are newer releases ahead, but we cannot easily upgrade to them since SSHD core 1.x is not binary compatible with the current release line we use.

* Diff: https://github.com/jenkinsci/sshd-module/compare/sshd-1.8...sshd-1.9
* Jenkins issue: https://issues.jenkins-ci.org/browse/JENKINS-40362
* Original issue: https://issues.apache.org/jira/browse/SSHD-330

SSHD Core Changelogs:
* 0.9: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310849&version=12323301
* 0.10.0: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310849&version=12324784 
* 0.10.1: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310849&version=12326289
* 0.11.0: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310849&version=12326277
* 0.12.0: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310849&version=12326775
* 0.13.0: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310849&version=12327342
* 0.14.0: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310849&version=12329012

@jenkinsci/code-reviewers 