### PR TITLE
[FIXED JENKINS-44120] Bump Trilead version to fix NPE in KEX negotiation

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -115,7 +115,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>trilead-ssh2</artifactId>
-      <version>build217-jenkins-10</version>
+      <version>build-217-jenkins-11</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
# Description

See [JENKINS-44120](https://issues.jenkins-ci.org/browse/JENKINS-44120).

Trilead throws a NullPointerException when trying to negotiate a Key Exchange using diffie-hellman-group1-sha1 or diffie-hellman-group14-sha1. This change moves to the latest version of Trilead that fixes this NullPointerException. Jenkins core does not contain any direct tests for Trilead, but test has been proven in https://github.com/jenkinsci/ssh-slaves-plugin/pull/54

### Changelog entries

Proposed changelog entries:

* Entry 1: Issue, Fix for NullPointerException whilst initiating some SSH connections

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests


### Desired reviewers

@oleg-nenashev @daniel-beck @jenkinsci/code-reviewers 
