### PR TITLE
[JENKINS-47940] Specified nodes count can be invalid

### DIFF
--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -79,7 +79,8 @@ AbstractProject.AssignedLabelString.InvalidBooleanExpression=\
 AbstractProject.AssignedLabelString.NoMatch=\
   There's no agent/cloud that matches this assignment
 AbstractProject.CustomWorkspaceEmpty=Custom workspace is empty.
-AbstractProject.LabelLink=<a href="{0}{2}">Label {1}</a> is serviced by {3,choice,0#no nodes|1#1 node|1<{3} nodes}{4,choice,0#|1# and 1 cloud|1< and {4} clouds}
+AbstractProject.LabelLink=<a href="{0}{2}">Label {1}</a> is serviced by {3,choice,0#no nodes|1#1 node|1<{3} nodes}{4,choice,0#|1# and 1 cloud|1< and {4} clouds}. \
+  Permissions or other restrictions provided by plugins may prevent this job from running on those nodes.
 
 Api.MultipleMatch=XPath "{0}" matched {1} nodes. \
     Create XPath that only matches one, or use the "wrapper" query parameter to wrap them all under a root element.


### PR DESCRIPTION
See [JENKINS-47940](https://issues.jenkins-ci.org/browse/JENKINS-47940).

The assigned nodes count on the job configuration page can be misleading. It doesn't take into account that permissions and external plugins could prevent some nodes to be used.

There is no test, as it's a simple `Message.properties` modification to add the warning.

Here is what the modification looks like:

![capture d ecran 2017-11-10 a 18 07 52](https://user-images.githubusercontent.com/985955/32669855-40f40632-c642-11e7-9a56-5e907c37dd5f.png)

### Proposed changelog entries

* Specify that the nodes count in label selection does not take into account permissions or other plugins.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@reviewbybees
