### PR TITLE
Added logging to FullDuplexHttpService

### DIFF
--- a/test/src/test/java/hudson/cli/CLIActionTest.java
+++ b/test/src/test/java/hudson/cli/CLIActionTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import jenkins.model.Jenkins;
 import jenkins.security.ApiTokenProperty;
+import jenkins.util.FullDuplexHttpService;
 import jenkins.util.Timer;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.TeeOutputStream;
@@ -257,7 +258,7 @@ public class CLIActionTest {
     @Issue("JENKINS-41745")
     @Test
     public void interleavedStdio() throws Exception {
-        logging.record(PlainCLIProtocol.class, Level.FINE);
+        logging.record(PlainCLIProtocol.class, Level.FINE).record(FullDuplexHttpService.class, Level.FINE);
         File jar = tmp.newFile("jenkins-cli.jar");
         FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
# Description

Amends #2795 to include some diagnostic logging which can help pinpoint the cause of any problems establishing an HTTP Duplex connection.

### Changelog entries

None required.

### Desired reviewers

@reviewbybees