### PR TITLE
[Fix JENKINS-46161] Make ReverseBuildTrigger#getUpstreamProjects null…

### DIFF
--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -76,6 +76,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
@@ -91,6 +92,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
 
     private static final Logger LOGGER = Logger.getLogger(ReverseBuildTrigger.class.getName());
 
+    @CheckForNull
     private String upstreamProjects;
     private Result threshold = Result.SUCCESS;
 
@@ -109,6 +111,11 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
         this.upstreamProjects = upstreamProjects;
     }
 
+    /**
+     * Gets the upstream projects.
+     * 
+     * @return Upstream projects or empty("") if upstream projects is null.
+     */
     public String getUpstreamProjects() {
         return Util.fixNull(upstreamProjects);
     }

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -110,7 +110,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     }
 
     public String getUpstreamProjects() {
-        return upstreamProjects;
+        return Util.fixNull(upstreamProjects);
     }
 
     public Result getThreshold() {
@@ -170,7 +170,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     }
 
     @Override public void buildDependencyGraph(final AbstractProject downstream, DependencyGraph graph) {
-        for (AbstractProject upstream : Items.fromNameList(downstream.getParent(), Util.fixNull(upstreamProjects), AbstractProject.class)) {
+        for (AbstractProject upstream : Items.fromNameList(downstream.getParent(), getUpstreamProjects(), AbstractProject.class)) {
             graph.addDependency(new DependencyGraph.Dependency(upstream, downstream) {
                 @Override public boolean shouldTriggerBuild(AbstractBuild upstreamBuild, TaskListener listener, List<Action> actions) {
                     return shouldTrigger(upstreamBuild, listener);
@@ -253,7 +253,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
                         continue;
                     }
                     List<Job> upstreams =
-                            Items.fromNameList(downstream.getParent(), Util.fixNull(trigger.upstreamProjects), Job.class);
+                            Items.fromNameList(downstream.getParent(), trigger.getUpstreamProjects(), Job.class);
                     LOGGER.log(Level.FINE, "from {0} see upstreams {1}", new Object[]{downstream, upstreams});
                     for (Job upstream : upstreams) {
                         if (upstream instanceof AbstractProject && downstream instanceof AbstractProject) {
@@ -311,7 +311,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
                     if (t != null) {
                         String revised =
                                 Items.computeRelativeNamesAfterRenaming(oldFullName, newFullName,
-                                        Util.fixNull(t.upstreamProjects), p.getParent());
+                                        t.getUpstreamProjects(), p.getParent());
                         if (!revised.equals(t.upstreamProjects)) {
                             t.upstreamProjects = revised;
                             try {

--- a/test/src/test/java/jenkins/triggers/ReverseBuildTriggerTest.java
+++ b/test/src/test/java/jenkins/triggers/ReverseBuildTriggerTest.java
@@ -224,4 +224,20 @@ public class ReverseBuildTriggerTest {
         // ReverseBuildTrigger.RunListenerImpl, so an additional test may be needed downstream.
         trigger.buildDependencyGraph(downstreamJob1, Jenkins.getInstance().getDependencyGraph());
     }
+
+    @Issue("JENKINS-46161")
+    @Test
+    public void testGetUpstreamProjectsShouldNullSafe() throws Exception {
+        ReverseBuildTrigger trigger1 = new ReverseBuildTrigger(null);
+        String upstream1 = trigger1.getUpstreamProjects();
+        assertEquals("", upstream1);
+
+        ReverseBuildTrigger trigger2 = new ReverseBuildTrigger("upstream");
+        String upstream2 = trigger2.getUpstreamProjects();
+        assertEquals("upstream", upstream2);
+
+        ReverseBuildTrigger trigger3 = new ReverseBuildTrigger("");
+        String upstream3 = trigger3.getUpstreamProjects();
+        assertEquals("", upstream3);
+    }
 }


### PR DESCRIPTION
…-safe

See [JENKINS-46161](https://issues.jenkins-ci.org/browse/JENKINS-46161).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev 

