### PR TITLE
Fix for translation tool newlines

### DIFF
--- a/translation-tool.pl
+++ b/translation-tool.pl
@@ -193,7 +193,7 @@ sub processFile {
          if (!$okeys{$_}) {
             if (!defined($okeys{$_})) {
                print F "# $ekeys{$_}\n" if ($ekeys{$_} && $ekeys{$_} ne "");
-               print F "$_=";
+               print F "$_=\n";
                if (defined($cache{$_})) {
                   print F $cache{$_}."\n";
                } else {


### PR DESCRIPTION
Without this, missing translations ended up on the same line, or had their comment appended to the previous translation.

Of course I don't know Perl so this may be completely wrong. All I know is…
![Works On My Machine](https://cloud.githubusercontent.com/assets/1831569/23621751/3e1fa142-029c-11e7-831d-dde9d3cba328.png)
