### PR TITLE
[FIX JENKINS-38175] Fix various ManagementLink related bugs

### DIFF
--- a/core/src/main/java/jenkins/management/ReloadLink.java
+++ b/core/src/main/java/jenkins/management/ReloadLink.java
@@ -56,5 +56,9 @@ public class ReloadLink extends ManagementLink {
     @Override public boolean getRequiresConfirmation() {
         return true;
     }
-    
+
+    @Override
+    public boolean getRequiresPOST() {
+        return true;
+    }
 }

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -32,15 +32,15 @@ THE SOFTWARE.
     <!-- table to show a map -->
     <d:tag name="feature">
       <j:set var="iconUrl" value="${icon.startsWith('/') ? resURL+icon : imagesURL+'/48x48/'+icon}"/>
-      ${taskTags!=null and attrs.contextMenu!='false' ? taskTags.add(href,iconUrl,title,requiresConfirmation,requiresConfirmation) : null}
+      ${taskTags!=null and attrs.contextMenu!='false' ? taskTags.add(href,iconUrl,title,post,requiresConfirmation) : null}
       <!-- TODO summary.jelly should be modified to accept requiresConfirmation so the icon link can be included -->
       <j:set var="_href" value="${href}"/>
       <t:summary icon="${icon}"
-                 href="${requiresConfirmation ? null : href}" iconOnly="true">
+                 href="${requiresConfirmation || post ? null : href}" iconOnly="true">
         <div class="link">
           <j:choose>
             <j:when test="${requiresConfirmation}">
-              <l:confirmationLink href="${_href}" post="true" message="${%are.you.sure(title)}">${title}</l:confirmationLink>
+              <l:confirmationLink href="${_href}" post="${post}" message="${%are.you.sure(title)}">${title}</l:confirmationLink>
             </j:when>
             <j:otherwise>
               <f:link href="${_href}" post="${post}">${title}</f:link>


### PR DESCRIPTION
1. In the context menu, the 'post' flag was set iff 'requiresConfirmation' was set, even though they're independent (e.g. 'Prepare for shutdown' requires the former but not the latter)
1. /manage screen: The icon (`t:summary`) does not support POST or confirmation links, but was set to not link _only_ if no confirmation was required (i.e. POST links did not POST when the icon was clicked -- now the icon is not clickable as a workaround, just like for confirmation links)
1. /manage screen: All links requiring confirmation did POST, which masked the fact that the 'Reload from disk' link wasn't set up to require POST (it was only broken in the context menu). Now, confirmation and POST are separate flags, and 'Reload from disk' link correctly requests POST.