### PR TITLE
[JENKINS-43825] - Refactor ProcessTree.Windows logic to propagate errors

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -407,7 +407,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         }
     };
 
-    private static class WindowsOSProcess extends OSProcess {
+    private class WindowsOSProcess extends OSProcess {
         
         private final WinProcess p;
         private EnvVars env;

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -407,13 +407,13 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         }
     };
 
-    private static class WindowsProcess extends OSProcess {
+    private static class WindowsOSProcess extends OSProcess {
         
         private final WinProcess p;
         private EnvVars env;
         private List<String> args;
         
-        WindowsProcess(WinProcess p) {
+        WindowsOSProcess(WinProcess p) {
             super(p.getPid());
             this.p = p;
         }
@@ -457,7 +457,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         public synchronized EnvVars getEnvironmentVariables() {
             try {
                return getEnvironmentVariables2();
-            } catch (WindowsProcessException e) {
+            } catch (WindowsOSProcessException e) {
                 if (LOGGER.isLoggable(FINEST)) {
                     LOGGER.log(FINEST, "Failed to get the environment variables of process with pid=" + p.getPid(), e);
                 }
@@ -465,7 +465,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             return null;
         }
         
-        private synchronized EnvVars getEnvironmentVariables2() throws WindowsProcessException {
+        private synchronized EnvVars getEnvironmentVariables2() throws WindowsOSProcessException {
             if(env !=null) {
               return env;
             }
@@ -474,12 +474,12 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             try {
                env.putAll(p.getEnvironmentVariables());
             } catch (WinpException e) {
-               throw new WindowsProcessException("Failed to get the environment variables", e);
+               throw new WindowsOSProcessException("Failed to get the environment variables", e);
             }
             return env;
         }
         
-        private boolean hasMatchingEnvVars2(Map<String,String> modelEnvVar) throws WindowsProcessException {
+        private boolean hasMatchingEnvVars2(Map<String,String> modelEnvVar) throws WindowsOSProcessException {
             if(modelEnvVar.isEmpty())
                 // sanity check so that we don't start rampage.
                 return false;
@@ -499,12 +499,12 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
     /**
      * Wrapper for runtime {@link WinpException}.
      */
-    private static class WindowsProcessException extends Exception {
-        WindowsProcessException(WinpException ex) {
+    private static class WindowsOSProcessException extends Exception {
+        WindowsOSProcessException(WinpException ex) {
             super(ex);
         }
         
-        WindowsProcessException(String message, WinpException ex) {
+        WindowsOSProcessException(String message, WinpException ex) {
             super(message, ex);
         }
     }
@@ -514,7 +514,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             for (final WinProcess p : WinProcess.all()) {
                 int pid = p.getPid();
                 if(pid == 0 || pid == 4) continue; // skip the System Idle and System processes
-                super.processes.put(pid, new WindowsProcess(p));
+                super.processes.put(pid, new WindowsOSProcess(p));
             }
         }
 
@@ -534,7 +534,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 boolean matched;
                 try {
                     matched = hasMatchingEnvVars(p, modelEnvVars);
-                } catch (WindowsProcessException e) {
+                } catch (WindowsOSProcessException e) {
                     // likely a missing privilege
                     // TODO: not a minor issue - causes process termination error in JENKINS-30782
                     if (LOGGER.isLoggable(FINEST)) {
@@ -556,16 +556,16 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         }
         
         private static boolean hasMatchingEnvVars(@Nonnull OSProcess p, @Nonnull Map<String, String> modelEnvVars)
-                throws WindowsProcessException {
-            if (p instanceof WindowsProcess) {
-                return ((WindowsProcess)p).hasMatchingEnvVars2(modelEnvVars);
+                throws WindowsOSProcessException {
+            if (p instanceof WindowsOSProcess) {
+                return ((WindowsOSProcess)p).hasMatchingEnvVars2(modelEnvVars);
             } else {
                 // Should never happen, but there is a risk of getting such class during deserialization
                 try {
                     return p.hasMatchingEnvVars(modelEnvVars);
                 } catch (WinpException e) {
                     // likely a missing privilege
-                    throw new WindowsProcessException(e);
+                    throw new WindowsOSProcessException(e);
                 }
             }
         }

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -406,62 +406,74 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         }
     };
 
+    static class WindowsProcess extends OSProcess {
+        
+        private final WinProcess p;
+        private EnvVars env;
+        private List<String> args;
+        
+        WindowsProcess(WinProcess p) {
+            super(p.getPid());
+            this.p = p;
+        }
+
+        @Override
+        public OSProcess getParent() {
+            // Windows process doesn't have parent/child relationship
+            return null;
+        }
+
+        @Override
+        public void killRecursively() throws InterruptedException {
+            if (getVeto() != null) 
+                return;
+
+            LOGGER.log(FINER, "Killing recursively {0}", getPid());
+            p.killRecursively();
+            killByKiller();
+        }
+
+        @Override
+        public void kill() throws InterruptedException {
+            if (getVeto() != null) {
+                return;
+            }
+            
+            LOGGER.log(FINER, "Killing {0}", getPid());
+            p.kill();
+            killByKiller();
+        }
+
+        @Override
+        public synchronized List<String> getArguments() {
+            if(args==null) {
+                args = Arrays.asList(QuotedStringTokenizer.tokenize(p.getCommandLine()));
+            }
+            return args;
+        }
+
+        @Override
+        public synchronized EnvVars getEnvironmentVariables() {
+            if(env !=null) {
+              return env;
+            }
+            env = new EnvVars();
+
+            try {
+               env.putAll(p.getEnvironmentVariables());
+            } catch (WinpException e) {
+               LOGGER.log(FINE, "Failed to get the environment variables ", e);
+            }
+            return env;
+        }
+    }
 
     private static final class Windows extends Local {
         Windows() {
             for (final WinProcess p : WinProcess.all()) {
                 int pid = p.getPid();
                 if(pid == 0 || pid == 4) continue; // skip the System Idle and System processes
-                super.processes.put(pid,new OSProcess(pid) {
-                    private EnvVars env;
-                    private List<String> args;
-
-                    public OSProcess getParent() {
-                        // windows process doesn't have parent/child relationship
-                        return null;
-                    }
-
-                    public void killRecursively() throws InterruptedException {
-                        if (getVeto() != null) 
-                            return;
-                        
-                        LOGGER.finer("Killing recursively "+getPid());
-                        p.killRecursively();
-                        killByKiller();
-                    }
-
-                    public void kill() throws InterruptedException {
-                        if (getVeto() != null) 
-                            return;
-
-                        LOGGER.finer("Killing "+getPid());
-                        p.kill();
-                        killByKiller();
-                    }
-
-                    @Override
-                    public synchronized List<String> getArguments() {
-                        if(args==null)  args = Arrays.asList(QuotedStringTokenizer.tokenize(p.getCommandLine()));
-                        return args;
-                    }
-
-                    @Override
-                    public synchronized EnvVars getEnvironmentVariables() {
-                        if(env !=null)
-                          return env;
-                        env = new EnvVars();
-
-                        try
-                        {
-                           env.putAll(p.getEnvironmentVariables());
-                        } catch (WinpException e)
-                        {
-                           LOGGER.log(FINE, "Failed to get environment variable ", e);
-                        }
-                        return env;
-                    }
-                });
-
+                super.processes.put(pid, new WindowsProcess(p));
             }
         }
 
@@ -470,12 +482,13 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             return get(new WinProcess(proc).getPid());
         }
 
+        @Override
         public void killAll(Map<String, String> modelEnvVars) throws InterruptedException {
             for( OSProcess p : this) {
                 if(p.getPid()<10)
                     continue;   // ignore system processes like "idle process"
 
-                LOGGER.finest("Considering to kill "+p.getPid());
+                LOGGER.log(FINEST, "Considering to kill {0}", p.getPid());
 
                 boolean matched;
                 try {

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -458,7 +458,9 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             try {
                return getEnvironmentVariables2();
             } catch (WindowsProcessException e) {
-               LOGGER.log(FINE, "Failed to get the environment variables ", e);
+                if (LOGGER.isLoggable(FINEST)) {
+                    LOGGER.log(FINEST, "Failed to get the environment variables of process with pid=" + p.getPid(), e);
+                }
             }
             return null;
         }
@@ -472,7 +474,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             try {
                env.putAll(p.getEnvironmentVariables());
             } catch (WinpException e) {
-               throw new WindowsProcessException("Failed to get the environment variables ", e);
+               throw new WindowsProcessException("Failed to get the environment variables", e);
             }
             return env;
         }
@@ -535,14 +537,16 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 } catch (WindowsProcessException e) {
                     // likely a missing privilege
                     // TODO: not a minor issue - causes process termination error in JENKINS-30782
-                    LOGGER.log(FINEST,"  Failed to check environment variable match",e);
+                    if (LOGGER.isLoggable(FINEST)) {
+                        LOGGER.log(FINEST, "Failed to check environment variable match for process with pid=" + p.getPid() ,e);
+                    }
                     continue;
                 }
 
                 if(matched) {
                     p.killRecursively();
                 } else {
-                    LOGGER.finest("Environment variable didn't matcha");
+                    LOGGER.log(Level.FINEST, "Environment variable didn't match for process with pid={0}", p.getPid());
                 }
             }
         }


### PR DESCRIPTION
# Description

See [JENKINS-43825](https://issues.jenkins-ci.org/browse/JENKINS-43825). This is a prerequisite for [JENKINS-30782](https://issues.jenkins-ci.org/browse/JENKINS-30782).

Details: 
- Decouple anonymous OSProcess class to WindowsOSProcess
- Refactor logging
- Introduce new private methods for propagating exceptions to killAll() 

The changes to don influence the public API, so they are technically backportable. I would prefer to keep it in such way till the [JENKINS-30782](https://issues.jenkins-ci.org/browse/JENKINS-30782) fix gets integrated. But I can refactor the existing APIs if code reviewers think that propagating errors from `getEnvironment()` is a generic use-case for all platforms.

No tests, since the behavior does not change. The coverage of the low-level logic is achieved at the WinP library level: https://github.com/kohsuke/winp 

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

* Not required (?) - The only "visible" change is PID mentions in stacktraces
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you want to get reviews from particular people, please CC them.
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
