### PR TITLE
[JENKINS-44608] Don't check for monitor activation if it is disabled

### DIFF
--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
@@ -78,8 +78,7 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
 
     public Collection<AdministrativeMonitor> getActiveAdministrativeMonitors() {
         Collection<AdministrativeMonitor> active = new ArrayList<>();
-        Collection<AdministrativeMonitor> ams = new ArrayList<>(Jenkins.getInstance().administrativeMonitors);
-        for (AdministrativeMonitor am : ams) {
+        for (AdministrativeMonitor am : Jenkins.getInstance().getActiveAdministrativeMonitors()) {
             if (am instanceof ReverseProxySetupMonitor) {
                 // TODO make reverse proxy monitor work when shown on any URL
                 continue;
@@ -88,9 +87,7 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
                 // TODO make URI encoding monitor work when shown on any URL
                 continue;
             }
-            if (am.isEnabled() && am.isActivated()) {
-                active.add(am);
-            }
+            active.add(am);
         }
         return active;
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2175,6 +2175,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     /**
      * Returns the enabled and activated administrative monitors.
+     * @since TODO
      */
     public List<AdministrativeMonitor> getActiveAdministrativeMonitors() {
         return administrativeMonitors.stream().filter(m -> m.isEnabled() && m.isActivated()).collect(Collectors.toList());

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -288,6 +288,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static hudson.Util.*;
 import static hudson.init.InitMilestone.*;
@@ -2170,6 +2171,13 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             if(m.id.equals(id))
                 return m;
         return null;
+    }
+
+    /**
+     * Returns the enabled and activated administrative monitors.
+     */
+    public List<AdministrativeMonitor> getActiveAdministrativeMonitors() {
+        return administrativeMonitors.stream().filter(m -> m.isEnabled() && m.isActivated()).collect(Collectors.toList());
     }
 
     public NodeDescriptor getDescriptor() {

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -60,10 +60,8 @@ THE SOFTWARE.
   <l:main-panel>
     <h1>${%Manage Jenkins}</h1>
 
-    <j:forEach var="am" items="${app.administrativeMonitors}">
-      <j:if test="${am.isActivated() and am.isEnabled()}">
-        <st:include page="message.jelly" it="${am}" />
-      </j:if>
+    <j:forEach var="am" items="${app.activeAdministrativeMonitors}">
+      <st:include page="message.jelly" it="${am}" />
     </j:forEach>
 
     <st:include page="downgrade.jelly" />


### PR DESCRIPTION
# Description

See [JENKINS-44608](https://issues.jenkins-ci.org/browse/JENKINS-44608).

Details: 

See ticket.

### Changelog entries

Proposed changelog entries:

* Administrative Monitors activation was checked even for disabled ones ([issue 44608](https://issues.jenkins-ci.org/browse/JENKINS-44608)).

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests: trivial change, tested manually that enable notifications appear both in the Manage Jenkins and the page decorator.
- [ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

### Desired reviewers

@reviewbybees