### PR TITLE
[JENKINS-42670] - Fix the potential File descriptor leak in the Windows Service installer

### DIFF
--- a/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
@@ -306,9 +306,9 @@ public class WindowsInstallerLink extends ManagementLink {
         try {
             return Kernel32Utils.waitForExitProcess(sei.hProcess);
         } finally {
-            FileInputStream fin = new FileInputStream(new File(pwd,"redirect.log"));
-            IOUtils.copy(fin, out.getLogger());
-            fin.close();
+            try (FileInputStream fin = new FileInputStream(new File(pwd,"redirect.log"))) {
+                IOUtils.copy(fin, out.getLogger());
+            }
         }
     }
 


### PR DESCRIPTION
# Description

See [JENKINS-42670](https://issues.jenkins-ci.org/browse/JENKINS-42670).

Details: Windows Service installer for the Jenkins master uses the "Redirect.log" to retrieve the result of the service start command. If the read issue happens, the file descriptor may be leaked. In such case new service start attempts within Jenkins will be failing till the instance restart. 

The PR contains no tests, because FindBugs is expected to become our best friend once it gets enabled

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

* JENKINS-42670: Prevent file descriptor logs when Windows Service installer fails to read data from the service startup log
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Link to JIRA ticket in description, if appropriate
- [X] Appropriate autotests or explanation to why this change has no tests
- [X] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you want to get reviews from particular people, please CC them.
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
