### PR TITLE
Update a reference to "Agent => Master Access Control"

### DIFF
--- a/core/src/main/resources/jenkins/security/s2m/MasterKillSwitchConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/security/s2m/MasterKillSwitchConfiguration/config.groovy
@@ -3,7 +3,7 @@ package jenkins.security.s2m.MasterKillSwitchConfiguration
 def f=namespace(lib.FormTagLib)
 
 if (instance.isRelevant()) {
-    f.optionalBlock(field:"masterToSlaveAccessControl", title:_("Enable Slave \u2192 Master Access Control")) {
+    f.optionalBlock(field:"masterToSlaveAccessControl", title:_("Enable Agent \u2192 Master Access Control")) {
         f.nested() {
             raw _("Rules can be tweaked <a href='${rootURL}/administrativeMonitor/slaveToMasterAccessControl/'>here</a>")
         }


### PR DESCRIPTION
Considering all the verbiage updates that happened last year, this reference
appears to have been missed and as such can be confusing to newer users.