### PR TITLE
[FIXED JENKINS-40886] - Enable the JNLP4 protocol by default

### DIFF
--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
@@ -58,7 +58,8 @@ import org.jenkinsci.remoting.protocol.cert.PublicKeyMatchingX509ExtendedTrustMa
  *
  * <p>@see {@link org.jenkinsci.remoting.engine.JnlpProtocol4Handler} for more details.
  *
- * @since 2.27
+ * @since 2.27 available as the experimental protocol 
+ * @since TODO enabled by default
  */
 @Extension
 public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
@@ -156,7 +157,7 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
      */
     @Override
     public boolean isOptIn() {
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
JNLP4 protocol has been soaked starting from 2.27, and after the last fixes in remoting 3.4 it seems to be good enough. I propose to enable it by default in order to get more testing before the next LTS baseline.

https://issues.jenkins-ci.org/browse/JENKINS-40886

@reviewbybees (esp. @stephenc  and @jtnord) and also @samrocketman