### PR TITLE
[JENKINS-44052] Document & fix intended behaviour

### DIFF
--- a/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
+++ b/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
@@ -171,7 +171,7 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
         }
 
     	WaitingItem item = Jenkins.getInstance().getQueue().schedule(
-                getJob(), delay.getTime(), new ParametersAction(values), new CauseAction(new Cause.UserIdCause()));
+                getJob(), delay.getTimeInSeconds(), new ParametersAction(values), new CauseAction(new Cause.UserIdCause()));
         if (item!=null) {
             String url = formData.optString("redirectTo");
             if (url==null || !Util.isSafeToRedirectTo(url))   // avoid open redirect
@@ -199,7 +199,7 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
         if (delay==null)    delay=new TimeDuration(getJob().getQuietPeriod());
 
         Queue.Item item = Jenkins.getInstance().getQueue().schedule2(
-                getJob(), delay.getTime(), new ParametersAction(values), ParameterizedJobMixIn.getBuildCause(getJob(), req)).getItem();
+                getJob(), delay.getTimeInSeconds(), new ParametersAction(values), ParameterizedJobMixIn.getBuildCause(getJob(), req)).getItem();
 
         if (item != null) {
             rsp.sendRedirect(SC_CREATED, req.getContextPath() + '/' + item.getUrl());

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -213,7 +213,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
         }
 
 
-        Queue.Item item = Jenkins.getInstance().getQueue().schedule2(asJob(), delay.getTime(), getBuildCause(asJob(), req)).getItem();
+        Queue.Item item = Jenkins.getInstance().getQueue().schedule2(asJob(), delay.getTimeInSeconds(), getBuildCause(asJob(), req)).getItem();
         if (item != null) {
             rsp.sendRedirect(SC_CREATED, req.getContextPath() + '/' + item.getUrl());
         } else {

--- a/core/src/main/java/jenkins/util/TimeDuration.java
+++ b/core/src/main/java/jenkins/util/TimeDuration.java
@@ -21,27 +21,59 @@ public class TimeDuration {
         this.millis = millis;
     }
 
+    /**
+     * Returns the duration of this instance in <em>milliseconds</em>.
+     * @deprecated use {@link #getTimeInMillis()} instead.
+     *
+     * This method has always returned a time in milliseconds, when various callers incorrectly assumed seconds.
+     * And this spread through the codebase. So this has been deprecated for clarity in favour of more explicitly named
+     * methods.
+     */
+    @Deprecated
     public int getTime() {
         return (int)millis;
     }
 
+    /**
+     * Returns the duration of this instance in <em>milliseconds</em>.
+     */
     public long getTimeInMillis() {
         return millis;
     }
+
+    /**
+     * Returns the duration of this instance in <em>milliseconds</em>.
+     */
+    public int getTimeInSeconds() {
+        return (int) (millis / 1000L);
+    }
+
 
     public long as(TimeUnit t) {
         return t.convert(millis,TimeUnit.MILLISECONDS);
     }
 
-    public static @CheckForNull TimeDuration fromString(@CheckForNull String delay) {
-        if (delay==null)
+    /**
+     * Creates a {@link TimeDuration} from the delay passed in parameter
+     * @param delay the delay either in milliseconds without unit, or in seconds if suffixed by sec or secs.
+     * @return the TimeDuration created from the delay expressed as a String.
+     */
+    @CheckForNull
+    public static TimeDuration fromString(@CheckForNull String delay) {
+        if (delay == null) {
             return null;
+        }
 
+        long unitMultiplier = 1L;
+        delay = delay.trim();
         try {
             // TODO: more unit handling
-            if(delay.endsWith("sec"))   delay=delay.substring(0,delay.length()-3);
-            if(delay.endsWith("secs"))  delay=delay.substring(0,delay.length()-4);
-            return new TimeDuration(Long.parseLong(delay));
+            if (delay.endsWith("sec") || delay.endsWith("secs")) {
+                delay = delay.substring(0, delay.lastIndexOf("sec"));
+                delay = delay.trim();
+                unitMultiplier = 1000L;
+            }
+            return new TimeDuration(Long.parseLong(delay.trim()) * unitMultiplier);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid time duration value: "+delay);
         }

--- a/core/src/test/java/jenkins/util/TimeDurationTest.java
+++ b/core/src/test/java/jenkins/util/TimeDurationTest.java
@@ -1,0 +1,27 @@
+package jenkins.util;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import static jenkins.util.TimeDuration.*;
+
+
+public class TimeDurationTest {
+
+    @Test
+    public void fromString() throws Exception {
+        assertEquals(1, TimeDuration.fromString("1").getTimeInMillis());
+
+        assertEquals(1000, TimeDuration.fromString("1sec").getTimeInMillis());
+        assertEquals(1000, TimeDuration.fromString("1secs").getTimeInMillis());
+        assertEquals(1000, TimeDuration.fromString("1 secs ").getTimeInMillis());
+        assertEquals(1000, TimeDuration.fromString(" 1 secs ").getTimeInMillis());
+
+        assertEquals(21000, TimeDuration.fromString(" 21  secs ").getTimeInMillis());
+    }
+
+}

--- a/core/src/test/java/jenkins/util/TimeDurationTest.java
+++ b/core/src/test/java/jenkins/util/TimeDurationTest.java
@@ -20,8 +20,10 @@ public class TimeDurationTest {
         assertEquals(1000, TimeDuration.fromString("1secs").getTimeInMillis());
         assertEquals(1000, TimeDuration.fromString("1 secs ").getTimeInMillis());
         assertEquals(1000, TimeDuration.fromString(" 1 secs ").getTimeInMillis());
+        assertEquals(1, TimeDuration.fromString(" 1 secs ").getTimeInSeconds());
 
         assertEquals(21000, TimeDuration.fromString(" 21  secs ").getTimeInMillis());
+        assertEquals(21, TimeDuration.fromString(" 21  secs ").getTimeInSeconds());
     }
 
 }


### PR DESCRIPTION
The unit was actually ignored... 
I.e. until now: `TimeUnit.fromString("3")` is exactly the same as `TimeUnit.fromString("3secs")`...

So I added some simple tests, and fixed the code so that at least the _advertised_ feature would work.
In the go, I decided to simply deprecate TimeUnit.getTime() to 1) avoid future bad usages and 2) warn people that may use this outside the core that they may be hit by that legacy bug that was finally fixed.

See [JENKINS-44052](https://issues.jenkins-ci.org/browse/JENKINS-44052).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: JENKINS-44052: Fix `TimeDuration` and its incorrect usage. TimeDuration assumed milliseconds, and was supposed to parse `sec` or `secs` suffix to switch to seconds, but that never worked.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/code-reviewers esp. @jglick who reported JENKINS-44052 :-)

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
