### PR TITLE
[JENKINS-46754] Remove org.mindrot:jbcrypt:0.4 since we already bundle org.connectbot.jbcrypt:jbcrypt:1.0.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -596,12 +596,6 @@ THE SOFTWARE.
       <version>1.3.1-jenkins-1</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.mindrot</groupId>
-      <artifactId>jbcrypt</artifactId>
-      <version>0.4</version>
-    </dependency>
-
     <!-- offline profiler API to put in the classpath if we need it -->
     <!--dependency>
       <groupId>com.yourkit.api</groupId>

--- a/test/src/test/java/jenkins/ClassPathTest.java
+++ b/test/src/test/java/jenkins/ClassPathTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins;
+
+import com.google.common.collect.Iterators;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.jar.JarFile;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.WarExploder;
+
+public class ClassPathTest {
+
+    @Rule
+    public ErrorCollector errors = new ErrorCollector();
+
+    @Ignore("TODO too many failures to solve them all now")
+    @Issue("JENKINS-46754")
+    @Test
+    public void uniqueness() throws Exception {
+        Map<String, List<String>> entries = new TreeMap<>();
+        for (File jar : new File(WarExploder.getExplodedDir(), "WEB-INF/lib").listFiles((dir, name) -> name.endsWith(".jar"))) {
+            String jarname = jar.getName();
+            try (JarFile jf = new JarFile(jar)) {
+                Iterators.forEnumeration(jf.entries()).forEachRemaining(e -> {
+                    String name = e.getName();
+                    if (name.startsWith("META-INF/") || name.endsWith("/") || !name.contains("/")) {
+                        return;
+                    }
+                    entries.computeIfAbsent(name, k -> new ArrayList<>()).add(jarname);
+                });
+            }
+        }
+        entries.forEach((name, jarnames) -> {
+            if (jarnames.size() > 1) { // Matchers.hasSize unfortunately does not display the collection
+                errors.addError(new AssertionError(name + " duplicated in " + jarnames));
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
See [JENKINS-46754](https://issues.jenkins-ci.org/browse/JENKINS-46754). Using passphrase-protected [ed25519](https://ed25519.cr.yp.to/) private keys in various ways sometimes failed.

In a nutshell, `jenkins.war` was accidentally bundling two distinct versions of the same library, under different GAs (so, invisibly to Maven). There are three GAs packaging the [JBCrypt library](http://www.mindrot.org/projects/jBCrypt/) that I know of:

* `org.mindrot:jbcrypt`, apparently an unauthorized upload from https://github.com/djmdjm/jBCrypt/pull/1.
* `de.svenkubiak:jBCrypt`, considered during SECURITY-354 but rejected since it required Java 8 to run, inappropriate for a security advisory.
* `org.connectbot.jbcrypt:jbcrypt`, which seems to have forked the library and done some additional development.

While I knew of the existence of the ConnectBot packaging when filing #2964, I did not realize that

* 1.0.0 is actually different from 0.4; https://github.com/kruton/jbcrypt/commit/37a5a774565b7eaf9e58f0fadba1291a3a06649f adds some new APIs.
* We were already bundling the ConnectBot fork! Since https://github.com/jenkinsci/trilead-ssh2/commit/dac7b1bdc80a845337a2a692a8e4f4cee8d19a1f and https://github.com/jenkinsci/trilead-ssh2/commit/30dbd420e6125a5d11fbc1426ece43949c34fb22 our “fork” of Trilead (at this point I guess the authoritative version) depends on those new APIs to decrypt certain kinds of keys. And Maven in its infinite wisdom was pulling that in as a transitive dependency.

Now when the WAR bundles two JAR files containing classes with the same FQN, the servlet container has to decide which one to load. As far as I can tell, Jetty does so essentially randomly, on the basis of the order of `File.list`, basically the directory iterator from the OS kernel. So if you were lucky, it would pick the ConnectBot version, which Trilead could link against, and all is well. If you were in the unlucky 50%, it would pick the older Mindrot version, which Trilead would fail to link against. I am adding a test here which detects this kind of mistake, but there are too many other failures to enable it yet. I plan to attempt to patch Jetty to make its load order deterministic.

Thanks @MarkEWaite for discovering. His test cases are run semi-manually; I plan to attempt to reproduce the issue (at least 50% of the time!) in `acceptance-test-harness`. (`JenkinsRule` would not suffice since then a version of JBCrypt would be loaded from `${java.class.path}`, deterministic according to Maven POMs: [JENKINS-41827](https://issues.jenkins-ci.org/browse/JENKINS-41827).)

I also note that in the case of the SSH launcher at least, the error is reported to the system log rather than the agent launch log where you might expect it. I plan to fix this in `ssh-credentials` too.

Timeline:
* [SECURITY-354](https://jenkins.io/security/advisory/2017-02-01/) in Jenkins 2.32.2 / 2.44 replaces Mindrot JBCrypt 0.3 with a repackaged private version of 0.4 for use from `HudsonPrivateSecurityRealm`.
* #2848 in 2.58 updates Trilead to a version relying on the ConnectBot JBCrypt, I suppose causing core to bundle it. Since these use distinct package names there is no conflict.
* #2964 in 2.73 switches to Mindrot 0.4, producing the clash.

This fix simply removes the older Mindrot library in favor of the newer ConnectBot fork already in use by Trilead, letting `HudsonPrivateSecurityRealm` share it also. To the objection that we should not be bundling a forked copy of a library where it could be used as an API, I would say
* Yes, though this is hardly the first time Jenkins has done so.
* I can find no direct usages of `BCrypt` from plugins, only Trilead and `HudsonPrivateSecurityRealm`. [This search](https://github.com/search?utf8=%E2%9C%93&q=user%3Ajenkinsci+%22import+org.mindrot.jbcrypt%22&type=Code) turns up just a false positive: https://github.com/jenkinsci/credentials-plugin/pull/91
* We have already been doing so since 2.58. Trying to hide it now, or revert to an older version, would be technically incompatible.
* It is unclear whether there even _is_ an authoritative version of the library. The Mindrot version seems to be moribund, as I asked in https://github.com/kruton/jbcrypt/issues/1. (Ironically, the author @djmdjm of JBCrypt seems to be active in the C version of the exact same thing: https://github.com/openssh/openssh-portable/commit/1ff130dac9b7aea0628f4ad30683431fe35e0020)

As an aside: https://github.com/jenkinsci/ssh-credentials-plugin/pull/27

### Proposed changelog entries

* Since 2.73, certain uses of passphrase-protected ed25519 private keys would sometimes fail.

@jenkinsci/code-reviewers @reviewbybees