### PR TITLE
[JENKINS-25625] Deleting obsolete SECURITY-144-compat exclusion

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -82,14 +82,6 @@ THE SOFTWARE.
           <artifactId>httpcore</artifactId>
         </exclusion>
         <exclusion>
-          <!--
-            during test, this jar gets loaded at the same level as remoting.jar and can cause conflicts depending on the order.
-            the package is also not signed, and it creates package conflicts between the signed package from remoting.jar
-          -->
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>SECURITY-144-compat</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
         </exclusion>


### PR DESCRIPTION
[JENKINS-25625](https://issues.jenkins-ci.org/browse/JENKINS-25625)

Follows up https://github.com/jenkinsci/maven-plugin/pull/45 (merged in 2.11) and https://github.com/jenkinsci/jenkins/pull/2606 to revert https://github.com/jenkinsci/jenkins/commit/4d60cdc824ce84b5b83ef1ea3b44f5102792689e which is no longer necessary.

@reviewbybees