### PR TITLE
Javadoc fix.

### DIFF
--- a/core/src/main/java/hudson/security/ACL.java
+++ b/core/src/main/java/hudson/security/ACL.java
@@ -270,7 +270,7 @@ public abstract class ACL {
      * <p>
      * This makes impersonation much easier within code as it can now be used using the try with resources construct:
      * <pre>
-     *     try (ACLContext _ = ACL.as(auth)) {
+     *     try (ACLContext ctx = ACL.as(auth)) {
      *        ...
      *     }
      * </pre>
@@ -292,7 +292,7 @@ public abstract class ACL {
      * <p>
      * This makes impersonation much easier within code as it can now be used using the try with resources construct:
      * <pre>
-     *     try (ACLContext _ = ACL.as(auth)) {
+     *     try (ACLContext ctx = ACL.as(auth)) {
      *        ...
      *     }
      * </pre>


### PR DESCRIPTION
The use of `_` as an identifier is discouraged in the JLS, therefor do
not suggest its use in our javadoc.

ref:
http://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.27.1

> It is a compile-time error if a lambda parameter has the name _ (that
is, a single underscore character).

> The use of the variable name _ in any context is discouraged. Future
versions of the Java programming language may reserve this name as a
keyword and/or give it special semantics.

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

Details: TODO

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

no changelog proposed, just a clarification in the javadoc.

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Link to JIRA ticket in description, if appropriate
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

### Desired reviewers

@reviewbybees
