### PR TITLE
JENKINS-42854: Added description field to the 'Computer' api

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1068,6 +1068,17 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     /**
+     * Returns the {@link Node} description for this computer
+     */
+    @Restricted(DoNotUse.class)
+    @Exported
+    public @Nonnull String getDescription() {
+        Node node = getNode();
+        return (node != null) ? node.getNodeDescription() : null;
+    }
+
+
+    /**
      * Called by {@link Executor} to kill excessive executors from this computer.
      */
     protected void removeExecutor(final Executor e) {


### PR DESCRIPTION
# Description

When creating a new slave node it is possible to add a description, however the description is not available when querying the api for the list of nodes. 

See [JENKINS-42854](https://issues.jenkins-ci.org/browse/JENKINS-42854).

Details: 

I have exposed the description field of a Slave Node that was previously missing in the api.

I have not provided new unit tests as the patch is trivial, also I have not found existing tests for that area of code.

### Changelog entries

Proposed changelog entries:

* API: Added description field to Slave Nodes

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@jglick @kohsuke @stephenc