### PR TITLE
Right-Top-Nav - remove multiple ids from breadcrumb. set ids and classes where missing.

### DIFF
--- a/core/src/main/resources/lib/layout/breadcrumbBar.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumbBar.jelly
@@ -41,17 +41,15 @@ THE SOFTWARE.
         <div class="top-sticker-inner">
           <div id="right-top-nav">
             <j:if test="${norefresh==null or norefresh==false}">
-              <div id="right-top-nav">
-                <div class="smallfont">
-                  <j:choose>
-                    <j:when test="${h.isAutoRefresh(request)}">
-                      <a href="?auto_refresh=false">${%DISABLE AUTO REFRESH}</a>
-                    </j:when>
-                    <j:otherwise>
-                      <a href="?auto_refresh=true">${%ENABLE AUTO REFRESH}</a>
-                    </j:otherwise>
-                  </j:choose>
-                </div>
+              <div id="auto-refresh" class="smallfont">
+                <j:choose>
+                  <j:when test="${h.isAutoRefresh(request)}">
+                    <a href="?auto_refresh=false" class="auto-refresh-text-link">${%DISABLE AUTO REFRESH}</a>
+                  </j:when>
+                  <j:otherwise>
+                    <a href="?auto_refresh=true" class="auto-refresh-text-link">${%ENABLE AUTO REFRESH}</a>
+                  </j:otherwise>
+                </j:choose>
               </div>
             </j:if>
           </div>

--- a/core/src/main/resources/lib/layout/breadcrumbBar.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumbBar.jelly
@@ -44,10 +44,10 @@ THE SOFTWARE.
               <div id="auto-refresh" class="smallfont">
                 <j:choose>
                   <j:when test="${h.isAutoRefresh(request)}">
-                    <a href="?auto_refresh=false" class="auto-refresh-text-link">${%DISABLE AUTO REFRESH}</a>
+                    <a href="?auto_refresh=false" id="auto-refresh-on" class="auto-refresh-text-link">${%DISABLE AUTO REFRESH}</a>
                   </j:when>
                   <j:otherwise>
-                    <a href="?auto_refresh=true" class="auto-refresh-text-link">${%ENABLE AUTO REFRESH}</a>
+                    <a href="?auto_refresh=true" id="auto-refresh-off" class="auto-refresh-text-link">${%ENABLE AUTO REFRESH}</a>
                   </j:otherwise>
                 </j:choose>
               </div>


### PR DESCRIPTION
**TL;DR Minor UI fixes on ids and classnames in breadcrumbBar**

Also see previous PR #2989.

![image](https://user-images.githubusercontent.com/12599965/29526392-e042a23a-8695-11e7-8689-f30e1f501e0a.png)



### Proposed changelog entries

* breadcrumbBar
  * remove multiple occurrences of `right-top-nav` id from breadcrumb. (IDs should be unique!)
  * set ids and classes for autoRefresh links


### Submitter checklist

- ~[ ] JIRA issue is well described~ 
  * *Minor improvement, so no JIRA issue.*
- [x] Changelog entry appropriate for the audience affected by the change:
  * Internal, developer
- [x] Appropriate autotests or explanation to why this change has no tests
  * I has not tests, since changes a minor UI changes that would require an E2E test.
  * Changes have been tested in multiple browsers.
- ~[ ] For dependency updates: links to external changelogs and, if possible, full diffs~


### Desired reviewers

@i386 as mentioned in PR #2989 I am on small mission to fix UI bugs regarding ids and classes.
