### PR TITLE
[FIXED JENKINS-44204] Provide essential views for clouds

### DIFF
--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -78,6 +78,12 @@ import java.util.concurrent.Future;
  * the resource (such as shutting down a virtual machine.) {@link Computer} needs to own this handle information
  * because by the time this happens, a {@link Slave} object is already long gone.
  *
+ * <h3>Views</h3>
+ *
+ * Since version TODO, Jenkins clouds are visualized in UI. Implementations can provide <tt>top</tt> or <tt>main</tt> view
+ * to be presented at the top of the page or at the bottom respectively. In the middle, actions have their <tt>summary</tt>
+ * views displayed. Actions further contribute to <tt>sidepanel</tt> with <tt>box</tt> views. All mentioned views are
+ * optional to preserve backward compatibility.
  *
  * @author Kohsuke Kawaguchi
  * @see NodeProvisioner
@@ -107,8 +113,13 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
      * @since TODO
      * @return Jenkins relative URL.
      */
-    public @Nonnull String getUrl() { return "cloud/" + name; }
+    public @Nonnull String getUrl() {
+        return "cloud/" + name;
+    }
 
+    /**
+     * {@inheritDoc}
+     */
     public @Nonnull String getSearchUrl() {
         return getUrl();
     }

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -26,6 +26,7 @@ package hudson.slaves;
 import hudson.ExtensionPoint;
 import hudson.Extension;
 import hudson.DescriptorExtensionList;
+import hudson.model.Actionable;
 import hudson.model.Computer;
 import hudson.model.Slave;
 import hudson.security.PermissionScope;
@@ -42,6 +43,7 @@ import hudson.security.Permission;
 import hudson.util.DescriptorList;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.concurrent.Future;
 
@@ -81,7 +83,7 @@ import java.util.concurrent.Future;
  * @see NodeProvisioner
  * @see AbstractCloudImpl
  */
