### PR TITLE
[JENKINS-40344] Don't log warning for invalid crumb from anon

### DIFF
--- a/core/src/main/java/hudson/security/csrf/CrumbFilter.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbFilter.java
@@ -72,7 +72,9 @@ public class CrumbFilter implements Filter {
                 if (crumbIssuer.validateCrumb(httpRequest, crumbSalt, crumb)) {
                     valid = true;
                 } else {
-                    LOGGER.log(Level.WARNING, "Found invalid crumb {0}.  Will check remaining parameters for a valid one...", crumb);
+                    // JENKINS-40344: Don't spam the log just because a session is expired
+                    Level level = Jenkins.getAuthentication() == Jenkins.ANONYMOUS ? Level.FINE : Level.WARNING;
+                    LOGGER.log(level, "Found invalid crumb {0}.  Will check remaining parameters for a valid one...", crumb);
                 }
             }
 

--- a/core/src/main/java/hudson/security/csrf/CrumbFilter.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbFilter.java
@@ -7,6 +7,7 @@ package hudson.security.csrf;
 
 import hudson.util.MultipartFormDataParser;
 import jenkins.model.Jenkins;
+import org.acegisecurity.providers.anonymous.AnonymousAuthenticationToken;
 
 import java.io.IOException;
 import java.util.Enumeration;
@@ -70,7 +71,7 @@ public class CrumbFilter implements Filter {
             }
 
             // JENKINS-40344: Don't spam the log just because a session is expired
-            Level level = Jenkins.getAuthentication() == Jenkins.ANONYMOUS ? Level.FINE : Level.WARNING;
+            Level level = Jenkins.getAuthentication() instanceof AnonymousAuthenticationToken ? Level.FINE : Level.WARNING;
 
             if (crumb != null) {
                 if (crumbIssuer.validateCrumb(httpRequest, crumbSalt, crumb)) {

--- a/core/src/main/java/hudson/security/csrf/CrumbFilter.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbFilter.java
@@ -83,7 +83,7 @@ public class CrumbFilter implements Filter {
             if (valid) {
                 chain.doFilter(request, response);
             } else {
-                LOGGER.log(level, "No valid crumb was included in request for {0}. Returning {1}.", new Object[] {httpRequest.getRequestURI(), HttpServletResponse.SC_FORBIDDEN});
+                LOGGER.log(level, "No valid crumb was included in request for {0} by {1}. Returning {2}.", new Object[] {httpRequest.getRequestURI(), Jenkins.getAuthentication().getName(), HttpServletResponse.SC_FORBIDDEN});
                 httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN,"No valid crumb was included in the request");
             }
         } else {


### PR DESCRIPTION
See [JENKINS-40344](https://issues.jenkins-ci.org/browse/JENKINS-40344).

Not worth the time to write a test for this IMO.

Untested, interactive test with PR build and two browser tabs (one with the ajax stuff, the other logging out) should do it.

### Proposed changelog entries

* Don't log warning when an anonymous user sends an invalid crumb, usually just an expired session. *(Or none because too minor)*

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@rtyler @aheritier @oleg-nenashev 
