### PR TITLE
Upgrade Remoting to 3.11

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -454,6 +454,9 @@ public class SlaveComputer extends Computer {
         }
         @Override public Integer call() {
             Channel c = Channel.current();
+            if (c == null) {
+                return -1;
+            }
             return resource ? c.resourceLoadingCount.get() : c.classLoadingCount.get();
         }
     }
@@ -471,6 +474,9 @@ public class SlaveComputer extends Computer {
         }
         @Override public Long call() {
             Channel c = Channel.current();
+            if (c == null) {
+                return Long.valueOf(-1);
+            }
             return resource ? c.resourceLoadingTime.get() : c.classLoadingTime.get();
         }
     }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -454,7 +454,7 @@ public class SlaveComputer extends Computer {
         }
         @Override public Integer call() {
             Channel c = Channel.current();
-            return resource ? c.resourceLoadingCount.get() : c.classLoadingCount.get();
+            return c == null ? 0 : resource ? c.resourceLoadingCount.get() : c.classLoadingCount.get();
         }
     }
 
@@ -471,7 +471,7 @@ public class SlaveComputer extends Computer {
         }
         @Override public Long call() {
             Channel c = Channel.current();
-            return resource ? c.resourceLoadingTime.get() : c.classLoadingTime.get();
+            return c == null ? 0 : resource ? c.resourceLoadingTime.get() : c.classLoadingTime.get();
         }
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -251,7 +251,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
-import java.lang.reflect.Field;
 import java.net.BindException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -903,27 +902,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
             adjuncts = new AdjunctManager(servletContext, pluginManager.uberClassLoader,"adjuncts/"+SESSION_HASH, TimeUnit2.DAYS.toMillis(365));
 
-            // TODO pending move to standard blacklist, or API to append filter
-            if (System.getProperty(ClassFilter.FILE_OVERRIDE_LOCATION_PROPERTY) == null) { // not using SystemProperties since ClassFilter does not either
-                try {
-                    Field blacklistPatternsF = ClassFilter.DEFAULT.getClass().getDeclaredField("blacklistPatterns");
-                    blacklistPatternsF.setAccessible(true);
-                    Object[] blacklistPatternsA = (Object[]) blacklistPatternsF.get(ClassFilter.DEFAULT);
-                    boolean found = false;
-                    for (int i = 0; i < blacklistPatternsA.length; i++) {
-                        if (blacklistPatternsA[i] instanceof Pattern) {
-                            blacklistPatternsA[i] = Pattern.compile("(" + blacklistPatternsA[i] + ")|(java[.]security[.]SignedObject)");
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) {
-                        throw new Error("no Pattern found among " + Arrays.toString(blacklistPatternsA));
-                    }
-                } catch (NoSuchFieldException | IllegalAccessException x) {
-                    throw new Error("Unexpected ClassFilter implementation in bundled remoting.jar: " + x, x);
-                }
-            }
+            ClassFilter.appendDefaultFilter(Pattern.compile("java[.]security[.]SignedObject")); // TODO move to standard blacklist
 
             // initialization consists of ...
             executeReactor( is,

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.10</version>
+        <version>3.11</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.10</version>
+        <version>3.11-20170705.163759-1</version> <!-- TODO https://github.com/jenkinsci/remoting/pull/178 -->
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Integrates an update of Remoting with some important updates.

### Proposed Changelog entries:

* Major RFE: Update Remoting from 3.10 to 3.11
  * Changelog: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#311
* RFE: [JENKINS-43985](https://issues.jenkins-ci.org/browse/JENKINS-43985) - Remoting 3.11: Require Java 8 in the Remoting executable.
  * Announcement blogpost: https://jenkins.io/blog/2017/08/11/remoting-update/
* RFE: [JENKINS-37567](https://issues.jenkins-ci.org/browse/JENKINS-37567) - Remoting 3.11: Change the Remoting code signing key (create a bug if there are issues with Java Web Start Agebts).
* RFE: [JENKINS-46259](https://issues.jenkins-ci.org/browse/JENKINS-46259), [JENKINS-45233](https://issues.jenkins-ci.org/browse/JENKINS-45233) - Remoting 3.11: Improve logging of exceptional states in remote requests.
* BUG: [JENKINS-45023](https://issues.jenkins-ci.org/browse/JENKINS-45023) - Remoting 3.11: Prevent execution of `UserRequest`s when the channel is closed or being closed. It prevents hanging of the channel in some cases.
* RFE: [JENKINS-45522](https://issues.jenkins-ci.org/browse/JENKINS-45522) - Internal: Remoting 3.11: Introduce public API for adding classes to the default blacklist in Remoting.
  * Javadoc: http://javadoc.jenkins.io/component/remoting/hudson/remoting/ClassFilter.html#appendDefaultFilter-java.util.regex.Pattern-

### Info

Full diff: https://github.com/jenkinsci/remoting/compare/remoting-3.10...remoting-3.11