### PR TITLE
[JENKINS-29537] EnvironmentContributingAction compatible with Workflow

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -881,7 +881,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 e.buildEnvVars(env);
 
         for (EnvironmentContributingAction a : getActions(EnvironmentContributingAction.class))
-            a.buildEnvVars(this,env);
+            a.buildEnvVars(this,env,getBuiltOn());
 
         EnvVars.resolve(env);
 

--- a/core/src/main/java/hudson/model/EnvironmentContributingAction.java
+++ b/core/src/main/java/hudson/model/EnvironmentContributingAction.java
@@ -32,6 +32,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.ProtectedExternally;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * {@link Action} that contributes environment variables during a build.
@@ -55,11 +56,13 @@ public interface EnvironmentContributingAction extends Action {
      * @param run
      *      The calling build. Never null.
      * @param node
-     *      The node execute on. Can be null.
+     *      The node execute on. Can be {@code null} when the Run is not binded to the node,
+     *      e.g. in Pipeline outside the {@code node() step}
      * @param env
      *      Environment variables should be added to this map.
+     * @since TODO
      */
-    default void buildEnvVars(Run<?, ?> run, EnvVars env, @CheckForNull Node node) {
+    default void buildEnvVars(@Nonnull Run<?, ?> run, @Nonnull EnvVars env, @CheckForNull Node node) {
         if (run instanceof AbstractBuild
                 && Util.isOverridden(EnvironmentContributingAction.class,
                                      getClass(), "buildEnvVars", AbstractBuild.class, EnvVars.class)) {

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -138,10 +138,11 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
         }
     }
 
-    public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
+    @Override
+    public void buildEnvVars(Run<?,?> run, EnvVars env, Node node) {
         for (ParameterValue p : getParameters()) {
             if (p == null) continue;
-            p.buildEnvironment(build, env); 
+            p.buildEnvironment(run, env);
         }
     }
 

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2302,6 +2302,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         for (EnvironmentContributor ec : EnvironmentContributor.all().reverseView())
             ec.buildEnvironmentFor(this,env,listener);
 
+        for (EnvironmentContributingAction a : getActions(EnvironmentContributingAction.class))
+            a.buildEnvVars(this,env,n);
+
         return env;
     }
 

--- a/core/src/test/java/hudson/model/EnvironmentContributingActionTest.java
+++ b/core/src/test/java/hudson/model/EnvironmentContributingActionTest.java
@@ -1,0 +1,159 @@
+package hudson.model;
+
+import hudson.EnvVars;
+import org.junit.Test;
+
+import javax.annotation.CheckForNull;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class EnvironmentContributingActionTest {
+    class OverrideRun extends InvisibleAction implements EnvironmentContributingAction {
+        private boolean wasCalled = false;
+
+        @Override
+        public void buildEnvVars(Run<?, ?> run, EnvVars env, @CheckForNull Node node) {
+            wasCalled = true;
+        }
+
+        boolean wasNewMethodCalled() {
+            return wasCalled;
+        }
+    }
+
+    class OverrideAbstractBuild extends InvisibleAction implements EnvironmentContributingAction {
+        private boolean wasCalled = false;
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public void buildEnvVars(AbstractBuild<?, ?> abstractBuild, EnvVars envVars) {
+            wasCalled = true;
+        }
+
+        boolean wasDeprecatedMethodCalled() {
+            return wasCalled;
+        }
+    }
+
+    class OverrideBoth extends InvisibleAction implements EnvironmentContributingAction {
+        private boolean wasCalledAstractBuild = false;
+        private boolean wasCalledRun = false;
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public void buildEnvVars(AbstractBuild<?, ?> abstractBuild, EnvVars envVars) {
+            wasCalledAstractBuild = true;
+        }
+
+        @Override
+        public void buildEnvVars(Run<?, ?> run, EnvVars env, @CheckForNull Node node) {
+            wasCalledRun = true;
+        }
+
+        boolean wasDeprecatedMethodCalled() {
+            return wasCalledAstractBuild;
+        }
+
+        boolean wasRunCalled() {
+            return wasCalledRun;
+        }
+    }
+
+    private final EnvVars envVars = mock(EnvVars.class);
+
+    @Test
+    public void testOverrideRunMethodAndCallNewMethod() throws Exception {
+        Run run = mock(Run.class);
+        Node node = mock(Node.class);
+
+        OverrideRun overrideRun = new OverrideRun();
+        overrideRun.buildEnvVars(run, envVars, node);
+
+        assertTrue(overrideRun.wasNewMethodCalled());
+    }
+
+    /**
+     * If only non-deprecated method was overridden it would be executed even if someone would call deprecated method.
+     * @throws Exception if happens.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testOverrideRunMethodAndCallDeprecatedMethod() throws Exception {
+        AbstractBuild abstractBuild = mock(AbstractBuild.class);
+        when(abstractBuild.getBuiltOn()).thenReturn(mock(Node.class));
+
+        OverrideRun overrideRun = new OverrideRun();
+        overrideRun.buildEnvVars(abstractBuild, envVars);
+
+        assertTrue(overrideRun.wasNewMethodCalled());
+    }
+
+    /**
+     * {@link AbstractBuild} should work as before.
+     * @throws Exception if happens.
+     */
+    @Test
+    public void testOverrideAbstractBuildAndCallNewMethodWithAbstractBuild() throws Exception {
+        AbstractBuild abstractBuild = mock(AbstractBuild.class);
+        Node node = mock(Node.class);
+
+        OverrideAbstractBuild action = new OverrideAbstractBuild();
+        action.buildEnvVars(abstractBuild, envVars, node);
+
+        assertTrue(action.wasDeprecatedMethodCalled());
+    }
+
+    /**
+     * {@link Run} should not execute method that was overridden for {@link AbstractBuild}.
+     * @throws Exception if happens.
+     */
+    @Test
+    public void testOverrideAbstractBuildAndCallNewMethodWithRun() throws Exception {
+        Run run = mock(Run.class);
+        Node node = mock(Node.class);
+
+        OverrideAbstractBuild action = new OverrideAbstractBuild();
+        action.buildEnvVars(run, envVars, node);
+
+        assertFalse(action.wasDeprecatedMethodCalled());
+    }
+
+    /**
+     * If someone wants to use overridden deprecated method, it would still work.
+     * @throws Exception if happens.
+     */
+    @Test
+    public void testOverrideAbstractBuildAndCallDeprecatedMethod() throws Exception {
+        AbstractBuild abstractBuild = mock(AbstractBuild.class);
+
+        OverrideAbstractBuild overrideRun = new OverrideAbstractBuild();
+        overrideRun.buildEnvVars(abstractBuild, envVars);
+
+        assertTrue(overrideRun.wasDeprecatedMethodCalled());
+    }
+
+    @Test
+    public void testOverrideBothAndCallNewMethod() throws Exception {
+        Run run = mock(Run.class);
+        Node node = mock(Node.class);
+
+        OverrideBoth overrideRun = new OverrideBoth();
+        overrideRun.buildEnvVars(run, envVars, node);
+
+        assertTrue(overrideRun.wasRunCalled());
+    }
+
+    @Test
+    public void testOverrideBothAndCallDeprecatedMethod() throws Exception {
+        AbstractBuild abstractBuild = mock(AbstractBuild.class);
+
+        OverrideBoth overrideRun = new OverrideBoth();
+        overrideRun.buildEnvVars(abstractBuild, envVars);
+
+        assertTrue(overrideRun.wasDeprecatedMethodCalled());
+    }
+}

--- a/core/src/test/java/hudson/model/ParametersActionTest.java
+++ b/core/src/test/java/hudson/model/ParametersActionTest.java
@@ -105,7 +105,7 @@ public class ParametersActionTest {
         
         // Interaction with build
         EnvVars vars = new EnvVars();
-        parametersAction.buildEnvVars(build, vars);
+        parametersAction.buildEnvVars(build, vars, build.getBuiltOn());
         assertEquals(2, vars.size());   
         parametersAction.createVariableResolver(build);
         


### PR DESCRIPTION
- Adds GenericEnvironmentContributingAction
- Deprecates EnvironmentContributingAction

See [JENKINS-29537](https://issues.jenkins-ci.org/browse/JENKINS-29537).

* Internal: JENKINS-29537, Add GenericEnvironmentContributingAction that supports `WorkflowJob`s as well as `AbstractProject`s.

Downstream PR:

* https://github.com/jenkinsci/gerrit-trigger-plugin/pull/319

@jglick, @rsandell 