### PR TITLE
[JENKINS-43326] Invalid (randomly) form submission JSON from optional blocks ("groupNode")

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1339,12 +1339,7 @@ function replaceDescription() {
  * and attached under the element identified by the specified id.
  */
 function applyNameRef(s,e,id) {
-    if ($(id).name === 'enforce') {
-        console.log('enforce - setting e.groupingNode = true');
-    }
-
-    $(id).groupingNode = true;
-    $(id).tomsmagicprop = true;
+    $(id).setAttribute('data-groupingNode', 'true');
     // s contains the node itself
     for(var x=$(s).next(); x!=e; x=x.next()) {
         // to handle nested <f:rowSet> correctly, don't overwrite the existing value
@@ -2535,13 +2530,7 @@ function buildFormTree(form) {
                 p = findParent(e);
                 var checked = xor(e.checked,Element.hasClassName(e,"negative"));
 
-                if (e.name === 'enforce') {
-                    console.log('enforce e.groupingNode:', e.groupingNode);
-                    console.log('enforce e.tomsmagicprop:', e.tomsmagicprop); // if this is gone too, then that suggests the e is being recreated from scratch?
-                    debugger; // to stop the page reloading and => losing the browser console log
-                }
-
-                if(!e.groupingNode) {
+                if(!e.getAttribute('data-groupingNode')) {
                     v = e.getAttribute("json");
                     if (v) {
                         // if the special attribute is present, we'll either set the value or not. useful for an array of checkboxes
@@ -2584,7 +2573,7 @@ function buildFormTree(form) {
                 while (e.name.substring(r,r+8)=='removeme')
                     r = e.name.indexOf('_',r+8)+1;
                 p = findParent(e);
-                if(e.groupingNode) {
+                if(e.getAttribute('data-groupingNode')) {
                     addProperty(p, e.name.substring(r), e.formDom = { value: e.value });
                 } else {
                     addProperty(p, e.name.substring(r), e.value);

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1339,6 +1339,10 @@ function replaceDescription() {
  * and attached under the element identified by the specified id.
  */
 function applyNameRef(s,e,id) {
+    if ($(id).name === 'enforce') {
+        console.log('enforce - setting e.groupingNode = true');
+    }
+
     $(id).groupingNode = true;
     // s contains the node itself
     for(var x=$(s).next(); x!=e; x=x.next()) {
@@ -2529,6 +2533,12 @@ function buildFormTree(form) {
             case "checkbox":
                 p = findParent(e);
                 var checked = xor(e.checked,Element.hasClassName(e,"negative"));
+
+                if (e.name === 'enforce') {
+                    console.log('enforce e.groupingNode:', e.groupingNode);
+                    debugger; // to stop the page reloading and => losing the browser console log
+                }
+
                 if(!e.groupingNode) {
                     v = e.getAttribute("json");
                     if (v) {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1344,6 +1344,7 @@ function applyNameRef(s,e,id) {
     }
 
     $(id).groupingNode = true;
+    $(id).tomsmagicprop = true;
     // s contains the node itself
     for(var x=$(s).next(); x!=e; x=x.next()) {
         // to handle nested <f:rowSet> correctly, don't overwrite the existing value
@@ -2536,6 +2537,7 @@ function buildFormTree(form) {
 
                 if (e.name === 'enforce') {
                     console.log('enforce e.groupingNode:', e.groupingNode);
+                    console.log('enforce e.tomsmagicprop:', e.tomsmagicprop); // if this is gone too, then that suggests the e is being recreated from scratch?
                     debugger; // to stop the page reloading and => losing the browser console log
                 }
 


### PR DESCRIPTION


See [JENKINS-43326](https://issues.jenkins-ci.org/browse/JENKINS-43326).

@recampbell @varmenise 

Guys, if you take a look at the commits you'll see the steps I went through.

TL;DR: some piece of async code is resetting some `behaviours.js` added properties on the optionalBlock element (actually looks as though the element is being recreated - didn't manage to find what code is doing this), causing the form submission value to be screwed when the form is being submitted (because the form submission code does not think the checkbox is relating to a "groupNode").

To fix, I changed the `behaviour.js` code and form submission code to set and get a DOM attribute value instead. This seems to work from the testing I've done i.e. I could see that the `groupNode` property on the `e` was being lost, while the attribute value was not being lost.

Of course, needs more testing and checking etc.