### PR TITLE
[JENKINS-48157] - Risk of NPE when migrating MyViewProperty without PrimaryView

### DIFF
--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -80,10 +80,11 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
     @DataBoundConstructor
     public MyViewsProperty(@CheckForNull String primaryViewName) {
         this.primaryViewName = primaryViewName;
+        readResolve(); // initialize fields
     }
 
     private MyViewsProperty() {
-        readResolve();
+        this(null);
     }
 
     public Object readResolve() {
@@ -95,7 +96,10 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
             // preserve the non-empty invariant
             views.add(new AllView(AllView.DEFAULT_VIEW_NAME, this));
         }
-        primaryViewName = AllView.migrateLegacyPrimaryAllViewLocalizedName(views, primaryViewName);
+        if (primaryViewName != null) {
+            // It may happen when the default constructor is invoked
+            primaryViewName = AllView.migrateLegacyPrimaryAllViewLocalizedName(views, primaryViewName);
+        }
 
         viewGroupMixIn = new ViewGroupMixIn(this) {
             protected List<View> views() { return views; }

--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 
 import jenkins.model.Jenkins;
@@ -61,6 +62,12 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  * @author Tom Huybrechts
  */
 public class MyViewsProperty extends UserProperty implements ModifiableViewGroup, Action, StaplerFallback {
+
+    /**
+     * Name of the primary view defined by the user.
+     * {@code null} means that the View is not defined.
+     */
+    @CheckForNull
     private String primaryViewName;
 
     /**
@@ -71,7 +78,7 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
     private transient ViewGroupMixIn viewGroupMixIn;
 
     @DataBoundConstructor
-    public MyViewsProperty(String primaryViewName) {
+    public MyViewsProperty(@CheckForNull String primaryViewName) {
         this.primaryViewName = primaryViewName;
     }
 
@@ -99,11 +106,17 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
         return this;
     }
 
+    @CheckForNull
     public String getPrimaryViewName() {
         return primaryViewName;
     }
 
-    public void setPrimaryViewName(String primaryViewName) {
+    /**
+     * Sets the primary view.
+     * @param primaryViewName Name of the primary view to be set.
+     *                        {@code null} to make the primary view undefined.
+     */
+    public void setPrimaryViewName(@CheckForNull String primaryViewName) {
         this.primaryViewName = primaryViewName;
     }
 

--- a/core/src/main/java/hudson/model/ViewGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ViewGroupMixIn.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * Implements {@link ViewGroup} to be used as a "mix-in".
@@ -66,27 +67,40 @@ public abstract class ViewGroupMixIn {
     private final ViewGroup owner;
 
     /**
-     * Returns all the views. This list must be concurrently iterable.
+     * Returns all the views. This list must be modifyable and concurrently iterable.
      */
+    @Nonnull
     protected abstract List<View> views();
+
+    /**
+     * Gets primary view of the mix-in.
+     * @return Name of the primary view, {@code null} if there is no primary one defined.
+     */
+    @CheckForNull
     protected abstract String primaryView();
+
+    /**
+     * Sets the primary view.
+     * @param newName Name of the primary view to be set.
+     *                {@code null} to make the primary view undefined.
+     */
     protected abstract void primaryView(String newName);
 
     protected ViewGroupMixIn(ViewGroup owner) {
         this.owner = owner;
     }
 
-    public void addView(View v) throws IOException {
+    public void addView(@Nonnull View v) throws IOException {
         v.owner = owner;
         views().add(v);
         owner.save();
     }
 
-    public boolean canDelete(View view) {
+    public boolean canDelete(@Nonnull View view) {
         return !view.isDefault();  // Cannot delete primary view
     }
 
-    public synchronized void deleteView(View view) throws IOException {
+    public synchronized void deleteView(@Nonnull View view) throws IOException {
         if (views().size() <= 1)
             throw new IllegalStateException("Cannot delete last view");
         views().remove(view);
@@ -101,11 +115,14 @@ public abstract class ViewGroupMixIn {
      */
     @CheckForNull
     public View getView(@CheckForNull String name) {
+        if (name == null) {
+            return null;
+        }
         for (View v : views()) {
             if(v.getViewName().equals(name))
                 return v;
         }
-        if (name != null && !name.equals(primaryView())) {
+        if (!name.equals(primaryView())) {
             // Fallback to subview of primary view if it is a ViewGroup
             View pv = getPrimaryView();
             if (pv instanceof ViewGroup)

--- a/core/src/main/java/hudson/model/ViewGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ViewGroupMixIn.java
@@ -67,7 +67,7 @@ public abstract class ViewGroupMixIn {
     private final ViewGroup owner;
 
     /**
-     * Returns all the views. This list must be modifyable and concurrently iterable.
+     * Returns all views in the group. This list must be modifiable and concurrently iterable.
      */
     @Nonnull
     protected abstract List<View> views();

--- a/test/src/test/java/hudson/model/MyViewsPropertyTest.java
+++ b/test/src/test/java/hudson/model/MyViewsPropertyTest.java
@@ -294,9 +294,12 @@ public class MyViewsPropertyTest {
     @Issue("JENKINS-48157")
     public void shouldNotFailWhenMigratingLegacyViewsWithoutPrimaryOne() throws IOException {
         rule.jenkins.setSecurityRealm(rule.createDummySecurityRealm());
+        User user = User.get("User");
 
         // Emulates creation of a new object with Reflection in User#load() does.
         MyViewsProperty property = new MyViewsProperty(null);
+        user.addProperty(property);
+
         // At AllView with non-default to invoke NPE path in AllView.migrateLegacyPrimaryAllViewLocalizedName()
         property.addView(new AllView("foobar"));
         property.readResolve();

--- a/test/src/test/java/hudson/model/MyViewsPropertyTest.java
+++ b/test/src/test/java/hudson/model/MyViewsPropertyTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import jenkins.model.Jenkins;
 import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.context.SecurityContextHolder;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import static org.junit.Assert.*;
 /**
@@ -287,6 +288,18 @@ public class MyViewsPropertyTest {
         assertTrue("User should control of himself.", property.hasPermission(Permission.CONFIGURE));
         auth.add(Jenkins.ADMINISTER, "User2");
         assertTrue("User User2 should configure permission for user User",property.hasPermission(Permission.CONFIGURE));
+    }
+
+    @Test
+    @Issue("JENKINS-48157")
+    public void shouldNotFailWhenMigratingLegacyViewsWithoutPrimaryOne() throws IOException {
+        rule.jenkins.setSecurityRealm(rule.createDummySecurityRealm());
+
+        // Emulates creation of a new object with Reflection in User#load() does.
+        MyViewsProperty property = new MyViewsProperty(null);
+        // At AllView with non-default to invoke NPE path in AllView.migrateLegacyPrimaryAllViewLocalizedName()
+        property.addView(new AllView("foobar"));
+        property.readResolve();
     }
     
 }


### PR DESCRIPTION
See [JENKINS-48157](https://issues.jenkins-ci.org/browse/JENKINS-48157). Actually it fixes two defects, let me know if I should file the second issue.

I was playing with `SetupWizardTest` fixes, but IDEA reported a Nonnull violation in the instrumented code (though NPE would not really happen there). The API for `primaryViewName` is not documented at all AND not used in the plugins, but an improper call of the default constructor will cause the issue. It happens in the user creation reflection in my tests.  This is a "regression" after JENKINS-38606 https://github.com/jenkinsci/jenkins/commit/fd2009a9712b8b0a8c310d687df07df60edbc8ad by @stephenc 1 year ago.

- [x] - Fix JENKINS-48157 - NPE when migrating "AllView" names for a property without Primary view defined 
- [x] - Fix NPE when using the public `MyViewsProperty(String)` constructor and almost any other class method after that
- [x] - Document nullness of the `primaryViewName` field according to the de-facto state. There is no affected external usages from what I see
- [x] - Unit test

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Bug, JENKINS-48157 - Prevent NullPointerException when migrating the default "All View" names for a My Views property without primary view defined 
* Bug, TODO - Prevent NullPointerException in MyViewsProperty when it is initialized using public API.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
