### PR TITLE
[FIX JENKINS-48407] Permission issue after upgrade to 2.93

### DIFF
--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -23,6 +23,8 @@
  */
 package hudson.util;
 
+import jenkins.model.Jenkins;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
@@ -35,6 +37,9 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -111,7 +116,12 @@ public class AtomicFileWriter extends Writer {
         }
 
         try {
-            tmpPath = Files.createTempFile(dir, "atomic", "tmp");
+            Set<PosixFilePermission> permissions = Jenkins.DEFAULT_FILE_PERMISSIONS;
+            if (Files.exists(destinationPath)) {
+                permissions = Files.getPosixFilePermissions(destinationPath);
+            }
+            tmpPath = Files.createTempFile(dir, "atomic", "tmp", PosixFilePermissions.asFileAttribute(permissions));
+
         } catch (IOException e) {
             throw new IOException("Failed to create a temporary file in "+ dir,e);
         }


### PR DESCRIPTION
See [JENKINS-48407](https://issues.jenkins-ci.org/browse/JENKINS-48407).

This was caused by https://github.com/jenkinsci/jenkins/pull/2548

Basically, NIO's `Files.createTempFile()` creates file with `0600` instead of `0644` previously with pre-NIO.
So the path chosen is the following: instead of applying `0644` back blindly:
* if the file exists, we re-apply the existing permissions
* if it does not, we use the default system permissions, not computed once at Jenkins startup.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* [JENKINS-48407](https://issues.jenkins-ci.org/browse/JENKINS-48407) : Fix permission issue in 2.93 caused by https://github.com/jenkinsci/jenkins/pull/2548

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
