### PR TITLE
[FIXED JENKINS-41987] Check for null return values from InstanceIdentityProvider methods

### DIFF
--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
@@ -101,7 +101,13 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
     public JnlpSlaveAgentProtocol4() throws KeyStoreException, KeyManagementException, IOException {
         // prepare our local identity and certificate
         X509Certificate identityCertificate = InstanceIdentityProvider.RSA.getCertificate();
+        if (identityCertificate == null) {
+            throw new KeyStoreException("no X509Certificate found; perhaps instance-identity is missing or too old");
+        }
         RSAPrivateKey privateKey = InstanceIdentityProvider.RSA.getPrivateKey();
+        if (privateKey == null) {
+            throw new KeyStoreException("no RSAPrivateKey found; perhaps instance-identity is missing or too old");
+        }
 
         // prepare our keyStore so we can provide our authentication
         keyStore = KeyStore.getInstance("JKS");

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
@@ -102,11 +102,11 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
         // prepare our local identity and certificate
         X509Certificate identityCertificate = InstanceIdentityProvider.RSA.getCertificate();
         if (identityCertificate == null) {
-            throw new KeyStoreException("no X509Certificate found; perhaps instance-identity is missing or too old");
+            throw new KeyStoreException("JENKINS-41987: no X509Certificate found; perhaps instance-identity module is missing or too old");
         }
         RSAPrivateKey privateKey = InstanceIdentityProvider.RSA.getPrivateKey();
         if (privateKey == null) {
-            throw new KeyStoreException("no RSAPrivateKey found; perhaps instance-identity is missing or too old");
+            throw new KeyStoreException("JENKINS-41987: no RSAPrivateKey found; perhaps instance-identity module is missing or too old");
         }
 
         // prepare our keyStore so we can provide our authentication


### PR DESCRIPTION
[JENKINS-41987](https://issues.jenkins-ci.org/browse/JENKINS-41987)

Otherwise you get a [cryptic error](https://gist.github.com/jglick/6d802b396c412950c8e0518021c94a2f) when `instance-identity` is misconfigured, for example in tests. This fixes the instantiation error to clearly reflect the actual problem.

@reviewbybees