### PR TITLE
[FIX JENKINS-9104] Add support for the slaves to access the veto list from the master

### DIFF
--- a/core/src/main/java/hudson/util/ProcessKillingVeto.java
+++ b/core/src/main/java/hudson/util/ProcessKillingVeto.java
@@ -30,6 +30,8 @@ import hudson.util.ProcessTreeRemoting.IOSProcess;
 import java.util.Collections;
 import java.util.List;
 
+import java.io.Serializable;
+
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
@@ -47,7 +49,7 @@ import jenkins.util.JenkinsJVM;
  * 
  * @author <a href="mailto:daniel.weber.dev@gmail.com">Daniel Weber</a>
  */
-public abstract class ProcessKillingVeto implements ExtensionPoint {
+public abstract class ProcessKillingVeto implements ExtensionPoint, Serializable {
 
     /**
      * Describes the cause for a process killing veto.
@@ -100,4 +102,6 @@ public abstract class ProcessKillingVeto implements ExtensionPoint {
      */
     @CheckForNull
     public abstract VetoCause vetoProcessKilling(@Nonnull IOSProcess p);
+    
+    private static final long serialVersionUID = 1L;
 }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -63,7 +63,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2.13</version>
+      <version>2.16</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
+++ b/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 import java.io.File;
 import java.io.IOException;
+import java.io.StringWriter;
 
 import hudson.EnvVars;
 import hudson.Functions;
@@ -13,6 +14,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Slave;
 import hudson.tasks.Maven;
 import hudson.tasks.Shell;
 import hudson.util.ProcessTreeRemoting.IOSProcess;
@@ -26,6 +28,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
 import com.google.common.collect.ImmutableMap;
+
 
 public class ProcessTreeKillerTest {
 
@@ -136,8 +139,44 @@ public class ProcessTreeKillerTest {
             // Means the process is still running
         }
     }
+    
+    @Test
+    @Issue("JENKINS-9104")
+    public void considersKillingVetosOnSlave() throws Exception {
+        // on some platforms where we fail to list any processes, this test will
+        // just not work
+        assumeTrue(ProcessTree.get() != ProcessTree.DEFAULT);
+        
+        // Define a process we (shouldn't) kill
+        ProcessBuilder pb = new ProcessBuilder();
+        pb.environment().put("cookie", "testKeepDaemonsAlive");
+        
+        if (File.pathSeparatorChar == ';') {
+            pb.command("cmd");
+        } else {
+            pb.command("sleep", "5m");
+        }
+        
+        // Create a slave so we can tell it to kill the process
+        Slave s = j.createSlave();
+        s.toComputer().connect(false).get();
+        
+        // Start the process
+        process = pb.start();
+        
+        // Call killall (somewhat roundabout though) to (not) kill it
+        StringWriter out = new StringWriter();
+        s.createLauncher(new StreamTaskListener(out)).kill(ImmutableMap.of("cookie", "testKeepDaemonsAlive"));
+        
+        try {
+            process.exitValue();
+            fail("Process should have been excluded from the killing");
+        } catch (IllegalThreadStateException e) {
+            // Means the process is still running
+        }
+    }
 
-    @TestExtension("considersKillingVetos")
+    @TestExtension({"considersKillingVetos", "considersKillingVetosOnSlave"})
     public static class VetoAllKilling extends ProcessKillingVeto {
         @Override
         public VetoCause vetoProcessKilling(IOSProcess p) {


### PR DESCRIPTION
This is based on my comments in [JENKINS-9104](https://issues.jenkins-ci.org/browse/JENKINS-9104).  I was able to add a test where the process got killed by a slave node and then add my other changes in to make the `ProcessKillingVeto` list get accessed in the same fashion as the `ProcessKillers` list.  Without this change, we have had to disable the process tree killer on any slaves that run Visual C++ so we avoid the issue where `mspdbsrv.exe` gets stopped by one build while a second build is still using it and ends up failing the second build.

I am hoping that this can get this included before the next LTS branch is created, I need it in an LTS branch in order to get our IT group to update the server to it.  The only other solution I could come up with is to somehow get the msbuild plugin to copy its `ProcessKillingVeto` child class to the slaves so that the ExtensionList is properly populated in that system.

I had to bump the version of jenkins-test-harness so I could mark the same extension class as being needed for two different tests.  The other option there would be to copy-paste the extension class and have one instance for each, but that didn't seem like a good solution.