### PR TITLE
[JENKINS-43653] - Ensure AbstractItem#delete() NPE safety when checking executors

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -86,7 +86,8 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-import static hudson.model.queue.Executables.getParentOf;
+import static hudson.model.queue.Executables.getParentOfOrNull;
+import hudson.model.queue.SubTask;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import org.apache.commons.io.FileUtils;
 import org.kohsuke.accmod.Restricted;
@@ -620,9 +621,10 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                 Map<Executor, Queue.Executable> buildsInProgress = new LinkedHashMap<>();
                 for (Computer c : Jenkins.getInstance().getComputers()) {
                     for (Executor e : c.getAllExecutors()) {
-                        WorkUnit workUnit = e.getCurrentWorkUnit();
-                        if (workUnit != null) {
-                            Item item = Tasks.getItemOf(getParentOf(workUnit.getExecutable()));
+                        final WorkUnit workUnit = e.getCurrentWorkUnit();
+                        final SubTask subtask = workUnit != null ? getParentOfOrNull(workUnit.getExecutable()) : null;
+                        if (subtask != null) {        
+                            Item item = Tasks.getItemOf(subtask);
                             if (item != null) {
                                 while (item != null) {
                                     if (item == this) {

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -31,6 +31,7 @@ import hudson.Util;
 import hudson.Functions;
 import hudson.BulkChange;
 import hudson.cli.declarative.CLIResolver;
+import hudson.model.Queue.Executable;
 import hudson.model.listeners.ItemListener;
 import hudson.model.listeners.SaveableListener;
 import hudson.model.queue.Tasks;
@@ -88,6 +89,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import static hudson.model.queue.Executables.getParentOfOrNull;
 import hudson.model.queue.SubTask;
+import java.util.Optional;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import org.apache.commons.io.FileUtils;
 import org.kohsuke.accmod.Restricted;
@@ -622,7 +624,8 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                 for (Computer c : Jenkins.getInstance().getComputers()) {
                     for (Executor e : c.getAllExecutors()) {
                         final WorkUnit workUnit = e.getCurrentWorkUnit();
-                        final SubTask subtask = workUnit != null ? getParentOfOrNull(workUnit.getExecutable()) : null;
+                        final Executable executable = workUnit != null ? workUnit.getExecutable() : null;
+                        final SubTask subtask = executable != null ? getParentOfOrNull(executable) : null;
                         if (subtask != null) {        
                             Item item = Tasks.getItemOf(subtask);
                             if (item != null) {

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -87,7 +87,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-import static hudson.model.queue.Executables.getParentOfOrFail;
+import static hudson.model.queue.Executables.getParentOf;
 import hudson.model.queue.SubTask;
 import java.lang.reflect.InvocationTargetException;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
@@ -625,15 +625,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                     for (Executor e : c.getAllExecutors()) {
                         final WorkUnit workUnit = e.getCurrentWorkUnit();
                         final Executable executable = workUnit != null ? workUnit.getExecutable() : null;
-                        SubTask subtask = null;
-                        if (executable != null) {
-                            try {
-                                subtask = getParentOfOrFail(executable);
-                            } catch(InvocationTargetException ex) {
-                                // Executable is not compatible with API changes in 1.377+
-                                LOGGER.log(Level.WARNING, "Cannot determine subtask for the executable with obsolete API implementation", ex);
-                            }
-                        }
+                        final SubTask subtask = executable != null ? getParentOf(executable) : null;
                                 
                         if (subtask != null) {        
                             Item item = Tasks.getItemOf(subtask);

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -844,7 +844,7 @@ public class Executor extends Thread implements ModelObject {
         lock.writeLock().lock(); // need write lock as interrupt will change the field
         try {
             if (executable != null) {
-                Tasks.getOwnerTaskOf(getParentOfOrFail(executable)).checkAbortPermission();
+                Tasks.getOwnerTaskOf(getParentOf(executable)).checkAbortPermission();
                 interrupt();
             }
         } finally {

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -64,7 +64,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static hudson.model.queue.Executables.*;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import static java.util.logging.Level.*;
 import javax.annotation.CheckForNull;
@@ -845,13 +844,7 @@ public class Executor extends Thread implements ModelObject {
         lock.writeLock().lock(); // need write lock as interrupt will change the field
         try {
             if (executable != null) {
-                final SubTask parentOf;
-                try {
-                   parentOf = getParentOfOrFail(executable);
-                } catch(InvocationTargetException ex) {
-                    return HttpResponses.error(500, ex);
-                }
-                Tasks.getOwnerTaskOf(parentOf).checkAbortPermission();
+                Tasks.getOwnerTaskOf(getParentOfOrFail(executable)).checkAbortPermission();
                 interrupt();
             }
         } finally {

--- a/core/src/main/java/hudson/model/queue/Executables.java
+++ b/core/src/main/java/hudson/model/queue/Executables.java
@@ -31,6 +31,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Convenience methods around {@link Executable}.
@@ -41,15 +43,17 @@ public class Executables {
     
     private static final Logger LOGGER = Logger.getLogger(Executables.class.getName());
     
+    // TODO: Deprecate getParentOf() and make the new API public
+    // @deprecated This method may throw Runtime exceptions for old cores
+    // Use {@link #getParentOfOrFail(hudson.model.Queue.Executable)} or {@link #getParentOfOrNull(hudson.model.Queue.Executable)} instead.
+    
     /**
      * Due to the return type change in {@link Executable}, the caller needs a special precaution now.
      * @param e Executable
+     * @return Discovered subtask
      * @throws Error Executable type does not offer the {@link Executable#getParent()} method or it fails with {@link Error}
      * @throws RuntimeException {@link Executable#getParent()} method fails with {@link Error}
-     * @deprecated This method may throw Runtime exceptions for old cores
-     *      Use {@link #getParentOfOrFail(hudson.model.Queue.Executable)} or {@link #getParentOfOrNull(hudson.model.Queue.Executable)} instead.
      */
-    @Deprecated
     public static @Nonnull SubTask getParentOf(@Nonnull Executable e) 
             throws Error, RuntimeException {
         try {
@@ -76,15 +80,13 @@ public class Executables {
      * Get parent subtask from which the executable has been created.
      * @param e Executable.
      * @return Parent subtask from which the executable has been created.
-     *         {@code null} if the Executable is {@code null} OR has incompatible API (old plugin depending on a core older than 1.377)
+     *         {@code null} if the Executable has incompatible API (old plugin depending on a core older than 1.377)
      * @since TODO
      * @see #getParentOfOrFail(hudson.model.Queue.Executable) 
      */
     @CheckForNull
-    public static SubTask getParentOfOrNull(@CheckForNull Executable e) {
-        if (e == null) {
-            return null;
-        }
+    @Restricted(NoExternalUse.class)
+    public static SubTask getParentOfOrNull(@Nonnull Executable e) {
         try {
             return getParentOf(e);
         } catch(RuntimeException | Error ex) {
@@ -101,6 +103,7 @@ public class Executables {
      * @since TODO
      */
     @Nonnull
+    @Restricted(NoExternalUse.class)
     public static SubTask getParentOfOrFail(@Nonnull Executable e) throws InvocationTargetException {
        try {
             return getParentOf(e);

--- a/core/src/main/java/hudson/model/queue/Executables.java
+++ b/core/src/main/java/hudson/model/queue/Executables.java
@@ -27,8 +27,6 @@ import hudson.model.Queue.Executable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.kohsuke.accmod.Restricted;
@@ -40,8 +38,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @author Kohsuke Kawaguchi
  */
 public class Executables {
-    
-    private static final Logger LOGGER = Logger.getLogger(Executables.class.getName());
     
     // TODO: Deprecate getParentOf() and make the new API public
     // @deprecated This method may throw Runtime exceptions for old cores
@@ -73,25 +69,6 @@ public class Executables {
                 if (y instanceof RuntimeException)     throw (RuntimeException)y;
                 throw new Error(x);
             }
-        }
-    }
-    
-    /**
-     * Get parent subtask from which the executable has been created.
-     * @param e Executable.
-     * @return Parent subtask from which the executable has been created.
-     *         {@code null} if the Executable has incompatible API (old plugin depending on a core older than 1.377)
-     * @since TODO
-     * @see #getParentOfOrFail(hudson.model.Queue.Executable) 
-     */
-    @CheckForNull
-    @Restricted(NoExternalUse.class)
-    public static SubTask getParentOfOrNull(@Nonnull Executable e) {
-        try {
-            return getParentOf(e);
-        } catch(RuntimeException | Error ex) {
-            LOGGER.log(Level.WARNING, formatUnsupportedExecutableAPIMessage(e), ex);
-            return null;
         }
     }
     

--- a/core/src/main/java/hudson/model/queue/Executables.java
+++ b/core/src/main/java/hudson/model/queue/Executables.java
@@ -29,8 +29,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Convenience methods around {@link Executable}.
@@ -39,19 +37,10 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  */
 public class Executables {
     
-    // TODO: Investigate if there are still plugins, which do not implement new API (last occurrence: JENKINS-8100)
-    // If yes, improve API by bits, which were proposed in https://github.com/jenkinsci/jenkins/pull/2854
-    
     /**
      * Due to the return type change in {@link Executable} in 1.377, the caller needs a special precaution now.
      * @param e Executable
      * @return Discovered subtask
-     * @throws Error Executable type does not offer the {@link Executable#getParent()} method or it fails with {@link Error}.
-     *         It may happen if and only if there is a plugin implementing old Executable API (for Jenkins older than 1.377). 
-     *         Last occurrence - JENKINS-8100 
-     * @throws RuntimeException {@link Executable#getParent()} method fails with {@link Error}
-     *         It may happen if and only if there is a plugin implementing old Executable API (for Jenkins older than 1.377). 
-     *         Last occurrence - JENKINS-8100 
      */
     public static @Nonnull SubTask getParentOf(@Nonnull Executable e) 
             throws Error, RuntimeException {

--- a/core/src/main/java/hudson/model/queue/Executables.java
+++ b/core/src/main/java/hudson/model/queue/Executables.java
@@ -39,16 +39,19 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  */
 public class Executables {
     
-    // TODO: Deprecate getParentOf() and make the new API public
-    // @deprecated This method may throw Runtime exceptions for old cores
-    // Use {@link #getParentOfOrFail(hudson.model.Queue.Executable)} or {@link #getParentOfOrNull(hudson.model.Queue.Executable)} instead.
+    // TODO: Investigate if there are still plugins, which do not implement new API (last occurrence: JENKINS-8100)
+    // If yes, improve API by bits, which were proposed in https://github.com/jenkinsci/jenkins/pull/2854
     
     /**
-     * Due to the return type change in {@link Executable}, the caller needs a special precaution now.
+     * Due to the return type change in {@link Executable} in 1.377, the caller needs a special precaution now.
      * @param e Executable
      * @return Discovered subtask
-     * @throws Error Executable type does not offer the {@link Executable#getParent()} method or it fails with {@link Error}
+     * @throws Error Executable type does not offer the {@link Executable#getParent()} method or it fails with {@link Error}.
+     *         It may happen if and only if there is a plugin implementing old Executable API (for Jenkins older than 1.377). 
+     *         Last occurrence - JENKINS-8100 
      * @throws RuntimeException {@link Executable#getParent()} method fails with {@link Error}
+     *         It may happen if and only if there is a plugin implementing old Executable API (for Jenkins older than 1.377). 
+     *         Last occurrence - JENKINS-8100 
      */
     public static @Nonnull SubTask getParentOf(@Nonnull Executable e) 
             throws Error, RuntimeException {
@@ -70,29 +73,6 @@ public class Executables {
                 throw new Error(x);
             }
         }
-    }
-    
-    /**
-     * Get parent subtask from which the executable has been created.
-     * @param e Executable
-     * @return Parent subtask from which the executable has been created
-     * @throws InvocationTargetException Operation failure due to the usage of incompatible API for old plugin depending on a core older than 1.377
-     * @since TODO
-     */
-    @Nonnull
-    @Restricted(NoExternalUse.class)
-    public static SubTask getParentOfOrFail(@Nonnull Executable e) throws InvocationTargetException {
-       try {
-            return getParentOf(e);
-        } catch(RuntimeException | Error ex) {
-            throw new InvocationTargetException(ex, formatUnsupportedExecutableAPIMessage(e));
-        } 
-    }
-    
-    @Nonnull
-    private static String formatUnsupportedExecutableAPIMessage(@Nonnull Executable e) {
-        return String.format("Cannot retrieve parent subtask of executable %s implementing API version below 1.377 (%s)", 
-                    new Object[] {e, e.getClass()});
     }
 
     /**

--- a/core/src/main/java/hudson/model/queue/WorkUnit.java
+++ b/core/src/main/java/hudson/model/queue/WorkUnit.java
@@ -79,6 +79,7 @@ public final class WorkUnit {
     /**
      * If the execution has already started, return the executable that was created.
      */
+    @CheckForNull
     public Executable getExecutable() {
         return executable;
     }


### PR DESCRIPTION
This is a regression introduced by https://github.com/jenkinsci/jenkins/pull/2789 in 2.55. See See [JENKINS-43653](https://issues.jenkins-ci.org/browse/JENKINS-43653).

This change adds missing NPE checks and also improves handling of Executables#getParentOf(), which may throw undocumented Runtime exceptions if Executable uses core API below 1.377 and does not implement getParent(). Executor#stop() has been also modified to explicitly handle the issue though there is still the same issue with estimated execution times.

No autotests since the fix is expedited to 2.56.

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

* JENKINS-43653: Ensure `NullPointerException` safety when aborting builds during item deletion (regression in 2.55).
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@reviewbybees @stephenc 

<!-- Comment:
If you want to get reviews from particular people, please CC them.
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
