### PR TITLE
[JENKINS-13153] - Use directory from env:BASE when writing jenkins.copies

### DIFF
--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -36,7 +36,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.FileWriter;
 import java.net.URL;
@@ -146,7 +145,7 @@ public class WindowsServiceLifecycle extends Lifecycle {
             throw new IOException(baos.toString());
     }
     
-    private static final File getBaseDir() throws FileNotFoundException {        
+    private static final File getBaseDir() {        
         File baseDir;
         
         String baseEnv = System.getenv("BASE");

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -145,7 +145,7 @@ public class WindowsServiceLifecycle extends Lifecycle {
             throw new IOException(baos.toString());
     }
     
-    private static final File getBaseDir() {        
+    private static final File getBaseDir() {
         File baseDir;
         
         String baseEnv = System.getenv("BASE");

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -146,13 +146,17 @@ public class WindowsServiceLifecycle extends Lifecycle {
             throw new IOException(baos.toString());
     }
     
-    private static final File getBaseDir() throws FileNotFoundException {
-        String baseEnv = System.getenv("BASE");
-        if (baseEnv == null) {
-            throw new FileNotFoundException("Unable to locate Jenkins base directory. Environment variable 'BASE' not found.");
-        }
+    private static final File getBaseDir() throws FileNotFoundException {        
+        File baseDir;
         
-        return new File(baseEnv);
+        String baseEnv = System.getenv("BASE");
+        if (baseEnv != null) {
+            baseDir = new File(baseEnv);
+        } else {
+            LOGGER.log(Level.WARNING, "Could not find environment variable 'BASE' for Jenkins base directory. Falling back to JENKINS_HOME");
+            baseDir = Jenkins.getInstance().getRootDir();
+        }
+        return baseDir;
     }
 
     private static final Logger LOGGER = Logger.getLogger(WindowsServiceLifecycle.class.getName());


### PR DESCRIPTION
… and when rewriting jenkins.exe

See [JENKINS-13153](https://issues.jenkins-ci.org/browse/JENKINS-13153).

"jenkins.copies" should be written to the folder containing the service wrapper executable(jenkins.exe). Currently, JENKINS_HOME is used. Using a custom JENKINS_HOME will cause the file to be written to a wrong directory. The service wrapper is setting the environment variable BASE which is the correct directory to use. 

### Proposed changelog entries

* Entry 1: JENKINS-13153, Fixing problem with Auto Upgrade when using custom JENKINS_HOME on Windows

