### PR TITLE
add missing @Symbol for agent protocols

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -58,6 +58,7 @@ import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -307,6 +308,7 @@ public final class TcpSlaveAgentListener extends Thread {
      * @since 1.653
      */
     @Extension
+    @Symbol("ping")
     public static class PingAgentProtocol extends AgentProtocol {
 
         private final byte[] ping;

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol3.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol3.java
@@ -14,6 +14,7 @@ import javax.inject.Inject;
 import jenkins.AgentProtocol;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.remoting.engine.JnlpClientDatabase;
 import org.jenkinsci.remoting.engine.JnlpConnectionState;
 import org.jenkinsci.remoting.engine.JnlpProtocol3Handler;
@@ -29,6 +30,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  */
 @Deprecated
 @Extension
+@Symbol("jnlp3")
 public class JnlpSlaveAgentProtocol3 extends AgentProtocol {
     private NioChannelSelector hub;
 

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
@@ -48,6 +48,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import jenkins.AgentProtocol;
 import jenkins.model.identity.InstanceIdentityProvider;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.remoting.engine.JnlpConnectionState;
 import org.jenkinsci.remoting.engine.JnlpProtocol4Handler;
 import org.jenkinsci.remoting.protocol.IOHub;
@@ -62,6 +63,7 @@ import org.jenkinsci.remoting.protocol.cert.PublicKeyMatchingX509ExtendedTrustMa
  * @since 2.41 enabled by default
  */
 @Extension
+@Symbol("jnlp4")
 public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
     /**
      * Our logger.


### PR DESCRIPTION
I just noticed JNLP3/4 and Ping agent protocols don't have `@Symbol` annotation, while JNLP1/2 have on

### Changelog Entry

* RFE - Add `@Symbol` annotations to JNLP4-connect, JNLP3-connect and Ping Remoting protocols
  * Protocol documentation: https://github.com/jenkinsci/remoting/blob/master/docs/protocols.md