### PR TITLE
[Jenkins-47056] nested JNLPLauncher settings ignored

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -234,8 +234,31 @@ public class SlaveComputer extends Computer {
         return launcher.isLaunchSupported();
     }
 
+    /**
+     * Return the {@code ComputerLauncher} for this SlaveComputer.
+     * @since 1.312
+     */
     public ComputerLauncher getLauncher() {
         return launcher;
+    }
+
+    /**
+     * Return the {@code ComputerLauncher} for this SlaveComputer, strips off
+     * any {@code DelegatingComputerLauncher}s or {@code ComputerLauncherFilter}s.
+     * @since 2.83
+     */
+    public ComputerLauncher getDelegatedLauncher() {
+        ComputerLauncher l = launcher;
+        while (true) {
+            if (l instanceof DelegatingComputerLauncher) {
+                l = ((DelegatingComputerLauncher) l).getLauncher();
+            } else if (l instanceof ComputerLauncherFilter) {
+                l = ((ComputerLauncherFilter) l).getCore();
+            } else {
+                break;
+            }
+        }
+        return l;
     }
 
     protected Future<?> _connect(boolean forceReconnect) {

--- a/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
@@ -46,14 +46,16 @@ THE SOFTWARE.
         <all-permissions/>
       </security>
 
+      <j:set var="launcher" value="${it.delegatedLauncher}"/>
+
       <resources>
         <j:set var="port" value="${request.getParameter('debugPort')}"/>
         <j:choose>
           <j:when test="${port!=null}">
-            <j2se version="1.8+" java-vm-args="${it.launcher.vmargs} -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=${port}" />
+            <j2se version="1.8+" java-vm-args="${launcher.vmargs} -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=${port}" />
           </j:when>
           <j:otherwise>
-            <j2se version="1.8+" java-vm-args="${it.launcher.vmargs}"/>
+            <j2se version="1.8+" java-vm-args="${launcher.vmargs}"/>
           </j:otherwise>
         </j:choose>
         <jar href="${rootURL}jnlpJars/remoting.jar"/>
@@ -62,23 +64,23 @@ THE SOFTWARE.
       <application-desc main-class="hudson.remoting.jnlp.Main">
         <argument>${it.jnlpMac}</argument>
         <argument>${it.node.nodeName}</argument>
-        <j:if test="${it.launcher.tunnel!=null}">
+        <j:if test="${launcher.tunnel!=null}">
           <argument>-tunnel</argument>
-          <argument>${it.launcher.tunnel}</argument>
+          <argument>${launcher.tunnel}</argument>
         </j:if>
-        <j:if test="${not it.launcher.workDirSettings.disabled}">
+        <j:if test="${not launcher.workDirSettings.disabled}">
           <argument>-workDir</argument>
           <j:choose>
-            <j:when test="${it.launcher.workDirSettings.useAgentRootDir}">
+            <j:when test="${launcher.workDirSettings.useAgentRootDir}">
               <argument>${it.node.remoteFS}</argument>
             </j:when>
             <j:otherwise>
-              <argument>${it.launcher.workDirSettings.workDirPath}</argument>
+              <argument>${launcher.workDirSettings.workDirPath}</argument>
             </j:otherwise>
           </j:choose>
           <argument>-internalDir</argument>
-          <argument>${it.launcher.workDirSettings.internalDir}</argument>
-          <j:if test="${it.launcher.workDirSettings.failIfWorkDirIsMissing}">
+          <argument>${launcher.workDirSettings.internalDir}</argument>
+          <j:if test="${launcher.workDirSettings.failIfWorkDirIsMissing}">
             <argument>-failIfWorkDirIsMissing</argument>
           </j:if>
         </j:if>

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -144,6 +144,7 @@ public class JNLPLauncherTest {
                 jnlpLauncher.getWorkDirSettings().isDisabled());
     }
     
