### PR TITLE
surefire.skipAfterFailureCount=100

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -320,6 +320,7 @@ THE SOFTWARE.
       <properties>
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
         <surefire.rerunFailingTestsCount>4</surefire.rerunFailingTestsCount>
+        <surefire.skipAfterFailureCount>100</surefire.skipAfterFailureCount>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
@jtnord was recently noting (perhaps in reference to #3181?) that there a cases where a bad PR causes massive test failures and we waste cycles running lots of failing tests. It would be better to just cut it short after enough failures have been recorded to make it clear what was wrong.

[Documented limitations](http://maven.apache.org/surefire/maven-surefire-plugin/examples/skip-after-failure.html#Limitations) suggest that this would not work reliably after https://github.com/jenkinsci/jenkins/pull/2264 but I have used this trick in private core builds successfully, so, we might as well give it a shot. Note that `Jenkinsfile` currently sets `failFast=false` so even if there are massive failures on one platform, we will still go through the full test suite on the other. Not sure if we want to change that too.

@reviewbybees @jenkinsci/code-reviewers