### PR TITLE
Fix typo in the SetupWizardTest#shouldProhibitAccessToPluginListWithoutAuth()

### DIFF
--- a/test/src/test/java/jenkins/install/SetupWizardTest.java
+++ b/test/src/test/java/jenkins/install/SetupWizardTest.java
@@ -111,7 +111,7 @@ public class SetupWizardTest {
     public void shouldProhibitAccessToPluginListWithoutAuth() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
         wc.assertFails("setupWizard/platformPluginList", 403);
-        wc.assertFails("setupWizard/createAdminUaser", 403);
+        wc.assertFails("setupWizard/createAdminUser", 403);
         wc.assertFails("setupWizard/completeInstall", 403);
     }
     


### PR DESCRIPTION
Just noticed it while I was around.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries
N/A, test fix

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
