### PR TITLE
[JENKINS-30084] Suppressing flaky QueueTest.shouldBeAbleToBlockFlyweightTaskAtTheLastMinute

### DIFF
--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -119,6 +119,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.*;
+import org.junit.Ignore;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -811,6 +812,8 @@ public class QueueTest {
         assertEquals("aws-linux-dummy", matrixProject.getBuilds().getLastBuild().getBuiltOn().getLabelString());
     }
 
+    @Ignore("TODO too flaky; upstream can finish before we even examine the queue")
+    @Issue("JENKINS-30084")
     @Test
     public void shouldBeAbleToBlockFlyweightTaskAtTheLastMinute() throws Exception {
         MatrixProject matrixProject = r.jenkins.createProject(MatrixProject.class, "downstream");
@@ -855,6 +858,7 @@ public class QueueTest {
             throw new Exception("the upstream task could not be scheduled, thus the test will be interrupted");
         }
         //let s wait for the Upstream to enter the buildable Queue
+        Thread.sleep(1000);
         boolean enteredTheQueue = false;
         while (!enteredTheQueue) {
             for (Queue.BuildableItem item : Queue.getInstance().getBuildableItems()) {


### PR DESCRIPTION
A test introduced in #1815 was not written correctly, leading originally to total hangs of the CI build, fixed in #3055, and then just flaky failures as in #3069. I am adding an example small sleep which reproduces the failure and demonstrates why the test as written cannot run reliably. I am not really sure how to salvage it or exactly what it was testing to begin with, so I am disabling it for now.

@reviewbybees