### PR TITLE
Minor memory optimisation in label parsing

### DIFF
--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -56,11 +56,11 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Collection;
 import java.util.Stack;
 import java.util.TreeSet;
 
@@ -583,11 +583,13 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
      * @since 1.308
      */
     public static Set<LabelAtom> parse(String labels) {
-        Set<LabelAtom> r = new TreeSet<LabelAtom>();
+        final Set<LabelAtom> r = new TreeSet<>();
         labels = fixNull(labels);
-        if(labels.length()>0)
-            for( String l : new QuotedStringTokenizer(labels).toArray())
-                r.add(Jenkins.getInstance().getLabelAtom(l));
+        if(labels.length()>0) {
+            final QuotedStringTokenizer tokenizer = new QuotedStringTokenizer(labels);
+            while (tokenizer.hasMoreTokens())
+                r.add(Jenkins.getInstance().getLabelAtom(tokenizer.nextToken()));
+            }
         return r;
     }
 

--- a/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
@@ -47,6 +47,7 @@ import org.jvnet.hudson.test.TestBuilder;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
@@ -262,5 +263,17 @@ public class LabelExpressionTest {
                 return null;
             }
         });
+    }
+
+    @Test
+    public void parseLabel() throws Exception {
+        Set<LabelAtom> result = Label.parse("one two three");
+        String[] expected = {"one", "two", "three"};
+
+        for(String e : expected) {
+            assertTrue(result.contains(new LabelAtom(e)));
+        }
+
+        assertEquals(result.size(), expected.length);
     }
 }


### PR DESCRIPTION
`new QuotedStringTokenizer(labels).toArray()` is not really needed. It creates a array with `DEFAULT_CAPACITY` (10) even if only one element is needed.
I don't expect much benefits, but I saw this method several times in memory consumption profiles (always far from top) and always wanted to optimise :)
Anyway this method is executed each time we run new build, so, it's better to avoid unnecessary allocation.