### PR TITLE
[FIXED JENKINS-44523] - Do not submit form when pressing Enter in the…

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -49,12 +49,13 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly"/>
     <l:main-panel>
       <st:adjunct includes="hudson.PluginManager._table"/>
-      <form method="post" action="install">
+      
         <div id="filter-container">
           ${%Filter}:
           <input type="text" id="filter-box"/>
         </div>
 
+        <form method="post" action="install">
         <j:set var="isUpdates" value="${attrs.page=='updates'}" />
         <local:tabBar page="${attrs.page}" xmlns:local="/hudson/PluginManager" />
         <div class="pane-frame">

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -50,12 +50,12 @@ THE SOFTWARE.
     <l:main-panel>
       <st:adjunct includes="hudson.PluginManager._table"/>
       
-        <div id="filter-container">
-          ${%Filter}:
-          <input type="text" id="filter-box"/>
-        </div>
+      <div id="filter-container">
+        ${%Filter}:
+        <input type="text" id="filter-box"/>
+      </div>
 
-        <form method="post" action="install">
+      <form method="post" action="install">
         <j:set var="isUpdates" value="${attrs.page=='updates'}" />
         <local:tabBar page="${attrs.page}" xmlns:local="/hudson/PluginManager" />
         <div class="pane-frame">


### PR DESCRIPTION
… PM filter field.

# Description

See [JENKINS-44523](https://issues.jenkins-ci.org/browse/JENKINS-44523).

Details: 
- Now pressing "Enter" button in the "Filter" field doesn't redirect to /updateCenter and install selected plugins.

<!-- Comment: 
If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
-->

### Changelog entries

Proposed changelog entries:

* Entry 1: Unexpected action when pressing "Enter" in the filter field in Plugin Manager

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

<!-- Comment: 
 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

<!-- Comment:
If you want to get reviews from particular people, please CC them.
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->