### PR TITLE
[JENKINS-44563] Use one-column layout for REST API page

### DIFF
--- a/core/src/main/resources/hudson/model/Api/index.jelly
+++ b/core/src/main/resources/hudson/model/Api/index.jelly
@@ -24,8 +24,8 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-	<l:layout title="Remote API">
-		<l:main-panel>
+  <l:layout title="Remote API" type="one-column">
+    <l:main-panel>
       <h1>REST API</h1>
 
       <p>
@@ -151,5 +151,5 @@ THE SOFTWARE.
 
       <st:include it="${it.bean}" page="_api.jelly" optional="true" />
     </l:main-panel>
-	</l:layout>
+  </l:layout>
 </j:jelly>


### PR DESCRIPTION
# Description

See [JENKINS-44563](https://issues.jenkins-ci.org/browse/JENKINS-44563).

## Before
![jenkins-44564_before](https://cloud.githubusercontent.com/assets/1021745/26592019/cc10eb4a-455f-11e7-8f7f-af1d1a41fae3.png)

## After
![jenkins-44563_after2](https://cloud.githubusercontent.com/assets/1021745/26635760/1ac93830-461b-11e7-948d-e865e3c4597b.png)


### Changelog entries

Proposed changelog entries:

* REST API page is using one-column layout

### Submitter checklist

- [X] JIRA issue is well described
- [X] Link to JIRA ticket in description, if appropriate

### Desired reviewers

@jenkinsci/code-reviewers 
@reviewbybees