### PR TITLE
[JENKINS-46760] - Disabled Agent Protocol monitor should not print warnings when TCP Agent port is disabled

### DIFF
--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.CheckForSigned;
 
 import javax.servlet.ServletException;
 
@@ -72,6 +73,12 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
         return Jenkins.getInstance().getMarkupFormatter();
     }
 
+    /**
+     * Get TCP port, which is used to connect Jenkins agents, Remoting CLI and other remote components.
+     * @return {@code 0} for random, {@code -1} to disable. 
+     *         Port number otherwise.
+     */
+    @CheckForSigned
     public int getSlaveAgentPort() {
         return Jenkins.getInstance().getSlaveAgentPort();
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1121,6 +1121,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return adjuncts;
     }
 
+    /**
+     * Get TCP port, which is used to connect Jenkins agents, Remoting CLI and other remote components.
+     * @return {@code 0} for random, {@code -1} to disable. 
+     *         Port number otherwise.
+     */
     @Exported
     public int getSlaveAgentPort() {
         return slaveAgentPort;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -294,6 +294,7 @@ import static hudson.init.InitMilestone.*;
 import hudson.init.Initializer;
 import hudson.util.LogTaskListener;
 import static java.util.logging.Level.*;
+import javax.annotation.CheckForSigned;
 import static javax.servlet.http.HttpServletResponse.*;
 import org.kohsuke.stapler.WebMethod;
 
@@ -576,10 +577,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     /**
      * TCP agent port.
-     * 0 for random, -1 to disable.
+     * {@code 0} for random, {@code -1} to disable.
      */
+    @CheckForSigned
     private int slaveAgentPort = getSlaveAgentPortInitialValue(0);
 
+    @CheckForSigned
     private static int getSlaveAgentPortInitialValue(int def) {
         return SystemProperties.getInteger(Jenkins.class.getName()+".slaveAgentPort", def);
     }
@@ -1127,6 +1130,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *         Port number otherwise.
      */
     @Exported
+    @CheckForSigned
     public int getSlaveAgentPort() {
         return slaveAgentPort;
     }
@@ -1279,6 +1283,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return Jenkins.class.getName() + ".slaveAgentPort";
         }
 
+        @CheckForSigned
         public int getExpectedPort() {
             int slaveAgentPort = j.slaveAgentPort;
             return Jenkins.getSlaveAgentPortInitialValue(slaveAgentPort);

--- a/core/src/main/java/jenkins/slaves/DeprecatedAgentProtocolMonitor.java
+++ b/core/src/main/java/jenkins/slaves/DeprecatedAgentProtocolMonitor.java
@@ -102,17 +102,4 @@ public class DeprecatedAgentProtocolMonitor extends AdministrativeMonitor {
         }
         return StringUtils.join(deprecatedProtocols, ',');
     }
-    
-    @Initializer(after = InitMilestone.JOB_LOADED)
-    @Restricted(NoExternalUse.class)
-    public static void initializerCheck() {
-        String protocols = getDeprecatedProtocolsString();
-        if(Jenkins.getInstance().getSlaveAgentPort() != -1 && protocols != null) {
-            LOGGER.log(Level.WARNING, "This Jenkins instance uses deprecated Remoting protocols: {0}"
-                    + "It may impact stability of the instance. " 
-                    + "If newer protocol versions are supported by all system components "
-                    + "(agents, CLI and other clients), "
-                    + "it is highly recommended to disable the deprecated protocols.", protocols);
-        } 
-    }
 }

