### PR TITLE
[FIXED JENKINS-47713] - Do not copy list of plugins on every call

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -254,7 +254,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     /**
      * All discovered plugins.
      */
-    protected final List<PluginWrapper> plugins = new ArrayList<PluginWrapper>();
+    protected final List<PluginWrapper> plugins = new CopyOnWriteArrayList<>();
 
     /**
      * All active plugins, topologically sorted so that when X depends on Y, Y appears in the list before X does.
@@ -463,10 +463,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                                         cgd.run(getPlugins());
 
                                         // obtain topologically sorted list and overwrite the list
-                                        ListIterator<PluginWrapper> litr = getPlugins().listIterator();
                                         for (PluginWrapper p : cgd.getSorted()) {
-                                            litr.next();
-                                            litr.set(p);
                                             if(p.isActive())
                                                 activePlugins.add(p);
                                         }
@@ -1132,9 +1129,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      */
     @Exported
     public List<PluginWrapper> getPlugins() {
-        List<PluginWrapper> out = new ArrayList<PluginWrapper>(plugins.size());
-        out.addAll(plugins);
-        return out;
+        return Collections.unmodifiableList(plugins);
     }
 
     public List<FailedPlugin> getFailedPlugins() {


### PR DESCRIPTION
Low hanging fruit. In our case we allocate ~150 MB per minute in `getPlugins`.

List of plugins should not be modified often after Jenkins initialisation is finished. 

Kind of follow up of: https://github.com/jenkinsci/jenkins/pull/1180

https://issues.jenkins-ci.org/browse/JENKINS-47713

### Proposed changelog entries

* Performance improvement: reduce memory footprint in case of installations with long list of plugins


### Desired reviewers

@olivergondza , @jglick , @oleg-nenashev 