### PR TITLE
[JENKINS-48405] Use NIO in tryOnceDeleteFile and makeWritable

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -288,7 +288,7 @@ public class Util {
                 File[] files = f.listFiles();
                 if(files!=null && files.length>0)
                     throw new IOException("Unable to delete " + f.getPath()+" - files in dir: "+Arrays.asList(files), e2);
-                throw new IOException("Unable to delete " + f.getPath(), e2);
+                throw e2;
             }
         }
     }

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -303,6 +303,7 @@ public class Util {
                 Set<PosixFilePermission> newPermissions = ((PosixFileAttributes)attrs).permissions();
                 newPermissions.add(PosixFilePermission.OWNER_WRITE);
                 Files.setPosixFilePermissions(path, newPermissions);
+                return;
             } catch (NoSuchFileException e) {
                 return;
             } catch (UnsupportedOperationException e) {

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -301,18 +301,19 @@ public class Util {
             if (!path.toFile().setWritable(true)) {
                 throw new IOException("Unable to make file writeable: " + path);
             }
-        }
-        try { 
-            PosixFileAttributes attrs = Files.readAttributes(path, PosixFileAttributes.class);
-            Set<PosixFilePermission> newPermissions = ((PosixFileAttributes)attrs).permissions();
-            newPermissions.add(PosixFilePermission.OWNER_WRITE);
-            Files.setPosixFilePermissions(path, newPermissions);
-        } catch (NoSuchFileException e) {
-            return;
-        } catch (UnsupportedOperationException e) {
-            // PosixFileAttributes not supported, fall back to non-NIO.
-            if (!path.toFile().setWritable(true)) {
-                throw new IOException("Unable to make file writeable: " + path);
+        } else {
+            try {
+                PosixFileAttributes attrs = Files.readAttributes(path, PosixFileAttributes.class);
+                Set<PosixFilePermission> newPermissions = ((PosixFileAttributes)attrs).permissions();
+                newPermissions.add(PosixFilePermission.OWNER_WRITE);
+                Files.setPosixFilePermissions(path, newPermissions);
+            } catch (NoSuchFileException e) {
+                return;
+            } catch (UnsupportedOperationException e) {
+                // PosixFileAttributes not supported, fall back to non-NIO.
+                if (!path.toFile().setWritable(true)) {
+                    throw new IOException("Unable to make file writeable: " + path);
+                }
             }
         }
     }

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -297,11 +297,7 @@ public class Util {
      * Makes the file at the given path writable by any means possible.
      */
     private static void makeWritable(@Nonnull Path path) throws IOException {
-        if (Functions.isWindows()) {
-            if (!path.toFile().setWritable(true)) {
-                throw new IOException("Unable to make file writeable: " + path);
-            }
-        } else {
+        if (!Functions.isWindows()) {
             try {
                 PosixFileAttributes attrs = Files.readAttributes(path, PosixFileAttributes.class);
                 Set<PosixFilePermission> newPermissions = ((PosixFileAttributes)attrs).permissions();
@@ -310,12 +306,16 @@ public class Util {
             } catch (NoSuchFileException e) {
                 return;
             } catch (UnsupportedOperationException e) {
-                // PosixFileAttributes not supported, fall back to non-NIO.
-                if (!path.toFile().setWritable(true)) {
-                    throw new IOException("Unable to make file writeable: " + path);
-                }
+                // PosixFileAttributes not supported, fall back to old IO.
             }
         }
+
+        /**
+         * We intentionally do not check the return code of setWritable, because if it
+         * is false we prefer to rethrow the exception thrown by Files.deleteIfExists,
+         * which will have a more useful message than something we make up here.
+         */
+        path.toFile().setWritable(true);
     }
 
     /**

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileSystemException;
 import java.nio.file.attribute.PosixFilePermissions;
 
 import static org.hamcrest.CoreMatchers.allOf;
@@ -287,12 +288,6 @@ public class UtilTest {
     @Test
     public void testDeleteFile_onWindows() throws Exception {
         Assume.assumeTrue(Functions.isWindows());
-        Class<?> c;
-        try {
-            c = Class.forName("java.nio.file.FileSystemException");
-        } catch (ClassNotFoundException x) {
-            throw new AssumptionViolatedException("prior to JDK 7", x);
-        }
         final int defaultDeletionMax = Util.DELETION_MAX;
         try {
             File f = tmp.newFile();
@@ -304,7 +299,7 @@ public class UtilTest {
                 Util.deleteFile(f);
                 fail("should not have been deletable");
             } catch (IOException x) {
-                assertThat(calcExceptionHierarchy(x), hasItem(c));
+                assertThat(calcExceptionHierarchy(x), hasItem(FileSystemException.class));
                 assertThat(x.getMessage(), containsString(f.getPath()));
             }
         } finally {

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -37,6 +37,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 
 import static org.hamcrest.CoreMatchers.allOf;
@@ -306,6 +308,19 @@ public class UtilTest {
             Util.DELETION_MAX = defaultDeletionMax;
             unlockFilesForDeletion();
         }
+    }
+
+    @Test
+    public void testDeleteFileReadOnly() throws Exception {
+        // Removing the calls to Util#makeWritable in Util#tryOnceDeleteFile should cause this test to fail.
+        Path file = tmp.newFolder().toPath().resolve("file.tmp");
+        Files.createDirectories(file.getParent());
+        Files.createFile(file);
+        // Using old IO so the test can run on Windows.
+        file.getParent().toFile().setWritable(false);
+        file.toFile().setWritable(false);
+        Util.deleteFile(file.toFile());
+        assertFalse(Files.exists(file));
     }
 
     @Test

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -324,6 +324,14 @@ public class UtilTest {
     }
 
     @Test
+    public void testDeleteFileDoesNotExist() throws Exception {
+        Path file = tmp.newFolder().toPath().resolve("file.tmp");
+        assertFalse(Files.exists(file));
+        // Should not throw an exception.
+        Util.deleteFile(file.toFile());
+    }
+
+    @Test
     public void testDeleteContentsRecursive() throws Exception {
         final File dir = tmp.newFolder();
         final File d1 = new File(dir, "d1");


### PR DESCRIPTION
See [JENKINS-48405](https://issues.jenkins-ci.org/browse/JENKINS-48405).

### Proposed changelog entries

* Use NIO to delete files for more robust error handling.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
  - [x] Needs testing to see how this impacts Unicode path issues such as [JENKINS-12610](https://issues.jenkins-ci.org/browse/JENKINS-12610): EDIT: It does not fix the issue.
  - [x] Verify that edge cases (file doesn't exist/isn't writable) are handled by existing tests or create new tests to verify the behavior.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees
