### PR TITLE
Suppress Windows tests for the moment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ properties([[$class: 'jenkins.model.BuildDiscarderProperty', strategy: [$class: 
                                                                         artifactNumToKeepStr: '20']]])
 
 // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc for information on what node types are available
-def buildTypes = ['Linux', 'Windows']
+def buildTypes = ['Linux'] // TODO add 'Windows'
 
 def builds = [:]
 for(i = 0; i < buildTypes.size(); i++) {


### PR DESCRIPTION
Currently there are [many failures](https://ci.jenkins.io/job/Core/job/jenkins/view/Pull%20Requests/job/PR-2732/1/testReport/), which merely cause confusion about whether an unrelated PR like #2732 is introducing test regressions.

The proper approach is to disable this platform in `master`, then file a PR which enables it, and fix up the tests in that branch until it is stable.

@reviewbybees