### PR TITLE
[JENKINS-40666] - Correctly state that Jenkins will refuse to load plugins.

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/table.properties
+++ b/core/src/main/resources/hudson/PluginManager/table.properties
@@ -25,13 +25,12 @@ compatWarning=\
  Consult the plugin release notes for details.
 coreWarning=\
  Warning: This plugin is built for Jenkins {0} or newer. \
- It may or may not work in your Jenkins.
+ Jenkins will refuse to load this plugin if installed.
 depCompatWarning=\
  Warning: This plugin requires dependent plugins be upgraded and at least one of these dependent plugins claims to use a different settings format than the installed version. \
  Jobs using that plugin may need to be reconfigured, and/or you may not be able to cleanly revert to the prior version without manually restoring old settings. \
  Consult the plugin release notes for details.
 depCoreWarning=\
- Warning: This plugin requires dependent plugins that are \
- built for Jenkins {0} or newer. The dependent plugins may \
- or may not work in your Jenkins and consequently this \
- plugin may or may not work in your Jenkins.
+ Warning: This plugin requires dependent plugins that require Jenkins {0} or newer. \
+ Jenkins will refuse to load the dependent plugins requiring a newer version of Jenkins, \
+ and in turn loading this plugin will fail.


### PR DESCRIPTION
With [JENKINS-21486](https://issues.jenkins-ci.org/browse/JENKINS-21486), this string needs updating.

We should also reconsider what versioned update site gets delivered to 'in between LTS baselines' releases of Jenkins, but for now, this change is needed in core.