### PR TITLE
Document and refactor the CanonicalIdResolver extension point

### DIFF
--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -1134,6 +1134,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
          * @param idOrFullName ID or full name of the user
          * @param context Context
          * @return Resolved User ID or {@code null} if the user ID cannot be resolved.
+         * @since TODO
          */
         @CheckForNull
         public static String resolve(@Nonnull String idOrFullName, @Nonnull Map<String, ?> context) {


### PR DESCRIPTION
The extension point has been introduced by @ndeloof  in https://github.com/jenkinsci/jenkins/commit/af42534defea4503347dfc0ec442fadf51cf3336
It does not follow common extension point practices (e.g. “all()” methods) and has no Javadoc.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Developer: Add documentation and convenience methods to the `CanonicalIdResolver` extension point
  * Extension point docs: https://jenkins.io/doc/developer/extensions/jenkins-core/#user-wbr-canonicalidresolver

No functional code changes, so no JIRA ticket/tests. I can create them on-demand

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @ndeloof 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
