### PR TITLE
[JENKINS-12251 follow up] Switch to the non-deprecated variable

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -846,7 +846,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
             if (!new File(root,"jobs").exists()) {
                 // if this is a fresh install, use more modern default layout that's consistent with agents
-                workspaceDir = "${JENKINS_HOME}/workspace/${ITEM_FULLNAME}";
+                workspaceDir = "${JENKINS_HOME}/workspace/${ITEM_FULL_NAME}";
             }
 
             // doing this early allows InitStrategy to set environment upfront


### PR DESCRIPTION
JENKINS-12251 deprecated `ITEM_FULLNAME` in favour of `ITEM_FULL_NAME`.. for new installs we should default to the correct variable

See [JENKINS-12251](https://issues.jenkins-ci.org/browse/JENKINS-12251).

### Proposed changelog entries

* Updated default workspace directory naming for new installations to use non-deprecated variable

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)

### Desired reviewers

@jglick 
