### PR TITLE
[FIXED JENKINS-37616] Make sure Cloud.PROVISION is properly initialized

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -28,6 +28,7 @@ package hudson.model;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher.ProcStarter;
+import hudson.slaves.Cloud;
 import jenkins.util.SystemProperties;
 import hudson.Util;
 import hudson.cli.declarative.CLIMethod;
@@ -1719,6 +1720,11 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     public static final Permission DISCONNECT = new Permission(PERMISSIONS,"Disconnect", Messages._Computer_DisconnectPermission_Description(), Jenkins.ADMINISTER, PermissionScope.COMPUTER);
     public static final Permission CONNECT = new Permission(PERMISSIONS,"Connect", Messages._Computer_ConnectPermission_Description(), DISCONNECT, PermissionScope.COMPUTER);
     public static final Permission BUILD = new Permission(PERMISSIONS, "Build", Messages._Computer_BuildPermission_Description(),  Permission.WRITE, PermissionScope.COMPUTER);
+
+    // This permission was historically scoped to this class albeit declared in Cloud. While deserializing, Jenkins loads
+    // the scope class to make sure the permission is initialized and registered. since Cloud class is used rather seldom,
+    // it might appear the permission does not exist. Referencing the permission from here to make sure it gets loaded.
+    private static final @Deprecated Permission CLOUD_PROVISION = Cloud.PROVISION;
 
     private static final Logger LOGGER = Logger.getLogger(Computer.class.getName());
 }

--- a/test/src/test/java/hudson/slaves/CloudTest.java
+++ b/test/src/test/java/hudson/slaves/CloudTest.java
@@ -7,11 +7,17 @@ import hudson.security.Permission;
 import hudson.security.SidACL;
 import jenkins.model.Jenkins;
 import org.acegisecurity.acls.sid.Sid;
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
 
 public class CloudTest {
 
-    @Test
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Test @WithoutJenkins @Issue("JENKINS-37616")
     public void provisionPermissionShouldBeIndependentFromAdminister() throws Exception {
         SidACL acl = new SidACL() {
             @Override protected Boolean hasPermission(Sid p, Permission permission) {
@@ -22,5 +28,12 @@ public class CloudTest {
         assertTrue(acl.hasPermission(Jenkins.ANONYMOUS, Cloud.PROVISION));
         assertFalse(acl.hasPermission(Jenkins.ANONYMOUS, Jenkins.ADMINISTER));
         assertEquals(Cloud.PROVISION, Computer.PERMISSIONS.find("Provision"));
+    }
+
+    @Test @Issue("JENKINS-37616")
+    public void ensureProvisionPermissionIsLoadable() throws Exception {
+        // Name introduced by JENKINS-37616
+        Permission p = Permission.fromId("hudson.model.Computer.Provision");
+        assertEquals("Provision", p.name);
     }
 }


### PR DESCRIPTION
# Description

See [JENKINS-37616](https://issues.jenkins-ci.org/browse/JENKINS-37616).

Due to a mistake of mine (https://github.com/jenkinsci/jenkins/pull/2521) the permission is declared in one class while scoped to another. When such a permission is deserialized from security realm config, it ensure the permission is registered (fields static initializer is invoked) by loading the class the permission is scoped to (https://github.com/jenkinsci/jenkins/blob/496703d/core/src/main/java/hudson/security/Permission.java#L248). In this case it does not guarantee declaring class (`Cloud`) gets loaded and if it is not loaded for some other reason, it blows up.

I have reproduced the problem and verified the fix on matrix-auth manually.

I do not like the way the fix clutters the `Computer` class but it is the simplest and safest way I found.

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

* Cloud.Provision permission might not be deserialized properly.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [*] JIRA issue is well described
- [*] Link to JIRA ticket in description, if appropriate
- [*] Appropriate autotests or explanation to why this change has no tests

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers
