### PR TITLE
[JENKINS-40665] Add support for "Run" and thus to Pipeline Jobs to Maven SettingsProvider and GlobalSettingsProvider

### DIFF
--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -24,6 +24,7 @@
 package hudson.tasks;
 
 import hudson.Extension;
+import hudson.FilePath;
 import jenkins.MasterToSlaveFileCallable;
 import hudson.Launcher;
 import hudson.Functions;
@@ -328,15 +329,15 @@ public class Maven extends Builder {
             
             
             if(!S_PATTERN.matcher(targets).find()){ // check the given target/goals do not contain settings parameter already
-                String settingsPath = SettingsProvider.getSettingsRemotePath(getSettings(), build, listener);
-                if(StringUtils.isNotBlank(settingsPath)){
-                    args.add("-s", settingsPath);
+                FilePath settingsPath = getSettings().supplySettings(build, build.getWorkspace(), listener);
+                if(settingsPath != null){
+                    args.add("-s", settingsPath.getRemote());
                 }
             }
             if(!GS_PATTERN.matcher(targets).find()){
-                String settingsPath = GlobalSettingsProvider.getSettingsRemotePath(getGlobalSettings(), build, listener);
-                if(StringUtils.isNotBlank(settingsPath)){
-                    args.add("-gs", settingsPath);
+                FilePath settingsPath = getGlobalSettings().supplySettings(build, build.getWorkspace(), listener);
+                if(settingsPath != null){
+                    args.add("-gs", settingsPath.getRemote());
                 }
             }
 

--- a/core/src/main/java/jenkins/mvn/DefaultGlobalSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/DefaultGlobalSettingsProvider.java
@@ -2,11 +2,13 @@ package jenkins.mvn;
 
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -20,7 +22,7 @@ public class DefaultGlobalSettingsProvider extends GlobalSettingsProvider {
     }
 
     @Override
-    public FilePath supplySettings(AbstractBuild<?, ?> project, TaskListener listener) {
+    public FilePath supplySettings(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull TaskListener listener) {
         return null;
     }
 

--- a/core/src/main/java/jenkins/mvn/DefaultSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/DefaultSettingsProvider.java
@@ -2,7 +2,7 @@ package jenkins.mvn;
 
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 
 import org.jenkinsci.Symbol;
@@ -20,7 +20,7 @@ public class DefaultSettingsProvider extends SettingsProvider {
     }
 
     @Override
-    public FilePath supplySettings(AbstractBuild<?, ?> project, TaskListener listener) {
+    public FilePath supplySettings(Run<?, ?> build, FilePath workspace, TaskListener listener) {
         return null;
     }
 

--- a/core/src/main/java/jenkins/mvn/FilePathSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/FilePathSettingsProvider.java
@@ -1,18 +1,15 @@
 package jenkins.mvn;
 
-import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.Util;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.util.IOUtils;
-
-import java.io.File;
-
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -20,6 +17,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @since 1.491
  */
 public class FilePathSettingsProvider extends SettingsProvider {
+    protected final static Logger LOGGER = Logger.getLogger(FilePathGlobalSettingsProvider.class.getName());
 
     private final String path;
 
@@ -33,33 +31,10 @@ public class FilePathSettingsProvider extends SettingsProvider {
     }
 
     @Override
-    public FilePath supplySettings(AbstractBuild<?, ?> build, TaskListener listener) {
-        if (StringUtils.isEmpty(path)) {
-            return null;
-        }
-
-        try {
-            EnvVars env = build.getEnvironment(listener);
-            String targetPath = Util.replaceMacro(this.path, build.getBuildVariableResolver());
-            targetPath = env.expand(targetPath);
-
-            if (IOUtils.isAbsolute(targetPath)) {
-                return new FilePath(new File(targetPath));
-            } else {
-                FilePath mrSettings = build.getModuleRoot().child(targetPath);
-                FilePath wsSettings = build.getWorkspace().child(targetPath);
-                try {
-                    if (!wsSettings.exists() && mrSettings.exists()) {
-                        wsSettings = mrSettings;
-                    }
-                } catch (Exception e) {
-                    throw new IllegalStateException("failed to find settings.xml at: " + wsSettings.getRemote());
-                }
-                return wsSettings;
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException("failed to prepare settings.xml");
-        }
+    public FilePath supplySettings(Run<?, ?> build, FilePath workspace, TaskListener listener) throws IOException, InterruptedException {
+        FilePath mavenSettingsFile = SettingsProviderHelper.supplySettings(this.path, build, workspace, listener);
+        LOGGER.log(Level.FINE, "Supply Maven settings.xml file {0} to {1}", new Object[]{mavenSettingsFile, build});
+        return mavenSettingsFile;
     }
 
     @Extension(ordinal = 10) @Symbol("filePath")

--- a/core/src/main/java/jenkins/mvn/GlobalSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/GlobalSettingsProvider.java
@@ -2,16 +2,22 @@ package jenkins.mvn;
 
 import hudson.ExtensionPoint;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -21,13 +27,57 @@ import org.kohsuke.stapler.StaplerRequest;
 public abstract class GlobalSettingsProvider extends AbstractDescribableImpl<GlobalSettingsProvider> implements ExtensionPoint {
 
     /**
+     * Configure maven launcher argument list with adequate settings path.
+     *
+     * <p>Implementations should
+     * <ul>Be aware that this method might get called multiple times during a build.</ul>
+     * <ul>Implement this method. This class provides a default implementation when the given {@code build} is an {@link AbstractBuild}
+     * delegating to {@link #supplySettings(AbstractBuild, TaskListener)} so that implementations have time to adapt.</ul>
+     * </p>
+     *
+     * @param build       the build to provide the settings for
+     * @param workspace the workspace in which the build takes place
+     * @param listener the listener of this given build
+     * @return the filepath to the provided file. {@code null} if no settings will be provided.
+     * @throws IOException typically occurs when the {@code supplySettings()} implementation accesses to the
+     *         build environment on the build agent (copying a file to disk...)
+     * @throws InterruptedException typically occurs while the {@code supplySettings()} implementation accesses to the
+     *         build environment on the build agent (copying a file to disk...)
+     * @since TODO
+     */
+    @CheckForNull
+    public FilePath supplySettings(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        if (build instanceof AbstractBuild && Util.isOverridden(GlobalSettingsProvider.class, this.getClass() , "supplySettings",AbstractBuild.class, TaskListener.class)) {
+            AbstractBuild abstractBuild = (AbstractBuild) build;
+            return supplySettings(abstractBuild, listener);
+        } else {
+            throw new AbstractMethodError("Class " + getClass() + " must override the new method supplySettings(Run<?, ?> run, FilePath workspace, TaskListener listener)");
+        }
+    }
+
+    /**
      * configure maven launcher argument list with adequate settings path
      * 
      * @param build
      *            the build to provide the settings for
-     * @return the filepath to the provided file. <code>null</code> if no settings will be provided.
+     * @return the filepath to the provided file. {@code null} if no settings will be provided.
+     * @throws RuntimeException if an {@link IOException} or an {@link InterruptedException} occurs. These {@link IOException}
+     *         or {@link InterruptedException} can typically occur when the {@link #supplySettings(AbstractBuild, TaskListener)}
+     *         implementation access to the build environment on the build agent (copying a file to disk...)
+     * @deprecated use {@link #supplySettings(Run, FilePath, TaskListener)}
      */
-    public abstract FilePath supplySettings(AbstractBuild<?, ?> build, TaskListener listener);
+    @Deprecated
+    public FilePath supplySettings(AbstractBuild<?, ?> build, TaskListener listener) {
+        try {
+            return supplySettings(build, build.getWorkspace(), listener);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to prepare Maven global settings.xml for " + build +
+                    " in workspace " + build.getWorkspace(), e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Failed to prepare Maven global settings.xml for " + build +
+                    " in workspace " + build.getWorkspace(), e);
+        }
+    }
 
     public static GlobalSettingsProvider parseSettingsProvider(StaplerRequest req) throws Descriptor.FormException, ServletException {
         JSONObject settings = req.getSubmittedForm().getJSONObject("globalSettings");
@@ -38,7 +88,7 @@ public abstract class GlobalSettingsProvider extends AbstractDescribableImpl<Glo
     }
 
     /**
-     * Convenience method handling all <code>null</code> checks. Provides the path on the (possible) remote settings file.
+     * Convenience method handling all {@code null} checks. Provides the path on the (possible) remote settings file.
      * 
      * @param settings
      *            the provider to be used
@@ -47,7 +97,9 @@ public abstract class GlobalSettingsProvider extends AbstractDescribableImpl<Glo
      * @param listener
      *            the listener of the current build
      * @return the path to the global settings.xml
+     * @deprecated directly invoke {@link #supplySettings(Run, FilePath, TaskListener)}
      */
+    @Deprecated
     public static final FilePath getSettingsFilePath(GlobalSettingsProvider settings, AbstractBuild<?, ?> build, TaskListener listener) {
         FilePath settingsPath = null;
         if (settings != null) {
@@ -57,7 +109,7 @@ public abstract class GlobalSettingsProvider extends AbstractDescribableImpl<Glo
     }
 
     /**
-     * Convenience method handling all <code>null</code> checks. Provides the path on the (possible) remote settings file.
+     * Convenience method handling all {@code null} checks. Provides the path on the (possible) remote settings file.
      * 
      * @param provider
      *            the provider to be used
@@ -66,7 +118,9 @@ public abstract class GlobalSettingsProvider extends AbstractDescribableImpl<Glo
      * @param listener
      *            the listener of the current build
      * @return the path to the global settings.xml
+     * @deprecated directly invoke {@link #supplySettings(Run, FilePath, TaskListener)}
      */
+    @Deprecated
     public static final String getSettingsRemotePath(GlobalSettingsProvider provider, AbstractBuild<?, ?> build, TaskListener listener) {
         FilePath fp = getSettingsFilePath(provider, build, listener);
         return fp == null ? null : fp.getRemote();

--- a/core/src/main/java/jenkins/mvn/SettingsProviderHelper.java
+++ b/core/src/main/java/jenkins/mvn/SettingsProviderHelper.java
@@ -1,0 +1,117 @@
+package jenkins.mvn;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+public class SettingsProviderHelper {
+    private final static Logger LOGGER = Logger.getLogger(SettingsProviderHelper.class.getName());
+
+    public static boolean ABSOlUTE_PATH_BACKWARD_COMPATIBILITY = Boolean.valueOf(System.getProperty("jenkins.mvn.SettingsProvider.absolutePathBackwardCompatibility"));
+
+    /**
+     * Provide the {@link FilePath} of the given plain text {@code path} for the desired Maven settings.xml file.
+     *
+     * @param build       the build to provide the settings for
+     * @param workspace the workspace in which the build takes place
+     * @param listener the listener of this given build
+     * @return the filepath to the provided file. {@code null} if no settings will be provided.
+     * @throws IOException exception accessing to the file system
+     * @throws InterruptedException occurs when the build is interrupted
+     */
+    @CheckForNull
+    public static FilePath supplySettings(String path, Run<?, ?> build, FilePath workspace, TaskListener listener) throws IOException, InterruptedException {
+        if (StringUtils.isEmpty(path)) {
+            return null;
+        }
+
+        try {
+            EnvVars env = build.getEnvironment(listener);
+
+            FilePath result;
+            if (build instanceof AbstractBuild) {
+                AbstractBuild abstractBuild = (AbstractBuild) build;
+                String targetPath = Util.replaceMacro(path, abstractBuild.getBuildVariableResolver());
+                targetPath = env.expand(targetPath);
+                if (IOUtils.isAbsolute(targetPath) && ABSOlUTE_PATH_BACKWARD_COMPATIBILITY) {
+                    File settingsFile = new File(targetPath);
+                    checkFileIsaMavenSettingsFile(settingsFile);
+                    return new FilePath(settingsFile);
+                } else {
+                    FilePath mrSettings = abstractBuild.getModuleRoot().child(targetPath);
+                    FilePath wsSettings = abstractBuild.getWorkspace().child(targetPath);
+                    if (wsSettings.exists()) {
+                        result = wsSettings;
+                    } else if (mrSettings.exists()) {
+                        result = mrSettings;
+                    } else {
+                        throw new FileNotFoundException(targetPath);
+                    }
+                }
+            } else {
+                String targetPath = env.expand(path);
+                result = workspace.child(targetPath);
+            }
+            return result;
+        } catch (IOException e) {
+            throw new IOException(
+                    "Failed to prepare Maven (global) settings.xml with path '" + path + "' for " + build +
+                            " in workspace " + workspace, e);
+        } catch (InterruptedException e) {
+            throw new IOException(
+                    "Failed to prepare Maven (global) settings.xml with path '" + path + "' for " + build +
+                            " in workspace " + workspace, e);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Failed to prepare Maven (global) settings.xml with path '" + path + "' for " + build +
+                            " in workspace " + workspace, e);
+        }
+    }
+
+    /**
+     * Check that the given file is a valid Maven settings.xml file
+     *
+     * @param file the file to check
+     * @throws IllegalStateException if the given file is not a valid settings.xml file
+     */
+    public static void checkFileIsaMavenSettingsFile(File file) throws IllegalStateException {
+        if (!file.exists()) {
+            throw new IllegalStateException(new FileNotFoundException("Maven settings file '" + file + "' not found"));
+        }
+        Document mavenSettingsDocument;
+        try {
+            mavenSettingsDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file);
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            throw new IllegalStateException("Invalid Maven settings file '" + file.getPath() + "': " + e.toString(), e);
+        }
+        Element documentElement = mavenSettingsDocument.getDocumentElement();
+        if (!"settings".equals(documentElement.getNodeName())) {
+            throw new IllegalStateException(
+                    "Invalid Maven settings file '" + file.getPath() + "', " +
+                            "actual document element: '" + documentElement.getNodeName() + "', " +
+                            "expected document element: 'settings'");
+        }
+        // we don't check the namespace as the XML parsers are often "non validating"
+
+    }
+}

--- a/core/src/test/java/jenkins/mvn/SettingsProviderHelperTest.java
+++ b/core/src/test/java/jenkins/mvn/SettingsProviderHelperTest.java
@@ -1,0 +1,39 @@
+package jenkins.mvn;
+
+import hudson.AbortException;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+public class SettingsProviderHelperTest {
+
+    @Test
+    public void checkFileIsaMavenSettingsFile_accepts_maven_settings_file() throws AbortException {
+        checkMavenSettingsFile("jenkins/mvn/settings.xml");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void checkFileIsaMavenSettingsFile_rejects_random_xml_file() throws AbortException {
+        checkMavenSettingsFile("jenkins/mvn/random-xml-file.xml");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void checkFileIsaMavenSettingsFile_rejects_random_non_xml_file() throws AbortException {
+        checkMavenSettingsFile("jenkins/mvn/random-text-file.txt");
+    }
+
+
+    @Test(expected = IllegalStateException.class)
+    public void checkFileIsaMavenSettingsFile_rejects_files_that_does_not_exist() throws AbortException {
+        SettingsProviderHelper.checkFileIsaMavenSettingsFile(new File(("jenkins/mvn/does-not-exist.txt")));
+    }
+
+    private void checkMavenSettingsFile(String mavenSettingsFilePath) throws AbortException {
+        URL resource = Thread.currentThread().getContextClassLoader().getResource(mavenSettingsFilePath);
+        SettingsProviderHelper.checkFileIsaMavenSettingsFile(new File(resource.getFile()));
+    }
+}

--- a/core/src/test/resources/jenkins/mvn/random-text-file.txt
+++ b/core/src/test/resources/jenkins/mvn/random-text-file.txt
@@ -1,0 +1,1 @@
+random text file

--- a/core/src/test/resources/jenkins/mvn/random-xml-file.xml
+++ b/core/src/test/resources/jenkins/mvn/random-xml-file.xml
@@ -1,0 +1,3 @@
+<a>
+    <b>random xml stuff</b>
+</a>

--- a/core/src/test/resources/jenkins/mvn/settings.xml
+++ b/core/src/test/resources/jenkins/mvn/settings.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | This is the configuration file for Maven. It can be specified at two levels:
+ |
+ |  1. User Level. This settings.xml file provides configuration for a single user,
+ |                 and is normally provided in ${user.home}/.m2/settings.xml.
+ |
+ |                 NOTE: This location can be overridden with the CLI option:
+ |
+ |                 -s /path/to/user/settings.xml
+ |
+ |  2. Global Level. This settings.xml file provides configuration for all Maven
+ |                 users on a machine (assuming they're all using the same Maven
+ |                 installation). It's normally provided in
+ |                 ${maven.home}/conf/settings.xml.
+ |
+ |                 NOTE: This location can be overridden with the CLI option:
+ |
+ |                 -gs /path/to/global/settings.xml
+ |
+ | The sections in this sample file are intended to give you a running start at
+ | getting the most out of your Maven installation. Where appropriate, the default
+ | values (values used when the setting is not specified) are provided.
+ |
+ |-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!-- localRepository
+     | The path to the local repository maven will use to store artifacts.
+     |
+     | Default: ~/.m2/repository
+    <localRepository>/path/to/local/repo</localRepository>
+    -->
+
+    <!-- interactiveMode
+     | This will determine whether maven prompts you when it needs input. If set to false,
+     | maven will use a sensible default value, perhaps based on some other setting, for
+     | the parameter in question.
+     |
+     | Default: true
+    <interactiveMode>true</interactiveMode>
+    -->
+
+    <!-- offline
+     | Determines whether maven should attempt to connect to the network when executing a build.
+     | This will have an effect on artifact downloads, artifact deployment, and others.
+     |
+     | Default: false
+    <offline>false</offline>
+    -->
+
+    <!-- pluginGroups
+     | This is a list of additional group identifiers that will be searched when resolving plugins by their prefix, i.e.
+     | when invoking a command line like "mvn prefix:goal". Maven will automatically add the group identifiers
+     | "org.apache.maven.plugins" and "org.codehaus.mojo" if these are not already contained in the list.
+     |-->
+    <pluginGroups>
+        <!-- pluginGroup
+         | Specifies a further group identifier to use for plugin lookup.
+        <pluginGroup>com.your.plugins</pluginGroup>
+        -->
+    </pluginGroups>
+
+    <!-- proxies
+     | This is a list of proxies which can be used on this machine to connect to the network.
+     | Unless otherwise specified (by system property or command-line switch), the first proxy
+     | specification in this list marked as active will be used.
+     |-->
+    <proxies>
+        <!-- proxy
+         | Specification for one proxy, to be used in connecting to the network.
+         |
+        <proxy>
+          <id>optional</id>
+          <active>true</active>
+          <protocol>http</protocol>
+          <username>proxyuser</username>
+          <password>proxypass</password>
+          <host>proxy.host.net</host>
+          <port>80</port>
+          <nonProxyHosts>local.net|some.host.com</nonProxyHosts>
+        </proxy>
+        -->
+    </proxies>
+
+    <!-- servers
+     | This is a list of authentication profiles, keyed by the server-id used within the system.
+     | Authentication profiles can be used whenever maven must make a connection to a remote server.
+     |-->
+    <servers>
+        <!-- server
+         | Specifies the authentication information to use when connecting to a particular server, identified by
+         | a unique name within the system (referred to by the 'id' attribute below).
+         |
+         | NOTE: You should either specify username/password OR privateKey/passphrase, since these pairings are
+         |       used together.
+         |
+        <server>
+          <id>deploymentRepo</id>
+          <username>repouser</username>
+          <password>repopwd</password>
+        </server>
+        -->
+
+        <!-- Another sample, using keys to authenticate.
+        <server>
+          <id>siteServer</id>
+          <privateKey>/path/to/private/key</privateKey>
+          <passphrase>optional; leave empty if not used.</passphrase>
+        </server>
+        -->
+    </servers>
+
+    <!-- mirrors
+     | This is a list of mirrors to be used in downloading artifacts from remote repositories.
+     |
+     | It works like this: a POM may declare a repository to use in resolving certain artifacts.
+     | However, this repository may have problems with heavy traffic at times, so people have mirrored
+     | it to several places.
+     |
+     | That repository definition will have a unique id, so we can create a mirror reference for that
+     | repository, to be used as an alternate download site. The mirror site will be the preferred
+     | server for that repository.
+     |-->
+    <mirrors>
+        <!-- mirror
+         | Specifies a repository mirror site to use instead of a given repository. The repository that
+         | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
+         | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
+         |
+        <mirror>
+          <id>mirrorId</id>
+          <mirrorOf>repositoryId</mirrorOf>
+          <name>Human Readable Name for this Mirror.</name>
+          <url>http://my.repository.com/repo/path</url>
+        </mirror>
+         -->
+    </mirrors>
+
+    <!-- profiles
+     | This is a list of profiles which can be activated in a variety of ways, and which can modify
+     | the build process. Profiles provided in the settings.xml are intended to provide local machine-
+     | specific paths and repository locations which allow the build to work in the local environment.
+     |
+     | For example, if you have an integration testing plugin - like cactus - that needs to know where
+     | your Tomcat instance is installed, you can provide a variable here such that the variable is
+     | dereferenced during the build process to configure the cactus plugin.
+     |
+     | As noted above, profiles can be activated in a variety of ways. One way - the activeProfiles
+     | section of this document (settings.xml) - will be discussed later. Another way essentially
+     | relies on the detection of a system property, either matching a particular value for the property,
+     | or merely testing its existence. Profiles can also be activated by JDK version prefix, where a
+     | value of '1.4' might activate a profile when the build is executed on a JDK version of '1.4.2_07'.
+     | Finally, the list of active profiles can be specified directly from the command line.
+     |
+     | NOTE: For profiles defined in the settings.xml, you are restricted to specifying only artifact
+     |       repositories, plugin repositories, and free-form properties to be used as configuration
+     |       variables for plugins in the POM.
+     |
+     |-->
+    <profiles>
+        <!-- profile
+         | Specifies a set of introductions to the build process, to be activated using one or more of the
+         | mechanisms described above. For inheritance purposes, and to activate profiles via <activatedProfiles/>
+         | or the command line, profiles have to have an ID that is unique.
+         |
+         | An encouraged best practice for profile identification is to use a consistent naming convention
+         | for profiles, such as 'env-dev', 'env-test', 'env-production', 'user-jdcasey', 'user-brett', etc.
+         | This will make it more intuitive to understand what the set of introduced profiles is attempting
+         | to accomplish, particularly when you only have a list of profile id's for debug.
+         |
+         | This profile example uses the JDK version to trigger activation, and provides a JDK-specific repo.
+        <profile>
+          <id>jdk-1.4</id>
+
+          <activation>
+            <jdk>1.4</jdk>
+          </activation>
+
+          <repositories>
+            <repository>
+              <id>jdk14</id>
+              <name>Repository for JDK 1.4 builds</name>
+              <url>http://www.myhost.com/maven/jdk14</url>
+              <layout>default</layout>
+              <snapshotPolicy>always</snapshotPolicy>
+            </repository>
+          </repositories>
+        </profile>
+        -->
+
+        <!--
+         | Here is another profile, activated by the system property 'target-env' with a value of 'dev',
+         | which provides a specific path to the Tomcat instance. To use this, your plugin configuration
+         | might hypothetically look like:
+         |
+         | ...
+         | <plugin>
+         |   <groupId>org.myco.myplugins</groupId>
+         |   <artifactId>myplugin</artifactId>
+         |
+         |   <configuration>
+         |     <tomcatLocation>${tomcatPath}</tomcatLocation>
+         |   </configuration>
+         | </plugin>
+         | ...
+         |
+         | NOTE: If you just wanted to inject this configuration whenever someone set 'target-env' to
+         |       anything, you could just leave off the <value/> inside the activation-property.
+         |
+        <profile>
+          <id>env-dev</id>
+
+          <activation>
+            <property>
+              <name>target-env</name>
+              <value>dev</value>
+            </property>
+          </activation>
+
+          <properties>
+            <tomcatPath>/path/to/tomcat/instance</tomcatPath>
+          </properties>
+        </profile>
+        -->
+    </profiles>
+
+    <!-- activeProfiles
+     | List of profiles that are active for all builds.
+     |
+    <activeProfiles>
+      <activeProfile>alwaysActiveProfile</activeProfile>
+      <activeProfile>anotherAlwaysActiveProfile</activeProfile>
+    </activeProfiles>
+    -->
+</settings>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -198,6 +198,18 @@ THE SOFTWARE.
       <version>4.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.test</groupId>
+      <artifactId>docker-fixtures</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-slaves</artifactId>
+      <version>1.13</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -198,18 +198,6 @@ THE SOFTWARE.
       <version>4.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.test</groupId>
-      <artifactId>docker-fixtures</artifactId>
-      <version>1.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>ssh-slaves</artifactId>
-      <version>1.13</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/test/src/test/java/jenkins/mvn/SettingsProviderTest.java
+++ b/test/src/test/java/jenkins/mvn/SettingsProviderTest.java
@@ -106,7 +106,7 @@ public class SettingsProviderTest {
      * the failure of the job
      */
     @Test
-    public void maven_build_with_settings_defined_globally_with_an_invalid_file_fails() throws Exception {
+    public void maven_build_with_global_settings_defined_globally_with_an_invalid_file_fails() throws Exception {
 
         SettingsProviderHelper.ABSOlUTE_PATH_BACKWARD_COMPATIBILITY = true;
         try {
@@ -114,7 +114,7 @@ public class SettingsProviderTest {
             URL settingsFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/random-text-file.txt");
             globalMavenConfig.setGlobalSettingsProvider(new FilePathGlobalSettingsProvider(settingsFile.getFile()));
 
-            MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-build-project-with-settings-defined-globally-with-an-invalid-file");
+            MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-build-project-with-global-settings-defined-globally-with-an-invalid-file");
             URL pomFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/pom.xml");
             project.setScm(new SingleFileSCM("pom.xml", pomFile));
             project.setGoals("clean");
@@ -135,7 +135,7 @@ public class SettingsProviderTest {
         URL settingsFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/settings.xml");
         globalMavenConfig.setGlobalSettingsProvider(new FilePathGlobalSettingsProvider(settingsFile.getFile()));
 
-        MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-build-project-with-settings-defined-globally");
+        MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-build-project-with-global-settings-defined-globally");
         URL pomFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/pom.xml");
         project.setScm(new SingleFileSCM("pom.xml", pomFile));
         project.setGoals("clean");

--- a/test/src/test/java/jenkins/mvn/SettingsProviderTest.java
+++ b/test/src/test/java/jenkins/mvn/SettingsProviderTest.java
@@ -1,0 +1,185 @@
+package jenkins.mvn;
+
+import hudson.maven.MavenModuleSet;
+import hudson.maven.MavenModuleSetBuild;
+import hudson.model.Node;
+import hudson.model.Result;
+import hudson.plugins.sshslaves.SSHLauncher;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.RetentionStrategy;
+import hudson.tasks.Maven;
+import org.jenkinsci.test.acceptance.docker.DockerRule;
+import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.SingleFileSCM;
+import org.jvnet.hudson.test.ToolInstallations;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author <a href="mailto:cleclerc@cloudbees.com">Cyrille Le Clerc</a>
+ */
+public class SettingsProviderTest {
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Rule
+    public DockerRule<JavaContainer> slaveRule = new DockerRule<>(JavaContainer.class);
+
+    @Before
+    public void setup() throws Exception {
+        // apache-maven version 3.0.1 is the version shipped with the test harness. 3.3.9 is not shipped in the test harness
+        ToolInstallations.configureDefaultMaven("apache-maven-3.0.1", Maven.MavenInstallation.MAVEN_30);
+
+        GlobalMavenConfig globalMavenConfig = jenkinsRule.get(GlobalMavenConfig.class);
+        globalMavenConfig.setGlobalSettingsProvider(new DefaultGlobalSettingsProvider());
+        globalMavenConfig.setSettingsProvider(new DefaultSettingsProvider());
+    }
+
+    @Test
+    public void basic_maven_build_succeeds() throws Exception {
+
+        MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-project");
+        URL pomFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/pom.xml");
+        project.setScm(new SingleFileSCM("pom.xml", pomFile));
+        project.setGoals("clean");
+
+        MavenModuleSetBuild build = project.scheduleBuild2(0).get(1, TimeUnit.MINUTES);
+        assertNotNull(build);
+        jenkinsRule.assertBuildStatusSuccess(build);
+    }
+
+    @Test
+    public void maven_build_with_specified_maven_installation_succeeds() throws Exception {
+
+        MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-project");
+        URL pomFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/pom.xml");
+        project.setScm(new SingleFileSCM("pom.xml", pomFile));
+        project.setGoals("clean");
+        project.setMaven("apache-maven-3.0.1");
+
+        MavenModuleSetBuild build = project.scheduleBuild2(0).get(1, TimeUnit.MINUTES);
+        assertNotNull(build);
+        jenkinsRule.assertBuildStatusSuccess(build);
+        jenkinsRule.assertLogContains("apache-maven-3.0.1", build);
+    }
+
+    /**
+     * TODO Fix "IllegalArgumentException: Argument for @Nonnull parameter 'primaryView'..."
+     * See https://gist.github.com/cyrille-leclerc/9dbb8d9dc5eed5973d59eb21da91e73d
+     */
+    @Ignore
+    @Test
+    public void basic_maven_build_on_remote_agent_succeeds() throws Exception {
+        JavaContainer slaveContainer = slaveRule.get();
+
+        DumbSlave remoteAgent = new DumbSlave("remote", "", "/home/test/slave", "1", Node.Mode.NORMAL, "",
+                new SSHLauncher(slaveContainer.ipBound(22), slaveContainer.port(22), "test", "test", "", ""),
+                RetentionStrategy.INSTANCE, Collections.<NodeProperty<?>>emptyList());
+
+        jenkinsRule.jenkins.addNode(remoteAgent);
+
+        MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-project");
+        URL pomFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/pom.xml");
+        project.setScm(new SingleFileSCM("pom.xml", pomFile));
+        project.setGoals("clean");
+        project.setAssignedNode(remoteAgent);
+
+        MavenModuleSetBuild build = project.scheduleBuild2(0).get(1, TimeUnit.MINUTES);
+        assertNotNull(build);
+        jenkinsRule.assertBuildStatusSuccess(build);
+    }
+
+    @Test
+    public void maven_build_with_settings_defined_globally_succeeds() throws Exception {
+
+        GlobalMavenConfig globalMavenConfig = jenkinsRule.get(GlobalMavenConfig.class);
+        URL settingsFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/settings.xml");
+        globalMavenConfig.setSettingsProvider(new FilePathSettingsProvider(settingsFile.getFile()));
+
+        MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-build-project-with-settings-defined-globally");
+        URL pomFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/pom.xml");
+        project.setScm(new SingleFileSCM("pom.xml", pomFile));
+        project.setGoals("clean");
+
+        MavenModuleSetBuild build = project.scheduleBuild2(0).get(1, TimeUnit.MINUTES);
+        assertNotNull(build);
+        jenkinsRule.assertBuildStatusSuccess(build);
+    }
+
+    @Test
+    public void maven_build_with_missing_settings_defined_globally_fails() throws Exception {
+
+        GlobalMavenConfig globalMavenConfig = jenkinsRule.get(GlobalMavenConfig.class);
+        globalMavenConfig.setSettingsProvider(new FilePathSettingsProvider("/tmp/settings-do-not-exist.xml"));
+
+        MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-build-project-with-missing-settings-defined-globally");
+        URL pomFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/pom.xml");
+        project.setScm(new SingleFileSCM("pom.xml", pomFile));
+        project.setGoals("clean");
+
+        MavenModuleSetBuild build = project.scheduleBuild2(0).get(1, TimeUnit.MINUTES);
+        assertNotNull(build);
+        jenkinsRule.assertBuildStatus(Result.FAILURE, build);
+    }
+
+
+    /**
+     * Using the ABSOlUTE_PATH_BACKWARD_COMPATIBILITY mode, providing a file that is not a valid maven settings file causes
+     * the failure of the job
+     */
+    @Test
+    public void maven_build_with_settings_defined_globally_with_an_invalid_file_fails() throws Exception {
+
+        SettingsProviderHelper.ABSOlUTE_PATH_BACKWARD_COMPATIBILITY = true;
+        try {
+            GlobalMavenConfig globalMavenConfig = jenkinsRule.get(GlobalMavenConfig.class);
+            URL settingsFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/random-text-file.txt");
+            globalMavenConfig.setGlobalSettingsProvider(new FilePathGlobalSettingsProvider(settingsFile.getFile()));
+
+            MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-build-project-with-settings-defined-globally-with-an-invalid-file");
+            URL pomFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/pom.xml");
+            project.setScm(new SingleFileSCM("pom.xml", pomFile));
+            project.setGoals("clean");
+
+            MavenModuleSetBuild build = project.scheduleBuild2(0).get(1, TimeUnit.MINUTES);
+            assertNotNull(build);
+            jenkinsRule.assertBuildStatus(Result.FAILURE, build);
+            jenkinsRule.assertLogContains("IllegalStateException: Failed to prepare Maven (global) settings.xml with path", build);
+        } finally {
+            SettingsProviderHelper.ABSOlUTE_PATH_BACKWARD_COMPATIBILITY = false;
+        }
+    }
+
+    @Test
+    public void maven_build_with_global_settings_defined_globally_succeeds() throws Exception {
+
+        GlobalMavenConfig globalMavenConfig = jenkinsRule.get(GlobalMavenConfig.class);
+        URL settingsFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/settings.xml");
+        globalMavenConfig.setGlobalSettingsProvider(new FilePathGlobalSettingsProvider(settingsFile.getFile()));
+
+        MavenModuleSet project = jenkinsRule.createProject(MavenModuleSet.class, "maven-build-project-with-settings-defined-globally");
+        URL pomFile = Thread.currentThread().getContextClassLoader().getResource("jenkins/mvn/pom.xml");
+        project.setScm(new SingleFileSCM("pom.xml", pomFile));
+        project.setGoals("clean");
+
+        MavenModuleSetBuild build = project.scheduleBuild2(0).get(1, TimeUnit.MINUTES);
+        assertNotNull(build);
+        jenkinsRule.assertBuildStatusSuccess(build);
+    }
+}

--- a/test/src/test/resources/jenkins/mvn/pom.xml
+++ b/test/src/test/resources/jenkins/mvn/pom.xml
@@ -1,0 +1,8 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>jenkins.mvn.test</groupId>
+  <artifactId>test</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+</project>
+

--- a/test/src/test/resources/jenkins/mvn/random-text-file.txt
+++ b/test/src/test/resources/jenkins/mvn/random-text-file.txt
@@ -1,0 +1,1 @@
+random text file

--- a/test/src/test/resources/jenkins/mvn/settings.xml
+++ b/test/src/test/resources/jenkins/mvn/settings.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | This is the configuration file for Maven. It can be specified at two levels:
+ |
+ |  1. User Level. This settings.xml file provides configuration for a single user,
+ |                 and is normally provided in ${user.home}/.m2/settings.xml.
+ |
+ |                 NOTE: This location can be overridden with the CLI option:
+ |
+ |                 -s /path/to/user/settings.xml
+ |
+ |  2. Global Level. This settings.xml file provides configuration for all Maven
+ |                 users on a machine (assuming they're all using the same Maven
+ |                 installation). It's normally provided in
+ |                 ${maven.home}/conf/settings.xml.
+ |
+ |                 NOTE: This location can be overridden with the CLI option:
+ |
+ |                 -gs /path/to/global/settings.xml
+ |
+ | The sections in this sample file are intended to give you a running start at
+ | getting the most out of your Maven installation. Where appropriate, the default
+ | values (values used when the setting is not specified) are provided.
+ |
+ |-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!-- localRepository
+     | The path to the local repository maven will use to store artifacts.
+     |
+     | Default: ~/.m2/repository
+    <localRepository>/path/to/local/repo</localRepository>
+    -->
+
+    <!-- interactiveMode
+     | This will determine whether maven prompts you when it needs input. If set to false,
+     | maven will use a sensible default value, perhaps based on some other setting, for
+     | the parameter in question.
+     |
+     | Default: true
+    <interactiveMode>true</interactiveMode>
+    -->
+
+    <!-- offline
+     | Determines whether maven should attempt to connect to the network when executing a build.
+     | This will have an effect on artifact downloads, artifact deployment, and others.
+     |
+     | Default: false
+    <offline>false</offline>
+    -->
+
+    <!-- pluginGroups
+     | This is a list of additional group identifiers that will be searched when resolving plugins by their prefix, i.e.
+     | when invoking a command line like "mvn prefix:goal". Maven will automatically add the group identifiers
+     | "org.apache.maven.plugins" and "org.codehaus.mojo" if these are not already contained in the list.
+     |-->
+    <pluginGroups>
+        <!-- pluginGroup
+         | Specifies a further group identifier to use for plugin lookup.
+        <pluginGroup>com.your.plugins</pluginGroup>
+        -->
+    </pluginGroups>
+
+    <!-- proxies
+     | This is a list of proxies which can be used on this machine to connect to the network.
+     | Unless otherwise specified (by system property or command-line switch), the first proxy
+     | specification in this list marked as active will be used.
+     |-->
+    <proxies>
+        <!-- proxy
+         | Specification for one proxy, to be used in connecting to the network.
+         |
+        <proxy>
+          <id>optional</id>
+          <active>true</active>
+          <protocol>http</protocol>
+          <username>proxyuser</username>
+          <password>proxypass</password>
+          <host>proxy.host.net</host>
+          <port>80</port>
+          <nonProxyHosts>local.net|some.host.com</nonProxyHosts>
+        </proxy>
+        -->
+    </proxies>
+
+    <!-- servers
+     | This is a list of authentication profiles, keyed by the server-id used within the system.
+     | Authentication profiles can be used whenever maven must make a connection to a remote server.
+     |-->
+    <servers>
+        <!-- server
+         | Specifies the authentication information to use when connecting to a particular server, identified by
+         | a unique name within the system (referred to by the 'id' attribute below).
+         |
+         | NOTE: You should either specify username/password OR privateKey/passphrase, since these pairings are
+         |       used together.
+         |
+        <server>
+          <id>deploymentRepo</id>
+          <username>repouser</username>
+          <password>repopwd</password>
+        </server>
+        -->
+
+        <!-- Another sample, using keys to authenticate.
+        <server>
+          <id>siteServer</id>
+          <privateKey>/path/to/private/key</privateKey>
+          <passphrase>optional; leave empty if not used.</passphrase>
+        </server>
+        -->
+    </servers>
+
+    <!-- mirrors
+     | This is a list of mirrors to be used in downloading artifacts from remote repositories.
+     |
+     | It works like this: a POM may declare a repository to use in resolving certain artifacts.
+     | However, this repository may have problems with heavy traffic at times, so people have mirrored
+     | it to several places.
+     |
+     | That repository definition will have a unique id, so we can create a mirror reference for that
+     | repository, to be used as an alternate download site. The mirror site will be the preferred
+     | server for that repository.
+     |-->
+    <mirrors>
+        <!-- mirror
+         | Specifies a repository mirror site to use instead of a given repository. The repository that
+         | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
+         | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
+         |
+        <mirror>
+          <id>mirrorId</id>
+          <mirrorOf>repositoryId</mirrorOf>
+          <name>Human Readable Name for this Mirror.</name>
+          <url>http://my.repository.com/repo/path</url>
+        </mirror>
+         -->
+    </mirrors>
+
+    <!-- profiles
+     | This is a list of profiles which can be activated in a variety of ways, and which can modify
+     | the build process. Profiles provided in the settings.xml are intended to provide local machine-
+     | specific paths and repository locations which allow the build to work in the local environment.
+     |
+     | For example, if you have an integration testing plugin - like cactus - that needs to know where
+     | your Tomcat instance is installed, you can provide a variable here such that the variable is
+     | dereferenced during the build process to configure the cactus plugin.
+     |
+     | As noted above, profiles can be activated in a variety of ways. One way - the activeProfiles
+     | section of this document (settings.xml) - will be discussed later. Another way essentially
+     | relies on the detection of a system property, either matching a particular value for the property,
+     | or merely testing its existence. Profiles can also be activated by JDK version prefix, where a
+     | value of '1.4' might activate a profile when the build is executed on a JDK version of '1.4.2_07'.
+     | Finally, the list of active profiles can be specified directly from the command line.
+     |
+     | NOTE: For profiles defined in the settings.xml, you are restricted to specifying only artifact
+     |       repositories, plugin repositories, and free-form properties to be used as configuration
+     |       variables for plugins in the POM.
+     |
+     |-->
+    <profiles>
+        <!-- profile
+         | Specifies a set of introductions to the build process, to be activated using one or more of the
+         | mechanisms described above. For inheritance purposes, and to activate profiles via <activatedProfiles/>
+         | or the command line, profiles have to have an ID that is unique.
+         |
+         | An encouraged best practice for profile identification is to use a consistent naming convention
+         | for profiles, such as 'env-dev', 'env-test', 'env-production', 'user-jdcasey', 'user-brett', etc.
+         | This will make it more intuitive to understand what the set of introduced profiles is attempting
+         | to accomplish, particularly when you only have a list of profile id's for debug.
+         |
+         | This profile example uses the JDK version to trigger activation, and provides a JDK-specific repo.
+        <profile>
+          <id>jdk-1.4</id>
+
+          <activation>
+            <jdk>1.4</jdk>
+          </activation>
+
+          <repositories>
+            <repository>
+              <id>jdk14</id>
+              <name>Repository for JDK 1.4 builds</name>
+              <url>http://www.myhost.com/maven/jdk14</url>
+              <layout>default</layout>
+              <snapshotPolicy>always</snapshotPolicy>
+            </repository>
+          </repositories>
+        </profile>
+        -->
+
+        <!--
+         | Here is another profile, activated by the system property 'target-env' with a value of 'dev',
+         | which provides a specific path to the Tomcat instance. To use this, your plugin configuration
+         | might hypothetically look like:
+         |
+         | ...
+         | <plugin>
+         |   <groupId>org.myco.myplugins</groupId>
+         |   <artifactId>myplugin</artifactId>
+         |
+         |   <configuration>
+         |     <tomcatLocation>${tomcatPath}</tomcatLocation>
+         |   </configuration>
+         | </plugin>
+         | ...
+         |
+         | NOTE: If you just wanted to inject this configuration whenever someone set 'target-env' to
+         |       anything, you could just leave off the <value/> inside the activation-property.
+         |
+        <profile>
+          <id>env-dev</id>
+
+          <activation>
+            <property>
+              <name>target-env</name>
+              <value>dev</value>
+            </property>
+          </activation>
+
+          <properties>
+            <tomcatPath>/path/to/tomcat/instance</tomcatPath>
+          </properties>
+        </profile>
+        -->
+    </profiles>
+
+    <!-- activeProfiles
+     | List of profiles that are active for all builds.
+     |
+    <activeProfiles>
+      <activeProfile>alwaysActiveProfile</activeProfile>
+      <activeProfile>anotherAlwaysActiveProfile</activeProfile>
+    </activeProfiles>
+    -->
+</settings>


### PR DESCRIPTION
Add support for "Run" jobs to Maven SettingsProvider and GlobalSettingsProvider so that Pipeline oriented plugins can integrate with Maven SettingsProvider and GlobalSettingsProvider.

# Description

See [JENKINS-40665](https://issues.jenkins-ci.org/browse/JENKINS-40665).

Replace #2678

Details: 

* Add support for "Run" and thus to Pipeline Jobs to Maven SettingsProvider and GlobalSettingsProvider
* Add "Run" compatible APIs
   * `jenkins.mvn.SettingsProvider#supplySettings(hudson.model.Run<?,?>, hudson.FilePath, hudson.model.TaskListener)`
   * `jenkins.mvn.GlobalSettingsProvider#supplySettings(hudson.model.Run<?,?>, hudson.FilePath, hudson.model.TaskListener)`
* Deprecate "AbstractBuild" oriented APIs as they are replaced by the new "Run" oriented APIs
   * `jenkins.mvn.SettingsProvider#supplySettings(hudson.model.AbstractBuild<?,?>, hudson.model.TaskListener)`
   * `jenkins.mvn.GlobalSettingsProvider#supplySettings(hudson.model.AbstractBuild<?,?>, hudson.model.TaskListener)`
* Cleanup `hudson.tasks.Maven` to stop using the deprecated APIs
* Adapt `FilePathSettingsProvider` and `FilePathGlobalSettingsProvider` to support these new APIs
   * Factorize shared code in `SettingsProviderHelper``
   * Disable the existing capability to use Maven settings files located on the master, 
      * Add a feature flag `-Djenkins.mvn.SettingsProvider.absolutePathBackwardCompatibility=true` to re-enable access to the maven files on the master
      * When using the backward compatibility mode, check that the file accessed on the master is a valid Maven settings XML file
* Introduce integration tests for Maven jobs with `SettingsProviderTest`

Notes: 

* I had to disable `jenkins.mvn.SettingsProviderTest#basic_maven_build_on_remote_agent_succeeds` due to a bug creating a remote agent `IllegalArgumentException: Argument for @Nonnull parameter 'primaryView' of hudson/model/AllView.migrateLegacyPrimaryAllViewLocalizedName must not be null`. See https://gist.github.com/cyrille-leclerc/9dbb8d9dc5eed5973d59eb21da91e73d
* I had to remove `jenkins.mvn.SettingsProviderTest#basic_maven_build_on_remote_agent_succeeds` and the dependency on the ssh-slave plugin due to a transitive dependency on credentials 2.1.2 that causes a `NoSuchMethodError: com.cloudbees.plugins.credentials.UserCredentialsProvider$UserFacingAction.<init>(Lhudson/model/User;)V` in some unit tests. See https://gist.github.com/cyrille-leclerc/cbe19b65b99753d92ea8c20cba0fbf5d

Tested with `withMaven(){}`:

* [JENKINS-40665 Maven SettingsProvider and GlobalSettingsProvider should support Pipeline jobs](https://issues.jenkins-ci.org/browse/JENKINS-40665)
* [JENKINS-39407 Use system default Maven, Maven Settings if not specified](https://issues.jenkins-ci.org/browse/JENKINS-39407)
* PR https://github.com/jenkinsci/pipeline-maven-plugin/pull/31
* PR https://github.com/jenkinsci/config-file-provider-plugin/pull/25

### Changelog entries

Proposed changelog entries:

* Entry 1: [JENKINS-40665](https://issues.jenkins-ci.org/browse/JENKINS-40665) Add support in Pipeline oriented plugins to Maven `SettingsProvider` and `GlobalSettingsProvider`

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Link to JIRA ticket in description, if appropriate
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@jglick @oleg-nenashev 
