### PR TITLE
[FIX JENKINS-43228] Consider time zone for cron validation

### DIFF
--- a/core/src/main/java/hudson/scheduler/CronTab.java
+++ b/core/src/main/java/hudson/scheduler/CronTab.java
@@ -532,4 +532,17 @@ public final class CronTab {
             return null;
         }
     }
+
+    /**
+     * Returns the configured time zone, or null if none is configured
+     *
+     * @return the configured time zone, or null if none is configured
+     * @since TODO
+     */
+    @CheckForNull public TimeZone getTimeZone() {
+        if (this.specTimezone == null) {
+            return null;
+        }
+        return TimeZone.getTimeZone(this.specTimezone);
+    }
 }

--- a/core/src/main/java/hudson/scheduler/CronTabList.java
+++ b/core/src/main/java/hudson/scheduler/CronTabList.java
@@ -131,7 +131,7 @@ public final class CronTabList {
     public @CheckForNull Calendar previous() {
         Calendar nearest = null;
         for (CronTab tab : tabs) {
-            Calendar scheduled = tab.floor(Calendar.getInstance());
+            Calendar scheduled = tab.floor(tab.getTimeZone() == null ? Calendar.getInstance() : Calendar.getInstance(tab.getTimeZone()));
             if (nearest == null || nearest.before(scheduled)) {
                 nearest = scheduled;
             }
@@ -143,7 +143,7 @@ public final class CronTabList {
     public @CheckForNull Calendar next() {
         Calendar nearest = null;
         for (CronTab tab : tabs) {
-            Calendar scheduled = tab.ceil(Calendar.getInstance());
+            Calendar scheduled = tab.ceil(tab.getTimeZone() == null ? Calendar.getInstance() : Calendar.getInstance(tab.getTimeZone()));
             if (nearest == null || nearest.after(scheduled)) {
                 nearest = scheduled;
             }


### PR DESCRIPTION
# Description

See [JENKINS-43228](https://issues.jenkins-ci.org/browse/JENKINS-43228).

Details: Time zones defined for cron weren't considered for the form validation (previous/next occurrence) 

**Untested, waiting for PR build for test results**

### Changelog entries

Proposed changelog entries:

* Consider time zone for cron validation.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

### Desired reviewers

@oleg-nenashev who still hasn't finished #1720. We're soon celebrating it's second birthday ;-)