### PR TITLE
[JENKINS-45977] Behave robustly when a UserProperty is missing its descriptor

### DIFF
--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -984,7 +984,14 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
     Map<Descriptor<T>,T> toMap(Iterable<T> describables) {
         Map<Descriptor<T>,T> m = new LinkedHashMap<Descriptor<T>,T>();
         for (T d : describables) {
-            m.put(d.getDescriptor(),d);
+            Descriptor<T> descriptor;
+            try {
+                descriptor = d.getDescriptor();
+            } catch (Throwable x) {
+                LOGGER.log(Level.WARNING, null, x);
+                continue;
+            }
+            m.put(descriptor, d);
         }
         return m;
     }

--- a/test/src/test/java/hudson/model/UserTest.java
+++ b/test/src/test/java/hudson/model/UserTest.java
@@ -25,8 +25,12 @@
 package hudson.model;
 
 import com.gargoylesoftware.htmlunit.WebAssert;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.util.WebConnectionWrapper;
+import hudson.ExtensionList;
 
 import hudson.security.ACL;
 import hudson.security.ACLContext;
@@ -41,8 +45,11 @@ import hudson.tasks.MailAddressResolver;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import jenkins.model.IdStrategy;
@@ -58,8 +65,7 @@ import org.acegisecurity.context.SecurityContextHolder;
 import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
@@ -731,6 +737,31 @@ public class UserTest {
                 return new SomeUserProperty();
             }
         }
+    }
+
+    @Issue("JENKINS-45977")
+    @Test
+    public void missingDescriptor() throws Exception {
+        ExtensionList.lookup(Descriptor.class).remove(j.jenkins.getDescriptor(SomeUserProperty.class));
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to("alice"));
+        User alice = User.get("alice");
+        alice.addProperty(new SomeUserProperty());
+        assertThat(alice.getProperties().values(), not(empty()));
+        JenkinsRule.WebClient wc = j.createWebClient();
+        final List<URL> failingResources = new ArrayList<>();
+        new WebConnectionWrapper(wc) { // https://stackoverflow.com/a/18853796/12916
+            @Override
+            public WebResponse getResponse(WebRequest request) throws IOException {
+                WebResponse r = super.getResponse(request);
+                if (r.getStatusCode() >= 400) {
+                    failingResources.add(request.getUrl());
+                }
+                return r;
+            }
+        };
+        wc.login("alice").goTo("me/configure");
+        assertThat(failingResources, empty());
     }
 
 }


### PR DESCRIPTION
See [JENKINS-45977](https://issues.jenkins-ci.org/browse/JENKINS-45977). This is a more conservative alternative to #3022. I managed to reproduce not only the error thrown up from `User.getProperties`, but also a 403 in an AJAX response coming from `MyViewsProperty/config.jelly` due to a null `instance` (see JIRA for details).

### Proposed changelog entries

* Stop breaking the `/me/configure` page when a `UserProperty` is missing its descriptor.

@reviewbybees @jenkinsci/code-reviewers