### PR TITLE
[JENKINS-42556] Run more system threads as SYSTEM

### DIFF
--- a/core/src/main/java/jenkins/security/ImpersonatingExecutorService.java
+++ b/core/src/main/java/jenkins/security/ImpersonatingExecutorService.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import jenkins.util.InterceptingExecutorService;
+import org.acegisecurity.Authentication;
+
+/**
+ * Uses {@link ACL#impersonate(Authentication)} for all tasks.
+ * @see SecurityContextExecutorService
+ * @since FIXME
+ */
+public final class ImpersonatingExecutorService extends InterceptingExecutorService {
+
+    private final Authentication authentication;
+
+    /**
+     * Creates a wrapper service.
+     * @param base the base service
+     * @param authentication for example {@link ACL#SYSTEM}
+     */
+    public ImpersonatingExecutorService(ExecutorService base, Authentication authentication) {
+        super(base);
+        this.authentication = authentication;
+    }
+
+    @Override
+    protected Runnable wrap(final Runnable r) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                try (ACLContext ctxt = ACL.as(authentication)) {
+                    r.run();
+                }
+            }
+        };
+    }
+
+    @Override
+    protected <V> Callable<V> wrap(final Callable<V> r) {
+        return new Callable<V>() {
+            @Override
+            public V call() throws Exception {
+                try (ACLContext ctxt = ACL.as(authentication)) {
+                    return r.call();
+                }
+            }
+        };
+    }
+
+}

--- a/core/src/main/java/jenkins/security/ImpersonatingScheduledExecutorService.java
+++ b/core/src/main/java/jenkins/security/ImpersonatingScheduledExecutorService.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security;
+
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import jenkins.util.InterceptingScheduledExecutorService;
+import org.acegisecurity.Authentication;
+
+/**
+ * Variant of {@link ImpersonatingExecutorService} for scheduled services.
+ * @since FIXME
+ */
+public final class ImpersonatingScheduledExecutorService extends InterceptingScheduledExecutorService {
+
+    private final Authentication authentication;
+
+    /**
+     * Creates a wrapper service.
+     * @param base the base service
+     * @param authentication for example {@link ACL#SYSTEM}
+     */
+    public ImpersonatingScheduledExecutorService(ScheduledExecutorService base, Authentication authentication) {
+        super(base);
+        this.authentication = authentication;
+    }
+
+    @Override
+    protected Runnable wrap(final Runnable r) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                try (ACLContext ctxt = ACL.as(authentication)) {
+                    r.run();
+                }
+            }
+        };
+    }
+
+    @Override
+    protected <V> Callable<V> wrap(final Callable<V> r) {
+        return new Callable<V>() {
+            @Override
+            public V call() throws Exception {
+                try (ACLContext ctxt = ACL.as(authentication)) {
+                    return r.call();
+                }
+            }
+        };
+    }
+
+}

--- a/core/src/main/java/jenkins/util/InterceptingScheduledExecutorService.java
+++ b/core/src/main/java/jenkins/util/InterceptingScheduledExecutorService.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.util;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Generalization of {@link InterceptingExecutorService} tp scheduled services.
+ * @since FIXME
+ */
+public abstract class InterceptingScheduledExecutorService extends InterceptingExecutorService implements ScheduledExecutorService {
+
+    protected InterceptingScheduledExecutorService(ScheduledExecutorService base) {
+        super(base);
+    }
+
+    @Override
+    protected ScheduledExecutorService delegate() {
+        return (ScheduledExecutorService) super.delegate();
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return delegate().schedule(wrap(command), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return delegate().schedule(wrap(callable), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return delegate().scheduleAtFixedRate(wrap(command), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return delegate().scheduleWithFixedDelay(wrap(command), initialDelay, delay, unit);
+    }
+
+}

--- a/core/src/main/java/jenkins/util/InterceptingScheduledExecutorService.java
+++ b/core/src/main/java/jenkins/util/InterceptingScheduledExecutorService.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Generalization of {@link InterceptingExecutorService} tp scheduled services.
+ * Generalization of {@link InterceptingExecutorService} to scheduled services.
  * @since FIXME
  */
 public abstract class InterceptingScheduledExecutorService extends InterceptingExecutorService implements ScheduledExecutorService {

--- a/core/src/main/java/jenkins/util/Timer.java
+++ b/core/src/main/java/jenkins/util/Timer.java
@@ -1,9 +1,11 @@
 package jenkins.util;
 
+import hudson.security.ACL;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.NamingThreadFactory;
 import javax.annotation.Nonnull;
 import java.util.concurrent.ScheduledExecutorService;
+import jenkins.security.ImpersonatingScheduledExecutorService;
 
 /**
  * Holds the {@link ScheduledExecutorService} for running all background tasks in Jenkins.
@@ -39,7 +41,8 @@ public class Timer {
         if (executorService == null) {
             // corePoolSize is set to 10, but will only be created if needed.
             // ScheduledThreadPoolExecutor "acts as a fixed-sized pool using corePoolSize threads"
-            executorService =  new ErrorLoggingScheduledThreadPoolExecutor(10, new NamingThreadFactory(new DaemonThreadFactory(), "jenkins.util.Timer"));
+            // TODO consider also wrapping in ContextResettingExecutorService
+            executorService = new ImpersonatingScheduledExecutorService(new ErrorLoggingScheduledThreadPoolExecutor(10, new NamingThreadFactory(new DaemonThreadFactory(), "jenkins.util.Timer")), ACL.SYSTEM);
         }
         return executorService;
     }


### PR DESCRIPTION
Suffices to fix [JENKINS-42556](https://issues.jenkins-ci.org/browse/JENKINS-42556) (and probably a variety of similar bugs, reported or not) by ensuring that code in `Timer` and `Queue` threads runs as `SYSTEM`, the way other background threads (for example, periodic tasks, or Jenkins startup) already were.

Proposed changelog entry: Run more system threads with full, rather than anonymous, authentication, to prevent bugs typically relating to jobs hidden from anonymous users.

@reviewbybees