### PR TITLE
[JENKINS-40494] Process warnings from update sites

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -528,7 +528,7 @@ public class UpdateSite {
          *
          * @since TODO
          */
-        public final Set<Warning> warnings = new HashSet<Warning>();
+        private final Set<Warning> warnings = new HashSet<Warning>();
 
         /**
          * If this is non-null, Jenkins is going to check the connectivity to this URL to make sure
@@ -571,6 +571,16 @@ public class UpdateSite {
             }
 
             connectionCheckUrl = (String)o.get("connectionCheckUrl");
+        }
+
+        /**
+         * Returns the set of warnings
+         * @return the set of warnings
+         * @since TODO
+         */
+        @Restricted(NoExternalUse.class)
+        public Set<Warning> getWarnings() {
+            return this.warnings;
         }
 
         /**
@@ -684,6 +694,7 @@ public class UpdateSite {
      *
      * @since TODO
      */
+    @Restricted(NoExternalUse.class)
     public static final class WarningVersionRange {
         /**
          * Human-readable English name for this version range, e.g. 'regular', 'LTS', '2.6 line'.
@@ -736,9 +747,10 @@ public class UpdateSite {
      *
      * @since TODO
      */
+    @Restricted(NoExternalUse.class)
     public static final class Warning {
 
-        private static enum Type {
+        public enum Type {
             CORE,
             PLUGIN,
             UNKNOWN
@@ -748,7 +760,7 @@ public class UpdateSite {
          * The type classifier for this warning.
          */
         @Nonnull
-        private /* final */ Type type;
+        public /* final */ Type type;
 
         /**
          * The globally unique ID of this warning.
@@ -846,24 +858,8 @@ public class UpdateSite {
             return id.hashCode();
         }
 
-        /**
-         * Returns true iff this warning is for Jenkins core
-         * @return true iff this warning is for Jenkins core
-         */
-        public boolean isCoreWarning() {
-            return this.type == Type.CORE;
-        }
-
-        /**
-         * Returns true iff this warning is for a plugin
-         * @return true iff this warning is for a plugin
-         */
-        public boolean isPluginWarning() {
-            return this.type == Type.PLUGIN;
-        }
-
         public boolean isPluginWarning(@Nonnull String pluginName) {
-            return isPluginWarning() && pluginName.equals(this.component);
+            return type == Type.PLUGIN && pluginName.equals(this.component);
         }
 
         /**
@@ -1139,7 +1135,7 @@ public class UpdateSite {
         public Set<Warning> getWarnings() {
             ExtensionList<UpdateSiteWarningsConfiguration> list = ExtensionList.lookup(UpdateSiteWarningsConfiguration.class);
             if (list.size() == 0) {
-                return null;
+                return Collections.emptySet();
             }
 
             Set<Warning> warnings = new HashSet<>();

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
@@ -25,28 +25,29 @@
 package jenkins.security;
 
 import hudson.Extension;
-import hudson.PluginManager;
 import hudson.PluginWrapper;
 import hudson.model.UpdateSite;
-import hudson.util.VersionNumber;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Objects;
 import java.util.Set;
 
+/**
+ * Configuration for update site-provided warnings.
+ *
+ * @see UpdateSiteWarningsMonitor
+ *
+ * @since TODO
+ */
 @Extension
 @Restricted(NoExternalUse.class)
 public class UpdateSiteWarningsConfiguration extends GlobalConfiguration {
@@ -80,7 +81,7 @@ public class UpdateSiteWarningsConfiguration extends GlobalConfiguration {
     }
 
     @Nonnull
-    public Set<UpdateSite.Warning> getApplicableWarnings() {
+    public Set<UpdateSite.Warning> getAllWarnings() {
         HashSet<UpdateSite.Warning> allWarnings = new HashSet<>();
 
         for (UpdateSite site : Jenkins.getInstance().getUpdateCenter().getSites()) {
@@ -89,6 +90,12 @@ public class UpdateSiteWarningsConfiguration extends GlobalConfiguration {
                 allWarnings.addAll(data.warnings);
             }
         }
+        return allWarnings;
+    }
+
+    @Nonnull
+    public Set<UpdateSite.Warning> getApplicableWarnings() {
+        Set<UpdateSite.Warning> allWarnings = getAllWarnings();
 
         HashSet<UpdateSite.Warning> applicableWarnings = new HashSet<>();
         for (UpdateSite.Warning warning: allWarnings) {

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
@@ -1,0 +1,158 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import hudson.Extension;
+import hudson.PluginManager;
+import hudson.PluginWrapper;
+import hudson.model.UpdateSite;
+import hudson.util.VersionNumber;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class UpdateSiteWarningsConfiguration extends GlobalConfiguration {
+
+    private HashSet<String> ignoredWarnings = new HashSet<>();
+
+    @Override
+    public GlobalConfigurationCategory getCategory() {
+        return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
+    }
+
+    @DataBoundConstructor
+    public UpdateSiteWarningsConfiguration() {
+        load();
+    }
+
+    public void ignore(String warningId) {
+        ignoredWarnings.add(warningId);
+        save();
+    }
+
+    public Set<String> getIgnoredWarnings() {
+        return Collections.unmodifiableSet(ignoredWarnings);
+    }
+
+    public boolean isIgnored(UpdateSite.Warning warning) {
+        return getIgnoredWarnings().contains(warning.id);
+    }
+
+    public PluginWrapper getPlugin(UpdateSite.Warning warning) {
+        if (!UpdateSite.Warning.TYPE_PLUGIN.equals(warning.type)) {
+            return null;
+        }
+        return Jenkins.getInstance().getPluginManager().getPlugin(warning.name);
+    }
+
+    public Set<UpdateSite.Warning> getApplicableWarnings() {
+        HashSet<UpdateSite.Warning> warnings = new HashSet<>();
+
+        for (UpdateSite site : Jenkins.getInstance().getUpdateCenter().getSites()) {
+            UpdateSite.Data data = site.getData();
+            if (data != null) {
+                warnings.addAll(data.warnings);
+            }
+        }
+
+        PluginManager pluginManager = Jenkins.getInstance().getPluginManager();
+
+        for (Iterator<UpdateSite.Warning> it = warnings.iterator(); it.hasNext(); ) {
+            UpdateSite.Warning warning = it.next();
+
+            if (UpdateSite.Warning.TYPE_PLUGIN.equals(warning.type)) {
+                PluginWrapper plugin = pluginManager.getPlugin(warning.name);
+
+                if (plugin == null) {
+                    // it's a warning for a plugin that's not installed
+                    it.remove();
+                    continue;
+                }
+
+                // check whether warning is relevant to installed version
+                VersionNumber current = plugin.getVersionNumber();
+                if (!isWarningRelevantToInstalledVersion(warning, current)) {
+                    it.remove();
+                }
+            }
+
+            if (UpdateSite.Warning.TYPE_CORE.equals(warning.type)
+                    && UpdateSite.Warning.NAME_CORE.equals(warning.name)) {
+
+                VersionNumber current = Jenkins.getVersion();
+
+                if (!isWarningRelevantToInstalledVersion(warning, current)) {
+                    it.remove();
+                }
+            }
+        }
+
+        return Collections.unmodifiableSet(warnings);
+    }
+
+    private boolean isWarningRelevantToInstalledVersion(UpdateSite.Warning warning, VersionNumber version) {
+        if (warning.versionRanges.isEmpty()) {
+            // no version ranges specified, so all versions are affected
+            return true;
+        }
+
+        for (UpdateSite.WarningVersionRange range : warning.versionRanges) {
+            if (range.pattern.matcher(version.toString()).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        ignoredWarnings.clear();
+        if (json.has("ignoredWarnings")) {
+            JSONArray warnings = json.optJSONArray("ignoredWarnings");
+            if (warnings != null) {
+                for (int i = 0; i < warnings.size(); i++) {
+                    ignore(warnings.getString(i));
+                }
+            } else {
+                // single item variant of a list thing
+                ignore(json.getString("ignoredWarnings"));
+            }
+        }
+        return true;
+    }
+}

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
@@ -74,7 +74,7 @@ public class UpdateSiteWarningsConfiguration extends GlobalConfiguration {
 
     @CheckForNull
     public PluginWrapper getPlugin(@Nonnull UpdateSite.Warning warning) {
-        if (!warning.isPluginWarning()) {
+        if (warning.type != UpdateSite.Warning.Type.PLUGIN) {
             return null;
         }
         return Jenkins.getInstance().getPluginManager().getPlugin(warning.component);
@@ -87,7 +87,7 @@ public class UpdateSiteWarningsConfiguration extends GlobalConfiguration {
         for (UpdateSite site : Jenkins.getInstance().getUpdateCenter().getSites()) {
             UpdateSite.Data data = site.getData();
             if (data != null) {
-                allWarnings.addAll(data.warnings);
+                allWarnings.addAll(data.getWarnings());
             }
         }
         return allWarnings;

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
@@ -89,7 +89,7 @@ public class UpdateSiteWarningsMonitor extends AdministrativeMonitor {
         List<UpdateSite.Warning> CoreWarnings = new ArrayList<>();
 
         for (UpdateSite.Warning warning : getActiveWarnings()) {
-            if (!warning.isCoreWarning()) {
+            if (warning.type != UpdateSite.Warning.Type.CORE) {
                 // this is not a core warning
                 continue;
             }
@@ -102,7 +102,7 @@ public class UpdateSiteWarningsMonitor extends AdministrativeMonitor {
         Map<PluginWrapper, List<UpdateSite.Warning>> activePluginWarningsByPlugin = new HashMap<>();
 
         for (UpdateSite.Warning warning : getActiveWarnings()) {
-            if (!warning.isPluginWarning()) {
+            if (warning.type != UpdateSite.Warning.Type.PLUGIN) {
                 // this is not a plugin warning
                 continue;
             }

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
@@ -1,0 +1,176 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.PluginWrapper;
+import hudson.model.AdministrativeMonitor;
+import hudson.model.UpdateSite;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * Administrative monitor showing plugin/core warnings published by the configured update site to the user.
+ *
+ * Terminology overview:
+ * - Applicable warnings are those relevant to currently installed components
+ * - Active warnings are those actually shown to users.
+ * - Hidden warnings are those _not_ shown to users due to them being configured to be hidden.
+ * - Inapplicable warnings are those that are not applicable.
+ *
+ * The following sets may be non-empty:
+ * - Intersection of applicable and active
+ * - Intersection of applicable and hidden
+ * - Intersection of hidden and inapplicable (although not really relevant)
+ * - Intersection of inapplicable and neither hidden nor active
+ *
+ * The following sets must necessarily be empty:
+ * - Intersection of applicable and inapplicable
+ * - Intersection of active and hidden
+ * - Intersection of active and inapplicable
+ *
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class UpdateSiteWarningsMonitor extends AdministrativeMonitor {
+    @Override
+    public boolean isActivated() {
+        return !getActiveCoreWarnings().isEmpty() || !getActivePluginWarningsByPlugin().isEmpty();
+    }
+
+    public List<UpdateSite.Warning> getActiveCoreWarnings() {
+        List<UpdateSite.Warning> CoreWarnings = new ArrayList<>();
+
+        for (UpdateSite.Warning warning : getActiveWarnings()) {
+            if (!UpdateSite.Warning.TYPE_CORE.equals(warning.type)
+                    || !UpdateSite.Warning.NAME_CORE.equals(warning.name)) {
+                // this is not a core warning
+                continue;
+            }
+            CoreWarnings.add(warning);
+        }
+        return CoreWarnings;
+    }
+
+    public Map<PluginWrapper, List<UpdateSite.Warning>> getActivePluginWarningsByPlugin() {
+        Map<PluginWrapper, List<UpdateSite.Warning>> activePluginWarningsByPlugin = new HashMap<>();
+
+        for (UpdateSite.Warning warning : getActiveWarnings()) {
+            if (!UpdateSite.Warning.TYPE_PLUGIN.equals(warning.type)) {
+                // this is not a plugin warning
+                continue;
+            }
+
+            String pluginName = warning.name;
+
+            PluginWrapper plugin = Jenkins.getInstance().getPluginManager().getPlugin(pluginName);
+
+            if (!activePluginWarningsByPlugin.containsKey(plugin)) {
+                activePluginWarningsByPlugin.put(plugin, new ArrayList<UpdateSite.Warning>());
+            }
+            activePluginWarningsByPlugin.get(plugin).add(warning);
+        }
+        return activePluginWarningsByPlugin;
+
+    }
+
+    private Set<UpdateSite.Warning> getActiveWarnings() {
+        ExtensionList<UpdateSiteWarningsConfiguration> configurations = ExtensionList.lookup(UpdateSiteWarningsConfiguration.class);
+        if (configurations.isEmpty()) {
+            return Collections.emptySet();
+        }
+        UpdateSiteWarningsConfiguration configuration = configurations.get(0);
+
+        HashSet<UpdateSite.Warning> warnings = new HashSet<>(configuration.getApplicableWarnings());
+
+        for (Iterator<UpdateSite.Warning> it = warnings.iterator(); it.hasNext(); ) {
+            UpdateSite.Warning warning = it.next();
+
+            if (configuration.getIgnoredWarnings().contains(warning.id)) {
+                it.remove();
+            }
+        }
+
+        return Collections.unmodifiableSet(warnings);
+    }
+
+    /**
+     * Redirects the user to the security configuration where they can configure which warnings to show/hide.
+     *
+     * For Stapler use only.
+     *
+     * @param req the request
+     * @param rsp the response
+     * @throws IOException
+     */
+    public void doAct(StaplerRequest req, StaplerResponse rsp, @QueryParameter String fix, @QueryParameter String configure) throws IOException {
+        if (fix != null) {
+            rsp.sendRedirect(req.getContextPath() + "/pluginManager");
+        }
+        if (configure != null) {
+            rsp.sendRedirect(req.getContextPath() + "/configureSecurity");
+        }
+
+        // shouldn't happen
+        rsp.sendRedirect(req.getContextPath());
+    }
+
+    /**
+     * Returns true iff there are applicable but ignored (i.e. hidden) warnings.
+     *
+     * @return true iff there are applicable but ignored (i.e. hidden) warnings.
+     */
+    public boolean hasApplicableHiddenWarnings() {
+        ExtensionList<UpdateSiteWarningsConfiguration> configurations = ExtensionList.lookup(UpdateSiteWarningsConfiguration.class);
+        if (configurations.isEmpty()) {
+            return false;
+        }
+
+        UpdateSiteWarningsConfiguration configuration = configurations.get(0);
+
+        return getActiveWarnings().size() < configuration.getApplicableWarnings().size();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Vulnerable Plugins"; // TODO i18n
+    }
+}

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
@@ -27,7 +27,6 @@ package jenkins.security;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.PluginWrapper;
-import hudson.Util;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.UpdateSite;
 import hudson.util.HttpResponses;
@@ -36,16 +35,12 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -79,6 +74,8 @@ import java.util.Set;
  *   <li>Intersection of active and hidden
  *   <li>Intersection of active and inapplicable
  * </ul>
+ *
+ * @since TODO
  */
 @Extension
 @Restricted(NoExternalUse.class)

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -110,6 +110,15 @@ THE SOFTWARE.
                       <j:if test="${p.isNeededDependenciesForNewerJenkins()}">
                         <div class="compatWarning">${%depCoreWarning(p.getNeededDependenciesRequiredCore().toString())}</div>
                       </j:if>
+                      <j:if test="${p.hasWarnings()}">
+                        <div class="securityWarning">${%securityWarning}
+                          <ul>
+                            <j:forEach var="warning" items="${p.getWarnings()}">
+                              <li><a href="${warning.url}" target="_blank">${warning.message}</a></li>
+                            </j:forEach>
+                          </ul>
+                        </div>
+                      </j:if>
                     </td>
                     <td class="pane"><st:out value="${p.version}" /></td>
                     <j:if test="${isUpdates}">

--- a/core/src/main/resources/hudson/PluginManager/table.properties
+++ b/core/src/main/resources/hudson/PluginManager/table.properties
@@ -34,3 +34,6 @@ depCoreWarning=\
  Warning: This plugin requires dependent plugins that require Jenkins {0} or newer. \
  Jenkins will refuse to load the dependent plugins requiring a newer version of Jenkins, \
  and in turn loading this plugin will fail.
+securityWarning=\
+  Warning: This plugin version may not be safe to use. Please review the following security notices:
+

--- a/core/src/main/resources/jenkins/security/Messages.properties
+++ b/core/src/main/resources/jenkins/security/Messages.properties
@@ -25,3 +25,4 @@ ApiTokenProperty.ChangeToken.TokenIsHidden=Token is hidden
 ApiTokenProperty.ChangeToken.Success=<div>Updated. See the new token in the field above</div>
 ApiTokenProperty.ChangeToken.SuccessHidden=<div>Updated. You need to login as the user to see the token</div>
 RekeySecretAdminMonitor.DisplayName=Re-keying
+UpdateSiteWarningsMonitor.DisplayName=Update Site Warnings

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.groovy
@@ -52,12 +52,12 @@ f.section(title:_("Hidden security warnings")) {
             table(width:"100%") {
 
                 descriptor.applicableWarnings.each { warning ->
-                    if (warning.coreWarning) {
+                    if (warning.type == hudson.model.UpdateSite.Warning.Type.CORE) {
                         printEntry(warning,
                                 _("warning.core", warning.message),
                                 !descriptor.isIgnored(warning))
                     }
-                    if (warning.pluginWarning) {
+                    else if (warning.type == hudson.model.UpdateSite.Warning.Type.PLUGIN) {
                         def plugin = descriptor.getPlugin(warning)
                         printEntry(warning,
                                 _("warning.plugin", plugin.displayName, warning.message),

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.groovy
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security.UpdateSiteWarningsConfiguration
+
+f = namespace(lib.FormTagLib)
+st = namespace("jelly:stapler")
+
+st.adjunct(includes: "jenkins.security.UpdateSiteWarningsConfiguration.style")
+
+def printEntry(warning, title, checked) {
+    f.block {
+        f.checkbox(name: "ignoredWarnings",
+                title: title,
+                checked: checked,
+                class: 'hideWarnings',
+                json: warning.id);
+        div(class: "setting-description") {
+            a(warning.uri, href: warning.uri)
+        }
+    }
+}
+
+f.section(title:_("Hidden security warnings")) {
+
+    f.advanced(title: _("Security warnings"), align:"left") {
+        f.block {
+            // TODO this behavior is crazy unintuitive.
+            text(_("blurb"))
+        }
+        f.entry(title: _("Security warnings"),
+                help: '/descriptorByName/UpdateSiteWarningsConfiguration/help') {
+            table(width:"100%") {
+
+                descriptor.applicableWarnings.each { warning ->
+                    if (warning.type == 'core') {
+                        printEntry(warning,
+                                _("warning.core", warning.message),
+                                descriptor.isIgnored(warning))
+                    }
+                    if (warning.type == 'plugin') {
+                        def plugin = descriptor.getPlugin(warning)
+                        printEntry(warning,
+                                _("warning.plugin", plugin.displayName, warning.message),
+                                descriptor.isIgnored(warning))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.groovy
@@ -31,13 +31,12 @@ st.adjunct(includes: "jenkins.security.UpdateSiteWarningsConfiguration.style")
 
 def printEntry(warning, title, checked) {
     f.block {
-        f.checkbox(name: "ignoredWarnings",
+        f.checkbox(name: warning.id,
                 title: title,
                 checked: checked,
-                class: 'hideWarnings',
-                json: warning.id);
+                class: 'hideWarnings');
         div(class: "setting-description") {
-            a(warning.uri, href: warning.uri)
+            a(warning.url, href: warning.url)
         }
     }
 }
@@ -46,7 +45,6 @@ f.section(title:_("Hidden security warnings")) {
 
     f.advanced(title: _("Security warnings"), align:"left") {
         f.block {
-            // TODO this behavior is crazy unintuitive.
             text(_("blurb"))
         }
         f.entry(title: _("Security warnings"),
@@ -54,16 +52,16 @@ f.section(title:_("Hidden security warnings")) {
             table(width:"100%") {
 
                 descriptor.applicableWarnings.each { warning ->
-                    if (warning.type == 'core') {
+                    if (warning.coreWarning) {
                         printEntry(warning,
                                 _("warning.core", warning.message),
-                                descriptor.isIgnored(warning))
+                                !descriptor.isIgnored(warning))
                     }
-                    if (warning.type == 'plugin') {
+                    if (warning.pluginWarning) {
                         def plugin = descriptor.getPlugin(warning)
                         printEntry(warning,
                                 _("warning.plugin", plugin.displayName, warning.message),
-                                descriptor.isIgnored(warning))
+                                !descriptor.isIgnored(warning))
                     }
                 }
             }

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.properties
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.properties
@@ -1,0 +1,27 @@
+# The MIT License
+#
+# Copyright (c) 2016, CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+warning.core = Jenkins core: {0}
+warning.plugin = {0}: {1} 
+
+blurb = This section allows you to disable warnings published on the update site. \
+  Checked warnings are hidden, unchecked warnings are shown.

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.properties
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.properties
@@ -24,4 +24,4 @@ warning.core = Jenkins core: {0}
 warning.plugin = {0}: {1} 
 
 blurb = This section allows you to disable warnings published on the update site. \
-  Checked warnings are hidden, unchecked warnings are shown.
+  Checked warnings are visible (the default), unchecked warnings are hidden.

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/help.html
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/help.html
@@ -1,0 +1,14 @@
+<p>
+    This list contains all warnings relevant to currently installed components published by the configured update sites.
+    These are typically security-related.
+    Warnings that have been published but are not relevant to currently installed components (either because the affected component isn't installed, or an unaffected version is installed) are not shown here.
+</p>
+<p>
+    Unchecked entries (the default) are <em>active</em>, i.e. they're shown to administrators in an administrative monitor.
+    Entries can be checked to hide them.
+    This can be useful if you've evaluated a specific warning and are confident it does not apply to your environment or configuration, and continued use of the specified component does not constitute a security problem.
+</p>
+<p>
+    Please note that only specific warnings can be disabled; it is not possible to disable all warnings about a certain component.
+    If you wish to disable the display of warnings entirely, then you can do so in <em>Configure System</em>.
+</p>

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/help.html
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/help.html
@@ -4,11 +4,11 @@
     Warnings that have been published but are not relevant to currently installed components (either because the affected component isn't installed, or an unaffected version is installed) are not shown here.
 </p>
 <p>
-    Unchecked entries (the default) are <em>active</em>, i.e. they're shown to administrators in an administrative monitor.
-    Entries can be checked to hide them.
+    Checked entries (the default) are <em>active</em>, i.e. they're shown to administrators in an administrative monitor.
+    Entries can be unchecked to hide them.
     This can be useful if you've evaluated a specific warning and are confident it does not apply to your environment or configuration, and continued use of the specified component does not constitute a security problem.
 </p>
 <p>
     Please note that only specific warnings can be disabled; it is not possible to disable all warnings about a certain component.
-    If you wish to disable the display of warnings entirely, then you can do so in <em>Configure System</em>.
+    If you wish to disable the display of warnings entirely, then you can disable the administrative monitor in <em>Configure System</em>.
 </p>

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/style.css
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/style.css
@@ -1,0 +1,9 @@
+.hideWarnings:checked + label {
+  color: grey;
+  text-decoration: line-through;
+}
+/*
+.hideWarnings:checked ~ div a {
+  color: grey;
+}
+*/

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/style.css
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/style.css
@@ -1,9 +1,4 @@
-.hideWarnings:checked + label {
+.hideWarnings:not(:checked) + label {
   color: grey;
   text-decoration: line-through;
 }
-/*
-.hideWarnings:checked ~ div a {
-  color: grey;
-}
-*/

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
@@ -29,7 +29,7 @@ def f = namespace(lib.FormTagLib)
 def listWarnings(warnings) {
     warnings.each { warning ->
         li {
-            a(warning.message, href: warning.uri)
+            a(warning.message, href: warning.url)
         }
     }
 }
@@ -67,7 +67,7 @@ div(class: "error") {
     }
 }
 
-form(method: "post", action: "${rootURL}/${it.url}/act") {
+form(method: "post", action: "${rootURL}/${it.url}/forward") {
     div {
         if (!pluginWarnings.isEmpty()) {
             f.submit(name: 'fix', value: _("pluginManager.link"))

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security.UpdateSiteWarningsMonitor
+
+def f = namespace(lib.FormTagLib)
+
+def listWarnings(warnings) {
+    warnings.each { warning ->
+        li {
+            a(warning.message, href: warning.uri)
+        }
+    }
+}
+
+def coreWarnings = my.activeCoreWarnings
+def pluginWarnings = my.activePluginWarningsByPlugin
+
+div(class: "error") {
+    text(_("blurb"))
+    ul {
+        if (!coreWarnings.isEmpty()) {
+            li {
+                text(_("coreTitle", jenkins.model.Jenkins.version))
+                ul {
+                    listWarnings(coreWarnings)
+                }
+            }
+        }
+
+        if (!pluginWarnings.isEmpty()) {
+            li {
+                pluginWarnings.each { plugin, warnings ->
+                    a(_("pluginTitle", plugin.displayName, plugin.version), href: plugin.url)
+
+                    ul {
+                        listWarnings(warnings)
+                    }
+                }
+            }
+        }
+    }
+
+    if (my.hasApplicableHiddenWarnings()) {
+        text(_("more"))
+    }
+}
+
+form(method: "post", action: "${rootURL}/${it.url}/act") {
+    div {
+        if (!pluginWarnings.isEmpty()) {
+            f.submit(name: 'fix', value: _("pluginManager.link"))
+        }
+        f.submit(name: 'configure', value: _("configureSecurity.link"))
+    }
+}

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.properties
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.properties
@@ -1,0 +1,31 @@
+# The MIT License
+#
+# Copyright (c) 2016, CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+pluginTitle = {0} {1}:
+coreTitle = Jenkins {0} core and libraries:
+
+blurb = Warnings have been published for the following currently installed components:
+more = Additional warnings are hidden due to the current security configuration.
+
+
+pluginManager.link = Go to plugin manager
+configureSecurity.link = Configure which of these warnings are shown

--- a/test/src/test/java/hudson/model/UpdateSiteTest.java
+++ b/test/src/test/java/hudson/model/UpdateSiteTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 
 import javax.servlet.ServletException;
@@ -41,6 +42,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.junit.Assert.*;
 
+import jenkins.security.UpdateSiteWarningsConfiguration;
+import jenkins.security.UpdateSiteWarningsMonitor;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
@@ -52,6 +55,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 public class UpdateSiteTest {
 
@@ -127,5 +131,24 @@ public class UpdateSiteTest {
         assertEquals(FormValidation.ok(), us.updateDirectly(/* TODO the certificate is now expired, and downloading a fresh copy did not seem to help */false).get());
         assertNotNull(us.getPlugin("AdaptivePlugin"));
     }
-    
+
+    @Test public void lackOfDataDoesNotFailWarningsCode() throws Exception {
+        assertNull("plugin data is not present", j.jenkins.getUpdateCenter().getSite("default").getData());
+
+        // nothing breaking?
+        j.jenkins.getExtensionList(UpdateSiteWarningsMonitor.class).get(0).getActivePluginWarningsByPlugin();
+        j.jenkins.getExtensionList(UpdateSiteWarningsMonitor.class).get(0).getActiveCoreWarnings();
+        j.jenkins.getExtensionList(UpdateSiteWarningsConfiguration.class).get(0).getAllWarnings();
+    }
+
+    @Test public void incompleteWarningsJson() throws Exception {
+        PersistedList<UpdateSite> sites = j.jenkins.getUpdateCenter().getSites();
+        sites.clear();
+        URL url = new URL(baseUrl, "/plugins/warnings-update-center-malformed.json");
+        UpdateSite site = new UpdateSite(UpdateCenter.ID_DEFAULT, url.toString());
+        sites.add(site);
+        assertEquals(FormValidation.ok(), site.updateDirectly(false).get());
+        assertEquals("number of warnings", 7, site.getData().warnings.size());
+        assertNotEquals("plugin data is present", Collections.emptyMap(), site.getData().plugins);
+    }
 }

--- a/test/src/test/java/hudson/model/UpdateSiteTest.java
+++ b/test/src/test/java/hudson/model/UpdateSiteTest.java
@@ -148,7 +148,7 @@ public class UpdateSiteTest {
         UpdateSite site = new UpdateSite(UpdateCenter.ID_DEFAULT, url.toString());
         sites.add(site);
         assertEquals(FormValidation.ok(), site.updateDirectly(false).get());
-        assertEquals("number of warnings", 7, site.getData().warnings.size());
+        assertEquals("number of warnings", 7, site.getData().getWarnings().size());
         assertNotEquals("plugin data is present", Collections.emptyMap(), site.getData().plugins);
     }
 }

--- a/test/src/test/resources/plugins/warnings-update-center-malformed.json
+++ b/test/src/test/resources/plugins/warnings-update-center-malformed.json
@@ -1,0 +1,264 @@
+{
+  "connectionCheckUrl": "http://www.google.com/",
+  "core": {
+    "buildDate": "Dec 18, 2016",
+    "name": "core",
+    "sha1": "x4rDgtNYm9l7zJ16RVuxMRgGoQE=",
+    "url": "http://updates.jenkins-ci.org/download/war/2.37/jenkins.war",
+    "version": "2.37"
+  },
+  "id": "jenkins40494",
+  "plugins": {
+    "display-url-api": {
+      "buildDate": "Sep 22, 2016",
+      "dependencies": [
+        {
+          "name": "junit",
+          "optional": false,
+          "version": "1.3"
+        }
+      ],
+      "developers": [
+        {
+          "developerId": "jdumay",
+          "email": "jdumay@cloudbees.com",
+          "name": "James Dumay"
+        }
+      ],
+      "excerpt": "\\\\  Provides the DisplayURLProvider extension point to provide alternate URLs for use in notifications.  URLs can be requested/extended for these UI locations:  * Root page. * Job. * Run. * Run changes. * Test result.  ",
+      "gav": "org.jenkins-ci.plugins:display-url-api:0.5",
+      "labels": [],
+      "name": "display-url-api",
+      "previousTimestamp": "2016-09-22T09:35:08.00Z",
+      "previousVersion": "0.4",
+      "releaseTimestamp": "2016-09-22T10:42:00.00Z",
+      "requiredCore": "1.625.3",
+      "scm": "github.com",
+      "sha1": "QEykyLSFuZTnFyHrzZEOgzSsYcU=",
+      "title": "Display URL API",
+      "url": "http://updates.jenkins-ci.org/download/plugins/display-url-api/0.5/display-url-api.hpi",
+      "version": "0.5",
+      "wiki": "https://wiki.jenkins-ci.org/display/JENKINS/Display+URL+API+Plugin"
+    },
+    "junit": {
+      "buildDate": "Oct 17, 2016",
+      "dependencies": [
+        {
+          "name": "structs",
+          "optional": false,
+          "version": "1.2"
+        }
+      ],
+      "developers": [
+        {
+          "developerId": "ogondza"
+        }
+      ],
+      "excerpt": "Allows JUnit-format test results to be published.",
+      "gav": "org.jenkins-ci.plugins:junit:1.19",
+      "labels": [
+        "report"
+      ],
+      "name": "junit",
+      "previousTimestamp": "2016-08-08T15:10:34.00Z",
+      "previousVersion": "1.18",
+      "releaseTimestamp": "2016-10-17T12:15:20.00Z",
+      "requiredCore": "1.580.1",
+      "scm": "github.com",
+      "sha1": "f3jcYlxz6/8PK43W3KL5LFtz7ro=",
+      "title": "JUnit Plugin",
+      "url": "http://updates.jenkins-ci.org/download/plugins/junit/1.19/junit.hpi",
+      "version": "1.19",
+      "wiki": "https://wiki.jenkins-ci.org/display/JENKINS/JUnit+Plugin"
+    },
+    "mailer": {
+      "buildDate": "Sep 04, 2016",
+      "dependencies": [
+        {
+          "name": "display-url-api",
+          "optional": false,
+          "version": "0.2"
+        }
+      ],
+      "developers": [
+        {
+          "developerId": "andresrc"
+        }
+      ],
+      "excerpt": "This plugin allows you to configure email notifications for build results. This is a break-out of the original core based email component. ",
+      "gav": "org.jenkins-ci.plugins:mailer:1.18",
+      "labels": [],
+      "name": "mailer",
+      "previousTimestamp": "2016-04-20T08:46:22.00Z",
+      "previousVersion": "1.17",
+      "releaseTimestamp": "2016-09-04T09:14:16.00Z",
+      "requiredCore": "1.625.3",
+      "scm": "github.com",
+      "sha1": "poG1EauZFM5lZE5hCBx5mqr/mMA=",
+      "title": "Jenkins Mailer Plugin",
+      "url": "http://updates.jenkins-ci.org/download/plugins/mailer/1.18/mailer.hpi",
+      "version": "1.18",
+      "wiki": "https://wiki.jenkins-ci.org/display/JENKINS/Mailer"
+    },
+    "extra-columns": {
+      "buildDate": "Apr 11, 2016",
+      "dependencies": [
+        {
+          "name": "junit",
+          "optional": false,
+          "version": "1.11"
+        }
+      ],
+      "developers": [
+        {
+          "developerId": "fredg",
+          "name": "Fred G."
+        }
+      ],
+      "excerpt": "This is a general listview-column plugin that currently contains the following columns: Test Result, Configure Project button, Disable/Enable Project button, Project Description, Build Description, SCM Type, Last/Current Build Console output, Job Type, Build Duration, Build Parameters.",
+      "gav": "org.jenkins-ci.plugins:extra-columns:1.17",
+      "labels": [
+        "listview-column"
+      ],
+      "name": "extra-columns",
+      "previousTimestamp": "2015-12-11T01:18:48.00Z",
+      "previousVersion": "1.16",
+      "releaseTimestamp": "2016-04-11T22:36:22.00Z",
+      "requiredCore": "1.475",
+      "scm": "github.com",
+      "sha1": "8y9Y91n7/Aw47G3pCxzJzTd94J0=",
+      "title": "Extra Columns Plugin",
+      "url": "http://updates.jenkins-ci.org/download/plugins/extra-columns/1.17/extra-columns.hpi",
+      "version": "1.17",
+      "wiki": "https://wiki.jenkins-ci.org/display/JENKINS/Extra+Columns+Plugin"
+    },
+    "structs": {
+      "buildDate": "Aug 30, 2016",
+      "dependencies": [],
+      "developers": [
+        {
+          "developerId": "jglick"
+        }
+      ],
+      "excerpt": "Library plugin for DSL plugins that need concise names for Jenkins extensions",
+      "gav": "org.jenkins-ci.plugins:structs:1.5",
+      "labels": [],
+      "name": "structs",
+      "previousTimestamp": "2016-08-26T14:11:44.00Z",
+      "previousVersion": "1.4",
+      "releaseTimestamp": "2016-08-30T14:10:10.00Z",
+      "requiredCore": "1.580.1",
+      "scm": "github.com",
+      "sha1": "fK+F0PEfSS//DOqmNJvX2rQYabo=",
+      "title": "Structs Plugin",
+      "url": "http://updates.jenkins-ci.org/download/plugins/structs/1.5/structs.hpi",
+      "version": "1.5",
+      "wiki": "https://wiki.jenkins-ci.org/display/JENKINS/Structs+plugin"
+    }
+  },
+  "warnings": [
+    {
+      "id": "SECURITY-208",
+      "type": "plugin",
+      "name": "google-login",
+      "message": "Authentication bypass vulnerability",
+      "url": "https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2015-10-12",
+      "versions": [
+        {
+          "lastVersion": "1.1",
+          "pattern": "1[.][01](|[.-].*)"
+        }
+      ]
+    },
+    {
+      "id": "SECURITY-136",
+      "type": "plugin",
+      "name": "extra-columns",
+      "message": "Stored XSS vulnerability",
+      "url": "https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-04-11",
+      "versions": [
+        {
+          "lastVersion": "1.16",
+          "pattern": "1[.](\\d|1[0123456])(|[.-].*)"
+        }
+      ]
+    },
+    {
+      "id": "SECURITY-258",
+      "type": "plugin",
+      "name": "extra-columns",
+      "message": "Groovy sandbox protection incomplete",
+      "url": "https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-04-11",
+      "versions": [
+        {
+          "lastVersion": "1.18",
+          "pattern": "1[.](\\d|1[012345678])(|[.-].*)"
+        }
+      ]
+    },
+    {
+      "id": "SECURITY-85",
+      "type": "plugin",
+      "name": "tap",
+      "message": "Path traversal vulnerability",
+      "url": "https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-06-20",
+      "versions": [
+        {
+          "lastVersion": "1.24",
+          "pattern": "1[.](\\d|1\\d|2[01234])(|[.-].*)"
+        }
+      ]
+    },
+    {
+      "id": "SECURITY-278",
+      "type": "plugin",
+      "name": "image-gallery",
+      "message": "Path traversal vulnerability",
+      "url": "https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-06-20",
+      "versions": [
+        {
+          "lastVersion": "1.3",
+          "pattern": "(0[.].*|1[.][0123])(|[.-].*)"
+        }
+      ]
+    },
+    {
+      "id": "SECURITY-290",
+      "type": "plugin",
+      "name": "build-failure-analyzer",
+      "message": "Cross-site scripting vulnerability",
+      "url": "https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-06-20",
+      "versions": [
+        {
+          "lastVersion": "1.15.0",
+          "pattern": "1[.](\\d|1[012345])[.]\\d+(|[.-].*)"
+        }
+      ]
+    },
+    {
+      "id": "SECURITY-305",
+      "type": "plugin",
+      "versions": [
+        {
+          "lastVersion": "1.7.24",
+          "pattern": "1[.]7[.](\\d(|[.-].*)|24)"
+        }
+      ]
+    },
+    {
+      "id": "SECURITY-309",
+      "type": "plugin",
+      "name": "cucumber-reports",
+      "message": "Plugin disables Content-Security-Policy for files served by Jenkins",
+      "url": "https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-07-27",
+      "versions": [
+        {
+          "firstVersion": "1.3.0",
+          "lastVersion": "2.5.1",
+          "pattern": "(1[.][34]|2[.][012345])(|[.-].*)"
+        }
+      ]
+    }
+  ],
+  "updateCenterVersion": "1"
+}

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1580,6 +1580,13 @@ TEXTAREA.rich-editor {
     color: #FF0000;
 }
 
+#plugins .securityWarning {
+    white-space: normal;
+    margin-top: 0.5em;
+    padding-left: 2em;
+    color: #FF0000;
+}
+
 /* ========================= progress bar ========================= */
 
 table.progress-bar {


### PR DESCRIPTION
- [x] Process warnings from update sites
- [x] Administrative monitor in case of applicable warnings
- [x] Allow hiding specific warnings
- [x] Flexible version matching using regular expressions
- [x] Show in 'Updates' tab of plugin manager (available version affected)
- [x] Show in 'Available' tab of plugin manager (available version affected)
- [x] Link to corresponding PR in backend-update-center2: https://github.com/jenkinsci/backend-update-center2/pull/96
- <s>Check new/updated dependencies of updates/available</s>
- <s>Show in 'Installed' tab of plugin manager (installed version affected, also dependencies)</s>


Sample `update-center.json` content for this (excerpt; see backend-update-center2 PR for real data):

```json
{
  "connectionCheckUrl": "http://www.google.com/",
  "core": {
    "buildDate": "Dec 18, 2016",
    "name": "core",
    "sha1": "x4rDgtNYm9l7zJ16RVuxMRgGoQE=",
    "url": "http://updates.jenkins-ci.org/download/war/2.37/jenkins.war",
    "version": "2.37"
  },
  "warnings": [
    {
      "id": "SECURITY-238",
      "type": "core",
      "name": "core",
      "message": "HTTP response splitting vulnerability",
      "uri": "https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-02-24",
      "versions": [
        {
          "lastVersion": "2.40",
          "pattern": "1[.].*|2[.](\\d|[123]\\d|40)(|[.-].*)"
        }
      ]
    },
    {
      "id": "20181106-0day",
      "type": "core",
      "name": "core",
      "message": "0-day remote code execution vulnerability",
      "uri": "https://jenkins.io/blog/2018-11-06-0-day-vulnerability"
    },
    {
      "id": "structs-1",
      "type": "plugin",
      "name": "structs",
      "message": "Cross-site scripting vulnerability",
      "uri": "https://google.com",
      "versions": [
        {
          "lastVersion": "2.0",
          "pattern": "[01][.].*|2[.]0(|[.-].*)"
        }
      ]
    }
  ],
…
```

(Entries are of course fake / adapted to show up in current development builds)

Screen shots (all content fake):

> <img width="821" alt="screen shot 2016-12-26 at 13 49 35" src="https://cloud.githubusercontent.com/assets/1831569/21482361/4ff903c8-cb73-11e6-9306-d7781e4b6aca.png">

> <img width="617" alt="screen shot 2016-12-26 at 13 51 46" src="https://cloud.githubusercontent.com/assets/1831569/21482364/55ee7dc6-cb73-11e6-8a36-f29f183af2a1.png">

@jenkinsci/code-reviewers @reviewbybees