### PR TITLE
Only inspect direct subdirectories for Surefire reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ for(i = 0; i < buildTypes.size(); i++) {
                     archiveArtifacts artifacts: '**/target/*.jar, **/target/*.war, **/target/*.hpi',
                                 fingerprint: true
                     if (runTests) {
-                        junit healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/TEST-*.xml'
+                        junit healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/*.xml'
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ for(i = 0; i < buildTypes.size(); i++) {
                     archiveArtifacts artifacts: '**/target/*.jar, **/target/*.war, **/target/*.hpi',
                                 fingerprint: true
                     if (runTests) {
-                        junit healthScaleFactor: 20.0, testResults: '**/target/surefire-reports/*.xml'
+                        junit healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/TEST-*.xml'
                     }
                 }
             }


### PR DESCRIPTION
#3165 is not the first to get weird errors like [this](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-3165/1/testReport/junit/org.jvnet.hudson.test/BuildTriggerTest/Windows___Windows_Publishing___testSomething/):

```
junit.framework.AssertionFailedError: test failure
	at junit.framework.Assert.fail(Assert.java:47)
	at org.jvnet.hudson.test.BuildTriggerTest.testSomething(BuildTriggerTest.java:7)
```

This is not an actual test of Jenkins; it is coming from `test/src/test/resources/hudson/tasks/maven-test-failure.zip!/src/test/java/org/jvnet/hudson/test/BuildTriggerTest.java`, which is used by the real `test/src/test/java/hudson/tasks/BuildTriggerTest.java`. Presumably under some conditions (Windows file locks?) the `jenkins-test-harness` fails to properly clean up temporary directories, and then an overzealous `Jenkinsfile` found this report file and thought it indicated a (non-meta) test failure.

@reviewbybees