### PR TITLE
[JENKINS-42861] - Properly deprecate the HudsonExceptionNote implementation

### DIFF
--- a/core/src/main/java/hudson/console/ConsoleAnnotator.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotator.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * Annotates one line of console output.
@@ -71,15 +73,16 @@ public abstract class ConsoleAnnotator<T> implements Serializable {
      * Annotates one line.
      *
      * @param context
-     *      The object that owns the console output. Never null.
+     *      The object that owns the console output. Never {@code null}.
      * @param text
      *      Contains a single line of console output, and defines convenient methods to add markup.
-     *      The callee should put markup into this object. Never null.
+     *      The callee should put markup into this object. Never {@code null}.
      * @return
      *      The {@link ConsoleAnnotator} object that will annotate the next line of the console output.
-     *      To indicate that you are not interested in the following lines, return null.
+     *      To indicate that you are not interested in the following lines, return {@code null}.
      */
-    public abstract ConsoleAnnotator annotate(T context, MarkupText text );
+    @CheckForNull
+    public abstract ConsoleAnnotator annotate(@Nonnull T context, @Nonnull MarkupText text );
 
     /**
      * Cast operation that restricts T.

--- a/core/src/main/java/hudson/console/HudsonExceptionNote.java
+++ b/core/src/main/java/hudson/console/HudsonExceptionNote.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2010-2011, CloudBees, Inc.
+ * Copyright (c) 2010-2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,16 +30,24 @@ import org.jenkinsci.Symbol;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+// TODO: consider providing alternate search mechanisms (JIRA, grepcode, etc.) as proposed in 
+// https://github.com/jenkinsci/jenkins/pull/2808#pullrequestreview-27467560
 /**
- * Placed on the beginning of the exception stack trace produced by Hudson, which in turn produces hyperlinked stack trace.
+ * Placed on the beginning of the exception stack trace produced by Jenkins, 
+ * which in turn produces hyperlinked stack trace.
  *
  * <p>
  * Exceptions in the user code (like junit etc) should be handled differently. This is only for exceptions
- * that occur inside Hudson.
+ * that occur inside Jenkins.
  *
  * @author Kohsuke Kawaguchi
- * @since 1.349
+ * @since 1.349 - produces search hyperlinks to the http://stacktrace.jenkins-ci.org service
+ * @since TODO - does nothing due to JENKINS-42861
+ * @deprecated This ConsoleNote used to provide hyperlinks to the
+ *             <code>http://stacktrace.jenkins-ci.org/</code> service, which is dead now (JENKINS-42861).
+ *             This console note does nothing right now.
  */
+@Deprecated
 public class HudsonExceptionNote extends ConsoleNote<Object> {
 
     @Override
@@ -59,7 +67,12 @@ public class HudsonExceptionNote extends ConsoleNote<Object> {
         text.addHyperlinkLowKey(charPos,end,annotateClassName(line.substring(charPos,end)));
 
         return new ConsoleAnnotator() {
+            @Override
             public ConsoleAnnotator annotate(Object context, MarkupText text) {
+                // TODO: the code below is deprecated due to JENKINS-42861
+                return null;
+                
+                /*
                 String line = text.getText();
 
                 Matcher m = STACK_TRACE_ELEMENT.matcher(line);
@@ -82,6 +95,7 @@ public class HudsonExceptionNote extends ConsoleNote<Object> {
 
                 // looks like we are done with the stack trace
                 return null;
+                */
             }
         };
     }

--- a/core/src/main/java/hudson/console/HudsonExceptionNote.java
+++ b/core/src/main/java/hudson/console/HudsonExceptionNote.java
@@ -27,11 +27,9 @@ import hudson.Extension;
 import hudson.MarkupText;
 import org.jenkinsci.Symbol;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-// TODO: consider providing alternate search mechanisms (JIRA, grepcode, etc.) as proposed in 
-// https://github.com/jenkinsci/jenkins/pull/2808#pullrequestreview-27467560
+// TODO: the implementation has been deprecated due to JENKINS-42861
+// Consider providing alternate search mechanisms (JIRA, grepcode, etc.) as proposed in 
+// https://github.com/jenkinsci/jenkins/pull/2808#pullrequestreview-27467560 (JENKINS-43612)
 /**
  * Placed on the beginning of the exception stack trace produced by Jenkins, 
  * which in turn produces hyperlinked stack trace.
@@ -52,62 +50,8 @@ public class HudsonExceptionNote extends ConsoleNote<Object> {
 
     @Override
     public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
-        // An exception stack trace looks like this:
-        // org.acme.FooBarException: message
-        // <TAB>at org.acme.Foo.method(Foo.java:123)
-        // Caused by: java.lang.ClassNotFoundException:
-        String line = text.getText();
-        int end = line.indexOf(':',charPos);
-        if (end<0) {
-            if (CLASSNAME.matcher(line.substring(charPos)).matches())
-                end = line.length();
-            else
-                return null;    // unexpected format. abort.
-        }
-        text.addHyperlinkLowKey(charPos,end,annotateClassName(line.substring(charPos,end)));
 
-        return new ConsoleAnnotator() {
-            @Override
-            public ConsoleAnnotator annotate(Object context, MarkupText text) {
-                // TODO: the code below is deprecated due to JENKINS-42861
-                return null;
-                
-                /*
-                String line = text.getText();
-
-                Matcher m = STACK_TRACE_ELEMENT.matcher(line);
-                if (m.find()) {// allow the match to happen in the middle of a line to cope with prefix. Ant and Maven put them, among many other tools.
-                    text.addHyperlinkLowKey(m.start()+4,m.end(),annotateMethodName(m.group(1),m.group(2),m.group(3),Integer.parseInt(m.group(4))));
-                    return this;
-                }
-
-                int idx = line.indexOf(CAUSED_BY);
-                if (idx>=0) {
-                    int s = idx + CAUSED_BY.length();
-                    int e = line.indexOf(':', s);
-                    if (e<0)    e = line.length();
-                    text.addHyperlinkLowKey(s,e,annotateClassName(line.substring(s,e)));
-                    return this;
-                }
-
-                if (AND_MORE.matcher(line).matches())
-                    return this;
-
-                // looks like we are done with the stack trace
-                return null;
-                */
-            }
-        };
-    }
-
-    // TODO; separate out the annotations and mark up
-
-    private String annotateMethodName(String className, String methodName, String sourceFileName, int lineNumber) {
-        return "http://stacktrace.jenkins-ci.org/search/?query="+className+'.'+methodName+"&entity=method";
-    }
-
-    private String annotateClassName(String className) {
-        return "http://stacktrace.jenkins-ci.org/search?query="+className;
+        return null;
     }
 
     @Extension @Symbol("stackTrace")
