### PR TITLE
Correction French translation

### DIFF
--- a/core/src/main/resources/hudson/model/Node/help-labelString_fr.html
+++ b/core/src/main/resources/hudson/model/Node/help-labelString_fr.html
@@ -1,5 +1,5 @@
 ﻿<div>
-  Les libellés (ou tags) sont utilisés pour grouper plusieurs esclaves
+  Les étiquettes (ou tags) sont utilisées pour grouper plusieurs esclaves
   dans un groupe logique.
 
   <p>

--- a/core/src/main/resources/jenkins/model/Jenkins/MasterComputer/configure_fr.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/MasterComputer/configure_fr.properties
@@ -21,6 +21,6 @@
 # THE SOFTWARE.
 
 \#\ of\ executors=Nb d''ex\u00E9cuteurs
-Labels=Titre
+Labels=\u00C9tiquettes
 Node\ Properties=Propri\u00E9t\u00E9s du N\u0153ud
 Save=Sauvegarder


### PR DESCRIPTION
In order to be consistent between master and node, the label was not translated correctly.

@reviewbybees