### PR TITLE
[Fix JENKINS-45977] Returns null instead of throwing error if no desc…

### DIFF
--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -984,6 +984,10 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
     Map<Descriptor<T>,T> toMap(Iterable<T> describables) {
         Map<Descriptor<T>,T> m = new LinkedHashMap<Descriptor<T>,T>();
         for (T d : describables) {
+            if (d.getDescriptor()==null) {
+                LOGGER.log(Level.WARNING, "Failed to load descriptor for {0}", d);
+                continue;
+            }
             m.put(d.getDescriptor(),d);
         }
         return m;

--- a/core/src/main/java/hudson/model/UserProperty.java
+++ b/core/src/main/java/hudson/model/UserProperty.java
@@ -32,6 +32,8 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.ExportedBean;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Extensible property of {@link User}.
  *
@@ -63,8 +65,8 @@ public abstract class UserProperty implements ReconfigurableDescribable<UserProp
     }
 
     // descriptor must be of the UserPropertyDescriptor type
-    public UserPropertyDescriptor getDescriptor() {
-        return (UserPropertyDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+    public @CheckForNull UserPropertyDescriptor getDescriptor() {
+        return (UserPropertyDescriptor) Jenkins.getInstance().getDescriptor(getClass());
     }
 
     /**
@@ -75,6 +77,10 @@ public abstract class UserProperty implements ReconfigurableDescribable<UserProp
     }
 
     public UserProperty reconfigure(StaplerRequest req, JSONObject form) throws FormException {
-        return form==null ? null : getDescriptor().newInstance(req, form);
+        if (form==null) {
+            return null;
+        }
+        UserPropertyDescriptor descriptor = getDescriptor();
+        return descriptor==null ? this : descriptor.newInstance(req, form);
     }
 }

--- a/core/src/test/java/hudson/model/DescriptorTest.java
+++ b/core/src/test/java/hudson/model/DescriptorTest.java
@@ -1,0 +1,58 @@
+package hudson.model;
+
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
+public class DescriptorTest {
+
+    private static class DescribableImpl implements Describable<DescribableImpl> {
+
+        private Descriptor<DescribableImpl> descriptor;
+
+        @Override
+        public Descriptor<DescribableImpl> getDescriptor() {
+            return descriptor;
+        }
+
+        private static class DummyDescriptor extends Descriptor<DescriptorTest.DescribableImpl> {
+        }
+    }
+
+    @Issue("JENKINS-45977")
+    @Test
+    public void testToMap() throws Exception {
+        DescribableImpl describable1 = new DescribableImpl();
+        describable1.descriptor = new DescribableImpl.DummyDescriptor();
+        DescribableImpl describable2 = new DescribableImpl();
+        describable2.descriptor = new DescribableImpl.DummyDescriptor();
+        Iterable<DescribableImpl> describables = Arrays.asList(describable1, describable2);
+        Map<Descriptor<DescribableImpl>, DescribableImpl> map1 = Descriptor.toMap(describables);
+        Map<Descriptor<DescribableImpl>, DescribableImpl> expected = new HashMap<>();
+        expected.put(describable1.descriptor, describable1);
+        expected.put(describable2.descriptor, describable2);
+        assertMapEquals(expected, map1);
+
+        // Descriptor might be null
+        expected.remove(describable1.descriptor);
+        describable1.descriptor = null;
+        Map<Descriptor<DescribableImpl>, DescribableImpl> map2 = Descriptor.toMap(describables);
+        assertMapEquals(expected, map2);
+    }
+
+    private void assertMapEquals(Map map, Map other) {
+        assertNotNull(map);
+        assertNotNull(other);
+        assertEquals(map.size(), other.size());
+        for (Object key : map.keySet()) {
+            assertEquals(map.get(key), other.get(key));
+        }
+    }
+}

--- a/test/src/test/java/hudson/model/UserTest.java
+++ b/test/src/test/java/hudson/model/UserTest.java
@@ -28,6 +28,8 @@ import com.gargoylesoftware.htmlunit.WebAssert;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
+import net.sf.json.JSONObject;
+
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.security.AbstractPasswordBasedSecurityRealm;
@@ -693,6 +695,22 @@ public class UserTest {
         assertSame("'user1' should resolve to u1", u1, u);
         u = User.getById("user2", false);
         assertSame("'user2' should resolve to u2", u2, u);
+    }
+    
+    @Test
+    @Issue("JENKINS-45977")
+    public void testAllowGetDescriptorReturnsNull() throws Exception {
+        UserProperty noDescriptor = new UserProperty() {
+            {}
+        };
+        assertNull(noDescriptor.getDescriptor());
+        UserProperty reconfigured1 = noDescriptor.reconfigure(null, new JSONObject());
+        assertEquals(noDescriptor, reconfigured1);
+        UserProperty hasDescriptor = new SomeUserProperty();
+        assertNotNull(hasDescriptor.getDescriptor());
+        UserProperty property = hasDescriptor.reconfigure(null, new JSONObject());
+        assertNotNull(property);
+        assertNotEquals(hasDescriptor, property);
     }
 
     @Test


### PR DESCRIPTION
…riptor found for UserProperty

See [JENKINS-45977](https://issues.jenkins-ci.org/browse/JENKINS-45977).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->



### Desired reviewers
@jtnord @oleg-nenashev 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
