### PR TITLE
Bump Trilead version to receive a number of security enhancements

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -115,7 +115,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>trilead-ssh2</artifactId>
-      <version>build217-jenkins-8</version>
+      <version>build217-jenkins-9</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
# Description
Move to a new version of Trilead to receive a number of improvements in SSH security handling
See:
* Related, but not fixed: [JENKINS-41606](https://issues.jenkins-ci.org/browse/JENKINS-41606)
* [JENKINS-33021](https://issues.jenkins-ci.org/browse/JENKINS-33021)
* [JENKINS-26379](https://issues.jenkins-ci.org/browse/JENKINS-26379)
* [JENKINS-31549](https://issues.jenkins-ci.org/browse/JENKINS-31549)

This is a stop-gap measure until [JENKINS-43610](https://issues.jenkins-ci.org/browse/JENKINS-43610) is completed.

This version of Trilead is backwards compatible with the previous version hence the lack of new tests. Jenkins CLI has not been updated since it seems to be out of sync with the core version, and has a hard-coded list of supported keys which doesn't include the new keys introduced in the latest version of Trilead.

**Note:** This plugin does introduce dependencies on two new JARs. It may be worth setting them to 'optional' in the Jenkins POM to prevent them being exposed to core dependents.

### Changelog entries

Proposed changelog entries:

* JENKINS-33021, JENKINS-26379, JENKINS-31549: Update the Trilead SSH library to get support of new Mac, Key, and Key Exchange Algorithms

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@jenkinsci/code-reviewers I'm particularly interested in views on whether we hide the new dependencies of Trilead.

