### PR TITLE
Implement default methods in TaskListener and BuildListener

### DIFF
--- a/core/src/main/java/hudson/model/BuildListener.java
+++ b/core/src/main/java/hudson/model/BuildListener.java
@@ -23,6 +23,7 @@
  */
 package hudson.model;
 
+import java.io.PrintStream;
 import java.util.List;
 
 /**
@@ -38,10 +39,23 @@ public interface BuildListener extends TaskListener {
      * @param causes
      *      Causes that started a build. See {@link Run#getCauses()}.
      */
-    void started(List<Cause> causes);
+    default void started(List<Cause> causes) {
+        PrintStream l = getLogger();
+        if (causes == null || causes.isEmpty()) {
+            l.println("Started");
+        } else {
+            for (Cause cause : causes) {
+                // TODO elide duplicates as per CauseAction.getCauseCounts (used in summary.jelly)
+                cause.print(this);
+            }
+        }
+    }
 
     /**
      * Called when a build is finished.
      */
-    void finished(Result result);
+    default void finished(Result result) {
+        getLogger().println("Finished: " + result);
+    }
+
 }

--- a/core/src/main/java/hudson/model/StreamBuildListener.java
+++ b/core/src/main/java/hudson/model/StreamBuildListener.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
-import java.util.List;
 
 /**
  * {@link BuildListener} that writes to an {@link OutputStream}.
@@ -64,20 +63,6 @@ public class StreamBuildListener extends StreamTaskListener implements BuildList
 
     public StreamBuildListener(PrintStream w, Charset charset) {
         super(w,charset);
-    }
-
-    public void started(List<Cause> causes) {
-        PrintStream l = getLogger();
-        if (causes==null || causes.isEmpty())
-            l.println("Started");
-        else for (Cause cause : causes) {
-            // TODO elide duplicates as per CauseAction.getCauseCounts (used in summary.jelly)
-            cause.print(this);
-        }
-    }
-
-    public void finished(Result result) {
-        getLogger().println("Finished: "+result);
     }
 
     private static final long serialVersionUID = 1L;

--- a/core/src/main/java/hudson/model/TaskListener.java
+++ b/core/src/main/java/hudson/model/TaskListener.java
@@ -25,15 +25,21 @@ package hudson.model;
 
 import hudson.console.ConsoleNote;
 import hudson.console.HyperlinkNote;
-import hudson.util.AbstractTaskListener;
 import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
 
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Formatter;
+import javax.annotation.Nonnull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.accmod.restrictions.ProtectedExternally;
 
 /**
  * Receives events that happen during some lengthy operation
@@ -55,24 +61,46 @@ import java.util.Formatter;
  * {@link StreamTaskListener} is the most typical implementation of this interface.
  * All the {@link TaskListener} implementations passed to plugins from Hudson core are remotable.
  *
- * @see AbstractTaskListener
  * @author Kohsuke Kawaguchi
  */
 public interface TaskListener extends Serializable {
     /**
      * This writer will receive the output of the build
-     *
-     * @return
-     *      must be non-null.
      */
+    @Nonnull
     PrintStream getLogger();
+
+    /**
+     * A charset to use for methods returning {@link PrintWriter}.
+     * Should match that used to construct {@link #getLogger}.
+     * @return by default, UTF-8
+     */
+    @Restricted(ProtectedExternally.class)
+    @Nonnull
+    default Charset getCharset() {
+        return StandardCharsets.UTF_8;
+    }
+
+    @Restricted(NoExternalUse.class) // TODO Java 9 make private
+    default PrintWriter _error(String prefix, String msg) {
+        PrintStream out = getLogger();
+        out.print(prefix);
+        out.println(msg);
+
+        // annotate(new HudsonExceptionNote()) if and when this is made to do something
+        Charset charset = getCharset();
+        return new PrintWriter(charset != null ? new OutputStreamWriter(out, charset) : new OutputStreamWriter(out), true);
+    }
 
     /**
      * Annotates the current position in the output log by using the given annotation.
      * If the implementation doesn't support annotated output log, this method might be no-op.
      * @since 1.349
      */
-    void annotate(ConsoleNote ann) throws IOException;
+    @SuppressWarnings("rawtypes")
+    default void annotate(ConsoleNote ann) throws IOException {
+        ann.encodeTo(getLogger());
+    }
 
     /**
      * Places a {@link HyperlinkNote} on the given text.
@@ -80,33 +108,48 @@ public interface TaskListener extends Serializable {
      * @param url
      *      If this starts with '/', it's interpreted as a path within the context path.
      */
-    void hyperlink(String url, String text) throws IOException;
+    default void hyperlink(String url, String text) throws IOException {
+        annotate(new HyperlinkNote(url, text.length()));
+        getLogger().print(text);
+    }
 
     /**
      * An error in the build.
      *
      * @return
-     *      A writer to receive details of the error. Not null.
+     *      A writer to receive details of the error.
      */
-    PrintWriter error(String msg);
+    @Nonnull
+    default PrintWriter error(String msg) {
+        return _error("ERROR: ", msg);
+    }
 
     /**
      * {@link Formatter#format(String, Object[])} version of {@link #error(String)}.
      */
-    PrintWriter error(String format, Object... args);
+    @Nonnull
+    default PrintWriter error(String format, Object... args) {
+        return error(String.format(format,args));
+    }
 
     /**
      * A fatal error in the build.
      *
      * @return
-     *      A writer to receive details of the error. Not null.
+     *      A writer to receive details of the error.
      */
-    PrintWriter fatalError(String msg);
+    @Nonnull
+    default PrintWriter fatalError(String msg) {
+        return _error("FATAL: ", msg);
+    }
 
     /**
      * {@link Formatter#format(String, Object[])} version of {@link #fatalError(String)}.
      */
-    PrintWriter fatalError(String format, Object... args);
+    @Nonnull
+    default PrintWriter fatalError(String format, Object... args) {
+        return fatalError(String.format(format, args));
+    }
 
     /**
      * {@link TaskListener} that discards the output.

--- a/core/src/main/java/hudson/util/AbstractTaskListener.java
+++ b/core/src/main/java/hudson/util/AbstractTaskListener.java
@@ -1,17 +1,11 @@
 package hudson.util;
 
-import hudson.console.HyperlinkNote;
 import hudson.model.TaskListener;
 
-import java.io.IOException;
 
 /**
- * Partial default implementation of {@link TaskListener}
- * @author Kohsuke Kawaguchi
+ * @deprecated implement {@link TaskListener} directly
  */
+@Deprecated
 public abstract class AbstractTaskListener implements TaskListener {
-    public void hyperlink(String url, String text) throws IOException {
-        annotate(new HyperlinkNote(url,text.length()));
-        getLogger().print(text);
-    }
 }

--- a/core/src/main/java/hudson/util/LogTaskListener.java
+++ b/core/src/main/java/hudson/util/LogTaskListener.java
@@ -27,11 +27,10 @@ package hudson.util;
 import hudson.console.ConsoleNote;
 import hudson.model.TaskListener;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -39,38 +38,27 @@ import java.util.logging.Logger;
 /**
  * {@link TaskListener} which sends messages to a {@link Logger}.
  */
-public class LogTaskListener extends AbstractTaskListener implements Serializable {
-    
+public class LogTaskListener implements TaskListener, Closeable {
+
+    // would be simpler to delegate to the LogOutputStream but this would incompatibly change the serial form
     private final TaskListener delegate;
 
     public LogTaskListener(Logger logger, Level level) {
         delegate = new StreamTaskListener(new LogOutputStream(logger, level, new Throwable().getStackTrace()[1]));
     }
 
+    @Override
     public PrintStream getLogger() {
         return delegate.getLogger();
     }
 
-    public PrintWriter error(String msg) {
-        return delegate.error(msg);
-    }
-
-    public PrintWriter error(String format, Object... args) {
-        return delegate.error(format, args);
-    }
-
-    public PrintWriter fatalError(String msg) {
-        return delegate.fatalError(msg);
-    }
-
-    public PrintWriter fatalError(String format, Object... args) {
-        return delegate.fatalError(format, args);
-    }
-
+    @Override
+    @SuppressWarnings("rawtypes")
     public void annotate(ConsoleNote ann) {
         // no annotation support
     }
 
+    @Override
     public void close() {
         delegate.getLogger().close();
     }
@@ -82,12 +70,13 @@ public class LogTaskListener extends AbstractTaskListener implements Serializabl
         private final StackTraceElement caller;
         private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        public LogOutputStream(Logger logger, Level level, StackTraceElement caller) {
+        LogOutputStream(Logger logger, Level level, StackTraceElement caller) {
             this.logger = logger;
             this.level = level;
             this.caller = caller;
         }
 
+        @Override
         public void write(int b) throws IOException {
             if (b == '\r' || b == '\n') {
                 flush();

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -24,8 +24,6 @@
 package hudson.util;
 
 import hudson.CloseProofOutputStream;
-import hudson.console.ConsoleNote;
-import hudson.console.HudsonExceptionNote;
 import hudson.model.TaskListener;
 import hudson.remoting.RemoteOutputStream;
 import java.io.Closeable;
@@ -34,16 +32,12 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
-import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.logging.Level;
@@ -58,7 +52,7 @@ import org.kohsuke.stapler.framework.io.WriterOutputStream;
  * 
  * @author Kohsuke Kawaguchi
  */
-public class StreamTaskListener extends AbstractTaskListener implements Serializable, Closeable {
+public class StreamTaskListener implements TaskListener, Closeable {
     private PrintStream out;
     private Charset charset;
 
@@ -151,44 +145,14 @@ public class StreamTaskListener extends AbstractTaskListener implements Serializ
         return new StreamTaskListener(System.err,Charset.defaultCharset());
     }
 
+    @Override
     public PrintStream getLogger() {
         return out;
     }
 
-    private PrintWriter _error(String prefix, String msg) {
-        out.print(prefix);
-        out.println(msg);
-
-        // the idiom in Jenkins is to use the returned writer for writing stack trace,
-        // so put the marker here to indicate an exception. if the stack trace isn't actually written,
-        // HudsonExceptionNote.annotate recovers gracefully.
-        try {
-            annotate(new HudsonExceptionNote());
-        } catch (IOException e) {
-            // for signature compatibility, we have to swallow this error
-        }
-        return new PrintWriter(
-            charset!=null ? new OutputStreamWriter(out,charset) : new OutputStreamWriter(out),true);
-    }
-
-    public PrintWriter error(String msg) {
-        return _error("ERROR: ",msg);
-    }
-
-    public PrintWriter error(String format, Object... args) {
-        return error(String.format(format,args));
-    }
-
-    public PrintWriter fatalError(String msg) {
-        return _error("FATAL: ",msg);
-    }
-
-    public PrintWriter fatalError(String format, Object... args) {
-        return fatalError(String.format(format,args));
-    }
-
-    public void annotate(ConsoleNote ann) throws IOException {
-        ann.encodeTo(out);
+    @Override
+    public Charset getCharset() {
+        return charset;
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {
@@ -202,6 +166,7 @@ public class StreamTaskListener extends AbstractTaskListener implements Serializ
         charset = name==null ? null : Charset.forName(name);
     }
 
+    @Override
     public void close() throws IOException {
         out.close();
     }

--- a/core/src/main/java/jenkins/util/BuildListenerAdapter.java
+++ b/core/src/main/java/jenkins/util/BuildListenerAdapter.java
@@ -26,17 +26,13 @@ package jenkins.util;
 
 import hudson.console.ConsoleNote;
 import hudson.model.BuildListener;
-import hudson.model.Cause;
-import hudson.model.Result;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.util.List;
 
 /**
  * Wraps a {@link TaskListener} as a {@link BuildListener} for compatibility with APIs which historically expected the latter.
- * Does not support {@link BuildListener#started} or {@link BuildListener#finished}.
  *
  * @since 1.577
  */
@@ -46,14 +42,6 @@ public final class BuildListenerAdapter implements BuildListener {
 
     public BuildListenerAdapter(TaskListener delegate) {
         this.delegate = delegate;
-    }
-
-    @Override public void started(List<Cause> causes) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override public void finished(Result result) {
-        throw new UnsupportedOperationException();
     }
 
     @Override public PrintStream getLogger() {


### PR DESCRIPTION
Would avoid the need for `LessAbstractTaskListener` in https://github.com/jenkinsci/workflow-support-plugin/pull/15, for example.

@reviewbybees