### PR TITLE
[JENKINS-45256] The reload-configuration CLI command ought to wait until the reload is finished

### DIFF
--- a/core/src/main/java/hudson/util/JenkinsReloadFailed.java
+++ b/core/src/main/java/hudson/util/JenkinsReloadFailed.java
@@ -9,7 +9,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @author Kohsuke Kawaguchi
  */
 public class JenkinsReloadFailed extends BootFailure {
-    @Restricted(NoExternalUse.class) @Deprecated
+    @Restricted(NoExternalUse.class)
     public final Throwable cause;
 
     public JenkinsReloadFailed(Throwable cause) {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3986,7 +3986,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         LOGGER.log(Level.WARNING, "Reloading Jenkins as requested by {0}", getAuthentication().getName());
 
         // engage "loading ..." UI and then run the actual task in a separate thread
-        servletContext.setAttribute("app", new HudsonIsLoading());
+        WebApp.get(servletContext).setApp(new HudsonIsLoading());
 
         new Thread("Jenkins config reload thread") {
             @Override
@@ -4025,7 +4025,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
         User.reload();
         queue.load();
-        servletContext.setAttribute("app", this);
+        WebApp.get(servletContext).setApp(this);
     }
 
     /**

--- a/test/src/test/java/hudson/cli/ReloadConfigurationCommandTest.java
+++ b/test/src/test/java/hudson/cli/ReloadConfigurationCommandTest.java
@@ -173,13 +173,6 @@ public class ReloadConfigurationCommandTest {
         final CLICommandInvoker.Result result = command.invoke();
 
         assertThat(result, succeededSilently());
-
-        // reload-configuration is performed in a separate thread
-        // we have to wait until it finishes
-        while (!(j.jenkins.servletContext.getAttribute("app") instanceof Jenkins)) {
-            System.out.println("Jenkins reload operation is performing, sleeping 1s...");
-            Thread.sleep(1000);
-        }
     }
 
     private void replace(String path, String search, String replace) {


### PR DESCRIPTION
### Proposed changelog entries

* JENKINS-45256 - The `reload-configuration` CLI command now waits until the reload is finished, and returns an error code if the reload failed.

### Desired reviewers

@reviewbybees