### PR TITLE
Suppress compiler warnings about non-API classes used by gadgets

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -280,6 +280,14 @@ THE SOFTWARE.
           </rules>
         </configuration>
       </plugin>
+      <plugin> <!-- https://stackoverflow.com/a/19503679/12916 ysoserial deliberately uses internal APIs; suppress warnings about them -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgument>-XDignore.symbol.file</compilerArgument>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Makes build output quieter. We will need to revisit when we want to build on Java 9 (I guess); perhaps we will move gadgets to a separate repository and consume them as binary artifacts.

### Proposed changelog entries

N/A

@reviewbybees