### PR TITLE
[JENKINS-47448] Make JDKInstaller work for old login site as well

### DIFF
--- a/core/src/main/java/hudson/tools/JDKInstaller.java
+++ b/core/src/main/java/hudson/tools/JDKInstaller.java
@@ -477,7 +477,12 @@ public class JDKInstaller extends ToolInstaller {
                     throw new IOException("Failed to request " + m.getURI() +" exit code="+r);
 
                 if (m.getURI().getHost().equals("login.oracle.com")) {
-                    /* Login flow:
+                    /* Oracle switched from old to new, and then back to old. This code should work for either.
+                     * Old Login flow:
+                     * 1. /mysso/signon.jsp: Form for username + password: Submit actions is:
+                     * 2. /oam/server/sso/auth_cred_submit: Returns a 302 to:
+                     * 3. https://edelivery.oracle.com/osso_login_success: Returns a 302 to the download.
+                     * New Login flow:
                      * 1. /oaam_server/oamLoginPage.jsp: Form for username + password. Submit action is:
                      * 2. /oaam_server/login.do: Returns a 302 to:
                      * 3. /oaam_server/loginAuth.do: After 2 seconds, JS sets window.location to:
@@ -485,9 +490,9 @@ public class JDKInstaller extends ToolInstaller {
                      * 5. /oam/server/dap/cred_submit: Returns a 302 to:
                      * 6. https://edelivery.oracle.com/osso_login_success: Returns a 302 to the download.
                      */
-                    if (m.getURI().getPath().contains("/loginAuth.do")) { // You are redirected to this page immediately after logging in.
+                    if (m.getURI().getPath().contains("/loginAuth.do")) {
                         try {
-                            Thread.sleep(2000); // Oracle website waits 2 seconds after logging in before redirecting.
+                            Thread.sleep(2000);
                             m.releaseConnection();
                             m = new GetMethod(new URI(m.getURI(), "/oaam_server/authJump.do?jump=false", true).toString());
                             continue;

--- a/core/src/main/java/hudson/tools/JDKInstaller.java
+++ b/core/src/main/java/hudson/tools/JDKInstaller.java
@@ -523,9 +523,9 @@ public class JDKInstaller extends ToolInstaller {
                         String n = extractAttribute(fragment,"name");
                         String v = extractAttribute(fragment,"value");
                         if (n==null || v==null)     continue;
-                        if (n.equals("userid"))
+                        if (n.equals("userid") || n.equals("ssousername"))
                             v = u;
-                        if (n.equals("pass")) {
+                        if (n.equals("pass") || n.equals("password")) {
                             v = p.getPlainText();
                             if (authCount++ > 3) {
                                 log.hyperlink(getCredentialPageUrl(),"Your Oracle account doesn't appear valid. Please specify a valid username/password\n");


### PR DESCRIPTION
See [JENKINS-47448](https://issues.jenkins-ci.org/browse/JENKINS-47448).

The fix introduced in Jenkins 2.86 (#3093) is no longer needed to download old versions of the JDK. This PR fixes downloads for the current website, and keeps the old logic in place in case the login flow is changed to work how it did at the time #3093 was merged.

### Proposed changelog entries

* Fix java.sun.com installation method for JDK tool for downloads requiring an Oracle login as the fix introduced in Jenkins 2.86 no longer works.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees
