### PR TITLE
[JENKINS-47530] Add null check to RunParameterDefinition#getProject()…

### DIFF
--- a/core/src/main/java/hudson/model/RunParameterDefinition.java
+++ b/core/src/main/java/hudson/model/RunParameterDefinition.java
@@ -23,6 +23,10 @@
  */
 package hudson.model;
 
+import static java.util.logging.Level.WARNING;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
@@ -164,20 +168,25 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
         }
 
         Run<?,?> lastBuild = null;
+        Job project = getProject();
+
+        if (project == null) {
+            return null;
+        }
 
         // use getFilter() so we dont have to worry about null filter value.
         switch (getFilter()) {
         case COMPLETED:
-            lastBuild = getProject().getLastCompletedBuild();
+            lastBuild = project.getLastCompletedBuild();
             break;
         case SUCCESSFUL:
-            lastBuild = getProject().getLastSuccessfulBuild();
+            lastBuild = project.getLastSuccessfulBuild();
             break;
         case STABLE	:
-            lastBuild = getProject().getLastStableBuild();
+            lastBuild = project.getLastStableBuild();
             break;
         default:
-            lastBuild = getProject().getLastBuild();
+            lastBuild = project.getLastBuild();
             break;
         }
 
@@ -199,4 +208,5 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
         return new RunParameterValue(getName(), value, getDescription());
     }
 
+    private static final Logger LOGGER = Logger.getLogger(RunParameterDefinition.class.getName());
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2871,7 +2871,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *      or it exists but it's no an instance of the given type.
      * @throws AccessDeniedException as per {@link ItemGroup#getItem}
      */
-    public @CheckForNull <T extends Item> T getItemByFullName(String fullName, Class<T> type) throws AccessDeniedException {
+    public @CheckForNull <T extends Item> T getItemByFullName(@Nonnull String fullName, Class<T> type) throws AccessDeniedException {
         StringTokenizer tokens = new StringTokenizer(fullName,"/");
         ItemGroup parent = this;
 

--- a/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
@@ -26,6 +26,7 @@ package hudson.model;
 
 import hudson.EnvVars;
 import static org.junit.Assert.*;
+
 import hudson.Launcher;
 import hudson.model.RunParameterDefinition.RunParameterFilter;
 import hudson.tasks.BuildStepMonitor;


### PR DESCRIPTION
… in RunParameterDefinition.getDefaultParameterValue()

See [JENKINS-47530](https://issues.jenkins-ci.org/browse/JENKINS-47530). This change adds a simple null check to RunParameterDefinition.getDefaultParameterValue(), to prevent the NullPointerException the User in the Issue is getting.

Disclaimer: This is my first Jenkins PR and this may only treat a symptom and not the actual cause of the issue. Thorough review is required.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* none

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
