### PR TITLE
Un-restrict the addCriticalField in XStream2

### DIFF
--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -131,7 +131,6 @@ public class XStream2 extends XStream {
      * @param clazz a class which we expect to hold a non-{@code transient} field
      * @param field a field name in that class
      */
-    @Restricted(NoExternalUse.class) // TODO could be opened up later
     public void addCriticalField(Class<?> clazz, String field) {
         reflectionConverter.addCriticalField(clazz, field);
     }

--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -130,6 +130,7 @@ public class XStream2 extends XStream {
      * Specifies that a given field of a given class should not be treated with laxity by {@link RobustCollectionConverter}.
      * @param clazz a class which we expect to hold a non-{@code transient} field
      * @param field a field name in that class
+     * @since TODO
      */
     public void addCriticalField(Class<?> clazz, String field) {
         reflectionConverter.addCriticalField(clazz, field);


### PR DESCRIPTION
Like mentioned in the previous comment in code, the method should be used in the other project, like authorize-project that require a field to be set as critical.

As discussed with Jesse and Oleg on Oct. 5, I can un-restrict the call to this method by plugins.

You can see the workaround used in authorize-project at the moment : [PR](https://github.com/jenkinsci/authorize-project-plugin/pull/30)

See [JENKINS-47342](https://issues.jenkins-ci.org/browse/JENKINS-47342).

### Proposed changelog entries

* Un-restrict the use of the addCriticalField in XStream2 to be used in plugins

### Desired reviewers

@reviewbybees
