### PR TITLE
[JENKINS-45519] Fix keepUndefinedParameters option for suppressing warnings

### DIFF
--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -326,7 +326,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
         for (ParameterValue v : this.parameters) {
             if (this.parameterDefinitionNames.contains(v.getName()) || isSafeParameter(v.getName())) {
                 filteredParameters.add(v);
-            } else if ("false".equalsIgnoreCase(shouldKeepFlag)) {
+            } else if (!"false".equalsIgnoreCase(shouldKeepFlag)) {
                 LOGGER.log(Level.WARNING, "Skipped parameter `{0}` as it is undefined on `{1}`. Set `-D{2}=true` to allow "
                         + "undefined parameters to be injected as environment variables or `-D{3}=[comma-separated list]` to whitelist specific parameter names, "
                         + "even though it represents a security breach or `-D{2}=false` to no longer show this message.",

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -316,8 +316,8 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
             return parameters;
         }
 
-        String shouldKeepFlag = SystemProperties.getString(KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME);
-        if ("true".equalsIgnoreCase(shouldKeepFlag)) {
+        Boolean shouldKeepFlag = SystemProperties.optBoolean(KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME);
+        if (shouldKeepFlag != null && shouldKeepFlag.booleanValue()) {
             return parameters;
         }
 
@@ -326,7 +326,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
         for (ParameterValue v : this.parameters) {
             if (this.parameterDefinitionNames.contains(v.getName()) || isSafeParameter(v.getName())) {
                 filteredParameters.add(v);
-            } else if (!"false".equalsIgnoreCase(shouldKeepFlag)) {
+            } else if (shouldKeepFlag == null) {
                 LOGGER.log(Level.WARNING, "Skipped parameter `{0}` as it is undefined on `{1}`. Set `-D{2}=true` to allow "
                         + "undefined parameters to be injected as environment variables or `-D{3}=[comma-separated list]` to whitelist specific parameter names, "
                         + "even though it represents a security breach or `-D{2}=false` to no longer show this message.",


### PR DESCRIPTION
See [JENKINS-45519](https://issues.jenkins-ci.org/browse/JENKINS-45519).

#2687 added a 'false' setting for this flag to prevent warning messages from being logged, but the logic doesn't match the message or the documentation. This updates the check, so that the warning message is correctly suppressed if `hudson.model.ParametersAction.keepUndefinedParameters` is set to false.

### Proposed changelog entries

* Entry 1: Bug, JENKINS-45519, Correctly show/suppress undefined parameters warnings based on system property

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

Minor logic update, no existing related tests to filtering.

### Desired reviewers
