### PR TITLE
[JENKINS-42645] Case insensitive search by default for new and anonymous users

### DIFF
--- a/core/src/main/java/hudson/search/FixedSet.java
+++ b/core/src/main/java/hudson/search/FixedSet.java
@@ -51,7 +51,7 @@ public class FixedSet implements SearchIndex {
                 token=token.toLowerCase();
                 name=name.toLowerCase();
             }
-            if(token.equals(i.getSearchName()))
+            if(token.equals(name))
                 result.add(i);
         }
     }

--- a/core/src/main/java/hudson/search/FixedSet.java
+++ b/core/src/main/java/hudson/search/FixedSet.java
@@ -27,12 +27,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
+
 /**
  * Set of {@link SearchItem}s that are statically known upfront.
  *
  * @author Kohsuke Kawaguchi
  */
 public class FixedSet implements SearchIndex {
+
     private final Collection<? extends SearchItem> items;
 
     public FixedSet(Collection<? extends SearchItem> items) {
@@ -45,27 +48,21 @@ public class FixedSet implements SearchIndex {
 
     public void find(String token, List<SearchItem> result) {
         boolean caseInsensitive = UserSearchProperty.isCaseInsensitive();
-        for (SearchItem i : items){
+        for (SearchItem i : items) {
             String name = i.getSearchName();
-            if(caseInsensitive){
-                token=token.toLowerCase();
-                name=name.toLowerCase();
-            }
-            if(token.equals(name))
+            if (name.equals(token) || (caseInsensitive && name.equalsIgnoreCase(token))) {
                 result.add(i);
+            }
         }
     }
 
     public void suggest(String token, List<SearchItem> result) {
         boolean caseInsensitive = UserSearchProperty.isCaseInsensitive();
-        for (SearchItem i : items){
+        for (SearchItem i : items) {
             String name = i.getSearchName();
-            if(caseInsensitive){
-                token=token.toLowerCase();
-                name=name.toLowerCase();
-            }
-            if(name.contains(token))
+            if (name.contains(token) || (caseInsensitive && StringUtils.containsIgnoreCase(name, token))) {
                 result.add(i);
+            }
         }
     }
 }

--- a/core/src/main/java/hudson/search/UserSearchProperty.java
+++ b/core/src/main/java/hudson/search/UserSearchProperty.java
@@ -11,7 +11,9 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 
 public class UserSearchProperty extends hudson.model.UserProperty {
-    
+
+    private static final boolean CASE_INSENSITIVE_SEARCH_MODE = true;
+
     private final boolean insensitiveSearch;
 
     public UserSearchProperty(boolean insensitiveSearch) {
@@ -25,11 +27,12 @@ public class UserSearchProperty extends hudson.model.UserProperty {
     
     public static boolean isCaseInsensitive(){
         User user = User.current();
-        boolean caseInsensitive = false;
-        if(user!=null && user.getProperty(UserSearchProperty.class).getInsensitiveSearch()){//Searching for anonymous user is case-sensitive
-          caseInsensitive=true;
+
+        if (user == null) {
+            return CASE_INSENSITIVE_SEARCH_MODE;
         }
-        return caseInsensitive;
+
+        return user.getProperty(UserSearchProperty.class).getInsensitiveSearch();
     }
     
 
@@ -40,7 +43,7 @@ public class UserSearchProperty extends hudson.model.UserProperty {
         }
 
         public UserProperty newInstance(User user) {
-            return new UserSearchProperty(false); //default setting is case-sensitive searching
+            return new UserSearchProperty(CASE_INSENSITIVE_SEARCH_MODE);
         }
 
         @Override

--- a/core/src/main/java/hudson/search/UserSearchProperty.java
+++ b/core/src/main/java/hudson/search/UserSearchProperty.java
@@ -12,7 +12,7 @@ import org.kohsuke.stapler.export.Exported;
 
 public class UserSearchProperty extends hudson.model.UserProperty {
 
-    private static final boolean CASE_INSENSITIVE_SEARCH_MODE = true;
+    private static final boolean DEFAULT_SEARCH_CASE_INSENSITIVE_MODE = true;
 
     private final boolean insensitiveSearch;
 
@@ -29,7 +29,7 @@ public class UserSearchProperty extends hudson.model.UserProperty {
         User user = User.current();
 
         if (user == null) {
-            return CASE_INSENSITIVE_SEARCH_MODE;
+            return DEFAULT_SEARCH_CASE_INSENSITIVE_MODE;
         }
 
         return user.getProperty(UserSearchProperty.class).getInsensitiveSearch();
@@ -43,7 +43,7 @@ public class UserSearchProperty extends hudson.model.UserProperty {
         }
 
         public UserProperty newInstance(User user) {
-            return new UserSearchProperty(CASE_INSENSITIVE_SEARCH_MODE);
+            return new UserSearchProperty(DEFAULT_SEARCH_CASE_INSENSITIVE_MODE);
         }
 
         @Override

--- a/core/src/test/java/hudson/model/ViewTest.java
+++ b/core/src/test/java/hudson/model/ViewTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import javax.servlet.ServletException;
@@ -98,7 +99,7 @@ public class ViewTest {
         final TopLevelItem rightJob = createJob("rightJob");
 
         Mockito.when(leftView.getItems()).thenReturn(Arrays.asList(leftJob, sharedJob));
-        Mockito.when(rightView.getItems()).thenReturn(Arrays.asList(rightJob));
+        Mockito.when(rightView.getItems()).thenReturn(Collections.singletonList(rightJob));
 
         final TopLevelItem[] expected = new TopLevelItem[] {rootJob, sharedJob, leftJob, rightJob};
 

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -37,8 +37,8 @@ import hudson.model.Run;
 import hudson.model.StringParameterValue;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -326,6 +326,7 @@ public class HistoryPageFilterTest {
     }
 
     @Test
+    @Issue("JENKINS-42645")
     public void should_be_case_insensitive_by_default() throws IOException {
         List<ModelObject> runs = Lists.<ModelObject>newArrayList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
         assertOneMatchingBuildForGivenSearchStringAndRunItems("failure", runs);
@@ -338,6 +339,7 @@ public class HistoryPageFilterTest {
     }
 
     @Test
+    @Issue("JENKINS-40718")
     public void should_search_builds_by_build_variables() throws IOException {
         List<ModelObject> runs = ImmutableList.<ModelObject>of(
                 new MockBuild(2).withBuildVariables(ImmutableMap.of("env", "dummyEnv")),
@@ -346,6 +348,7 @@ public class HistoryPageFilterTest {
     }
 
     @Test
+    @Issue("JENKINS-40718")
     public void should_search_builds_by_build_params() throws IOException {
         List<ModelObject> runs = ImmutableList.<ModelObject>of(
                 new MockBuild(2).withBuildParameters(ImmutableMap.of("env", "dummyEnv")),
@@ -354,6 +357,7 @@ public class HistoryPageFilterTest {
     }
 
     @Test
+    @Issue("JENKINS-40718")
     public void should_ignore_sensitive_parameters_in_search_builds_by_build_params() throws IOException {
         List<ModelObject> runs = ImmutableList.<ModelObject>of(
                 new MockBuild(2).withBuildParameters(ImmutableMap.of("plainPassword", "pass1plain")),

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -326,24 +326,19 @@ public class HistoryPageFilterTest {
     }
 
     @Test
-    public void test_search_should_be_case_sensitive_for_anonymous_user() throws IOException {
-        //given
-        HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
-        //and
-        historyPageFilter.setSearchString("failure");
-        //and
+    public void should_be_case_insensitive_by_default() throws IOException {
         List<ModelObject> runs = Lists.<ModelObject>newArrayList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
-        List<Queue.Item> queueItems = newQueueItems(3, 4);
-
-        //when
-        historyPageFilter.add(runs, queueItems);
-
-        //then
-        Assert.assertEquals(0, historyPageFilter.runs.size());
+        assertOneMatchingBuildForGivenSearchStringAndRunItems("failure", runs);
     }
 
     @Test
-    public void test_search_builds_by_build_variables() throws IOException {
+    public void should_lower_case_search_string_in_case_insensitive_search() throws IOException {
+        List<ModelObject> runs = Lists.<ModelObject>newArrayList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
+        assertOneMatchingBuildForGivenSearchStringAndRunItems("FAILure", runs);
+    }
+
+    @Test
+    public void should_search_builds_by_build_variables() throws IOException {
         List<ModelObject> runs = ImmutableList.<ModelObject>of(
                 new MockBuild(2).withBuildVariables(ImmutableMap.of("env", "dummyEnv")),
                 new MockBuild(1).withBuildVariables(ImmutableMap.of("env", "otherEnv")));
@@ -351,7 +346,7 @@ public class HistoryPageFilterTest {
     }
 
     @Test
-    public void test_search_builds_by_build_params() throws IOException {
+    public void should_search_builds_by_build_params() throws IOException {
         List<ModelObject> runs = ImmutableList.<ModelObject>of(
                 new MockBuild(2).withBuildParameters(ImmutableMap.of("env", "dummyEnv")),
                 new MockBuild(1).withBuildParameters(ImmutableMap.of("env", "otherEnv")));
@@ -359,7 +354,7 @@ public class HistoryPageFilterTest {
     }
 
     @Test
-    public void test_ignore_sensitive_parameters_in_search_builds_by_build_params() throws IOException {
+    public void should_ignore_sensitive_parameters_in_search_builds_by_build_params() throws IOException {
         List<ModelObject> runs = ImmutableList.<ModelObject>of(
                 new MockBuild(2).withBuildParameters(ImmutableMap.of("plainPassword", "pass1plain")),
                 new MockBuild(1).withSensitiveBuildParameters("password", "pass1"));


### PR DESCRIPTION
# Description

See [JENKINS-42645](https://issues.jenkins-ci.org/browse/JENKINS-42645).

**In short**: Search is case insensitive by default (for newly created and anonymous users)

TODO: This PR changes behavior for newly created and anonymous users. It would be good to have it also for already existing users. Nevertheless it is more complicated and should be rather moved to another issue. Implementation suggestions are welcome: https://groups.google.com/d/msg/jenkinsci-dev/I9PVV3j0Eb8/Ln4njJlGDgAJ (or in [JENKINS-42701](https://issues.jenkins-ci.org/browse/JENKINS-42701)).

### Changelog entries

Proposed changelog entries:

* Entry 1: JENKINS-42645, Search is case insensitive by default (for newly created and anonymous users)

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

### Desired reviewers

@daniel-beck - in relation to #2683