### PR TITLE
never allow a flyweight task to execute on a restricted node

### DIFF
--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -374,16 +374,8 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         if(l!=null && !l.contains(this))
             return CauseOfBlockage.fromMessage(Messages._Node_LabelMissing(getDisplayName(), l));   // the task needs to be executed on label that this node doesn't have.
 
-        if(l==null && getMode()== Mode.EXCLUSIVE) {
-            // flyweight tasks need to get executed somewhere, if every node
-            if (!(item.task instanceof Queue.FlyweightTask && (
-                    this instanceof Jenkins
-                            || Jenkins.getInstance().getNumExecutors() < 1
-                            || Jenkins.getInstance().getMode() == Mode.EXCLUSIVE)
-            )) {
-                return CauseOfBlockage.fromMessage(Messages._Node_BecauseNodeIsReserved(getDisplayName()));   // this node is reserved for tasks that are tied to it
-            }
-        }
+        if(l==null && getMode()== Mode.EXCLUSIVE)
+            return CauseOfBlockage.fromMessage(Messages._Node_BecauseNodeIsReserved(getNodeName()));   // this node is reserved for tasks that are tied to it
 
         Authentication identity = item.authenticate();
         if (!getACL().hasPermission(identity,Computer.BUILD)) {


### PR DESCRIPTION
A previous commit 55bf88329027 ("If every node is restricted to tied
jobs only, Matrix build jobs can never start.", 2013-06-18) made the
decision to sometimes allow flyweight tasks to execute on an exclusive
node. The condition chosen here was that the master executor must either
have <1 executor or be marked exclusive. Unfortunately this means that
sometimes without an obvious explanation, a flyweight task might choose
to pick an exclusive node, even if some other slave node besides the
master was not marked as exclusive.

Revert this fix so that the exclusive nodes remain exclusive. If the
original goal is desirable, an alternative approach would be to check
*every* node and only allow flyweight tasks on an exclusive node if
every node is marked exclusive, rather than only bothering to check
master.

[JENKINS-5076]
[JENKINS-23459]