### PR TITLE
Fix "Manage Jenkins" icon on Global Tool Configuration

### DIFF
--- a/core/src/main/resources/jenkins/tools/GlobalToolConfiguration/index.groovy
+++ b/core/src/main/resources/jenkins/tools/GlobalToolConfiguration/index.groovy
@@ -11,7 +11,7 @@ l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
     l.side_panel {
         l.tasks {
             l.task(icon:"icon-up icon-md", href:rootURL+'/', title:_("Back to Dashboard"))
-            l.task(icon:"icon-setting icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"))
+            l.task(icon:"icon-gear2 icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"))
         }
     }
     l.main_panel {


### PR DESCRIPTION
All "Manage Jenkins" links from different pages use gear icon except this one.