### PR TITLE
[JENKINS-41825] Display an informative message, rather than a Groovy exception, when View.getItems fails

### DIFF
--- a/core/src/main/resources/hudson/model/View/main.groovy
+++ b/core/src/main/resources/hudson/model/View/main.groovy
@@ -3,7 +3,9 @@ package hudson.model.View;
 t=namespace(lib.JenkinsTagLib)
 st=namespace("jelly:stapler")
 
-if (items.isEmpty()) {
+if (items == null) {
+    p(_('broken'))
+} else if (items.isEmpty()) {
     if (app.items.size() != 0) {
         set("views",my.owner.views);
         set("currentView",my);

--- a/core/src/main/resources/hudson/model/View/main.properties
+++ b/core/src/main/resources/hudson/model/View/main.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright 2017 CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+broken=An error occurred when retrieving jobs for this view. Please consult the Jenkins logs for details.

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -53,6 +53,9 @@ import hudson.util.HudsonIsLoading;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import jenkins.model.ProjectNamingStrategy;
 import jenkins.security.NotReallyRoleSensitiveCallable;
 import static org.junit.Assert.*;
@@ -61,6 +64,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.TestExtension;
@@ -73,6 +77,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class ViewTest {
 
     @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public LoggerRule logging = new LoggerRule();
 
     @Issue("JENKINS-7100")
     @Test public void xHudsonHeader() throws Exception {
@@ -506,7 +512,34 @@ public class ViewTest {
     private void assertCheckJobName(ViewGroup context, String name, FormValidation.Kind expected) {
         assertEquals(expected, context.getPrimaryView().doCheckJobName(name).kind);
     }
-    
+
+    @Issue("JENKINS-41825")
+    @Test
+    public void brokenGetItems() throws Exception {
+        logging.capture(100).record("", Level.INFO);
+        j.jenkins.addView(new BrokenView());
+        j.createWebClient().goTo("view/broken/");
+        boolean found = false;
+        LOGS: for (LogRecord record : logging.getRecords()) {
+            for (Throwable t = record.getThrown(); t != null; t = t.getCause()) {
+                if (t instanceof IllegalStateException && BrokenView.ERR.equals(t.getMessage())) {
+                    found = true;
+                    break LOGS;
+                }
+            }
+        }
+        assertTrue(found);
+    }
+    private static class BrokenView extends ListView {
+        static final String ERR = "oops I cannot retrieve items";
+        BrokenView() {
+            super("broken");
+        }
+        @Override
+        public List<TopLevelItem> getItems() {
+            throw new IllegalStateException(ERR);
+        }
+    }
     
     @Test
     @Issue("JENKINS-36908")


### PR DESCRIPTION
[JENKINS-41825](https://issues.jenkins-ci.org/browse/JENKINS-41825)

@reviewbybees