### PR TITLE
[JENKINS-42590] : remove text mentioning getDisplayName==null

### DIFF
--- a/core/src/main/java/hudson/model/ReconfigurableDescribable.java
+++ b/core/src/main/java/hudson/model/ReconfigurableDescribable.java
@@ -43,8 +43,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * <h2>Invisible Property</h2>
  * <p>
  * This mechanism can be used to create an entirely invisible {@link Describable}, which is handy
- * for {@link NodeProperty}, {@link JobProperty}, etc. To do so, define a descriptor with null
- * {@linkplain Descriptor#getDisplayName() display name} and empty config.jelly to prevent it from
+ * for {@link NodeProperty}, {@link JobProperty}, etc. To do so, define an empty config.jelly to prevent it from
  * showing up in the config UI, then implement {@link #reconfigure(StaplerRequest, JSONObject)}
  * and simply return {@code this}.
  *


### PR DESCRIPTION
After some checks on the code base it seems that indeed displayName is not null anymore.
I assume that in the javadoc text only the jelly part is still valid that's why I would like to contribute this pull request. I hope it is alright and if it is not the case .... sorry :disappointed: 

https://issues.jenkins-ci.org/browse/JENKINS-42590