-public abstract class Cloud extends AbstractModelObject implements ExtensionPoint, Describable<Cloud>, AccessControlled {
+public abstract class Cloud extends Actionable implements ExtensionPoint, Describable<Cloud>, AccessControlled {
 
     /**
      * Uniquely identifies this {@link Cloud} instance among other instances in {@link jenkins.model.Jenkins#clouds}.
@@ -99,8 +101,16 @@ public abstract class Cloud extends AbstractModelObject implements ExtensionPoin
         return name;
     }
 
-    public String getSearchUrl() {
-        return "cloud/"+name;
+    /**
+     * Get URL of the cloud.
+     *
+     * @since TODO
+     * @return Jenkins relative URL.
+     */
+    public @Nonnull String getUrl() { return "cloud/" + name; }
+
+    public @Nonnull String getSearchUrl() {
+        return getUrl();
     }
 
     public ACL getACL() {

--- a/core/src/main/resources/hudson/slaves/Cloud/index.jelly
+++ b/core/src/main/resources/hudson/slaves/Cloud/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:layout title="${it.name}">
         <st:include page="sidepanel.jelly" it="${it}"/>
         <l:main-panel>
-            <h1>Cloud ${it.name}</h1>
+            <h1>${%Cloud} ${it.name}</h1>
 
             <st:include page="top.jelly" optional="true"/>
 

--- a/core/src/main/resources/hudson/slaves/Cloud/index.jelly
+++ b/core/src/main/resources/hudson/slaves/Cloud/index.jelly
@@ -1,0 +1,42 @@
+<!--
+The MIT License
+
+Copyright (c) 2017 Red Hat, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!-- This page have not existed historically so plugins might well not provide any views. -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+    <l:layout title="${it.name}">
+        <st:include page="sidepanel.jelly" it="${it}"/>
+        <l:main-panel>
+            <h1>Cloud ${it.name}</h1>
+
+            <st:include page="top.jelly" optional="true"/>
+
+            <j:forEach var="action" items="${it.allActions}">
+                <st:include page="summary.jelly" from="${action}" optional="true" it="${action}" />
+            </j:forEach>
+
+            <st:include page="main.jelly" optional="true"/>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/core/src/main/resources/hudson/slaves/Cloud/sidepanel.jelly
+++ b/core/src/main/resources/hudson/slaves/Cloud/sidepanel.jelly
@@ -1,0 +1,36 @@
+<!--
+The MIT License
+
+Copyright (c) 2017 Red Hat, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
+    <l:header />
+    <l:side-panel>
+        <l:tasks>
+            <t:actions />
+        </l:tasks>
+        <j:forEach var="action" items="${it.allActions}">
+            <st:include it="${action}" page="box.jelly" optional="true"/>
+        </j:forEach>
+    </l:side-panel>
+</j:jelly>

--- a/test/src/test/java/hudson/slaves/CloudTest.java
+++ b/test/src/test/java/hudson/slaves/CloudTest.java
@@ -1,17 +1,36 @@
 package hudson.slaves;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.Assert.*;
 
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.model.Action;
 import hudson.model.Computer;
+import hudson.model.Label;
 import hudson.security.Permission;
 import hudson.security.SidACL;
 import jenkins.model.Jenkins;
+import jenkins.model.TransientActionFactory;
 import org.acegisecurity.acls.sid.Sid;
+import org.apache.tools.ant.taskdefs.Javadoc;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.WithoutJenkins;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerResponse;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
 public class CloudTest {
 
@@ -35,5 +54,92 @@ public class CloudTest {
         // Name introduced by JENKINS-37616
         Permission p = Permission.fromId("hudson.model.Computer.Provision");
         assertEquals("Provision", p.name);
+    }
+
+    @Test
+    public void ui() throws Exception {
+        ACloud aCloud = new ACloud("a", "0");
+        j.jenkins.clouds.add(aCloud);
+
+        assertThat(aCloud.getAllActions(), containsInAnyOrder(
+                instanceOf(TaskCloudAction.class),
+                instanceOf(ReportingCloudAction.class)
+        ));
+
+        HtmlPage page = j.createWebClient().goTo(aCloud.getUrl());
+        String out = page.getWebResponse().getContentAsString();
+        assertThat(out, containsString("Cloud a")); // index.jelly
+        assertThat(out, containsString("Top cloud view.")); // top.jelly
+        assertThat(out, containsString("custom cloud main groovy")); // main.jelly
+        assertThat(out, containsString("Task Action")); // TaskCloudAction
+        assertThat(out, containsString("Sidepanel action box.")); // TaskCloudAction/box.jelly
+        assertThat(out, containsString("Report Here")); // ReportingCloudAction/summary.jelly
+
+        HtmlPage actionPage = page.getAnchorByText("Task Action").click();
+        out = actionPage.getWebResponse().getContentAsString();
+        assertThat(out, containsString("doIndex called")); // doIndex
+    }
+
+    public static final class ACloud extends AbstractCloudImpl {
+
+        protected ACloud(String name, String instanceCapStr) {
+            super(name, instanceCapStr);
+        }
+
+        @Override public Collection<NodeProvisioner.PlannedNode> provision(Label label, int excessWorkload) {
+            return Collections.emptyList();
+        }
+
+        @Override public boolean canProvision(Label label) {
+            return false;
+        }
+    }
+
+    @TestExtension
+    public static final class CloudActionFactory extends TransientActionFactory<Cloud> {
+
+        @Override public Class<Cloud> type() {
+            return Cloud.class;
+        }
+
+        @Nonnull @Override public Collection<? extends Action> createFor(@Nonnull Cloud target) {
+            return Arrays.asList(new TaskCloudAction(), new ReportingCloudAction());
+        }
+    }
+
+    @TestExtension
+    public static final class TaskCloudAction implements Action {
+
+        @Override public String getIconFileName() {
+            return "notepad";
+        }
+
+        @Override public String getDisplayName() {
+            return "Task Action";
+        }
+
+        @Override public String getUrlName() {
+            return "task";
+        }
+
+        public void doIndex(StaplerResponse rsp) throws IOException {
+            rsp.getOutputStream().println("doIndex called");
+        }
+    }
+
+    @TestExtension
+    public static final class ReportingCloudAction implements Action {
+
+        @Override public String getIconFileName() {
+            return null; // not task bar icon
+        }
+
+        @Override public String getDisplayName() {
+            return "Reporting Action";
+        }
+
+        @Override public String getUrlName() {
+            return null; // not URL space
+        }
     }
 }

--- a/test/src/test/resources/hudson/slaves/CloudTest/ACloud/main.groovy
+++ b/test/src/test/resources/hudson/slaves/CloudTest/ACloud/main.groovy
@@ -1,0 +1,3 @@
+package hudson.slaves.CloudTest.ACloud
+
+text("custom cloud main groovy")

--- a/test/src/test/resources/hudson/slaves/CloudTest/ACloud/top.jelly
+++ b/test/src/test/resources/hudson/slaves/CloudTest/ACloud/top.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+    <l:pane title="Pane" width="100%">
+        Top cloud view.
+    </l:pane>
+</j:jelly>

--- a/test/src/test/resources/hudson/slaves/CloudTest/ReportingCloudAction/summary.groovy
+++ b/test/src/test/resources/hudson/slaves/CloudTest/ReportingCloudAction/summary.groovy
@@ -1,0 +1,3 @@
+package hudson.slaves.CloudTest.ReportingCloudAction
+
+h3("Report Here")

--- a/test/src/test/resources/hudson/slaves/CloudTest/TaskCloudAction/box.jelly
+++ b/test/src/test/resources/hudson/slaves/CloudTest/TaskCloudAction/box.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+    <l:pane title="Pane" width="100%">
+        Sidepanel action box.
+    </l:pane>
+</j:jelly>


### PR DESCRIPTION
# Description

Provide essential views for clouds
    
Cloud pages can now be customized by actions and sidepanel, that can be further customized by widgets.

- Clouds now have default `index` view so they can be linked.
- `Cloud` is actionable now.
- Clouds can present relevant info via `main` or `top` view instead of overriding the `index` page as a whole.
- Cloud is now actionable and actions can contribute snippets for main portion of `index` view, sidepanel's task list or list of boxes underneath.

cloud-stats plugin integration in downstream PR: https://github.com/jenkinsci/cloud-stats-plugin/pull/3
![cloud-stats](https://cloud.githubusercontent.com/assets/206841/26101353/2c16a35c-3a31-11e7-9b0f-0cca213a0ef3.png)

See [JENKINS-44204](https://issues.jenkins-ci.org/browse/JENKINS-44204).

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Views for Jenkins clouds.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@jenkinsci/code-reviewers, this is a new view API for cloud plugins.