--- a/core/src/main/java/jenkins/slaves/DeprecatedAgentProtocolMonitor.java
+++ b/core/src/main/java/jenkins/slaves/DeprecatedAgentProtocolMonitor.java
@@ -107,7 +107,7 @@ public class DeprecatedAgentProtocolMonitor extends AdministrativeMonitor {
     @Restricted(NoExternalUse.class)
     public static void initializerCheck() {
         String protocols = getDeprecatedProtocolsString();
-        if(protocols != null) {
+        if(Jenkins.getInstance().getSlaveAgentPort() != -1 && protocols != null) {
             LOGGER.log(Level.WARNING, "This Jenkins instance uses deprecated Remoting protocols: {0}"
                     + "It may impact stability of the instance. " 
                     + "If newer protocol versions are supported by all system components "

--- a/core/src/main/java/jenkins/slaves/DeprecatedAgentProtocolMonitor.java
+++ b/core/src/main/java/jenkins/slaves/DeprecatedAgentProtocolMonitor.java
@@ -66,7 +66,12 @@ public class DeprecatedAgentProtocolMonitor extends AdministrativeMonitor {
 
     @Override
     public boolean isActivated() {
-        final Set<String> agentProtocols = Jenkins.getInstance().getAgentProtocols();
+        final Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins.getSlaveAgentPort() == -1) {
+            // TCP Agent Port is disabled, no need to worry about enabled protocols, right?
+            return false;
+        }
+        final Set<String> agentProtocols = jenkins.getAgentProtocols();
         for (String name : agentProtocols) {
             AgentProtocol pr = AgentProtocol.of(name);
             if (pr != null && pr.isDeprecated()) {

--- a/test/src/test/java/jenkins/slaves/DeprecatedAgentProtocolMonitorTest.java
+++ b/test/src/test/java/jenkins/slaves/DeprecatedAgentProtocolMonitorTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Oleg Nenashev.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.slaves;
+
+import static jenkins.AgentProtocolTest.assertMonitorNotActive;
+import static jenkins.AgentProtocolTest.assertProtocols;
+import static jenkins.AgentProtocolTest.assertMonitorTriggered;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+/**
+ * Tests for {@link DeprecatedAgentProtocolMonitor}
+ * @author Oleg Nenashev
+ */
+public class DeprecatedAgentProtocolMonitorTest {
+    
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    /**
+     * Checks that Jenkins does not disable agent protocols by default after the upgrade.
+     * 
+     * @throws Exception Test failure
+     * @see SetupWizardTest#shouldDisableUnencryptedProtocolsByDefault() 
+     */
+    @Test
+    @LocalData
+    @Issue("JENKINS-45841")
+    public void noAdministrativeMonitorWhenPortIsDisabled() throws Exception {
+        assertProtocols(j.jenkins, true, "Legacy Non-encrypted JNLP/CLI protocols should be enabled", 
+                "JNLP-connect", "JNLP2-connect", "JNLP4-connect", "CLI-connect");
+        assertProtocols(j.jenkins, true, "Default encrypted protocols should be enabled", "JNLP4-connect", "CLI2-connect");
+        assertProtocols(j.jenkins, true, "Protocol should be enabled due to CLI settings", "CLI2-connect");
+        assertProtocols(j.jenkins, false, "JNLP3-connect protocol should be disabled by default", "JNLP3-connect");
+        assertMonitorNotActive();
+    }
+}

--- a/test/src/test/java/jenkins/slaves/DeprecatedAgentProtocolMonitorTest.java
+++ b/test/src/test/java/jenkins/slaves/DeprecatedAgentProtocolMonitorTest.java
@@ -25,7 +25,6 @@ package jenkins.slaves;
 
 import static jenkins.AgentProtocolTest.assertMonitorNotActive;
 import static jenkins.AgentProtocolTest.assertProtocols;
-import static jenkins.AgentProtocolTest.assertMonitorTriggered;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -41,15 +40,9 @@ public class DeprecatedAgentProtocolMonitorTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
     
-    /**
-     * Checks that Jenkins does not disable agent protocols by default after the upgrade.
-     * 
-     * @throws Exception Test failure
-     * @see SetupWizardTest#shouldDisableUnencryptedProtocolsByDefault() 
-     */
     @Test
     @LocalData
-    @Issue("JENKINS-45841")
+    @Issue("JENKINS-46760")
     public void noAdministrativeMonitorWhenPortIsDisabled() throws Exception {
         assertProtocols(j.jenkins, true, "Legacy Non-encrypted JNLP/CLI protocols should be enabled", 
                 "JNLP-connect", "JNLP2-connect", "JNLP4-connect", "CLI-connect");

--- a/test/src/test/resources/jenkins/AgentProtocolTest/testShouldDisableCLIProtocolsWhenCLIisDisabled/config.xml
+++ b/test/src/test/resources/jenkins/AgentProtocolTest/testShouldDisableCLIProtocolsWhenCLIisDisabled/config.xml
@@ -27,7 +27,7 @@
     </hudson.model.AllView>
   </views>
   <primaryView>all</primaryView>
-  <slaveAgentPort>0</slaveAgentPort>
+  <slaveAgentPort>5000</slaveAgentPort>
   <enabledAgentProtocols>
     <string>CLI-connect</string>
     <string>CLI2-connect</string>

--- a/test/src/test/resources/jenkins/AgentProtocolTest/testShouldNotOverrideUserConfiguration/config.xml
+++ b/test/src/test/resources/jenkins/AgentProtocolTest/testShouldNotOverrideUserConfiguration/config.xml
@@ -27,7 +27,7 @@
     </hudson.model.AllView>
   </views>
   <primaryView>all</primaryView>
-  <slaveAgentPort>0</slaveAgentPort>
+  <slaveAgentPort>5000</slaveAgentPort>
   <!-- YOLO: unstable configuration -->
   <enabledAgentProtocols>
     <string>CLI-connect</string>

--- a/test/src/test/resources/jenkins/slaves/DeprecatedAgentProtocolMonitorTest/noAdministrativeMonitorWhenPortIsDisabled/config.xml
+++ b/test/src/test/resources/jenkins/slaves/DeprecatedAgentProtocolMonitorTest/noAdministrativeMonitorWhenPortIsDisabled/config.xml
@@ -27,7 +27,7 @@
     </hudson.model.AllView>
   </views>
   <primaryView>all</primaryView>
-  <slaveAgentPort>5000</slaveAgentPort>
+  <slaveAgentPort>-1</slaveAgentPort>
   <!-- Disabled to emulate defaults
   <enabledAgentProtocols>
     <string>JNLP4-connect</string>


### PR DESCRIPTION
See [JENKINS-46760](https://issues.jenkins-ci.org/browse/JENKINS-46760). I am not sure whether it's actually a bug, but I do not care much about instances without [Remoting] agents. So be it. Also added some annotations.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Disabled Agent Protocol monitor now does not print warnings when the TCP Agent Listener Port is disabled on the instance
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck @reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
