### PR TITLE
[JENKINS-44103] - Cleanup usages of the "JNLP" term in TcpSlaveAgentListener

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -23,6 +23,7 @@
  */
 package hudson;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayInputStream;
 import java.io.SequenceInputStream;
 import java.io.Writer;
@@ -57,9 +58,11 @@ import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
- * Listens to incoming TCP connections from JNLP agents and CLI.
+ * Listens to incoming TCP connections from JNLP agents and Remoting CLI.
  *
  * <p>
  * Aside from the HTTP endpoint, Jenkins runs {@link TcpSlaveAgentListener} that listens on a TCP socket.
@@ -95,7 +98,7 @@ public final class TcpSlaveAgentListener extends Thread {
         }
         this.configuredPort = port;
 
-        LOGGER.log(Level.FINE, "JNLP agent listener started on TCP port {0}", getPort());
+        LOGGER.log(Level.FINE, "TCP agent listener started on port {0}", getPort());
 
         start();
     }
@@ -155,7 +158,7 @@ public final class TcpSlaveAgentListener extends Thread {
             }
         } catch (IOException e) {
             if(!shuttingDown) {
-                LOGGER.log(Level.SEVERE,"Failed to accept JNLP agent connections",e);
+                LOGGER.log(Level.SEVERE,"Failed to accept TCP connections", e);
             }
         }
     }
@@ -241,14 +244,14 @@ public final class TcpSlaveAgentListener extends Thread {
                 LOGGER.log(Level.WARNING,"Connection #"+id+" aborted",e);
                 try {
                     s.close();
-                } catch (IOException _) {
+                } catch (IOException ex) {
                     // try to clean up the socket
                 }
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING,"Connection #"+id+" failed",e);
                 try {
                     s.close();
-                } catch (IOException _) {
+                } catch (IOException ex) {
                     // try to clean up the socket
                 }
             }
@@ -292,7 +295,7 @@ public final class TcpSlaveAgentListener extends Thread {
 
         private void error(PrintWriter out, String msg) throws IOException {
             out.println(msg);
-            LOGGER.log(Level.WARNING,"Connection #"+id+" is aborted: "+msg);
+            LOGGER.log(Level.WARNING, "Connection #{0} is aborted: {1}", new Object[]{id, msg});
             s.close();
         }
     }
@@ -398,6 +401,8 @@ public final class TcpSlaveAgentListener extends Thread {
      *
      * TODO: think about how to expose this (including whether this needs to be exposed at all.)
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
+    @Restricted(NoExternalUse.class)
     public static String CLI_HOST_NAME = SystemProperties.getString(TcpSlaveAgentListener.class.getName()+".hostName");
 
     /**
@@ -410,6 +415,8 @@ public final class TcpSlaveAgentListener extends Thread {
      *
      * @since 1.611
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
+    @Restricted(NoExternalUse.class)
     public static Integer CLI_PORT = SystemProperties.getInteger(TcpSlaveAgentListener.class.getName()+".port");
 }
 

--- a/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
+++ b/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" trim="true">
   <st:contentType value="text/plain;charset=UTF-8"/>
   <!--
-    Publicize the TCP port number for JNLP agents so that they know where to connect.
+    Publicize the TCP port number for TCP agents and Remoting CLI so that they know where to connect.
     Keep the legacy header for better backward compatibility
   -->
   <st:header name="X-Hudson-JNLP-Port" value="${app.tcpSlaveAgentListener.advertisedPort}" />


### PR DESCRIPTION
Just a minor cleanup of the class

See [JENKINS-44103](https://issues.jenkins-ci.org/browse/JENKINS-44103).


<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

* Entry 1: Remove the "JNLP" protocol references from the TCP Agent Listener log messages
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Desired reviewers

@mention

<!-- Comment:
If you want to get reviews from particular people, please CC them.
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
