### PR TITLE
[JENKINS-46759] Fixed bug in build queue filtering for views

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -114,6 +114,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jenkins.scm.RunWithSCM.*;
@@ -455,34 +456,49 @@ public abstract class View extends AbstractModelObject implements AccessControll
         return false;
     }
 
+    private final static int FILTER_LOOP_MAX_COUNT = 10;
+
     private List<Queue.Item> filterQueue(List<Queue.Item> base) {
         if (!isFilterQueue()) {
             return base;
         }
-
         Collection<TopLevelItem> items = getItems();
-        List<Queue.Item> result = new ArrayList<Queue.Item>();
-        for (Queue.Item qi : base) {
-            // Check if the task of parent tasks are in the list of items.
-            // Pipeline jobs and other jobs which allow parts require us to
-            // check owner tasks as well.
-            Queue.Task currentTask = null;
-            do {
-                currentTask = currentTask == null ? qi.task : currentTask.getOwnerTask();
-                if (items.contains(currentTask)) {
-                    result.add(qi);
-                    break;
-                }
-            } while (currentTask.getOwnerTask() != currentTask);
-            // Check root project for sub-job projects (e.g. matrix jobs).
-            if (qi.task instanceof AbstractProject<?, ?>) {
-                AbstractProject<?,?> project = (AbstractProject<?, ?>) qi.task;
-                if (items.contains(project.getRootProject())) {
-                    result.add(qi);
-                }
+        return base.stream().filter(qi -> filterQueueItemTest(qi, items))
+                .collect(Collectors.toList());
+    }
+
+    private boolean filterQueueItemTest(Queue.Item item, Collection<TopLevelItem> viewItems) {
+        // Check if the task of parent tasks are in the list of viewItems.
+        // Pipeline jobs and other jobs which allow parts require us to
+        // check owner tasks as well.
+        Queue.Task currentTask = item.task;
+        for (int count = 1;; count++) {
+            if (viewItems.contains(currentTask)) {
+                return true;
+            }
+            Queue.Task next = currentTask.getOwnerTask();
+            if (next == currentTask) {
+                break;
+            } else {
+                currentTask = next;
+            }
+            if (count == FILTER_LOOP_MAX_COUNT) {
+                LOGGER.warning(String.format(
+                        "Failed to find root task for queue item '%s' for " +
+                        "view '%s' in under %d iterations, aborting!",
+                        item.getDisplayName(), getDisplayName(),
+                        FILTER_LOOP_MAX_COUNT));
+                break;
             }
         }
-        return result;
+        // Check root project for sub-job projects (e.g. matrix jobs).
+        if (item.task instanceof AbstractProject<?, ?>) {
+            AbstractProject<?,?> project = (AbstractProject<?, ?>) item.task;
+            if (viewItems.contains(project.getRootProject())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public List<Queue.Item> getQueueItems() {

--- a/core/src/test/java/hudson/model/MockItem.java
+++ b/core/src/test/java/hudson/model/MockItem.java
@@ -37,6 +37,10 @@ public class MockItem extends Queue.Item {
         super(null, Collections.<Action>emptyList(), id, null);
     }
 
+    public MockItem(Queue.Task task) {
+        super(task, Collections.emptyList(), -1, null);
+    }
+
     public MockItem(Queue.Task task, List<Action> actions, long id) {
         super(task, actions, id, null);
     }

--- a/core/src/test/java/hudson/model/ViewTest.java
+++ b/core/src/test/java/hudson/model/ViewTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
 
 public class ViewTest {
 
@@ -110,6 +111,62 @@ public class ViewTest {
         final TopLevelItem rootJob = Mockito.mock(TopLevelItem.class);
         Mockito.when(rootJob.getDisplayName()).thenReturn(jobName);
         return rootJob;
+    }
+
+    @Test
+    public void buildQueueFiltering() throws Exception {
+        // Mimic a freestyle job
+        FreeStyleProject singleItemJob = Mockito.mock(FreeStyleProject.class);
+        Mockito.when(singleItemJob.getOwnerTask()).thenReturn(singleItemJob);
+        Queue.Item singleItemQueueItem = new MockItem(singleItemJob);
+
+        // Mimic pattern of a Matrix job, i.e. with root item in view and sub
+        // items in queue.
+        FreeStyleProject multiItemJob = Mockito.mock(FreeStyleProject.class);
+        Project multiItemSubJob = Mockito.mock(Project.class);
+        Mockito.when(multiItemSubJob.getRootProject()).thenReturn(multiItemJob);
+        Mockito.when(multiItemSubJob.getOwnerTask()).thenReturn(multiItemSubJob);
+        Queue.Item multiItemQueueItem = new MockItem(multiItemSubJob);
+
+        // Mimic pattern of a Pipeline job, i.e. with item in view and
+        // sub-steps in queue.
+        BuildableTopLevelItem multiStepJob
+                = Mockito.mock(BuildableTopLevelItem.class);
+        Mockito.when(multiStepJob.getOwnerTask()).thenReturn(multiStepJob);
+        BuildableItem multiStepSubStep = Mockito.mock(BuildableItem.class);
+        Mockito.when(multiStepSubStep.getOwnerTask()).thenReturn(multiStepJob);
+        Queue.Item multiStepQueueItem = new MockItem(multiStepSubStep);
+
+        // Construct the view
+        View view = Mockito.mock(View.class);
+        List<Queue.Item> queue = Arrays.asList(singleItemQueueItem,
+                multiItemQueueItem, multiStepQueueItem);
+        Mockito.when(view.isFilterQueue()).thenReturn(true);
+
+        // Positive test, ensure that queue items are included
+        List<TopLevelItem> viewJobs = Arrays.asList(singleItemJob, multiItemJob, multiStepJob);
+        Mockito.when(view.getItems()).thenReturn(viewJobs);
+        assertEquals(
+                Arrays.asList(singleItemQueueItem,
+                        multiItemQueueItem, multiStepQueueItem),
+                Whitebox.invokeMethod(view, "filterQueue", queue)
+        );
+
+        // Negative test, ensure that queue items are excluded
+        Mockito.when(view.getItems()).thenReturn(Collections.emptyList());
+        List<Queue.Item> expected = Arrays.asList(singleItemQueueItem,
+                multiItemQueueItem, multiStepQueueItem);
+        assertEquals(
+                Collections.emptyList(),
+                Whitebox.<List<Queue.Item>>invokeMethod(view, "filterQueue", queue)
+        );
+    }
+
+    /**
+     * This interface fulfills both TopLevelItem and BuildableItem interface,
+     * this allows it for being present in a view as well as the build queue!
+     */
+    private interface BuildableTopLevelItem extends TopLevelItem, BuildableItem {
     }
 
     public static class CompositeView extends View implements ViewGroup {


### PR DESCRIPTION
Fixed so that pipeline build parts show up in the build queue of views which filter build queue.
I've created a test case but I'm not 100% sure that this is the best way to test it, feedback is very much appreciated!

See [JENKINS-46759](https://issues.jenkins-ci.org/browse/JENKINS-46759).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fixed so that pipeline build parts show up in the build queue of views which filter build queue

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

