### PR TITLE
[JENKINS-6290] Add New View link to sidebar

### DIFF
--- a/core/src/main/resources/hudson/model/View/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/View/sidepanel.jelly
@@ -43,6 +43,18 @@ THE SOFTWARE.
         <l:task href="${rootURL}/${it.viewUrl}newJob" icon="icon-new-package icon-md" it="${app}" permission="${it.itemCreatePermission}" title="${%NewJob(it.newPronoun)}"/>
       </st:include>
 
+
+      <j:choose>
+        <j:when test="${it.class.name=='hudson.model.AllView'}">
+          <l:task href="${rootURL}/newView" icon="icon-new-document icon-md" permission="${it.CREATE}" title="${%NewView}"/>
+        </j:when>
+        <j:otherwise>
+          <l:task href="${rootURL}/${it.viewUrl}/newView" icon="icon-new-document icon-md" permission="${it.CREATE}" title="${%NewView}"/>
+        </j:otherwise>
+      </j:choose>
+
+
+
       <j:choose>
         <j:when test="${it.class.name=='hudson.model.AllView'}">
           <l:task href="${rootURL}/asynchPeople/" icon="icon-user icon-md" title="${%People}"/>

--- a/core/src/main/resources/hudson/model/View/sidepanel.properties
+++ b/core/src/main/resources/hudson/model/View/sidepanel.properties
@@ -1,1 +1,2 @@
 NewJob=New {0}
+NewView=New View

--- a/core/src/main/resources/hudson/model/View/sidepanel_de.properties
+++ b/core/src/main/resources/hudson/model/View/sidepanel_de.properties
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 
 NewJob={0} anlegen
+NewView=Ansicht anlegen
 People=Benutzer
 Build\ History=Build-Verlauf
 Edit\ View=Ansicht bearbeiten


### PR DESCRIPTION
See [JENKINS-6290](https://issues.jenkins-ci.org/browse/JENKINS-6290).

Some notes:
- I wasn't sure how to test this. I had at look at the ATH but didn't know if that was the right place for this change. Could you point out to me where to put tests and what kind?
- I picked the new document logo for now because there were no other new-* logos and I wanted to choose a different one than the one that is used for _New Item_. I didn't know where to get other images so please let me know if and how you want me to change it.


### Proposed changelog entries

* Entry 1: Add link to create new views from main sidebar

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests

