### PR TITLE
[JENKINS-34254] Fix RequirePOST form

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.254-SNAPSHOT</stapler.version>
+    <stapler.version>1.254</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.11</groovy.version>
     <!-- TODO: Actually many issues are being filtered by src/findbugs/findbugs-excludes.xml -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.253</stapler.version>
+    <stapler.version>1.254-SNAPSHOT</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.11</groovy.version>
     <!-- TODO: Actually many issues are being filtered by src/findbugs/findbugs-excludes.xml -->

--- a/core/src/main/java/hudson/security/csrf/CrumbFilter.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbFilter.java
@@ -8,6 +8,9 @@ package hudson.security.csrf;
 import hudson.util.MultipartFormDataParser;
 import jenkins.model.Jenkins;
 import org.acegisecurity.providers.anonymous.AnonymousAuthenticationToken;
+import org.kohsuke.MetaInfServices;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.ForwardToView;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
@@ -43,13 +46,16 @@ public class CrumbFilter implements Filter {
         return h.getCrumbIssuer();
     }
 
+    @Restricted(NoExternalUse.class)
+    @MetaInfServices
+    public static class ErrorCustomizer implements RequirePOST.ErrorCustomizer {
+        @Override
+        public ForwardToView getForwardView() {
+            return new ForwardToView(CrumbFilter.class, "retry");
+        }
+    }
+
     public void init(FilterConfig filterConfig) throws ServletException {
-        RequirePOST.Processor.registerErrorHandler(new RequirePOST.ErrorHandler() {
-            @Override
-            public ForwardToView getForwardView() {
-                return new ForwardToView(CrumbFilter.this, "retry");
-            }
-        });
     }
 
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {

--- a/core/src/main/java/hudson/security/csrf/CrumbFilter.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbFilter.java
@@ -8,6 +8,8 @@ package hudson.security.csrf;
 import hudson.util.MultipartFormDataParser;
 import jenkins.model.Jenkins;
 import org.acegisecurity.providers.anonymous.AnonymousAuthenticationToken;
+import org.kohsuke.stapler.ForwardToView;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import java.io.IOException;
 import java.util.Enumeration;
@@ -42,6 +44,12 @@ public class CrumbFilter implements Filter {
     }
 
     public void init(FilterConfig filterConfig) throws ServletException {
+        RequirePOST.Processor.registerErrorHandler(new RequirePOST.ErrorHandler() {
+            @Override
+            public ForwardToView getForwardView() {
+                return new ForwardToView(CrumbFilter.this, "retry");
+            }
+        });
     }
 
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {

--- a/core/src/main/resources/hudson/security/csrf/CrumbFilter/retry.jelly
+++ b/core/src/main/resources/hudson/security/csrf/CrumbFilter/retry.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
+    <st:statusCode value="405"/>
     <l:layout norefresh="true" title="${%Method Not Allowed}">
 
         <l:main-panel>

--- a/core/src/main/resources/hudson/security/csrf/CrumbFilter/retry.jelly
+++ b/core/src/main/resources/hudson/security/csrf/CrumbFilter/retry.jelly
@@ -1,0 +1,42 @@
+<!--
+The MIT License
+
+Copyright (c) 2017, Daniel Beck
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+    <l:layout norefresh="true" title="${%Method Not Allowed}">
+
+        <l:main-panel>
+            <h1>${%This URL requires POST}</h1>
+            <p>
+                ${%blurb}
+            </p>
+            <p><tt>${requestURL}</tt></p>
+            <p><strong>${%warning}</strong></p>
+            <f:form method="post">
+                <f:submit value="${%Retry using POST}"/>
+            </f:form>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/core/src/main/resources/hudson/security/csrf/CrumbFilter/retry.jelly
+++ b/core/src/main/resources/hudson/security/csrf/CrumbFilter/retry.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
             </p>
             <p><tt>${requestURL}</tt></p>
             <p><strong>${%warning}</strong></p>
-            <f:form method="post">
+            <f:form method="post" name="retry">
                 <f:submit value="${%Retry using POST}"/>
             </f:form>
         </l:main-panel>

--- a/core/src/main/resources/hudson/security/csrf/CrumbFilter/retry.properties
+++ b/core/src/main/resources/hudson/security/csrf/CrumbFilter/retry.properties
@@ -1,0 +1,4 @@
+blurb = The URL you're trying to access requires that requests be sent using POST (like a form submission). \
+  The button below allows you to retry accessing this URL using POST. \
+  URL being accessed:
+warning = If you were sent here from an untrusted source, please proceed with caution.


### PR DESCRIPTION
See [JENKINS-34254](https://issues.jenkins-ci.org/browse/JENKINS-34254).

Downstream of https://github.com/stapler/stapler/pull/135. Alternative to https://github.com/jenkinsci/jenkins/pull/3186.

`SNAPSHOT` dependency on Stapler because I couldn't figure out how to handle the different dates in each stapler component  other than not using the `stapler.version` property at all.

### Proposed changelog entries

* Make the form that shows up when a URL requiring POST is accessed using a different verb work with CSRF protection enabled

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@jenkinsci/code-reviewers
