### PR TITLE
Suppressing test flakiness

### DIFF
--- a/test/src/test/java/hudson/model/MyViewTest.java
+++ b/test/src/test/java/hudson/model/MyViewTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.Matchers.*;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 import org.jvnet.hudson.test.LoggerRule;
 
 /**
@@ -86,6 +87,7 @@ public class MyViewTest {
         itemType.click();
         rule.submit(form);
         Item item = rule.jenkins.getItem("job");
+        assumeThat("TODO sometimes on Windows CI the submission does not seem to be really processed (most log messages are missing)", item, notNullValue());
         assertThat(view.getItems(), contains(equalTo(item)));
     }
     


### PR DESCRIPTION
Follows up #2809. From failures [like this](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-2858/1/testReport/hudson.model/MyViewTest/testDoCreateItem/)

```
java.lang.AssertionError: 

Expected: iterable containing [null]
     but: No item matched: null
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at hudson.model.MyViewTest.testDoCreateItem(MyViewTest.java:89)
```

we can see only limited messages

```
…
Apr 25, 2017 12:48:48 PM org.eclipse.jetty.server.Server doStart
INFO: Started @23460ms
Apr 25, 2017 12:48:57 PM com.gargoylesoftware.htmlunit.javascript.host.css.CSSStyleSheet isValidSelector
WARNING: Unhandled CSS condition type '7'. Accepting it silently.
Apr 25, 2017 12:48:57 PM com.gargoylesoftware.htmlunit.javascript.StrictErrorReporter runtimeError
SEVERE: runtimeError: message=[An invalid or illegal selector was specified (selector: '*,:x' error: Invalid selector: *:x).] sourceName=[http://localhost:54567/jenkins/static/c50bea0f/assets/jquery-detached/jsmodules/jquery2.js] line=[996] lineSource=[null] lineOffset=[0]
Apr 25, 2017 12:49:01 PM org.eclipse.jetty.server.AbstractConnector doStop
INFO: Stopped ServerConnector@52c3cb31{HTTP/1.1}{localhost:0}
…
```

whereas normally there would be lots more messages from HtmlUnit, as well as three from `AbstractItem.getUrl`. Not sure what is going on; perhaps an HtmlUnit issue. Cannot reproduce locally on XP. Anyway, time to stop marking random PRs as broken due to this.

@reviewbybees