### PR TITLE
[JENKINS-16634] Do not fail to write a log file just because something deleted the parent directory

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -772,6 +772,7 @@ THE SOFTWARE.
           <forkCount>0.5C</forkCount>
           <reuseForks>true</reuseForks>
           <argLine>-XX:MaxPermSize=128m -noverify</argLine> <!-- some versions of JDK7/8 causes VerifyError during mock tests: http://code.google.com/p/powermock/issues/detail?id=504 -->
+          <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
         </configuration>
       </plugin>
       <plugin><!-- set main class -->

--- a/core/src/main/java/hudson/util/io/RewindableFileOutputStream.java
+++ b/core/src/main/java/hudson/util/io/RewindableFileOutputStream.java
@@ -28,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import org.apache.commons.io.FileUtils;
 
 /**
  * {@link OutputStream} that writes to a file.
@@ -48,6 +49,7 @@ public class RewindableFileOutputStream extends OutputStream {
     private synchronized OutputStream current() throws IOException {
         if (current == null) {
             if (!closed) {
+                FileUtils.forceMkdir(out.getParentFile());
                 try {
                     current = new FileOutputStream(out,false);
                 } catch (FileNotFoundException e) {


### PR DESCRIPTION
[JENKINS-16634](https://issues.jenkins-ci.org/browse/JENKINS-16634)

No one is sure _why_ the directory is deleted, but refusing to connect an agent because of this is not graceful. Test reproduced a similar error.

@reviewbybees