### PR TITLE
[JENKINS-43852] add caching options for captcha

### DIFF
--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -403,9 +403,9 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
             String id = req.getSession().getId();
             rsp.setContentType("image/png");
             // source: https://stackoverflow.com/a/3414217
-            rsp.addHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-            rsp.addHeader("Pragma", "no-cache");
-            rsp.addHeader("Expires", "0");
+            rsp.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+            rsp.setHeader("Pragma", "no-cache");
+            rsp.setHeader("Expires", "0");
             captchaSupport.generateImage(id, rsp.getOutputStream());
         }
     }

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -402,7 +402,10 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
         if (captchaSupport != null) {
             String id = req.getSession().getId();
             rsp.setContentType("image/png");
-            rsp.addHeader("Cache-Control", "no-cache");
+            // source: https://stackoverflow.com/a/3414217
+            rsp.addHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+            rsp.addHeader("Pragma", "no-cache");
+            rsp.addHeader("Expires", "0");
             captchaSupport.generateImage(id, rsp.getOutputStream());
         }
     }

--- a/test/src/test/java/hudson/security/SecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/SecurityRealmTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc. and others
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/test/java/hudson/security/SecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/SecurityRealmTest.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package hudson.security;
 
 import com.gargoylesoftware.htmlunit.WebResponse;

--- a/test/src/test/java/hudson/security/SecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/SecurityRealmTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2015, CloudBees, Inc. and others
+ * Copyright (c) 2017, CloudBees, Inc. and others
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/test/java/hudson/security/SecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/SecurityRealmTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc. and others
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.security;
+
+import com.gargoylesoftware.htmlunit.WebResponse;
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SecurityRealmTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-43852")
+    public void testCacheHeaderInResponse() throws Exception {
+        WebResponse response = j.createWebClient()
+                .goTo("securityRealm/captcha", "image/png")
+                .getWebResponse();
+
+        assertThat(response.getResponseHeaderValue("Cache-Control"), is("no-cache, no-store, must-revalidate"));
+        assertThat(response.getResponseHeaderValue("Pragma"), is("no-cache"));
+        assertThat(response.getResponseHeaderValue("Expires"), is("0"));
+    }
+}

--- a/test/src/test/java/hudson/security/SecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/SecurityRealmTest.java
@@ -25,17 +25,21 @@ package hudson.security;
 
 import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import hudson.security.captcha.CaptchaSupport;
 import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class SecurityRealmTest {
@@ -46,12 +50,33 @@ public class SecurityRealmTest {
     @Test
     @Issue("JENKINS-43852")
     public void testCacheHeaderInResponse() throws Exception {
+        SecurityRealm securityRealm = j.createDummySecurityRealm();
+        j.jenkins.setSecurityRealm(securityRealm);
+
         WebResponse response = j.createWebClient()
+                .goTo("securityRealm/captcha", "")
+                .getWebResponse();
+        assertEquals(response.getContentAsString(), "");
+
+        securityRealm.setCaptchaSupport(new DummyCaptcha());
+
+        response = j.createWebClient()
                 .goTo("securityRealm/captcha", "image/png")
                 .getWebResponse();
 
         assertThat(response.getResponseHeaderValue("Cache-Control"), is("no-cache, no-store, must-revalidate"));
         assertThat(response.getResponseHeaderValue("Pragma"), is("no-cache"));
         assertThat(response.getResponseHeaderValue("Expires"), is("0"));
+    }
+
+    private class DummyCaptcha extends CaptchaSupport {
+        @Override
+        public boolean validateCaptcha(String id, String text) {
+            return false;
+        }
+
+        @Override
+        public void generateImage(String id, OutputStream ios) throws IOException {
+        }
     }
 }


### PR DESCRIPTION
- as requested by James Nord, no-store value was added in cache-control
- but also other attribute to help other browser to achieve same goal

See [JENKINS-43852](https://issues.jenkins-ci.org/browse/JENKINS-43852).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Enforce caching strategy for Captcha images in login page

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jtnord 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
