### PR TITLE
Fix FileBoolean constructor not using the platform file separator

### DIFF
--- a/core/src/main/java/jenkins/util/io/FileBoolean.java
+++ b/core/src/main/java/jenkins/util/io/FileBoolean.java
@@ -30,7 +30,7 @@ public class FileBoolean {
     }
 
     public FileBoolean(Class owner, String name) {
-        this(new File(Jenkins.getInstance().getRootDir(),owner.getName().replace('$','.')+'/'+name));
+        this(new File(Jenkins.getInstance().getRootDir(),owner.getName().replace('$','.')+File.separatorChar+name));
     }
 
     /**


### PR DESCRIPTION
It's using '/' as a hardcoded separator for the path, and that's going to be a problem on Windows. 

Since this is a trivial one-line fix, I'm omitting the JIRA and there's no need for additional unit tests to verify a core Java API does what it says on the can. 

### Proposed changelog entries

Too trivial to be worth mentioning, I think.

### Desired reviewers

@reviewbybees
