### PR TITLE
Rss Bar and Legend Link (Job List Footer) Added Classes and IDs to enable easy styling for external themes

### DIFF
--- a/core/src/main/resources/lib/hudson/rssBar.jelly
+++ b/core/src/main/resources/lib/hudson/rssBar.jelly
@@ -33,9 +33,10 @@ THE SOFTWARE.
     }
     #rss-bar {
       margin:1em;
+      text-align:right;
     }
   </style>
-  <div id="rss-bar" align="right">
+  <div id="rss-bar">
     <a href="${rootURL}/legend" id="rss-bar-legend-link">${%Legend}</a>
     <span id="rss-bar-rss-all" class="rss-bar-item">
       <a href="rssAll" class="rss-bar-item-icon-link"><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Feed"/></a>

--- a/core/src/main/resources/lib/hudson/rssBar.jelly
+++ b/core/src/main/resources/lib/hudson/rssBar.jelly
@@ -24,6 +24,18 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <style type="text/css">
+    .icon-rss {
+      border: 0;
+    }
+    .rss-bar-item {
+      padding-left: 1em;
+    }
+    #rss-bar {
+      margin:1em;
+      text-align:right;
+    }
+  </style>
   <div id="rss-bar">
     <a href="${rootURL}/legend" id="rss-bar-legend-link">${%Legend}</a>
     <span id="rss-bar-rss-all" class="rss-bar-item">

--- a/core/src/main/resources/lib/hudson/rssBar.jelly
+++ b/core/src/main/resources/lib/hudson/rssBar.jelly
@@ -24,18 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <style type="text/css">
-    .icon-rss {
-      border: 0;
-    }
-    .rss-bar-item {
-      padding-left: 1em;
-    }
-    #rss-bar {
-      margin:1em;
-      text-align:right;
-    }
-  </style>
   <div id="rss-bar">
     <a href="${rootURL}/legend" id="rss-bar-legend-link">${%Legend}</a>
     <span id="rss-bar-rss-all" class="rss-bar-item">

--- a/core/src/main/resources/lib/hudson/rssBar.jelly
+++ b/core/src/main/resources/lib/hudson/rssBar.jelly
@@ -25,21 +25,21 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div id="rss-bar">
-    <a href="${rootURL}/legend" id="rss-bar-legend-link">${%Legend}</a>
-    <span id="rss-bar-rss-all" class="rss-bar-item">
+    <a href="${rootURL}/legend" class="rss-bar-legend-link">${%Legend}</a>
+    <span class="rss-bar-item">
       <a href="rssAll" class="rss-bar-item-icon-link"><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Feed"/></a>
       <st:nbsp/>
-      <a href="rssAll" class="rss-bar-item-text-link">RSS ${%for all}</a>
+      <a href="rssAll" class="rss-bar-item-link">RSS ${%for all}</a>
     </span>
-    <span id="rss-bar-rss-failed" class="rss-bar-item">
+    <span class="rss-bar-item">
       <a href="rssFailed" class="rss-bar-item-icon-link"><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Feed"/></a>
       <st:nbsp/>
-      <a href="rssFailed" class="rss-bar-item-text-link">RSS ${%for failures}</a>
+      <a href="rssFailed" class="rss-bar-item-link">RSS ${%for failures}</a>
     </span>
-    <span id="rss-bar-rss-latest" class="rss-bar-item">
+    <span class="rss-bar-item">
       <a href="rssLatest" class="rss-bar-item-icon-link" ><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Feed"/></a>
       <st:nbsp/>
-      <a href="rssLatest" class="rss-bar-item-text-link">RSS ${%for just latest builds}</a>
+      <a href="rssLatest" class="rss-bar-item-link">RSS ${%for just latest builds}</a>
     </span>
   </div>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/rssBar.jelly
+++ b/core/src/main/resources/lib/hudson/rssBar.jelly
@@ -24,22 +24,33 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div align="right" style="margin:1em">
-    <a href="${rootURL}/legend">${%Legend}</a>
-    <span style="padding-left:1em">
-      <a href="rssAll"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+  <style type="text/css">
+    .icon-rss {
+      border: 0;
+    }
+    .rss-bar-item {
+      padding-left: 1em;
+    }
+    #rss-bar {
+      margin:1em;
+    }
+  </style>
+  <div id="rss-bar" align="right">
+    <a href="${rootURL}/legend" id="rss-bar-legend-link">${%Legend}</a>
+    <span id="rss-bar-rss-all" class="rss-bar-item">
+      <a href="rssAll" class="rss-bar-item-icon-link"><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Feed"/></a>
       <st:nbsp/>
-      <a href="rssAll">RSS ${%for all}</a>
+      <a href="rssAll" class="rss-bar-item-text-link">RSS ${%for all}</a>
     </span>
-    <span style="padding-left:1em">
-      <a href="rssFailed"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+    <span id="rss-bar-rss-failed" class="rss-bar-item">
+      <a href="rssFailed" class="rss-bar-item-icon-link"><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Feed"/></a>
       <st:nbsp/>
-      <a href="rssFailed">RSS ${%for failures}</a>
+      <a href="rssFailed" class="rss-bar-item-text-link">RSS ${%for failures}</a>
     </span>
-    <span style="padding-left:1em">
-      <a href="rssLatest"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+    <span id="rss-bar-rss-latest" class="rss-bar-item">
+      <a href="rssLatest" class="rss-bar-item-icon-link" ><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Feed"/></a>
       <st:nbsp/>
