### PR TITLE
[FIXED JENKINS-36872] Switch to com.mysema.maven:apt-maven-plugin for Java 8 support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -852,18 +852,6 @@ THE SOFTWARE.
       <id>release</id>
       <build>
         <plugins>
-          <plugin><!-- execute apt:process for "Extension points" Wiki page generation -->
-            <groupId>com.mysema.maven</groupId>
-            <artifactId>apt-maven-plugin</artifactId>
-            <!-- version specified in parent pom -->
-            <executions>
-              <execution>
-                <goals>
-                  <goal>process</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <!--
               generate jelly taglib docs from src/main/resoruces.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -853,9 +853,9 @@ THE SOFTWARE.
       <build>
         <plugins>
           <plugin><!-- execute apt:process for "Extension points" Wiki page generation -->
-            <groupId>org.codehaus.mojo</groupId>
+            <groupId>com.mysema.maven</groupId>
             <artifactId>apt-maven-plugin</artifactId>
-            <!-- version specified in grandparent pom -->
+            <!-- version specified in parent pom -->
             <executions>
               <execution>
                 <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@ THE SOFTWARE.
         <artifactId>mockito-core</artifactId>
         <version>1.10.19</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
@@ -495,9 +495,9 @@ THE SOFTWARE.
           <version>2.1</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>com.mysema.maven</groupId>
           <artifactId>apt-maven-plugin</artifactId>
-          <version>1.0-alpha-5</version>
+          <version>1.1.3</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -665,7 +665,7 @@ THE SOFTWARE.
         <configuration>
           <source>1.${java.level}</source>
           <target>1.${java.level}</target>
-          <!-- default reuseCreated is more performant 
+          <!-- default reuseCreated is more performant
           feel free to uncomment if you have any issues on your platform
           <compilerReuseStrategy>alwaysNew</compilerReuseStrategy>
           -->
@@ -760,8 +760,8 @@ THE SOFTWARE.
           </execution>
         </executions>
       </plugin>
-      
-      
+
+
     </plugins>
 
     <extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -495,11 +495,6 @@ THE SOFTWARE.
           <version>2.1</version>
         </plugin>
         <plugin>
-          <groupId>com.mysema.maven</groupId>
-          <artifactId>apt-maven-plugin</artifactId>
-          <version>1.1.3</version>
-        </plugin>
-        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cobertura-maven-plugin</artifactId>
           <version>2.5.2</version>


### PR DESCRIPTION
[JENKINS-36872](https://issues.jenkins-ci.org/browse/JENKINS-36872)

This is a blocker for dropping Java 7 support as the release is broken by this. The LTS RC at least. I reproduced the release is passing with this change.

@kohsuke, @rtyler, @jglick, Any idea how to verify this does not break https://wiki.jenkins-ci.org/display/JENKINS/Extension+points? If it is needed at all...