### PR TITLE
Minor fixes to the title of a view

### DIFF
--- a/core/src/main/resources/hudson/model/View/index.jelly
+++ b/core/src/main/resources/hudson/model/View/index.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <l:layout title="${it.class.name=='hudson.model.AllView' ? '%Dashboard' : it.viewName}${not empty it.ownerItemGroup.fullDisplayName?' ['+it.ownerItemGroup.fullDisplayName+']':''}" norefresh="${!it.automaticRefreshEnabled}">
+    <l:layout title="${(it.class.name=='hudson.model.AllView' and it.ownerItemGroup == app) ? '%Dashboard' : it.displayName}${not empty it.ownerItemGroup.fullDisplayName?' ['+it.ownerItemGroup.fullDisplayName+']':''}" norefresh="${!it.automaticRefreshEnabled}">
       <j:set var="view" value="${it}"/> <!-- expose view to the scripts we include from owner -->
         <st:include page="sidepanel.jelly" />
         <l:main-panel>


### PR DESCRIPTION
- Use display name rather than name
- Only use the special 'Dashboard' label outside any folder

---

Motivation: Go to https://ci.jenkins.io/job/Core/ and look at the title bar.

Probably leftovers from @stephenc's https://github.com/jenkinsci/jenkins/pull/2603

Too minor of an RFE/fix for an issue. Not worth any backport.

### Proposed changelog entries

* Bug: Show display name of the current view in window title
