### PR TITLE
[JENKINS-47127] Downgrade to m-war-p 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,9 @@ THE SOFTWARE.
     <java.level>8</java.level>
 
     <changelog.url>https://jenkins.io/changelog</changelog.url>
+
+    <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
+
   </properties>
 
   <!-- Note that the 'repositories' and 'pluginRepositories' blocks below are actually copy-pasted


### PR DESCRIPTION
Supersedes https://github.com/jenkinsci/jenkins/pull/3048
I don't think `maven-war-plugin:3.1.1` will be released before the end of this week.
See [MWAR-407](https://issues.apache.org/jira/browse/MWAR-407) to follow the issue fixed in the _svn trunk_.

-----

MWAR-404 introduced the regression in maven-war-plugin 3.1.0that makes
every files be filtered, including binaries.

MWAR-407 has been filed to revert MWAR-404, but that will be only in
m-war-p 3.1.1 or 3.2.0 which are not yet released.

So we downgrade to 3.0.0 for now.

See [JENKINS-47127](https://issues.jenkins-ci.org/browse/JENKINS-47127).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* JENKINS-47127: favicon.ico and other binaries were broken, because they were incorrectly filtered.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees for more eyes

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
