### PR TITLE
[JENKINS-45245] Start deploying war-for-test again

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -414,6 +414,29 @@ THE SOFTWARE.
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- deploy the war as a jar, so that the tests can pull this into the classpath -->
+            <id>deploy-war-for-test</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.directory}/${project.build.finalName}.war</file>
+                  <type>jar</type>
+                  <classifier>war-for-test</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin><!-- generate licenses.xml -->
         <groupId>com.cloudbees</groupId>
         <artifactId>maven-license-plugin</artifactId>


### PR DESCRIPTION
See [JENKINS-45245](https://issues.jenkins-ci.org/browse/JENKINS-45245).

This is just the first part, but at the very least it'll mean that
when the rest of JENKINS-24064 gets reverted, core versions from when
this is merged onward will work with newer plugin parents/test
harness/maven-hpi-plugin/etc.

### Proposed changelog entries

* Entry 1: JENKINS-45245, start building and deploying `war-for-test` artifact again.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees
