### PR TITLE
[JENKINS-6290] Add New View link to sidebar

### DIFF
--- a/core/src/main/java/jenkins/model/NewViewLink.java
+++ b/core/src/main/java/jenkins/model/NewViewLink.java
@@ -1,0 +1,52 @@
+package jenkins.model;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.TransientViewActionFactory;
+import hudson.model.View;
+import java.util.Collections;
+import java.util.List;
+
+@Extension
+public class NewViewLink extends TransientViewActionFactory {
+
+    @VisibleForTesting
+    static final String ICON_FILE_NAME = "folder";
+    @VisibleForTesting
+    public static final String URL_NAME = "newView";
+
+    @Override
+    public List<Action> createFor(View v) {
+        return Collections.singletonList(new Action() {
+
+            @Override
+            public String getIconFileName() {
+                if (!hasPermission(v)) {
+                    return null;
+                }
+
+                return ICON_FILE_NAME;
+            }
+
+            @Override
+            public String getDisplayName() {
+                if (!hasPermission(v)) {
+                    return null;
+                }
+
+                return Messages.NewViewLink_NewView();
+            }
+
+            @Override
+            public String getUrlName() {
+                return URL_NAME;
+            }
+
+            private boolean hasPermission(View view) {
+                return view.hasPermission(View.CREATE);
+            }
+
+        });
+    }
+}

--- a/core/src/main/resources/jenkins/model/Messages.properties
+++ b/core/src/main/resources/jenkins/model/Messages.properties
@@ -58,6 +58,8 @@ IdStrategy.CaseSensitiveEmailAddress.DisplayName=Case sensitive (email address)
 Mailer.Address.Not.Configured=address not configured yet <nobody@nowhere>
 Mailer.Localhost.Error=Please set a valid host name, instead of localhost
 
+NewViewLink.NewView=New View
+
 PatternProjectNamingStrategy.DisplayName=Pattern
 PatternProjectNamingStrategy.NamePatternRequired=Name Pattern is required
 PatternProjectNamingStrategy.NamePatternInvalidSyntax=regular expression's syntax is invalid.

--- a/core/src/main/resources/jenkins/model/Messages_de.properties
+++ b/core/src/main/resources/jenkins/model/Messages_de.properties
@@ -49,6 +49,8 @@ DefaultProjectNamingStrategy.DisplayName=keine Einschr\u00E4nkung
 Mailer.Address.Not.Configured=Adresse nicht konfiguriert <nobody@nowhere>
 Mailer.Localhost.Error=Bitte verwenden Sie einen konkreten Hostnamen anstelle von <tt>localhost</tt>.
 
+NewViewLink.NewView=Ansicht anlegen
+
 PatternProjectNamingStrategy.DisplayName=Muster
 PatternProjectNamingStrategy.NamePatternRequired=Der Regul\u00E4re Ausdruck darf nicht leer sein.
 PatternProjectNamingStrategy.NamePatternInvalidSyntax=Der Regul\u00E4re Ausdruck ist ung\u00FCltig.

--- a/core/src/test/java/jenkins/model/NewViewLinkTest.java
+++ b/core/src/test/java/jenkins/model/NewViewLinkTest.java
@@ -1,0 +1,46 @@
+package jenkins.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import hudson.model.Action;
+import hudson.model.View;
+import java.util.List;
+import org.junit.Test;
+
+public class NewViewLinkTest {
+
+    private NewViewLink newViewLink = new NewViewLink();
+
+    private View view = mock(View.class);
+
+    @Test
+    public void getActionsHasPermission() throws Exception {
+        when(view.hasPermission(any())).thenReturn(true);
+
+        final List<Action> actions = newViewLink.createFor(view);
+
+        assertEquals(1, actions.size());
+        final Action action = actions.get(0);
+        assertEquals(Messages.NewViewLink_NewView(), action.getDisplayName());
+        assertEquals(NewViewLink.ICON_FILE_NAME, action.getIconFileName());
+        assertEquals(NewViewLink.URL_NAME, action.getUrlName());
+    }
+
+    @Test
+    public void getActionsNoPermission() throws Exception {
+        when(view.hasPermission(any())).thenReturn(false);
+
+        final List<Action> actions = newViewLink.createFor(view);
+
+        assertEquals(1, actions.size());
+        final Action action = actions.get(0);
+        assertNull(action.getDisplayName());
+        assertNull(action.getIconFileName());
+        assertEquals(NewViewLink.URL_NAME, action.getUrlName());
+    }
+
+}


### PR DESCRIPTION
See [JENKINS-6290](https://issues.jenkins-ci.org/browse/JENKINS-6290).

Replaces #3084

Some notes:

- I wasn't sure how in which package to put the new class. Please let me know if I should change it.
- I didn't know which logo to pick or how to create a new one.

### Proposed changelog entries

* Entry 1: Add link to create new views from main sidebar

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@daniel-beck 
