### PR TITLE
[JENKINS-44589] Adding some missing calls to cleanUp

### DIFF
--- a/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
@@ -230,6 +230,7 @@ public class WindowsInstallerLink extends ManagementLink {
                         }
                     });
 
+                    Jenkins.getInstance().cleanUp();
                     System.exit(0);
                 } catch (InterruptedException e) {
                     e.printStackTrace();

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -944,6 +944,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
 
             if(KILL_AFTER_LOAD)
+                // TODO cleanUp?
                 System.exit(0);
 
             setupWizard = new SetupWizard();
@@ -4253,6 +4254,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             }
         }
 
+        cleanUp();
         System.exit(0);
     }
 


### PR DESCRIPTION
# Description

[JENKINS-44589](https://issues.jenkins-ci.org/browse/JENKINS-44589)

Complements [JENKINS-32820](https://issues.jenkins-ci.org/browse/JENKINS-32820) fixed in #2019—there were a couple of other places where `System.exit` was being called from the Jenkins master JVM where you would expect `Jenkins.cleanUp` to be called but it was not. Symptoms could include a missing `queue.xml` as in [JENKINS-34281](https://issues.jenkins-ci.org/browse/JENKINS-34281) (fixed in #2280) or various other issues.

### Changelog entries

Proposed changelog entries:

* Jenkins failed to perform some cleanup tasks, including saving the build queue, if stopped via REST `/exit` ~ CLI `shutdown`, or when restarting from **Install as Windows Service**.

### Desired reviewers

@reviewbybees