### PR TITLE
Update manage_da.properties, fix typo

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/manage_da.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage_da.properties
@@ -22,7 +22,7 @@
 
 Add,\ remove,\ control\ and\ monitor\ the\ various\ nodes\ that\ Jenkins\ runs\ jobs\ on.=Tilf\u00F8j, slet, h\u00E5ndter og overv\u00E5g de forskellige noder som Jenkins k\u00F8rer jobs p\u00E5.
 Jenkins\ CLI=Jenkins CLI (kommandolinie)
-Manage\ Jenkins=Andministr\u00E9r Jenkins
+Manage\ Jenkins=Administr\u00E9r Jenkins
 Manage\ Nodes=Bestyr noder
 Prepare\ for\ Shutdown=Forbered nedlukning
 are.you.sure={0}: er du sikker?


### PR DESCRIPTION
There was a simple typo. Andministrer is not a word in danish, while administrer is.



### Proposed changelog entries

* Entry 1: Typo, fix in Danish localization
