### PR TITLE
return a String from StringParameterValue.getValue()

### DIFF
--- a/core/src/main/java/hudson/model/StringParameterValue.java
+++ b/core/src/main/java/hudson/model/StringParameterValue.java
@@ -70,7 +70,7 @@ public class StringParameterValue extends ParameterValue {
     }
 
     @Override
-    public Object getValue() {
+    public String getValue() {
         return value;
     }
      


### PR DESCRIPTION
Make use of covariant return types to return a String rather than an
Object.

The return value from getValue() in a XXXParamterValue() should be as close to the type of XXX as possible.  The other types already use covariant return types, but the StringParameterValue did not, so adjust the return type.

### Proposed changelog entries

*  `Internal:` `StringParameterValue.getValue()` now returns a `String` avoiding an unnecessary cast.

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees esp @jglick 