### PR TITLE
[JENKINS-47115] - Add trim option to String Parameter

### DIFF
--- a/core/src/main/java/hudson/model/StringParameterDefinition.java
+++ b/core/src/main/java/hudson/model/StringParameterDefinition.java
@@ -24,11 +24,10 @@
 package hudson.model;
 
 import hudson.Extension;
+import hudson.Util;
 import javax.annotation.Nonnull;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -79,13 +78,11 @@ public class StringParameterDefinition extends SimpleParameterDefinition {
      * @return original or trimmed defaultValue (depending on trim)
      * @since TODO
      */
-    @Restricted(NoExternalUse.class)
     public String getDefaultValue4Build() {
-        if (isTrim() && defaultValue != null) {
-            return defaultValue.trim();
-        } else {
-            return defaultValue;
+        if (isTrim()) {
+            return Util.fixNull(defaultValue).trim();
         }
+        return defaultValue;
     }
     
     public void setDefaultValue(String defaultValue) {
@@ -137,7 +134,7 @@ public class StringParameterDefinition extends SimpleParameterDefinition {
 
     public ParameterValue createValue(String str) {
         StringParameterValue value = new StringParameterValue(getName(), str, getDescription());
-        if (isTrim()&& value!=null) {
+        if (isTrim() && value!=null) {
             value.doTrim();
         }
         return value;

--- a/core/src/main/java/hudson/model/StringParameterDefinition.java
+++ b/core/src/main/java/hudson/model/StringParameterDefinition.java
@@ -29,7 +29,7 @@ import javax.annotation.Nonnull;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -48,10 +48,6 @@ public class StringParameterDefinition extends SimpleParameterDefinition {
         this.trim = trim;
     }
 
-    /** 
-     *
-     * @since TODO
-     */
     @Nonnull
     public StringParameterDefinition(String name, String defaultValue, String description) {
         this(name, defaultValue, description, false);
@@ -79,7 +75,7 @@ public class StringParameterDefinition extends SimpleParameterDefinition {
      * 
      * @return original or trimmed defaultValue (depending on trim)
      */
-    @Restricted(NoExternalUse.class)
+    @Restricted(DoNotUse.class) // Jelly
     public String getDefaultValue4Build() {
         if (isTrim()) {
             return Util.fixNull(defaultValue).trim();

--- a/core/src/main/java/hudson/model/StringParameterDefinition.java
+++ b/core/src/main/java/hudson/model/StringParameterDefinition.java
@@ -24,8 +24,11 @@
 package hudson.model;
 
 import hudson.Extension;
+import javax.annotation.Nonnull;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -35,15 +38,26 @@ import org.kohsuke.stapler.StaplerRequest;
 public class StringParameterDefinition extends SimpleParameterDefinition {
 
     private String defaultValue;
+    private final boolean trim;
 
     @DataBoundConstructor
-    public StringParameterDefinition(String name, String defaultValue, String description) {
+    public StringParameterDefinition(String name, String defaultValue, String description, boolean trim) {
         super(name, description);
         this.defaultValue = defaultValue;
+        this.trim = trim;
     }
 
+    /** 
+     *
+     * @since TODO
+     */
+    @Nonnull
+    public StringParameterDefinition(String name, String defaultValue, String description) {
+        this(name, defaultValue, description, false);
+    }
+    
     public StringParameterDefinition(String name, String defaultValue) {
-        this(name, defaultValue, null);
+        this(name, defaultValue, null, false);
     }
 
     @Override
@@ -60,14 +74,42 @@ public class StringParameterDefinition extends SimpleParameterDefinition {
         return defaultValue;
     }
 
+    /**
+     * 
+     * @return original or trimmed defaultValue (depending on trim)
+     * @since TODO
+     */
+    @Restricted(NoExternalUse.class)
+    public String getDefaultValue4Build() {
+        if (isTrim() && defaultValue != null) {
+            return defaultValue.trim();
+        } else {
+            return defaultValue;
+        }
+    }
+    
     public void setDefaultValue(String defaultValue) {
         this.defaultValue = defaultValue;
+    }
+
+    /**
+     * 
+     * @return trim - {@code true}, if trim options has been selected, else return {@code false}.
+     *      Trimming will happen when creating {@link StringParameterValue}s,
+     *      the value in the config will not be changed.
+     * @since TODO
+     */
+    public boolean isTrim() {
+        return trim;
     }
     
     @Override
     public StringParameterValue getDefaultParameterValue() {
-        StringParameterValue v = new StringParameterValue(getName(), defaultValue, getDescription());
-        return v;
+        StringParameterValue value = new StringParameterValue(getName(), defaultValue, getDescription());
+        if (isTrim()) {
+            value.doTrim();
+        }
+        return value;
     }
 
     @Extension @Symbol({"string","stringParam"})
@@ -86,11 +128,18 @@ public class StringParameterDefinition extends SimpleParameterDefinition {
     @Override
     public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
         StringParameterValue value = req.bindJSON(StringParameterValue.class, jo);
+        if (isTrim() && value!=null) {
+            value.doTrim();
+        }
         value.setDescription(getDescription());
         return value;
     }
 
-    public ParameterValue createValue(String value) {
-        return new StringParameterValue(getName(), value, getDescription());
+    public ParameterValue createValue(String str) {
+        StringParameterValue value = new StringParameterValue(getName(), str, getDescription());
+        if (isTrim()&& value!=null) {
+            value.doTrim();
+        }
+        return value;
     }
 }

--- a/core/src/main/java/hudson/model/StringParameterDefinition.java
+++ b/core/src/main/java/hudson/model/StringParameterDefinition.java
@@ -28,6 +28,8 @@ import hudson.Util;
 import javax.annotation.Nonnull;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -76,8 +78,8 @@ public class StringParameterDefinition extends SimpleParameterDefinition {
     /**
      * 
      * @return original or trimmed defaultValue (depending on trim)
-     * @since TODO
      */
+    @Restricted(NoExternalUse.class)
     public String getDefaultValue4Build() {
         if (isTrim()) {
             return Util.fixNull(defaultValue).trim();

--- a/core/src/main/java/hudson/model/StringParameterValue.java
+++ b/core/src/main/java/hudson/model/StringParameterValue.java
@@ -30,13 +30,17 @@ import org.kohsuke.stapler.export.Exported;
 import java.util.Locale;
 
 import hudson.util.VariableResolver;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * {@link ParameterValue} created from {@link StringParameterDefinition}.
  */
 public class StringParameterValue extends ParameterValue {
     @Exported(visibility=4)
-    public final String value;
+    @Restricted(NoExternalUse.class)
+    public String value;
+    private boolean trim;
 
     @DataBoundConstructor
     public StringParameterValue(String name, String value) {
@@ -48,6 +52,17 @@ public class StringParameterValue extends ParameterValue {
         this.value = value;
     }
 
+    /**
+     * 
+     * @param trim - {@code true}, if trim options select, else - {@code false}.
+     * @return {@code StringParameterValue} object with {@code trim} parameter.
+     * @since TODO
+     */
+    public StringParameterValue withTrim(boolean trim) {
+        this.trim = trim;
+        return this;
+    }
+    
     /**
      * Exposes the name/value as an environment variable.
      */
@@ -69,6 +84,15 @@ public class StringParameterValue extends ParameterValue {
     @Override
     public Object getValue() {
         return value;
+    }
+     
+    /**
+     * Trimming for value
+     */
+    public void doTrim() {
+        if (value != null) {
+           value = value.trim(); 
+        } 
     }
 
     @Override

--- a/core/src/main/java/hudson/model/StringParameterValue.java
+++ b/core/src/main/java/hudson/model/StringParameterValue.java
@@ -40,7 +40,6 @@ public class StringParameterValue extends ParameterValue {
     @Exported(visibility=4)
     @Restricted(NoExternalUse.class)
     public String value;
-    private boolean trim;
 
     @DataBoundConstructor
     public StringParameterValue(String name, String value) {
@@ -50,17 +49,6 @@ public class StringParameterValue extends ParameterValue {
     public StringParameterValue(String name, String value, String description) {
         super(name, description);
         this.value = value;
-    }
-
-    /**
-     * 
-     * @param trim - {@code true}, if trim options select, else - {@code false}.
-     * @return {@code StringParameterValue} object with {@code trim} parameter.
-     * @since TODO
-     */
-    public StringParameterValue withTrim(boolean trim) {
-        this.trim = trim;
-        return this;
     }
     
     /**
@@ -88,6 +76,7 @@ public class StringParameterValue extends ParameterValue {
      
     /**
      * Trimming for value
+     * @since TODO
      */
     public void doTrim() {
         if (value != null) {

--- a/core/src/main/java/hudson/model/StringParameterValue.java
+++ b/core/src/main/java/hudson/model/StringParameterValue.java
@@ -50,7 +50,7 @@ public class StringParameterValue extends ParameterValue {
         super(name, description);
         this.value = value;
     }
-    
+
     /**
      * Exposes the name/value as an environment variable.
      */

--- a/core/src/main/resources/hudson/model/StringParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/StringParameterDefinition/config.jelly
@@ -35,4 +35,7 @@ THE SOFTWARE.
     <f:entry title="${%Description}" help="/help/parameter/description.html">
         <f:textarea name="parameter.description" value="${instance.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
     </f:entry>
+    <f:entry field="trim">
+        <f:checkbox default="false" title="${%Trim the string}"/>
+    </f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/StringParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/StringParameterDefinition/config.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
     <f:entry title="${%Description}" help="/help/parameter/description.html">
         <f:textarea name="parameter.description" value="${instance.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />
     </f:entry>
-    <f:entry field="trim">
+    <f:entry field="trim" help="/help/parameter/trim.html">
         <f:checkbox default="false" title="${%Trim the string}"/>
     </f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/StringParameterDefinition/index.jelly
+++ b/core/src/main/resources/hudson/model/StringParameterDefinition/index.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
         <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
 		<div name="parameter">
 			<input type="hidden" name="name" value="${it.name}" />
-			<f:textbox name="value" value="${it.defaultValue}" />
+			<f:textbox name="value" value="${it.defaultValue4Build}" />
 		</div>
 	</f:entry>
 </j:jelly>

--- a/war/src/main/webapp/help/parameter/trim.html
+++ b/war/src/main/webapp/help/parameter/trim.html
@@ -1,0 +1,3 @@
+<div>
+    Strip whitespace from the beginning and end of a string.
+</div>

--- a/war/src/main/webapp/help/parameter/trim.html
+++ b/war/src/main/webapp/help/parameter/trim.html
@@ -1,3 +1,3 @@
 <div>
-    Strip whitespace from the beginning and end of a string.
+    Strip whitespace from the beginning and end of the string.
 </div>


### PR DESCRIPTION
See [JENKINS-47115](https://issues.jenkins-ci.org/browse/JENKINS-47115).

String parameters will be trimmed, if has been selected checkbox "Trim the string" in Configure page:
<img width="639" alt="2017-10-23 12 53 23" src="https://user-images.githubusercontent.com/5075432/31897009-6f5c334a-b815-11e7-9849-1a424d926599.png">

Build dialog:
<img width="461" alt="2017-10-23 12 54 02" src="https://user-images.githubusercontent.com/5075432/31897028-7eab0650-b815-11e7-8e6d-f6d7345dd910.png">

After build:
<img width="552" alt="2017-10-23 12 54 34" src="https://user-images.githubusercontent.com/5075432/31897061-9e4e8f68-b815-11e7-9e44-8fb1deb4addd.png">


<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Add "Trim the string" checkbox in parameters for job
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->