### PR TITLE
[JENKINS-42969] UnsupportedOperationException from Computer.addAction

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1046,6 +1046,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         return Collections.unmodifiableList(actions);
     }
 
+    // TODO implement addAction, addOrReplaceAction, removeAction, removeActions, replaceActions
+
     /**
      * Gets the {@link Node} where this project was last built on.
      *

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -25,6 +25,7 @@
  */
 package hudson.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher.ProcStarter;
@@ -267,6 +268,18 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     	}
     	return Collections.unmodifiableList(result);
     }
+
+    @SuppressWarnings({"ConstantConditions","deprecation"})
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
+    @Override
+    public void addAction(@Nonnull Action a) {
+        if (a == null) {
+            throw new IllegalArgumentException("Action must be non-null");
+        }
+        super.getActions().add(a);
+    }
+
+    // TODO implement addOrReplaceAction, removeAction, removeActions, replaceActions
 
     /**
      * This is where the log from the remote agent goes.

--- a/core/src/main/java/hudson/model/labels/LabelAtom.java
+++ b/core/src/main/java/hudson/model/labels/LabelAtom.java
@@ -106,6 +106,8 @@ public class LabelAtom extends Label implements Saveable {
         return Collections.unmodifiableList(actions);
     }
 
+    // TODO implement addAction, addOrReplaceAction, removeAction, removeActions, replaceActions
+
     protected void updateTransientActions() {
         Vector<Action> ta = new Vector<Action>();
 

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.*;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.xml.XmlPage;
 
 import java.io.File;
@@ -40,7 +39,6 @@ import jenkins.model.Jenkins;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -114,4 +112,17 @@ public class ComputerTest {
         assertThat(content, not(containsString("ApiTokenProperty")));
         assertThat(content, not(containsString("apiToken")));
     }
+
+    @Issue("JENKINS-42969")
+    @Test
+    public void addAction() throws Exception {
+        Computer c = j.createSlave().toComputer();
+        class A extends InvisibleAction {}
+        assertEquals(0, c.getActions(A.class).size());
+        c.addAction(new A());
+        assertEquals(1, c.getActions(A.class).size());
+        c.addAction(new A());
+        assertEquals(2, c.getActions(A.class).size());
+    }
+
 }


### PR DESCRIPTION
# Description

See [JENKINS-42969](https://issues.jenkins-ci.org/browse/JENKINS-42969). Corrects a regression in #2624. Worked around in https://github.com/jenkinsci/ssh-slaves-plugin/pull/50.

### Changelog entries

Proposed changelog entries:

* `Computer.addAction` would throw an `UnsupportedOperationException` since Jenkins 2.30. Such a call site was released in [SECURITY-161](https://jenkins.io/security/advisory/2017-03-20/).

### Desired reviewers

@reviewbybees