### PR TITLE
[FIXED JENKINS-42043] Catch and log RuntimeException in setNode

### DIFF
--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -36,6 +36,7 @@ import org.kohsuke.stapler.StaplerProxy;
 
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 
@@ -115,7 +116,12 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
         Computer c;
         c = byNameMap.get(n.getNodeName());
         if (c!=null) {
-            c.setNode(n); // reuse
+            try {
+                c.setNode(n); // reuse
+                used.add(c);
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING, "Error updating node " + n.getNodeName() + ", continuing", e);
+            }
         } else {
             // we always need Computer for the master as a fallback in case there's no other Computer.
             if(n.getNumExecutors()>0 || n==Jenkins.getInstance()) {
@@ -131,8 +137,8 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
                     }
                 }
             }
+            used.add(c);
         }
-        used.add(c);
     }
 
     /*package*/ void removeComputer(final Computer computer) {


### PR DESCRIPTION
# Description

See [JENKINS-42043](https://issues.jenkins-ci.org/browse/JENKINS-42043).

Details: Catch and log `RuntimeException` in call to `SlaveComputer.setNode(n)` in `AbstractCIBase.updateComputerList(...)`. Also make sure we don't mark the `Computer` as used so that we kill any executors that may be related to it somehow.

Not sure how to test this - suggestions?

### Changelog entries

Proposed changelog entries:

* Entry 1: JENKINS-42043, RuntimeException in SlaveComputer.setNode(n) will no longer prevent Jenkins startup

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

### Desired reviewers

@reviewbybees @batmat @jglick 