### PR TITLE
[JENKINS-45516] Fix null pointer exception when checking for previous completed build

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -337,7 +337,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         AbstractBuild<P,R> p = getPreviousCompletedBuild();
         if (upstreamCulprits) {
             // If we have dependencies since the last successful build, add their authors to our list
-            if (p.getPreviousNotFailedBuild() != null) {
+            if (p != null && p.getPreviousNotFailedBuild() != null) {
                 Map<AbstractProject, AbstractBuild.DependencyChange> depmap =
                         p.getDependencyChanges(p.getPreviousSuccessfulBuild());
                 for (AbstractBuild.DependencyChange dep : depmap.values()) {


### PR DESCRIPTION
… completed build

See [JENKINS-45516](https://issues.jenkins-ci.org/browse/JENKINS-45516).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* JENKINS-45516 - BUG - Prevent `NullPointerException` when a previous completed build is missing for upstream culprits check.
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
