### PR TITLE
[JENKINS-42585] - Replace Hashtable by more efficient ConcurrentHashMap

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -117,7 +117,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -1952,7 +1951,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      * Stores {@link Plugin} instances.
      */
     /*package*/ static final class PluginInstanceStore {
-        final Map<PluginWrapper,Plugin> store = new Hashtable<PluginWrapper,Plugin>();
+        final Map<PluginWrapper,Plugin> store = new ConcurrentHashMap<PluginWrapper,Plugin>();
     }
 
     /**


### PR DESCRIPTION
Today we had small problems during normal work hours. Jenkins stuck for several seconds (without GC! :) ) multiple times. Here is one of a reasons. According javadoc:
> If a thread-safe highly-concurrent implementation is desired, then it is recommended to use java.util.concurrent.ConcurrentHashMap in place of Hashtable.

https://docs.oracle.com/javase/8/docs/api/java/util/Hashtable.html

![screen shot 2017-03-02 at 16 59 30](https://cloud.githubusercontent.com/assets/4785672/23515644/17133cb4-ff6b-11e6-8e35-fbbdcdfcbcf0.png)