### PR TITLE
[JENKINS-47429] User.getLegacyConfigFilesFor no longer seems to be necessary

### DIFF
--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -432,6 +432,10 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
      *      {@code create} is false.
      */
     private static @Nullable User getOrCreate(@Nonnull String id, @Nonnull String fullName, boolean create) {
+        return getOrCreate(id, fullName, create, getUnsanitizedLegacyConfigFileFor(id));
+    }
+
+    private static @Nullable User getOrCreate(@Nonnull String id, @Nonnull String fullName, boolean create, File unsanitizedLegacyConfigFile) {
         String idkey = idStrategy().keyFor(id);
 
         byNameLock.readLock().lock();
@@ -442,49 +446,17 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
             byNameLock.readLock().unlock();
         }
         final File configFile = getConfigFileFor(id);
-        if (u == null && !configFile.isFile() && !configFile.getParentFile().isDirectory()) {
-            // check for legacy users and migrate if safe to do so.
-            File[] legacy = getLegacyConfigFilesFor(id);
-            if (legacy != null && legacy.length > 0) {
-                for (File legacyUserDir : legacy) {
-                    final XmlFile legacyXml = new XmlFile(XSTREAM, new File(legacyUserDir, "config.xml"));
-                    try {
-                        Object o = legacyXml.read();
-                        if (o instanceof User) {
-                            if (idStrategy().equals(id, legacyUserDir.getName()) && !idStrategy().filenameOf(legacyUserDir.getName())
-                                    .equals(legacyUserDir.getName())) {
-                                if (legacyUserDir.renameTo(configFile.getParentFile())) {
-                                    LOGGER.log(Level.INFO, "Migrated user record from {0} to {1}", new Object[] {legacyUserDir, configFile.getParentFile()});
-                                } else {
-                                    LOGGER.log(Level.WARNING, "Failed to migrate user record from {0} to {1}",
-                                            new Object[]{legacyUserDir, configFile.getParentFile()});
-                                }
-                                break;
-                            }
-                        } else {
-                            LOGGER.log(Level.FINE, "Unexpected object loaded from {0}: {1}",
-                                    new Object[]{ legacyUserDir, o });
-                        }
-                    } catch (IOException e) {
-                        LOGGER.log(Level.FINE, String.format("Exception trying to load user from %s: %s",
-                                new Object[]{ legacyUserDir, e.getMessage() }), e);
-                    }
-                }
-            }
-        }
-
-        File unsanitizedLegacyConfigFile = getUnsanitizedLegacyConfigFileFor(id);
         if (unsanitizedLegacyConfigFile.exists() && !unsanitizedLegacyConfigFile.equals(configFile)) {
             File ancestor = unsanitizedLegacyConfigFile.getParentFile();
             if (!configFile.exists()) {
                 try {
                     Files.createDirectory(configFile.getParentFile().toPath());
                     Files.move(unsanitizedLegacyConfigFile.toPath(), configFile.toPath());
-                    LOGGER.log(Level.INFO, "Migrated unsafe user record from {0} to {1}", new Object[] {unsanitizedLegacyConfigFile, configFile});
+                    LOGGER.log(Level.INFO, "Migrated user record from {0} to {1}", new Object[] {unsanitizedLegacyConfigFile, configFile});
                 } catch (IOException | InvalidPathException e) {
                     LOGGER.log(
                             Level.WARNING,
-                            String.format("Failed to migrate user record from %s to %s, see SECURITY-499 for more information", idStrategy().legacyFilenameOf(id), idStrategy().filenameOf(id)),
+                            String.format("Failed to migrate user record from %s to %s", unsanitizedLegacyConfigFile, configFile),
                             e);
                 }
             }
@@ -725,16 +697,6 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
 
     private static final File getConfigFileFor(String id) {
         return new File(getRootDir(), idStrategy().filenameOf(id) +"/config.xml");
-    }
-
-    private static final File[] getLegacyConfigFilesFor(final String id) {
-        return getRootDir().listFiles(new FileFilter() {
-            @Override
-            public boolean accept(File pathname) {
-                return pathname.isDirectory() && new File(pathname, "config.xml").isFile() && idStrategy().equals(
-                        pathname.getName(), id);
-            }
-        });
     }
 
     private static File getUnsanitizedLegacyConfigFileFor(String id) {
@@ -1057,9 +1019,10 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
             File[] subdirs = getRootDir().listFiles((FileFilter) DirectoryFileFilter.INSTANCE);
             if (subdirs != null) {
                 for (File subdir : subdirs) {
-                    if (new File(subdir, "config.xml").exists()) {
+                    File configFile = new File(subdir, "config.xml");
+                    if (configFile.exists()) {
                         String name = strategy.idFromFilename(subdir.getName());
-                        getOrCreate(name, /* <init> calls load(), probably clobbering this anyway */name, true);
+                        getOrCreate(name, /* <init> calls load(), probably clobbering this anyway */name, true, configFile);
                     }
                 }
             }


### PR DESCRIPTION
See [JENKINS-47429](https://issues.jenkins-ci.org/browse/JENKINS-47429). Would allow #2251 to be closed.

This patch still has `getOrCreate` doing some filesystem stats (though now at least O(1) per user!), which you might expect would actually be totally unnecessary, since `getAll` ought to have checked for every `config.xml` during startup and initialized the cache of users, doing any required file renames along the way. I looked into a more ambitious change which would remove the post-startup stats, and in fact allow `IdStrategy.legacyFilenameOf` to be deleted. (Fortunately it has not been exposed as a public API.) This seemed tricky, though; it would be hard to make `scanAll` do *all* migration because even if it did a deep scan of `$JENKINS_HOME/users/**/config.xml` rather than a flat scan of `$JENKINS_HOME/users/*/config.xml` we cannot always reconstruct what `id` was intended from, for example, `$JENKINS_HOME/users/foo/bar/config.xml`. The `legacyUserConfigDirsMigrated` test actually cheats a little bit: the migration only occurs if and when someone actually looks up the weird usernames, as for example would happen when that user tried to log in. (Cf. the funky behavior in #3134.) `idFromFilename` implementations could start by actually doing something with unexpected characters in the filename (currently `/` is just silently discarded!), but we still have no way of knowing whether, say, `%JENKINS_HOME%\users\foo\bar\config.xml` was supposed to be for `foo/bar` or `foo\bar`—this information is simply not recorded in the old storage format.

### Proposed changelog entries

* Faster user lookup, for example from Git changelog calculation.

### Desired reviewers

@reviewbybees @jenkinsci/code-reviewers