### PR TITLE
Introduce the new UserIdCause constructor, which accepts userId as an argument.

### DIFF
--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -454,7 +454,7 @@ public abstract class Cause {
         @Override
         public void print(TaskListener listener) {
             listener.getLogger().println(Messages.Cause_UserIdCause_ShortDescription(
-                    // TODO better to use ModelHyperlinkNote.encodeTo(User), or User.getUrl, since it handles URL escaping
+                    // TODO JENKINS-48467 - better to use ModelHyperlinkNote.encodeTo(User), or User.getUrl, since it handles URL escaping
                     ModelHyperlinkNote.encodeTo("/user/"+getUserIdOrUnknown(), getUserName())));
         }
 

--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -402,16 +402,35 @@ public abstract class Cause {
      */
     public static class UserIdCause extends Cause {
 
+        @CheckForNull
         private String userId;
 
+        /**
+         * Constructor, which uses the current {@link User}.
+         */
         public UserIdCause() {
             User user = User.current();
             this.userId = (user == null) ? null : user.getId();
         }
 
+        /**
+         * Constructor.
+         * @param userId User ID. {@code null} if the user is unknown.
+         * @since TODO
+         */
+        public UserIdCause(@CheckForNull String userId) {
+            this.userId = userId;
+        }
+
         @Exported(visibility = 3)
+        @CheckForNull
         public String getUserId() {
             return userId;
+        }
+        
+        @Nonnull
+        private String getUserIdOrUnknown() {
+            return  userId != null ? userId : User.getUnknown().getId();
         }
 
         @Exported(visibility = 3)
@@ -436,7 +455,7 @@ public abstract class Cause {
         public void print(TaskListener listener) {
             listener.getLogger().println(Messages.Cause_UserIdCause_ShortDescription(
                     // TODO better to use ModelHyperlinkNote.encodeTo(User), or User.getUrl, since it handles URL escaping
-                    ModelHyperlinkNote.encodeTo("/user/"+getUserId(), getUserName())));
+                    ModelHyperlinkNote.encodeTo("/user/"+getUserIdOrUnknown(), getUserName())));
         }
 
         @Override


### PR DESCRIPTION
I hit the issue with the missing constructor while working on https://github.com/jenkinsci/job-restrictions-plugin/pull/20, ant actually it was not the first time I hit it. So I decided to add a new API method and to document the behavior while I was around.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Developer: Introduce the new `hudson.model.Cause.UserIdCause(String userId)` constructor, which allows creating causes for custom IDs without switching the user context.
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

No issue and no tests, just a minor developer update

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
