### PR TITLE
Make Computer a DescriptorByNameOwner

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -523,10 +523,6 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         }
     }
 
-    public Descriptor getDescriptorByName(String className) {
-        return Jenkins.getInstance().getDescriptorByName(className);
-    }
-
     /**
      * Accepts the new description.
      */

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1624,11 +1624,6 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         }
     }
 
-    @Override
-    public Descriptor getDescriptorByName(String className) {
-        return Jenkins.getInstance().getDescriptorByName(className);
-    }
-
     /**
      * A value class to provide a consistent snapshot view of the state of an executor to avoid race conditions
      * during rendering of the executors list.

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -147,7 +147,7 @@ import static javax.servlet.http.HttpServletResponse.*;
  * @author Kohsuke Kawaguchi
  */
 @ExportedBean
-public /*transient*/ abstract class Computer extends Actionable implements AccessControlled, ExecutorListener {
+public /*transient*/ abstract class Computer extends Actionable implements AccessControlled, ExecutorListener, DescriptorByNameOwner {
 
     private final CopyOnWriteArrayList<Executor> executors = new CopyOnWriteArrayList<Executor>();
     // TODO:
@@ -1622,6 +1622,11 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
                 assert false;
             }
         }
+    }
+
+    @Override
+    public Descriptor getDescriptorByName(String className) {
+        return Jenkins.getInstance().getDescriptorByName(className);
     }
 
     /**

--- a/core/src/main/java/hudson/model/DescriptorByNameOwner.java
+++ b/core/src/main/java/hudson/model/DescriptorByNameOwner.java
@@ -23,6 +23,8 @@
  */
 package hudson.model;
 
+import jenkins.model.Jenkins;
+
 /**
  * Adds {@link #getDescriptorByName(String)} to bind {@link Descriptor}s to URL.
  * Binding them at some specific object (instead of {@link jenkins.model.Jenkins}), allows
@@ -46,5 +48,7 @@ public interface DescriptorByNameOwner extends ModelObject {
      * @param id
      *      Either {@link Descriptor#getId()} (recommended) or the short name.
      */
-    Descriptor getDescriptorByName(String id);    
+    default Descriptor getDescriptorByName(String id) {
+        return Jenkins.getInstance().getDescriptorByName(id);
+    }
 }

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1015,11 +1015,6 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         return id != null ? id : Integer.toString(number);
     }
     
-    @Override
-    public @CheckForNull Descriptor getDescriptorByName(String className) {
-        return Jenkins.getInstance().getDescriptorByName(className);
-    }
-
     /**
      * Get the root directory of this {@link Run} on the master.
      * Files related to this {@link Run} should be stored below this directory.

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -935,10 +935,6 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
         return r;
     }
 
-    public Descriptor getDescriptorByName(String className) {
-        return Jenkins.getInstance().getDescriptorByName(className);
-    }
-    
     public Object getDynamic(String token) {
         for(Action action: getTransientActions()){
             if(Objects.equals(action.getUrlName(), token))


### PR DESCRIPTION
This will allow Computers to be used as AncestorInPath e.g. for
form validation.

---

Too trivial for new tests, or have an issue. Downstream demo PR could be a followup to https://github.com/jenkinsci/matrix-auth-plugin/pull/18/files#diff-4846dbdfaa05c64975de0e83c8b4273fR169 which more clearly demos the new behavior as that PR gracefully falls back to Overall/Administer if there's no `@AncestorInPath Computer`.

Tested locally with a snapshot though, and someone without Administer (just Computer/Configure) gets the form validation there.

CC @jglick who requested this.

### Proposed changelog entries

* Internal: `Computer` is now a `DescriptorByNameOwner` allowing its use as `@AncestorInPath`

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [WIP] For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc)
