### PR TITLE
Indicate the actual protocol being served by TcpSlaveAgentListener

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -201,6 +201,8 @@ public final class TcpSlaveAgentListener extends Thread {
         @Override
         public void run() {
             try {
+                LOGGER.log(Level.FINE, "Accepted connection #{0} from {1}", new Object[] {id, s.getRemoteSocketAddress()});
+
                 DataInputStream in = new DataInputStream(s.getInputStream());
                 PrintWriter out = new PrintWriter(
                         new BufferedWriter(new OutputStreamWriter(s.getOutputStream(),"UTF-8")),

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -201,8 +201,6 @@ public final class TcpSlaveAgentListener extends Thread {
         @Override
         public void run() {
             try {
-                LOGGER.log(Level.INFO, "Accepted connection #{0} from {1}", new Object[]{id,s.getRemoteSocketAddress()});
-
                 DataInputStream in = new DataInputStream(s.getInputStream());
                 PrintWriter out = new PrintWriter(
                         new BufferedWriter(new OutputStreamWriter(s.getOutputStream(),"UTF-8")),
@@ -227,6 +225,7 @@ public final class TcpSlaveAgentListener extends Thread {
                     AgentProtocol p = AgentProtocol.of(protocol);
                     if (p!=null) {
                         if (Jenkins.getInstance().getAgentProtocols().contains(protocol)) {
+                            LOGGER.log(Level.INFO, "Accepted {0} connection #{1} from {2}", new Object[] {protocol, id, this.s.getRemoteSocketAddress()});
                             p.handle(this.s);
                         } else {
                             error(out, "Disabled protocol:" + s);


### PR DESCRIPTION
# Description

Useful for distinguishing, say, deprecated `-remoting` CLI from JNLP agent connections.

### Changelog entries

None required.

### Desired reviewers

@reviewbybees