### PR TITLE
make POST requests when checking AbstractCommandInstaller.command

### DIFF
--- a/core/src/main/resources/hudson/tools/AbstractCommandInstaller/config.jelly
+++ b/core/src/main/resources/hudson/tools/AbstractCommandInstaller/config.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:t="/hudson/tools">
     <t:label />
     <f:entry title="${%Command}" field="command">
-        <f:textarea/>
+        <f:textarea checkMethod="post"/>
     </f:entry>
     <f:entry title="${%Tool Home}" field="toolHome">
         <f:textbox/>


### PR DESCRIPTION
See [JENKINS-47058](https://issues.jenkins-ci.org/browse/JENKINS-47058).

The textarea for configuring Shell or Batch scripts ToolInstallers is linked to a check method:
https://github.com/jenkinsci/jenkins/blob/39dfa055b0e3bcf3a0fdb1f12c0de9673ab8581c/core/src/main/java/hudson/tools/AbstractCommandInstaller.java#L90

When the script is modified, it gets URL-encoded and sent as parameter of a GET query, which easily fails if the script is a bit verbose (Jenkins gives an error 414 if the URL is >8KB for instance, but the error may be different if using proxy servers).

I see the Pipeline editor textarea uses POST request instead:
https://github.com/jenkinsci/workflow-cps-plugin/blob/c69e3862bf26ac122dbc26345f1bb73b906c6824/src/main/resources/org/jenkinsci/plugins/workflow/editor/workflow-editor.jelly#L16

This PR is simply about doing the same for the AbstractCommandInstaller.command textarea.

Note that an alternative would be to get rid of the "doCheckCommand" method, whose only purpose is to check the script is not empty...

### Proposed changelog entries

* Fix HTTP 414 error on validation of long Batch/Shell tool installer scripts

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). 
- [X] Appropriate autotests or explanation to why this change has no tests => _no test, this change is hopefully simple enough..._ 
- [ ] ~~For dependency updates: links to external changelogs and, if possible, full diffs~~ => _N/A_
