### PR TITLE
[JENKINS-42852] - Jenkins Configuration Save Option

### DIFF
--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsConfiguration.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsConfiguration.java
@@ -27,6 +27,7 @@ package jenkins.management;
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -41,9 +42,15 @@ import java.util.logging.Logger;
 public class AdministrativeMonitorsConfiguration extends GlobalConfiguration {
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        JSONArray monitors = json.optJSONArray("administrativeMonitor");
         for (AdministrativeMonitor am : AdministrativeMonitor.all()) {
             try {
-                boolean disable = !json.getJSONArray("administrativeMonitor").contains(am.id);
+                boolean disable;
+                if(monitors != null) {
+                    disable = !monitors.contains(am.id);
+                }else {
+                    disable = !am.id.equals(json.optString("administrativeMonitor"));
+                }
                 am.disable(disable);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to process form submission for " + am.id, e);


### PR DESCRIPTION
# Description

When all the AdministrativeMonitor is disabled, Jenkins global configuration save option is broke.
This pull request fixes that.

<img width="1141" alt="screen shot 2017-04-03 at 11 44 09 pm" src="https://cloud.githubusercontent.com/assets/6861239/24624947/0234a304-18cb-11e7-986e-500c0e5369b7.png">
