### PR TITLE
[JENKINS-45892] Prevent model objects from being serialized except at top level

### DIFF
--- a/core/src/main/java/hudson/XmlFile.java
+++ b/core/src/main/java/hudson/XmlFile.java
@@ -50,8 +50,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.Serializable;
 import java.io.Writer;
 import java.io.StringWriter;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.IOUtils;
@@ -114,6 +119,7 @@ import org.apache.commons.io.IOUtils;
 public final class XmlFile {
     private final XStream xs;
     private final File file;
+    private static final Map<Object, Void> beingWritten = Collections.synchronizedMap(new IdentityHashMap<>());
 
     public XmlFile(File file) {
         this(DEFAULT_XSTREAM,file);
@@ -168,12 +174,38 @@ public final class XmlFile {
         AtomicFileWriter w = new AtomicFileWriter(file);
         try {
             w.write("<?xml version='1.0' encoding='UTF-8'?>\n");
-            xs.toXML(o,w);
+            beingWritten.put(o, null);
+            try {
+                xs.toXML(o, w);
+            } finally {
+                beingWritten.remove(o);
+            }
             w.commit();
         } catch(StreamException e) {
             throw new IOException(e);
         } finally {
             w.abort();
+        }
+    }
+
+    /**
+     * Provides an XStream replacement for an object unless a call to {@link #write} is currently in progress.
+     * As per JENKINS-45892 this may be used by any class which expects to be written at top level to an XML file
+     * but which cannot safely be serialized as a nested object (for example, because it expects some {@code onLoad} hook):
+     * implement a {@code writeReplace} method delegating to this method.
+     * The replacement need not be {@link Serializable} since it is only necessary for use from XStream.
+     * @param o an object ({@code this} from {@code writeReplace})
+     * @param replacement a supplier of a safely serializable replacement object with a {@code readResolve} method
+     * @return {@code o}, if {@link #write} is being called on it, else the replacement
+     * @since FIXME
+     */
+    public static Object replaceIfNotAtTopLevel(Object o, Supplier<Object> replacement) {
+        if (beingWritten.containsKey(o)) {
+            return o;
+        } else {
+            // Unfortunately we cannot easily tell which XML file is actually being saved here, at least without implementing a custom Converter.
+            LOGGER.log(Level.WARNING, "JENKINS-45892: reference to {0} being saved but not at top level", o);
+            return replacement.get();
         }
     }
 

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -44,9 +44,12 @@ import hudson.util.AlternativeUiTextProvider.Message;
 import hudson.util.AtomicFileWriter;
 import hudson.util.IOUtils;
 import hudson.util.Secret;
+import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
@@ -511,12 +514,46 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      */
     public synchronized void save() throws IOException {
         if(BulkChange.contains(this))   return;
-        getConfigFile().write(this);
+        synchronized (saving) {
+            saving.add(this);
+        }
+        try {
+            getConfigFile().write(this);
+        } finally {
+            synchronized (saving) {
+                saving.remove(this);
+            }
+        }
         SaveableListener.fireOnChange(this, getConfigFile());
     }
 
     public final XmlFile getConfigFile() {
         return Items.getConfigFile(this);
+    }
+
+    private static final Set<AbstractItem> saving = new HashSet<>();
+
+    private Object writeReplace() {
+        synchronized (saving) {
+            if (saving.contains(this)) {
+                return this;
+            } else {
+                LOGGER.log(Level.WARNING, "JENKINS-45892: reference to {0} being saved but not at top level", this);
+                return new Replacer(this);
+            }
+        }
+    }
+
+    /** Not {@link Serializable} for now, since we are only expecting to use this from XStream. */
+    private static class Replacer {
+        private final String fullName;
+        Replacer(AbstractItem i) {
+            fullName = i.getFullName();
+        }
+        private Object readResolve() {
+            // May or may not work:
+            return Jenkins.getInstance().getItemByFullName(fullName);
+        }
     }
 
     public Descriptor getDescriptorByName(String className) {

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -551,8 +551,12 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
             fullName = i.getFullName();
         }
         private Object readResolve() {
-            // May or may not work:
-            return Jenkins.getInstance().getItemByFullName(fullName);
+            Jenkins j = Jenkins.getInstanceOrNull();
+            if (j == null) {
+                return null;
+            }
+            // Will generally only work if called after job loading:
+            return j.getItemByFullName(fullName);
         }
     }
 

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -51,7 +51,6 @@ import hudson.cli.declarative.CLIMethod;
 import hudson.model.Descriptor.FormException;
 import hudson.model.listeners.RunListener;
 import hudson.model.listeners.SaveableListener;
-import hudson.model.queue.Executables;
 import hudson.model.queue.SubTask;
 import hudson.search.SearchIndexBuilder;
 import hudson.security.ACL;
@@ -2356,7 +2355,10 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         } catch (NumberFormatException x) {
             throw new IllegalArgumentException(x);
         }
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.getInstanceOrNull();
+        if (j == null) {
+            return null;
+        }
         Job<?,?> job = j.getItemByFullName(jobName, Job.class);
         if (job == null) {
             return null;

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1947,7 +1947,8 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             if (saving.contains(this)) {
                 return this;
             } else {
-                LOGGER.warning("JENKINS-45892: improper backreference detected in " + getDataFile());
+                // Unfortunately we cannot easily tell which XML file is actually being saved here, at least without implementing a custom Converter.
+                LOGGER.log(WARNING, "JENKINS-45892: reference to {0} being saved but not at top level", this);
                 return new Replacer(this);
             }
         }

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -50,7 +50,6 @@ import hudson.util.XStream2;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -732,33 +731,13 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
             throw FormValidation.error(Messages.User_IllegalFullname(fullName));
         }
         if(BulkChange.contains(this))   return;
