### PR TITLE
Add a default implementation for SecurityListener

### DIFF
--- a/core/src/main/java/jenkins/security/LastGrantedAuthoritiesProperty.java
+++ b/core/src/main/java/jenkins/security/LastGrantedAuthoritiesProperty.java
@@ -91,14 +91,6 @@ public class LastGrantedAuthoritiesProperty extends UserProperty {
     @Extension
     public static class SecurityListenerImpl extends SecurityListener {
         @Override
-        protected void authenticated(@Nonnull UserDetails details) {
-        }
-
-        @Override
-        protected void failedToAuthenticate(@Nonnull String username) {
-        }
-
-        @Override
         protected void loggedIn(@Nonnull String username) {
             try {
                 // user should have been created but may not have been saved for some realms
@@ -142,10 +134,6 @@ public class LastGrantedAuthoritiesProperty extends UserProperty {
 //            } catch (IOException e) {
 //                LOGGER.log(Level.WARNING, "Failed to record granted authorities",e);
 //            }
-        }
-
-        @Override
-        protected void loggedOut(@Nonnull String username) {
         }
     }
 

--- a/core/src/main/java/jenkins/security/SecurityListener.java
+++ b/core/src/main/java/jenkins/security/SecurityListener.java
@@ -50,34 +50,34 @@ public abstract class SecurityListener implements ExtensionPoint {
      * Only {@link AbstractPasswordBasedSecurityRealm}s are considered.
      * @param details details of the newly authenticated user, such as name and groups
      */
-    protected abstract void authenticated(@Nonnull UserDetails details);
+    protected void authenticated(@Nonnull UserDetails details){}
 
     /**
      * Fired when a user tried to authenticate by password but failed.
      * @param username the user
      * @see #authenticated
      */
-    protected abstract void failedToAuthenticate(@Nonnull String username);
+    protected void failedToAuthenticate(@Nonnull String username){}
 
     /**
      * Fired when a user has logged in via the web UI.
      * Would be called after {@link #authenticated}.
      * @param username the user
      */
-    protected abstract void loggedIn(@Nonnull String username);
+    protected void loggedIn(@Nonnull String username){}
 
     /**
      * Fired when a user has failed to log in via the web UI.
      * Would be called after {@link #failedToAuthenticate}.
      * @param username the user
      */
-    protected abstract void failedToLogIn(@Nonnull String username);
+    protected void failedToLogIn(@Nonnull String username){}
 
     /**
      * Fired when a user logs out.
      * @param username the user
      */
-    protected abstract void loggedOut(@Nonnull String username);
+    protected void loggedOut(@Nonnull String username){}
 
     /** @since 1.569 */
     public static void fireAuthenticated(@Nonnull UserDetails details) {


### PR DESCRIPTION
Proposition to add a default implementation on the SecurityListener class that is currently abstract by simply removing the abstract modifiers on the methods.
Two other possibilities could have been chosen:
1) using an interface instead of an abstract class, but this implies two things, first we cannot have private static method (the all() method) but it's not really important since other extensions have set their own "all" to public ; the second is that the binary compatibility could be broken due to the change from class to interface.
2) adding a layer like that was done for Swing, you have the simili interface SecurityListener that stays abstract with abstract method and a new abstract class that implements (empty body) each mandatory methods to let them becomes optional.

Could simplify a bit the [#3074](https://github.com/jenkinsci/jenkins/pull/3074) like proposed on [this comment](https://github.com/jenkinsci/jenkins/pull/3074/files/b2c068e1d77eb49da1850d019d12dd8559db187b#r144217367)

No tests added since it's a modification that do not change behaviors, existing tests suffice to check non-regression.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
