### PR TITLE
[JENKINS-38185] Always follow redirects for DownloadService

### DIFF
--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -40,7 +40,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
@@ -169,7 +171,12 @@ public class DownloadService extends PageDecorator {
      */
     @Restricted(NoExternalUse.class)
     public static String loadJSON(URL src) throws IOException {
-        try (InputStream is = ProxyConfiguration.open(src).getInputStream()) {
+        URLConnection con = ProxyConfiguration.open(src);
+        if (con instanceof HttpURLConnection) {
+            // prevent problems from misbehaving plugins disabling redirects by default
+            ((HttpURLConnection) con).setInstanceFollowRedirects(true);
+        }
+        try (InputStream is = con.getInputStream()) {
             String jsonp = IOUtils.toString(is, "UTF-8");
             int start = jsonp.indexOf('{');
             int end = jsonp.lastIndexOf('}');
@@ -189,7 +196,12 @@ public class DownloadService extends PageDecorator {
      */
     @Restricted(NoExternalUse.class)
     public static String loadJSONHTML(URL src) throws IOException {
-        try (InputStream is = ProxyConfiguration.open(src).getInputStream()) {
+        URLConnection con = ProxyConfiguration.open(src);
+        if (con instanceof HttpURLConnection) {
+            // prevent problems from misbehaving plugins disabling redirects by default
+            ((HttpURLConnection) con).setInstanceFollowRedirects(true);
+        }
+        try (InputStream is = con.getInputStream()) {
             String jsonp = IOUtils.toString(is, "UTF-8");
             String preamble = "window.parent.postMessage(JSON.stringify(";
             int start = jsonp.indexOf(preamble);


### PR DESCRIPTION
See [JENKINS-38185](https://issues.jenkins-ci.org/browse/JENKINS-38185) (well, mostly, may need rewriting to robustness improvement).

Can I disable redirects JVM-wide in a test, or would that have unintended side effects?

### Proposed changelog entries

* RFE: Always follow redirects for downloading update center metadata, so misbehaving plugins cannot break it. (issue 38185)

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)

### Notes

Alternatively, we could change `ProxyConfiguration`, but I'm not sure that's desirable.

	$ git diff
	diff --git a/core/src/main/java/hudson/ProxyConfiguration.java b/core/src/main/java/hudson/ProxyConfiguration.java
	index 7c2809c53f..5c3913ff1f 100644
	--- a/core/src/main/java/hudson/ProxyConfiguration.java
	+++ b/core/src/main/java/hudson/ProxyConfiguration.java
	@@ -247,7 +247,11 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
	                 });
	             }
	         }
	-        
	+
	+        if (con instanceof HttpURLConnection) {
	+            ((HttpURLConnection) con).setInstanceFollowRedirects(true);
	+        }
	+
	         if(DEFAULT_CONNECT_TIMEOUT_MILLIS > 0) {
	             con.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS);
	         }
