### PR TITLE
[FIXES JENKINS-42371] - Update remoting from 3.5 to 3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.6</version>
+        <version>3.7</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.5</version>
+        <version>3.6</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Changes:

* [JENKINS-42371](https://issues.jenkins-ci.org/browse/JENKINS-42371) - Properly close the `URLConnection` when parsing connection arguments from the JNLP file. It was causing a descriptor leak in the case of multiple connection attempts. ([PR #152](https://github.com/jenkinsci/remoting/pull/152))
* JNLP4 Protocol documentation updates

Full diff: https://github.com/jenkinsci/remoting/compare/remoting-3.5...remoting-3.7

CC @nehaljwani and @jenkinsci/code-reviewers 