### PR TITLE
[INFRA-1032] hack around by forcing user.name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ for(i = 0; i < buildTypes.size(); i++) {
                             if(isUnix()) {
                                 sh mvnCmd
                             } else {
-                                bat mvnCmd
+                                bat "$mvnCmd -Duser.name=yay" // INFRA-1032 workaround
                             }
                         }
                     }


### PR DESCRIPTION
@rtyler @daniel-beck @jtnord 

I _think_ this should work, because I just tested the contrary on my Linux box, and I do reproduce the issue of this agent: https://gist.github.com/batmat/76d9789c7a8fdbaa1b04bf0da4671464