### PR TITLE
Skip JENKINS-16634 test on Windows

### DIFF
--- a/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
+++ b/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
@@ -2,8 +2,10 @@ package hudson.util.io;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assume.assumeFalse;
 
 import hudson.FilePath;
+import hudson.Functions;
 import org.junit.Test;
 
 import java.io.File;
@@ -43,6 +45,7 @@ public class RewindableRotatingFileOutputStreamTest {
     @Issue("JENKINS-16634")
     @Test
     public void deletedFolder() throws Exception {
+        assumeFalse(Functions.isWindows()); // TODO make work on Windows
         File dir = tmp.newFolder("dir");
         File base = new File(dir, "x.log");
         RewindableRotatingFileOutputStream os = new RewindableRotatingFileOutputStream(base, 3);


### PR DESCRIPTION
# Description

This test keeps failing PR builds. AFAIU it can't work on Windows due to file locking. To restore operation of the PR builder, ignore this test on Windows.

### Changelog entries

None

### Submitter checklist

Not applicable

### Desired reviewers

@jtnord (Windows guy), @jglick (test author)