### PR TITLE
[JENKINS-46659] Avoid Jetty timeouts by sending pings

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -704,6 +704,22 @@ public class CLI implements AutoCloseable {
                     }
                 }
             }.start();
+            new Thread("ping") { // JENKINS-46659
+                @Override
+                public void run() {
+                    try {
+                        Thread.sleep(10_000);
+                        while (!connection.complete) {
+                            LOGGER.fine("sending ping");
+                            connection.sendEncoding(Charset.defaultCharset().name()); // no-op at this point
+                            Thread.sleep(10_000);
+                        }
+                    } catch (IOException | InterruptedException x) {
+                        LOGGER.log(Level.WARNING, null, x);
+                    }
+                }
+
+            }.start();
             synchronized (connection) {
                 while (!connection.complete) {
                     connection.wait();

--- a/cli/src/main/java/hudson/cli/PlainCLIProtocol.java
+++ b/cli/src/main/java/hudson/cli/PlainCLIProtocol.java
@@ -34,7 +34,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadPendingException;
-import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.IOUtils;
@@ -112,13 +111,6 @@ class PlainCLIProtocol {
                         } catch (EOFException x) {
                             handleClose();
                             break; // TODO verify that we hit EOF immediately, not partway into framelen
-                        } catch (IOException x) {
-                            if (x.getCause() instanceof TimeoutException) { // TODO on Tomcat this seems to be SocketTimeoutException
-                                LOGGER.log(Level.FINE, "ignoring idle timeout, perhaps from Jetty", x);
-                                continue;
-                            } else {
-                                throw x;
-                            }
                         }
                         if (framelen < 0) {
                             throw new IOException("corrupt stream: negative frame length");

--- a/test/src/test/java/hudson/cli/CLIActionTest.java
+++ b/test/src/test/java/hudson/cli/CLIActionTest.java
@@ -40,7 +40,6 @@ import org.apache.commons.io.output.TeeOutputStream;
 import org.codehaus.groovy.runtime.Security218;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -256,7 +255,6 @@ public class CLIActionTest {
         // -ssh mode does not pass client locale or encoding
     }
 
-    @Ignore("TODO JENKINS-46659 seems to be broken")
     @Issue("JENKINS-41745")
     @Test
     public void interleavedStdio() throws Exception {


### PR DESCRIPTION
See [JENKINS-46659](https://issues.jenkins-ci.org/browse/JENKINS-46659).

### Proposed changelog entries

* Avoid a possible server-side timeout on long-running CLI commands using plain HTTP mode by sending periodic pings from the client.

### Desired reviewers

@reviewbybees