### PR TITLE
[JENKINS-45387] Fix validation error displaying in setup wizard's "create first admin" form

### DIFF
--- a/core/src/main/java/hudson/security/AccountCreationFailedException.java
+++ b/core/src/main/java/hudson/security/AccountCreationFailedException.java
@@ -32,6 +32,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  *
  * @author Philipp Nowak
  */
+@Restricted(NoExternalUse.class)
 public class AccountCreationFailedException extends Exception {
     public AccountCreationFailedException(String message) {
         super(message);

--- a/core/src/main/java/hudson/security/AccountCreationFailedException.java
+++ b/core/src/main/java/hudson/security/AccountCreationFailedException.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Jenkins contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.security;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Thrown if an account creation was attempted but failed due to invalid data being entered into a form.
+ *
+ * @author Philipp Nowak
+ */
+public class AccountCreationFailedException extends Exception {
+    public AccountCreationFailedException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -244,18 +244,18 @@ public class SetupWizard extends PageDecorator {
     public HttpResponse doCreateAdminUser(StaplerRequest req, StaplerResponse rsp) throws IOException {
         Jenkins j = Jenkins.getInstance();
         j.checkPermission(Jenkins.ADMINISTER);
-        
+
         // This will be set up by default. if not, something changed, ok to fail
-        HudsonPrivateSecurityRealm securityRealm = (HudsonPrivateSecurityRealm)j.getSecurityRealm();
-        
+        HudsonPrivateSecurityRealm securityRealm = (HudsonPrivateSecurityRealm) j.getSecurityRealm();
+
         User admin = securityRealm.getUser(SetupWizard.initialSetupAdminUserName);
         try {
-            if(admin != null) {
+            if (admin != null) {
                 admin.delete(); // assume the new user may well be 'admin'
             }
-            
-            User u = securityRealm.createAccountFromSetupWizard(req);
-            if(admin != null) {
+
+            User newUser = securityRealm.createAccountFromSetupWizard(req);
+            if (admin != null) {
                 admin = null;
             }
 
@@ -269,9 +269,9 @@ public class SetupWizard extends PageDecorator {
             InstallUtil.proceedToNextStateFrom(InstallState.CREATE_ADMIN_USER);
 
             // ... and then login
-            Authentication a = new UsernamePasswordAuthenticationToken(u.getId(),req.getParameter("password1"));
-            a = securityRealm.getSecurityComponents().manager.authenticate(a);
-            SecurityContextHolder.getContext().setAuthentication(a);
+            Authentication auth = new UsernamePasswordAuthenticationToken(newUser.getId(), req.getParameter("password1"));
+            auth = securityRealm.getSecurityComponents().manager.authenticate(auth);
+            SecurityContextHolder.getContext().setAuthentication(auth);
             CrumbIssuer crumbIssuer = Jenkins.getInstance().getCrumbIssuer();
             JSONObject data = new JSONObject();
             if (crumbIssuer != null) {
@@ -279,10 +279,15 @@ public class SetupWizard extends PageDecorator {
             }
             return HttpResponses.okJSON(data);
         } catch (AccountCreationFailedException e) {
-            rsp.setStatus(400);
+            /*
+            Return Unprocessable Entity from WebDAV. While this is not technically in the HTTP/1.1 standard, browsers
+            seem to accept this. 400 Bad Request is technically inappropriate because that implies invalid *syntax*,
+            not incorrect data. The client only cares about it being >200 anyways.
+             */
+            rsp.setStatus(422);
             return HttpResponses.forwardToView(securityRealm, "/jenkins/install/SetupWizard/setupWizardFirstUser.jelly");
         } finally {
-            if(admin != null) {
+            if (admin != null) {
                 admin.save(); // recreate this initial user if something failed
             }
         }

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -241,6 +241,7 @@ public class SetupWizard extends PageDecorator {
      * Called during the initial setup to create an admin user
      */
     @RequirePOST
+    @Restricted(NoExternalUse.class)
     public HttpResponse doCreateAdminUser(StaplerRequest req, StaplerResponse rsp) throws IOException {
         Jenkins j = Jenkins.getInstance();
         j.checkPermission(Jenkins.ADMINISTER);

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -872,45 +872,37 @@ var createPluginSetupWizard = function(appendTarget) {
 			$c.slideDown();
 		}
 	};
-	
-	var handleStaplerSubmit = function(data) {
-		if(data.status && data.status > 200) {
-			// Nothing we can really do here
-			setPanel(errorPanel, { errorMessage: data.statusText });
-			return;
-		}
-		
-		try {
-			if(JSON.parse(data).status === 'ok') {
-				showStatePanel();
-				return;
-			}
-		} catch(e) {
-			// ignore JSON parsing issues, this may be HTML
-		}
-		// we get 200 OK
-		var responseText = data.responseText;
-		var $page = $(responseText);
-		var $errors = $page.find('.error');
-		if($errors.length > 0) {
-			var $main = $page.find('#main-panel').detach();
-			if($main.length > 0) {
-				responseText = responseText.replace(/body([^>]*)[>](.|[\r\n])+[<][/]body/,'body$1>'+$main.html()+'</body');
-			}
-			var doc = $('iframe[src]').contents()[0];
-			doc.open();
-			doc.write(responseText);
-			doc.close();
-		}
-		else {
+
+	var handleFirstUserResponseSuccess = function (data) {
+		if (data.status === 'ok') {
 			showStatePanel();
+		} else {
+			setPanel(errorPanel, {errorMessage: 'Error trying to create first user: ' + data.statusText});
 		}
+	};
+
+	var handleFirstUserResponseError = function(res) {
+		// We're expecting a full HTML page to replace the form
+		// We can only replace the _whole_ iframe due to XSS rules
+		// https://stackoverflow.com/a/22913801/1117552
+		var responseText = res.responseText;
+		var $page = $(responseText);
+		var $main = $page.find('#main-panel').detach();
+		if($main.length > 0) {
+			responseText = responseText.replace(/body([^>]*)[>](.|[\r\n])+[<][/]body/,'body$1>'+$main.html()+'</body');
+		}
+		var doc = $('iframe#setup-first-user').contents()[0];
+		doc.open();
+		doc.write(responseText);
+		doc.close();
+		$('button').prop({disabled:false});
 	};
 	
 	// call to submit the firstuser
 	var saveFirstUser = function() {
 		$('button').prop({disabled:true});
-		securityConfig.saveFirstUser($('iframe[src]').contents().find('form:not(.no-json)'), handleStaplerSubmit, handleStaplerSubmit);
+		var $form = $('iframe#setup-first-user').contents().find('form:not(.no-json)');
+		securityConfig.saveFirstUser($form, handleFirstUserResponseSuccess, handleFirstUserResponseError);
 	};
 
 	var skipFirstUser = function() {

--- a/war/src/main/js/templates/firstUserPanel.hbs
+++ b/war/src/main/js/templates/firstUserPanel.hbs
@@ -3,7 +3,7 @@
 </div>
 <div class="modal-body">
 	<div class="jumbotron welcome-panel security-panel">
-		<iframe src="{{baseUrl}}/setupWizard/setupWizardFirstUser"></iframe>
+		<iframe src="{{baseUrl}}/setupWizard/setupWizardFirstUser" id="setup-first-user"></iframe>
 	</div>
 </div>
 <div class="modal-footer">


### PR DESCRIPTION
See [JENKINS-45387](https://issues.jenkins-ci.org/browse/JENKINS-45387).

### Synopsis
This PR resolves validation errors not being properly displayed in the setup wizard's "create first admin user" form. For that, it creates a new special account creation method in the security realm. In the frontend, it adapts the error handling to work.

### Technical issue description
1. The SetupWizard was sending two responses if the form had validation errors. The first was sent in the security realm's `createAccount` method, and the second on the null check for the created user. This needed an API change in the security realm because the SetupWizard is forced to send a request (dictated by return type).
2. The frontend was expecting errors and successes in the same callback. However, the success callback accepts a `data` (JSON object received) parameter, while the error callback accepts a `response` (HTTP response object) parameter. This wasn't compatible.
3. The frontend tried to write to the `iframe`s `document` directly, which was (apparently) prevented by browsers (Chrome) for XSS protection. (This seems obvious, so I didn't research it further - correct me if I'm wrong!) Therefore, the whole `iframe` needed to be replaced instead of just the content.
4. The submit buttons stayed disabled even after receiving the response.

### Technical summary
For (1), I extracted the validation logic in the realm into a new private method and the creation logic into another `createAccount()` that accepts a `SignupInfo` parameter. This leaves the initial `createAccount()` , which is used by the 'normal' account creation forms trivial. Therefore, I was able to create a new account creation method for the setup wizard, which throws an exception if invalid data is entered. This allowed me to catch that exception in the wizard and redirect to the HTML page there.

For the frontend issues, I split the response handling into two methods. The success method does the same thing as before, just without the unnecessary parsing and with a slightly more meaningful error message.

The failure method now doesn't check the response for the error class any more and just displays it. The distinction didn't seem to be working, and seemed unnecessary to me. It also replaces the `iframe` element completely now, since I wasn't able to change its underlying `document` otherwise. My suspicion is that Chrome (and probably other major browsers) [prevents this as XSS protection](https://stackoverflow.com/a/22913801/1117552), which seems completely reasonable to me. Further, that method now resets the `disabled` attribute on the submit buttons.

### Known caveats
1. Receiving responses from the backend as HTML and putting them into an `iframe` really doesn't smell good. I don't think that's an XSS issue though, because an adversary could just inject their JS into any other Jenkins page if they can control the templates. I tried to change the response to JSON, but as mentioned, `iframe` documents (afaik) can't be modified by their parent documents to prevent cross-site scripting. (Maybe there's a header to change that) Changing the response to JSON however would probably require the form to be moved to the frontend, so I didn't bother with that.
2. I noticed that the `400 Bad Request` response code that I'm returning with my HTML response doesn't seem to be consistent with the other responses I've seen in the code. This is however necessary for the distinction between error/success callback.
3. I haven't seen any neighbouring methods using exceptions to signal errors, so this might be a source of inconsistency. I don't see another way of passing the response/error message to the caller with a `User` return type though.
4. I'm a first-time contributor and don't have a full overview of the Jenkins system yet, so it's possible that I'm missing some context. I did conduct a usage search in IntelliJ for existing code that I changed though.

### Tests
I have not included automated tests for this change because I frankly don't think it's worth the effort for this type of change. To test the UI would require full-blown UI tests and checking the backend response for the error code would just be repeating the production code in a test. I have manually tested the changes in Chrome and Firefox on Arch Linux though.

To always start the setup wizard, I (locally and temporarily) added the `jenkins.install.state=INITIAL_SECURITY_SETUP` and `jenkins.install.runWizard=true` system properties in the `jenkins-war` `pom-xml` at `build plugins plugin[artifactId='maven-jenkins-dev-plugin'] configuration systemProperties`. Also, I short-circuited `SetupWizard#isUsingSecurityDefaults()` to `true` using `if(true) return true;` to save me from having to re-create `war/work` every startup.

I have not run the full test suite on this and am waiting for the CI to do it for me. When I first set up the project, I accidentally ran it with `mvn install` and it took about one to two forevers (I aborted it).

### Proposed changelog entries
* bug: [JENKINS-45387]: Resolve setup wizard not displaying form validation errors in "create first admin user" form

### Submitter checklist
- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
- [x] Appropriate autotests or explanation to why this change has no tests

@jenkinsci/hacktoberfest

I'm looking forward to hear what you think!