### PR TITLE
[FIXED JENKINS-42194] Do not display a warning when no schedules

### DIFF
--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -367,8 +367,12 @@ public class SCMTrigger extends Trigger<Item> {
         public FormValidation doCheckScmpoll_spec(@QueryParameter String value,
                                                   @QueryParameter boolean ignorePostCommitHooks,
                                                   @AncestorInPath Item item) {
-            if (ignorePostCommitHooks && StringUtils.isBlank(value)) {
-                return FormValidation.ok(Messages.SCMTrigger_no_schedules_no_hooks());
+            if (StringUtils.isBlank(value)) {
+                if (ignorePostCommitHooks) {
+                    return FormValidation.ok(Messages.SCMTrigger_no_schedules_no_hooks());
+                } else {
+                    return FormValidation.ok(Messages.SCMTrigger_no_schedules_hooks());
+                }
             } else {
                 return Jenkins.getInstance().getDescriptorByType(TimerTrigger.DescriptorImpl.class)
                         .doCheckSpec(value, item);

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -72,10 +72,12 @@ import jenkins.util.SystemProperties;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.jelly.XMLOutput;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -357,6 +359,20 @@ public class SCMTrigger extends Trigger<Item> {
             if (value != null && "".equals(value.trim()))
                 return FormValidation.ok();
             return FormValidation.validateNonNegativeInteger(value);
+        }
+
+        /**
+         * Performs syntax check.
+         */
+        public FormValidation doCheckScmpoll_spec(@QueryParameter String value,
+                                                  @QueryParameter boolean ignorePostCommitHooks,
+                                                  @AncestorInPath Item item) {
+            if (ignorePostCommitHooks && StringUtils.isBlank(value)) {
+                return FormValidation.ok(Messages.SCMTrigger_no_schedules_no_hooks());
+            } else {
+                return Jenkins.getInstance().getDescriptorByType(TimerTrigger.DescriptorImpl.class)
+                        .doCheckSpec(value, item);
+            }
         }
     }
 

--- a/core/src/main/resources/hudson/triggers/Messages.properties
+++ b/core/src/main/resources/hudson/triggers/Messages.properties
@@ -23,6 +23,7 @@
 SCMTrigger.DisplayName=Poll SCM
 SCMTrigger.getDisplayName={0} Polling Log
 SCMTrigger.BuildAction.DisplayName=Polling Log
+SCMTrigger.no_schedules_no_hooks=Post commit hooks are being ignored and no schedules so will never run
 SCMTrigger.SCMTriggerCause.ShortDescription=Started by an SCM change
 TimerTrigger.DisplayName=Build periodically
 TimerTrigger.MissingWhitespace=You appear to be missing whitespace between * and *.

--- a/core/src/main/resources/hudson/triggers/Messages.properties
+++ b/core/src/main/resources/hudson/triggers/Messages.properties
@@ -23,7 +23,8 @@
 SCMTrigger.DisplayName=Poll SCM
 SCMTrigger.getDisplayName={0} Polling Log
 SCMTrigger.BuildAction.DisplayName=Polling Log
-SCMTrigger.no_schedules_no_hooks=Post commit hooks are being ignored and no schedules so will never run
+SCMTrigger.no_schedules_no_hooks=Post commit hooks are being ignored and no schedules so will never run due to SCM changes
+SCMTrigger.no_schedules_hooks=No schedules so will only run due to SCM changes if triggered by a post-commit hook
 SCMTrigger.SCMTriggerCause.ShortDescription=Started by an SCM change
 TimerTrigger.DisplayName=Build periodically
 TimerTrigger.MissingWhitespace=You appear to be missing whitespace between * and *.

--- a/core/src/main/resources/hudson/triggers/SCMTrigger/config.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/config.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Schedule}" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
-    <f:textarea field="scmpoll_spec" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value='+encodeURIComponent(this.value)"/>
+    <f:textarea field="scmpoll_spec"/>
   </f:entry>
   <f:entry field="ignorePostCommitHooks" title="${%Ignore post-commit hooks}">
     <f:checkbox />


### PR DESCRIPTION
See [JENKINS-42914](https://issues.jenkins-ci.org/browse/JENKINS-42194)

Screenshots:

Before:

<img width="995" alt="ignore-post-commit-hooks-recommended" src="https://cloud.githubusercontent.com/assets/209336/23120939/4b544e90-f756-11e6-9797-5c951bebd8ff.png">

After:

<img width="972" alt="empty-ok-when-ignoring" src="https://cloud.githubusercontent.com/assets/209336/23120942/54d640ae-f756-11e6-8baf-b3741030f327.png">

And validation is unaffected other that for the special case of ignoring post commit hooks with an empty spec:

<img width="988" alt="ok-warning" src="https://cloud.githubusercontent.com/assets/209336/23120960/671f8838-f756-11e6-9e89-52a82d83d59c.png">
<img width="982" alt="validation-when-ignoring" src="https://cloud.githubusercontent.com/assets/209336/23120966/69fe3838-f756-11e6-9c4d-559e4cec0a22.png">

@reviewbybees
