### PR TITLE
[FIXED JENKINS-47181] - Recover the agent protocol handling tests.

### DIFF
--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -88,7 +88,7 @@ import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import javax.annotation.CheckForNull;
 
 /**
- * Tests of {@link Jenkins} class instance logic.
+ * Tests of the {@link Jenkins} class instance logic.
  * @see Jenkins
  * @see JenkinsRule
  */


### PR DESCRIPTION
The protocol handling logic does not longer use bogus assumptions anymore.
Instead of that, there are extra `MockAgentProtocol` instances (to be moved to JTH?)

See [JENKINS-47181](https://issues.jenkins-ci.org/browse/JENKINS-47181).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

N/A, test fixes

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
