### PR TITLE
[JENKINS-43713] Integrate Winstone 4 (Jetty 9.4.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,7 @@ THE SOFTWARE.
           <!-- this is really just a patched version of maven-jetty-plugin to workaround issue #932 -->
           <groupId>org.jenkins-ci.tools</groupId>
           <artifactId>maven-jenkins-dev-plugin</artifactId>
-          <version>9.2.15.v20160210-jenkins-1</version>
+          <version>9.4.5.v20170502-jenkins-1</version>
         </plugin>
         <plugin>
           <groupId>org.jvnet.updatecenter2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19.1</version> <!-- ignoring ${maven-surefire-plugin.version} -->
+          <version>2.20</version> <!-- ignoring ${maven-surefire-plugin.version} -->
           <configuration>
             <argLine>-noverify</argLine> <!-- some versions of JDK7/8 causes VerifyError during mock tests: http://code.google.com/p/powermock/issues/detail?id=504 -->
             <systemPropertyVariables>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -93,7 +93,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>3.5-SNAPSHOT</version>
+      <version>4.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -93,7 +93,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>3.3</version>
+      <version>3.5-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -187,20 +187,6 @@ THE SOFTWARE.
     </dependency-->
   </dependencies>
 
-  <repositories>
-    <!-- can be removed when jetty 9.4.5 released -->
-    <repository>
-      <id>jetty.snapshots</id>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <url>https://oss.sonatype.org/content/repositories/jetty-snapshots</url>
-    </repository>
-  </repositories>
-
   <build>
     <finalName>jenkins</finalName>
     <plugins>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -187,6 +187,20 @@ THE SOFTWARE.
     </dependency-->
   </dependencies>
 
+  <repositories>
+    <!-- can be removed when jetty 9.4.5 released -->
+    <repository>
+      <id>jetty.snapshots</id>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <url>https://oss.sonatype.org/content/repositories/jetty-snapshots</url>
+    </repository>
+  </repositories>
+
   <build>
     <finalName>jenkins</finalName>
     <plugins>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -177,7 +177,6 @@ THE SOFTWARE.
     </dependency>
 
     <!-- offline profiler API when we need it -->
-
     <!--dependency
       <groupId>com.yourkit.api</groupId>
       <artifactId>yjp</artifactId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -93,7 +93,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>4.0-SNAPSHOT</version>
+      <version>4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
# Description
See [JENKINS-43713](https://issues.jenkins-ci.org/browse/JENKINS-43713).
ATM depends on jetty 9.4.5-SNAPSHOT and winstone 3.5-SNAPSHOT so it's only here for manual testing purpose (as I have no idea if winstone snapshot are deployed somewhere)
So for testing purpose build this first: https://github.com/jenkinsci/winstone/pull/32

- [x] Update to Winstone with new Jetty
- [x] Update jenkinsci/maven-hudson-dev-plugin

# Changelog 

* [JENKINS-43713] - Winstone 4.0: Update Jetty from 9.2.15.v20160210 to 9.4.5.v20170502
* [PR 2850] Winstone 4.0: Remove support of the deprecated [SPDY](http://www.eclipse.org/jetty/documentation/9.1.5.v20140505/spdy.html) protocol mode, which has been removed from Jetty. `-spdy` parameter in the command line will not work anymore.

