### PR TITLE
[JENKINS-26143] Make choice parameter work with choices list in pipeline

### DIFF
--- a/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
@@ -40,7 +40,7 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
 
     public ChoiceParameterDefinition(String name, String choices, String description) {
         super(name, description);
-        this.choices = Arrays.asList(choices.split(CHOICES_DELIMITER));
+        setChoicesText(choices);
         defaultValue = null;
     }
 
@@ -57,9 +57,10 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
     }
 
     /**
+     * Databound constructor for reflective instantiation.
      *
-     * @param name
-     * @param description
+     * @param name parameter name
+     * @param description parameter description
      *
      * @since TODO
      */
@@ -93,15 +94,16 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
             return;
         }
         if (choices instanceof Collection) {
-            this.choices = new ArrayList<>();
+            ArrayList<String> newChoices = new ArrayList<>();
             for (Object o : (Collection) choices) {
                 if (o != null) {
-                    this.choices.add(o.toString());
+                    newChoices.add(o.toString());
                 }
             }
+            this.choices = newChoices;
             return;
         }
-        throw new IllegalArgumentException("expected String or Collection, but got " + choices);
+        throw new IllegalArgumentException("expected String or Collection, but got " + choices.getClass().getName());
     }
 
     private void setChoicesText(String choices) {
@@ -169,9 +171,7 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
             String name = formData.getString("name");
             String desc = formData.getString("description");
             String choiceText = formData.getString("choices");
-            ChoiceParameterDefinition parameterDefinition = new ChoiceParameterDefinition(name, desc);
-            parameterDefinition.setChoicesText(choiceText);
-            return parameterDefinition;
+            return new ChoiceParameterDefinition(name, choiceText, desc);
         }
 
         /**

--- a/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
@@ -16,7 +16,6 @@ import hudson.Extension;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Arrays;
 
@@ -93,9 +92,9 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
             setChoicesText((String) choices);
             return;
         }
-        if (choices instanceof Collection) {
+        if (choices instanceof List) {
             ArrayList<String> newChoices = new ArrayList<>();
-            for (Object o : (Collection) choices) {
+            for (Object o : (List) choices) {
                 if (o != null) {
                     newChoices.add(o.toString());
                 }
@@ -103,7 +102,7 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
             this.choices = newChoices;
             return;
         }
-        throw new IllegalArgumentException("expected String or Collection, but got " + choices.getClass().getName());
+        throw new IllegalArgumentException("expected String or List, but got " + choices.getClass().getName());
     }
 
     private void setChoicesText(String choices) {


### PR DESCRIPTION
See [JENKINS-26143](https://issues.jenkins-ci.org/browse/JENKINS-26143).

Rage driven development: It's not pretty, but neither is JENKINS-26143.

Manually tested only, please provide advice how to test this (ATH?).

- Configuring and building freestyle project works
- Configuring and reconfiguring (existing parameter) single-branch pipeline works
- Building single-branch pipeline (with `properties` both string and list args) works
- Snippet generator works (still generates a list)

### Proposed changelog entries

* Allow use of lists of options as provided by the pipeline snippet generator for choice parameters.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@jenkinsci/code-reviewers @jglick @abayer 
