### PR TITLE
[JENKINS-29470] - Prevent NPE in AbstractProject.checkout when agent disconnects during the build

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1211,7 +1211,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             workspace.mkdirs();
         }
         else{
-            return true;
+            LOGGER.log(Level.SEVERE,"Workspace does not exist!!");
+            return false;
         }
 
 

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1209,9 +1209,8 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         FilePath workspace = build.getWorkspace();
         if(workspace!=null){
             workspace.mkdirs();
-        }
-        else{
-            throw new AbortException(); // workspace is undefined
+        } else {
+            throw new AbortException("Cannot checkout SCM, workspace is not defined");
         }
 
 

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1211,8 +1211,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             workspace.mkdirs();
         }
         else{
-            LOGGER.log(Level.SEVERE,"Workspace does not exist!!");
-            return false;
+            throw new AbortException(); // workspace is undefined
         }
 
 

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1207,7 +1207,13 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             return true;    // no SCM
 
         FilePath workspace = build.getWorkspace();
-        workspace.mkdirs();
+        if(workspace!=null){
+            workspace.mkdirs();
+        }
+        else{
+            return true;
+        }
+
 
         boolean r = scm.checkout(build, launcher, workspace, listener, changelogFile);
         if (r) {


### PR DESCRIPTION
See [JENKINS-29470](https://issues.jenkins-ci.org/browse/JENKINS-29470).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Bug: Prevent NPE in AbstractProject.checkout when agent disconnects during the build
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
