### PR TITLE
Require at least Java 8u101 for the updates.jenkins.io certs

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -582,6 +582,10 @@ THE SOFTWARE.
                     <requireMavenVersion>
                       <version>3.1.0</version>
                     </requireMavenVersion>
+                    <requireJavaVersion>
+                      <!-- let's encrypt certs used for https://updates.jenkins.io -->
+                      <version>[1.8.0-101,]</version>
+                    </requireJavaVersion>
                   </rules>
                 </configuration>
               </execution>


### PR DESCRIPTION
Downstream from https://github.com/jenkinsci/jenkins/pull/2996: If we keep that around (I'm not convinced that's the best approach TBH), let's enforce `jenkins-war` is built by 8u101 or newer, otherwise it will just be annoying to debug it.

Not sure this is a good idea to do (it's unnecessary for actual building), feedback welcome.

@jenkinsci/code-reviewers 