### PR TITLE
[FIXED JENKINS-43834] Stop using deprecated ABORT permission

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -60,8 +60,8 @@ THE SOFTWARE.
         </div>
         <j:if test="${build.building}">
           <div class="build-stop">
-            <!-- Check ABORT permission for Project, Admin permission otherwise -->
-            <j:if test="${empty(it.widget.owner.ABORT) ? h.hasPermission(app.ADMINISTER) : it.widget.owner.hasPermission(it.widget.owner.ABORT)}">
+            <!-- Check CANCEL permission for Project, Admin permission otherwise -->
+            <j:if test="${empty(it.widget.owner.CANCEL) ? h.hasPermission(app.ADMINISTER) : it.widget.owner.hasPermission(it.widget.owner.CANCEL)}">
               <l:stopButton href="${link}stop" alt="[cancel]" confirm="${%confirm(build.fullDisplayName)}" />
             </j:if>
           </div>


### PR DESCRIPTION
See [JENKINS-43834](https://issues.jenkins-ci.org/browse/JENKINS-43834).

This is the only place it's actually referenced, so let's get rid of
it entirely.

### Proposed changelog entries

* Entry 1: JENKINS-43834, stop using the deprecated Job/ABORT permission in the build history widget.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees
