### PR TITLE
github-organization-folder is deprecated

### DIFF
--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -47,7 +47,8 @@
         "category":"Pipelines and Continuous Delivery",
         "plugins": [
             { "name": "workflow-aggregator", "suggested": true, "added": "2.0" },
-            { "name": "github-organization-folder", "suggested": true, "added": "2.0" },
+            { "name": "github-branch-source", "suggested": true, "added": "2.0" },
+            { "name": "pipeline-github-lib", "suggested": true, "added": "2.0" },
             { "name": "pipeline-stage-view", "suggested": true, "added": "2.0" },
             { "name": "build-pipeline-plugin" },
             { "name": "conditional-buildstep" },


### PR DESCRIPTION
# Description

Follows up https://github.com/jenkinsci/github-organization-folder-plugin/pull/39.

### Changelog entries

None required I think.

### Desired reviewers

@reviewbybees

By the way @i386 you probably want to recommend `blueocean` on new installs now, right?