### PR TITLE
[FIXES JENKINS-47439] Setup wizard does not resume after restart

### DIFF
--- a/core/src/main/java/hudson/util/PluginServletFilter.java
+++ b/core/src/main/java/hudson/util/PluginServletFilter.java
@@ -113,6 +113,12 @@ public class PluginServletFilter implements Filter, ExtensionPoint {
         }
     }
 
+    /**
+     * Checks whether the given filter is already registered in the chain.
+     * @param filter the filter to check.
+     * @return true if the filter is already registered in the chain.
+     * @since XXX
+     */
     public static boolean hasFilter(Filter filter) {
         Jenkins j = Jenkins.getInstanceOrNull();
         PluginServletFilter container = null;

--- a/core/src/main/java/hudson/util/PluginServletFilter.java
+++ b/core/src/main/java/hudson/util/PluginServletFilter.java
@@ -117,7 +117,7 @@ public class PluginServletFilter implements Filter, ExtensionPoint {
      * Checks whether the given filter is already registered in the chain.
      * @param filter the filter to check.
      * @return true if the filter is already registered in the chain.
-     * @since XXX
+     * @since FIXME
      */
     public static boolean hasFilter(Filter filter) {
         Jenkins j = Jenkins.getInstanceOrNull();

--- a/core/src/main/java/hudson/util/PluginServletFilter.java
+++ b/core/src/main/java/hudson/util/PluginServletFilter.java
@@ -113,6 +113,19 @@ public class PluginServletFilter implements Filter, ExtensionPoint {
         }
     }
 
+    public static boolean hasFilter(Filter filter) {
+        Jenkins j = Jenkins.getInstanceOrNull();
+        PluginServletFilter container = null;
+        if(j != null) {
+            container = getInstance(j.servletContext);
+        }
+        if (j == null || container == null) {
+            return LEGACY.contains(filter);
+        } else {
+            return container.list.contains(filter);
+        }
+    }
+
     public static void removeFilter(Filter filter) throws ServletException {
         Jenkins j = Jenkins.getInstanceOrNull();
         if (j==null || getInstance(j.servletContext) == null) {

--- a/core/src/main/java/jenkins/install/InstallState.java
+++ b/core/src/main/java/jenkins/install/InstallState.java
@@ -49,7 +49,12 @@ public class InstallState implements ExtensionPoint {
      * Need InstallState != NEW for tests by default
      */
     @Extension
-    public static final InstallState UNKNOWN = new InstallState("UNKNOWN", true);
+    public static final InstallState UNKNOWN = new InstallState("UNKNOWN", true) {
+        @Override
+        public void initializeState() {
+            InstallUtil.proceedToNextStateFrom(this);
+        }
+    };
     
     /**
      * After any setup / restart / etc. hooks are done, states should be running
@@ -94,7 +99,7 @@ public class InstallState implements ExtensionPoint {
      */
     @Extension
     public static final InstallState INITIAL_PLUGINS_INSTALLING = new InstallState("INITIAL_PLUGINS_INSTALLING", false);
-    
+
     /**
      * Security setup for a new Jenkins install.
      */
@@ -106,7 +111,7 @@ public class InstallState implements ExtensionPoint {
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
-            
+
             InstallUtil.proceedToNextStateFrom(INITIAL_SECURITY_SETUP);
         }
     };
@@ -116,7 +121,7 @@ public class InstallState implements ExtensionPoint {
      */
     @Extension
     public static final InstallState NEW = new InstallState("NEW", false);
-    
+
     /**
      * Restart of an existing Jenkins install.
      */

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -92,7 +92,7 @@ public class InstallUtil {
      */
     public static void proceedToNextStateFrom(InstallState prior) {
         InstallState next = getNextInstallState(prior);
-        LOGGER.log(Main.isDevelopmentMode ? Level.INFO : Level.FINE, "Install state transitioning from: " + prior + " to: " + next);
+        LOGGER.log(Main.isDevelopmentMode ? Level.INFO : Level.FINE, "Install state transitioning from: {0} to : {1}", new Object[] { prior, next });
         if (next != null) {
             Jenkins.getInstance().setInstallState(next);
         }

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -92,7 +92,6 @@ public class InstallUtil {
      */
     public static void proceedToNextStateFrom(InstallState prior) {
         InstallState next = getNextInstallState(prior);
-        LOGGER.log(Main.isDevelopmentMode ? Level.INFO : Level.FINE, "Install state transitioning from: {0} to : {1}", new Object[] { prior, next });
         if (next != null) {
             Jenkins.getInstance().setInstallState(next);
         }

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -92,7 +92,7 @@ public class InstallUtil {
      */
     public static void proceedToNextStateFrom(InstallState prior) {
         InstallState next = getNextInstallState(prior);
-        if (Main.isDevelopmentMode) LOGGER.info("Install state transitioning from: " + prior + " to: " + next);
+        LOGGER.log(Main.isDevelopmentMode ? Level.INFO : Level.FINE, "Install state transitioning from: " + prior + " to: " + next);
         if (next != null) {
             Jenkins.getInstance().setInstallState(next);
         }

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -195,6 +195,16 @@ public class SetupWizard extends PageDecorator {
         }
     }
 
+    private void tearDownFilter() {
+        try {
+            if (PluginServletFilter.hasFilter(FORCE_SETUP_WIZARD_FILTER)) {
+                PluginServletFilter.removeFilter(FORCE_SETUP_WIZARD_FILTER);
+            }
+        } catch (ServletException e) {
+            throw new RuntimeException("Unable to remove PluginServletFilter for the SetupWizard", e);
+        }
+    }
+
     /**
      * Indicates a generated password should be used - e.g. this is a new install, no security realm set up
      */
@@ -523,7 +533,11 @@ public class SetupWizard extends PageDecorator {
      * @since FIXME
      */
     public void onInstallStateUpdate(InstallState state) {
-        setUpFilter();
+        if (state.isSetupComplete()) {
+            tearDownFilter();
+        } else {
+            setUpFilter();
+        }
     }
 
     /**

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -527,7 +527,7 @@ public class SetupWizard extends PageDecorator {
 
     /**
      * Returns whether the setup wizard filter is currently registered.
-     * @since XXX
+     * @since FIXME
      */
     public boolean hasSetupWizardFilter() {
         return PluginServletFilter.hasFilter(FORCE_SETUP_WIZARD_FILTER);

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -508,7 +508,14 @@ public class SetupWizard extends PageDecorator {
         }
         return InstallState.valueOf(name);
     }
-    
+
+    /**
+     * Returns whether the setup wizard filter is currently registered.
+     */
+    public boolean hasSetupWizardFilter() {
+        return PluginServletFilter.hasFilter(FORCE_SETUP_WIZARD_FILTER);
+    }
+
     /**
      * This filter will validate that the security token is provided
      */

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -520,6 +520,7 @@ public class SetupWizard extends PageDecorator {
     /**
      * Called upon install state update.
      * @param state the new install state.
+     * @since FIXME
      */
     public void onInstallStateUpdate(InstallState state) {
         setUpFilter();

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -527,6 +527,7 @@ public class SetupWizard extends PageDecorator {
 
     /**
      * Returns whether the setup wizard filter is currently registered.
+     * @since XXX
      */
     public boolean hasSetupWizardFilter() {
         return PluginServletFilter.hasFilter(FORCE_SETUP_WIZARD_FILTER);

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -328,7 +328,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * The Jenkins instance startup type i.e. NEW, UPGRADE etc
      */
-    private transient InstallState installState = InstallState.UNKNOWN;
+    private InstallState installState;
     
     /**
      * If we're in the process of an initial setup, 
@@ -924,7 +924,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 System.exit(0);
 
             setupWizard = new SetupWizard();
-            InstallUtil.proceedToNextStateFrom(InstallState.UNKNOWN);
+            getInstallState().initializeState();
 
             launchTcpSlaveAgentListener();
 
@@ -1033,9 +1033,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public void setInstallState(@Nonnull InstallState newState) {
         InstallState prior = installState;
         installState = newState;
-        if (!prior.equals(newState)) {
+        LOGGER.info("setInstallState (Previous:" + prior + ", New: " + installState + ")");
+        if (!newState.equals(prior)) {
             newState.initializeState();
+            getSetupWizard().onInstallStateUpdate(newState);
         }
+        saveQuietly();
     }
 
     /**

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1033,10 +1033,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public void setInstallState(@Nonnull InstallState newState) {
         InstallState prior = installState;
         installState = newState;
-        LOGGER.info("setInstallState (Previous:" + prior + ", New: " + installState + ")");
+        LOGGER.log(Main.isDevelopmentMode ? Level.INFO : Level.FINE, "Install state transitioning from: {0} to : {1}", new Object[] { prior, installState });
         if (!newState.equals(prior)) {
-            newState.initializeState();
             getSetupWizard().onInstallStateUpdate(newState);
+            newState.initializeState();
         }
         saveQuietly();
     }

--- a/test/src/test/java/jenkins/install/SetupWizardRestartTest.java
+++ b/test/src/test/java/jenkins/install/SetupWizardRestartTest.java
@@ -1,0 +1,50 @@
+package jenkins.install;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import hudson.Main;
+import jenkins.model.Jenkins;
+
+public class SetupWizardRestartTest {
+    @Rule
+    public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+
+    @Issue("JENKINS-47439")
+    @Test
+    public void restartKeepsSetupWizardState() {
+        rr.addStep(new Statement() {
+            @Override
+            public void evaluate() throws IOException {
+                // Modify state so that we get into the same conditions as a real start
+                Main.isUnitTest = false;
+                FileUtils.write(InstallUtil.getLastExecVersionFile(), "");
+                Jenkins j = rr.j.getInstance();
+                // Re-evaluate current state based on the new context
+                InstallUtil.proceedToNextStateFrom(InstallState.UNKNOWN);
+                assertEquals("Unexpected install state", InstallState.NEW, j.getInstallState());
+                assertTrue("Expecting setup wizard filter to be up", j.getSetupWizard().hasSetupWizardFilter());
+                InstallUtil.saveLastExecVersion();
+            }
+        });
+        // Check that the state is retained after a restart
+        rr.addStep(new Statement() {
+            @Override
+            public void evaluate() {
+                Jenkins j = rr.j.getInstance();
+                assertEquals("Unexpected install state", InstallState.NEW, j.getInstallState());
+                assertTrue("Expecting setup wizard filter to be up after restart",  j.getSetupWizard().hasSetupWizardFilter());
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
See [JENKINS-47439](https://issues.jenkins-ci.org/browse/JENKINS-47439).

More details about the fix available in commit logs.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Setup wizard is now resumed upon restart if it hasn't been completed (regression from 2.80)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/code-reviewers 
@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
