### PR TITLE
Ignore deletedFolder test on Windows

### DIFF
--- a/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
+++ b/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import hudson.FilePath;
+import hudson.Functions;
 import org.junit.Test;
 
 import java.io.File;
@@ -13,6 +14,8 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
+
+import static org.junit.Assume.assumeFalse
 
 public class RewindableRotatingFileOutputStreamTest {
 
@@ -43,6 +46,8 @@ public class RewindableRotatingFileOutputStreamTest {
     @Issue("JENKINS-16634")
     @Test
     public void deletedFolder() throws Exception {
+        assumeFalse("Windows does not allow deleting a directory with a "
+            + "file open, so this case should never occur", Functions.isWindows());
         File dir = tmp.newFolder("dir");
         File base = new File(dir, "x.log");
         RewindableRotatingFileOutputStream os = new RewindableRotatingFileOutputStream(base, 3);

--- a/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
+++ b/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
@@ -15,7 +15,7 @@ import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 
-import static org.junit.Assume.assumeFalse
+import static org.junit.Assume.assumeFalse;
 
 public class RewindableRotatingFileOutputStreamTest {
 


### PR DESCRIPTION
Windows doesn't allow deleting directories that have a file open inside of them, so this test is invalid on windows.