### PR TITLE
[JENKINS-36282] Add link to cc.xml?recursive from build history page

### DIFF
--- a/core/src/main/resources/hudson/model/View/builds.jelly
+++ b/core/src/main/resources/hudson/model/View/builds.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
       <div style="height:2em"/><!-- spacer -->
 
       <div>
-          <a href="cc.xml">${%Export as plain XML}</a> (<a href="cc.xml?recursive">${%Recursively include jobs in folders}</a>)
+          <a href="cc.xml">${%Export as plain XML}</a> (<a href="cc.xml?recursive">${%Recurse in subfolders}</a>)
       </div>
       <t:buildListTable builds="${it.builds}"/>
     </l:main-panel>

--- a/core/src/main/resources/hudson/model/View/builds.jelly
+++ b/core/src/main/resources/hudson/model/View/builds.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
       <div style="height:2em"/><!-- spacer -->
 
       <div>
-          <a href="cc.xml">${%Export as plain XML}</a>
+          <a href="cc.xml">${%Export as plain XML}</a> (<a href="cc.xml?recursive">${%Recursively include jobs in folders}</a>)
       </div>
       <t:buildListTable builds="${it.builds}"/>
     </l:main-panel>


### PR DESCRIPTION
See [JENKINS-36282](https://issues.jenkins-ci.org/browse/JENKINS-36282).

Add a link to `cc.xml?recursive` in builds.jelly so that users can discover the functionality introduced in #3060.

### Proposed changelog entries

* Add link to <code>cc.xml?recursive</code> in build history page to export jobs in folders recursively.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees @oleg-nenashev @daniel-beck 
