### PR TITLE
upgrade access-modifier to 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@ THE SOFTWARE.
     <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
-    <access-modifier.version>1.11</access-modifier.version>
+    <access-modifier.version>1.12</access-modifier.version>
     <access-modifier-annotation.version>${access-modifier.version}</access-modifier-annotation.version> <!-- differing only where needed for timestamped snapshots -->
     <access-modifier-checker.version>${access-modifier.version}</access-modifier-checker.version>
 


### PR DESCRIPTION
with 1.12 @Restricted annotation are kept for runtime, which is a requirement for [configuration-as-code](https://github.com/jenkinsci/configuration-as-code-plugin) to detect technical attribute which should not be exposed (typically : `Jenkins#setInstallState()`)

See [JENKINS-31094](https://issues.jenkins-ci.org/browse/JENKINS-31094).

### Proposed changelog entries

* Internal: upgrade access-modifier annotation to 1.12. `@Restricted` can now be checked at runtime

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change : developer
- [x] Appropriate autotests or explanation to why this change has no tests
    configuration-as-code is the simpler way to demonstrate this

### Desired reviewers

@jenkinsci/code-reviewers
