### PR TITLE
[FIXED JENKINS-20272] Don't monitor response on offline agents

### DIFF
--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -48,7 +48,7 @@ public class ResponseTimeMonitor extends NodeMonitor {
     public static final AbstractNodeMonitorDescriptor<Data> DESCRIPTOR = new AbstractAsyncNodeMonitorDescriptor<Data>() {
         @Override
         protected Callable<Data,IOException> createCallable(Computer c) {
-            if (c.isOffline()) {
+            if (c.getChannel() == null) {
                 return null;
             }
             return new Step1(get(c));

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -23,7 +23,6 @@
  */
 package hudson.node_monitors;
 
-import hudson.Util;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.remoting.Callable;
@@ -49,6 +48,9 @@ public class ResponseTimeMonitor extends NodeMonitor {
     public static final AbstractNodeMonitorDescriptor<Data> DESCRIPTOR = new AbstractAsyncNodeMonitorDescriptor<Data>() {
         @Override
         protected Callable<Data,IOException> createCallable(Computer c) {
+            if (c.isOffline()) {
+                return null;
+            }
             return new Step1(get(c));
         }
 

--- a/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
+++ b/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
@@ -36,7 +36,7 @@ public class ResponseTimeMonitorTest {
 
         // Now try as actually disconnected.
         c.setTemporarilyOffline(false, null);
-        c.disconnect(new OfflineCause.UserCause(User.getUnknown(), "Disconnecting"));
+        j.disconnectSlave(s);
         assertNull(ResponseTimeMonitor.DESCRIPTOR.monitor(c));
 
         // Now reconnect and make sure we get a non-null response.

--- a/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
+++ b/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
@@ -1,0 +1,48 @@
+package hudson.node_monitors;
+
+import hudson.model.User;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.OfflineCause;
+import hudson.slaves.SlaveComputer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Andrew Bayer
+ */
+public class ResponseTimeMonitorTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    /**
+     * Makes sure that it doesn't try to monitor an already-offline agent.
+     */
+    @Test
+    @Issue("JENKINS-20272")
+    public void skipOfflineAgent() throws Exception {
+        DumbSlave s = j.createSlave();
+        SlaveComputer c = s.getComputer();
+        c.connect(false).get(); // wait until it's connected
+
+        // Try as temporarily offline first.
+        c.setTemporarilyOffline(true, new OfflineCause.UserCause(User.getUnknown(), "Temporarily offline"));
+        assertNull(ResponseTimeMonitor.DESCRIPTOR.monitor(c));
+
+        // Now try as actually disconnected.
+        c.setTemporarilyOffline(false, null);
+        c.disconnect(new OfflineCause.UserCause(User.getUnknown(), "Disconnecting"));
+        assertNull(ResponseTimeMonitor.DESCRIPTOR.monitor(c));
+
+        // Now reconnect and make sure we get a non-null response.
+        c.connect(false).get(); // wait until it's connected
+
+        assertNotNull(ResponseTimeMonitor.DESCRIPTOR.monitor(c));
+    }
+
+}

--- a/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
+++ b/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
@@ -32,7 +32,7 @@ public class ResponseTimeMonitorTest {
 
         // Try as temporarily offline first.
         c.setTemporarilyOffline(true, new OfflineCause.UserCause(User.getUnknown(), "Temporarily offline"));
-        assertNull(ResponseTimeMonitor.DESCRIPTOR.monitor(c));
+        assertNotNull(ResponseTimeMonitor.DESCRIPTOR.monitor(c));
 
         // Now try as actually disconnected.
         c.setTemporarilyOffline(false, null);


### PR DESCRIPTION
# Description

See [JENKINS-20272](https://issues.jenkins-ci.org/browse/JENKINS-20272).

Details: Don't monitor response time on offline agents. We know they're offline. We don't need to check.

### Changelog entries

Proposed changelog entries:

* Entry 1: JENKINS-20272, Don't monitor response time on offline agents.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

### Desired reviewers

@reviewbybees @oleg-nenashev @daniel-beck 