### PR TITLE
annotation-indexer 1.12

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -197,7 +197,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.11</version>
+      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
# Description

Picks up https://github.com/jenkinsci/lib-annotation-indexer/pull/4. No known user-visible defect (corrects a problem known from functional tests).

### Changelog entries

Proposed changelog entries:

- Update Annotation Indexer to 1.12 in order to prevent `NullPointerException` when looking for  `@Symbol`descriptor objects in Java 1.8.0_131
  * Link 1: Annotation Indexer: https://github.com/jenkinsci/lib-annotation-indexer (no changelog)
  * Link 2: Corresponding JDK bug: https://bugs.openjdk.java.net/browse/JDK-8182744

### Desired reviewers

@reviewbybees