### PR TITLE
[JENKINS-47426] getPropertyKey is not consistent over time

### DIFF
--- a/core/src/main/java/hudson/cli/ClientAuthenticationCache.java
+++ b/core/src/main/java/hudson/cli/ClientAuthenticationCache.java
@@ -38,7 +38,12 @@ public class ClientAuthenticationCache implements Serializable {
 
     private static final HMACConfidentialKey MAC = new HMACConfidentialKey(ClientAuthenticationCache.class, "MAC");
     private static final Logger LOGGER = Logger.getLogger(ClientAuthenticationCache.class.getName());
-
+    
+    /**
+     * Unique id used only by this instance for that run
+     */
+    private static volatile String randomId;
+    
     /**
      * Where the store should be placed.
      */
@@ -104,7 +109,7 @@ public class ClientAuthenticationCache implements Serializable {
             return Jenkins.ANONYMOUS;
         }
     }
-
+    
     /**
      * Computes the key that identifies this Hudson among other Hudsons that the user has a credential for.
      */
@@ -114,7 +119,15 @@ public class ClientAuthenticationCache implements Serializable {
         if (url!=null)  return url;
         
         LOGGER.log(Level.WARNING, "The instance is not configured using a rootUrl, the key that represents your instance will not be stable");
-        return Secret.fromString("key").getEncryptedValue();
+        if(randomId == null){
+            synchronized (this){
+                if(randomId == null){
+                    randomId = Secret.fromString("key").getEncryptedValue();
+                }
+            }
+        }
+
+        return randomId;
     }
 
     /**

--- a/core/src/main/java/hudson/cli/ClientAuthenticationCache.java
+++ b/core/src/main/java/hudson/cli/ClientAuthenticationCache.java
@@ -40,11 +40,6 @@ public class ClientAuthenticationCache implements Serializable {
     private static final Logger LOGGER = Logger.getLogger(ClientAuthenticationCache.class.getName());
     
     /**
-     * Unique id used only by this instance for that run
-     */
-    private static volatile String randomId;
-    
-    /**
      * Where the store should be placed.
      */
     private final FilePath store;
@@ -109,25 +104,18 @@ public class ClientAuthenticationCache implements Serializable {
             return Jenkins.ANONYMOUS;
         }
     }
