### PR TITLE
Improved OldDataMonitorTest.unlocatableRun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ jenkins_*.changes
 push-build.sh
 war/node_modules/
 .java-version
+
+# cf. Jenkinsfile
+/.repository/

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,3 @@ jenkins_*.changes
 push-build.sh
 war/node_modules/
 .java-version
-
-# cf. Jenkinsfile
-/.repository/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,7 @@ for(i = 0; i < buildTypes.size(); i++) {
                             def mvnCmd = "mvn -Pdebug -U clean install javadoc:javadoc ${runTests ? '-Dmaven.test.failure.ignore=true' : '-DskipTests'} -V -B -Dmaven.repo.local=${pwd()}/.repository" 
                             if(isUnix()) {
                                 sh mvnCmd
+                                sh 'test `git status --short | tee /dev/stderr | wc --bytes` -eq 0'
                             } else {
                                 bat "$mvnCmd -Duser.name=yay" // INFRA-1032 workaround
                             }
@@ -97,8 +98,6 @@ void withMavenEnv(List envVars = [], def body) {
     }
 }
 
-// This hacky method is used because File is not whitelisted,
-// so we can't use renameTo or friends
 void renameFiles(def files, String prefix) {
     for(i = 0; i < files.length; i++) {
         def newPath = files[i].path.replace(files[i].name, "${prefix}-${files[i].name}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,10 +41,8 @@ for(i = 0; i < buildTypes.size(); i++) {
                         withMavenEnv(["JAVA_OPTS=-Xmx1536m -Xms512m",
                                     "MAVEN_OPTS=-Xmx1536m -Xms512m"]) {
                             // Actually run Maven!
-                            // The -Dmaven.repo.local=${pwd()}/.repository means that Maven will create a
-                            // .repository directory at the root of the build (which it gets from the
-                            // pwd() Workflow call) and use that for the local Maven repository.
-                            def mvnCmd = "mvn -Pdebug -U clean install javadoc:javadoc ${runTests ? '-Dmaven.test.failure.ignore=true' : '-DskipTests'} -V -B -Dmaven.repo.local=${pwd()}/.repository" 
+                            // -Dmaven.repo.local=… tells Maven to create a subdir in the temporary directory for the local Maven repository
+                            def mvnCmd = "mvn -Pdebug -U clean install javadoc:javadoc ${runTests ? '-Dmaven.test.failure.ignore=true' : '-DskipTests'} -V -B -Dmaven.repo.local=${pwd tmp: true}/m2repo" 
                             if(isUnix()) {
                                 sh mvnCmd
                                 sh 'test `git status --short | tee /dev/stderr | wc --bytes` -eq 0'

--- a/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
@@ -28,7 +28,7 @@ import hudson.XmlFile;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.InvisibleAction;
-
+import hudson.model.Saveable;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
@@ -39,23 +39,16 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-
-import hudson.model.Saveable;
-import jenkins.model.Jenkins;
 import jenkins.model.lazy.BuildReference;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MemoryAssert;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.kohsuke.stapler.Stapler;
-
 
 public class OldDataMonitorTest {
 
@@ -153,11 +146,10 @@ public class OldDataMonitorTest {
     @Issue("JENKINS-26718")
     @Test public void unlocatableRun() throws Exception {
         OldDataMonitor odm = OldDataMonitor.get(r.jenkins);
-        FreeStyleProject p = mock(FreeStyleProject.class);
-        when(p.getParent()).thenReturn(Jenkins.getInstance());
-        when(p.getFullName()).thenReturn("notfound");
-        FreeStyleBuild build = new FreeStyleBuild(p);
-        odm.report(build, (String) null);
+        FreeStyleProject p = r.createFreeStyleProject();
+        FreeStyleBuild build = r.buildAndAssertSuccess(p);
+        p.delete();
+        OldDataMonitor.report(build, (String) null);
 
         assertEquals(Collections.singleton(build), odm.getData().keySet());
         odm.doDiscard(null, null);

--- a/test/src/test/java/hudson/util/ArgumentListBuilder2Test.java
+++ b/test/src/test/java/hudson/util/ArgumentListBuilder2Test.java
@@ -28,8 +28,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.*;
 import hudson.Functions;
 import hudson.Launcher.LocalLauncher;
 import hudson.Launcher.RemoteLauncher;
@@ -45,6 +44,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import com.google.common.base.Joiner;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.StringWriter;
 import java.net.URL;
 
@@ -92,12 +92,10 @@ public class ArgumentListBuilder2Test {
     }
 
     public String echoArgs(String... arguments) throws Exception {
-        String testHarnessJar = Class.forName("hudson.util.EchoCommand")
+        String testHarnessJar = new File(Class.forName("hudson.util.EchoCommand")
                 .getProtectionDomain()
                 .getCodeSource()
-                .getLocation()
-                .getFile()
-                .replaceAll("^/", "");
+                .getLocation().toURI()).getAbsolutePath();
 
         ArgumentListBuilder args = new ArgumentListBuilder(
                     JavaEnvUtils.getJreExecutable("java").replaceAll("^\"|\"$", ""),
@@ -117,7 +115,7 @@ public class ArgumentListBuilder2Test {
         int code = p.join();
         listener.close();
 
-        assertThat(code, equalTo(0));
+        assumeThat("Failed to run " + args, code, equalTo(0));
         return out.toString();
     }
 }


### PR DESCRIPTION
# Description

Amends #1557 to avoid creating unversioned file `test/0/build.xml` discovered in #2851.

Tried backing out original fix to `referTo` and confirmed that the revised test fails.

### Changelog entries

None required.

### Desired reviewers

@reviewbybees & @recena