### PR TITLE
[FIX JENKINS-44769] Don't access response when called from CLI

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4129,7 +4129,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             restart();
         }
 
-        rsp.sendRedirect2(".");
+        if (rsp != null) {
+            rsp.sendRedirect2(".");
+        }
     }
 
     /**


### PR DESCRIPTION
# Description

See [JENKINS-44769](https://issues.jenkins-ci.org/browse/JENKINS-44769).

Details: https://github.com/jenkinsci/jenkins/commit/23f4809e6c10a221e9d67f2e841536845387b42d improperly reverted https://github.com/jenkinsci/jenkins/commit/e69c28e44dae41322112471e1c80f840bde314d4#diff-9e24c3bccc9e921f1a5cc216abc25d03R3381

No tests as we're just getting back to the previous implementation.

### Changelog entries

Proposed changelog entries:

* Bug: Prevent null pointer exception when calling `restart` CLI command

### Submitter checklist

- [x] JIRA issue is well described
- [x] Link to JIRA ticket in description, if appropriate
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)

### Desired reviewers

@jglick PTAL
