### PR TITLE
[JENKINS-48080] Setup Wizard hangs if confirm password is incorrect while creating admin user

### DIFF
--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -889,16 +889,17 @@ var createPluginSetupWizard = function(appendTarget) {
 			// ignore JSON parsing issues, this may be HTML
 		}
 		// we get 200 OK
-		var $page = $(data);
+		var responseText = data.responseText;
+		var $page = $(responseText);
 		var $errors = $page.find('.error');
 		if($errors.length > 0) {
 			var $main = $page.find('#main-panel').detach();
 			if($main.length > 0) {
-				data = data.replace(/body([^>]*)[>](.|[\r\n])+[<][/]body/,'body$1>'+$main.html()+'</body');
+				responseText = responseText.replace(/body([^>]*)[>](.|[\r\n])+[<][/]body/,'body$1>'+$main.html()+'</body');
 			}
 			var doc = $('iframe[src]').contents()[0];
 			doc.open();
-			doc.write(data);
+			doc.write(responseText);
 			doc.close();
 		}
 		else {


### PR DESCRIPTION
See [JENKINS-48080](https://issues.jenkins-ci.org/browse/JENKINS-48080).

Any unsuccessful validation when the first user is created was not showing its error message. The response object was precessed instead of the HTML content.

### Proposed changelog entries

Proposed changelog entries:

* Show unsuccessful validation when the first admin user is created preventing the Setup Wizard to hang.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).

### Desired reviewers
@jenkinsci/code-reviewers
@reviewbybees