### PR TITLE
jenkins-core: Bump jnr-posix version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -105,7 +105,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.0.1</version>
+      <version>3.0.41</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
# Description

This allows Jenkins slaves to run on AArch64.

Details: The version of `jnr-posix` previously shipped an extremely dated version of `libffi` which had no support for AArch64.

### Changelog entries

Proposed changelog entries:

* Update jnr-posix from 3.0.1 to 3.0.41 to pick improvements and fixes in the POSIX platforms support

### Desired reviewers

@reviewbybees