+    @Test
     @Issue("JENKINS-44112")
     public void testDefaults() throws Exception {
         String errorMsg = "Work directory should be disabled for agents created via old API";

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -32,9 +32,11 @@ import hudson.model.Node;
 import hudson.model.Node.Mode;
 import hudson.model.Slave;
 import hudson.remoting.Which;
+import hudson.slaves.DelegatingComputerLauncher;
 import hudson.util.ArgumentListBuilder;
 
 import jenkins.security.SlaveToMasterCallable;
+import jenkins.slaves.RemotingWorkDirSettings;
 
 import org.junit.Assume;
 import org.junit.Rule;
@@ -152,6 +154,32 @@ public class JNLPLauncherTest {
         assertTrue(errorMsg, new JNLPLauncher(null, null).getWorkDirSettings().isDisabled());
     }
 
+    @Test
+    @Issue("JENKINS-47056")
+    public void testDelegatingComputerLauncher() throws Exception {
+        Assume.assumeFalse("Skipping JNLPLauncherTest.testDelegatingComputerLauncher because we are running headless", GraphicsEnvironment.isHeadless());
+        File workDir = tmpDir.newFolder("workDir");
+
+        ComputerLauncher launcher = new JNLPLauncher("", "", new RemotingWorkDirSettings(false, workDir.getAbsolutePath(), "internalDir", false));
+        launcher = new DelegatingComputerLauncherImpl(launcher);
+        Computer c = addTestSlave(launcher);
+        launchJnlpAndVerify(c, buildJnlpArgs(c));
+        assertTrue("Remoting work dir should have been created", new File(workDir, "internalDir").exists());
+    }
+
+    @Test
+    @Issue("JENKINS-47056")
+    public void testComputerLauncherFilter() throws Exception {
+        Assume.assumeFalse("Skipping JNLPLauncherTest.testComputerLauncherFilter because we are running headless", GraphicsEnvironment.isHeadless());
+        File workDir = tmpDir.newFolder("workDir");
+
+        ComputerLauncher launcher = new JNLPLauncher("", "", new RemotingWorkDirSettings(false, workDir.getAbsolutePath(), "internalDir", false));
+        launcher = new ComputerLauncherFilterImpl(launcher);
+        Computer c = addTestSlave(launcher);
+        launchJnlpAndVerify(c, buildJnlpArgs(c));
+        assertTrue("Remoting work dir should have been created", new File(workDir, "internalDir").exists());
+    }
+
     @TestExtension("testHeadlessLaunch")
     public static class ListenerImpl extends ComputerListener {
         int offlined = 0;
@@ -163,13 +191,25 @@ public class JNLPLauncherTest {
         }
     }
 
+    private static class DelegatingComputerLauncherImpl extends DelegatingComputerLauncher {
+        public DelegatingComputerLauncherImpl(ComputerLauncher launcher) {
+            super(launcher);
+        }
+    }
+
+    private static class ComputerLauncherFilterImpl extends ComputerLauncherFilter {
+        public ComputerLauncherFilterImpl(ComputerLauncher launcher) {
+            super(launcher);
+        }
+    }
+
     private ArgumentListBuilder buildJnlpArgs(Computer c) throws Exception {
         ArgumentListBuilder args = new ArgumentListBuilder();
         args.add(new File(new File(System.getProperty("java.home")),"bin/java").getPath(),"-jar");
         args.add(Which.jarFile(netx.jnlp.runtime.JNLPRuntime.class).getAbsolutePath());
         args.add("-headless","-basedir");
         args.add(j.createTmpDir());
-        args.add("-nosecurity","-jnlp", getJnlpLink(c));
+        args.add("-nosecurity","-jnlp", j.getURL() + "computer/"+c.getName()+"/slave-agent.jnlp");
         
         if (c instanceof SlaveComputer) {
             SlaveComputer sc = (SlaveComputer)c;
@@ -213,23 +253,20 @@ public class JNLPLauncherTest {
     }
 
     /**
-     * Determines the link to the .jnlp file.
+     * Adds a JNLP {@link Slave} to the system and returns it.
      */
-    private String getJnlpLink(Computer c) throws Exception {
-        HtmlPage p = j.createWebClient().goTo("computer/"+c.getName()+"/");
-        String href = ((HtmlAnchor) p.getElementById("jnlp-link")).getHrefAttribute();
-        href = new URL(new URL(p.getUrl().toExternalForm()),href).toExternalForm();
-        return href;
+    private Computer addTestSlave(boolean enableWorkDir) throws Exception {
+        return addTestSlave(new JNLPLauncher(enableWorkDir));
     }
 
     /**
      * Adds a JNLP {@link Slave} to the system and returns it.
      */
-    private Computer addTestSlave(boolean enableWorkDir) throws Exception {
+    private Computer addTestSlave(ComputerLauncher launcher) throws Exception {
         List<Node> slaves = new ArrayList<Node>(j.jenkins.getNodes());
         File dir = Util.createTempDir();
         slaves.add(new DumbSlave("test","dummy",dir.getAbsolutePath(),"1", Mode.NORMAL, "",
-                new JNLPLauncher(enableWorkDir), RetentionStrategy.INSTANCE, new ArrayList<NodeProperty<?>>()));
+                launcher, RetentionStrategy.INSTANCE, new ArrayList<NodeProperty<?>>()));
         j.jenkins.setNodes(slaves);
         Computer c = j.jenkins.getComputer("test");
         assertNotNull(c);


### PR DESCRIPTION
See [JENKINS-47056](https://issues.jenkins-ci.org/browse/JENKINS-47056).

fixed by stripping off DelegatedComputerLaunchers to render slave-agent.jnlp

### Proposed changelog entries

* Entry 1: fixed nested JNLPLauncher settings (e.g. slave-setup plugin)
