### PR TITLE
[FIX JENKINS-34855] Create a FileChannelWriter and use it for AtomicFileWriter "enforced" flushing

### DIFF
--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -117,7 +117,7 @@ public class AtomicFileWriter extends Writer {
             throw new IOException("Failed to create a temporary file in "+ dir,e);
         }
 
-        core = new FileChannelWriter(tmpPath, charset, StandardOpenOption.WRITE);
+        core = new FileChannelWriter(tmpPath, charset, false, StandardOpenOption.WRITE);
     }
 
     @Override

--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -116,7 +117,7 @@ public class AtomicFileWriter extends Writer {
             throw new IOException("Failed to create a temporary file in "+ dir,e);
         }
 
-        core = Files.newBufferedWriter(tmpPath, charset);
+        core = new FileChannelWriter(tmpPath, charset, StandardOpenOption.WRITE);
     }
 
     @Override

--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -54,12 +54,12 @@ public class AtomicFileWriter extends Writer {
 
     private static final Logger LOGGER = Logger.getLogger(AtomicFileWriter.class.getName());
 
-    private static /* final */ boolean LOSE_INTEGRITY = SystemProperties.getBoolean(
-            AtomicFileWriter.class.getName() + ".LOSE_DATA_INTEGRITY_FOR_PERFORMANCE");
+    private static /* final */ boolean DISABLE_FORCED_FLUSH = SystemProperties.getBoolean(
+            AtomicFileWriter.class.getName() + ".DISABLE_FORCED_FLUSH");
 
     static {
-        if (LOSE_INTEGRITY) {
-            LOGGER.log(Level.SEVERE, "LOSE_DATA_INTEGRITY_FOR_PERFORMANCE flag used, YOU RISK LOSING DATA.");
+        if (DISABLE_FORCED_FLUSH) {
+            LOGGER.log(Level.WARNING, "DISABLE_FORCED_FLUSH flag used, this could result in dataloss if failures happen in your storage subsystem.");
         }
     }
 
@@ -143,10 +143,7 @@ public class AtomicFileWriter extends Writer {
             throw new IOException("Failed to create a temporary file in "+ dir,e);
         }
 
-        if (LOSE_INTEGRITY) {
-            // We should log it in WARN, but as this code is called often, this would create huge logs in prod system
-            // Hence why a similar log is logged once above in a static block.
-            LOGGER.log(Level.FINE, "WARNING: YOU SET A FLAG THAT COULD LEAD TO DATA LOSS.");
+        if (DISABLE_FORCED_FLUSH) {
             integrityOnFlush = false;
             integrityOnClose = false;
         }

--- a/core/src/main/java/hudson/util/FileChannelWriter.java
+++ b/core/src/main/java/hudson/util/FileChannelWriter.java
@@ -47,15 +47,21 @@ public class FileChannelWriter extends Writer {
     private boolean forceOnFlush;
 
     /**
+     * See forceOnFlush. You probably never want to set forceOnClose to false.
+     */
+    private boolean forceOnClose;
+
+    /**
      * @param filePath     the path of the file to write to.
      * @param charset      the charset to use when writing characters.
      * @param forceOnFlush set to true if you want {@link FileChannel#force(boolean)} to be called on {@link #flush()}.
      * @param options      the options for opening the file.
      * @throws IOException if something went wrong.
      */
-    FileChannelWriter(Path filePath, Charset charset, boolean forceOnFlush, OpenOption... options) throws IOException {
+    FileChannelWriter(Path filePath, Charset charset, boolean forceOnFlush, boolean forceOnClose, OpenOption... options) throws IOException {
         this.charset = charset;
         this.forceOnFlush = forceOnFlush;
+        this.forceOnClose = forceOnClose;
         channel = FileChannel.open(filePath, options);
     }
 
@@ -79,7 +85,9 @@ public class FileChannelWriter extends Writer {
     @Override
     public void close() throws IOException {
         if(channel.isOpen()) {
-            channel.force(true);
+            if (forceOnClose) {
+                channel.force(true);
+            }
             channel.close();
         }
     }

--- a/core/src/main/java/hudson/util/FileChannelWriter.java
+++ b/core/src/main/java/hudson/util/FileChannelWriter.java
@@ -1,0 +1,57 @@
+package hudson.util;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+
+/**
+ * This class has been created to help make {@link AtomicFileWriter} hopefully more reliable in some corner cases.
+ * We created this wrapper to be able to access {@link FileChannel#force(boolean)} which seems to be one of the rare
+ * ways to actually have a guarantee that data be flushed to the physical device (only guaranteed for local, not for
+ * remote obviously though).
+ *
+ * <p>The goal using this is to reduce as much as we can the likeliness to see zero-length files be created in place
+ * of the original ones.</p>
+ *
+ * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-34855">JENKINS-34855</a>
+ * @see <a href="https://github.com/jenkinsci/jenkins/pull/2548">PR-2548</a>
+ */
+@Restricted(NoExternalUse.class)
+public class FileChannelWriter extends Writer {
+
+    private final Charset charset;
+    private final FileChannel channel;
+
+    FileChannelWriter(Path filePath, Charset charset, OpenOption... options) throws IOException {
+        this.charset = charset;
+        channel = FileChannel.open(filePath, options);
+    }
+
+    @Override
+    public void write(char cbuf[], int off, int len) throws IOException {
+        final CharBuffer charBuffer = CharBuffer.wrap(cbuf, off, len);
+        ByteBuffer byteBuffer = charset.encode(charBuffer);
+        channel.write(byteBuffer);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        channel.force(true);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if(channel.isOpen()) {
+            channel.force(true);
+            channel.close();
+        }
+    }
+}

--- a/core/src/test/java/hudson/util/FileChannelWriterTest.java
+++ b/core/src/test/java/hudson/util/FileChannelWriterTest.java
@@ -1,0 +1,63 @@
+package hudson.util;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.StandardOpenOption;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class FileChannelWriterTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    File file;
+    FileChannelWriter writer;
+
+    @Before
+    public void setUp() throws Exception {
+        file = temporaryFolder.newFile();
+        writer = new FileChannelWriter(file.toPath(), StandardCharsets.UTF_8, StandardOpenOption.WRITE);
+    }
+
+    @Test
+    public void write() throws Exception {
+        writer.write("helloooo");
+        writer.close();
+
+        assertContent("helloooo");
+    }
+
+
+    @Test
+    public void flush() throws Exception {
+        writer.write("hello é è à".toCharArray());
+
+        writer.flush();
+        assertContent("hello é è à");
+    }
+
+    @Test(expected = ClosedChannelException.class)
+    public void close() throws Exception {
+        writer.write("helloooo");
+        writer.close();
+
+        writer.write("helloooo");
+        fail("Should have failed the line above");
+    }
+
+
+    private void assertContent(String string) throws IOException {
+        assertThat(FileUtils.readFileToString(file, StandardCharsets.UTF_8), equalTo(string));
+    }
+}

--- a/core/src/test/java/hudson/util/FileChannelWriterTest.java
+++ b/core/src/test/java/hudson/util/FileChannelWriterTest.java
@@ -27,7 +27,7 @@ public class FileChannelWriterTest {
     @Before
     public void setUp() throws Exception {
         file = temporaryFolder.newFile();
-        writer = new FileChannelWriter(file.toPath(), StandardCharsets.UTF_8, true, StandardOpenOption.WRITE);
+        writer = new FileChannelWriter(file.toPath(), StandardCharsets.UTF_8, true, true,  StandardOpenOption.WRITE);
     }
 
     @Test

--- a/core/src/test/java/hudson/util/FileChannelWriterTest.java
+++ b/core/src/test/java/hudson/util/FileChannelWriterTest.java
@@ -27,7 +27,7 @@ public class FileChannelWriterTest {
     @Before
     public void setUp() throws Exception {
         file = temporaryFolder.newFile();
-        writer = new FileChannelWriter(file.toPath(), StandardCharsets.UTF_8, StandardOpenOption.WRITE);
+        writer = new FileChannelWriter(file.toPath(), StandardCharsets.UTF_8, true, StandardOpenOption.WRITE);
     }
 
     @Test

--- a/test/src/test/java/hudson/util/AtomicFileWriterPerfTest.java
+++ b/test/src/test/java/hudson/util/AtomicFileWriterPerfTest.java
@@ -24,7 +24,7 @@ public class AtomicFileWriterPerfTest {
      * <strong>really</strong> bad performance regressions.
      */
     @Issue("JENKINS-34855")
-    @Test(timeout = 30 * 1000L)
+    @Test(timeout = 50 * 1000L)
     public void poorManPerformanceTestBed() throws Exception {
         int count = 1000;
         while (count-- > 0) {


### PR DESCRIPTION
See [JENKINS-34855](https://issues.jenkins-ci.org/browse/JENKINS-34855).

Followup of #2548 & #3165

After a lot of reading and some testing, the only reliable ways to force a **local** device sync from Java code appear to be either by using `FileChannel.force(boolean)` or `FileDescriptor.sync()`.

So even if the issues around this have generally been seen more when using remote FS, I think we can hope (?) that making sure we actually flush to local disk could at least make the probability for that issue (i.e. zero-length files seen in the wild) to happen overall (far?) less _likely_.

This change rewires the current internal `core` writer in `AtomicFileWriter` to delegate to a `FileChannel`, giving then us access to `FileChannel.force()`.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* `Internal:` [JENKINS-34855](https://issues.jenkins-ci.org/browse/JENKINS-34855) `AtomicFileWriter` now uses a `FileChannel` internally and forces a disk sync when `commit`ting.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

#### ToDos after merge

* [ ] Update https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties with the new sysprop
* [ ] File an improvement followup from James' comment: https://github.com/jenkinsci/jenkins/pull/3170#pullrequestreview-80799082
 
### Desired reviewers

@reviewbybees esp. @jtnord 