### PR TITLE
[JENKINS-40290] Fix test failing on Windows because of line feed assumption

### DIFF
--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -189,7 +189,8 @@ public class RunTest {
         for (int i = 1; i < 10; i++) {
             assertEquals("dummy" + (10+i), logLines.get(i));
         }
-        assertEquals("[...truncated 68 B...]", logLines.get(0));
+        int truncatedCount = 10* ("dummyN".length() + System.getProperty("line.separator").length()) - 2;
+        assertEquals("[...truncated "+truncatedCount+" B...]", logLines.get(0));
     }
 
     @Test


### PR DESCRIPTION
The line separator length was assumed to be 1 byte wide, although it could be 2 on some platforms (aka Windows).

@jtnord @slide @jglick as you commented in https://issues.jenkins-ci.org/browse/JENKINS-40290

@jenkinsci/code-reviewers 