### PR TITLE
[JENKINS-34464] Switch ReverseBuildTrigger.threshold to DataBoundSetter

### DIFF
--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -73,6 +73,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.Nonnull;
@@ -91,12 +92,11 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     private static final Logger LOGGER = Logger.getLogger(ReverseBuildTrigger.class.getName());
 
     private String upstreamProjects;
-    private final Result threshold;
+    private Result threshold = Result.SUCCESS;
 
     @DataBoundConstructor
-    public ReverseBuildTrigger(String upstreamProjects, Result threshold) {
+    public ReverseBuildTrigger(String upstreamProjects) {
         this.upstreamProjects = upstreamProjects;
-        this.threshold = threshold;
     }
 
     public String getUpstreamProjects() {
@@ -105,6 +105,11 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
 
     public Result getThreshold() {
         return threshold;
+    }
+
+    @DataBoundSetter
+    public void setThreshold(Result r) {
+        this.threshold = r;
     }
 
     private boolean shouldTrigger(Run upstreamBuild, TaskListener listener) {

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -94,6 +94,10 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     private String upstreamProjects;
     private Result threshold = Result.SUCCESS;
 
+    /**
+     * Legacy constructor used before {@link #threshold} was moved to a {@code @DataBoundSetter}. Kept around for binary
+     * compatibility.
+     */
     @Deprecated
     public ReverseBuildTrigger(String upstreamProjects, Result threshold) {
         this(upstreamProjects);

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -94,6 +94,12 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     private String upstreamProjects;
     private Result threshold = Result.SUCCESS;
 
+    @Deprecated
+    public ReverseBuildTrigger(String upstreamProjects, Result threshold) {
+        this(upstreamProjects);
+        this.threshold = threshold;
+    }
+
     @DataBoundConstructor
     public ReverseBuildTrigger(String upstreamProjects) {
         this.upstreamProjects = upstreamProjects;


### PR DESCRIPTION
# Description

See [JENKINS-34464](https://issues.jenkins-ci.org/browse/JENKINS-34464).

Details: Adding `ReverseBuildTrigger.setThreshold(Result)` as a `@DataBoundSetter`, defaulting `threshold` to `Result.SUCCESS`.

### Changelog entries

Proposed changelog entries:

* Entry 1: Simpler syntax for `upstream` build trigger in Pipelines.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests (no new tests needed - existing behavior continues to work)
- [ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

### Desired reviewers

@reviewbybees
