### PR TITLE
Do not report -noCertificateCheck warning on STDOUT

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -415,7 +415,7 @@ public class CLI implements AutoCloseable {
                 continue;
             }
             if (head.equals("-noCertificateCheck")) {
-                System.out.println("Skipping HTTPS certificate checks altogether. Note that this is not secure at all.");
+                System.err.println("Skipping HTTPS certificate checks altogether. Note that this is not secure at all.");
                 SSLContext context = SSLContext.getInstance("TLS");
                 context.init(null, new TrustManager[]{new NoCheckTrustManager()}, new SecureRandom());
                 HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());


### PR DESCRIPTION
Extremely impractical for `get-*` commands.