### PR TITLE
[JENKINS-41899] Update version-number dependency to 1.3

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -65,7 +65,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.1</version>
+      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
See [JENKINS-41899](https://issues.jenkins-ci.org/browse/JENKINS-41899)

(while there is a tag for 1.2 there is no binary release due to broken javadoc comments)

@reviewbybees