### PR TITLE
Launch SSHD service asynchronously

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -134,7 +134,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
-      <version>2.0</version>
+      <version>2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>


### PR DESCRIPTION
Changes: https://github.com/jenkinsci/sshd-module/compare/sshd-2.0...master

- Do not delay Jenkins launch by SSHD init.
  - Mostly useful for parallel `jenkins-test-harness` tests that can get slowed down by SSHD depleting system entropy.
- Fix unlikely race condition in `init` / `setPort`.

### Proposed changelog entries

* Do not delay Jenkins startup until SSHD service is ready.
  * CLI and other clients using SSH may need to wait till SSHD starts up.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs
