### PR TITLE
Fix the race condtion in QueueTaskDispatcherTest

### DIFF
--- a/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
+++ b/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
@@ -28,14 +28,13 @@ public class QueueTaskDispatcherTest {
     @Test
     public void canRunBlockageIsDisplayed() throws Exception {
         FreeStyleProject project = r.createFreeStyleProject();
-        r.jenkins.getQueue().schedule(project);
+        r.jenkins.getQueue().schedule(project, 0);
+
+        r.getInstance().getQueue().maintain();
 
         Item item = r.jenkins.getQueue().getItem(project);
-        for (int i = 0; i < 4 * 60 && !item.isBlocked(); i++) {
-            Thread.sleep(250);
-            item = r.jenkins.getQueue().getItem(project);
-        }
-        assertTrue("Not blocked after 60 seconds", item.isBlocked());
+
+        assertTrue("Not blocked", item.isBlocked());
         assertEquals("Expected CauseOfBlockage to be returned", "blocked by canRun", item.getWhy());
     }
 
@@ -56,18 +55,17 @@ public class QueueTaskDispatcherTest {
     @Test
     public void canTakeBlockageIsDisplayed() throws Exception {
         FreeStyleProject project = r.createFreeStyleProject();
-        r.jenkins.getQueue().schedule(project);
-        Queue.Item item;
-        while (true) {
-            item = r.jenkins.getQueue().getItem(project);
-            if (item.isBuildable()) {
-                break;
-            }
-            Thread.sleep(100);
-        }
+
+        r.jenkins.getQueue().schedule(project, 0);
+        r.getInstance().getQueue().maintain();
+
+        Queue.Item item = r.jenkins.getQueue().getItem(project);
+        assertNotNull(item);
+
         CauseOfBlockage cob = item.getCauseOfBlockage();
         assertNotNull(cob);
         assertThat(cob.getShortDescription(), containsString("blocked by canTake"));
+
         StringWriter w = new StringWriter();
         TaskListener l = new StreamTaskListener(w);
         cob.print(l);


### PR DESCRIPTION
During work on https://github.com/jenkinsci/jenkins/pull/3038 I found one flaky test in `QueueTaskDispatcherTest` class.

Race condition happens if Queue polling thread (`Timer`) is called with some delay. In this case `Main` thread calls `BuildableItem.getCauseOfBlockage` directly and test fails like [this](https://ci.jenkins.io/blue/rest/organizations/jenkins/pipelines/Core/pipelines/jenkins/branches/PR-3038/runs/2/nodes/7/steps/28/log/?start=0):
```
[ERROR] canTakeBlockageIsDisplayed(hudson.model.queue.QueueTaskDispatcherTest)  Time elapsed: 10.258 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: a string containing "blocked by canTake"
     but: was "Waiting for next available executor"
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at hudson.model.queue.QueueTaskDispatcherTest.canTakeBlockageIsDisplayed(QueueTaskDispatcherTest.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.jvnet.hudson.test.JenkinsRule$2.evaluate(JenkinsRule.java:550)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:272)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:236)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:386)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:323)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:143)
```

### Proposed changelog entries

I think it's super-minor thing.

### Desired reviewers

@jglick, @oleg-nenashev