### PR TITLE
[JENKINS-47168] - Print "built on" using display name

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -456,7 +456,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 if (node instanceof Jenkins) {
                     listener.getLogger().print(Messages.AbstractBuild_BuildingOnMaster());
                 } else {
-                    listener.getLogger().print(Messages.AbstractBuild_BuildingRemotely(ModelHyperlinkNote.encodeTo("/computer/" + builtOn, builtOn)));
+                    listener.getLogger().print(Messages.AbstractBuild_BuildingRemotely(ModelHyperlinkNote.encodeTo("/computer/" + node.getDisplayName(), builtOn)));
                     Set<LabelAtom> assignedLabels = new HashSet<LabelAtom>(node.getAssignedLabels());
                     assignedLabels.remove(node.getSelfLabel());
                     if (!assignedLabels.isEmpty()) {

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -456,7 +456,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 if (node instanceof Jenkins) {
                     listener.getLogger().print(Messages.AbstractBuild_BuildingOnMaster());
                 } else {
-                    listener.getLogger().print(Messages.AbstractBuild_BuildingRemotely(ModelHyperlinkNote.encodeTo("/computer/" + node.getDisplayName(), builtOn)));
+                    listener.getLogger().print(Messages.AbstractBuild_BuildingRemotely(ModelHyperlinkNote.encodeTo("/computer/" + builtOn, node.getDisplayName())));
                     Set<LabelAtom> assignedLabels = new HashSet<LabelAtom>(node.getAssignedLabels());
                     assignedLabels.remove(node.getSelfLabel());
                     if (!assignedLabels.isEmpty()) {


### PR DESCRIPTION
Pipelines print their built on using the display name of the node.  This changes regular builds to be the same. This has the advantage that the node display name for other node/computer classes (like cloud nodes) can be overridden to provide useful information.

### Changelog Entry

* Use node display name when printing "built on" message in the build log for abstract builds.

See [JENKINS-47168](https://issues.jenkins-ci.org/browse/JENKINS-47168).