### PR TITLE
[JENKINS-45522] Use ClassFilter.appendDefaultFilter

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -454,7 +454,7 @@ public class SlaveComputer extends Computer {
         }
         @Override public Integer call() {
             Channel c = Channel.current();
-            return resource ? c.resourceLoadingCount.get() : c.classLoadingCount.get();
+            return c == null ? 0 : resource ? c.resourceLoadingCount.get() : c.classLoadingCount.get();
         }
     }
 
@@ -471,7 +471,7 @@ public class SlaveComputer extends Computer {
         }
         @Override public Long call() {
             Channel c = Channel.current();
-            return resource ? c.resourceLoadingTime.get() : c.classLoadingTime.get();
+            return c == null ? 0 : resource ? c.resourceLoadingTime.get() : c.classLoadingTime.get();
         }
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -251,7 +251,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
-import java.lang.reflect.Field;
 import java.net.BindException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -903,27 +902,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
             adjuncts = new AdjunctManager(servletContext, pluginManager.uberClassLoader,"adjuncts/"+SESSION_HASH, TimeUnit2.DAYS.toMillis(365));
 
-            // TODO pending move to standard blacklist, or API to append filter
-            if (System.getProperty(ClassFilter.FILE_OVERRIDE_LOCATION_PROPERTY) == null) { // not using SystemProperties since ClassFilter does not either
-                try {
-                    Field blacklistPatternsF = ClassFilter.DEFAULT.getClass().getDeclaredField("blacklistPatterns");
-                    blacklistPatternsF.setAccessible(true);
-                    Object[] blacklistPatternsA = (Object[]) blacklistPatternsF.get(ClassFilter.DEFAULT);
-                    boolean found = false;
-                    for (int i = 0; i < blacklistPatternsA.length; i++) {
-                        if (blacklistPatternsA[i] instanceof Pattern) {
-                            blacklistPatternsA[i] = Pattern.compile("(" + blacklistPatternsA[i] + ")|(java[.]security[.]SignedObject)");
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) {
-                        throw new Error("no Pattern found among " + Arrays.toString(blacklistPatternsA));
-                    }
-                } catch (NoSuchFieldException | IllegalAccessException x) {
-                    throw new Error("Unexpected ClassFilter implementation in bundled remoting.jar: " + x, x);
-                }
-            }
+            ClassFilter.appendDefaultFilter(Pattern.compile("java[.]security[.]SignedObject")); // TODO move to standard blacklist
 
             // initialization consists of ...
             executeReactor( is,

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.10</version>
+        <version>3.11-20170705.163759-1</version> <!-- TODO https://github.com/jenkinsci/remoting/pull/178 -->
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/remoting/pull/178. Allows us to revert 1700464921c1171d56eab4cc8f8ee4ff57ac5f1a & 9137d6be0b6ab0f83a7c3f51f924ed2c8596fd52 & a64f10163f1900efdac28108f285628d2aab2bbd.

(If tests pass, as a follow-up I could move `SignedObject` too.)

@reviewbybees