### PR TITLE
[FIXED JENKINS-43611] Fix name migration log message

### DIFF
--- a/core/src/main/java/hudson/model/AllView.java
+++ b/core/src/main/java/hudson/model/AllView.java
@@ -164,7 +164,7 @@ public class AllView extends View {
                         // bingo JENKINS-38606 detected
                         LOGGER.log(Level.INFO,
                                 "JENKINS-38606 detected for AllView in {0}; renaming view from {1} to {2}",
-                                new Object[]{allView.owner.getUrl(), DEFAULT_VIEW_NAME});
+                                new Object[]{allView.owner.getUrl(), primaryView, DEFAULT_VIEW_NAME});
                         allView.name = DEFAULT_VIEW_NAME;
                         return DEFAULT_VIEW_NAME;
                     }


### PR DESCRIPTION
Noticed this message on Jenkins 2.50, unknown previous release:

    INFO: JENKINS-38606 detected for AllView in ; renaming view from all to {2}

Untested.

@stephenc PTAL.

https://issues.jenkins-ci.org/browse/JENKINS-43611