### PR TITLE
[JENKINS-40718] Search by build params in build history widget

### DIFF
--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -31,6 +31,7 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.Queue;
 import hudson.model.Run;
+import hudson.search.UserSearchProperty;
 import hudson.widgets.HistoryWidget;
 
 import javax.annotation.Nonnull;
@@ -365,15 +366,19 @@ public class HistoryPageFilter<T> {
             return true;
         }
 
-        if (data != null) {
-            if (data instanceof Number) {
-                return data.toString().equals(searchString);
-            } else {
-                return data.toString().toLowerCase().contains(searchString.toLowerCase());
-            }
+        if (data == null) {
+            return false;
         }
 
-        return false;
+        if (data instanceof Number) {
+            return data.toString().equals(searchString);
+        } else {
+            if (UserSearchProperty.isCaseInsensitive()) {
+                return data.toString().toLowerCase().contains(searchString.toLowerCase());
+            } else {
+                return data.toString().contains(searchString);
+            }
+        }
     }
 
     private boolean fitsSearchBuildVariables(AbstractBuild<?, ?> runAsBuild) {

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -25,6 +25,7 @@ package jenkins.widgets;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
+import hudson.model.Build;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Run;
@@ -37,6 +38,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * History page filter.
@@ -343,6 +345,10 @@ public class HistoryPageFilter<T> {
             return true;
         } else if (fitsSearchString(run.getResult())) {
             return true;
+        } else if (run instanceof Build) {
+            if (fitsSearchBuild((Build) run)) {
+                return true;
+            }
         }
         
         // Non of the fuzzy matches "liked" the search term. 
@@ -361,7 +367,17 @@ public class HistoryPageFilter<T> {
                 return data.toString().toLowerCase().contains(searchString);
             }
         }
-        
+
         return false;