@@ -117,21 +61,4 @@ public class HudsonExceptionNote extends ConsoleNote<Object> {
             return "Exception Stack Trace";
         }
     }
-
-    /**
-     * Regular expression that represents a valid class name.
-     */
-    private static final String CLASSNAME_PATTERN = "[\\p{L}0-9$_.]+";
-
-    private static final Pattern CLASSNAME = Pattern.compile(CLASSNAME_PATTERN+"\r?\n?");
-
-    /**
-     * Matches to the line like "\tat org.acme.Foo.method(File.java:123)"
-     * and captures class name, method name, source file name, and line number separately.
-     */
-    private static final Pattern STACK_TRACE_ELEMENT = Pattern.compile("\tat ("+CLASSNAME_PATTERN+")\\.([\\p{L}0-9$_<>]+)\\((\\S+):([0-9]+)\\)");
-
-    private static final String CAUSED_BY = "Caused by: ";
-
-    private static final Pattern AND_MORE = Pattern.compile("\t... [0-9]+ more\n");
 }

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -142,7 +142,7 @@ public class StreamTaskListener extends AbstractTaskListener implements Serializ
         out.print(prefix);
         out.println(msg);
 
-        // the idiom in Hudson is to use the returned writer for writing stack trace,
+        // the idiom in Jenkins is to use the returned writer for writing stack trace,
         // so put the marker here to indicate an exception. if the stack trace isn't actually written,
         // HudsonExceptionNote.annotate recovers gracefully.
         try {


### PR DESCRIPTION
It is a replacement of the original fix in https://github.com/jenkinsci/jenkins/pull/2808 by @daniel-beck, which I've unintentionally derailed.

The implementation provides deprecates the annotation of the new stacktraces, but it retains the binary and the persisted data compatibility, which were missing in the original PR.
In the longer-term the hyperlinks should be replaced by the best possible equivalent (JIRA search, grepcode or whatever).

See [JENKINS-42861](https://issues.jenkins-ci.org/browse/JENKINS-42861).

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

* Entry 1: JENKINS-42861, Remove links in stack traces to the `stacktrace.jenkins-ci.org` service that has been shut down.
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@daniel-beck 

<!-- Comment:
If you want to get reviews from particular people, please CC them.
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
