### PR TITLE
Queue.Item.authenticate honors QueueItemAuthenticatorProvider; Tasks.getAuthenticationOf should as well

### DIFF
--- a/core/src/main/java/hudson/model/queue/Tasks.java
+++ b/core/src/main/java/hudson/model/queue/Tasks.java
@@ -34,9 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import javax.annotation.Nonnull;
 import jenkins.security.QueueItemAuthenticator;
-import jenkins.security.QueueItemAuthenticatorConfiguration;
-
-import static hudson.model.queue.Executables.getParentOf;
+import jenkins.security.QueueItemAuthenticatorProvider;
 
 /**
  * Convenience methods around {@link Task} and {@link SubTask}.
@@ -136,7 +134,7 @@ public class Tasks {
      * @since 1.560
      */
     public static @Nonnull Authentication getAuthenticationOf(@Nonnull Task t) {
-        for (QueueItemAuthenticator qia : QueueItemAuthenticatorConfiguration.get().getAuthenticators()) {
+        for (QueueItemAuthenticator qia : QueueItemAuthenticatorProvider.authenticators()) {
             Authentication a = qia.authenticate(t);
             if (a != null) {
                 return a;

--- a/core/src/main/java/jenkins/security/QueueItemAuthenticator.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticator.java
@@ -9,6 +9,7 @@ import hudson.model.CauseAction;
 import hudson.model.Queue;
 import hudson.model.Queue.Item;
 import hudson.model.Queue.Task;
+import hudson.model.queue.Tasks;
 import java.util.Calendar;
 import java.util.Collections;
 import javax.annotation.CheckForNull;
@@ -20,8 +21,9 @@ import org.acegisecurity.Authentication;
  * @author Kohsuke Kawaguchi
  * @since 1.520
  * @see QueueItemAuthenticatorConfiguration
+ * @see QueueItemAuthenticatorProvider
  * @see Item#authenticate()
- * @see Task#getDefaultAuthentication()
+ * @see Tasks#getAuthenticationOf
  */
 public abstract class QueueItemAuthenticator extends AbstractDescribableImpl<QueueItemAuthenticator> implements ExtensionPoint {
     /**

--- a/core/src/main/java/jenkins/security/QueueItemAuthenticatorConfiguration.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticatorConfiguration.java
@@ -1,6 +1,7 @@
 package jenkins.security;
 
 import hudson.Extension;
+import hudson.model.queue.Tasks;
 import hudson.util.DescribableList;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
@@ -38,6 +39,14 @@ public class QueueItemAuthenticatorConfiguration extends GlobalConfiguration {
         return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
     }
 
+    /**
+     * Provides all user-configured authenticators.
+     * Note that if you are looking to determine all <em>effective</em> authenticators,
+     * including any potentially supplied by plugins rather than user configuration,
+     * you should rather call {@link QueueItemAuthenticatorProvider#authenticators};
+     * or if you are looking for the authentication of an actual project, build, etc., use
+     * {@link hudson.model.Queue.Item#authenticate} or {@link Tasks#getAuthenticationOf}.
+     */
     public DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor> getAuthenticators() {
         return authenticators;
     }


### PR DESCRIPTION
# Description

Completes 65b71c20b126f8ac66bfa2de037a550af9fe90af.

### Changelog entries

* RFE: Internal API: Tasks.getAuthenticationOf now honors authentication contributed by `QueueItemAuthenticatorProvider` extensions 

### Desired reviewers

@reviewbybees