### PR TITLE
Fix Javadoc generation error due to incomplete class reference

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1800,7 +1800,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     /**
      * Gets a view by the specified name.
-     * The method iterates through {@link ViewGroup}s if required.
+     * The method iterates through {@link hudson.model.ViewGroup}s if required.
      * @param name Name of the view
      * @return View instance or {@code null} if it is missing
      */


### PR DESCRIPTION
# Description

Builds (master and PRs) have been failing on ci.jenkins.io since 4074818b97d50b98b754f723842f03306a1ddaea was committed. This is due to the Javadoc plugin throwing an error on an un-resolvable class in an \@link reference.

The commit fixes that reference. There are no tests or Jira tickets as this is a minor, single line Javadoc change with no functional impact.

### Changelog entries
_No changelog entry_

### Submitter checklist

- [ ] JIRA issue is well described (_not applicable_)
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) (_not applicable_)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@oleg-nenashev (original author) and @daniel-beck (original reviewer). FYI: one of the pull request verification checks did fail on the original PR so this shouldn't really have made it into master, even if it is just a Javadoc issue.

