### PR TITLE
Do not clutter logs with computer update times

### DIFF
--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -205,9 +205,10 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
                 for (Node s : getNodes()) {
                     long start = System.currentTimeMillis();
                     updateComputer(s, byName, used, automaticSlaveLaunch);
-                    if(LOG_STARTUP_PERFORMANCE)
-                        LOGGER.info(String.format("Took %dms to update node %s",
-                                System.currentTimeMillis()-start, s.getNodeName()));
+                    if (LOG_STARTUP_PERFORMANCE && LOGGER.isLoggable(Level.FINE)) {
+                        LOGGER.fine(String.format("Took %dms to update node %s",
+                                System.currentTimeMillis() - start, s.getNodeName()));
+                    }
                 }
 
                 // find out what computers are removed, and kill off all executors.


### PR DESCRIPTION
The log is being polluted by `INFO: Took 0ms to update node NODE-NAME` annoyingly often (10K to 100K times a day on smallish instance) when cloud nodes are used and when `logStartupPerformance` is on. The underlying reason for that is, it is triggered every time node list is manipulated and not only during startup. The [code](https://github.com/jenkinsci/jenkins/commit/95f11705a55e8878ed7636cd0b9e460555374424#diff-85c740e6c3585efa8e48f36b638b7426R176) was added over 5 years ago and I suspect nobody care any longer. Hence I am removing it instead of trying to limit it to startup, which is not straightforward.

### Proposed changelog entries

None given how minor this is

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist
- [x] Appropriate autotests or explanation to why this change has no tests
  - Verifying whether the message is not logged any longer is a bit too much.

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@kutzi, just in case author has some comments. @jenkinsci/code-reviewers, to give a range of users the chance to object.