### PR TITLE
[FIXED JENKINS-45895] - JNLPLauncher config.jelly should not display Work Dir settings when included from other class

### DIFF
--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -163,6 +163,22 @@ public class JNLPLauncher extends ComputerLauncher {
         public String getDisplayName() {
             return Messages.JNLPLauncher_displayName();
         }
+        
+        /**
+         * Checks if Work Dir settings should be displayed.
+         * 
+         * This flag is checked in {@code config.jelly} before displaying the 
+         * {@link JNLPLauncher#workDirSettings} property.
+         * By default the configuration is displayed only for {@link JNLPLauncher},
+         * but the implementation can be overridden.
+         * @return {@code true} if work directories are supported by the launcher type.
+         * @since TODO
+         */
+        public boolean isWorkDirSupported() {
+            // This property is included only for JNLPLauncher by default. 
+            // Causes JENKINS-45895 in the case of includes otherwise
+            return DescriptorImpl.class.equals(getClass());
+        }
     };
 
     /**

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/config.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/config.jelly
@@ -24,7 +24,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:property title="${%Enable work directory}" field="workDirSettings" />
+  <!-- This property is included only if used directly. Causes JENKINS-45895 in the case of includes otherwise -->
+  <j:if test="${descriptor.workDirSupported}"> 
+    <f:property title="${%Enable work directory}" field="workDirSettings" />
+  </j:if>
   <f:advanced>
     <f:entry title="${%Tunnel connection through}" help="/help/system-config/master-slave/jnlp-tunnel.html">
       <f:textbox field="tunnel"/>


### PR DESCRIPTION
See [JENKINS-45895](https://issues.jenkins-ci.org/browse/JENKINS-45895).

Honestly I think it is a misbehavior of the Docker plugin, which includes the configuration in such improper way: https://github.com/jenkinsci/docker-plugin/blob/master/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher/config.jelly#L8 . But I would prefer to fix it in the core since it hammers community ratings of the weekly and the Docker Plugin is rather dead than alive.

No tests for hacks

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: JENKINS-45895, Bug - Modify the JNLPLauncher configuration page in order to workaround regression in Docker Plugin (regression in 2.72).
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
