### PR TITLE
Remove invalid CSS rule

### DIFF
--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
@@ -29,7 +29,6 @@
     height: auto;
     z-index: 0;
     padding: 2em;
-    border: 1px solid #aa;
     text-align: left;
     display: block;
     background-color: #fff;


### PR DESCRIPTION
I saw a warning message in a test output related to this broken CSS rule and decided to fix it.

Current presentation (before *and* after):

> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/24317921/bc09122c-10fd-11e7-8f82-82d5002a7ac4.png)

The one that possibly was intended (using `#aaa` as border color):

> ![screen shot](https://cloud.githubusercontent.com/assets/1831569/24317923/cc0c6034-10fd-11e7-80d0-b837ff390813.png)

CC @kzantow who originally authored this (I think, #2558 doesn't make it clear to me who did what, I may have messed up committer/author there), and @recena who asked to be copied on any Jenkins UI changes (although I doubt this qualifies as a "change") 