### PR TITLE
[JENKINS-40470] Jobs didn't finish on Solaris 11 Intel node

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -792,7 +792,8 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
              * try reading before giving up. This avoids having readLine() loop
              * over the entire process address space if this class has bugs.
              */
-            private static final int LINE_LENGTH_LIMIT = 10000;
+            private final int LINE_LENGTH_LIMIT =
+                SystemProperties.getInteger(Solaris.class.getName()+".lineLimit", 10000);
 
             /*
              * True if target process is 64-bit (Java process may be different).


### PR DESCRIPTION
The fix is the addition of the two calls to `to64()` that should have been included in the original change. The rest is code to avoid having other bugs in this area hang jobs in a tight `while(true)` loop, which is what was happening here.

Summary
=======

The call to `getEnvironmentVariables()` is hung in a call to `readLine()` in the `while(true)` loop, the loop is proceeding and incrementing `addr`, but it never encounters a null byte because the original `addr` that was passed in was garbage, and so the loop never terminates. It doesn't matter if your job has no steps, we still call `getEnvironmentVariables()` for all processes when the job finishes and we hang on the first call to `readLine()` if any process is a 32-bit process. 

I can reliably reproduce this issue on Solaris 11 using a 64-bit JVM. I cannot reproduce it at all on Solaris 10 (even with a 64-bit JVM) or with a 32-bit JVM. Logging statements in this code indicate that while all the math _seems_ right, when the actual `pread()` is done we are getting back the wrong data (as compared to other tools reading what should be the same address).

The problem is that when the JVM is 64-bit and the process being inspected is 32-bit we need to convert the `envp` entries we iterate over (which we get from the 32-bit process's address space) from 4-byte addresses to Java longs, the original change let Java do this conversion from `int` to `long` implicitly, which means the result was wrong for "negative numbers" (Java thinks these are signed numbers, not memory addresses). The fix uses the `to64()` function, which does the conversion correctly.

Using logging it looks like Solaris 10 uses a different part of the address space to store the `envp` entries than Solaris 11. By coincidence the Solaris 10 addresses are not negative numbers when treated as signed integers, so they don't see this issue, but the bug theoretically still exists on Solaris 10.

Testing
=====

I confirmed that before this change I could reproduce the issue on Solaris 11, but not Solaris 10, with empty Freestyle Jobs, with 64-bit JVMs on the Solaris side (i.e. on Solaris 11 the job never terminates, on Solaris 10 it does). After this change both jobs terminate correctly with both 64-bit and 32-bit JVMs.

I confirmed on both Solaris 10 and 11 (with both 64-bit and 32-bit JVMs) that pipeline jobs with long running shell steps could still be terminated after this change (i.e. I haven't broken the fix to the original issue).

My original testing for #2507 had only been done on Solaris 10.