### PR TITLE
[JENKINS-48116] - Restore AbstractTaskListener binary compatibility in the core.

### DIFF
--- a/core/src/main/java/hudson/util/AbstractTaskListener.java
+++ b/core/src/main/java/hudson/util/AbstractTaskListener.java
@@ -1,11 +1,16 @@
 package hudson.util;
 
+import hudson.RestrictedSince;
 import hudson.model.TaskListener;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 
 /**
  * @deprecated implement {@link TaskListener} directly
  */
 @Deprecated
+@Restricted(NoExternalUse.class)
+@RestrictedSince("2.91")
 public abstract class AbstractTaskListener implements TaskListener {
 }

--- a/core/src/main/java/hudson/util/LogTaskListener.java
+++ b/core/src/main/java/hudson/util/LogTaskListener.java
@@ -35,10 +35,13 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+// TODO: AbstractTaskListener is empty now, but there are dependencies on that e.g. Ruby Runtime - JENKINS-48116)
+// The change needs API deprecation policy or external usages cleanup.
+
 /**
  * {@link TaskListener} which sends messages to a {@link Logger}.
  */
-public class LogTaskListener implements TaskListener, Closeable {
+public class LogTaskListener extends AbstractTaskListener implements TaskListener, Closeable {
 
     // would be simpler to delegate to the LogOutputStream but this would incompatibly change the serial form
     private final TaskListener delegate;

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -44,6 +44,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.kohsuke.stapler.framework.io.WriterOutputStream;
 
+// TODO: AbstractTaskListener is empty now, but there are dependencies on that e.g. Ruby Runtime - JENKINS-48116)
+// The change needs API deprecation policy or external usages cleanup.
+
 /**
  * {@link TaskListener} that generates output into a single stream.
  *
@@ -52,7 +55,7 @@ import org.kohsuke.stapler.framework.io.WriterOutputStream;
  * 
  * @author Kohsuke Kawaguchi
  */
-public class StreamTaskListener implements TaskListener, Closeable {
+public class StreamTaskListener extends AbstractTaskListener implements TaskListener, Closeable {
     private PrintStream out;
     private Charset charset;
 


### PR DESCRIPTION
Reverts some bits from #3122 by @jglick. 

Since we have the confirmed regression due to the binary compatibility change, I think we need to restore the compatibility. OTOH, I restricted the class, so all users will be forced to stop using it when they upgrade the core.

See [JENKINS-48116](https://issues.jenkins-ci.org/browse/JENKINS-48116).

No tests required, it does not change the behavior of the core itself

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Restore binary compatibility for external `AbstractTaskListener` usages (regression in 2.91, impacts Ruby Runtime Plugin and its dependencies). 
  * Ruby Runtime Plugin: https://plugins.jenkins.io/ruby-runtime

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jglick @daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
