### PR TITLE
[JENKINS-47043] Support restartCommand configuration (Option#1)

### DIFF
--- a/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
@@ -30,10 +30,13 @@ import com.sun.jna.StringArray;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import static hudson.util.jna.GNUCLibrary.*;
 
 import hudson.Platform;
+import jenkins.model.Configuration;
 import jenkins.model.Jenkins;
 
 /**
@@ -42,11 +45,16 @@ import jenkins.model.Jenkins;
  *
  * <p>
  * Restart by exec to self.
+ * The restartCommand configuration may override executable program instead of argv[0]
+ * that is being used.
  *
  * @author Kohsuke Kawaguchi
  * @since 1.304
  */
 public class UnixLifecycle extends Lifecycle {
+    @Restricted(NoExternalUse.class)
+    private static final String RESTART_COMMAND = Configuration.getStringConfigParameter("restartCommand", null);
+
     private JavaVMArguments args;
     private Throwable failedToObtainArgs;
 
@@ -85,7 +93,7 @@ public class UnixLifecycle extends Lifecycle {
         }
 
         // exec to self
-        String exe = args.get(0);
+        String exe = RESTART_COMMAND != null ? RESTART_COMMAND : args.get(0);
         LIBC.execvp(exe, new StringArray(args.toArray(new String[args.size()])));
         throw new IOException("Failed to exec '"+exe+"' "+LIBC.strerror(Native.getLastError()));
     }


### PR DESCRIPTION
If set, the restartCommand is used as command to be executed when
jenkins is restarted instead of using the original argv[0]. This is
usable when there is an external watchdog such as SystemD.

SystemD service example:

   ExecStart=@/usr/bin/java jenkins $JAVA_OPTIONS -DJENKINS_HOME=${JENKINS_HOME} -Djenkins.model.Jenkins.restartCommand=/bin/true -jar $JENKINS_WAR --debug=${JENKINS_DEBUG_LEVEL} --httpPort=${JENKINS_PORT} --httpListenAddress=${JENKINS_LISTEN_ADDRESS} $JENKINS_ARGS
   Restart=on-success

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
