### PR TITLE
[JENKINS-46282] - Update WinSW from 2.1.0 to 2.1.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -771,7 +771,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>com.sun.winsw</groupId>
                   <artifactId>winsw</artifactId>
-                  <version>2.1.0</version>
+                  <version>2.1.2</version>
                   <classifier>bin</classifier>
                   <type>exe</type>
                   <outputDirectory>${project.build.outputDirectory}/windows-service</outputDirectory>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>windows-slave-installer</artifactId>
-      <version>1.9</version>
+      <version>1.9.1-20170817.200042-1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -114,7 +114,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>windows-slave-installer</artifactId>
-      <version>1.9.1-20170817.200042-1</version>
+      <version>1.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
Fixes [JENKINS-46282](https://issues.jenkins-ci.org/browse/JENKINS-46282), which impacts the default installation.
Also updates Parent POM in the module

Full list of fixes:



Downstream of https://github.com/jenkinsci/windows-slave-installer-module/pull/16

Full Diffs: 
* https://github.com/kohsuke/winsw/compare/winsw-v2.1.0...winsw-v2.1.2
* https://github.com/jenkinsci/windows-slave-installer-module/compare/windows-slave-installer-1.9...windows-slave-installer-1.9.1

### Proposed changelog entries

3 Bugs:

* JENKINS-46282 - Update Windows service wrapper from 2.1.0 to 2.1.2: `stopTimeoutMs` in Runaway Process Killer extension was ignored, default configuration of the Master service was impacted.
  * WinSW changelog: https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md
  * Module changelog: https://github.com/jenkinsci/windows-slave-installer-module/blob/master/CHANGELOG.md
* Windows service wrapper 2.1.2: Prevent printing of log entries in the `status` command
  * WinSW Issue 206 - https://github.com/kohsuke/winsw/issues/206)
* Windows service wrapper 2.1.2: Prevent hanging of the stop executable when its logs are not being drained do the parent process
  * WinSW Issue 218 - https://github.com/kohsuke/winsw/issues/218

No tests in the Jenkins core, it is covered by WinSW autotests.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
