### PR TITLE
[FIX JENKINS-40749] Set default disk free threshold to 10GB

### DIFF
--- a/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageChecker.java
+++ b/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageChecker.java
@@ -64,10 +64,10 @@ public class HudsonHomeDiskUsageChecker extends PeriodicWork {
     private static final Logger LOGGER = Logger.getLogger(HudsonHomeDiskUsageChecker.class.getName());
 
     /**
-     * Gets the minimum amount of space to check for, with a default of 1GB
+     * Gets the minimum amount of space to check for, with a default of 10GB
      */
     public static long FREE_SPACE_THRESHOLD = Long.getLong(
             HudsonHomeDiskUsageChecker.class.getName() + ".freeSpaceThreshold",
-            1024L*1024*1024);
+            1024L*1024*1024*10);
 
 }


### PR DESCRIPTION
It's 2017. If you have 1GB of free disk space, your disk is full.

After merge: Update https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties