### PR TITLE
[JENKINS-47517] Revert the change to the default behavior of Queue.Task.getCauseOfBlockage

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1016,24 +1016,6 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * <p>
-     * A project must be blocked if its own previous build is in progress,
-     * or if the blockBuildWhenUpstreamBuilding option is true and an upstream
-     * project is building, but derived classes can also check other conditions.
-     */
-    @Override
-    public boolean isBuildBlocked() {
-        return getCauseOfBlockage()!=null;
-    }
-
-    public String getWhyBlocked() {
-        CauseOfBlockage cb = getCauseOfBlockage();
-        return cb!=null ? cb.getShortDescription() : null;
-    }
-
-    /**
      * @deprecated use {@link BlockedBecauseOfBuildInProgress} instead.
      */
     @Deprecated
@@ -1075,6 +1057,14 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * A project must be blocked if its own previous build is in progress,
+     * or if the blockBuildWhenUpstreamBuilding option is true and an upstream
+     * project is building, but derived classes can also check other conditions.
+     */
     @Override
     public CauseOfBlockage getCauseOfBlockage() {
         // Block builds until they are done with post-production

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1814,18 +1814,22 @@ public class Queue extends ResourceController implements Saveable {
         /**
          * Returns true if the execution should be blocked
          * for temporary reasons.
-         *
-         * <p>
-         * Short-hand for {@code getCauseOfBlockageForItem()!=null}.
+         * @deprecated Use {@link #getCauseOfBlockage} != null
          */
-        boolean isBuildBlocked();
+        @Deprecated
+        default boolean isBuildBlocked() {
+            return getCauseOfBlockage() != null;
+        }
 
         /**
          * @deprecated as of 1.330
          *      Use {@link CauseOfBlockage#getShortDescription()} instead.
          */
         @Deprecated
-        String getWhyBlocked();
+        default String getWhyBlocked() {
+            CauseOfBlockage cause = getCauseOfBlockage();
+            return cause != null ? cause.getShortDescription() : null;
+        }
 
         /**
          * If the execution of this task should be blocked for temporary reasons,

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1841,9 +1841,6 @@ public class Queue extends ResourceController implements Saveable {
          */
         @CheckForNull
         default CauseOfBlockage getCauseOfBlockage() {
-            if (isBuildBlocked()) {
-                return CauseOfBlockage.fromMessage(Messages._Queue_Unknown());
-            }
             return null;
         }
 

--- a/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
@@ -56,10 +56,12 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.getLastBuiltOn();
     }
 
+    @Deprecated
     public boolean isBuildBlocked() {
         return base.isBuildBlocked();
     }
 
+    @Deprecated
     public String getWhyBlocked() {
         return base.getWhyBlocked();
     }

--- a/core/src/test/java/hudson/model/queue/AbstractQueueTaskTest.java
+++ b/core/src/test/java/hudson/model/queue/AbstractQueueTaskTest.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model.queue;
+
+import hudson.model.Queue;
+import java.io.IOException;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.jvnet.hudson.test.Issue;
+
+@SuppressWarnings("deprecation")
+public class AbstractQueueTaskTest {
+
+    @Issue("JENKINS-47517")
+    @Test
+    public void causeOfBlockageOverrides() {
+        Queue.Task t = new LegacyTask();
+        assertFalse(t.isBuildBlocked());
+        assertNull(t.getWhyBlocked());
+        assertNull(t.getCauseOfBlockage());
+    }
+    static class LegacyTask extends AbstractQueueTask {
+        @Override
+        public boolean isBuildBlocked() {
+            return getCauseOfBlockage() != null;
+        }
+        @Override
+        public String getWhyBlocked() {
+            CauseOfBlockage causeOfBlockage = getCauseOfBlockage();
+            return causeOfBlockage != null ? causeOfBlockage.getShortDescription() : null;
+        }
+        @Override
+        public String getName() {
+            return null;
+        }
+        @Override
+        public String getFullDisplayName() {
+            return null;
+        }
+        @Override
+        public void checkAbortPermission() {
+        }
+        @Override
+        public boolean hasAbortPermission() {
+            return false;
+        }
+        @Override
+        public String getUrl() {
+            return null;
+        }
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+        @Override
+        public Queue.Executable createExecutable() throws IOException {
+            throw new IOException();
+        }
+    }
+
+}

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -547,8 +547,7 @@ public class QueueTest {
         @Override public int hashCode() {
             return cnt.hashCode();
         }
-        @Override public boolean isBuildBlocked() {return isBlocked;}
-        @Override public String getWhyBlocked() {return null;}
+        @Override public CauseOfBlockage getCauseOfBlockage() {return isBlocked ? CauseOfBlockage.fromMessage(Messages._Queue_Unknown()) : null;}
         @Override public String getName() {return "test";}
         @Override public String getFullDisplayName() {return "Test";}
         @Override public void checkAbortPermission() {}

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -989,20 +989,6 @@ public class QueueTest {
     }
 
     @Test
-    public void testDefaultImplementationOfGetCauseOfBlockageForBlocked() throws Exception {
-        Queue queue = r.getInstance().getQueue();
-        queue.schedule2(new TestTask(new AtomicInteger(0), true), 0);
-
-        queue.maintain();
-
-        assertEquals(1, r.jenkins.getQueue().getBlockedItems().size());
-        CauseOfBlockage actual = r.jenkins.getQueue().getBlockedItems().get(0).getCauseOfBlockage();
-        CauseOfBlockage expected = CauseOfBlockage.fromMessage(Messages._Queue_Unknown());
-
-        assertEquals(expected.getShortDescription(), actual.getShortDescription());
-    }
-
-    @Test
     public void testGetCauseOfBlockageForNonConcurrentFreestyle() throws Exception {
         Queue queue = r.getInstance().getQueue();
         FreeStyleProject t1 = r.createFreeStyleProject("project");


### PR DESCRIPTION
See [JENKINS-47517](https://issues.jenkins-ci.org/browse/JENKINS-47517). Reverts an inessential-seeming, and extremely incompatible, part of #3038.

### Proposed changelog entries

* `StackOverflowError` thrown under some conditions when using Pipeline on 2.85.

@reviewbybees @jenkinsci/code-reviewers
