### PR TITLE
Clarify PermissionGroup.owner is @Nonnull

### DIFF
--- a/core/src/main/java/hudson/security/PermissionGroup.java
+++ b/core/src/main/java/hudson/security/PermissionGroup.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 import org.jvnet.localizer.Localizable;
 
 /**
@@ -39,6 +41,8 @@ import org.jvnet.localizer.Localizable;
  */
 public final class PermissionGroup implements Iterable<Permission>, Comparable<PermissionGroup> {
     private final SortedSet<Permission> permissions = new TreeSet<Permission>(Permission.ID_COMPARATOR);
+
+    @Nonnull
     public final Class owner;
 
     /**
@@ -53,7 +57,7 @@ public final class PermissionGroup implements Iterable<Permission>, Comparable<P
      * @param title sets {@link #title}
      * @throws IllegalStateException if this group was already registered
      */
-    public PermissionGroup(Class owner, Localizable title) throws IllegalStateException {
+    public PermissionGroup(@Nonnull Class owner, Localizable title) throws IllegalStateException {
         this.owner = owner;
         this.title = title;
         register(this);


### PR DESCRIPTION
I was reading the `Permission` class and realized that:

* [Permission.owner is already marked @Nonnull](https://github.com/jenkinsci/jenkins/blob/496703d0fe133445e10c7d8d07fa7afd351c8854/core/src/main/java/hudson/security/Permission.java#L67-L67) ; and
* `Permission.owner` is built from [`PermisionGroup.owner`](https://github.com/jenkinsci/jenkins/blob/496703d0fe133445e10c7d8d07fa7afd351c8854/core/src/main/java/hudson/security/Permission.java#L154-L154)

# Description

Details: Mark Permission.owner as @Nonnull

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

* Mark PermissionGroup.owner @Nonnull (note: can *not* change current behaviour as this is only a compiler/IDE hint)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] ~~JIRA issue is well described~~
- [x] ~~Link to JIRA ticket in description, if appropriate~~
- [X] Appropriate autotests or explanation to why this change has no tests
- [x] ~~For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)~~

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you want to get reviews from particular people, please CC them.
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
