### PR TITLE
Change rss feed build name

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2422,10 +2422,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
     private static class DefaultFeedAdapter implements FeedAdapter<Run> {
         public String getEntryTitle(Run entry) {
-            if (entry.hasCustomDisplayName()) {
-                return entry.getDisplayName()+" ("+entry.getBuildStatusSummary().message+")";
-            }
-            return entry+" ("+entry.getBuildStatusSummary().message+")";
+            return entry.getFullDisplayName();
         }
 
         public String getEntryUrl(Run entry) {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2422,7 +2422,10 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
     private static class DefaultFeedAdapter implements FeedAdapter<Run> {
         public String getEntryTitle(Run entry) {
-            return entry.getDisplayName()+" ("+entry.getBuildStatusSummary().message+")";
+            if (entry.hasCustomDisplayName()) {
+                return entry.getDisplayName()+" ("+entry.getBuildStatusSummary().message+")";
+            }
+            return entry+" ("+entry.getBuildStatusSummary().message+")";
         }
 
         public String getEntryUrl(Run entry) {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2422,7 +2422,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
     private static class DefaultFeedAdapter implements FeedAdapter<Run> {
         public String getEntryTitle(Run entry) {
-            return entry.getFullDisplayName();
+            return entry.getFullDisplayName()+" ("+entry.getBuildStatusSummary().message+")";
         }
 
         public String getEntryUrl(Run entry) {


### PR DESCRIPTION
# Description

With https://github.com/jenkinsci/jenkins/pull/2845 (released with Jenkins 2.58), if no display name is explicitly set the feed title contains only the build number, which is not very useful for non project specific feeds like the global /rssFailed feed.

This commit restores the old behaviour and honours the new behaviour of pull request 2845.



Proposed changelog entries:

* Use build display names in RSS feed titles as introduced with https://github.com/jenkinsci/jenkins/pull/2845, but also honour the pre 2.58 behaviour, if no custom display name is set.
