### PR TITLE
[JENKINS-43444] Connect new JNLP Agent should be one-click

### DIFF
--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -24,6 +24,53 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+
+    <style>
+        .copiable {
+            font-family: "courier", "sans-serif";
+            width: 60%;
+            border: none;
+        }
+    </style>
+
+    <script type="text/javascript">
+        function addCopyCommandTo(selector) {
+        console.log('Selecting: ', selector);
+            document.querySelector(selector).select();
+            document.execCommand("copy");
+        }
+
+        document.addEventListener("DOMContentLoaded", function(event) {
+
+            var copiables = document.querySelectorAll('textarea.copiable');
+            if(copiables) {
+                var i = 1;
+                copiables.forEach (function(element) {
+                    console.log("Adding copy feature to ", element);
+
+                    var dataAttr = 'copiable' + i
+                    element.setAttribute('data-copiable', dataAttr);
+
+                    var fragment = document.createDocumentFragment();
+                    var button = document.createElement("button");
+                    var selector = 'textarea[data-copiable="' + dataAttr + '"]';
+                    button.setAttribute('onclick','addCopyCommandTo(\''+selector+'\');' );
+                    button.textContent = "Copy";
+                    fragment.appendChild(button)
+
+                    element.parentNode.insertBefore(fragment, element.nextSibling);
+
+                    i++;
+                });
+            }
+        });
+
+        function switchText(selector, attributeNameToUse) {
+          document.querySelectorAll(selector).forEach(function(element) {
+            element.value=element.getAttribute(attributeNameToUse).replace('\\n', '\n');
+          });
+        }
+    </script>
   <j:choose>
     <j:when test="${app.slaveAgentPort==-1}">
       <div class="error">
@@ -51,13 +98,17 @@ THE SOFTWARE.
                 <p>
                   ${%Run from agent command line:}
                 </p>
-                <pre>javaws ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp</pre>
+                <textarea class="copiable" readonly="readonly">javaws ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp</textarea>
               </li>
               <li>
                 <p>
                   ${%Or if the agent is headless:}
                 </p>
-                <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar <a href="${rootURL}/jnlpJars/slave.jar">slave.jar</a> -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp</pre>
+                  <textarea class="copiable" readonly="readonly"
+                            data-windows="Invoke-WebRequest -Uri $theurl -OutFile slave.jar\njava${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar slave.jar -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp"
+                            data-linux="curl -O ${h.inferHudsonURL(request)}jnlpJars/slave.jar\njava${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar slave.jar -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp">curl -O ${h.inferHudsonURL(request)}jnlpJars/slave.jar
+java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar slave.jar -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp
+                  </textarea>
               </li>
             </j:when>
             <j:otherwise>
@@ -66,10 +117,16 @@ THE SOFTWARE.
                   ${%Run from agent command line:}
                 </p>
                 <!-- TODO conceal secret w/ JS if possible -->
-                <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar <a href="${rootURL}/jnlpJars/slave.jar">slave.jar</a> -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp -secret ${it.jnlpMac}</pre>
+                <textarea class="copiable" readonly="readonly"
+                data-windows="Invoke-WebRequest -Uri $theurl -OutFile \njava${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar slave.jar -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp -secret ${it.jnlpMac}"
+                data-linux="curl -O ${h.inferHudsonURL(request)}jnlpJars/slave.jar\njava${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar slave.jar -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp -secret ${it.jnlpMac}">curl -O ${h.inferHudsonURL(request)}jnlpJars/slave.jar
+java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar slave.jar -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp -secret ${it.jnlpMac}
+                </textarea>
               </li>
             </j:otherwise>
           </j:choose>
+          <button id="linux"   style="width:10em" onclick="switchText('textarea.copiable[data-linux]','data-linux');  ">Linux</button>
+          <button id="windows" style="width:10em" onclick="switchText('textarea.copiable[data-linux]','data-windows');">Windows</button>
         </ul>
         <!--
         <p>

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -125,7 +125,7 @@ java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar slave.jar
               </li>
             </j:otherwise>
           </j:choose>
-          <button id="linux"   style="width:10em" onclick="switchText('textarea.copiable[data-linux]','data-linux');  ">Linux</button>
+          <button id="linux"   style="width:10em" onclick="switchText('textarea.copiable[data-linux]','data-linux');  ">cURL</button>
           <button id="windows" style="width:10em" onclick="switchText('textarea.copiable[data-linux]','data-windows');">Windows</button>
         </ul>
         <!--


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-43444
Not only provide the `java -jar ...` command, but also a `curl` or Windows command to download the 
then run the slave.jar. Plus a nowadays more and more common "Copy" button to save yet a bit more time.

Screenshot of the slightly changed UI (if you click on the `Linux` button, which is the default display when the page shows up):

![image](https://cloud.githubusercontent.com/assets/223853/24820838/75f2faf2-1beb-11e7-86cf-32b650db6810.png)


If you click on the `Windows` button:

![image](https://cloud.githubusercontent.com/assets/223853/24820814/5b5aea60-1beb-11e7-9697-2e6bb130da61.png)

From a technical standpoint, essentially:
* defines 'copiable' class that then enables the auto addition of a copy
  button for marked textareas
* Use of `data-windows` and `data-linux` attributes to store command for respective
  platforms. I could have used a JS var to fill the field when showing the
  page, but I wanted to have something that would still show up in case JS
  is disabled or at least a bit broken (and not an empty textarea in that
  case)
