### PR TITLE
Deprecate TimeUnit2

### DIFF
--- a/core/src/main/java/hudson/Plugin.java
+++ b/core/src/main/java/hudson/Plugin.java
@@ -23,7 +23,7 @@
  */
 package hudson;
 
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
 import hudson.model.Descriptor;
 import hudson.model.Saveable;
@@ -237,7 +237,7 @@ public abstract class Plugin implements Saveable {
         String requestPath = req.getRequestURI().substring(req.getContextPath().length());
         boolean staticLink = requestPath.startsWith("/static/");
 
-        long expires = staticLink ? TimeUnit2.DAYS.toMillis(365) : -1;
+        long expires = staticLink ? TimeUnit.DAYS.toMillis(365) : -1;
 
         // use serveLocalizedFile to support automatic locale selection
         try {

--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -28,7 +28,7 @@ package hudson.console;
 import com.trilead.ssh2.crypto.Base64;
 import jenkins.model.Jenkins;
 import hudson.remoting.ObjectInputStreamEx;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import jenkins.security.CryptoConfidentialKey;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.kohsuke.stapler.Stapler;
@@ -123,7 +123,7 @@ public class AnnotatedLargeText<T> extends LargeText {
                         Jenkins.getInstance().pluginManager.uberClassLoader);
                 try {
                     long timestamp = ois.readLong();
-                    if (TimeUnit2.HOURS.toMillis(1) > abs(System.currentTimeMillis()-timestamp))
+                    if (TimeUnit.HOURS.toMillis(1) > abs(System.currentTimeMillis()-timestamp))
                         // don't deserialize something too old to prevent a replay attack
                         return (ConsoleAnnotator)ois.readObject();
                 } finally {

--- a/core/src/main/java/hudson/console/ConsoleAnnotationDescriptor.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotationDescriptor.java
@@ -27,7 +27,7 @@ import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.WebMethod;
@@ -80,12 +80,12 @@ public abstract class ConsoleAnnotationDescriptor extends Descriptor<ConsoleNote
 
     @WebMethod(name="script.js")
     public void doScriptJs(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        rsp.serveFile(req, hasResource("/script.js"), TimeUnit2.DAYS.toMillis(1));
+        rsp.serveFile(req, hasResource("/script.js"), TimeUnit.DAYS.toMillis(1));
     }
 
     @WebMethod(name="style.css")
     public void doStyleCss(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        rsp.serveFile(req, hasResource("/style.css"), TimeUnit2.DAYS.toMillis(1));
+        rsp.serveFile(req, hasResource("/style.css"), TimeUnit.DAYS.toMillis(1));
     }
 
     /**

--- a/core/src/main/java/hudson/console/ConsoleAnnotatorFactory.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotatorFactory.java
@@ -27,7 +27,7 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Run;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import org.jvnet.tiger_types.Types;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -114,12 +114,12 @@ public abstract class ConsoleAnnotatorFactory<T> implements ExtensionPoint {
      */
     @WebMethod(name="script.js")
     public void doScriptJs(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        rsp.serveFile(req, getResource("/script.js"), TimeUnit2.DAYS.toMillis(1));
+        rsp.serveFile(req, getResource("/script.js"), TimeUnit.DAYS.toMillis(1));
     }
 
     @WebMethod(name="style.css")
     public void doStyleCss(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        rsp.serveFile(req, getResource("/style.css"), TimeUnit2.DAYS.toMillis(1));
+        rsp.serveFile(req, getResource("/style.css"), TimeUnit.DAYS.toMillis(1));
     }
 
     /**

--- a/core/src/main/java/hudson/diagnosis/MemoryUsageMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/MemoryUsageMonitor.java
@@ -23,7 +23,7 @@
  */
 package hudson.diagnosis;
 
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import hudson.util.ColorPalette;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
@@ -116,7 +116,7 @@ public final class MemoryUsageMonitor extends PeriodicWork {
     }
 
     public long getRecurrencePeriod() {
-        return TimeUnit2.SECONDS.toMillis(10);
+        return TimeUnit.SECONDS.toMillis(10);
     }
 
     protected void doRun() {

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -76,7 +76,6 @@ import hudson.util.AlternativeUiTextProvider;
 import hudson.util.AlternativeUiTextProvider.Message;
 import hudson.util.DescribableList;
 import hudson.util.FormValidation;
-import hudson.util.TimeUnit2;
 import hudson.widgets.HistoryWidget;
 import java.io.File;
 import java.io.IOException;
@@ -93,6 +92,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.Vector;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -1363,7 +1363,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
                 // However, first there are some conditions in which we do not want to do so.
                 // give time for agents to come online if we are right after reconnection (JENKINS-8408)
                 long running = Jenkins.getInstance().getInjector().getInstance(Uptime.class).getUptime();
-                long remaining = TimeUnit2.MINUTES.toMillis(10)-running;
+                long remaining = TimeUnit.MINUTES.toMillis(10)-running;
                 if (remaining>0 && /* this logic breaks tests of polling */!Functions.getIsUnitTest()) {
                     listener.getLogger().print(Messages.AbstractProject_AwaitingWorkspaceToComeOnline(remaining/1000));
                     listener.getLogger().println( " (" + workspaceOfflineReason.name() + ")");

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -35,7 +35,7 @@ import hudson.util.FormValidation;
 import hudson.util.FormValidation.Kind;
 import hudson.util.QuotedStringTokenizer;
 import hudson.util.TextFile;
-import static hudson.util.TimeUnit2.DAYS;
+import static java.util.concurrent.TimeUnit.DAYS;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -33,7 +33,7 @@ import hudson.model.queue.Tasks;
 import hudson.model.queue.WorkUnit;
 import hudson.security.ACL;
 import hudson.util.InterceptingProxy;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.CauseOfInterruption.UserInterruption;
 import jenkins.model.InterruptedBuildAction;
@@ -722,7 +722,7 @@ public class Executor extends Thread implements ModelObject {
             return d * 10 < elapsed;
         } else {
             // if no ETA is available, a build taking longer than a day is considered stuck
-            return TimeUnit2.MILLISECONDS.toHours(elapsed) > 24;
+            return TimeUnit.MILLISECONDS.toHours(elapsed) > 24;
         }
     }
 

--- a/core/src/main/java/hudson/model/MultiStageTimeSeries.java
+++ b/core/src/main/java/hudson/model/MultiStageTimeSeries.java
@@ -23,7 +23,7 @@
  */
 package hudson.model;
 
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import hudson.util.NoOverlapCategoryAxis;
 import hudson.util.ChartUtil;
 
@@ -152,9 +152,9 @@ public class MultiStageTimeSeries implements Serializable {
      * Choose which datapoint to use.
      */
     public enum TimeScale {
-        SEC10(TimeUnit2.SECONDS.toMillis(10)),
-        MIN(TimeUnit2.MINUTES.toMillis(1)),
-        HOUR(TimeUnit2.HOURS.toMillis(1));
+        SEC10(TimeUnit.SECONDS.toMillis(10)),
+        MIN(TimeUnit.MINUTES.toMillis(1)),
+        HOUR(TimeUnit.HOURS.toMillis(1));
 
         /**
          * Number of milliseconds (10 secs, 1 min, and 1 hour)

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -68,7 +68,7 @@ import java.nio.file.InvalidPathException;
 import jenkins.security.QueueItemAuthenticatorProvider;
 import jenkins.util.Timer;
 import hudson.triggers.SafeTimerTask;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import hudson.util.XStream2;
 import hudson.util.ConsistentHash;
 import hudson.util.ConsistentHash.Hash;
@@ -2565,7 +2565,7 @@ public class Queue extends ResourceController implements Saveable {
                 return elapsed > Math.max(d,60000L)*10;
             } else {
                 // more than a day in the queue
-                return TimeUnit2.MILLISECONDS.toHours(elapsed)>24;
+                return TimeUnit.MILLISECONDS.toHours(elapsed)>24;
             }
         }
 

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -36,7 +36,7 @@ import hudson.util.FormValidation;
 import hudson.util.FormValidation.Kind;
 import hudson.util.HttpResponses;
 import hudson.util.TextFile;
-import static hudson.util.TimeUnit2.*;
+import static java.util.concurrent.TimeUnit.*;
 import hudson.util.VersionNumber;
 import java.io.File;
 import java.io.IOException;

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -29,7 +29,7 @@ import hudson.Util;
 import hudson.Extension;
 import hudson.node_monitors.ArchitectureMonitor.DescriptorImpl;
 import hudson.util.Secret;
-import static hudson.util.TimeUnit2.DAYS;
+import static java.util.concurrent.TimeUnit.DAYS;
 
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;

--- a/core/src/main/java/hudson/model/queue/BackFiller.java
+++ b/core/src/main/java/hudson/model/queue/BackFiller.java
@@ -12,7 +12,7 @@ import hudson.model.queue.MappingWorksheet.ExecutorChunk;
 import hudson.model.queue.MappingWorksheet.ExecutorSlot;
 import hudson.model.queue.MappingWorksheet.Mapping;
 import hudson.model.queue.MappingWorksheet.WorkChunk;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -124,7 +124,7 @@ public class BackFiller extends LoadPredictor {
             // The downside of guessing the duration wrong is that we can end up creating tentative plans
             // afterward that may be incorrect, but those plans will be rebuilt.
             long d = bi.task.getEstimatedDuration();
-            if (d<=0)    d = TimeUnit2.MINUTES.toMillis(5);
+            if (d<=0)    d = TimeUnit.MINUTES.toMillis(5);
 
             TimeRange slot = new TimeRange(System.currentTimeMillis(), d);
 

--- a/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.util.logging.Logger;
 
-import static hudson.util.TimeUnit2.*;
+import static java.util.concurrent.TimeUnit.*;
 import java.util.logging.Level;
 import static java.util.logging.Level.*;
 

--- a/core/src/main/java/hudson/slaves/CloudSlaveRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/CloudSlaveRetentionStrategy.java
@@ -2,7 +2,7 @@ package hudson.slaves;
 
 import hudson.model.Computer;
 import hudson.model.Node;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -72,7 +72,7 @@ public class CloudSlaveRetentionStrategy<T extends Computer> extends RetentionSt
     }
 
     // for debugging, it's convenient to be able to reduce this time
-    public static long TIMEOUT = SystemProperties.getLong(CloudSlaveRetentionStrategy.class.getName()+".timeout", TimeUnit2.MINUTES.toMillis(10));
+    public static long TIMEOUT = SystemProperties.getLong(CloudSlaveRetentionStrategy.class.getName()+".timeout", TimeUnit.MINUTES.toMillis(10));
 
     private static final Logger LOGGER = Logger.getLogger(CloudSlaveRetentionStrategy.class.getName());
 }

--- a/core/src/main/java/hudson/slaves/ConnectionActivityMonitor.java
+++ b/core/src/main/java/hudson/slaves/ConnectionActivityMonitor.java
@@ -27,7 +27,7 @@ import hudson.model.AsyncPeriodicWork;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
 import hudson.model.Computer;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import hudson.remoting.VirtualChannel;
 import hudson.remoting.Channel;
 import hudson.Extension;
@@ -84,20 +84,20 @@ public class ConnectionActivityMonitor extends AsyncPeriodicWork {
     }
 
     public long getRecurrencePeriod() {
-        return enabled ? FREQUENCY : TimeUnit2.DAYS.toMillis(30);
+        return enabled ? FREQUENCY : TimeUnit.DAYS.toMillis(30);
     }
 
     /**
      * Time till initial ping
      */
-    private static final long TIME_TILL_PING = SystemProperties.getLong(ConnectionActivityMonitor.class.getName()+".timeToPing",TimeUnit2.MINUTES.toMillis(3));
+    private static final long TIME_TILL_PING = SystemProperties.getLong(ConnectionActivityMonitor.class.getName()+".timeToPing",TimeUnit.MINUTES.toMillis(3));
 
-    private static final long FREQUENCY = SystemProperties.getLong(ConnectionActivityMonitor.class.getName()+".frequency",TimeUnit2.SECONDS.toMillis(10));
+    private static final long FREQUENCY = SystemProperties.getLong(ConnectionActivityMonitor.class.getName()+".frequency",TimeUnit.SECONDS.toMillis(10));
 
     /**
      * When do we abandon the effort and cut off?
      */
-    private static final long TIMEOUT = SystemProperties.getLong(ConnectionActivityMonitor.class.getName()+".timeToPing",TimeUnit2.MINUTES.toMillis(4));
+    private static final long TIMEOUT = SystemProperties.getLong(ConnectionActivityMonitor.class.getName()+".timeToPing",TimeUnit.MINUTES.toMillis(4));
 
 
     // disabled by default until proven in the production

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -45,7 +45,7 @@ import hudson.util.FormValidation;
 import hudson.util.NamingThreadFactory;
 import hudson.util.SequentialExecutionQueue;
 import hudson.util.StreamTaskListener;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -748,5 +748,5 @@ public class SCMTrigger extends Trigger<Item> {
     /**
      * How long is too long for a polling activity to be in the queue?
      */
-    public static long STARVATION_THRESHOLD = SystemProperties.getLong(SCMTrigger.class.getName()+".starvationThreshold", TimeUnit2.HOURS.toMillis(1));
+    public static long STARVATION_THRESHOLD = SystemProperties.getLong(SCMTrigger.class.getName()+".starvationThreshold", TimeUnit.HOURS.toMillis(1));
 }

--- a/core/src/main/java/hudson/util/TimeUnit2.java
+++ b/core/src/main/java/hudson/util/TimeUnit2.java
@@ -67,8 +67,8 @@ import java.util.concurrent.TimeUnit;
  *
  * @since 1.5
  * @author Doug Lea
- * @deprecated use {@link TimeUnit}. (Java 5 did not have all the units required, so TimeUnit2 was introduced because it
- * had better conversion until Java 6 went out.)
+ * @deprecated use {@link TimeUnit}. (Java 5 did not have all the units required, so {@link TimeUnit2} was introduced
+ * because it had better conversion until Java 6 went out.)
  */
 @Deprecated
 @RestrictedSince("TODO")

--- a/core/src/main/java/hudson/util/TimeUnit2.java
+++ b/core/src/main/java/hudson/util/TimeUnit2.java
@@ -29,6 +29,9 @@
 
 package hudson.util;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -67,6 +70,7 @@ import java.util.concurrent.TimeUnit;
  * had better conversion until Java 6 went out.)
  */
 @Deprecated
+@Restricted(DoNotUse.class)
 public enum TimeUnit2 {
     NANOSECONDS {
         @Override public long toNanos(long d)   { return d; }

--- a/core/src/main/java/hudson/util/TimeUnit2.java
+++ b/core/src/main/java/hudson/util/TimeUnit2.java
@@ -63,7 +63,10 @@ import java.util.concurrent.TimeUnit;
  *
  * @since 1.5
  * @author Doug Lea
+ * @deprecated use {@link TimeUnit}. (Java 5 did not have all the units required, so TimeUnit2 was introduced because it
+ * had better conversion until Java 6 went out.)
  */
+@Deprecated
 public enum TimeUnit2 {
     NANOSECONDS {
         @Override public long toNanos(long d)   { return d; }

--- a/core/src/main/java/hudson/util/TimeUnit2.java
+++ b/core/src/main/java/hudson/util/TimeUnit2.java
@@ -31,7 +31,7 @@ package hudson.util;
 
 import hudson.RestrictedSince;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.util.concurrent.TimeUnit;
 
@@ -72,7 +72,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Deprecated
 @RestrictedSince("TODO")
-@Restricted(DoNotUse.class)
+@Restricted(NoExternalUse.class)
 public enum TimeUnit2 {
     NANOSECONDS {
         @Override public long toNanos(long d)   { return d; }

--- a/core/src/main/java/hudson/util/TimeUnit2.java
+++ b/core/src/main/java/hudson/util/TimeUnit2.java
@@ -29,6 +29,7 @@
 
 package hudson.util;
 
+import hudson.RestrictedSince;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
@@ -70,6 +71,7 @@ import java.util.concurrent.TimeUnit;
  * had better conversion until Java 6 went out.)
  */
 @Deprecated
+@RestrictedSince("TODO")
 @Restricted(DoNotUse.class)
 public enum TimeUnit2 {
     NANOSECONDS {

--- a/core/src/main/java/jenkins/model/AssetManager.java
+++ b/core/src/main/java/jenkins/model/AssetManager.java
@@ -2,7 +2,7 @@ package jenkins.model;
 
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -60,7 +60,7 @@ public class AssetManager implements UnprotectedRootAction {
         // to create unique URLs. Recognize that and set a long expiration header.
         String requestPath = req.getRequestURI().substring(req.getContextPath().length());
         boolean staticLink = requestPath.startsWith("/static/");
-        long expires = staticLink ? TimeUnit2.DAYS.toMillis(365) : -1;
+        long expires = staticLink ? TimeUnit.DAYS.toMillis(365) : -1;
 
         // use serveLocalizedFile to support automatic locale selection
         rsp.serveLocalizedFile(req, resource, expires);

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -165,7 +165,7 @@ import hudson.util.PluginServletFilter;
 import hudson.util.RemotingDiagnostics;
 import hudson.util.RemotingDiagnostics.HeapDump;
 import hudson.util.TextFile;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import hudson.util.VersionNumber;
 import hudson.util.XStream2;
 import hudson.views.DefaultMyViewsTabBar;
@@ -900,7 +900,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             // JSON binding needs to be able to see all the classes from all the plugins
             WebApp.get(servletContext).setClassLoader(pluginManager.uberClassLoader);
 
-            adjuncts = new AdjunctManager(servletContext, pluginManager.uberClassLoader,"adjuncts/"+SESSION_HASH, TimeUnit2.DAYS.toMillis(365));
+            adjuncts = new AdjunctManager(servletContext, pluginManager.uberClassLoader,"adjuncts/"+SESSION_HASH, TimeUnit.DAYS.toMillis(365));
 
             // TODO pending move to standard blacklist, or API to append filter
             if (System.getProperty(ClassFilter.FILE_OVERRIDE_LOCATION_PROPERTY) == null) { // not using SystemProperties since ClassFilter does not either
@@ -966,7 +966,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 protected void doRun() throws Exception {
                     trimLabels();
                 }
-            }, TimeUnit2.MINUTES.toMillis(5), TimeUnit2.MINUTES.toMillis(5), TimeUnit.MILLISECONDS);
+            }, TimeUnit.MINUTES.toMillis(5), TimeUnit.MINUTES.toMillis(5), TimeUnit.MILLISECONDS);
 
             updateComputerList();
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ THE SOFTWARE.
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
     <test-annotations.version>1.2</test-annotations.version>
-    <access-modifier.version>1.12-PR6-SNAPSHOT</access-modifier.version>
+    <access-modifier.version>1.11</access-modifier.version>
     <access-modifier-annotation.version>${access-modifier.version}</access-modifier-annotation.version> <!-- differing only where needed for timestamped snapshots -->
     <access-modifier-checker.version>${access-modifier.version}</access-modifier-checker.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ THE SOFTWARE.
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
     <test-annotations.version>1.2</test-annotations.version>
-    <access-modifier.version>1.11</access-modifier.version>
+    <access-modifier.version>1.12-PR6-SNAPSHOT</access-modifier.version>
     <access-modifier-annotation.version>${access-modifier.version}</access-modifier-annotation.version> <!-- differing only where needed for timestamped snapshots -->
     <access-modifier-checker.version>${access-modifier.version}</access-modifier-checker.version>
 

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -34,7 +34,7 @@ import com.gargoylesoftware.htmlunit.TextPage;
 import hudson.Functions;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.util.TextFile;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.text.MessageFormat;

--- a/test/src/test/java/hudson/model/UpdateCenterTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterTest.java
@@ -24,7 +24,7 @@
 package hudson.model;
 
 import com.trilead.ssh2.crypto.Base64;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 import net.sf.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
@@ -67,7 +67,7 @@ public class UpdateCenterTest {
         JSONObject signature = json.getJSONObject("signature");
         for (Object cert : signature.getJSONArray("certificates")) {
             X509Certificate c = (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(Base64.decode(cert.toString().toCharArray())));
-            c.checkValidity(new Date(System.currentTimeMillis() + TimeUnit2.DAYS.toMillis(30)));
+            c.checkValidity(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30)));
         }
     }
 }

--- a/test/src/test/java/hudson/node_monitors/ClockMonitorDescriptorTest.java
+++ b/test/src/test/java/hudson/node_monitors/ClockMonitorDescriptorTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.fail;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.SlaveComputer;
 import hudson.util.ClockDifference;
-import hudson.util.TimeUnit2;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,10 +32,10 @@ public class ClockMonitorDescriptorTest {
 
         ClockDifference cd = ClockMonitor.DESCRIPTOR.monitor(c);
         long diff = cd.diff;
-        assertTrue(diff < TimeUnit2.SECONDS.toMillis(5));
-        assertTrue(diff > TimeUnit2.SECONDS.toMillis(-5));
+        assertTrue(diff < TimeUnit.SECONDS.toMillis(5));
+        assertTrue(diff > TimeUnit.SECONDS.toMillis(-5));
         assertTrue(cd.abs() >= 0);
-        assertTrue(cd.abs() < TimeUnit2.SECONDS.toMillis(5));
+        assertTrue(cd.abs() < TimeUnit.SECONDS.toMillis(5));
         assertFalse(cd.isDangerous());
         assertTrue("html output too short", cd.toHtml().length() > 0);
     }


### PR DESCRIPTION
`java.util.concurrent.TimeUnit` is preferrable now.

Quoting Stephen:
> Java 5 did not have all the units required. So TU2 was one that had better conversion. Can be deprecated 
once we upgrade to Java 6 ;-)

# Description

* I didn't file a JENKINS issue since this is a pretty internal/dev oriented change. But if this is judged necessary, please tell me so and I'll do it.

Details: see title, very small change. And 0 risk from a runtime perspective. 

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

_N/A_ I don't even think this should have an entry in the changelog, should it?

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- ~~[ ] JIRA issue is well described~~
- ~~[ ] Link to JIRA ticket in description, if appropriate~~
- [X] Appropriate autotests or explanation to why this change has no tests
- ~~[ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)~~

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you want to get reviews from particular people, please CC them.
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
