### PR TITLE
Update node, npm, download-maven-plugin, & frontend-maven-plugin

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -41,8 +41,8 @@ THE SOFTWARE.
     <JENKINS_HOME>${basedir}/work</JENKINS_HOME>
     <contextPath>/jenkins</contextPath><!-- context path during test -->
     <port>8080</port><!-- HTTP listener port -->
-    <node.version>4.0.0</node.version>
-    <npm.version>3.8.9</npm.version>
+    <node.version>6.10.2</node.version>
+    <npm.version>3.10.10</npm.version>
   </properties>
 
   <dependencies>
@@ -642,7 +642,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.0</version>
             <executions>
               <execution>
                 <id>get-node</id>
@@ -706,7 +706,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>1.0</version>
+            <version>1.4</version>
             <executions>
 
               <execution>


### PR DESCRIPTION
# Description

[Core build #324 failed](https://ci.jenkins.io/job/Core/job/jenkins/job/master/324/execution/node/47/log/?consoleFull) and I am not sure why—possibly a network problem?

@cliffmeyers suggested updating npm, and I am throwing in an update of node, and adaptations of https://github.com/jenkinsci/plugin-pom/pull/48, https://github.com/jenkinsci/plugin-pom/pull/50, and https://github.com/jenkinsci/plugin-pom/pull/53, just in case.

Tested a clean build of the `war` on a new user dir and all the setup wizard, new item, and stage view UI stuff seems fine.

### Changelog entries

None required.

### Desired reviewers

@jenkinsci/code-reviewers & @reviewbybees