### PR TITLE
[JENKINS-44117] - use getFullDisplayName for RSS feed name

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2422,7 +2422,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
     private static class DefaultFeedAdapter implements FeedAdapter<Run> {
         public String getEntryTitle(Run entry) {
-            return entry.getDisplayName()+" ("+entry.getBuildStatusSummary().message+")";
+            return entry.getFullDisplayName()+" ("+entry.getBuildStatusSummary().message+")";
         }
 
         public String getEntryUrl(Run entry) {


### PR DESCRIPTION
# Description

See [JENKINS-44117](https://issues.jenkins-ci.org/browse/JENKINS-44117).

### Details: 

With #2845 project name was not displayed  in rss feed. This PR use Run::getFullDisplayName() to display project name with build name.

### Changelog

JENKINS-44117 - Use full display name for runs in RSS feed to restore the project name there (regression in 2.59)

### Desired reviewers

@oleg-nenashev 
@daniel-beck 
