### PR TITLE
[JENKINS-32820, JENKINS-42164] - Windows service restart does not retain the build queue

### DIFF
--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -393,8 +393,13 @@ public class WebAppMain implements ServletContextListener {
     public void contextDestroyed(ServletContextEvent event) {
         terminated = true;
         Jenkins instance = Jenkins.getInstance();
-        if(instance!=null)
-            instance.cleanUp();
+        try {
+            if (instance != null) {
+                instance.cleanUp();
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to clean up. Restart will continue.", e);
+        }
         Thread t = initThread;
         if (t != null && t.isAlive()) {
             LOGGER.log(Level.INFO, "Shutting down a Jenkins instance that was still starting up", new Throwable("reason"));

--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -391,7 +391,6 @@ public class WebAppMain implements ServletContextListener {
     }
 
     public void contextDestroyed(ServletContextEvent event) {
-        terminated = true;
         Jenkins instance = Jenkins.getInstance();
         try {
             if (instance != null) {
@@ -400,6 +399,8 @@ public class WebAppMain implements ServletContextListener {
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to clean up. Restart will continue.", e);
         }
+
+        terminated = true;
         Thread t = initThread;
         if (t != null && t.isAlive()) {
             LOGGER.log(Level.INFO, "Shutting down a Jenkins instance that was still starting up", new Throwable("reason"));

--- a/core/src/main/java/hudson/lifecycle/SolarisSMFLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SolarisSMFLifecycle.java
@@ -26,6 +26,8 @@ package hudson.lifecycle;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * {@link Lifecycle} for Hudson installed as SMF service.
@@ -38,9 +40,16 @@ public class SolarisSMFLifecycle extends Lifecycle {
      */
     @Override
     public void restart() throws IOException, InterruptedException {
-        Jenkins h = Jenkins.getInstance();
-        if (h != null)
-            h.cleanUp();
+        Jenkins jenkins = Jenkins.getInstance();
+        try {
+            if (jenkins != null) {
+                jenkins.cleanUp();
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to clean up. Restart will continue.", e);
+        }
         System.exit(0);
     }
+
+    private static final Logger LOGGER = Logger.getLogger(SolarisSMFLifecycle.class.getName());
 }

--- a/core/src/main/java/hudson/lifecycle/SolarisSMFLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SolarisSMFLifecycle.java
@@ -40,7 +40,7 @@ public class SolarisSMFLifecycle extends Lifecycle {
      */
     @Override
     public void restart() throws IOException, InterruptedException {
-        Jenkins h = Jenkins.getInstanceOrNull(); // guard against repeated concurrent calls to restart
+        Jenkins jenkins = Jenkins.getInstanceOrNull(); // guard against repeated concurrent calls to restart
         try {
             if (jenkins != null) {
                 jenkins.cleanUp();

--- a/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
@@ -28,6 +28,8 @@ import com.sun.jna.Native;
 import com.sun.jna.StringArray;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static hudson.util.jna.GNUCLibrary.*;
 
@@ -65,9 +67,14 @@ public class UnixLifecycle extends Lifecycle {
 
     @Override
     public void restart() throws IOException, InterruptedException {
-        Jenkins h = Jenkins.getInstance();
-        if (h != null)
-            h.cleanUp();
+        Jenkins jenkins = Jenkins.getInstance();
+        try {
+            if (jenkins != null) {
+                jenkins.cleanUp();
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to clean up. Restart will continue.", e);
+        }
 
         // close all files upon exec, except stdin, stdout, and stderr
         int sz = LIBC.getdtablesize();
@@ -96,4 +103,6 @@ public class UnixLifecycle extends Lifecycle {
         if (args==null)
             throw new RestartNotSupportedException("Failed to obtain the command line arguments of the process",failedToObtainArgs);
     }
+
+    private static final Logger LOGGER = Logger.getLogger(UnixLifecycle.class.getName());
 }

--- a/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
@@ -67,7 +67,7 @@ public class UnixLifecycle extends Lifecycle {
 
     @Override
     public void restart() throws IOException, InterruptedException {
-        Jenkins h = Jenkins.getInstanceOrNull(); // guard against repeated concurrent calls to restart
+        Jenkins jenkins = Jenkins.getInstanceOrNull(); // guard against repeated concurrent calls to restart
         try {
             if (jenkins != null) {
                 jenkins.cleanUp();

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -120,6 +120,11 @@ public class WindowsServiceLifecycle extends Lifecycle {
 
     @Override
     public void restart() throws IOException, InterruptedException {
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins != null) {
+            jenkins.cleanUp();
+        }
+
         File me = getHudsonWar();
         File home = me.getParentFile();
 

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -121,8 +121,12 @@ public class WindowsServiceLifecycle extends Lifecycle {
     @Override
     public void restart() throws IOException, InterruptedException {
         Jenkins jenkins = Jenkins.getInstance();
-        if (jenkins != null) {
-            jenkins.cleanUp();
+        try {
+            if (jenkins != null) {
+                jenkins.cleanUp();
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to clean up. Restart will continue.", e);
         }
 
         File me = getHudsonWar();

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -117,7 +117,7 @@ public class WindowsServiceLifecycle extends Lifecycle {
 
     @Override
     public void restart() throws IOException, InterruptedException {
-        Jenkins jenkins = Jenkins.getInstance();
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
         try {
             if (jenkins != null) {
                 jenkins.cleanUp();


### PR DESCRIPTION
This is a merged version of #2019 from @atcarmo

- [x] - [JENKINS-32820](https://issues.jenkins-ci.org/browse/JENKINS-32820) Jenkins.cleanUp() was not called inside WindowsServiceLifecycle.restart()
- [x] - [JENKINS-42164](https://issues.jenkins-ci.org/browse/JENKINS-42164) Perform restart if the cleanup fails

> Basically Jenkins.cleanUp() is not being called inside the implementation of the restart method of WindowsServifeLifecycle. This caused, among other things, the queue not to be persisted on restart while Jenkins is installed as a Windows Service.

@jenkinsci/code-reviewers @daniel-beck  Please approve (especially the exception suppression logic) 