### PR TITLE
[JENKINS-47634] Move metadata about split plugins into a resource file

### DIFF
--- a/core/src/main/resources/jenkins/split-plugin-cycles.txt
+++ b/core/src/main/resources/jenkins/split-plugin-cycles.txt
@@ -1,0 +1,8 @@
+credentials matrix-auth
+credentials windows-slaves
+script-security antisamy-markup-formatter
+script-security bouncycastle-api
+script-security command-launcher
+script-security matrix-auth
+script-security matrix-project
+script-security windows-slaves

--- a/core/src/main/resources/jenkins/split-plugin-cycles.txt
+++ b/core/src/main/resources/jenkins/split-plugin-cycles.txt
@@ -1,5 +1,9 @@
+# See ClassicPluginStrategy.BREAK_CYCLES. As of JENKINS-47634 also used by plugin-compat-tester.
+# JENKINS-28942 could make this obsolete.
+
 credentials matrix-auth
 credentials windows-slaves
+
 script-security antisamy-markup-formatter
 script-security bouncycastle-api
 script-security command-launcher

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -1,0 +1,16 @@
+maven-plugin 1.296 1.296
+subversion 1.310 1.0
+cvs 1.340 0.1
+ant 1.430 1.0
+javadoc 1.430 1.0
+external-monitor-job 1.467 1.0
+ldap 1.467 1.0
+pam-auth 1.467 1.0
+mailer 1.493 1.2
+matrix-auth 1.535 1.0.2
+windows-slaves 1.547 1.0
+antisamy-markup-formatter 1.553 1.0
+matrix-project 1.561 1.0
+junit 1.577 1.0
+bouncycastle-api 2.16 2.16.0
+command-launcher 2.86 1.0

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -1,3 +1,5 @@
+# See ClassicPluginStrategy.DETACHED_LIST. As of JENKINS-47634 also used by plugin-compat-tester.
+
 maven-plugin 1.296 1.296
 subversion 1.310 1.0
 cvs 1.340 0.1
@@ -13,4 +15,5 @@ antisamy-markup-formatter 1.553 1.0
 matrix-project 1.561 1.0
 junit 1.577 1.0
 bouncycastle-api 2.16 2.16.0
+# JENKINS-47393
 command-launcher 2.86 1.0


### PR DESCRIPTION
So that `plugin-compat-tester` need not be manually synchronized.

See [JENKINS-47634](https://issues.jenkins-ci.org/browse/JENKINS-47634).

### Proposed changelog entries

* Metadata about plugins split from core is now accessible from `plugin-compat-tester`, simplifying some test scenarios.

@reviewbybees @jenkinsci/code-reviewers