### PR TITLE
[JENKINS-48349] - Cache permission id to avoid allocating of new strings

### DIFF
--- a/core/src/main/java/hudson/security/Permission.java
+++ b/core/src/main/java/hudson/security/Permission.java
@@ -68,6 +68,9 @@ public final class Permission {
 
     public final @Nonnull PermissionGroup group;
 
+    // if some plugin serialized old version of this class using XStream, `id` can be null
+    private final @CheckForNull String id;
+
     /**
      * Human readable ID of the permission.
      *
@@ -158,6 +161,7 @@ public final class Permission {
         this.impliedBy = impliedBy;
         this.enabled = enable;
         this.scopes = ImmutableSet.copyOf(scopes);
+        this.id = owner.getName() + '.' + name;
 
         group.add(this);
         ALL.add(this);
@@ -222,7 +226,10 @@ public final class Permission {
      * @see #fromId(String)
      */
     public @Nonnull String getId() {
-        return owner.getName()+'.'+name;
+        if (id == null) {
+            return owner.getName() + '.' + name;
+        }
+        return id;
     }
 
     @Override public boolean equals(Object o) {


### PR DESCRIPTION
Every request that comes from Jelly is checked against Permissions.
As result it leads to a call of `getId` method that produces the new string.
Usually it's not a problem, but in case of stop-the-world pause user requests are accumulated.
So, once pause is finished, we forcibly allocated tons of strings for
every request. That leads to new stop-the-world pause. (And this cycle
can repeat multiple times)

Now to help Jenkins to recover we need to turn off nginx for 1 minute :(

### Proposed changelog entries

* Performance: Jenkins can recover faster after FullGC/stop-the-world pause

### Desired reviewers

@svanoort, @oleg-nenashev, @jglick, @daniel-beck 

Screenshots that show memory allocations in 1.5 seconds just after stop-the-world pause:
![screen shot 2017-11-21 at 15 12 05](https://user-images.githubusercontent.com/4785672/33077455-2e9afb76-ced0-11e7-92bb-ec62f6c8dd0c.png)
![screen shot 2017-11-21 at 15 09 33](https://user-images.githubusercontent.com/4785672/33077457-2ec52d92-ced0-11e7-9900-b9e2708c5049.png)
