### PR TITLE
Simplify the pull-request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,8 +19,8 @@ The changelogs will be integrated by the core maintainers after the merge.  See 
 ### Submitter checklist
 
 - [ ] JIRA issue is well described
-- [ ] Changelog entries provide a human-readable description of the change. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
-   * Use `Internal: ` prefix if it addresses the API changes which do not impact the user-visible behavior
+- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
+      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
 - [ ] Appropriate autotests or explanation to why this change has no tests
 - [ ] For dependency updates: links to external changelogs and, if possible, full diffs
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,14 @@
-# Description
-
 See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).
 
-Details: TODO
-
 <!-- Comment: 
-If the issue is not fully described in the ticket, please put additional comments (justification, pull request links, etc.).
+If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
+
+ * We do not require JIRA issues for minor improvements.
+ * Bugfixes should have a JIRA issue (backporting process).
+ * Major new features should have a JIRA issue reference.
 -->
 
-### Changelog entries
-
-Proposed changelog entries:
+### Proposed changelog entries
 
 * Entry 1: Issue, Human-readable Text
 * ...
@@ -21,21 +19,17 @@ The changelogs will be integrated by the core maintainers after the merge.  See 
 ### Submitter checklist
 
 - [ ] JIRA issue is well described
-- [ ] Link to JIRA ticket in description, if appropriate
+- [ ] Changelog entries provide a human-readable description of the change. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
+   * Use `Internal: ` prefix if it addresses the API changes which do not impact the user-visible behavior
 - [ ] Appropriate autotests or explanation to why this change has no tests
-- [ ] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)
+- [ ] For dependency updates: links to external changelogs and, if possible, full diffs
 
-<!-- Comment: 
- * We do not require JIRA issues for minor improvements.
- * Bugfixes should have a JIRA issue (backporting process).
- * Major new features should have a JIRA issue reference.
--->
+<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
 
 ### Desired reviewers
 
 @mention
 
 <!-- Comment:
-If you want to get reviews from particular people, please CC them.
 If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
 -->


### PR DESCRIPTION
* Remove the description header. It is confusing because commit message body goes before it
* Explicitly require human-readable changelogs
* Explicitly require links to the external changelogs/diffs

CC @daniel-beck 