### PR TITLE
[JENKINS-31598] upgrade commons-collections due to CVE against v3.2.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -491,7 +491,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.winp</groupId>

--- a/test/src/test/java/jenkins/security/Security218CliTest.java
+++ b/test/src/test/java/jenkins/security/Security218CliTest.java
@@ -57,7 +57,7 @@ public class Security218CliTest {
     @Test
     @Issue("SECURITY-218")
     public void probeCommonsCollections1() throws Exception {
-        probe(Payload.CommonsCollections1, PayloadCaller.EXIT_CODE_REJECTED);
+        probe(Payload.CommonsCollections1, 1);
     }
     
     @PresetData(PresetData.DataSet.ANONYMOUS_READONLY)
@@ -73,7 +73,7 @@ public class Security218CliTest {
     @Test
     @Issue("SECURITY-317")
     public void probeCommonsCollections3() throws Exception {
-        probe(Payload.CommonsCollections3, PayloadCaller.EXIT_CODE_REJECTED);
+        probe(Payload.CommonsCollections3, 1);
     }
 
     @PresetData(PresetData.DataSet.ANONYMOUS_READONLY)
@@ -87,14 +87,14 @@ public class Security218CliTest {
     @Test
     @Issue("SECURITY-317")
     public void probeCommonsCollections5() throws Exception {
-        probe(Payload.CommonsCollections5, PayloadCaller.EXIT_CODE_REJECTED);
+        probe(Payload.CommonsCollections5, 1);
     }
 
     @PresetData(PresetData.DataSet.ANONYMOUS_READONLY)
     @Test
     @Issue("SECURITY-317")
     public void probeCommonsCollections6() throws Exception {
-        probe(Payload.CommonsCollections6, PayloadCaller.EXIT_CODE_REJECTED);
+        probe(Payload.CommonsCollections6, 1);
     }
 
     @PresetData(PresetData.DataSet.ANONYMOUS_READONLY)


### PR DESCRIPTION
v3.2.2 is binary compatible with v3.2.1 and even the issue in commons-collections is not exploitable, it's good to take away the risk