### PR TITLE
[JENKINS-25333] Update to Winstone 3.2 to support Java 8

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -93,7 +93,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>3.1</version>
+      <version>3.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
[JENKINS-25333](https://issues.jenkins-ci.org/browse/JENKINS-25333)

[Changes](https://github.com/jenkinsci/winstone/compare/winstone-3.1...winstone-3.2) mainly https://github.com/jenkinsci/winstone/pull/29.

@reviewbybees