### PR TITLE
[JENKINS-39971] Always display the  recheck button

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -139,18 +139,18 @@ THE SOFTWARE.
           </table>
         </div>
 
-        <j:if test="${!empty(list)}">
-          <div id="bottom-sticker" >
-            <div class="bottom-sticker-inner">
+        <div id="bottom-sticker" >
+          <div class="bottom-sticker-inner">
+            <j:if test="${!empty(list)}">
               <j:if test="${!isUpdates}">
                 <f:submit value="${%Install without restart}" name="dynamicLoad" />
                 <span style="margin-left:2em;"></span>
               </j:if>
               <f:submit value="${%Download now and install after restart}" />
-              <st:include page="check.jelly"/>
+            </j:if>
+            <st:include page="check.jelly"/>
             </div>
           </div>
-        </j:if>
         <d:invokeBody />
       </form>
     </l:main-panel>


### PR DESCRIPTION
The re-check updatecenter button should be visible even if there are
currently no pending updates.

https://issues.jenkins-ci.org/browse/JENKINS-39971