### PR TITLE
[FIX JENKINS-41778] - setup wizard issues when failures

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1934,8 +1934,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                                         throw new RuntimeException(e);
                                     }
                                 }
+                                // Must check for success, otherwise may have failed installation
+                                if (ij.status instanceof Success) {
+                                    return true;
+                                }
                             }
-                            return true;
                         }
                     }
                 }

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -461,9 +461,34 @@ var createPluginSetupWizard = function(appendTarget) {
 			setPanel(pluginSuccessPanel, { installingPlugins : installingPlugins, failedPlugins: true });
 			return;
 		}
-
+		
+		var attachScrollEvent = function() {
+			var $c = $('.install-console-scroll');
+			if (!$c.length) {
+				setTimeout(attachScrollEvent, 50);
+				return;
+			}
+			var events = $._data($c[0], "events");
+			if (!events || !events.scroll) {
+				$c.on('scroll', function() {
+				    if (!$c.data('wasAutoScrolled')) {
+				    	var top = $c[0].scrollHeight - $c.height();
+				        if ($c.scrollTop() === top) {
+				        	// resume auto-scroll
+				        	$c.data('userScrolled', false);
+				        } else {
+				        	// user scrolled up
+					    	$c.data('userScrolled', true);
+				        }
+				    } else {
+				    	$c.data('wasAutoScrolled', false);
+				    }
+				});
+			}
+		};
+		
 		initInstallingPluginList();
-		setPanel(progressPanel, { installingPlugins : installingPlugins });
+		setPanel(progressPanel, { installingPlugins : installingPlugins }, attachScrollEvent);
 
 		// call to the installStatus, update progress bar & plugin details; transition on complete
 		var updateStatus = function() {
@@ -491,8 +516,8 @@ var createPluginSetupWizard = function(appendTarget) {
 				$('.progress-bar').css({width: ((100.0 * complete)/total) + '%'});
 
 				// update details
-				var $c = $('.install-text');
-				$c.children().remove();
+				var $txt = $('.install-text');
+				$txt.children().remove();
 
 				for(i = 0; i < jobs.length; i++) {
 					j = jobs[i];
@@ -538,7 +563,7 @@ var createPluginSetupWizard = function(appendTarget) {
 						else {
 							$div.addClass('dependent');
 						}
-						$c.append($div);
+						$txt.append($div);
 
 						var $itemProgress = $('.selected-plugin[id="installing-' + jenkins.idIfy(j.name) + '"]');
 						if($itemProgress.length > 0 && !$itemProgress.is('.'+state)) {
@@ -547,13 +572,14 @@ var createPluginSetupWizard = function(appendTarget) {
 					}
 				}
 
-				$c = $('.install-console-scroll');
-				if($c.is(':visible')) {
+				var $c = $('.install-console-scroll');
+				if($c && $c.is(':visible') && !$c.data('userScrolled')) {
+					$c.data('wasAutoScrolled', true);
 					$c.scrollTop($c[0].scrollHeight);
 				}
 
 				// keep polling while install is running
-				if(complete < total || data.state === 'INITIAL_PLUGINS_INSTALLING') {
+				if(complete < total && data.state === 'INITIAL_PLUGINS_INSTALLING') {
 					setPanel(progressPanel, { installingPlugins : installingPlugins });
 					// wait a sec
 					setTimeout(updateStatus, 250);


### PR DESCRIPTION
# Description

This corrects a few issues with the setup wizard: most notably, it gets stuck when plugins fail to install, also allows scrolling the mini-console and fixed the retry option

See [JENKINS-41778](https://issues.jenkins-ci.org/browse/JENKINS-41778).

Details: issues in setup wizard when failures occur. not really sure how to write tests for this, dependent on network issues or other failures that don't typically happen

### Changelog entries

Proposed changelog entries:

* Setup wizard gets into bad state when failures occur

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@jenkinsci/code-reviewers
cc: @jtnord 
