### PR TITLE
[JENKINS-46288] - Fix ProxyConfiguration validation for NTLM authentication

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -396,7 +396,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
             if (userName.indexOf('\\') >= 0){
                 final String domain = userName.substring(0, userName.indexOf('\\'));
                 final String user = userName.substring(userName.indexOf('\\') + 1);
-                return new NTCredentials(user, Secret.fromString(password).getPlainText(), domain, "");
+                return new NTCredentials(user, Secret.fromString(password).getPlainText(), "", domain);
             } else {
                 return new UsernamePasswordCredentials(userName, Secret.fromString(password).getPlainText());
             }


### PR DESCRIPTION
The constructor of NTCredentials has one mistake order, host first then domain:

/**
     * Constructor.
     * @param userName The user name.  This should not include the domain to authenticate with.
     * For example: "user" is correct whereas "DOMAIN\\user" is not.
     * @param password The password.
     * @param host The host the authentication request is originating from.  Essentially, the
     * computer name for this machine.
     * @param domain The domain to authenticate within.
     */

## Proposed changelog:

* Bug: Proxy Configuration's "Validate" button in Update Manager / Advanced now works correctly when NTLM authorization is defined
