### PR TITLE
[FIXED JENKINS-39835] - Update remoting to 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.3</version>
+        <version>3.4</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Effectively this update picks only one change: https://github.com/jenkinsci/remoting/pull/133

Fixed issues:

* [JENKINS-39835](https://issues.jenkins-ci.org/browse/JENKINS-39835) - Be extra defensive about unhandled `Errors` and `Exception`s. In the case of such issues remoting tries to properly terminate the connection instead of just leaving the hanging channel. ([PR #133](https://github.com/jenkinsci/remoting/pull/133))

All changes: https://github.com/jenkinsci/remoting/compare/remoting-3.3...remoting-3.4

https://issues.jenkins-ci.org/browse/JENKINS-39835