### PR TITLE
[JENKINS-47448] Fix JDKInstaller for downloads requiring an Oracle login

### DIFF
--- a/test/src/test/java/hudson/tools/JDKInstallerTest.java
+++ b/test/src/test/java/hudson/tools/JDKInstallerTest.java
@@ -15,28 +15,20 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import hudson.model.JDK;
-import hudson.model.FreeStyleProject;
-import hudson.model.FreeStyleBuild;
 import hudson.model.TaskListener;
-import hudson.tasks.Shell;
 import hudson.util.StreamTaskListener;
 import hudson.tools.JDKInstaller.Platform;
-import hudson.tools.JDKInstaller.CPU;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher.LocalLauncher;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.logging.Logger;
 
 import org.junit.rules.TemporaryFolder;
-import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.xml.sax.SAXException;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -99,74 +91,6 @@ public class JDKInstallerTest {
         InstallSourceProperty isp = jdk.getProperties().get(InstallSourceProperty.class);
         assertEquals(1,isp.installers.size());
         j.assertEqualBeans(installer, isp.installers.get(JDKInstaller.class), "id,acceptLicense");
-    }
-
-    /**
-     * Can we locate the bundles?
-     */
-    @Test
-    public void locate() throws Exception {
-        Assume.assumeTrue("this is a really time consuming test, so only run it when we really want", Boolean.getBoolean("jenkins.testJDKInstaller"));
-
-        retrieveUpdateCenterData();
-
-        JDKInstaller i = new JDKInstaller("jdk-7u3-oth-JPR", true);
-        StreamTaskListener listener = StreamTaskListener.fromStdout();
-        i.locate(listener, Platform.LINUX, CPU.i386);
-        i.locate(listener, Platform.WINDOWS, CPU.amd64);
-        i.locate(listener, Platform.SOLARIS, CPU.Sparc);
-    }
-
-    private void retrieveUpdateCenterData() throws IOException, SAXException {
-        j.createWebClient().goTo("/"); // make sure data is loaded
-    }
-
-    /**
-     * Tests the auto installation.
-     */
-    @Test
-    public void autoInstallation6u13() throws Exception {
-        doTestAutoInstallation("jdk-6u13-oth-JPR@CDS-CDS_Developer", "1.6.0_13-b03");
-    }
-
-    /**
-     * JDK7 is distributed as a gzip file
-     */
-    @Test
-    public void autoInstallation7() throws Exception {
-        doTestAutoInstallation("jdk-7-oth-JPR", "1.7.0-b147");
-    }
-
-    @Test
-    @Issue("JENKINS-3989")
-    public void autoInstallation142_17() throws Exception {
-        doTestAutoInstallation("j2sdk-1.4.2_17-oth-JPR@CDS-CDS_Developer", "1.4.2_17-b06");
-    }
-
-    /**
-     * End-to-end installation test.
-     */
-    private void doTestAutoInstallation(String id, String fullversion) throws Exception {
-        Assume.assumeTrue("this is a really time consuming test, so only run it when we really want", Boolean.getBoolean("jenkins.testJDKInstaller"));
-
-        retrieveUpdateCenterData();
-
-        JDKInstaller installer = new JDKInstaller(id, true);
-
-        JDK jdk = new JDK("test", tmp.getRoot().getAbsolutePath(), Arrays.asList(
-                new InstallSourceProperty(Arrays.<ToolInstaller>asList(installer))));
-
-        j.jenkins.getJDKs().add(jdk);
-
-        FreeStyleProject p = j.createFreeStyleProject();
-        p.setJDK(jdk);
-        p.getBuildersList().add(new Shell("java -fullversion\necho $JAVA_HOME"));
-        FreeStyleBuild b = j.buildAndAssertSuccess(p);
-        @SuppressWarnings("deprecation") String log = b.getLog();
-        System.out.println(log);
-        // make sure it runs with the JDK that just got installed
-        assertTrue(log.contains(fullversion));
-        assertTrue(log.contains(tmp.getRoot().getAbsolutePath()));
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-47448](https://issues.jenkins-ci.org/browse/JENKINS-47448).

This PR makes JDKInstaller work with Oracle's new login page.

I verified that `jdk-9` and `jdk-8u144` work before and after the change, because they do not require login. I also verified that `jdk-8u141`, `jdk-8u131`, and `jdk-7u80` work after the change, and fail before the change, because they require login.

### Proposed changelog entries

* Fix <code>download.oracle.com</code> installation method for JDK tool for downloads requiring an Oracle login

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
  - [x] ~Move network-related JDKInstaller tests to ATH~ There is an [existing test](https://github.com/dwnusbaum/acceptance-test-harness/blob/master/src/test/java/core/JdkTest.java) in the ATH, which is fixed by jenkinsci/acceptance-test-harness#371
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees @jglick @oleg-nenashev @daniel-beck 

