### PR TITLE
JENKINS-42319: Fix broken compareTo method of Run

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -413,13 +413,14 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
     /**
      * Ordering based on build numbers.
+     * If numbers are equal order based on names of parent projects.
      */
     public int compareTo(@Nonnull RunT that) {
-        final int res = this.getParent().getFullName().compareTo(that.getParent().getFullName());
-        if (res != 0)
-            return res;
+        final int res = this.number - that.number;
+        if (res == 0)
+            return this.getParent().getFullName().compareTo(that.getParent().getFullName());
 
-        return this.number - that.number;
+        return res;
     }
 
     /**

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -415,6 +415,10 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * Ordering based on build numbers.
      */
     public int compareTo(@Nonnull RunT that) {
+        final int res = this.getParent().getFullName().compareTo(that.getParent().getFullName());
+        if (res != 0)
+            return res;
+
         return this.number - that.number;
     }
 

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -25,7 +25,6 @@
 package hudson.model;
 
 import java.io.IOException;
-import hudson.model.Run.Artifact;
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.List;
@@ -211,5 +210,38 @@ public class RunTest {
         assertEquals("b2", logLines.get(1));
         assertEquals("", logLines.get(2));
         assertEquals("c3", logLines.get(3));
+    }
+
+    public void compareSameJob() throws Exception {
+        final ItemGroup group = Mockito.mock(ItemGroup.class);
+        final Job j = Mockito.mock(Job.class);
+
+        Mockito.when(j.getParent()).thenReturn(group);
+        Mockito.when(group.getFullName()).thenReturn("j");
+        Mockito.when(j.assignBuildNumber()).thenReturn(1, 2);
+
+        Run r1 = new Run(j) {};
+        Run r2 = new Run(j) {};
+
+        assertTrue(r1.compareTo(r2) < 0);
+    }
+
+    @Test
+    public void compareDifferentJob() throws Exception {
+        final ItemGroup group1 = Mockito.mock(ItemGroup.class);
+        final ItemGroup group2 = Mockito.mock(ItemGroup.class);
+        final Job j1 = Mockito.mock(Job.class);
+        final Job j2 = Mockito.mock(Job.class);
+        Mockito.when(j1.getParent()).thenReturn(group1);
+        Mockito.when(j2.getParent()).thenReturn(group2);
+        Mockito.when(group1.getFullName()).thenReturn("g1");
+        Mockito.when(group2.getFullName()).thenReturn("g2");
+        Mockito.when(j1.assignBuildNumber()).thenReturn(1);
+        Mockito.when(j2.assignBuildNumber()).thenReturn(1);
+
+        Run r1 = new Run(j1) {};
+        Run r2 = new Run(j2) {};
+
+        assertTrue(r1.compareTo(r2) != 0);
     }
 }

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -29,7 +29,9 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.TimeZone;
+import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -212,7 +214,8 @@ public class RunTest {
         assertEquals("c3", logLines.get(3));
     }
 
-    public void compareSameJob() throws Exception {
+    @Test
+    public void compareRunsFromSameJobWithDifferentNumbers() throws Exception {
         final ItemGroup group = Mockito.mock(ItemGroup.class);
         final Job j = Mockito.mock(Job.class);
 
@@ -223,11 +226,17 @@ public class RunTest {
         Run r1 = new Run(j) {};
         Run r2 = new Run(j) {};
 
+        final Set<Run> treeSet = new TreeSet<>();
+        treeSet.add(r1);
+        treeSet.add(r2);
+
         assertTrue(r1.compareTo(r2) < 0);
+        assertTrue(treeSet.size() == 2);
     }
 
+    @Issue("JENKINS-42319")
     @Test
-    public void compareDifferentJob() throws Exception {
+    public void compareRunsFromDifferentParentsWithSameNumber() throws Exception {
         final ItemGroup group1 = Mockito.mock(ItemGroup.class);
         final ItemGroup group2 = Mockito.mock(ItemGroup.class);
         final Job j1 = Mockito.mock(Job.class);
@@ -242,6 +251,11 @@ public class RunTest {
         Run r1 = new Run(j1) {};
         Run r2 = new Run(j2) {};
 
+        final Set<Run> treeSet = new TreeSet<>();
+        treeSet.add(r1);
+        treeSet.add(r2);
+
         assertTrue(r1.compareTo(r2) != 0);
+        assertTrue(treeSet.size() == 2);
     }
 }


### PR DESCRIPTION
Fix broken some time ago method compareTo of Run object.
Current implementation relies on fact that users always compare run objects with same parent. But this is not always the case.