### PR TITLE
[JENKINS-45915] - Fix a ConsoleNote Base64 decoding bottleneck by switching to Java 8 Base64 Impl

### DIFF
--- a/core/src/main/java/hudson/util/UnbufferedBase64InputStream.java
+++ b/core/src/main/java/hudson/util/UnbufferedBase64InputStream.java
@@ -1,11 +1,10 @@
 package hudson.util;
 
-import org.apache.commons.codec.binary.Base64;
-
 import java.io.DataInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Base64;
 
 /**
  * Filter InputStream that decodes base64 without doing any buffering.
@@ -22,6 +21,7 @@ public class UnbufferedBase64InputStream extends FilterInputStream {
     private byte[] decoded;
     private int pos;
     private final DataInputStream din;
+    private static final Base64.Decoder decoder = Base64.getMimeDecoder();
 
     public UnbufferedBase64InputStream(InputStream in) {
         super(in);
@@ -38,7 +38,7 @@ public class UnbufferedBase64InputStream extends FilterInputStream {
 
         if (pos==decoded.length) {
             din.readFully(encoded);
-            decoded = Base64.decodeBase64(encoded);
+            decoded = decoder.decode(encoded);
             if (decoded.length==0)  return -1; // EOF
             pos = 0;
         }


### PR DESCRIPTION
See [JENKINS-45915](https://issues.jenkins-ci.org/browse/JENKINS-45915).

The decoder implementation is a drop-in replacement of a spec, and should be covered by existing tests where needed.

This is similar to #2855 (which is replacing Trilead implementations)

### Proposed changelog entries

* Improve Performance When Reading the ConsoleText from a Run

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
