### PR TITLE
[JENKINS-34138] Fix maven installs from stepping on each other

### DIFF
--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -709,6 +709,27 @@ public class Maven extends Builder {
                 return ((MavenInstallation)obj).mavenHome;
             }
         }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            final MavenInstallation that = (MavenInstallation) o;
+
+            if (getName() != null ? !getName().equals(that.getName()) : that.getName() != null) return false;
+            if (getHome() != null ? !getHome().equals(that.getHome()) : that.getHome() != null) return false;
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = getName() != null ? getName().hashCode() : 0;
+            result = 31 * result + (getHome() != null ? getHome().hashCode() : 0);
+            //result = 31 * result + (getProperties() != null ? getProperties().hashCode() : 0);
+            return result;
+        }
+
     }
 
     /**

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -717,15 +717,15 @@ public class Maven extends Builder {
 
             final MavenInstallation that = (MavenInstallation) o;
 
-            if (getName() != null ? !getName().equals(that.getName()) : that.getName() != null) return false;
             if (getHome() != null ? !getHome().equals(that.getHome()) : that.getHome() != null) return false;
+            if (getName() != null ? !getName().equals(that.getName()) : that.getName() != null) return false;
             return true;
         }
 
         @Override
         public int hashCode() {
-            int result = getName() != null ? getName().hashCode() : 0;
-            result = 31 * result + (getHome() != null ? getHome().hashCode() : 0);
+            int result = getHome() != null ? getHome().hashCode() : 0;
+            result = 31 * result + (getName() != null ? getName().hashCode() : 0);
             //result = 31 * result + (getProperties() != null ? getProperties().hashCode() : 0);
             return result;
         }

--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -355,6 +355,7 @@ public class MavenTest {
                 log.contains("-DTEST_PROP1=VAL1") && log.contains("-DTEST_PROP2=VAL2"));
     }
 
+    @Issue("JENKINS-34138")
     @Test public void checkMavenInstallationEquals() throws Exception {
         MavenInstallation maven = ToolInstallations.configureMaven3();
         MavenInstallation maven2 = ToolInstallations.configureMaven3();
@@ -362,6 +363,7 @@ public class MavenTest {
         assertTrue(maven.equals(maven2));
     }
 
+    @Issue("JENKINS-34138")
     @Test public void checkMavenInstallationNotEquals() throws Exception {
         MavenInstallation maven3 = ToolInstallations.configureMaven3();
         MavenInstallation maven2 = ToolInstallations.configureDefaultMaven();

--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -23,49 +23,47 @@
  */
 package hudson.tasks;
 
+import com.gargoylesoftware.htmlunit.html.HtmlButton;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.EnvVars;
 import hudson.model.Build;
+import hudson.model.Cause.LegacyCodeCause;
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.JDK;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.PasswordParameterDefinition;
+import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
+import hudson.tasks.Maven.MavenInstallation;
+import hudson.tasks.Maven.MavenInstallation.DescriptorImpl;
+import hudson.tasks.Maven.MavenInstaller;
+import hudson.tools.InstallSourceProperty;
+import hudson.tools.ToolProperty;
+import hudson.tools.ToolPropertyDescriptor;
+import hudson.util.DescribableList;
 import jenkins.mvn.DefaultGlobalSettingsProvider;
 import jenkins.mvn.DefaultSettingsProvider;
 import jenkins.mvn.FilePathGlobalSettingsProvider;
 import jenkins.mvn.FilePathSettingsProvider;
 import jenkins.mvn.GlobalMavenConfig;
-import hudson.model.JDK;
-import hudson.model.ParametersDefinitionProperty;
-import hudson.model.Result;
-import hudson.model.StringParameterDefinition;
-import hudson.model.ParametersAction;
-import hudson.model.StringParameterValue;
-import hudson.model.Cause.LegacyCodeCause;
-import hudson.slaves.EnvironmentVariablesNodeProperty;
-import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
-import hudson.tasks.Maven.MavenInstallation;
-import hudson.tasks.Maven.MavenInstaller;
-import hudson.tasks.Maven.MavenInstallation.DescriptorImpl;
-import hudson.tools.ToolProperty;
-import hudson.tools.ToolPropertyDescriptor;
-import hudson.tools.InstallSourceProperty;
-import hudson.util.DescribableList;
-
-import java.util.Collections;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
-
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlButton;
-import hudson.EnvVars;
-import hudson.model.FreeStyleBuild;
-import hudson.model.PasswordParameterDefinition;
-import org.jvnet.hudson.test.Issue;
-import static org.junit.Assert.*;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -355,5 +353,19 @@ public class MavenTest {
         log = j.buildAndAssertSuccess(p).getLog();
         assertTrue("Properties should always be injected, even when build variables injection is enabled",
                 log.contains("-DTEST_PROP1=VAL1") && log.contains("-DTEST_PROP2=VAL2"));
+    }
+
+    @Test public void checkMavenInstallationEquals() throws Exception {
+        MavenInstallation maven = ToolInstallations.configureMaven3();
+        MavenInstallation maven2 = ToolInstallations.configureMaven3();
+        assertEquals(maven.hashCode(), maven2.hashCode());
+        assertTrue(maven.equals(maven2));
+    }
+
+    @Test public void checkMavenInstallationNotEquals() throws Exception {
+        MavenInstallation maven3 = ToolInstallations.configureMaven3();
+        MavenInstallation maven2 = ToolInstallations.configureDefaultMaven();
+        assertNotEquals(maven3.hashCode(), maven2.hashCode());
+        assertFalse(maven3.equals(maven2));
     }
 }


### PR DESCRIPTION
When multiple maven projects are launched on a new node the installs can step on each other.  There is locking inside InstallerTranslator but because maven does not have equals/hashcode method and the maven installs are different instances they can run concurrently.  This only works for the JDK because the same instance is used (populated from a global location on the abstract project).  

See [JENKINS-34138](https://issues.jenkins-ci.org/browse/JENKINS-34138).

### Proposed changelog entries

* Entry 1: Fixes maven installs on remote nodes from stepping on each other

### Submitter checklist

### Desired reviewers

@mention
@jenkinsci/code-reviewers
