### PR TITLE
[FIXED JENKINS-44330] - Prevent classloading of Target comparator in LogRecorder#orderedTargets()

### DIFF
--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -73,17 +73,14 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
     private volatile String name;
 
     public final CopyOnWriteList<Target> targets = new CopyOnWriteList<Target>();
-
+    private final static TargetComparator TARGET_COMPARATOR = new TargetComparator();
+    
     @Restricted(NoExternalUse.class)
     Target[] orderedTargets() {
         // will contain targets ordered by reverse name length (place specific targets at the beginning)
         Target[] ts = targets.toArray(new Target[]{});
 
-        Arrays.sort(ts, new Comparator<Target>() {
-            public int compare(Target left, Target right) {
-                return right.getName().length() - left.getName().length();
-            }
-        });
+        Arrays.sort(ts, TARGET_COMPARATOR);
 
         return ts;
     }
@@ -205,6 +202,14 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
             new SetLevel(name, null).broadcast();
         }
 
+    }
+    
+    private static class TargetComparator implements Comparator<Target> {
+
+        @Override
+        public int compare(Target left, Target right) {
+            return right.getName().length() - left.getName().length();
+        }
     }
 
     private static final class SetLevel extends MasterToSlaveCallable<Void,Error> {


### PR DESCRIPTION
It is just a hotfix, there may be other LogRecorders affected. Ideally we need a response from Jetty maintainers to https://github.com/eclipse/jetty.project/issues/1563. No tests since I see no way to trigger such classloading + no actual need in it.

See [JENKINS-44330](https://issues.jenkins-ci.org/browse/JENKINS-44330).

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

* Bug: Prevent StackOverflow in Jenkins LogRecorder when Debug logging is enabled for Jetty WebAppClassLoader (regression due to the Jetty update in 2.61)
  * Jetty issue: https://github.com/eclipse/jetty.project/issues/1563
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@reviewbybees @olamy @damphyr

<!-- Comment:
If you want to get reviews from particular people, please CC them.
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
