### PR TITLE
Remove unnecessary Secret casting

### DIFF
--- a/core/src/main/java/hudson/cli/ClientAuthenticationCache.java
+++ b/core/src/main/java/hudson/cli/ClientAuthenticationCache.java
@@ -80,7 +80,7 @@ public class ClientAuthenticationCache implements Serializable {
     private String getPropertyKey() {
         String url = Jenkins.getActiveInstance().getRootUrl();
         if (url!=null)  return url;
-        return Secret.fromString("key").toString();
+        return "key";
     }
 
     /**


### PR DESCRIPTION
The return statement uses `Secret.fromString()` to cast a plain string to a `Secret` and `Secret.toString()` back to the same `String`.  I didn't see why it would be useful to do that so I'm opening this PR for discussion/fixing.