### PR TITLE
[JENKINS-39224] Make js search in historywidget case-insensitive.

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2038,7 +2038,7 @@ function updateBuildHistory(ajaxUrl,nBuild) {
         }
 
         function loadPage(params, focusOnSearch) {
-            var searchString = pageSearchInput.value;
+            var searchString = pageSearchInput.value.toLowerCase();
 
             if (searchString !== '') {
                 if (params === undefined) {


### PR DESCRIPTION
How to reproduce:
1.Name your builds with capital letters e.g. COMPILATION-125-LINUX, COMPILATION-125-WINDOWS
2.You want to filter in build history widget only windows builds
3.You type WINDOWS and nothing is returned. (instead, if you type windows all *WINDOWS builds will appear)