### PR TITLE
[JENKINS-47500] Secret.decrypt launches ArrayIndexOutOfBoundsException when data is "{}"

### DIFF
--- a/core/src/main/java/hudson/util/Secret.java
+++ b/core/src/main/java/hudson/util/Secret.java
@@ -165,7 +165,7 @@ public final class Secret implements Serializable {
      */
     @CheckForNull
     public static Secret decrypt(@CheckForNull String data) {
-        if(data==null)      return null;
+        if(data==null || "{}".equals(data))      return null;
 
         if (data.startsWith("{") && data.endsWith("}")) { //likely CBC encrypted/containing metadata but could be plain text
             byte[] payload;

--- a/core/src/main/java/hudson/util/Secret.java
+++ b/core/src/main/java/hudson/util/Secret.java
@@ -165,7 +165,7 @@ public final class Secret implements Serializable {
      */
     @CheckForNull
     public static Secret decrypt(@CheckForNull String data) {
-        if(data==null || "{}".equals(data))      return null;
+        if(!isValidData(data))      return null;
 
         if (data.startsWith("{") && data.endsWith("}")) { //likely CBC encrypted/containing metadata but could be plain text
             byte[] payload;
@@ -213,6 +213,16 @@ public final class Secret implements Serializable {
                 return null;
             }
         }
+    }
+
+    private static boolean isValidData(String data) {
+        if (data == null || "{}".equals(data) || "".equals(data.trim())) return false;
+
+        if (data.startsWith("{") && data.endsWith("}")) {
+            return !"".equals(data.substring(1, data.length()-1).trim());
+        }
+
+        return true;
     }
 
     /**

--- a/core/src/test/java/hudson/util/SecretUtilTest.java
+++ b/core/src/test/java/hudson/util/SecretUtilTest.java
@@ -1,0 +1,23 @@
+package hudson.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+public class SecretUtilTest {
+
+    @Issue("JENKINS-47500")
+    @Test
+    public void decrypt() throws Exception {
+        String data = "{}";
+
+        try {
+            Secret secret = Secret.decrypt(data);
+            Assert.assertNull(secret);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            Assert.fail(data + " shouldn't throw an ArrayIndexOutOfBoundsException but returning null");
+        }
+
+    }
+
+}

--- a/core/src/test/java/hudson/util/SecretUtilTest.java
+++ b/core/src/test/java/hudson/util/SecretUtilTest.java
@@ -20,4 +20,46 @@ public class SecretUtilTest {
 
     }
 
+
+    @Issue("JENKINS-47500")
+    @Test
+    public void decryptJustSpace() throws Exception {
+        String data = " ";
+
+        try {
+            Secret secret = Secret.decrypt(data);
+            Assert.assertNull(secret);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            Assert.fail(data + " shouldn't throw an ArrayIndexOutOfBoundsException but returning null");
+        }
+
+    }
+
+    @Issue("JENKINS-47500")
+    @Test
+    public void decryptWithSpace() throws Exception {
+        String data = "{ }";
+
+        try {
+            Secret secret = Secret.decrypt(data);
+            Assert.assertNull(secret);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            Assert.fail(data + " shouldn't throw an ArrayIndexOutOfBoundsException but returning null");
+        }
+
+    }
+
+    @Issue("JENKINS-47500")
+    @Test
+    public void decryptWithSpaces() throws Exception {
+        String data = "{     }";
+
+        try {
+            Secret secret = Secret.decrypt(data);
+            Assert.assertNull(secret);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            Assert.fail(data + " shouldn't throw an ArrayIndexOutOfBoundsException but returning null");
+        }
+
+    }
 }


### PR DESCRIPTION
See [JENKINS-47500](https://issues.jenkins-ci.org/browse/JENKINS-47500).

unit test for bug added.

### Desired reviewers
@oleg-nenashev 

