### PR TITLE
[FIXED JENKINS-45909] ReverseBuildTrigger.upstreamProjects should be null safe

### DIFF
--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -170,7 +170,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     }
 
     @Override public void buildDependencyGraph(final AbstractProject downstream, DependencyGraph graph) {
-        for (AbstractProject upstream : Items.fromNameList(downstream.getParent(), upstreamProjects, AbstractProject.class)) {
+        for (AbstractProject upstream : Items.fromNameList(downstream.getParent(), Util.fixNull(upstreamProjects), AbstractProject.class)) {
             graph.addDependency(new DependencyGraph.Dependency(upstream, downstream) {
                 @Override public boolean shouldTriggerBuild(AbstractBuild upstreamBuild, TaskListener listener, List<Action> actions) {
                     return shouldTrigger(upstreamBuild, listener);
@@ -253,7 +253,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
                         continue;
                     }
                     List<Job> upstreams =
-                            Items.fromNameList(downstream.getParent(), trigger.upstreamProjects, Job.class);
+                            Items.fromNameList(downstream.getParent(), Util.fixNull(trigger.upstreamProjects), Job.class);
                     LOGGER.log(Level.FINE, "from {0} see upstreams {1}", new Object[]{downstream, upstreams});
                     for (Job upstream : upstreams) {
                         if (upstream instanceof AbstractProject && downstream instanceof AbstractProject) {
@@ -310,8 +310,8 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
                     ReverseBuildTrigger t = ParameterizedJobMixIn.getTrigger(p, ReverseBuildTrigger.class);
                     if (t != null) {
                         String revised =
-                                Items.computeRelativeNamesAfterRenaming(oldFullName, newFullName, t.upstreamProjects,
-                                        p.getParent());
+                                Items.computeRelativeNamesAfterRenaming(oldFullName, newFullName,
+                                        Util.fixNull(t.upstreamProjects), p.getParent());
                         if (!revised.equals(t.upstreamProjects)) {
                             t.upstreamProjects = revised;
                             try {

--- a/test/src/test/java/jenkins/triggers/ReverseBuildTriggerTest.java
+++ b/test/src/test/java/jenkins/triggers/ReverseBuildTriggerTest.java
@@ -209,4 +209,19 @@ public class ReverseBuildTriggerTest {
         assertThat("Build should be not triggered", downstreamJob1.getBuilds(), hasSize(0));
         assertThat("Build should be triggered", downstreamJob2.getBuilds(), not(hasSize(0)));
     }
+
+    @Issue("JENKINS-45909")
+    @Test
+    public void nullUpstreamProjectsNoNPE() throws Exception {
+        //job with trigger.upstreamProjects == null
+        final FreeStyleProject downstreamJob1 = r.createFreeStyleProject("downstream1");
+        ReverseBuildTrigger trigger = new ReverseBuildTrigger(null);
+        downstreamJob1.addTrigger(trigger);
+        downstreamJob1.save();
+        r.configRoundtrip(downstreamJob1);
+
+        // The reported issue was with Pipeline jobs, which calculate their dependency graphs via
+        // ReverseBuildTrigger.RunListenerImpl, so an additional test may be needed downstream.
+        trigger.buildDependencyGraph(downstreamJob1, Jenkins.getInstance().getDependencyGraph());
+    }
 }


### PR DESCRIPTION
See [JENKINS-45909](https://issues.jenkins-ci.org/browse/JENKINS-45909).

This probably merits a downstream test in `workflow-job` or `workflow-multibranch`, but I'm not sure it's worth bumping the core version in one of those for just a test.

### Proposed changelog entries

* JENKINS-45909, don't fail dependency graph calculation for null ReverseBuildTrigger#upstreamProjects.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees
@jenkinsci/code-reviewers 
