### PR TITLE
[JENKINS-43929] Specific cache control header on ajax.jelly

### DIFF
--- a/core/src/main/resources/lib/layout/ajax.jelly
+++ b/core/src/main/resources/lib/layout/ajax.jelly
@@ -42,6 +42,7 @@ THE SOFTWARE.
       evaluating a page that has called l:layout tag.
     </st:attribute>
   </st:documentation>
+  <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate" />
   <j:choose>
     <j:when test="${rootURL!=null}">
       <!-- no envelope needed, since this is called during full HTML rendering. Don't overwrite content-type either -->


### PR DESCRIPTION
# Description

See [JENKINS-43929](https://issues.jenkins-ci.org/browse/JENKINS-43929).

Might be related to [JENKINS-24337](https://issues.jenkins-ci.org/browse/JENKINS-24337), which also adds `no-store,must-revalidate`, so I applied the same here based on the same reasoning.

This change affects all uses of `<l:ajax>` so it's already covered by existent tests.

### Changelog entries

Proposed changelog entries:

* JENKINS-43929: Internet Explorer is caching AJAX requests by default so a specific `Cache-Control: no-cache` header is needed.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] N/A - For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

### Desired reviewers

@reviewbybees