### PR TITLE
Updating Powermock and Objenesis to avoid Mockito/Hamcrest library mismatches

### DIFF
--- a/cli/src/test/java/hudson/cli/PrivateKeyProviderTest.java
+++ b/cli/src/test/java/hudson/cli/PrivateKeyProviderTest.java
@@ -47,7 +47,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(CLI.class) // When mocking new operator caller has to be @PreparedForTest, not class itself
+@PrepareForTest({CLI.class, CLIConnectionFactory.class}) // When mocking new operator caller has to be @PreparedForTest, not class itself
 public class PrivateKeyProviderTest {
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -153,12 +153,17 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
-        <version>1.6.2</version>
+        <version>1.6.6</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito</artifactId>
-        <version>1.6.2</version>
+        <version>1.6.6</version>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>2.6</version>
       </dependency>
 
       <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -207,7 +207,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
-      <version>2.5.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Noticed that my IDE was showing `hudson.cli.PrivateKeyProviderTest` as being erroneous, and when I went to take a look, it turned out there were two versions of `ArgumentMatcher` floating around, one from `mockito-all` which came in as a transitive dependency of `powermock-api-mockito`, and which bundled some of Hamcrest, including an incompatible version of `BaseMatcher`…anyway, updating PowerMock seems to solve that—I guess they realized the horror of ever using `*-all` artifacts. And then `objenesis` was a mismatch, so I just upgraded that, and then `PrivateKeyProviderTest` failed for some reason completely opaque to me but anyway “preparing for test” another class seems to have solved it. If I had my way Mockito and PowerMock would be listed in the banned dependencies Enforcer rule, but that is another matter.

@reviewbybees