-    }    
+    }
+
+    private boolean fitsSearchBuild(Build runAsBuild) {
+        Map buildVariables = runAsBuild.getBuildVariables();
+        for (Object paramsValues : buildVariables.values()) {
+            if (fitsSearchString(paramsValues)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -27,6 +27,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import hudson.model.AbstractBuild;
 import hudson.model.Job;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
 import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.widgets.HistoryWidget;
@@ -345,8 +347,11 @@ public class HistoryPageFilter<T> {
             return true;
         } else if (fitsSearchString(run.getResult())) {
             return true;
-        } else if (run instanceof AbstractBuild) {
-            if (fitsSearchBuild((AbstractBuild) run)) {
+        } else if (run instanceof AbstractBuild && fitsSearchBuildVariables((AbstractBuild) run)) {
+            return true;
+        } else {
+            ParametersAction parametersAction = run.getAction(ParametersAction.class);
+            if (parametersAction != null && fitsSearchBuildParameters(parametersAction)) {
                 return true;
             }
         }
@@ -371,10 +376,22 @@ public class HistoryPageFilter<T> {
         return false;
     }
 
-    private boolean fitsSearchBuild(AbstractBuild runAsBuild) {
+    private boolean fitsSearchBuildVariables(AbstractBuild runAsBuild) {
         Map buildVariables = runAsBuild.getBuildVariables();
+        //TODO: Add isSensitive filtering
         for (Object paramsValues : buildVariables.values()) {
             if (fitsSearchString(paramsValues)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean fitsSearchBuildParameters(ParametersAction parametersAction) {
+        List<ParameterValue> parameters = parametersAction.getParameters();
+        //TODO: Add isSensitive filtering
+        for (ParameterValue parameter : parameters) {
+            if (fitsSearchString(parameter.getValue())) {
                 return true;
             }
         }

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -54,8 +54,8 @@ public class HistoryPageFilter<T> {
 
     // Need to use different Lists for Queue.Items and Runs because
     // we need access to them separately in the jelly files for rendering.
-    public final List<HistoryPageEntry<Queue.Item>> queueItems = new ArrayList<HistoryPageEntry<Queue.Item>>();
-    public final List<HistoryPageEntry<Run>> runs = new ArrayList<HistoryPageEntry<Run>>();
+    public final List<HistoryPageEntry<Queue.Item>> queueItems = new ArrayList<>();
+    public final List<HistoryPageEntry<Run>> runs = new ArrayList<>();
 
     public boolean hasUpPage = false; // there are newer builds than on this page
     public boolean hasDownPage = false; // there are older builds than on this page

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -25,7 +25,7 @@ package jenkins.widgets;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import hudson.model.Build;
+import hudson.model.AbstractBuild;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Run;
@@ -345,8 +345,8 @@ public class HistoryPageFilter<T> {
             return true;
         } else if (fitsSearchString(run.getResult())) {
             return true;
-        } else if (run instanceof Build) {
-            if (fitsSearchBuild((Build) run)) {
+        } else if (run instanceof AbstractBuild) {
+            if (fitsSearchBuild((AbstractBuild) run)) {
                 return true;
             }
         }
@@ -371,7 +371,7 @@ public class HistoryPageFilter<T> {
         return false;
     }
 
-    private boolean fitsSearchBuild(Build runAsBuild) {
+    private boolean fitsSearchBuild(AbstractBuild runAsBuild) {
         Map buildVariables = runAsBuild.getBuildVariables();
         for (Object paramsValues : buildVariables.values()) {
             if (fitsSearchString(paramsValues)) {

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -364,7 +364,7 @@ public class HistoryPageFilter<T> {
             if (data instanceof Number) {
                 return data.toString().equals(searchString);
             } else {
-                return data.toString().toLowerCase().contains(searchString);
+                return data.toString().toLowerCase().contains(searchString.toLowerCase());
             }
         }
 

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -376,10 +376,9 @@ public class HistoryPageFilter<T> {
         return false;
     }
 
-    private boolean fitsSearchBuildVariables(AbstractBuild runAsBuild) {
-        Map buildVariables = runAsBuild.getBuildVariables();
-        //TODO: Add isSensitive filtering
-        for (Object paramsValues : buildVariables.values()) {
+    private boolean fitsSearchBuildVariables(AbstractBuild<?, ?> runAsBuild) {
+        Map<String, String> buildVariables = runAsBuild.getBuildVariables();
+        for (String paramsValues : buildVariables.values()) {
             if (fitsSearchString(paramsValues)) {
                 return true;
             }
@@ -389,9 +388,8 @@ public class HistoryPageFilter<T> {
 
     private boolean fitsSearchBuildParameters(ParametersAction parametersAction) {
         List<ParameterValue> parameters = parametersAction.getParameters();
-        //TODO: Add isSensitive filtering
         for (ParameterValue parameter : parameters) {
-            if (fitsSearchString(parameter.getValue())) {
+            if (!parameter.isSensitive() && fitsSearchString(parameter.getValue())) {
                 return true;
             }
         }

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -335,11 +335,28 @@ public class HistoryPageFilterTest {
     }
 
     @Test
+    public void test_case_insensitivity_in_search_runs() throws IOException {
+        //given
+        HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
+        List<ModelObject> runs = Lists.<ModelObject>newArrayList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
+        List<Queue.Item> queueItems = newQueueItems(3, 4);
+        //and
+        historyPageFilter.setSearchString("FAILure");
+
+        //when
+        historyPageFilter.add(runs, queueItems);
+
+        //then
+        Assert.assertEquals(1, historyPageFilter.runs.size());
+        Assert.assertEquals(HistoryPageEntry.getEntryId(2), historyPageFilter.runs.get(0).getEntryId());
+    }
+
+    @Test
     public void test_search_builds_by_build_params() throws IOException {
         //given
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
         //and
-        historyPageFilter.setSearchString("dummyenv");
+        historyPageFilter.setSearchString("dummyEnv");
         //and
         List<ModelObject> runs = new ArrayList<>();
         runs.add(new MockBuild(2, ImmutableMap.of("env", "dummyEnv")));

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -343,92 +343,49 @@ public class HistoryPageFilterTest {
     @Test
     @Ignore //User with insensitiveSearch enabled needs to be injected
     public void test_search_runs_by_build_result() throws IOException {
-        //given
         //TODO: Set user with insensitiveSearch enabled
-        HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
-        //and
-        historyPageFilter.setSearchString("failure");
-        //and
-        List<ModelObject> runs = Lists.<ModelObject>newArrayList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
-        List<Queue.Item> queueItems = newQueueItems(3, 4);
-
-        //when
-        historyPageFilter.add(runs, queueItems);
-
-        //then
-        Assert.assertEquals(1, historyPageFilter.runs.size());
-        Assert.assertEquals(HistoryPageEntry.getEntryId(2), historyPageFilter.runs.get(0).getEntryId());
+        List<ModelObject> runs = ImmutableList.<ModelObject>of(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
+        assertOneMatchingBuildForGivenSearchStringAndRunItems("failure", runs);
     }
 
     @Test
     @Ignore //User with insensitiveSearch enabled needs to be injected
     public void test_case_insensitivity_in_search_runs() throws IOException {
-        //given
         //TODO: Set user with insensitiveSearch enabled
-        HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
-        List<ModelObject> runs = Lists.<ModelObject>newArrayList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
-        List<Queue.Item> queueItems = newQueueItems(3, 4);
-        //and
-        historyPageFilter.setSearchString("FAILure");
-
-        //when
-        historyPageFilter.add(runs, queueItems);
-
-        //then
-        Assert.assertEquals(1, historyPageFilter.runs.size());
-        Assert.assertEquals(HistoryPageEntry.getEntryId(2), historyPageFilter.runs.get(0).getEntryId());
+        List<ModelObject> runs = ImmutableList.<ModelObject>of(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
+        assertOneMatchingBuildForGivenSearchStringAndRunItems("FAILure", runs);
     }
 
     @Test
     public void test_search_builds_by_build_variables() throws IOException {
-        //given
-        HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
-        //and
-        historyPageFilter.setSearchString("dummyEnv");
-        //and
-        List<ModelObject> runs = new ArrayList<>();
-        runs.add(new MockBuild(2).withBuildVariables(ImmutableMap.of("env", "dummyEnv")));
-        runs.add(new MockBuild(1).withBuildVariables(ImmutableMap.of("env", "otherEnv")));
-        List<Queue.Item> queueItems = newQueueItems(3, 4);
-
-        //when
-        historyPageFilter.add(runs, queueItems);
-
-        //then
-        Assert.assertEquals(1, historyPageFilter.runs.size());
-        Assert.assertEquals(HistoryPageEntry.getEntryId(2), historyPageFilter.runs.get(0).getEntryId());
+        List<ModelObject> runs = ImmutableList.<ModelObject>of(
+                new MockBuild(2).withBuildVariables(ImmutableMap.of("env", "dummyEnv")),
+                new MockBuild(1).withBuildVariables(ImmutableMap.of("env", "otherEnv")));
+        assertOneMatchingBuildForGivenSearchStringAndRunItems("dummyEnv", runs);
     }
 
     @Test
     public void test_search_builds_by_build_params() throws IOException {
-        //given
-        HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
-        //and
-        historyPageFilter.setSearchString("dummyEnv");
-        //and
-        List<ModelObject> runs = new ArrayList<>();
-        runs.add(new MockBuild(2).withBuildParameters(ImmutableMap.of("env", "dummyEnv")));
-        runs.add(new MockBuild(1).withBuildParameters(ImmutableMap.of("env", "otherEnv")));
-        List<Queue.Item> queueItems = newQueueItems(3, 4);
-
-        //when
-        historyPageFilter.add(runs, queueItems);
-
-        //then
-        Assert.assertEquals(1, historyPageFilter.runs.size());
-        Assert.assertEquals(HistoryPageEntry.getEntryId(2), historyPageFilter.runs.get(0).getEntryId());
+        List<ModelObject> runs = ImmutableList.<ModelObject>of(
+                new MockBuild(2).withBuildParameters(ImmutableMap.of("env", "dummyEnv")),
+                new MockBuild(1).withBuildParameters(ImmutableMap.of("env", "otherEnv")));
+        assertOneMatchingBuildForGivenSearchStringAndRunItems("dummyEnv", runs);
     }
 
     @Test
     public void test_ignore_sensitive_parameters_in_search_builds_by_build_params() throws IOException {
+        List<ModelObject> runs = ImmutableList.<ModelObject>of(
+                new MockBuild(2).withBuildParameters(ImmutableMap.of("plainPassword", "pass1plain")),
+                new MockBuild(1).withSensitiveBuildParameters("password", "pass1"));
+        assertOneMatchingBuildForGivenSearchStringAndRunItems("pass1", runs);
+    }
+
+    private void assertOneMatchingBuildForGivenSearchStringAndRunItems(String searchString, List<ModelObject> runs) {
         //given
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
         //and
-        historyPageFilter.setSearchString("pass1");
+        historyPageFilter.setSearchString(searchString);
         //and
-        List<ModelObject> runs = new ArrayList<>();
-        runs.add(new MockBuild(2).withBuildParameters(ImmutableMap.of("plainPassword", "pass1plain")));
-        runs.add(new MockBuild(1).withSensitiveBuildParameters("password", "pass1"));
         List<Queue.Item> queueItems = newQueueItems(3, 4);
 
         //when

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -54,6 +54,8 @@ import com.google.common.collect.Lists;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ *
+ * See also HistoryPageFilterInsensitiveSearchTest integration test.
  */
 public class HistoryPageFilterTest {
 
@@ -338,22 +340,6 @@ public class HistoryPageFilterTest {
 
         //then
         Assert.assertEquals(0, historyPageFilter.runs.size());
-    }
-
-    @Test
-    @Ignore //User with insensitiveSearch enabled needs to be injected
-    public void test_search_runs_by_build_result() throws IOException {
-        //TODO: Set user with insensitiveSearch enabled
-        List<ModelObject> runs = ImmutableList.<ModelObject>of(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
-        assertOneMatchingBuildForGivenSearchStringAndRunItems("failure", runs);
-    }
-
-    @Test
-    @Ignore //User with insensitiveSearch enabled needs to be injected
-    public void test_case_insensitivity_in_search_runs() throws IOException {
-        //TODO: Set user with insensitiveSearch enabled
-        List<ModelObject> runs = ImmutableList.<ModelObject>of(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
-        assertOneMatchingBuildForGivenSearchStringAndRunItems("FAILure", runs);
     }
 
     @Test

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -37,6 +37,7 @@ import hudson.model.Run;
 import hudson.model.StringParameterValue;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -323,8 +324,27 @@ public class HistoryPageFilterTest {
     }
 
     @Test
+    public void test_search_should_be_case_sensitive_for_anonymous_user() throws IOException {
+        //given
+        HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
+        //and
+        historyPageFilter.setSearchString("failure");
+        //and
+        List<ModelObject> runs = Lists.<ModelObject>newArrayList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
+        List<Queue.Item> queueItems = newQueueItems(3, 4);
+
+        //when
+        historyPageFilter.add(runs, queueItems);
+
+        //then
+        Assert.assertEquals(0, historyPageFilter.runs.size());
+    }
+
+    @Test
+    @Ignore //User with insensitiveSearch enabled needs to be injected
     public void test_search_runs_by_build_result() throws IOException {
         //given
+        //TODO: Set user with insensitiveSearch enabled
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
         //and
         historyPageFilter.setSearchString("failure");
@@ -341,8 +361,10 @@ public class HistoryPageFilterTest {
     }
 
     @Test
+    @Ignore //User with insensitiveSearch enabled needs to be injected
     public void test_case_insensitivity_in_search_runs() throws IOException {
         //given
+        //TODO: Set user with insensitiveSearch enabled
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
         List<ModelObject> runs = Lists.<ModelObject>newArrayList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
         List<Queue.Item> queueItems = newQueueItems(3, 4);

--- a/test/src/test/java/jenkins/widgets/HistoryPageFilterInsensitiveSearchTest.java
+++ b/test/src/test/java/jenkins/widgets/HistoryPageFilterInsensitiveSearchTest.java
@@ -1,0 +1,114 @@
+package jenkins.widgets;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+
+import com.google.common.collect.ImmutableList;
+import hudson.model.Job;
+import hudson.model.ModelObject;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.User;
+import hudson.search.UserSearchProperty;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import hudson.security.AuthorizationStrategy;
+
+/**
+ * TODO: Code partially duplicated with HistoryPageFilterTest in core
+ */
+public class HistoryPageFilterInsensitiveSearchTest {
+
+    private static final String TEST_USER_NAME = "testUser";
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void should_search_insensitively_when_enabled_for_user() throws IOException {
+        setUserContextAndAssertCaseInsensitivitySearchForGivenSearchString("failure");
+    }
+
+    @Test
+    public void should_also_lower_search_query_in_insensitive_search_enabled() throws IOException {
+        setUserContextAndAssertCaseInsensitivitySearchForGivenSearchString("FAILure");
+    }
+
+    private void setUserContextAndAssertCaseInsensitivitySearchForGivenSearchString(final String searchString) throws IOException {
+        AuthorizationStrategy.Unsecured strategy = new AuthorizationStrategy.Unsecured();
+        j.jenkins.setAuthorizationStrategy(strategy);
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+
+        UsernamePasswordAuthenticationToken testUserAuthentication = new UsernamePasswordAuthenticationToken(TEST_USER_NAME, "any");
+        try (ACLContext acl = ACL.as(testUserAuthentication)) {
+            User.get(TEST_USER_NAME).addProperty(new UserSearchProperty(true));
+
+            //test logic
+            List<ModelObject> runs = ImmutableList.<ModelObject>of(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
+            assertOneMatchingBuildForGivenSearchStringAndRunItems(searchString, runs);
+        }
+    }
+
+    private void assertOneMatchingBuildForGivenSearchStringAndRunItems(String searchString, List<ModelObject> runs) {
+        //given
+        HistoryPageFilter<ModelObject> historyPageFilter = new HistoryPageFilter<>(5);
+        //and
+        historyPageFilter.setSearchString(searchString);
+
+        //when
+        historyPageFilter.add(runs, Collections.<Queue.Item>emptyList());
+
+        //then
+        Assert.assertEquals(1, historyPageFilter.runs.size());
+        Assert.assertEquals(HistoryPageEntry.getEntryId(2), historyPageFilter.runs.get(0).getEntryId());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static class MockRun extends Run {
+        private final long queueId;
+
+        public MockRun(long queueId) throws IOException {
+            super(Mockito.mock(Job.class));
+            this.queueId = queueId;
+        }
+
+        public MockRun(long queueId, Result result) throws IOException {
+            this(queueId);
+            this.result = result;
+        }
+
+        @Override
+        public int compareTo(Run o) {
+            return 0;
+        }
+
+        @Override
+        public Result getResult() {
+            return result;
+        }
+
+        @Override
+        public boolean isBuilding() {
+            return false;
+        }
+
+        @Override
+        public long getQueueId() {
+            return queueId;
+        }
+
+        @Override
+        public int getNumber() {
+            return (int) queueId;
+        }
+    }
+}


### PR DESCRIPTION
In some kind of parameterized jobs (e.g. deploy to user selected environment) it would be useful to have an ability to search by build parameters values in a Build history widget.

By the way, a true case insensitivity of search parameters has been provided, more tests and some minor clean ups related to Java 7.