### PR TITLE
[Fix JENKINS-23411] Throws Failure if the item does not exist

### DIFF
--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -380,7 +380,7 @@ public class ListView extends View implements DirectlyModifiableView {
 
         TopLevelItem item = resolveName(name);
         if (item==null)
-            throw new Failure("Query parameter 'name' does not correspond to a known item");
+            throw new Failure("Query parameter 'name' does not correspond to a known and readable item");
 
         if (remove(item))
             owner.save();

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -45,6 +45,7 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.concurrent.GuardedBy;
 import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
@@ -378,13 +379,16 @@ public class ListView extends View implements DirectlyModifiableView {
             throw new Failure("Query parameter 'name' is required");
 
         TopLevelItem item = resolveName(name);
+        if (item==null)
+            throw new Failure("Query parameter 'name' does not correspond to a known item");
+
         if (remove(item))
             owner.save();
 
         return HttpResponses.ok();
     }
 
-    private TopLevelItem resolveName(String name) {
+    private @CheckForNull TopLevelItem resolveName(String name) {
         TopLevelItem item = getOwner().getItemGroup().getItem(name);
         if (item == null) {
             name = Items.getCanonicalName(getOwner().getItemGroup(), name);

--- a/test/src/test/java/hudson/model/ListViewTest.java
+++ b/test/src/test/java/hudson/model/ListViewTest.java
@@ -259,6 +259,32 @@ public class ListViewTest {
         assertEquals("job1", items.get(0).getName());
     }
 
+    @Issue("JENKINS-23411")
+    @Test public void doRemoveJobFromViewNullItem() throws Exception {
+        MockFolder folder = j.createFolder("folder");
+        ListView view = new ListView("view", folder);
+        folder.addView(view);
+        FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job1");
+        view.add(job);
+        
+        List<TopLevelItem> items = view.getItems();
+        assertEquals(1, items.size());
+        assertEquals("job1", items.get(0).getName());
+
+        // remove a contained job
+        view.doRemoveJobFromView("job1");
+        List<TopLevelItem> itemsNow = view.getItems();
+        assertEquals(0, itemsNow.size());
+        
+        // remove a not contained job
+        try {
+            view.doRemoveJobFromView("job2");
+            fail("Remove job2");
+        } catch(Failure e) {
+            assertEquals(e.getMessage(), "Query parameter 'name' does not correspond to a known item");
+        }
+    }
+
     private static class AllButViewsAuthorizationStrategy extends AuthorizationStrategy {
         @Override public ACL getRootACL() {
             return UNSECURED.getRootACL();


### PR DESCRIPTION
See [JENKINS-23411](https://issues.jenkins-ci.org/browse/JENKINS-23411).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->
Another option is swallow the exception. Happy to hear any comments.

### Proposed changelog entries

* BUG: Prevent NullPointerException when deleting an item from List View happens in parallel with another item deletion (race condition).
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
