### PR TITLE
Add setBuildResult option to ArtifactArchiver

### DIFF
--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -318,10 +318,34 @@ public class ArtifactArchiverTest {
 
     private static class RemoveReadPermission extends MasterToSlaveFileCallable<Object> {
         @Override
-        public Object invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+        public Object invoke(java.io.File f, VirtualChannel channel) throws IOException, InterruptedException {
             assertTrue(f.createNewFile());
             assertTrue(f.setReadable(false));
             return null;
         }
     }
+
+    @Test
+    public void setBuildResultWithEmptyArchive() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        ArtifactArchiver aa = new ArtifactArchiver("f");
+        aa.setSetBuildResult(false);
+        project.getPublishersList().replaceBy(Collections.singleton(aa));
+        assertEquals("(no artifacts)", Result.SUCCESS, build(project));
+
+        project = j.createFreeStyleProject();
+        aa = new ArtifactArchiver("f");
+        aa.setSetBuildResult(true);
+        aa.setAllowEmptyArchive(true);
+        project.getPublishersList().replaceBy(Collections.singleton(aa));
+        assertEquals("(no artifacts)", Result.SUCCESS, build(project));
+
+        project = j.createFreeStyleProject();
+        aa = new ArtifactArchiver("f");
+        aa.setSetBuildResult(true);
+        aa.setAllowEmptyArchive(false);
+        project.getPublishersList().replaceBy(Collections.singleton(aa));
+        assertEquals("(no artifacts)", Result.FAILURE, build(project));
+    }
+
 }


### PR DESCRIPTION
This change is a continuation in the spirit of https://github.com/jenkinsci/jenkins/pull/732 and allows the end user to choose whether or not ArtifactArchiver is allowed to change the build status at all, putting the decision about what makes a build successful or not back under their control. This defaults to `true`, maintaining the old behaviour. 

The primary reason for this PR is that on complex pipeline builds that may have multiple places where they archive large numbers of artifacts (i.e. logs and test framework reports), the change for a rogue IOException increases. In these situations, ArtifactArchiver sets the build result to Failed without throwing an exception.  The run continues but prevents a deployment or other step in a CICD process that depends on reading the result of the previous job. In these jobs, the lack of a single log file can be annoying, but is not reason enough to mark the job as unsuccessful.