### PR TITLE
[JENKINS-20046] - Do not query queue dispatchers from UI

### DIFF
--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -69,6 +69,7 @@ import hudson.triggers.SCMTrigger.SCMTriggerCause;
 import hudson.triggers.TimerTrigger.TimerTriggerCause;
 import hudson.util.OneShotEvent;
 import hudson.util.XStream2;
+import jenkins.model.BlockedBecauseOfBuildInProgress;
 import jenkins.model.Jenkins;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
 import jenkins.triggers.ReverseBuildTrigger;
@@ -527,16 +528,24 @@ public class QueueTest {
     }
     static class TestTask implements Queue.Task {
         private final AtomicInteger cnt;
+        private final boolean isBlocked;
+
         TestTask(AtomicInteger cnt) {
-            this.cnt = cnt;
+            this(cnt, false);
         }
+
+        TestTask(AtomicInteger cnt, boolean isBlocked) {
+            this.cnt = cnt;
+            this.isBlocked = isBlocked;
+        }
+
         @Override public boolean equals(Object o) {
             return o instanceof TestTask && cnt == ((TestTask) o).cnt;
         }
         @Override public int hashCode() {
             return cnt.hashCode();
         }
-        @Override public boolean isBuildBlocked() {return false;}
+        @Override public boolean isBuildBlocked() {return isBlocked;}
         @Override public String getWhyBlocked() {return null;}
         @Override public String getName() {return "test";}
         @Override public String getFullDisplayName() {return "Test";}
@@ -769,7 +778,7 @@ public class QueueTest {
         final FreeStyleProject projectB = r.createFreeStyleProject(prefix+"B");
         projectB.getBuildersList().add(new SleepBuilder(10000));     
         projectB.setBlockBuildWhenUpstreamBuilding(true);
-        
+
         final FreeStyleProject projectC = r.createFreeStyleProject(prefix+"C");
         projectC.getBuildersList().add(new SleepBuilder(10000));
         projectC.setBlockBuildWhenUpstreamBuilding(true);
@@ -964,5 +973,38 @@ public class QueueTest {
                 }
             };
         }
+    }
+
+    @Test
+    public void testDefaultImplementationOfGetCauseOfBlockageForBlocked() throws Exception {
+        Queue queue = r.getInstance().getQueue();
+        queue.schedule2(new TestTask(new AtomicInteger(0), true), 0);
+
+        queue.maintain();
+
+        assertEquals(1, r.jenkins.getQueue().getBlockedItems().size());
+        CauseOfBlockage actual = r.jenkins.getQueue().getBlockedItems().get(0).getCauseOfBlockage();
+        CauseOfBlockage expected = CauseOfBlockage.fromMessage(Messages._Queue_Unknown());
+
+        assertEquals(expected.getShortDescription(), actual.getShortDescription());
+    }
+
+    @Test
+    public void testGetCauseOfBlockageForNonConcurrentFreestyle() throws Exception {
+        Queue queue = r.getInstance().getQueue();
+        FreeStyleProject t1 = r.createFreeStyleProject("project");
+        t1.getBuildersList().add(new SleepBuilder(TimeUnit.SECONDS.toMillis(30)));
+        t1.setConcurrentBuild(false);
+
+        t1.scheduleBuild2(0).waitForStart();
+        t1.scheduleBuild2(0);
+
+        queue.maintain();
+
+        assertEquals(1, r.jenkins.getQueue().getBlockedItems().size());
+        CauseOfBlockage actual = r.jenkins.getQueue().getBlockedItems().get(0).getCauseOfBlockage();
+        CauseOfBlockage expected = new BlockedBecauseOfBuildInProgress(t1.getFirstBuild());
+
+        assertEquals(expected.getShortDescription(), actual.getShortDescription());
     }
 }


### PR DESCRIPTION
During work on https://github.com/jenkinsci/gerrit-trigger-plugin/pull/325 I was surprised that Jenkins calls `canRun` for `QueueTaskDispatcher.all()` during `getWhy` every time User opens the UI... So, I decided to fix this - maybe it will help a little bit for tickets I mentioned below:

See [JENKINS-27650](https://issues.jenkins-ci.org/browse/JENKINS-27650) and [JENKINS-20046](https://issues.jenkins-ci.org/browse/JENKINS-20046).

### Proposed changelog entries

* Do not query queue dispatchers from UI

### Submitter checklist

- [-] JIRA issue is well described
- [+] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [+] Appropriate autotests or explanation to why this change has no tests

I did not write any new tests because this PR should not change any behaviour in the system.