### PR TITLE
[JENKINS-44112] - Enable WorkDir in JNLPLauncher

### DIFF
--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -225,7 +225,8 @@ public abstract class Slave extends Node implements Serializable {
     }
 
     public ComputerLauncher getLauncher() {
-        return launcher == null ? new JNLPLauncher() : launcher;
+        // Default launcher does not use Work Directory
+        return launcher == null ? new JNLPLauncher(false) : launcher;
     }
 
     public void setLauncher(ComputerLauncher launcher) {
@@ -504,7 +505,7 @@ public abstract class Slave extends Node implements Serializable {
         // convert the old format to the new one
         if (launcher == null) {
             launcher = (agentCommand == null || agentCommand.trim().length() == 0)
-                    ? new JNLPLauncher()
+                    ? new JNLPLauncher(false)
                     : new CommandLauncher(agentCommand);
         }
         if(nodeProperties==null)

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -81,17 +81,33 @@ public class JNLPLauncher extends ComputerLauncher {
         // TODO: Enable workDir by default in API? Otherwise classes inheriting from JNLPLauncher
         // will need to enable the feature by default as well.
         // https://github.com/search?q=org%3Ajenkinsci+%22extends+JNLPLauncher%22&type=Code
-        this(tunnel, vmargs, RemotingWorkDirSettings.getDefaultLegacyValue());
+        this(tunnel, vmargs, RemotingWorkDirSettings.getDisabledDefaults());
     }
 
+    /**
+     * @deprecated This Launcher does not enable the work directory.
+     *             It is recommended to use {@link #JNLPLauncher(boolean)}
+     */
     @Deprecated
     public JNLPLauncher() {
-        this(null,null);
+        this(false);
+    }
+    
+    /**
+     * Constructor with default options.
+     * 
+     * @param enableWorkDir If {@code true}, the work directory will be enabled with default settings.
+     */
+    public JNLPLauncher(boolean enableWorkDir) {
+        this(null, null, enableWorkDir 
+                ? RemotingWorkDirSettings.getEnabledDefaults() 
+                : RemotingWorkDirSettings.getDisabledDefaults());
     }
     
     protected Object readResolve() {
         if (workDirSettings == null) {
-            workDirSettings = RemotingWorkDirSettings.getDefaultLegacyValue();
+            // For the migrated code agents are always disabled
+            workDirSettings = RemotingWorkDirSettings.getDisabledDefaults();
         }
         return this;
     }
@@ -123,7 +139,7 @@ public class JNLPLauncher extends ComputerLauncher {
     public static /*almost final*/ Descriptor<ComputerLauncher> DESCRIPTOR;
 
     /**
-     * gets 
+     * Gets work directory options as a String. 
      * @param computer
      * @return 
      */

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -139,9 +139,11 @@ public class JNLPLauncher extends ComputerLauncher {
     public static /*almost final*/ Descriptor<ComputerLauncher> DESCRIPTOR;
 
     /**
-     * Gets work directory options as a String. 
-     * @param computer
-     * @return 
+     * Gets work directory options as a String.
+     * 
+     * In public API {@code getWorkDirSettings().toCommandLineArgs(computer)} should be used instead
+     * @param computer Computer
+     * @return Command line options for launching with the WorkDir
      */
     @Nonnull
     @Restricted(NoExternalUse.class)

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -38,6 +38,7 @@ import java.io.Serializable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 /**
  * Used to build up arguments for a process invocation.
@@ -127,6 +128,16 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
     }
 
     public ArgumentListBuilder add(String... args) {
+        for (String arg : args) {
+            add(arg);
+        }
+        return this;
+    }
+    
+    /**
+     * @since TODO 
+     */
+    public ArgumentListBuilder add(@Nonnull Iterable<String> args) {
         for (String arg : args) {
             add(arg);
         }

--- a/core/src/main/java/jenkins/slaves/RemotingWorkDirSettings.java
+++ b/core/src/main/java/jenkins/slaves/RemotingWorkDirSettings.java
@@ -47,6 +47,8 @@ public class RemotingWorkDirSettings implements Describable<RemotingWorkDirSetti
     
     private static final String DEFAULT_INTERNAL_DIR = "remoting";
     private static final RemotingWorkDirSettings LEGACY_DEFAULT = new RemotingWorkDirSettings(true, null, DEFAULT_INTERNAL_DIR, false);
+    private static final RemotingWorkDirSettings ENABLED_DEFAULT = new RemotingWorkDirSettings(false, null, DEFAULT_INTERNAL_DIR, false);
+    
     
     private final boolean disabled;
     @CheckForNull
@@ -167,11 +169,20 @@ public class RemotingWorkDirSettings implements Describable<RemotingWorkDirSetti
     }
     
     /**
-     * Gets legacy value for the migrated agents.
+     * Gets default settings for the disabled work directory.
      * 
      * @return Legacy value: disabled work directory.
      */
-    public static RemotingWorkDirSettings getDefaultLegacyValue() {
+    @Nonnull
+    public static RemotingWorkDirSettings getDisabledDefaults() {
         return LEGACY_DEFAULT;
+    }
+    
+    /**
+     * Gets default settings of the enabled work directory.
+     */
+    @Nonnull
+    public static RemotingWorkDirSettings getEnabledDefaults() {
+        return ENABLED_DEFAULT;
     }
 }

--- a/core/src/main/java/jenkins/slaves/RemotingWorkDirSettings.java
+++ b/core/src/main/java/jenkins/slaves/RemotingWorkDirSettings.java
@@ -1,0 +1,177 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.slaves;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Slave;
+import hudson.slaves.SlaveComputer;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Defines settings of the Remoting work directory.
+ * 
+ * This class contains Remoting Work Directory settings, which can be used when starting Jenkins agents. 
+ * See <a href="https://github.com/jenkinsci/remoting/blob/master/docs/workDir.md">Remoting Work Dir Documentation</a>.
+ * 
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public class RemotingWorkDirSettings implements Describable<RemotingWorkDirSettings> {
+    
+    private static final String DEFAULT_INTERNAL_DIR = "remoting";
+    private static final RemotingWorkDirSettings LEGACY_DEFAULT = new RemotingWorkDirSettings(true, null, DEFAULT_INTERNAL_DIR, false);
+    
+    private final boolean disabled;
+    @CheckForNull
+    private final String  workDirPath;
+    @Nonnull
+    private final String  internalDir;
+    private final boolean failIfWorkDirIsMissing;
+
+    @DataBoundConstructor
+    public RemotingWorkDirSettings(boolean disabled, 
+            @CheckForNull String workDirPath, @CheckForNull String internalDir, 
+            boolean failIfWorkDirIsMissing) {
+        this.disabled = disabled;
+        this.workDirPath = Util.fixEmptyAndTrim(workDirPath);
+        this.failIfWorkDirIsMissing = failIfWorkDirIsMissing;
+        String internalDirName = Util.fixEmptyAndTrim(internalDir);
+        this.internalDir = internalDirName != null ? internalDirName : DEFAULT_INTERNAL_DIR;
+    }
+
+    public RemotingWorkDirSettings() {
+        // Enabled by default
+        this(false, null, DEFAULT_INTERNAL_DIR, false);
+    }
+
+    /**
+     * Check if workdir is disabled.
+     * 
+     * @return {@code true} if the property is disabled.
+     *         In such case Remoting will use the legacy mode.
+     */
+    public boolean isDisabled() {
+        return disabled;
+    }
+    
+    /**
+     * Indicates that agent root directory should be used as work directory.
+     * 
+     * @return {@code true} if the agent root should be a work directory.
+     */
+    public boolean isUseAgentRootDir() {
+        return workDirPath == null;
+    }
+
+    /**
+     * Check if startup should fail if the workdir is missing.
+     * 
+     * @return {@code true} if Remoting should fail if the the work directory is missing instead of creating it
+     */
+    public boolean isFailIfWorkDirIsMissing() {
+        return failIfWorkDirIsMissing;
+    }
+
+    /**
+     * Gets path to the custom workdir path.
+     * 
+     * @return Custom workdir path.
+     *         If {@code null}, an agent root directory path should be used instead.
+     */
+    @CheckForNull
+    public String getWorkDirPath() {
+        return workDirPath;
+    }
+
+    @Nonnull
+    public String getInternalDir() {
+        return internalDir;
+    }
+
+    @Override
+    public Descriptor<RemotingWorkDirSettings> getDescriptor() {
+        return Jenkins.getInstance().getDescriptor(RemotingWorkDirSettings.class);
+    }
+    
+    /**
+     * Gets a command line string, which can be passed to agent start command.
+     * 
+     * @param computer Computer, for which the arguments need to be constructed.
+     * @return Command line arguments. 
+     *         It may be empty if the working directory is disabled or
+     *         if the Computer type is not {@link SlaveComputer}.
+     */
+    @Nonnull
+    public String toCommandLineString(@Nonnull SlaveComputer computer) {
+        if(disabled) {
+            return "";
+        }
+        
+        StringBuilder bldr = new StringBuilder();
+        bldr.append("-workDir \"");
+        if (workDirPath == null) {
+            Slave node = computer.getNode();
+            if (node == null) {
+                // It is not possible to launch this node anyway.
+                return "";
+            }
+            bldr.append(node.getRemoteFS());
+        } else {
+            bldr.append(workDirPath);
+        }
+        bldr.append("\"");
+        
+        if (!DEFAULT_INTERNAL_DIR.equals(internalDir)) {
+            bldr.append(" -internalDir \"");
+            bldr.append(internalDir);
+            bldr.append("\"");
+        }
+        
+        if (failIfWorkDirIsMissing) {
+            bldr.append(" -failIfWorkDirIsMissing"); 
+        }
+                
+        return bldr.toString();
+    }
+    
+    @Extension
+    public static class DescriptorImpl extends Descriptor<RemotingWorkDirSettings> {
+        
+    }
+    
+    /**
+     * Gets legacy value for the migrated agents.
+     * 
+     * @return Legacy value: disabled work directory.
+     */
+    public static RemotingWorkDirSettings getDefaultLegacyValue() {
+        return LEGACY_DEFAULT;
+    }
+}

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
                 <p>
                   ${%Or if the agent is headless:}
                 </p>
-                <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar <a href="${rootURL}/jnlpJars/slave.jar">slave.jar</a> -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp</pre>
+                <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar <a href="${rootURL}/jnlpJars/slave.jar">slave.jar</a> -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp ${it.launcher.getWorkDirOptions(it)}</pre>
               </li>
             </j:when>
             <j:otherwise>
@@ -66,7 +66,7 @@ THE SOFTWARE.
                   ${%Run from agent command line:}
                 </p>
                 <!-- TODO conceal secret w/ JS if possible -->
-                <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar <a href="${rootURL}/jnlpJars/slave.jar">slave.jar</a> -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp -secret ${it.jnlpMac}</pre>
+                <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar <a href="${rootURL}/jnlpJars/slave.jar">slave.jar</a> -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp -secret ${it.jnlpMac} ${it.launcher.getWorkDirOptions(it)}</pre>
               </li>
             </j:otherwise>
           </j:choose>

--- a/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
@@ -66,6 +66,22 @@ THE SOFTWARE.
           <argument>-tunnel</argument>
           <argument>${it.launcher.tunnel}</argument>
         </j:if>
+        <j:if test="${not it.launcher.workDirSettings.disabled}">
+          <argument>-workDir</argument>
+          <j:choose>
+            <j:when test="${it.launcher.workDirSettings.useAgentRootDir}">
+              <argument>${it.node.remoteFS}</argument>
+            </j:when>
+            <j:otherwise>
+              <argument>${it.launcher.workDirSettings.workDirPath}</argument>
+            </j:otherwise>
+          </j:choose>
+          <argument>-internalDir</argument>
+          <argument>${it.launcher.workDirSettings.internalDir}</argument>
+          <j:if test="${it.launcher.workDirSettings.failIfWorkDirIsMissing}">
+            <argument>-failIfWorkDirIsMissing</argument>
+          </j:if>
+        </j:if>
 
         <argument>-url</argument>
         <argument>${rootURL}</argument>

--- a/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/config.jelly
+++ b/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/config.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+Copyright (c) 2017-, CloudBees, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,13 +24,16 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:property title="${%Enable work directory}" field="workDirSettings" />
-  <f:advanced>
-    <f:entry title="${%Tunnel connection through}" help="/help/system-config/master-slave/jnlp-tunnel.html">
-      <f:textbox field="tunnel"/>
-    </f:entry>
-    <f:entry title="${%JVM options}" field="vmargs">
-      <f:textbox />
-    </f:entry>
-  </f:advanced>
+  <f:entry title="${%Disable WorkDir}" field="disabled">
+    <f:checkbox/>
+  </f:entry>
+  <f:entry title="${%Custom WorkDir path}" field="workDirPath">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Internal data directory}" field="internalDir">
+    <f:textbox default="remoting"/>
+  </f:entry>
+  <f:entry title="${%Fail if workspace is missing}" field="failIfWorkDirIsMissing">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>

--- a/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/help-disabled.html
+++ b/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/help-disabled.html
@@ -1,0 +1,4 @@
+<div>
+  Allows disabling <a href="https://github.com/jenkinsci/remoting/blob/master/docs/workDir.md">Remoting Work Directory</a> for the agent.
+  In such case the agent will be running in the legacy mode without logging enabled by default.
+</div>

--- a/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/help-failIfWorkDirIsMissing.html
+++ b/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/help-failIfWorkDirIsMissing.html
@@ -1,0 +1,4 @@
+<div>
+  If defined, Remoting will fail the startup if the target work directory is missing.
+  The option may be used to detect infrastructure issues like failed mount.
+</div>

--- a/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/help-failIfWorkDirIsMissing.html
+++ b/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/help-failIfWorkDirIsMissing.html
@@ -1,4 +1,4 @@
 <div>
-  If defined, Remoting will fail the startup if the target work directory is missing.
+  If defined, Remoting will fail at startup if the target work directory is missing.
   The option may be used to detect infrastructure issues like failed mount.
 </div>

--- a/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/help-internalDir.html
+++ b/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/help-internalDir.html
@@ -1,0 +1,4 @@
+<div>
+  Defines a storage directory for the internal data.
+  This directory will be created within the Remoting working directory.
+</div>

--- a/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/help-workDirPath.html
+++ b/core/src/main/resources/jenkins/slaves/RemotingWorkDirSettings/help-workDirPath.html
@@ -1,0 +1,4 @@
+<div>
+  If defined, a custom Remoting work directory will be used instead of the Agent Root Directory.
+  This option has no environment variable resolution so far, it is recommended to use only absolute paths.
+</div>

--- a/test/src/test/java/hudson/bugs/JnlpAccessWithSecuredHudsonTest.java
+++ b/test/src/test/java/hudson/bugs/JnlpAccessWithSecuredHudsonTest.java
@@ -64,7 +64,7 @@ public class JnlpAccessWithSecuredHudsonTest extends HudsonTestCase {
      * Creates a new slave that needs to be launched via JNLP.
      */
     protected Slave createNewJnlpSlave(String name) throws Exception {
-        return new DumbSlave(name,"",System.getProperty("java.io.tmpdir")+'/'+name,"2", Mode.NORMAL, "", new JNLPLauncher(), RetentionStrategy.INSTANCE, Collections.EMPTY_LIST);
+        return new DumbSlave(name,"",System.getProperty("java.io.tmpdir")+'/'+name,"2", Mode.NORMAL, "", new JNLPLauncher(true), RetentionStrategy.INSTANCE, Collections.EMPTY_LIST);
     }
 
     @PresetData(DataSet.NO_ANONYMOUS_READACCESS)

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -51,11 +51,11 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.awt.*;
 import static org.hamcrest.Matchers.instanceOf;
-import org.junit.Assert;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.recipes.LocalData;
@@ -132,11 +132,11 @@ public class JNLPLauncherTest {
     @Issue("JENKINS-44112")
     public void testNoWorkDirMigration() throws Exception {
         Computer computer = j.jenkins.getComputer("Foo");
-        Assert.assertThat(computer, instanceOf(SlaveComputer.class));
+        assertThat(computer, instanceOf(SlaveComputer.class));
         
         SlaveComputer c = (SlaveComputer)computer;
         ComputerLauncher launcher = c.getLauncher();
-        Assert.assertThat(launcher, instanceOf(JNLPLauncher.class));
+        assertThat(launcher, instanceOf(JNLPLauncher.class));
         JNLPLauncher jnlpLauncher = (JNLPLauncher)launcher;
         assertNotNull("Work Dir Settings should be defined", 
                 jnlpLauncher.getWorkDirSettings());

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -54,8 +54,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.awt.*;
+import static org.hamcrest.Matchers.instanceOf;
+import org.junit.Assert;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
  * Tests of {@link JNLPLauncher}.
@@ -112,6 +115,23 @@ public class JNLPLauncherTest {
         Computer c = addTestSlave();
         launchJnlpAndVerify(c, buildJnlpArgs(c).add("-arg","-headless", "-workDir", workDir.getAbsolutePath()));
         assertEquals(1, ComputerListener.all().get(ListenerImpl.class).offlined);
+    }
+    
+    @Test
+    @LocalData
+    @Issue("JENKINS-44112")
+    public void testNoWorkDirMigration() throws Exception {
+        Computer computer = j.jenkins.getComputer("Foo");
+        Assert.assertThat(computer, instanceOf(SlaveComputer.class));
+        
+        SlaveComputer c = (SlaveComputer)computer;
+        ComputerLauncher launcher = c.getLauncher();
+        Assert.assertThat(launcher, instanceOf(JNLPLauncher.class));
+        JNLPLauncher jnlpLauncher = (JNLPLauncher)launcher;
+        assertNotNull("Work Dir Settings should be defined", 
+                jnlpLauncher.getWorkDirSettings());
+        assertTrue("Work directory should be disabled for the migrated agebt", 
+                jnlpLauncher.getWorkDirSettings().isDisabled());
     }
 
     @TestExtension("testHeadlessLaunch")

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -130,8 +130,15 @@ public class JNLPLauncherTest {
         JNLPLauncher jnlpLauncher = (JNLPLauncher)launcher;
         assertNotNull("Work Dir Settings should be defined", 
                 jnlpLauncher.getWorkDirSettings());
-        assertTrue("Work directory should be disabled for the migrated agebt", 
+        assertTrue("Work directory should be disabled for the migrated agent", 
                 jnlpLauncher.getWorkDirSettings().isDisabled());
+    }
+    
+    @Issue("JENKINS-44112")
+    public void testDefaults() throws Exception {
+        String errorMsg = "Work directory should be disabled for agents created via old API";
+        assertTrue(errorMsg, new JNLPLauncher().getWorkDirSettings().isDisabled());
+        assertTrue(errorMsg, new JNLPLauncher(null, null).getWorkDirSettings().isDisabled());
     }
 
     @TestExtension("testHeadlessLaunch")

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -205,11 +205,11 @@ public class JNLPLauncherTest {
     /**
      * Adds a JNLP {@link Slave} to the system and returns it.
      */
-    private Computer addTestSlave() throws Exception {
+    private Computer addTestSlave(boolean enableWorkDir) throws Exception {
         List<Node> slaves = new ArrayList<Node>(j.jenkins.getNodes());
         File dir = Util.createTempDir();
         slaves.add(new DumbSlave("test","dummy",dir.getAbsolutePath(),"1", Mode.NORMAL, "",
-                new JNLPLauncher(), RetentionStrategy.INSTANCE, new ArrayList<NodeProperty<?>>()));
+                new JNLPLauncher(enableWorkDir), RetentionStrategy.INSTANCE, new ArrayList<NodeProperty<?>>()));
         j.jenkins.setNodes(slaves);
         Computer c = j.jenkins.getComputer("test");
         assertNotNull(c);

--- a/test/src/test/java/hudson/tools/InstallerTranslatorTest.java
+++ b/test/src/test/java/hudson/tools/InstallerTranslatorTest.java
@@ -52,7 +52,7 @@ public class InstallerTranslatorTest {
 
     @Issue("JENKINS-23517")
     @Test public void offlineNodeForJDK() throws Exception {
-        Node slave = new DumbSlave("disconnected-slave", null, "/wherever", "1", Node.Mode.NORMAL, null, new JNLPLauncher(), RetentionStrategy.NOOP, Collections.<NodeProperty<?>>emptyList());
+        Node slave = new DumbSlave("disconnected-slave", null, "/wherever", "1", Node.Mode.NORMAL, null, new JNLPLauncher(true), RetentionStrategy.NOOP, Collections.<NodeProperty<?>>emptyList());
         String globalDefaultLocation = "/usr/lib/jdk";
         JDK jdk = new JDK("my-jdk", globalDefaultLocation, Collections.singletonList(new InstallSourceProperty(Collections.singletonList(new CommandInstaller(null, "irrelevant", "/opt/jdk")))));
         r.jenkins.getJDKs().add(jdk);

--- a/test/src/test/java/jenkins/security/Security218Test.java
+++ b/test/src/test/java/jenkins/security/Security218Test.java
@@ -80,7 +80,7 @@ public class Security218Test implements Serializable {
      * @see #launchJnlpSlave(Slave)
      */
     public DumbSlave createJnlpSlave(String name) throws Exception {
-        DumbSlave s = new DumbSlave(name, "", System.getProperty("java.io.tmpdir") + '/' + name, "2", Mode.NORMAL, "", new JNLPLauncher(), RetentionStrategy.INSTANCE, Collections.EMPTY_LIST);
+        DumbSlave s = new DumbSlave(name, "", System.getProperty("java.io.tmpdir") + '/' + name, "2", Mode.NORMAL, "", new JNLPLauncher(true), RetentionStrategy.INSTANCE, Collections.EMPTY_LIST);
         j.jenkins.addNode(s);
         return s;
     }

--- a/test/src/test/resources/hudson/slaves/JNLPLauncherTest/testNoWorkDirMigration/config.xml
+++ b/test/src/test/resources/hudson/slaves/JNLPLauncherTest/testNoWorkDirMigration/config.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>1.0</version>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>all</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>all</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <enabledAgentProtocols>
+    <string>JNLP4-connect</string>
+  </enabledAgentProtocols>
+  <label></label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>

--- a/test/src/test/resources/hudson/slaves/JNLPLauncherTest/testNoWorkDirMigration/nodes/Foo/config.xml
+++ b/test/src/test/resources/hudson/slaves/JNLPLauncherTest/testNoWorkDirMigration/nodes/Foo/config.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<slave>
+  <name>Foo</name>
+  <description></description>
+  <remoteFS>/myfs/jenkins/agent</remoteFS>
+  <numExecutors>1</numExecutors>
+  <mode>NORMAL</mode>
+  <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
+  <launcher class="hudson.slaves.JNLPLauncher">
+    <!-- No WorkDir settings  -->
+  </launcher>
+  <label>foo bar</label>
+  <nodeProperties/>
+</slave>


### PR DESCRIPTION
See [JENKINS-44112](https://issues.jenkins-ci.org/browse/JENKINS-44112). Since Jenkins 2.57 we can enable [Remoting Work Directories](https://github.com/jenkinsci/remoting/blob/master/docs/workDir.md).

- [x] Enable Work Directories by default in new agents with JNLP launcher for both Java Web Start and Manual start options
- [x] Make new Remoting WorkDir options configurable via UI
- [x] Disable work directories for existing JNLP Agents
- [x] TBD: Enable work directories in child classes? Likely no. https://github.com/search?q=org%3Ajenkinsci+%22extends+JNLPLauncher%22&type=Code
- [x] TBD: Check if the UI change is reflected in clild launcher types properly. Maybe use `@DataBoundSetter` to get it supported in child classes automagically?
  * ON: All JNLPLauncher implementations use the default constructor, We are safe
- [x] Polish UI
- [x] Add autotests

### UI samples

Config:
<img width="1024" alt="screen shot 2017-07-24 at 17 30 57" src="https://user-images.githubusercontent.com/3000480/28528265-e89f0bb4-7095-11e7-95fd-52a2aec1cb5c.png">


Main page:
<img width="923" alt="screen shot 2017-07-24 at 17 33 08" src="https://user-images.githubusercontent.com/3000480/28528383-33c7aa9c-7096-11e7-99a9-022c56e9eee1.png">


### Proposed changelog entries

* Entry 1: Enable Remoting work directories by default for newly created agents with JNLP (Java Web Start Launcher).
  * Documentation: https://github.com/jenkinsci/remoting/blob/master/docs/workDir.md
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees
@batmat since it collides with #2775