-    
+
     /**
      * Computes the key that identifies this Hudson among other Hudsons that the user has a credential for.
      */
     @VisibleForTesting
     String getPropertyKey() {
-        String url = Jenkins.getActiveInstance().getRootUrl();
+        Jenkins j = Jenkins.getActiveInstance();
+        String url = j.getRootUrl();
         if (url!=null)  return url;
         
         LOGGER.log(Level.WARNING, "The instance is not configured using a rootUrl, the key that represents your instance will not be stable");
-        if(randomId == null){
-            synchronized (this){
-                if(randomId == null){
-                    randomId = Secret.fromString("key").getEncryptedValue();
-                }
-            }
-        }
-
-        return randomId;
+        return j.getLegacyInstanceId();
     }
 
     /**

--- a/core/src/main/java/hudson/cli/ClientAuthenticationCache.java
+++ b/core/src/main/java/hudson/cli/ClientAuthenticationCache.java
@@ -112,6 +112,8 @@ public class ClientAuthenticationCache implements Serializable {
     String getPropertyKey() {
         String url = Jenkins.getActiveInstance().getRootUrl();
         if (url!=null)  return url;
+        
+        LOGGER.log(Level.WARNING, "The instance is not configured using a rootUrl, the key that represents your instance will not be stable");
         return Secret.fromString("key").getEncryptedValue();
     }
 

--- a/test/src/test/java/hudson/cli/ClientAuthenticationCacheTest.java
+++ b/test/src/test/java/hudson/cli/ClientAuthenticationCacheTest.java
@@ -126,7 +126,6 @@ public class ClientAuthenticationCacheTest {
     }
     
     @Test
-    @Ignore("Currently the getPropertyKey is not consistent if the rootUrl is not set")
     public void getPropertyKey_mustBeEquivalentOverTime_rootUrlNotSet() throws Exception {
         ClientAuthenticationCache cache = new ClientAuthenticationCache(null);
         JenkinsLocationConfiguration.get().setUrl(null);

--- a/test/src/test/java/hudson/cli/ClientAuthenticationCacheTest.java
+++ b/test/src/test/java/hudson/cli/ClientAuthenticationCacheTest.java
@@ -116,6 +116,7 @@ public class ClientAuthenticationCacheTest {
     }
     
     @Test
+    @Issue("JENKINS-47426")
     public void getPropertyKey_mustBeEquivalentOverTime_rootUrlSet() throws Exception {
         ClientAuthenticationCache cache = new ClientAuthenticationCache(null);
 
@@ -126,6 +127,7 @@ public class ClientAuthenticationCacheTest {
     }
     
     @Test
+    @Issue("JENKINS-47426")
     public void getPropertyKey_mustBeEquivalentOverTime_rootUrlNotSet() throws Exception {
         ClientAuthenticationCache cache = new ClientAuthenticationCache(null);
         JenkinsLocationConfiguration.get().setUrl(null);

--- a/test/src/test/java/hudson/cli/ClientAuthenticationCacheTest.java
+++ b/test/src/test/java/hudson/cli/ClientAuthenticationCacheTest.java
@@ -114,6 +114,28 @@ public class ClientAuthenticationCacheTest {
         String key = cache.getPropertyKey();
         assertTrue(key, Secret.decrypt(key) != null);
     }
+    
+    @Test
+    public void getPropertyKey_mustBeEquivalentOverTime_rootUrlSet() throws Exception {
+        ClientAuthenticationCache cache = new ClientAuthenticationCache(null);
+
+        String key1 = cache.getPropertyKey();
+        String key2 = cache.getPropertyKey();
+
+        assertEquals("Two calls to the getPropertyKey() must be equivalent over time", key1, key2);
+    }
+    
+    @Test
+    @Ignore("Currently the getPropertyKey is not consistent if the rootUrl is not set")
+    public void getPropertyKey_mustBeEquivalentOverTime_rootUrlNotSet() throws Exception {
+        ClientAuthenticationCache cache = new ClientAuthenticationCache(null);
+        JenkinsLocationConfiguration.get().setUrl(null);
+
+        String key1 = cache.getPropertyKey();
+        String key2 = cache.getPropertyKey();
+
+        assertEquals("Two calls to the getPropertyKey() must be equivalent over time", key1, key2);
+    }
 
     private void assertCLI(int code, @CheckForNull String output, File jar, String... args) throws Exception {
         List<String> commands = Lists.newArrayList("java", "-jar", jar.getAbsolutePath(), "-s", r.getURL().toString(), "-noKeyAuth", "-remoting");

--- a/test/src/test/java/hudson/cli/ClientAuthenticationCacheTest.java
+++ b/test/src/test/java/hudson/cli/ClientAuthenticationCacheTest.java
@@ -112,7 +112,7 @@ public class ClientAuthenticationCacheTest {
         assertEquals(r.getURL().toString(), cache.getPropertyKey());
         JenkinsLocationConfiguration.get().setUrl(null);
         String key = cache.getPropertyKey();
-        assertTrue(key, Secret.decrypt(key) != null);
+        assertEquals(r.jenkins.getLegacyInstanceId(), key);
     }
     
     @Test

--- a/test/src/test/java/hudson/cli/ClientAuthenticationCacheTest.java
+++ b/test/src/test/java/hudson/cli/ClientAuthenticationCacheTest.java
@@ -117,25 +117,20 @@ public class ClientAuthenticationCacheTest {
     
     @Test
     @Issue("JENKINS-47426")
-    public void getPropertyKey_mustBeEquivalentOverTime_rootUrlSet() throws Exception {
+    public void getPropertyKey_mustBeEquivalentOverTime() throws Exception {
         ClientAuthenticationCache cache = new ClientAuthenticationCache(null);
 
         String key1 = cache.getPropertyKey();
         String key2 = cache.getPropertyKey();
 
-        assertEquals("Two calls to the getPropertyKey() must be equivalent over time", key1, key2);
-    }
-    
-    @Test
-    @Issue("JENKINS-47426")
-    public void getPropertyKey_mustBeEquivalentOverTime_rootUrlNotSet() throws Exception {
-        ClientAuthenticationCache cache = new ClientAuthenticationCache(null);
+        assertEquals("Two calls to the getPropertyKey() must be equivalent over time, with rootUrl", key1, key2);
+
         JenkinsLocationConfiguration.get().setUrl(null);
 
-        String key1 = cache.getPropertyKey();
-        String key2 = cache.getPropertyKey();
+        key1 = cache.getPropertyKey();
+        key2 = cache.getPropertyKey();
 
-        assertEquals("Two calls to the getPropertyKey() must be equivalent over time", key1, key2);
+        assertEquals("Two calls to the getPropertyKey() must be equivalent over time, without rootUrl", key1, key2);
     }
 
     private void assertCLI(int code, @CheckForNull String output, File jar, String... args) throws Exception {


### PR DESCRIPTION
Objective:
- getPropertyKey must be consistent over time, not necessarily between instance startup
- instead of just returning the random value, we store it at the first call and return it instead of a new random

See [JENKINS-47426](https://issues.jenkins-ci.org/browse/JENKINS-47426).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Changelog entry

* JENKINS-47426, Bug, Client Authentication Cache property keys were not consistent when Jenkins rootUrl was not set

### Desired reviewers

@reviewbybees @jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
