### PR TITLE
Introducing AccessControlled.hasPermission(Authentication, Permission)

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1443,14 +1443,14 @@ public class Fingerprint implements ModelObject, Saveable {
 
             // To get the item existence fact, a user needs Item.DISCOVER for the item
             // and Item.READ for all container folders.
-            boolean canDiscoverTheItem = itemBySystemUser.getACL().hasPermission(userAuth, Item.DISCOVER);
+            boolean canDiscoverTheItem = itemBySystemUser.hasPermission(userAuth, Item.DISCOVER);
             if (canDiscoverTheItem) {
                 ItemGroup<?> current = itemBySystemUser.getParent();
                 do {
                     if (current instanceof Item) {
                         final Item i = (Item) current;
                         current = i.getParent();
-                        if (!i.getACL().hasPermission(userAuth, Item.READ)) {
+                        if (!i.hasPermission(userAuth, Item.READ)) {
                             canDiscoverTheItem = false;
                         }
                     } else {

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -394,7 +394,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         }
 
         Authentication identity = item.authenticate();
-        if (!getACL().hasPermission(identity,Computer.BUILD)) {
+        if (!hasPermission(identity,Computer.BUILD)) {
             // doesn't have a permission
             return CauseOfBlockage.fromMessage(Messages._Node_LackingBuildPermission(identity.getName(), getDisplayName()));
         }

--- a/core/src/main/java/hudson/security/AccessControlled.java
+++ b/core/src/main/java/hudson/security/AccessControlled.java
@@ -25,6 +25,7 @@ package hudson.security;
 
 import javax.annotation.Nonnull;
 import org.acegisecurity.AccessDeniedException;
+import org.acegisecurity.Authentication;
 
 /**
  * Object that has an {@link ACL}
@@ -51,6 +52,14 @@ public interface AccessControlled {
      */
     default boolean hasPermission(@Nonnull Permission permission) {
         return getACL().hasPermission(permission);
+    }
+
+    /**
+     * Convenient short-cut for {@code getACL().hasPermission(a, permission)}
+     * @since FIXME
+     */
+    default boolean hasPermission(@Nonnull Authentication a, @Nonnull Permission permission) {
+        return getACL().hasPermission(a, permission);
     }
 
 }

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -410,7 +410,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
                         return FormValidation.error(Messages.BuildTrigger_NotBuildable(projectName));
                     // check whether the supposed user is expected to be able to build
                     Authentication auth = Tasks.getAuthenticationOf(project);
-                    if (!item.getACL().hasPermission(auth, Item.BUILD)) {
+                    if (!item.hasPermission(auth, Item.BUILD)) {
                         return FormValidation.error(Messages.BuildTrigger_you_have_no_permission_to_build_(projectName));
                     }
                     hasProjects = true;

--- a/core/src/main/resources/META-INF/upgrade/AccessControlled.hint
+++ b/core/src/main/resources/META-INF/upgrade/AccessControlled.hint
@@ -1,0 +1,1 @@
+$ac.getACL().hasPermission($a, $p) :: $ac instanceof hudson.security.AccessControlled && $a instanceof org.acegisecurity.Authentication && $p instanceof hudson.security.Permission => $ac.hasPermission($a, $p);;

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -407,7 +407,7 @@ public class SearchTest {
 
 
         // Alice can't
-        assertFalse("no permission", j.jenkins.getView("foo").getACL().hasPermission(User.get("alice").impersonate(), View.READ));
+        assertFalse("no permission", j.jenkins.getView("foo").hasPermission(User.get("alice").impersonate(), View.READ));
         ACL.impersonate(User.get("alice").impersonate(), new Runnable() {
             @Override
             public void run() {

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -416,7 +416,7 @@ public class JenkinsTest {
         j.jenkins.setAuthorizationStrategy(auth);
 
         // no anonymous read access
-        assertTrue(!Jenkins.getInstance().getACL().hasPermission(Jenkins.ANONYMOUS,Jenkins.READ));
+        assertTrue(!Jenkins.getInstance().hasPermission(Jenkins.ANONYMOUS,Jenkins.READ));
 
         WebClient wc = j.createWebClient();
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);


### PR DESCRIPTION
Extends #2999 with another overload used in some cases (https://github.com/jenkinsci/active-choices-plugin/pull/17 for example).

### Proposed changelog entries

* API: added `AccessControlled.hasPermission(Authentication, Permission)`.

### Desired reviewers

@reviewbybees @jenkinsci/code-reviewers