### PR TITLE
Disable flaky SetupWizardTest#shouldDisableUnencrypterProtocolsByDefault()

### DIFF
--- a/test/src/test/java/jenkins/AgentProtocolTest.java
+++ b/test/src/test/java/jenkins/AgentProtocolTest.java
@@ -132,9 +132,10 @@ public class AgentProtocolTest {
         }
     }
     
-    public static void assertMonitorNotActive() {
+    public static void assertMonitorNotActive(JenkinsRule j) {
         DeprecatedAgentProtocolMonitor monitor = new DeprecatedAgentProtocolMonitor();
-        assertFalse("Deprecated Agent Protocol Monitor should not be activated", monitor.isActivated());
+        assertFalse("Deprecated Agent Protocol Monitor should not be activated. Current protocols: "
+                + StringUtils.join(j.jenkins.getAgentProtocols(), ","), monitor.isActivated());
     }
     
     public static void assertMonitorTriggered(String ... expectedProtocols) {

--- a/test/src/test/java/jenkins/install/SetupWizardTest.java
+++ b/test/src/test/java/jenkins/install/SetupWizardTest.java
@@ -32,12 +32,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import jenkins.AgentProtocolTest;
 import jenkins.slaves.DeprecatedAgentProtocolMonitor;
 import org.apache.commons.io.FileUtils;
 import static org.hamcrest.Matchers.*;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -114,16 +117,20 @@ public class SetupWizardTest {
         wc.assertFails("setupWizard/createAdminUser", 403);
         wc.assertFails("setupWizard/completeInstall", 403);
     }
-    
+
+    //TODO: The test randomly fails on Jenkins CI
+    // Oleg Nenashev: I am not able to reproduce it
     @Test
     @Issue("JENKINS-45841")
+    @Ignore
     public void shouldDisableUnencryptedProtocolsByDefault() throws Exception {
         AgentProtocolTest.assertProtocols(j.jenkins, true, 
                 "Encrypted JNLP4-protocols protocol should be enabled", "JNLP4-connect");
         AgentProtocolTest.assertProtocols(j.jenkins, false, 
                 "Non-encrypted JNLP protocols should be disabled by default", 
                 "JNLP-connect", "JNLP2-connect", "CLI-connect");
-        AgentProtocolTest.assertMonitorNotActive();
+        // The CI test fails here, presumably due to the CLI protocols.
+        AgentProtocolTest.assertMonitorNotActive(j);
     }
         
     private String jsonRequest(JenkinsRule.WebClient wc, String path) throws Exception {


### PR DESCRIPTION
I cannot reproduce the issue locally, but it happens in CI (due to the parallel tests?). I I would prefer to just disable it for now.

My plan is to recover tests as a part of https://issues.jenkins-ci.org/browse/JENKINS-47181

@reviewbybees @jglick 