### PR TITLE
[FIX JENKINS-41864] Add warning for rare dates

### DIFF
--- a/core/src/main/java/hudson/scheduler/CronTab.java
+++ b/core/src/main/java/hudson/scheduler/CronTab.java
@@ -328,8 +328,14 @@ public final class CronTab {
      * This method modifies the given calendar and returns the same object.
      */
     public Calendar ceil(Calendar cal) {
+        Calendar twoYearsFuture = (Calendar) cal.clone();
+        twoYearsFuture.add(Calendar.YEAR, 2);
         OUTER:
         while (true) {
+            if (cal.compareTo(twoYearsFuture) > 0) {
+                // we went at least two years into the future
+                throw new RareOrImpossibleDateException();
+            }
             for (CalendarField f : CalendarField.ADJUST_ORDER) {
                 int cur = f.valueOf(cal);
                 int next = f.ceil(this,cur);
@@ -380,8 +386,15 @@ public final class CronTab {
      * This method modifies the given calendar and returns the same object.
      */
     public Calendar floor(Calendar cal) {
+        Calendar twoYearsAgo = (Calendar) cal.clone();
+        twoYearsAgo.add(Calendar.YEAR, -2);
+
         OUTER:
         while (true) {
+            if (cal.compareTo(twoYearsAgo) < 0) {
+                // we went at least two years into the past
+                throw new RareOrImpossibleDateException();
+            }
             for (CalendarField f : CalendarField.ADJUST_ORDER) {
                 int cur = f.valueOf(cal);
                 int next = f.floor(this,cur);

--- a/core/src/main/java/hudson/scheduler/CronTab.java
+++ b/core/src/main/java/hudson/scheduler/CronTab.java
@@ -326,6 +326,9 @@ public final class CronTab {
      * See {@link #ceil(long)}.
      *
      * This method modifies the given calendar and returns the same object.
+     *
+     * @throws RareOrImpossibleDateException if the date isn't hit in the 2 years after it indicates an impossible
+     * (e.g. Jun 31) date, or at least a date too rare to be useful. This addresses JENKINS-41864 and was added in TODO
      */
     public Calendar ceil(Calendar cal) {
         Calendar twoYearsFuture = (Calendar) cal.clone();
@@ -333,7 +336,7 @@ public final class CronTab {
         OUTER:
         while (true) {
             if (cal.compareTo(twoYearsFuture) > 0) {
-                // we went at least two years into the future
+                // we went too far into the future
                 throw new RareOrImpossibleDateException();
             }
             for (CalendarField f : CalendarField.ADJUST_ORDER) {
@@ -384,6 +387,9 @@ public final class CronTab {
      * See {@link #floor(long)}
      *
      * This method modifies the given calendar and returns the same object.
+     *
+     * @throws RareOrImpossibleDateException if the date isn't hit in the 2 years before it indicates an impossible
+     * (e.g. Jun 31) date, or at least a date too rare to be useful. This addresses JENKINS-41864 and was added in TODO
      */
     public Calendar floor(Calendar cal) {
         Calendar twoYearsAgo = (Calendar) cal.clone();
@@ -392,7 +398,7 @@ public final class CronTab {
         OUTER:
         while (true) {
             if (cal.compareTo(twoYearsAgo) < 0) {
-                // we went at least two years into the past
+                // we went too far into the past
                 throw new RareOrImpossibleDateException();
             }
             for (CalendarField f : CalendarField.ADJUST_ORDER) {

--- a/core/src/main/java/hudson/scheduler/RareOrImpossibleDateException.java
+++ b/core/src/main/java/hudson/scheduler/RareOrImpossibleDateException.java
@@ -26,6 +26,28 @@ package hudson.scheduler;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+import java.util.Calendar;
+
+/**
+ * This exception is thrown when trying to determine the previous or next occurrence of a given date determines
+ * that it's not happened, or going to happen, within some time period (e.g. within the next year).
+ *
+ * <p>This can typically have a few different reasons:</p>
+ *
+ * <ul>
+ *   <li>The date is impossible. For example, June 31 does never happen, so <tt>0 0 31 6 *</tt> will never happen</li>
+ *   <li>The date happens only rarely
+ *     <ul>
+ *       <li>February 29 being the obvious one</li>
+ *       <li>Cron tab patterns specifying all of month, day of month, and day of week can also occur so rarely to trigger this exception</li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ *
+ * @see CronTab#floor(Calendar)
+ * @see CronTab#ceil(Calendar)
+ * @since TODO
+ */
 @Restricted(NoExternalUse.class)
 public class RareOrImpossibleDateException extends RuntimeException {
 }

--- a/core/src/main/java/hudson/scheduler/RareOrImpossibleDateException.java
+++ b/core/src/main/java/hudson/scheduler/RareOrImpossibleDateException.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.scheduler;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public class RareOrImpossibleDateException extends RuntimeException {
+}

--- a/core/src/main/java/hudson/triggers/TimerTrigger.java
+++ b/core/src/main/java/hudson/triggers/TimerTrigger.java
@@ -32,6 +32,7 @@ import hudson.model.Cause;
 import hudson.model.Item;
 import hudson.scheduler.CronTabList;
 import hudson.scheduler.Hash;
+import hudson.scheduler.RareOrImpossibleDateException;
 import hudson.util.FormValidation;
 import java.text.DateFormat;
 import java.util.ArrayList;
@@ -104,13 +105,17 @@ public class TimerTrigger extends Trigger<BuildableItem> {
         }
 
         private void updateValidationsForNextRun(Collection<FormValidation> validations, CronTabList ctl) {
-            Calendar prev = ctl.previous();
-            Calendar next = ctl.next();
-            if (prev != null && next != null) {
-                DateFormat fmt = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL);
-                validations.add(FormValidation.ok(Messages.TimerTrigger_would_last_have_run_at_would_next_run_at(fmt.format(prev.getTime()), fmt.format(next.getTime()))));
-            } else {
-                validations.add(FormValidation.warning(Messages.TimerTrigger_no_schedules_so_will_never_run()));
+            try {
+                Calendar prev = ctl.previous();
+                Calendar next = ctl.next();
+                if (prev != null && next != null) {
+                    DateFormat fmt = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL);
+                    validations.add(FormValidation.ok(Messages.TimerTrigger_would_last_have_run_at_would_next_run_at(fmt.format(prev.getTime()), fmt.format(next.getTime()))));
+                } else {
+                    validations.add(FormValidation.warning(Messages.TimerTrigger_no_schedules_so_will_never_run()));
+                }
+            } catch (RareOrImpossibleDateException ex) {
+                validations.add(FormValidation.warning(Messages.TimerTrigger_the_specified_cron_tab_is_rare_or_impossible()));
             }
         }
     }

--- a/core/src/main/resources/hudson/triggers/Messages.properties
+++ b/core/src/main/resources/hudson/triggers/Messages.properties
@@ -29,7 +29,7 @@ TimerTrigger.MissingWhitespace=You appear to be missing whitespace between * and
 TimerTrigger.no_schedules_so_will_never_run=No schedules so will never run
 TimerTrigger.TimerTriggerCause.ShortDescription=Started by timer
 TimerTrigger.would_last_have_run_at_would_next_run_at=Would last have run at {0}; would next run at {1}.
-TimerTrigger.the_specified_cron_tab_is_rare_or_impossible=This cron tab will match dates only rarely (e.g. February 29) or \
+TimerTrigger.the_specified_cron_tab_is_rare_or_impossible=This schedule will match dates only rarely (e.g. February 29) or \
   never (e.g. June 31), so this job may be triggered very rarely, if at all.
 Trigger.init=Initializing timer for triggers
 SCMTrigger.AdministrativeMonitorImpl.DisplayName=Too Many SCM Polling Threads

--- a/core/src/main/resources/hudson/triggers/Messages.properties
+++ b/core/src/main/resources/hudson/triggers/Messages.properties
@@ -29,5 +29,7 @@ TimerTrigger.MissingWhitespace=You appear to be missing whitespace between * and
 TimerTrigger.no_schedules_so_will_never_run=No schedules so will never run
 TimerTrigger.TimerTriggerCause.ShortDescription=Started by timer
 TimerTrigger.would_last_have_run_at_would_next_run_at=Would last have run at {0}; would next run at {1}.
+TimerTrigger.the_specified_cron_tab_is_rare_or_impossible=This cron tab will match dates only rarely (e.g. February 29) or \
+  never (e.g. June 31), so this job may be triggered very rarely, if at all.
 Trigger.init=Initializing timer for triggers
 SCMTrigger.AdministrativeMonitorImpl.DisplayName=Too Many SCM Polling Threads


### PR DESCRIPTION
Previously, impossible dates caused 100% CPU while Jenkins was
trying to find the previous/next occurrence of the date.

---

Whitespace ignoring diff: https://github.com/jenkinsci/jenkins/pull/2759/files?w=1

This could probably be done more nicely directly in `crontab.g` but I didn't want to learn ANTLR 2 (AFAICT), a version whose archived website doesn't even work anymore.

Not sure how great the new `RuntimeException` subtype is, but didn't want to catch all `RuntimeException`s. So for now it's just `@Restricted`.

> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/23134064/ac0569c6-f793-11e6-88c0-19bda7e76675.png)
