### PR TITLE
[JENKINS-47127] Binaries are filtered when they should not

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -194,6 +194,24 @@ THE SOFTWARE.
         <!-- version specified in grandparent pom -->
         <configuration>
           <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+          <nonFilteredFileExtensions>
+            <nonFilteredExtension>eot</nonFilteredExtension>
+            <nonFilteredExtension>hudson-community</nonFilteredExtension>
+            <nonFilteredExtension>hudson</nonFilteredExtension>
+            <nonFilteredExtension>ico</nonFilteredExtension>
+            <nonFilteredExtension>jenkins-update-center-root-ca</nonFilteredExtension>
+            <nonFilteredExtension>otf</nonFilteredExtension>
+            <nonFilteredExtension>psd</nonFilteredExtension>
+            <nonFilteredExtension>svg</nonFilteredExtension>
+            <nonFilteredExtension>swf</nonFilteredExtension>
+            <nonFilteredExtension>ttf</nonFilteredExtension>
+            <nonFilteredExtension>vsd</nonFilteredExtension>
+            <nonFilteredExtension>woff2</nonFilteredExtension>
+            <nonFilteredExtension>woff</nonFilteredExtension>
+            <nonFilteredExtension>xcf</nonFilteredExtension>
+          </nonFilteredFileExtensions>
+
+
           <!-- for putting Main-Class into war -->
           <archive>
             <manifest>


### PR DESCRIPTION
The regression comes from a fix: https://github.com/apache/maven-plugins/commit/4ebaa8bac7e20772a6b6438b273c48582c63550e
(revision 1792380 on SVN)

Apparently the

```
          <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
```

was not honored previously (see [MWAR-404](https://issues.apache.org/jira/browse/MWAR-404)).

So that is how we ended up having our .ico and .ttf, .woff, etc. borked,
after we bumped to 3.1.0 (where [MWAR-404](https://issues.apache.org/jira/browse/MWAR-404) got fixed).

So, FTR, here is the full list of extensions I could find under the war module.
Then I kept what I think should never be filtered.

Granted, this is awkward, this would be far safer to *include* only the
things we want filtered, but does not seem possible, so here we go.

```
$ for i in $(find . -type f )
do
filename=$(basename "$i")
extension="${filename##*.}"
echo "<nonFilteredExtension>$extension</nonFilteredExtension>"
done | sort -u

<nonFilteredExtension>css</nonFilteredExtension>
<nonFilteredExtension>effpom</nonFilteredExtension>
<nonFilteredExtension>eot</nonFilteredExtension>
<nonFilteredExtension>gif</nonFilteredExtension>
<nonFilteredExtension>gitignore</nonFilteredExtension>
<nonFilteredExtension>groovy</nonFilteredExtension>
<nonFilteredExtension>hbs</nonFilteredExtension>
<nonFilteredExtension>html</nonFilteredExtension>
<nonFilteredExtension>hudson-community</nonFilteredExtension>
<nonFilteredExtension>hudson</nonFilteredExtension>
<nonFilteredExtension>ico</nonFilteredExtension>
<nonFilteredExtension>iml</nonFilteredExtension>
<nonFilteredExtension>jenkins-update-center-root-ca</nonFilteredExtension>
<nonFilteredExtension>js</nonFilteredExtension>
<nonFilteredExtension>json</nonFilteredExtension>
<nonFilteredExtension>less</nonFilteredExtension>
<nonFilteredExtension>lock</nonFilteredExtension>
<nonFilteredExtension>otf</nonFilteredExtension>
<nonFilteredExtension>png</nonFilteredExtension>
<nonFilteredExtension>properties</nonFilteredExtension>
<nonFilteredExtension>psd</nonFilteredExtension>
<nonFilteredExtension>rb</nonFilteredExtension>
<nonFilteredExtension>sh</nonFilteredExtension>
<nonFilteredExtension>svg2png</nonFilteredExtension>
<nonFilteredExtension>svg</nonFilteredExtension>
<nonFilteredExtension>swf</nonFilteredExtension>
<nonFilteredExtension>ttf</nonFilteredExtension>
<nonFilteredExtension>txt</nonFilteredExtension>
<nonFilteredExtension>url</nonFilteredExtension>
<nonFilteredExtension>vsd</nonFilteredExtension>
<nonFilteredExtension>woff2</nonFilteredExtension>
<nonFilteredExtension>woff</nonFilteredExtension>
<nonFilteredExtension>xcf</nonFilteredExtension>
<nonFilteredExtension>xmi</nonFilteredExtension>
<nonFilteredExtension>xml</nonFilteredExtension>
```

See [JENKINS-47127](https://issues.jenkins-ci.org/browse/JENKINS-47127).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* JENKINS-47127: favicon.ico and other binaries were incorrectly filtered

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck as you pinged me on this and @oleg-nenashev who commented on the JIRA
cc @reviewbybees for possibly more eyes, even if I'm out of work time ;-)

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

