### PR TITLE
[JENKINS-47139] Fix setup wizard

### DIFF
--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -54,6 +54,7 @@ import hudson.model.UpdateCenter.DownloadJob.Installing;
 import hudson.model.UpdateCenter.InstallationJob;
 import hudson.model.UpdateCenter.UpdateCenterJob;
 import hudson.util.VersionNumber;
+import java.util.logging.Level;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
 import jenkins.util.xml.XMLUtils;
@@ -256,6 +257,7 @@ public class InstallUtil {
                 try {
                     String lastVersion = XMLUtils.getValue("/hudson/version", configFile);
                     if (lastVersion.length() > 0) {
+                        LOGGER.log(Level.FINE, "discovered serialized lastVersion {0}", lastVersion);
                         return lastVersion;
                     }
                 } catch (Exception e) {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3191,7 +3191,13 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     public synchronized void save() throws IOException {
         if(BulkChange.contains(this))   return;
-        version = VERSION;
+
+        if (initLevel == InitMilestone.COMPLETED) {
+            LOGGER.log(FINE, "setting version {0} to {1}", new Object[] {version, VERSION});
+            version = VERSION;
+        } else {
+            LOGGER.log(FINE, "refusing to set version {0} to {1} during {2}", new Object[] {version, VERSION, initLevel});
+        }
 
         getConfigFile().write(this);
         SaveableListener.fireOnChange(this, getConfigFile());


### PR DESCRIPTION
See [JENKINS-47139](https://issues.jenkins-ci.org/browse/JENKINS-47139). Amends #3010.

- [X] fix (passes `InstallWizardTest.wizardInstallSugestedTest`)
- [x] verify that JENKINS-42577 is still fixed

### Proposed changelog entries

* Jenkins 2.80 introduced a regression preventing the setup wizard from being run on new installations, and thus allowing Jenkins to run without security.

### Desired reviewers

@reviewbybees @jenkinsci/code-reviewers