### PR TITLE
[JENKINS-41631, JENKINS-40088, JENKINS-43715, JENKINS-40979] - Update Stapler and Enforce upper bound deps

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.252-SNAPSHOT</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/123 -->
+    <stapler.version>1.252</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.11</groovy.version>
     <!-- TODO: Actually many issues are being filtered by src/findbugs/findbugs-excludes.xml -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.250</stapler.version>
+    <stapler.version>1.252-SNAPSHOT</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/123 -->
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.11</groovy.version>
     <!-- TODO: Actually many issues are being filtered by src/findbugs/findbugs-excludes.xml -->
@@ -95,6 +95,12 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <exclusions>
+        <exclusion> <!-- TODO it seems to want Guava 16; apparently it manages to run against 11 -->
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency> <!-- for compatibility only; all new code should use JNR -->
@@ -602,6 +608,12 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <exclusions>
+        <exclusion> <!-- pick up from Stapler -->
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ THE SOFTWARE.
     <patch.tracker.serverId>jenkins-jira</patch.tracker.serverId>
 
     <guavaVersion>11.0.1</guavaVersion>
-    <slf4jVersion>1.7.7</slf4jVersion> <!-- < 1.6.x version didn't specify the license (MIT) -->
+    <slf4jVersion>1.7.25</slf4jVersion>
     <maven-plugin.version>2.14</maven-plugin.version>
     <matrix-project.version>1.4.1</matrix-project.version>
     <sorcerer.version>0.11</sorcerer.version>
@@ -207,7 +207,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.1.3</version>
+        <version>1.2</version>
         <scope>provided</scope><!-- by jcl-over-slf4j -->
       </dependency>
       <dependency>
@@ -558,6 +558,11 @@ THE SOFTWARE.
             </dependency>
           </dependencies>
         </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M1</version> <!-- TODO 3.0.0 when released -->
+      </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>
         	<groupId>org.eclipse.m2e</groupId>
@@ -690,6 +695,7 @@ THE SOFTWARE.
                 <enforceBytecodeVersion>
                   <maxJdkVersion>1.${java.level}</maxJdkVersion>
                 </enforceBytecodeVersion>
+                <requireUpperBoundDeps/>
               </rules>
             </configuration>
           </execution>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -53,7 +53,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2.20</version>
+      <version>2.23</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -85,6 +85,14 @@ THE SOFTWARE.
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.inject</groupId>
+          <artifactId>guice</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -106,7 +114,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.2-beta-4</version>
+      <version>1.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -119,6 +127,12 @@ THE SOFTWARE.
       <groupId>org.jvnet.mock-javamail</groupId>
       <artifactId>mock-javamail</artifactId>
       <version>1.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.mail</groupId>
+          <artifactId>mail</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -128,7 +142,7 @@ THE SOFTWARE.
     <dependency><!-- we exclude this transient dependency from htmlunit, which we actually need in the test -->
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
       <exclusions>
         <exclusion>
           <groupId>xml-apis</groupId>
@@ -156,6 +170,16 @@ THE SOFTWARE.
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
       <version>0.9.9</version>
+      <exclusions>
+        <exclusion> <!-- TODO requests 15; apparently works well enough with the 11 we bundle -->
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion> <!-- pick up from Stapler -->
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.geb</groupId>
@@ -237,6 +261,23 @@ THE SOFTWARE.
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>
           <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin> <!-- TODO pending JENKINS-45271 fix, would be best to finish moving MavenModuleSet-specific tests to maven-plugin and delete the test dep here -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <rules>
+            <requireUpperBoundDeps>
+              <excludes combine.children="append">
+                <exclude>org.apache.maven:maven-embedder</exclude>
+                <exclude>org.codehaus.plexus:plexus-classworlds</exclude>
+                <exclude>org.apache.maven:maven-core</exclude>
+                <exclude>org.apache.maven:maven-aether-provider</exclude>
+                <exclude>org.codehaus.plexus:plexus-utils</exclude>
+              </excludes>
+            </requireUpperBoundDeps>
+          </rules>
         </configuration>
       </plugin>
     </plugins>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -571,7 +571,6 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>1.3.1</version>
             <executions>
               <execution>
                 <id>enforce-versions</id>


### PR DESCRIPTION
Follow-up to https://github.com/jenkinsci/plugin-pom/pull/67. Downstream of https://github.com/stapler/stapler/pull/123.

Proposed changelog entries:

* Cleanup of Maven dependencies in Jenkins core, allowing plugins depending on this version or later to build without “upper bound” dependency warnings.
* Stapler library updated [from 1.250 to 1.252](https://github.com/stapler/stapler/blob/master/CHANGELOG.md#1252):
  * order of search for web method overloads is now deterministic in case of ambiguity
  *  deprecated `HttpResponses.html` and `.plainText` in favor of `.literalHtml` and `.text`
  * related to JENKINS-40088: configurable export API behavior
  * JENKINS-43715: `NullPointerException` fix
  * related to JENKINS-40979: `NullPointerException` fix
  * JENKINS-45903: Prevent file handle leak in `LargeText.GzipAwareSession`

@reviewbybees