### PR TITLE
[FIXED JENKINS-37590] Return a null property if no parameters

### DIFF
--- a/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
+++ b/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
@@ -222,6 +222,15 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
     @Symbol("parameters")
     public static class DescriptorImpl extends OptionalJobPropertyDescriptor {
         @Override
+        public ParametersDefinitionProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            ParametersDefinitionProperty prop = (ParametersDefinitionProperty)super.newInstance(req, formData);
+            if (prop != null && prop.parameterDefinitions.isEmpty()) {
+                return null;
+            }
+            return prop;
+        }
+
+        @Override
         public boolean isApplicable(Class<? extends Job> jobType) {
             return ParameterizedJobMixIn.ParameterizedJob.class.isAssignableFrom(jobType);
         }

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -386,5 +386,3 @@ Jenkins.IsRestarting=Jenkins is restarting
 
 User.IllegalUsername="{0}" is prohibited as a username for security reasons.
 User.IllegalFullname="{0}" is prohibited as a full name for security reasons.
-
-Hudson.NoParamsSpecified=No Parameters are specified for this parameterized build

--- a/core/src/main/resources/jenkins/model/Messages.properties
+++ b/core/src/main/resources/jenkins/model/Messages.properties
@@ -42,7 +42,6 @@ Hudson.NotUsesUTF8ToDecodeURL=\
   See <a href="http://wiki.jenkins-ci.org/display/JENKINS/Containers">Containers</a> and \
   <a href="http://wiki.jenkins-ci.org/display/JENKINS/Tomcat#Tomcat-i18n">Tomcat i18n</a> for more details.
 Hudson.NodeDescription=the master Jenkins node
-Hudson.NoParamsSpecified=No Parameters are specified for this parameterized build
 
 CLI.restart.shortDescription=Restart Jenkins.
 CLI.safe-restart.shortDescription=Safely restart Jenkins.


### PR DESCRIPTION
[JENKINS-37590](https://issues.jenkins-ci.org/browse/JENKINS-37590)

At least part of the impetus for this issue was dealt with a while
back by a revert of PR #2444, but this gives us a better solution
anyway by guaranteeing we have a null property rather than one without
parameters.

cc @reviewbybees esp @jglick 