### PR TITLE
Simplifying naming of publish stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ for(i = 0; i < buildTypes.size(); i++) {
                 }
 
                 // Once we've built, archive the artifacts and the test results.
-                stage("${buildType} Archive Artifacts / Test Results") {
+                stage("${buildType} Publishing") {
                     def files = findFiles(glob: '**/target/*.jar, **/target/*.war, **/target/*.hpi')
                     renameFiles(files, buildType.toLowerCase())
 


### PR DESCRIPTION
Rather than having test results named like

> Linux / Linux Archive Artifacts / Test Results / jenkins.install.SetupWizardTest.shouldDisableUnencryptedProtocolsByDefault

(which is verbose and misleadingly suggests that there are three levels of nesting when there are only two), prefer

> Linux / Linux Publishing / jenkins.install.SetupWizardTest.shouldDisableUnencryptedProtocolsByDefault

@reviewbybees