### PR TITLE
Update to Remoting 3.15 and Cleanup issues in Channel#current() usages

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -1307,12 +1307,12 @@ public abstract class Launcher {
                         // make sure I/O is delivered to the remote before we return
                         Channel taskChannel = null;
                         try {
-                            // Sync IO will fail automatically if the channel is being closed
+                            // Sync IO will fail automatically if the channel is being closed, no need to use getOpenChannelOrFail()
                             taskChannel = Channel.currentOrFail();
                             taskChannel.syncIO();
                         } catch (Throwable t) {
                             // this includes a failure to sync, agent.jar too old, etc
-                            LOGGER.log(Level.INFO, "Failed to synchronize IO streams on the channel " + channel, t);
+                            LOGGER.log(Level.INFO, "Failed to synchronize IO streams on the channel " + taskChannel, t);
                         }
                     }
                 }

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -1289,6 +1289,7 @@ public abstract class Launcher {
         }
 
         public RemoteProcess call() throws IOException {
+            final Channel channel = getOpenChannelOrFail();
             Launcher.ProcStarter ps = new LocalLauncher(listener).launch();
             ps.cmds(cmd).masks(masks).envs(env).stdin(in).stdout(out).stderr(err).quiet(quiet);
             if(workDir!=null)   ps.pwd(workDir);
@@ -1298,16 +1299,20 @@ public abstract class Launcher {
 
             final Proc p = ps.start();
 
-            return Channel.current().export(RemoteProcess.class,new RemoteProcess() {
+            return channel.export(RemoteProcess.class,new RemoteProcess() {
                 public int join() throws InterruptedException, IOException {
                     try {
                         return p.join();
                     } finally {
                         // make sure I/O is delivered to the remote before we return
+                        Channel taskChannel = null;
                         try {
-                            Channel.current().syncIO();
+                            // Sync IO will fail automatically if the channel is being closed
+                            taskChannel = Channel.currentOrFail();
+                            taskChannel.syncIO();
                         } catch (Throwable t) {
                             // this includes a failure to sync, agent.jar too old, etc
+                            LOGGER.log(Level.INFO, "Failed to synchronize IO streams on the channel " + channel, t);
                         }
                     }
                 }

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1420,10 +1420,11 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
 
     private static final class DumpExportTableTask extends MasterToSlaveCallable<String,IOException> {
         public String call() throws IOException {
+            final Channel ch = getChannelOrFail();
             StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            Channel.current().dumpExportTable(pw);
-            pw.close();
+            try (PrintWriter pw = new PrintWriter(sw)) {
+                ch.dumpExportTable(pw);
+            }
             return sw.toString();
         }
     }

--- a/core/src/main/java/hudson/slaves/ChannelPinger.java
+++ b/core/src/main/java/hudson/slaves/ChannelPinger.java
@@ -133,7 +133,8 @@ public class ChannelPinger extends ComputerListener {
 
         @Override
         public Void call() throws IOException {
-            setUpPingForChannel(Channel.current(), null, pingTimeoutSeconds, pingIntervalSeconds, false);
+            // No sense in setting up channel pinger if the channel is being closed
+            setUpPingForChannel(getOpenChannelOrFail(), null, pingTimeoutSeconds, pingIntervalSeconds, false);
             return null;
         }
 

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -867,7 +867,7 @@ public class SlaveComputer extends Computer {
                 // ignore this error.
             }
 
-            Channel.current().setProperty("slave",Boolean.TRUE); // indicate that this side of the channel is the slave side.
+            Channel.currentOrFail().setProperty("slave",Boolean.TRUE); // indicate that this side of the channel is the slave side.
 
             return null;
         }

--- a/core/src/main/java/jenkins/FilePathFilter.java
+++ b/core/src/main/java/jenkins/FilePathFilter.java
@@ -102,7 +102,7 @@ public abstract class FilePathFilter {
 
     /**
      * Returns an {@link FilePathFilter} object that represents all the in-scope filters,
-     * or null if none is needed.
+     * or {@code null} if none is needed.
      */
     public static @CheckForNull FilePathFilter current() {
         Channel ch = Channel.current();

--- a/core/src/main/java/jenkins/slaves/StandardOutputSwapper.java
+++ b/core/src/main/java/jenkins/slaves/StandardOutputSwapper.java
@@ -39,9 +39,7 @@ public class StandardOutputSwapper extends ComputerListener {
     private static final class ChannelSwapper extends MasterToSlaveCallable<Boolean,Exception> {
         public Boolean call() throws Exception {
             if (File.pathSeparatorChar==';')    return false;   // Windows
-
-            Channel c = Channel.current();
-
+            Channel c = getOpenChannelOrFail();
             StandardOutputStream sos = (StandardOutputStream) c.getProperty(StandardOutputStream.class);
             if (sos!=null) {
                 swap(sos);

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.15-20171222.113525-10</version>
+        <version>3.15</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.15-20171116.114049-2</version>
+        <version>3.15-20171222.113525-10</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.14</version>
+        <version>3.15-20171116.114049-2</version>
       </dependency>
 
       <dependency>

--- a/test/src/test/java/hudson/bugs/JnlpAccessWithSecuredHudsonTest.java
+++ b/test/src/test/java/hudson/bugs/JnlpAccessWithSecuredHudsonTest.java
@@ -153,7 +153,7 @@ public class JnlpAccessWithSecuredHudsonTest {
         }
         @Override
         public String call() throws Exception {
-            return Channel.current().call(new ScriptLoader(path));
+            return getChannelOrFail().call(new ScriptLoader(path));
         }
     }
 

--- a/test/src/test/java/jenkins/security/Security218CliTest.java
+++ b/test/src/test/java/jenkins/security/Security218CliTest.java
@@ -239,7 +239,7 @@ public class Security218CliTest {
             
             // Invoke backward call
             try {
-                Channel.current().call(new Callable<String, Exception>() {
+                getChannelOrFail().call(new Callable<String, Exception>() {
                     private static final long serialVersionUID = 1L;
 
                     @Override


### PR DESCRIPTION
This change adds some missing null/closing channel checks.
In some cases the change prevents spawning threads if the channel is in the invalid state.

Full diff: https://github.com/jenkinsci/remoting/compare/remoting-3.14...6c4624e3a40d437eed325a2d824c7b92fe5d2b81

Changelog: https://github.com/jenkinsci/remoting/pull/245

No autotests, all changes are edge cases

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Major RFE: Update Remoting from 3.14 to 3.15
  * Full changelog: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#315
  * Issues to link: JENKINS-48133, JENKINS-48055, JENKINS-37566, JENKINS-48309, JENKINS-47965, JENKINS-48130, JENKINS-37670, JENKINS-46724, JENKINS-38696
* Bug: JENKINS-48309 - Prevent timeout in `FutureImpl#get(timeout)` when a spurious thread wakeup happens before the timeout expiration.
  * Javadoc: http://javadoc.jenkins.io/hudson/model/queue/FutureImpl.html
  * Comment: I think it deserves a separate changelog entry due to the potential impact

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
