### PR TITLE
Add ExtensionList#lookupFirst convenience method

### DIFF
--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -424,6 +424,7 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
      *
      * @param type The type to look up.
      * @return the singleton instance of the given type in its list.
+     * @throws IllegalStateException if there are no instances, or more than one
      *
      * @since TODO
      */

--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -422,8 +422,7 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
      * Equivalent to {@code ExtensionList.lookup(Class).get(Class)}.
      *
      * @param type The type to look up.
-     * @param <U>
-     * @return
+     * @return the first instance of the given type in its list.
      *
      * @since TODO
      */

--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -418,16 +418,21 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
     }
 
     /**
-     * Convenience method allowing lookup of the first instance of a given type.
-     * Equivalent to {@code ExtensionList.lookup(Class).get(Class)}.
+     * Convenience method allowing lookup of the only instance of a given type.
+     * Equivalent to {@code ExtensionList.lookup(Class).get(Class)} if there is one instance,
+     * and throws an {@code IllegalStateException} otherwise.
      *
      * @param type The type to look up.
-     * @return the first instance of the given type in its list.
+     * @return the singleton instance of the given type in its list.
      *
      * @since TODO
      */
-    public static @CheckForNull <U> U lookupFirst(Class<U> type) {
-        return lookup(type).get(type);
+    public static @Nonnull <U> U lookupSingleton(Class<U> type) {
+        ExtensionList<U> all = lookup(type);
+        if (all.size() != 1) {
+            throw new IllegalStateException("Expected 1 instance of " + type.getName() + " but got " + all.size());
+        }
+        return all.get(0);
     }
 
     /**

--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -418,6 +418,20 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
     }
 
     /**
+     * Convenience method allowing lookup of the first instance of a given type.
+     * Equivalent to {@code ExtensionList.lookup(Class).get(Class)}.
+     *
+     * @param type The type to look up.
+     * @param <U>
+     * @return
+     *
+     * @since TODO
+     */
+    public static @CheckForNull <U> U lookupFirst(Class<U> type) {
+        return lookup(type).get(type);
+    }
+
+    /**
      * Places to store static-scope legacy instances.
      */
     private static final Memoizer<Class,CopyOnWriteArrayList> staticLegacyInstances = new Memoizer<Class,CopyOnWriteArrayList>() {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2000,8 +2000,8 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
          * Convenience method to ease access to this monitor, this allows other plugins to register required updates.
          * @return this monitor.
          */
-        public static final PluginUpdateMonitor getInstance() {
-            return ExtensionList.lookup(PluginUpdateMonitor.class).get(0);
+        public static PluginUpdateMonitor getInstance() {
+            return ExtensionList.lookupSingleton(PluginUpdateMonitor.class);
         }
 
         /**

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -1122,14 +1122,8 @@ public class UpdateSite {
         @CheckForNull
         @Restricted(NoExternalUse.class)
         public Set<Warning> getWarnings() {
-            ExtensionList<UpdateSiteWarningsConfiguration> list = ExtensionList.lookup(UpdateSiteWarningsConfiguration.class);
-            if (list.size() == 0) {
-                return Collections.emptySet();
-            }
-
+            UpdateSiteWarningsConfiguration configuration = ExtensionList.lookupSingleton(UpdateSiteWarningsConfiguration.class);
             Set<Warning> warnings = new HashSet<>();
-
-            UpdateSiteWarningsConfiguration configuration = list.get(0);
 
             for (Warning warning: configuration.getAllWarnings()) {
                 if (configuration.isIgnored(warning)) {

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -1026,11 +1026,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
          */
         @GuardedBy("User.byNameLock")
         static ConcurrentMap<String,User> byName() {
-            ExtensionList<AllUsers> instances = ExtensionList.lookup(AllUsers.class);
-            if (instances.size() != 1) {
-                throw new IllegalStateException();
-            }
-            return instances.get(0).byName;
+            return ExtensionList.lookupSingleton(AllUsers.class).byName;
         }
 
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3709,9 +3709,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         try {
             JSONObject json = req.getSubmittedForm();
 
-            MasterBuildConfiguration mbc = MasterBuildConfiguration.all().get(MasterBuildConfiguration.class);
-            if (mbc!=null)
-                mbc.configure(req,json);
+            MasterBuildConfiguration mbc = ExtensionList.lookupSingleton(MasterBuildConfiguration.class);
+            mbc.configure(req,json);
 
             getNodeProperties().rebuild(req, json.optJSONObject("nodeProperties"), NodeProperty.all());
         } finally {
@@ -4520,7 +4519,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @RestrictedSince("2.37")
     @Deprecated
     public FormValidation doCheckURIEncoding(StaplerRequest request) throws IOException {
-        return ExtensionList.lookup(URICheckEncodingMonitor.class).get(0).doCheckURIEncoding(request);
+        return ExtensionList.lookupSingleton(URICheckEncodingMonitor.class).doCheckURIEncoding(request);
     }
 
     /**
@@ -4530,7 +4529,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @RestrictedSince("2.37")
     @Deprecated
     public static boolean isCheckURIEncodingEnabled() {
-        return ExtensionList.lookup(URICheckEncodingMonitor.class).get(0).isCheckEnabled();
+        return ExtensionList.lookupSingleton(URICheckEncodingMonitor.class).isCheckEnabled();
     }
 
     /**

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3709,8 +3709,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         try {
             JSONObject json = req.getSubmittedForm();
 
-            MasterBuildConfiguration mbc = ExtensionList.lookupSingleton(MasterBuildConfiguration.class);
-            mbc.configure(req,json);
+            ExtensionList.lookupSingleton(MasterBuildConfiguration.class).configure(req,json);
 
             getNodeProperties().rebuild(req, json.optJSONObject("nodeProperties"), NodeProperty.all());
         } finally {

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
@@ -121,12 +121,7 @@ public class UpdateSiteWarningsMonitor extends AdministrativeMonitor {
     }
 
     private Set<UpdateSite.Warning> getActiveWarnings() {
-        ExtensionList<UpdateSiteWarningsConfiguration> configurations = ExtensionList.lookup(UpdateSiteWarningsConfiguration.class);
-        if (configurations.isEmpty()) {
-            return Collections.emptySet();
-        }
-        UpdateSiteWarningsConfiguration configuration = configurations.get(0);
-
+        UpdateSiteWarningsConfiguration configuration = ExtensionList.lookupSingleton(UpdateSiteWarningsConfiguration.class);
         HashSet<UpdateSite.Warning> activeWarnings = new HashSet<>();
 
         for (UpdateSite.Warning warning : configuration.getApplicableWarnings()) {
@@ -160,13 +155,7 @@ public class UpdateSiteWarningsMonitor extends AdministrativeMonitor {
      * @return true iff there are applicable but ignored (i.e. hidden) warnings.
      */
     public boolean hasApplicableHiddenWarnings() {
-        ExtensionList<UpdateSiteWarningsConfiguration> configurations = ExtensionList.lookup(UpdateSiteWarningsConfiguration.class);
-        if (configurations.isEmpty()) {
-            return false;
-        }
-
-        UpdateSiteWarningsConfiguration configuration = configurations.get(0);
-
+        UpdateSiteWarningsConfiguration configuration = ExtensionList.lookupSingleton(UpdateSiteWarningsConfiguration.class);
         return getActiveWarnings().size() < configuration.getApplicableWarnings().size();
     }
 

--- a/core/src/main/java/jenkins/security/UserDetailsCache.java
+++ b/core/src/main/java/jenkins/security/UserDetailsCache.java
@@ -83,7 +83,7 @@ public final class UserDetailsCache {
      * @return the cache
      */
     public static UserDetailsCache get() {
-        return ExtensionList.lookup(UserDetailsCache.class).get(UserDetailsCache.class);
+        return ExtensionList.lookupSingleton(UserDetailsCache.class);
     }
 
     /**


### PR DESCRIPTION
I find myself typing `ExtensionList.lookup(Whatever.class).get(Whatever.class)` a lot to get the singleton instance for a registered `@Extension`.

If I'm not the only one (and haven't missed something obvious), maybe this is useful? @jenkinsci/code-reviewers More to tell me there's an obvious alternative I've missed.