### PR TITLE
[JENKINS-43780] Remove references to Trilead classes

### DIFF
--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -31,7 +31,6 @@ import java.nio.file.StandardOpenOption;
 import jenkins.util.SystemProperties;
 import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
 import com.thoughtworks.xstream.core.JVM;
-import com.trilead.ssh2.util.IOUtils;
 import hudson.model.Hudson;
 import hudson.security.ACL;
 import hudson.util.BootFailure;

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -23,7 +23,6 @@
  */
 package hudson.model;
 
-import com.trilead.ssh2.crypto.Base64;
 import hudson.PluginWrapper;
 import hudson.Util;
 import hudson.Extension;
@@ -58,6 +57,7 @@ import java.security.interfaces.RSAKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import com.jcraft.jzlib.GZIPOutputStream;
 import jenkins.util.SystemProperties;
@@ -186,7 +186,7 @@ public class UsageStatistics extends PageDecorator {
                 o.write(w);
             }
 
-            return new String(Base64.encode(baos.toByteArray()));
+            return new String(Base64.getEncoder().encode(baos.toByteArray()));
         } catch (GeneralSecurityException e) {
             throw new Error(e); // impossible
         }

--- a/core/src/main/java/hudson/util/ConsistentHash.java
+++ b/core/src/main/java/hudson/util/ConsistentHash.java
@@ -23,8 +23,8 @@
  */
 package hudson.util;
 
