### PR TITLE
Disable the flaky AgentProtocolTest test

### DIFF
--- a/test/src/test/java/jenkins/AgentProtocolTest.java
+++ b/test/src/test/java/jenkins/AgentProtocolTest.java
@@ -40,6 +40,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -55,7 +57,8 @@ public class AgentProtocolTest {
     
     @Rule
     public JenkinsRule j = new JenkinsRule();
-    
+
+    //TODO: Test is unstable on CI due to the race condition, needs to be reworked
     /**
      * Checks that Jenkins does not disable agent protocols by default after the upgrade.
      * 
@@ -63,6 +66,7 @@ public class AgentProtocolTest {
      * @see SetupWizardTest#shouldDisableUnencryptedProtocolsByDefault() 
      */
     @Test
+    @Ignore
     @LocalData
     @Issue("JENKINS-45841")
     public void testShouldNotDisableProtocolsForMigratedInstances() throws Exception {


### PR DESCRIPTION
I just want to make CI green again.

### Proposed changelog entries

* N/A

### Desired reviewers

@reviewbybees @jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