-        synchronized (saving) {
-            saving.add(this);
-        }
-        try {
-            getConfigFile().write(this);
-        } finally {
-            synchronized (saving) {
-                saving.remove(this);
-            }
-        }
+        getConfigFile().write(this);
         SaveableListener.fireOnChange(this, getConfigFile());
     }
 
-    private static final Set<User> saving = new HashSet<>();
-
     private Object writeReplace() {
-        synchronized (saving) {
-            if (saving.contains(this)) {
-                return this;
-            } else {
-                LOGGER.log(Level.WARNING, "JENKINS-45892: reference to {0} being saved but not at top level", this);
-                return new Replacer(this);
-            }
-        }
+        return XmlFile.replaceIfNotAtTopLevel(this, () -> new Replacer(this));
     }
-
-    /** Not {@link Serializable} for now, since we are only expecting to use this from XStream. */
     private static class Replacer {
         private final String id;
         Replacer(User u) {

--- a/core/src/main/java/jenkins/model/RunAction2.java
+++ b/core/src/main/java/jenkins/model/RunAction2.java
@@ -29,6 +29,7 @@ import hudson.model.Run;
 
 /**
  * Optional interface for {@link Action}s that add themselves to a {@link Run}.
+ * You may keep a {@code transient} reference to an owning build, restored in {@link #onLoad}.
  * @since 1.519, 1.509.3
  */
 public interface RunAction2 extends Action {

--- a/test/src/test/java/hudson/model/AbstractItem2Test.java
+++ b/test/src/test/java/hudson/model/AbstractItem2Test.java
@@ -48,8 +48,8 @@ public class AbstractItem2Test {
                 FreeStyleProject p2 = rr.j.createFreeStyleProject("p2");
                 p2.addProperty(new BadProperty(p1));
                 String text = p2.getConfigFile().asString();
-                System.out.println(text);
                 assertThat(text, not(containsString("<description>this is p1</description>")));
+                assertThat(text, containsString("<fullName>p1</fullName>"));
             }
         });
         rr.addStep(new Statement() {

--- a/test/src/test/java/hudson/model/RunActionTest.java
+++ b/test/src/test/java/hudson/model/RunActionTest.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model;
+
+import hudson.XmlFile;
+import java.io.File;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class RunActionTest {
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule
+    public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+
+    @Issue("JENKINS-45892")
+    @Test
+    public void badSerialization() {
+        rr.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                FreeStyleProject p = rr.j.createFreeStyleProject("p");
+                FreeStyleBuild b1 = rr.j.buildAndAssertSuccess(p);
+                FreeStyleBuild b2 = rr.j.buildAndAssertSuccess(p);
+                b2.addAction(new BadAction(b1));
+                b2.save();
+                String text = new XmlFile(new File(b2.getRootDir(), "build.xml")).asString();
+                System.out.println(text);
+                assertThat(text, not(containsString("<owner class=\"build\">")));
+            }
+        });
+        rr.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                FreeStyleProject p = rr.j.jenkins.getItemByFullName("p", FreeStyleProject.class);
+                assertEquals(p.getBuildByNumber(1), p.getBuildByNumber(2).getAction(BadAction.class).owner);
+            }
+        });
+    }
+    static class BadAction extends InvisibleAction {
+        final Run<?, ?> owner; // oops, should have been transient and used RunAction2
+        BadAction(Run<?, ?> owner) {
+            this.owner = owner;
+        }
+    }
+
+}

--- a/test/src/test/java/hudson/model/RunActionTest.java
+++ b/test/src/test/java/hudson/model/RunActionTest.java
@@ -51,8 +51,8 @@ public class RunActionTest {
                 b2.addAction(new BadAction(b1));
                 b2.save();
                 String text = new XmlFile(new File(b2.getRootDir(), "build.xml")).asString();
-                System.out.println(text);
                 assertThat(text, not(containsString("<owner class=\"build\">")));
+                assertThat(text, containsString("<id>p#1</id>"));
             }
         });
         rr.addStep(new Statement() {

--- a/test/src/test/java/hudson/model/UserRestartTest.java
+++ b/test/src/test/java/hudson/model/UserRestartTest.java
@@ -74,8 +74,8 @@ public class UserRestartTest {
                 u.save();
                 p.addProperty(new BadProperty(u));
                 String text = p.getConfigFile().asString();
-                System.out.println(text);
                 assertThat(text, not(containsString("<fullName>Pat Q. Hacker</fullName>")));
+                assertThat(text, containsString("<id>pqhacker</id>"));
             }
         });
         rr.addStep(new Statement() {


### PR DESCRIPTION
See [JENKINS-45892](https://issues.jenkins-ci.org/browse/JENKINS-45892).

- [X] handle `Run`
- [x] handle `AbstractItem`
- [x] handle `User`

### Proposed changelog entries

* Jenkins will now prevent core or plugin code from mistakenly attempting to serialize jobs, builds, or users except in their intended top-level XML file positions, preventing a class of serious errors.

@reviewbybees