### PR TITLE
[FIXED JENKINS-40863] Don't use javax.servlet imports for remoting call

### DIFF
--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -24,7 +24,6 @@
 package hudson.tasks;
 
 import hudson.FilePath;
-import hudson.Functions;
 import hudson.Util;
 import hudson.Extension;
 import hudson.model.AbstractProject;
@@ -35,6 +34,7 @@ import java.io.ObjectStreamException;
 import hudson.util.LineEndingConversion;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -153,8 +153,9 @@ public class Shell extends CommandInterpreter {
          */
         @Deprecated
         public String getShellOrDefault() {
-            if(shell==null)
-                return Functions.isWindows() ?"sh":"/bin/sh";
+            if (shell == null) {
+                return SystemUtils.IS_OS_WINDOWS ? "sh" : "/bin/sh";
+            }
             return shell;
         }
 
@@ -229,7 +230,7 @@ public class Shell extends CommandInterpreter {
             private static final long serialVersionUID = 1L;
 
             public String call() throws IOException {
-                return Functions.isWindows() ? "sh" : "/bin/sh";
+                return SystemUtils.IS_OS_WINDOWS ? "sh" : "/bin/sh";
             }
         }
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-40863
SystemUtils has only one - File import. 

Note: i don't know why exactly this happens and i see that there are more references to Functions.isWindows() from remoting calls.

cc @stephenc @jglick

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jenkins/2707)
<!-- Reviewable:end -->
