### PR TITLE
[JENKINS-45553] - Cache the Mac so we do not need to constantly recreate it

### DIFF
--- a/core/src/main/java/jenkins/security/HMACConfidentialKey.java
+++ b/core/src/main/java/jenkins/security/HMACConfidentialKey.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
  */
 public class HMACConfidentialKey extends ConfidentialKey {
     private volatile SecretKey key;
+    private Mac mac;
     private final int length;
 
     /**
@@ -61,12 +62,18 @@ public class HMACConfidentialKey extends ConfidentialKey {
         this(owner,shortName,Integer.MAX_VALUE);
     }
 
+    private synchronized Mac getMac() {
+        if (mac == null) {
+            mac = createMac();
+        }
+        return mac;
+    }
 
     /**
      * Computes the message authentication code for the specified byte sequence.
      */
     public byte[] mac(byte[] message) {
-        return chop(createMac().doFinal(message));
+        return chop(getMac().doFinal(message));
     }
 
     /**

--- a/core/src/main/java/jenkins/security/HMACConfidentialKey.java
+++ b/core/src/main/java/jenkins/security/HMACConfidentialKey.java
@@ -62,18 +62,14 @@ public class HMACConfidentialKey extends ConfidentialKey {
         this(owner,shortName,Integer.MAX_VALUE);
     }
 
-    private synchronized Mac getMac() {
-        if (mac == null) {
-            mac = createMac();
-        }
-        return mac;
-    }
-
     /**
      * Computes the message authentication code for the specified byte sequence.
      */
-    public byte[] mac(byte[] message) {
-        return chop(getMac().doFinal(message));
+    public synchronized byte[] mac(byte[] message) {
+        if (mac == null) {
+            mac = createMac();
+        }
+        return chop(mac.doFinal(message));
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-45553](https://issues.jenkins-ci.org/browse/JENKINS-45553).

```
"Running CpsFlowExecution[Owner[…]]" …
   java.lang.Thread.State: RUNNABLE
	at java.security.Provider$ServiceKey.<init>(Provider.java:872)
	at java.security.Provider$ServiceKey.<init>(Provider.java:865)
	at java.security.Provider.getService(Provider.java:1039)
	- locked <0x00000006c726a548> (a sun.security.provider.Sun)
	at sun.security.jca.ProviderList$ServiceList.tryGet(ProviderList.java:437)
	at sun.security.jca.ProviderList$ServiceList.access$200(ProviderList.java:376)
	at sun.security.jca.ProviderList$ServiceList$1.hasNext(ProviderList.java:486)
	at javax.crypto.Mac.getInstance(Mac.java:174)
	at jenkins.security.HMACConfidentialKey.createMac(HMACConfidentialKey.java:111)
	at jenkins.security.HMACConfidentialKey.mac(HMACConfidentialKey.java:69)
	at hudson.console.ConsoleNote.encodeToBytes(ConsoleNote.java:193)
	at hudson.console.ConsoleNote.encodeTo(ConsoleNote.java:167)
	at org.jenkinsci.plugins.workflow.job.console.WorkflowMetadataConsoleFilter.eol(WorkflowMetadataConsoleFilter.java:45)
	at org.jenkinsci.plugins.workflow.job.console.WorkflowConsoleLogger.logAnnot(WorkflowConsoleLogger.java:70)
	at org.jenkinsci.plugins.workflow.job.console.WorkflowConsoleLogger.log(WorkflowConsoleLogger.java:64)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.logNodeMessage(WorkflowRun.java:981)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.access$1300(WorkflowRun.java:134)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:964)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1221)
	at …
```

Calling `Mac.getInstance` every time we print a console note (needed for a recent-ish security advisory) is wasteful.

### Proposed changelog entries

* Minor optimization to printing of console notes.

@reviewbybees