### PR TITLE
Change rss feed build name

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2410,7 +2410,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
     private static class DefaultFeedAdapter implements FeedAdapter<Run> {
         public String getEntryTitle(Run entry) {
-            return entry+" ("+entry.getBuildStatusSummary().message+")";
+            return entry.getDisplayName()+" ("+entry.getBuildStatusSummary().message+")";
         }
 
         public String getEntryUrl(Run entry) {


### PR DESCRIPTION
We are always show default build name as build name in rss feed. Currently default build name is a build number. This is incorrect becouse we can change build display name during build process and it will be changed in build history list but not in rss feed.

This patch is change rss feed build name from build number to display name.

### Proposed Changelog Entry

* Use build display names in RSS feed titles 
