### PR TITLE
Default the built-in Jenkins Update Center URL to https://updates.jenkins.io

### DIFF
--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -132,18 +132,6 @@ public class DownloadService extends PageDecorator {
     }
 
     private String mapHttps(String url) {
-        /*
-            HACKISH:
-
-            Loading scripts in HTTP from HTTPS pages cause browsers to issue a warning dialog.
-            The elegant way to solve the problem is to always load update center from HTTPS,
-            but our backend mirroring scheme isn't ready for that. So this hack serves regular
-            traffic in HTTP server, and only use HTTPS update center for Jenkins in HTTPS.
-
-            We'll monitor the traffic to see if we can sustain this added traffic.
-         */
-        if (url.startsWith("http://updates.jenkins-ci.org/") && Jenkins.getInstance().isRootUrlSecure())
-            return "https"+url.substring(4);
         return url;
     }
 

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -148,7 +148,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 @ExportedBean
 public class UpdateCenter extends AbstractModelObject implements Saveable, OnMaster {
 
-    private static final String UPDATE_CENTER_URL = SystemProperties.getString(UpdateCenter.class.getName()+".updateCenterUrl","http://updates.jenkins-ci.org/");
+    private static final String UPDATE_CENTER_URL = SystemProperties.getString(UpdateCenter.class.getName()+".updateCenterUrl","https://updates.jenkins.io/");
 
     /**
      * Read timeout when downloading plugins, defaults to 1 minute

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -485,18 +485,6 @@ public class UpdateSite {
      */
     @Deprecated
     public String getDownloadUrl() {
-        /*
-            HACKISH:
-
-            Loading scripts in HTTP from HTTPS pages cause browsers to issue a warning dialog.
-            The elegant way to solve the problem is to always load update center from HTTPS,
-            but our backend mirroring scheme isn't ready for that. So this hack serves regular
-            traffic in HTTP server, and only use HTTPS update center for Jenkins in HTTPS.
-
-            We'll monitor the traffic to see if we can sustain this added traffic.
-         */
-        if (url.equals("http://updates.jenkins-ci.org/update-center.json") && Jenkins.getInstance().isRootUrlSecure())
-            return "https"+url.substring(4);
         return url;
     }
 

--- a/test/src/test/java/hudson/model/UpdateCenterTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterTest.java
@@ -44,8 +44,8 @@ import org.junit.Test;
 public class UpdateCenterTest {
     @Test public void data() throws Exception {
         try {
-            doData("http://updates.jenkins-ci.org/update-center.json?version=build");
-            doData("http://updates.jenkins-ci.org/stable/update-center.json?version=build");
+            doData("https://updates.jenkins.io/update-center.json?version=build");
+            doData("https://updates.jenkins.io/stable/update-center.json?version=build");
         } catch (Exception x) {
             // TODO this should not be in core at all; should be in repo built by a separate job somewhere
             assumeNoException("Might be no Internet connectivity, or might start failing due to expiring certificate through no fault of code changes", x);


### PR DESCRIPTION
Now that we're using JDK8, we can rely on our Let's Encrypt-based certificates
on *.jenkins.io

Live from Jenkins World!

### Changelog:

* Default the built-in Jenkins Update Center URL to https://updates.jenkins.io instead of obsolete HTTP endpoint

Signed-off-by: M. Allan <max.allan@surevine.com>
Signed-off-by: R. Tyler Croy <tyler@monkeypox.org>
