### PR TITLE
When -Dtest is set, set -DfailIfNoTests=false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -882,5 +882,16 @@ THE SOFTWARE.
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>single-test</id>
+      <activation>
+        <property>
+          <name>test</name>
+        </property>
+      </activation>
+      <properties>
+        <failIfNoTests>false</failIfNoTests>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -883,7 +883,7 @@ THE SOFTWARE.
       </build>
     </profile>
     <profile>
-      <id>single-test</id>
+      <id>specific-test</id>
       <activation>
         <property>
           <name>test</name>


### PR DESCRIPTION
I'm sick of trying to run a single test, using `-Dtest=WhateverTest`, only to have the build fail because that particular test isn't in the CLI, or core, but in the Jenkins test harness at `test/`.

The error message suggests to set `-DfailIfNoTests=false`, so let's automate that.