-import com.trilead.ssh2.crypto.digest.MD5;
-
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -289,15 +289,18 @@ public class ConsistentHash<T> {
      * Compresses a string into an integer with MD5.
      */
     private int md5(String s) {
-        MD5 md5 = new MD5();
-        md5.update(s.getBytes());
-        byte[] digest = new byte[16];
-        md5.digest(digest);
+        try {
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            md5.update(s.getBytes());
+            byte[] digest = md5.digest();
 
-        // 16 bytes -> 4 bytes
-        for (int i=0; i<4; i++)
-            digest[i] ^= digest[i+4]+digest[i+8]+digest[i+12];
-        return (b2i(digest[0])<< 24)|(b2i(digest[1])<<16)|(b2i(digest[2])<< 8)|b2i(digest[3]);
+            // 16 bytes -> 4 bytes
+            for (int i=0; i<4; i++)
+                digest[i] ^= digest[i+4]+digest[i+8]+digest[i+12];
+            return (b2i(digest[0])<< 24)|(b2i(digest[1])<<16)|(b2i(digest[2])<< 8)|b2i(digest[3]);
+        } catch (GeneralSecurityException e) {
+            throw new Error("Could not generate MD5 hash", e);
+        }
     }
 
     /**

--- a/core/src/main/java/hudson/util/FormFieldValidator.java
+++ b/core/src/main/java/hudson/util/FormFieldValidator.java
@@ -622,9 +622,9 @@ public abstract class FormFieldValidator {
                     return;
                 }
                 
-                com.trilead.ssh2.crypto.Base64.decode(v.toCharArray());
+                java.util.Base64.getDecoder().decode(v);
                 ok();
-            } catch (IOException e) {
+            } catch (IOException | IllegalArgumentException e) {
                 fail();
             }
         }

--- a/core/src/main/java/hudson/util/FormValidation.java
+++ b/core/src/main/java/hudson/util/FormValidation.java
@@ -54,7 +54,9 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -437,9 +439,9 @@ public abstract class FormValidation extends IOException implements HttpResponse
             if(!allowEmpty && v.length()==0)
                 return error(errorMessage);
 
-            com.trilead.ssh2.crypto.Base64.decode(v.toCharArray());
+            Base64.getDecoder().decode(v.getBytes(StandardCharsets.UTF_8));
             return ok();
-        } catch (IOException e) {
+        } catch (IllegalArgumentException e) {
             return error(errorMessage);
         }
     }

--- a/core/src/main/java/hudson/util/HistoricalSecrets.java
+++ b/core/src/main/java/hudson/util/HistoricalSecrets.java
@@ -24,7 +24,6 @@
  */
 package hudson.util;
 
-import com.trilead.ssh2.crypto.Base64;
 import hudson.Util;
 import jenkins.model.Jenkins;
 import jenkins.security.CryptoConfidentialKey;
@@ -34,7 +33,9 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.util.Base64;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -45,7 +46,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class HistoricalSecrets {
 
     /*package*/ static Secret decrypt(String data, CryptoConfidentialKey key) throws IOException, GeneralSecurityException {
-        byte[] in = Base64.decode(data.toCharArray());
+        byte[] in;
+        try {
+            in = Base64.getDecoder().decode(data.getBytes(StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException ex) {
+            throw new IOException("Could not decode secret", ex);
+        }
         Secret s = tryDecrypt(key.decrypt(), in);
         if (s!=null)    return s;
 

--- a/core/src/main/java/hudson/util/Scrambler.java
+++ b/core/src/main/java/hudson/util/Scrambler.java
@@ -23,10 +23,8 @@
  */
 package hudson.util;
 
-import com.trilead.ssh2.crypto.Base64;
-
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * Scrambles, but does not encrypt, text.
@@ -39,18 +37,14 @@ import java.io.UnsupportedEncodingException;
 public class Scrambler {
     public static String scramble(String secret) {
         if(secret==null)    return null;
-        try {
-            return new String(Base64.encode(secret.getBytes("UTF-8")));
-        } catch (UnsupportedEncodingException e) {
-            throw new Error(e); // impossible
-        }
+        return new String(Base64.getEncoder().encode(secret.getBytes(StandardCharsets.UTF_8)));
     }
 
     public static String descramble(String scrambled) {
         if(scrambled==null)    return null;
         try {
-            return new String(Base64.decode(scrambled.toCharArray()),"UTF-8");
-        } catch (IOException e) {
+            return new String(Base64.getDecoder().decode(scrambled.getBytes(StandardCharsets.UTF_8)),StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
             return "";  // corrupted data.
         }
     }

--- a/core/src/main/java/hudson/util/Secret.java
+++ b/core/src/main/java/hudson/util/Secret.java
@@ -29,7 +29,6 @@ import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
-import com.trilead.ssh2.crypto.Base64;
 import jenkins.util.SystemProperties;
 import java.util.Arrays;
 import jenkins.model.Jenkins;
@@ -42,6 +41,7 @@ import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Base64;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -144,7 +144,7 @@ public final class Secret implements Serializable {
             System.arraycopy(iv, 0, payload, pos, iv.length);
             pos+=iv.length;
             System.arraycopy(encrypted, 0, payload, pos, encrypted.length);
-            return "{"+new String(Base64.encode(payload))+"}";
+            return "{"+new String(Base64.getEncoder().encode(payload))+"}";
         } catch (GeneralSecurityException e) {
             throw new Error(e); // impossible
         }
@@ -170,8 +170,8 @@ public final class Secret implements Serializable {
         if (data.startsWith("{") && data.endsWith("}")) { //likely CBC encrypted/containing metadata but could be plain text
             byte[] payload;
             try {
-                payload = Base64.decode(data.substring(1, data.length()-1).toCharArray());
-            } catch (IOException e) {
+                payload = Base64.getDecoder().decode(data.substring(1, data.length()-1));
+            } catch (IllegalArgumentException e) {
                 return null;
             }
             switch (payload[0]) {

--- a/core/src/main/java/hudson/util/SecretRewriter.java
+++ b/core/src/main/java/hudson/util/SecretRewriter.java
@@ -1,10 +1,10 @@
 package hudson.util;
 
-import com.trilead.ssh2.crypto.Base64;
 import hudson.Functions;
 import hudson.model.TaskListener;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import javax.crypto.Cipher;
@@ -12,13 +12,13 @@ import javax.crypto.SecretKey;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.nio.file.LinkOption;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -62,8 +62,8 @@ public class SecretRewriter {
 
         byte[] in;
         try {
-            in = Base64.decode(s.toCharArray());
-        } catch (IOException e) {
+            in = Base64.getDecoder().decode(s.getBytes(StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException e) {
             return s;   // not a valid base64
         }
         cipher.init(Cipher.DECRYPT_MODE, key);

--- a/core/src/test/groovy/hudson/util/SecretRewriterTest.groovy
+++ b/core/src/test/groovy/hudson/util/SecretRewriterTest.groovy
@@ -1,6 +1,5 @@
 package hudson.util
 
-import com.trilead.ssh2.crypto.Base64
 import hudson.FilePath
 import hudson.Functions
 import jenkins.security.ConfidentialStoreRule
@@ -68,7 +67,7 @@ class SecretRewriterTest {
     String encryptOld(str) {
         def cipher = Secret.getCipher("AES");
         cipher.init(Cipher.ENCRYPT_MODE, HistoricalSecrets.legacyKey);
-        return new String(Base64.encode(cipher.doFinal((str + HistoricalSecrets.MAGIC).getBytes("UTF-8"))))
+        return new String(Base64.getEncoder().encode(cipher.doFinal((str + HistoricalSecrets.MAGIC).getBytes("UTF-8"))))
     }
 
     String encryptNew(str) {

--- a/core/src/test/groovy/hudson/util/SecretTest.groovy
+++ b/core/src/test/groovy/hudson/util/SecretTest.groovy
@@ -23,7 +23,6 @@
  */
 package hudson.util
 
-import com.trilead.ssh2.crypto.Base64;
 import jenkins.model.Jenkins
 import jenkins.security.ConfidentialStoreRule;
 import org.apache.commons.lang.RandomStringUtils;
@@ -123,7 +122,7 @@ public class SecretTest {
         ["Hello world","","\u0000unprintable"].each { str ->
             def cipher = Secret.getCipher("AES");
             cipher.init(Cipher.ENCRYPT_MODE, legacy);
-            def old = new String(Base64.encode(cipher.doFinal((str + HistoricalSecrets.MAGIC).getBytes("UTF-8"))))
+            def old = new String(Base64.getEncoder().encode(cipher.doFinal((str + HistoricalSecrets.MAGIC).getBytes("UTF-8"))))
             def s = Secret.fromString(old)
             assert s.plainText==str : "secret by the old key should decrypt"
             assert s.encryptedValue!=old : "but when encrypting, ConfidentialKey should be in use"

--- a/test/src/test/java/hudson/model/UpdateCenterTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterTest.java
@@ -23,14 +23,15 @@
  */
 package hudson.model;
 
-import com.trilead.ssh2.crypto.Base64;
 import hudson.util.TimeUnit2;
 import net.sf.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Date;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
@@ -66,7 +67,7 @@ public class UpdateCenterTest {
         CertificateFactory cf = CertificateFactory.getInstance("X509");
         JSONObject signature = json.getJSONObject("signature");
         for (Object cert : signature.getJSONArray("certificates")) {
-            X509Certificate c = (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(Base64.decode(cert.toString().toCharArray())));
+            X509Certificate c = (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(cert.toString().getBytes(StandardCharsets.UTF_8))));
             c.checkValidity(new Date(System.currentTimeMillis() + TimeUnit2.DAYS.toMillis(30)));
         }
     }

--- a/test/src/test/java/hudson/model/UsageStatisticsTest.java
+++ b/test/src/test/java/hudson/model/UsageStatisticsTest.java
@@ -24,12 +24,13 @@
 package hudson.model;
 
 import com.google.common.io.Resources;
-import com.trilead.ssh2.crypto.Base64;
 import hudson.ClassicPluginStrategy;
 import hudson.Util;
 import hudson.model.UsageStatistics.CombinedCipherInputStream;
 import hudson.node_monitors.ArchitectureMonitor;
-import hudson.util.VersionNumber;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Set;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -85,7 +86,7 @@ public class UsageStatisticsTest {
         KeyFactory keyFactory = KeyFactory.getInstance("RSA");
         RSAPrivateKey priv = (RSAPrivateKey)keyFactory.generatePrivate(new PKCS8EncodedKeySpec(Util.fromHexString(privateKey)));
 
-        byte[] cipherText = Base64.decode(data.toCharArray());
+        byte[] cipherText = Base64.getDecoder().decode(data.getBytes(StandardCharsets.UTF_8));
         InputStreamReader r = new InputStreamReader(new GZIPInputStream(
                 new CombinedCipherInputStream(new ByteArrayInputStream(cipherText),priv,"AES")), "UTF-8");
         JSONObject o = JSONObject.fromObject(IOUtils.toString(r));

--- a/test/src/test/java/jenkins/security/RekeySecretAdminMonitorTest.java
+++ b/test/src/test/java/jenkins/security/RekeySecretAdminMonitorTest.java
@@ -5,7 +5,6 @@ import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.trilead.ssh2.crypto.Base64;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.util.Secret;
@@ -21,6 +20,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.util.Base64;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertThat;
@@ -154,7 +154,7 @@ public class RekeySecretAdminMonitorTest extends HudsonTestCase {
     private String encryptOld(String str) throws Exception {
         Cipher cipher = Secret.getCipher("AES");
         cipher.init(Cipher.ENCRYPT_MODE, Util.toAes128Key(TEST_KEY));
-        return new String(Base64.encode(cipher.doFinal((str + "::::MAGIC::::").getBytes("UTF-8"))));
+        return new String(Base64.getEncoder().encode(cipher.doFinal((str + "::::MAGIC::::").getBytes("UTF-8"))));
     }
 
     private String encryptNew(String str) {


### PR DESCRIPTION
# Description

See [JENKINS-43780](https://issues.jenkins-ci.org/browse/JENKINS-43780).

Details: Removes references to Trilead classes in Jenkins core to allow the Trilead JAR to be split out of core at some future point.

This change does not modify CLI - which bundles Trilead independently of the version in Core - nor does it modify the SFTPClient class in core as this depends on Trilead's implementation and will therefore need migrated out of core alongside the JAR. 

Change is covered under existing Unit tests, no new tests added.

### Changelog entries

Proposed changelog entries:
_No proposed changelog entry - this change has no impact on functionality._

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)


