### PR TITLE
[JENKINS-42191] Enhance CLI HTTP proxy support

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -460,9 +460,9 @@ public class CLI implements AutoCloseable {
             if(head.equals("-v")) {
                 args = args.subList(1,args.size());
                 Logger l = Logger.getLogger(ROOT_LOGGER_NAME);
-                l.setLevel(FINE);
+                l.setLevel(FINEST);
                 for (Handler h : l.getHandlers()) {
-                    h.setLevel(FINE);
+                    h.setLevel(FINEST);
                 }
                 continue;
             }

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -191,7 +191,7 @@ public class CLI implements AutoCloseable {
             String head = new BufferedReader(new StringReader(rsp.toString("ISO-8859-1"))).readLine();
             if (!(head.startsWith("HTTP/1.0 200 ") || head.startsWith("HTTP/1.1 200 "))) {
                 s.close();
-                System.out.println("Failed to tunnel the CLI port through the HTTP proxy. Falling back to HTTP.");
+                LOGGER.log(Level.SEVERE, "Failed to tunnel the CLI port through the HTTP proxy. Falling back to HTTP.");
                 throw new IOException("Failed to establish a connection through HTTP proxy: " + rsp);
             }
 

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -72,6 +72,8 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import static java.util.logging.Level.*;
@@ -177,6 +179,7 @@ public class CLI implements AutoCloseable {
 
         if (httpsProxyTunnel!=null) {
             String[] tokens = httpsProxyTunnel.split(":");
+            LOGGER.log(Level.FINE, "Using HTTP proxy {0}:{1} to connect to CLI port", new Object[]{tokens[0], tokens[1]});
             s.connect(new InetSocketAddress(tokens[0], Integer.parseInt(tokens[1])));
             PrintStream o = new PrintStream(s.getOutputStream());
             o.print("CONNECT " + clip.endpoint.getHostString() + ":" + clip.endpoint.getPort() + " HTTP/1.0\r\n\r\n");
@@ -378,12 +381,12 @@ public class CLI implements AutoCloseable {
     }
 
     public static void main(final String[] _args) throws Exception {
-//        Logger l = Logger.getLogger(Channel.class.getName());
-//        l.setLevel(ALL);
-//        ConsoleHandler h = new ConsoleHandler();
-//        h.setLevel(ALL);
-//        l.addHandler(h);
-//
+        Logger l = Logger.getLogger(ROOT_LOGGER_NAME);
+        l.setLevel(SEVERE);
+        ConsoleHandler h = new ConsoleHandler();
+        h.setLevel(SEVERE);
+        l.addHandler(h);
+
         try {
             System.exit(_main(_args));
         } catch (Throwable t) {
@@ -452,6 +455,15 @@ public class CLI implements AutoCloseable {
             if(head.equals("-p") && args.size()>=2) {
                 httpProxy = args.get(1);
                 args = args.subList(2,args.size());
+                continue;
+            }
+            if(head.equals("-v")) {
+                args = args.subList(1,args.size());
+                Logger l = Logger.getLogger(ROOT_LOGGER_NAME);
+                l.setLevel(FINE);
+                for (Handler h : l.getHandlers()) {
+                    h.setLevel(FINE);
+                }
                 continue;
             }
             break;
@@ -590,4 +602,5 @@ public class CLI implements AutoCloseable {
     }
 
     private static final Logger LOGGER = Logger.getLogger(CLI.class.getName());
+    private static final String ROOT_LOGGER_NAME = CLI.class.getPackage().getName();
 }

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -179,7 +179,7 @@ public class CLI implements AutoCloseable {
             String[] tokens = httpsProxyTunnel.split(":");
             s.connect(new InetSocketAddress(tokens[0], Integer.parseInt(tokens[1])));
             PrintStream o = new PrintStream(s.getOutputStream());
-            o.print("CONNECT " + clip.endpoint.getHostName() + ":" + clip.endpoint.getPort() + " HTTP/1.0\r\n\r\n");
+            o.print("CONNECT " + clip.endpoint.getHostString() + ":" + clip.endpoint.getPort() + " HTTP/1.0\r\n\r\n");
 
             // read the response from the proxy
             ByteArrayOutputStream rsp = new ByteArrayOutputStream();
@@ -189,8 +189,11 @@ public class CLI implements AutoCloseable {
                 rsp.write(ch);
             }
             String head = new BufferedReader(new StringReader(rsp.toString("ISO-8859-1"))).readLine();
-            if (!head.startsWith("HTTP/1.0 200 "))
-                throw new IOException("Failed to establish a connection through HTTP proxy: "+rsp);
+            if (!(head.startsWith("HTTP/1.0 200 ") || head.startsWith("HTTP/1.1 200 "))) {
+                s.close();
+                System.err.println("Failed to tunnel the CLI port through the HTTP proxy. Falling back to HTTP.");
+                throw new IOException("Failed to establish a connection through HTTP proxy: " + rsp);
+            }
 
             // HTTP proxies (at least the one I tried --- squid) doesn't seem to do half-close very well.
             // So instead of relying on it, we'll just send the close command and then let the server

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -191,7 +191,7 @@ public class CLI implements AutoCloseable {
             String head = new BufferedReader(new StringReader(rsp.toString("ISO-8859-1"))).readLine();
             if (!(head.startsWith("HTTP/1.0 200 ") || head.startsWith("HTTP/1.1 200 "))) {
                 s.close();
-                System.err.println("Failed to tunnel the CLI port through the HTTP proxy. Falling back to HTTP.");
+                System.out.println("Failed to tunnel the CLI port through the HTTP proxy. Falling back to HTTP.");
                 throw new IOException("Failed to establish a connection through HTTP proxy: " + rsp);
             }
 

--- a/cli/src/main/resources/hudson/cli/client/Messages.properties
+++ b/cli/src/main/resources/hudson/cli/client/Messages.properties
@@ -6,7 +6,7 @@ CLI.Usage=Jenkins CLI\n\
    -p HOST:PORT : HTTP proxy host and port for HTTPS proxy tunneling. See http://jenkins-ci.org/https-proxy-tunnel\n\
    -noCertificateCheck : bypass HTTPS certificate check entirely. Use with caution\n\
    -noKeyAuth   : don't try to load the SSH authentication private key. Conflicts with -i\n\
-   -v           : verbose output. Display logs on the console\n\
+   -v           : verbose output. Display logs on the console by setting j.u.l log level to FINEST\n\
   \n\
   The available commands depend on the server. Run the 'help' command to\n\
   see the list.

--- a/cli/src/main/resources/hudson/cli/client/Messages.properties
+++ b/cli/src/main/resources/hudson/cli/client/Messages.properties
@@ -6,6 +6,7 @@ CLI.Usage=Jenkins CLI\n\
    -p HOST:PORT : HTTP proxy host and port for HTTPS proxy tunneling. See http://jenkins-ci.org/https-proxy-tunnel\n\
    -noCertificateCheck : bypass HTTPS certificate check entirely. Use with caution\n\
    -noKeyAuth   : don't try to load the SSH authentication private key. Conflicts with -i\n\
+   -v           : verbose output. Display logs on the console\n\
   \n\
   The available commands depend on the server. Run the 'help' command to\n\
   see the list.


### PR DESCRIPTION
Fix few issues around proxy support in CLI:

* make proxy support work with recent Squid version which reply with HTTP/1.1 even if request is HTTP 1.0
* close the socket connected to the proxy if the connection failed
* output an error message when proxy connection failed
* don't do a reverse DNS lookup, instead use the host string provided in X-Jenkins-CLI-Host headers. It can be a IP address passed with `hudson.TcpSlaveAgentListener.hostName` (we don't know if the DNS resolver on the proxy will be able to resolve the name correctly, or like us).

@reviewbybees