### PR TITLE
[FIX JENKINS-45679] JNLP needs to request Java 8

### DIFF
--- a/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
@@ -50,10 +50,10 @@ THE SOFTWARE.
         <j:set var="port" value="${request.getParameter('debugPort')}"/>
         <j:choose>
           <j:when test="${port!=null}">
-            <j2se version="1.7+" java-vm-args="${it.launcher.vmargs} -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=${port}" />
+            <j2se version="1.8+" java-vm-args="${it.launcher.vmargs} -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=${port}" />
           </j:when>
           <j:otherwise>
-            <j2se version="1.7+" java-vm-args="${it.launcher.vmargs}"/>
+            <j2se version="1.8+" java-vm-args="${it.launcher.vmargs}"/>
           </j:otherwise>
         </j:choose>
         <jar href="${rootURL}jnlpJars/remoting.jar"/>


### PR DESCRIPTION
See [JENKINS-45679](https://issues.jenkins-ci.org/browse/JENKINS-45679).

### Proposed changelog entries

* Entry 1: Bug: JNLP for launching agents now requests Java 8

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
