### PR TITLE
Stop warning about not keeping undefined parameters

### DIFF
--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -75,6 +75,11 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
     public static final String SAFE_PARAMETERS_SYSTEM_PROPERTY_NAME = ParametersAction.class.getName() +
             ".safeParameters";
 
+    /**
+     * Allow jenkins to stop warns when an undefined parameter is skipped.
+     *
+     * @since TODO
+     */
     @Restricted(NoExternalUse.class)
     public static final String DONT_KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME = ParametersAction.class.getName() +
             ".dontKeepUndefinedParameters";

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -75,6 +75,10 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
     public static final String SAFE_PARAMETERS_SYSTEM_PROPERTY_NAME = ParametersAction.class.getName() +
             ".safeParameters";
 
+    @Restricted(NoExternalUse.class)
+    public static final String DONT_KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME = ParametersAction.class.getName() +
+            ".dontKeepUndefinedParameters";
+
     private Set<String> safeParameters;
 
     private final List<ParameterValue> parameters;
@@ -315,11 +319,11 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
         for (ParameterValue v : this.parameters) {
             if (this.parameterDefinitionNames.contains(v.getName()) || isSafeParameter(v.getName())) {
                 filteredParameters.add(v);
-            } else {
+            } else if (!SystemProperties.getBoolean(DONT_KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME, false)) {
                 LOGGER.log(Level.WARNING, "Skipped parameter `{0}` as it is undefined on `{1}`. Set `-D{2}=true` to allow "
                         + "undefined parameters to be injected as environment variables or `-D{3}=[comma-separated list]` to whitelist specific parameter names, "
-                        + "even though it represents a security breach",
-                        new Object [] { v.getName(), run.getParent().getFullName(), KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME, SAFE_PARAMETERS_SYSTEM_PROPERTY_NAME });
+                        + "even though it represents a security breach or `-D{4}=true to explicitly forbid it without warning.",
+                        new Object [] { v.getName(), run.getParent().getFullName(), KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME, SAFE_PARAMETERS_SYSTEM_PROPERTY_NAME, DONT_KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME });
             }
         }
 

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -329,7 +329,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
             } else if ("false".equalsIgnoreCase(shouldKeepFlag)) {
                 LOGGER.log(Level.WARNING, "Skipped parameter `{0}` as it is undefined on `{1}`. Set `-D{2}=true` to allow "
                         + "undefined parameters to be injected as environment variables or `-D{3}=[comma-separated list]` to whitelist specific parameter names, "
-                        + "even though it represents a security breach or `-D{2}=false to explicitly forbid it without warning.",
+                        + "even though it represents a security breach or `-D{2}=false` to no longer show this message.",
                         new Object [] { v.getName(), run.getParent().getFullName(), KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME, SAFE_PARAMETERS_SYSTEM_PROPERTY_NAME });
             }
         }


### PR DESCRIPTION
On job chain, jenkins can "pass all current variables" to the next job.

The next job will (by default and this is good) consume only the variables that are defined as parameters.

Currently, when this appends it will write a warning. As we use a lot this kind of chaining, Jenkins produce a lot of logs (sometimes 3Gb a day) with almost only this warning.

The MR adds a parameter to jenkins `hudson.model.ParametersAction.dontKeepUndefinedParameters` (default `false`) which explicitly said that this behavior is wanted and stop produce warnings.