### PR TITLE
[JENKINS-35459] - Prevent Duplicated elements with incorrect URL when using the search on DashBoard View

### DIFF
--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -169,9 +169,8 @@ public class ListView extends View implements DirectlyModifiableView {
     public DescribableList<ListViewColumn, Descriptor<ListViewColumn>> getColumns() {
         return columns;
     }
-    
 
-     @Override
+
      public List<TopLevelItem> getItems() {
         return getItems(this.recurse);
      }
@@ -184,7 +183,7 @@ public class ListView extends View implements DirectlyModifiableView {
      * <p>
      * This method returns a separate copy each time to avoid
      * concurrent modification issue.
-     * @param recurse false not to recurse in ItemGroups
+     * @param recurse {@code false} not to recurse in ItemGroups
      * true to recurse in ItemGroups
      */
      private List<TopLevelItem> getItems(boolean recurse) {

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -178,14 +178,14 @@ public class ListView extends View implements DirectlyModifiableView {
 
 
     /**
-    * Returns a read-only view of all {@link Job}s in this view.
+     * Returns a read-only view of all {@link Job}s in this view.
      *
      *
      * <p>
-     *     This method returns a separate copy each time to avoid
-     *     concurrent modification issue.
-     *     @Param recurse false not to recurse in ItemGroups
-     *     true to recurse in ItemGroups
+     * This method returns a separate copy each time to avoid
+     * concurrent modification issue.
+     * @param recurse false not to recurse in ItemGroups
+     * true to recurse in ItemGroups
      */
      private List<TopLevelItem> getItems(boolean recurse) {
         SortedSet<String> names;
@@ -240,7 +240,7 @@ public class ListView extends View implements DirectlyModifiableView {
             }
         });
         // add the display name for each item in the search index
-        addDisplayNamesToSearchIndex(sib, getItems(false));
+        addDisplayNamesToSearchIndex(sib, getItems(true));
         return sib;
     }
 

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -29,6 +29,8 @@ import hudson.Util;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.Descriptor.FormException;
 import hudson.model.listeners.ItemListener;
+import hudson.search.CollectionSearchIndex;
+import hudson.search.SearchIndexBuilder;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.util.CaseInsensitiveComparator;
@@ -168,15 +170,24 @@ public class ListView extends View implements DirectlyModifiableView {
         return columns;
     }
     
+
+     @Override
+     public List<TopLevelItem> getItems() {
+        return getItems(this.recurse);
+     }
+
+
     /**
-     * Returns a read-only view of all {@link Job}s in this view.
+    * Returns a read-only view of all {@link Job}s in this view.
+     *
      *
      * <p>
-     * This method returns a separate copy each time to avoid
-     * concurrent modification issue.
+     *     This method returns a separate copy each time to avoid
+     *     concurrent modification issue.
+     *     @Param recurse false not to recurse in ItemGroups
+     *     true to recurse in ItemGroups
      */
-    @Override
-    public List<TopLevelItem> getItems() {
+     private List<TopLevelItem> getItems(boolean recurse) {
         SortedSet<String> names;
         List<TopLevelItem> items = new ArrayList<TopLevelItem>();
 
@@ -214,6 +225,23 @@ public class ListView extends View implements DirectlyModifiableView {
         items = new ArrayList<TopLevelItem>(new LinkedHashSet<TopLevelItem>(items));
         
         return items;
+    }
+
+    @Override
+    public SearchIndexBuilder makeSearchIndex() {
+        SearchIndexBuilder sib = new SearchIndexBuilder().addAllAnnotations(this);
+        sib.add(new CollectionSearchIndex<TopLevelItem>() {// for jobs in the view
+            protected TopLevelItem get(String key) { return getItem(key); }
+            protected Collection<TopLevelItem> all() { return getItems(); }
+            @Override
+            protected String getName(TopLevelItem o) {
+                // return the name instead of the display for suggestion searching
+                return o.getName();
+            }
+        });
+        // add the display name for each item in the search index
+        addDisplayNamesToSearchIndex(sib, getItems(false));
+        return sib;
     }
 
     private List<TopLevelItem> expand(Collection<TopLevelItem> items, List<TopLevelItem> allItems) {

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -478,7 +478,6 @@ public class SearchTest {
         j.assertGoodStatus(result);
 
         String content = result.getWebResponse().getContentAsString();
-        System.out.println(content);
         JSONObject jsonContent = (JSONObject)JSONSerializer.toJSON(content);
         assertNotNull(jsonContent);
         JSONArray jsonArray = jsonContent.getJSONArray("suggestions");

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -454,4 +454,44 @@ public class SearchTest {
         index.suggest(term, result);
         return result;
     }
+
+    @Issue("JENKINS-35459")
+    @Test
+    public void testProjectNameInAListView() throws Exception {
+        MockFolder myMockFolder = j.createFolder("folder");
+        FreeStyleProject freeStyleProject = myMockFolder.createProject(FreeStyleProject.class, "myJob");
+
+        ListView listView = new ListView("ListView", j.jenkins);
+        listView.setRecurse(true);
+        listView.add(myMockFolder);
+        listView.add(freeStyleProject);
+
+        j.jenkins.addView(listView);
+        j.jenkins.setPrimaryView(listView);
+
+        assertEquals(2, j.jenkins.getPrimaryView().getAllItems().size());
+
+        WebClient wc = j.createWebClient();
+        Page result = wc.goTo("search/suggest?query=" + freeStyleProject.getName(), "application/json");
+
+        assertNotNull(result);
+        j.assertGoodStatus(result);
+
+        String content = result.getWebResponse().getContentAsString();
+        System.out.println(content);
+        JSONObject jsonContent = (JSONObject)JSONSerializer.toJSON(content);
+        assertNotNull(jsonContent);
+        JSONArray jsonArray = jsonContent.getJSONArray("suggestions");
+        assertNotNull(jsonArray);
+
+        assertEquals(1, jsonArray.size());
+
+        Page searchResult = wc.goTo("search?q=" + myMockFolder.getName() + "%2F" + freeStyleProject.getName());
+
+        assertNotNull(searchResult);
+        j.assertGoodStatus(searchResult);
+
+        URL resultUrl = searchResult.getUrl();
+        assertTrue(resultUrl.toString().equals(j.getInstance().getRootUrl() + freeStyleProject.getUrl()));
+    }
 }

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -484,7 +484,7 @@ public class SearchTest {
         JSONArray jsonArray = jsonContent.getJSONArray("suggestions");
         assertNotNull(jsonArray);
 
-        assertEquals(1, jsonArray.size());
+        assertEquals(2, jsonArray.size());
 
         Page searchResult = wc.goTo("search?q=" + myMockFolder.getName() + "%2F" + freeStyleProject.getName());
 


### PR DESCRIPTION
Fixing the search bar not working for folders because Felix’s PR is
good: https://github.com/jenkinsci/jenkins/pull/2401 but needed to fix
some tests

https://issues.jenkins-ci.org/browse/JENKINS-35459

### Changelog entry

* JENKINS-35459, Bug: Prevent Duplicated elements with incorrect URL when using the search on DashBoard View
