### PR TITLE
[JENKINS-24064] Replace war-for-test classifier with executable-war type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.jenkins-ci.tools</groupId>
           <artifactId>maven-hpi-plugin</artifactId>
-          <version>2.0-20170524.211828-1</version> <!-- TODO https://github.com/jenkinsci/maven-hpi-plugin/pull/65 -->
+          <version>2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.jenkins-ci.tools</groupId>
           <artifactId>maven-hpi-plugin</artifactId>
-          <version>1.122</version>
+          <version>2.0-20170524.211828-1</version> <!-- TODO https://github.com/jenkinsci/maven-hpi-plugin/pull/65 -->
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -44,14 +44,11 @@ THE SOFTWARE.
 
   <dependencies>
     <dependency>
-      <!--
-        put hudson.war in the classpath. we can't pull in the war artifact directly
-        because Maven excludes all wars from classpath automatically. so we need a jar artifact.
-      -->
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-war</artifactId>
       <version>${project.version}</version>
-      <classifier>war-for-test</classifier>
+      <type>executable-war</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -189,6 +186,11 @@ THE SOFTWARE.
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
       <plugin>
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>maven-stapler-plugin</artifactId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -414,29 +414,6 @@ THE SOFTWARE.
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- deploy the war as a jar, so that the tests can pull this into the classpath -->
-            <id>deploy-war-for-test</id>
-            <phase>package</phase>
-            <goals>
-              <goal>attach-artifact</goal>
-            </goals>
-            <configuration>
-              <artifacts>
-                <artifact>
-                  <file>${project.build.directory}/${project.build.finalName}.war</file>
-                  <type>jar</type>
-                  <classifier>war-for-test</classifier>
-                </artifact>
-              </artifacts>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin><!-- generate licenses.xml -->
         <groupId>com.cloudbees</groupId>
         <artifactId>maven-license-plugin</artifactId>


### PR DESCRIPTION
# Description

Downstream of https://github.com/jenkinsci/maven-hpi-plugin/pull/65; avoids the upload which is now unnecessary. Supersedes #2634.

### Changelog entries

Proposed changelog entries:

* Plugins using this version or newer as a baseline must also update the parent POM.

### Desired reviewers

@reviewbybees