### PR TITLE
[JENKINS-42707] AccessDeniedException exception in ReverseBuildTrigger

### DIFF
--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -149,8 +149,8 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
                 listener.getLogger().println(Messages.ReverseBuildTrigger_running_as_cannot_even_see_for_trigger_f(auth.getName(),
                         upstream.getFullName(), job.getFullName()));
             } else  {
-                LOGGER.log(Level.WARNING, Messages.ReverseBuildTrigger_running_as_cannot_even_see_but_cannot_tell(auth.getName(),
-                        downstreamDiscoverable ? "READ" : "DISCOVER", upstream, job, originalAuth.getName()));
+                LOGGER.log(Level.WARNING, "Running as {0} cannot even {1} {2} for trigger from {3}, (but cannot tell {4} that)",
+                        new Object [] { auth.getName(), downstreamDiscoverable ? "READ" : "DISCOVER", upstream, job, originalAuth.getName()});
             }
             return false;
         }

--- a/core/src/main/resources/jenkins/triggers/Messages.properties
+++ b/core/src/main/resources/jenkins/triggers/Messages.properties
@@ -22,5 +22,4 @@
 
 ReverseBuildTrigger.build_after_other_projects_are_built=Build after other projects are built
 ReverseBuildTrigger.running_as_cannot_even_see_for_trigger_f=Running as {0} cannot even see {1} for trigger from {2}
-ReverseBuildTrigger.running_as_cannot_even_see_but_cannot_tell=Running as {0} cannot even {1} {2} for trigger from {3}, (but cannot tell {4} that)
 SCMTriggerItem.PollingVetoed=SCM polling vetoed by {0}

--- a/core/src/main/resources/jenkins/triggers/Messages.properties
+++ b/core/src/main/resources/jenkins/triggers/Messages.properties
@@ -22,4 +22,5 @@
 
 ReverseBuildTrigger.build_after_other_projects_are_built=Build after other projects are built
 ReverseBuildTrigger.running_as_cannot_even_see_for_trigger_f=Running as {0} cannot even see {1} for trigger from {2}
+ReverseBuildTrigger.running_as_cannot_even_see_but_cannot_tell=Running as {0} cannot even {1} {2} for trigger from {3}, (but cannot tell {4} that)
 SCMTriggerItem.PollingVetoed=SCM polling vetoed by {0}


### PR DESCRIPTION
# Description

See [JENKINS-42707](https://issues.jenkins-ci.org/browse/JENKINS-42707).

Details: If `anonymous` user has *Overall/Read* and *Item/Discover* permission, the ReverseBuildTrigger may display an AccessDeniedException in the console log. It should instead display the expected warning shown at https://github.com/jenkinsci/jenkins/blob/jenkins-2.50/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java#L130

TODO:

- [x] Code Fix
- [x] Test case
- [ ] ATH Test

### Changelog entries

Proposed changelog entries:

* [JENKINS-42707]: Fix AccessDeniedException risk in ReverseBuildTrigger when user has `Item.DISCOVER` permission without `Item.READ`. Warning is displayed in the console log.

### Desired reviewers

@reviewbybees