### PR TITLE
[JENKINS-41932, JENKINS-42176] - Update libzfs4j from 0.5 to 0.8

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -531,7 +531,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>libzfs</artifactId>
-      <version>0.7</version>
+      <version>0.8</version>
     </dependency>
     <dependency>
       <groupId>com.sun.solaris</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -529,7 +529,7 @@ THE SOFTWARE.
       <version>1.8</version>
     </dependency>
     <dependency>
-      <groupId>org.jvnet.libzfs</groupId>
+      <groupId>org.kohsuke</groupId>
       <artifactId>libzfs</artifactId>
       <version>0.7</version>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -531,7 +531,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jvnet.libzfs</groupId>
       <artifactId>libzfs</artifactId>
-      <version>0.5</version>
+      <version>0.7</version>
     </dependency>
     <dependency>
       <groupId>com.sun.solaris</groupId>


### PR DESCRIPTION
So this PR updates `libzfs` from a 8-year-old release (0.5) to the newest one, which has been updated by @kohsuke and @jimklimov in order to get better support of new forks of Solaris.

Full diff: https://github.com/kohsuke/libzfs4j/compare/libzfs-0.5...libzfs-0.8. Reviews are welcome

## Changelog entry:

* JENKINS-41949, JENKINS-41932 - Update LibZFS from 0.5 to 0.8 to fix compatibility issues with ZFS filesystem and illumos distributions.

CC @jimklimov