### PR TITLE
Removing extra slash in static resources urls

### DIFF
--- a/core/src/main/java/hudson/tasks/UserAvatarResolver.java
+++ b/core/src/main/java/hudson/tasks/UserAvatarResolver.java
@@ -33,6 +33,7 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.Functions;
 import hudson.model.User;
+import hudson.Util;
 import javax.annotation.CheckForNull;
 
 /**
@@ -87,7 +88,7 @@ public abstract class UserAvatarResolver implements ExtensionPoint {
      */
     public static String resolve(User u, String avatarSize) {
         String avatar = resolveOrNull(u, avatarSize);
-        return avatar != null ? avatar : Jenkins.getInstance().getRootUrl() + Functions.getResourcePath() + "/images/" + avatarSize + "/user.png";
+        return avatar != null ? avatar : Util.removeTrailingSlash(Jenkins.getInstance().getRootUrl()) + Functions.getResourcePath() + "/images/" + avatarSize + "/user.png";
     }
 
     /**

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4936,7 +4936,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         if(ver.equals(UNCOMPUTED_VERSION) || SystemProperties.getBoolean("hudson.script.noCache"))
             RESOURCE_PATH = "";
         else
-            RESOURCE_PATH = "static/"+SESSION_HASH;
+            RESOURCE_PATH = "/static/"+SESSION_HASH;
 
         VIEW_RESOURCE_PATH = "/resources/"+ SESSION_HASH;
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4936,7 +4936,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         if(ver.equals(UNCOMPUTED_VERSION) || SystemProperties.getBoolean("hudson.script.noCache"))
             RESOURCE_PATH = "";
         else
-            RESOURCE_PATH = "/static/"+SESSION_HASH;
+            RESOURCE_PATH = "static/"+SESSION_HASH;
 
         VIEW_RESOURCE_PATH = "/resources/"+ SESSION_HASH;
     }


### PR DESCRIPTION
The way `RESOURCE_PATH` is used is e.g. `Jenkins.getInstance().getRootUrl() + Functions.getResourcePath()`  while under `getRootUrl` there is a `return Util.ensureEndsWith(url,"/");` which means the combination becomes `http://root//static/bla`. This change will make it `http://root/static/bla`. The double slash generally works fine except for a bug in a specific reverse proxy (traefik) which fails to load the resource because of the double slashes. See https://github.com/containous/traefik/issues/1323

I realize the path `/static/` means to convey that it should be at the root and not in a subdirectory - but it seems there is a requirement to call `getRootUrl` anyway. I did not do the due diligence to verify this fix does not break anything else so I hope there's a test that runs on this PR.

Note that for some reason, the only place this problem arises is under `<img src="${h.getUserAvatar(it,'48x48')}" alt="" height="48" width="48" />` in this file which is the user profile image in the user profile page. https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/model/User/index.jelly#L30

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

Details: TODO

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Link to JIRA ticket in description, if appropriate
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@mention

<!-- Comment:
If you want to get reviews from particular people, please CC them.
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
