### PR TITLE
[Fix JENKINS-42577] Save jenkins version in Jenkins.save()

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3181,6 +3181,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     public synchronized void save() throws IOException {
         if(BulkChange.contains(this))   return;
+        version = VERSION;
+
         getConfigFile().write(this);
         SaveableListener.fireOnChange(this, getConfigFile());
     }
@@ -3658,9 +3660,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             boolean result = true;
             for (Descriptor<?> d : Functions.getSortedDescriptorsForGlobalConfigUnclassified())
                 result &= configureDescriptor(req,json,d);
-
-            version = VERSION;
-
+            
             save();
             updateComputerList();
             if(result)

--- a/test/src/test/java/jenkins/install/InstallUtilTest.java
+++ b/test/src/test/java/jenkins/install/InstallUtilTest.java
@@ -23,7 +23,6 @@
  */
 package jenkins.install;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -81,6 +80,9 @@ public class InstallUtilTest {
      */
     @Test
     public void test_typeTransitions() {
+        InstallUtil.getLastExecVersionFile().delete();
+        InstallUtil.getConfigFile().delete();
+        
         // A new test instance sets up security first
         Assert.assertEquals(InstallState.INITIAL_SECURITY_SETUP, InstallUtil.getNextInstallState(InstallState.UNKNOWN));
 
@@ -127,12 +129,10 @@ public class InstallUtilTest {
     }
 
     private void setStoredVersion(String version) throws Exception {
-        Field versionField = Jenkins.class.getDeclaredField("version");
-        versionField.setAccessible(true);
-        versionField.set(jenkinsRule.jenkins, version);
-        Assert.assertEquals(version, Jenkins.getStoredVersion().toString());
+        Jenkins.VERSION = version;
         // Force a save of the config.xml
         jenkinsRule.jenkins.save();
+        Assert.assertEquals(version, Jenkins.getStoredVersion().toString());
     }
 
     /**

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -62,6 +62,7 @@ import hudson.slaves.ComputerListener;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
 import hudson.util.FormValidation;
+import hudson.util.VersionNumber;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -600,5 +601,20 @@ public class JenkinsTest {
                 j.jenkins.getAgentProtocols(), not(hasItem(protocolToDisable1)));
         assertThat(protocolToDisable2 + " must be disabled after the roundtrip", 
                 j.jenkins.getAgentProtocols(), not(hasItem(protocolToDisable2)));
+    }
+
+    @Issue("JENKINS-42577")
+    @Test
+    public void versionIsSavedInSave() throws Exception {
+        Jenkins.VERSION = "1.0";
+        j.jenkins.save();
+        VersionNumber storedVersion = Jenkins.getStoredVersion();
+        assertNotNull(storedVersion);
+        assertEquals(storedVersion.toString(), "1.0");
+
+        Jenkins.VERSION = null;
+        j.jenkins.save();
+        VersionNumber nullVersion = Jenkins.getStoredVersion();
+        assertNull(nullVersion);
     }
 }


### PR DESCRIPTION
See [JENKINS-42577](https://issues.jenkins-ci.org/browse/JENKINS-42577).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* BUG: Fix persistence of actual Jenkins version in config.xml when saving Jenkins configuration programatically. It solves issues in upgrade logic checks (e.g. Jenkins.isUpgradedFromBefore)
  *  Javadoc link: http://javadoc.jenkins.io/jenkins/model/Jenkins.html#isUpgradedFromBefore-hudson.util.VersionNumber-
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Desired reviewers

@jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