-      <a href="rssLatest">RSS ${%for just latest builds}</a>
+      <a href="rssLatest" class="rss-bar-item-text-link">RSS ${%for just latest builds}</a>
     </span>
   </div>
 </j:jelly>

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Daniel Dyer, Stephen Connolly
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -54,12 +54,12 @@ body, table, form, input, td, th, p, textarea, select
 @media (min-width:1600px){
   body#jenkins.j-hide-left #main-panel{max-width:75%}
   body, table, form, input, td, th, p, textarea, select, #tasks .task
-    {font-size:14px;}  
+    {font-size:14px;}
 }
 @media (min-width:2000px){
   body#jenkins.j-hide-left #main-panel{max-width:85%}
   body, table, form, input, td, th, p, textarea, select, #tasks .task
-    {font-size:15px;}  
+    {font-size:15px;}
 }
 body, table, form, td, th, p
 {
@@ -257,7 +257,7 @@ pre {/* see http://users.tkk.fi/tkarvine/pre-wrap-css3-mozilla-opera-ie.html */
 }
 
 pre a {
-    word-wrap: break-word;  
+    word-wrap: break-word;
 }
 
 pre.console {
@@ -1477,7 +1477,7 @@ DIV.yahooTree td {
   height: 24px;
   padding-left: 20px;
   width: 15em;
-  position: static; 
+  position: static;
   border: 1px solid #DDD;
   border-radius: 4px;
   box-shadow: 0 0 5px #DDD inset;
@@ -1733,7 +1733,7 @@ select.select-ajax-pending {
 
 /* ========================= Button styles ================= */
 .btn-box {
-  display:block; 
+  display:block;
   margin-top:2em
 }
 #disable-project {
@@ -1912,4 +1912,19 @@ body.no-sticker #bottom-sticker {
 .icon-xlg {
     width: 48px;
     height: 48px;
+}
+
+/* rss-bar */
+
+.icon-rss {
+    border: 0;
+}
+
+.rss-bar-item {
+    padding-left: 1em;
+}
+
+#rss-bar {
+    margin:1em;
+    text-align:right;
 }

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- *
+ * 
  * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, Daniel Dyer, Stephen Connolly
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -54,12 +54,12 @@ body, table, form, input, td, th, p, textarea, select
 @media (min-width:1600px){
   body#jenkins.j-hide-left #main-panel{max-width:75%}
   body, table, form, input, td, th, p, textarea, select, #tasks .task
-    {font-size:14px;}
+    {font-size:14px;}  
 }
 @media (min-width:2000px){
   body#jenkins.j-hide-left #main-panel{max-width:85%}
   body, table, form, input, td, th, p, textarea, select, #tasks .task
-    {font-size:15px;}
+    {font-size:15px;}  
 }
 body, table, form, td, th, p
 {
@@ -257,7 +257,7 @@ pre {/* see http://users.tkk.fi/tkarvine/pre-wrap-css3-mozilla-opera-ie.html */
 }
 
 pre a {
-    word-wrap: break-word;
+    word-wrap: break-word;  
 }
 
 pre.console {
@@ -1477,7 +1477,7 @@ DIV.yahooTree td {
   height: 24px;
   padding-left: 20px;
   width: 15em;
-  position: static;
+  position: static; 
   border: 1px solid #DDD;
   border-radius: 4px;
   box-shadow: 0 0 5px #DDD inset;
@@ -1733,7 +1733,7 @@ select.select-ajax-pending {
 
 /* ========================= Button styles ================= */
 .btn-box {
-  display:block;
+  display:block; 
   margin-top:2em
 }
 #disable-project {
@@ -1912,19 +1912,4 @@ body.no-sticker #bottom-sticker {
 .icon-xlg {
     width: 48px;
     height: 48px;
-}
-
-/* rss-bar */
-
-.icon-rss {
-    border: 0;
-}
-
-.rss-bar-item {
-    padding-left: 1em;
-}
-
-#rss-bar {
-    margin:1em;
-    text-align:right;
 }

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1913,3 +1913,19 @@ body.no-sticker #bottom-sticker {
     width: 48px;
     height: 48px;
 }
+
+/* rss-bar */
+
+#rss-bar {
+    margin:1em;
+    text-align:right;
+}
+
+#rss-bar .icon-rss {
+    border: 0;
+}
+
+#rss-bar .rss-bar-item {
+    padding-left: 1em;
+}
+


### PR DESCRIPTION
**TL;DR: Minor improvement to give RSS Bar Classes and IDs to enable easy styling.**

![image](https://user-images.githubusercontent.com/12599965/29522426-542490bc-8689-11e7-88f9-da3c29d88793.png)

### Proposed changelog entries

* RSS bar now has IDs and Classes on all its elements, so that external themes can better style the rss bar (which currently is almost not possible).
  * RSS bar Icons now obey the convention for icon classes `icon-NAME icon-SIZE` e.g. `icon-rss icon-sm`
  * Migrated inline styles to styling by classes/ids. Migrated HTML styling attributes like `width` to CSS.

### Submitter checklist

- ~[ ] JIRA issue is well described~ 
  * *Minor improvement, so no JIRA issue.*
- [x] Changelog entry appropriate for the audience affected by the change:
  * Internal, developer
- [x] Appropriate autotests or explanation to why this change has no tests
  * I has not tests, since changes a minor UI changes that would require an E2E test.
  * Changes have been tested in multiple browsers.
- ~[ ] For dependency updates: links to external changelogs and, if possible, full diffs~

### Desired reviewers

@i386 Maybe you remember me from the [PR on the favorite plugin](https://github.com/jenkinsci/favorite-plugin/pull/9/files). I would like to do the same to the RSS Bar and just give it proper classes and ids :)
If it is ok I would add some more small PRs on this topic for other elements that have missing classes/ids that make them hard to style.