### PR TITLE
[JENKINS-48480] Deleting DeprecatedAgentProtocolMonitor.initializerCheck

### DIFF
--- a/core/src/main/java/jenkins/slaves/DeprecatedAgentProtocolMonitor.java
+++ b/core/src/main/java/jenkins/slaves/DeprecatedAgentProtocolMonitor.java
@@ -24,14 +24,10 @@
 package jenkins.slaves;
 
 import hudson.Extension;
-import hudson.init.InitMilestone;
-import hudson.init.Initializer;
 import hudson.model.AdministrativeMonitor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import jenkins.AgentProtocol;
 import jenkins.model.Jenkins;
@@ -53,8 +49,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 public class DeprecatedAgentProtocolMonitor extends AdministrativeMonitor {
     
-    private static final Logger LOGGER = Logger.getLogger(DeprecatedAgentProtocolMonitor.class.getName());
-
     public DeprecatedAgentProtocolMonitor() {
         super();
     }
@@ -96,18 +90,5 @@ public class DeprecatedAgentProtocolMonitor extends AdministrativeMonitor {
             return null;
         }
         return StringUtils.join(deprecatedProtocols, ',');
-    }
-    
-    @Initializer(after = InitMilestone.JOB_LOADED)
-    @Restricted(NoExternalUse.class)
-    public static void initializerCheck() {
-        String protocols = getDeprecatedProtocolsString();
-        if(protocols != null) {
-            LOGGER.log(Level.WARNING, "This Jenkins instance uses deprecated Remoting protocols: {0}"
-                    + "It may impact stability of the instance. " 
-                    + "If newer protocol versions are supported by all system components "
-                    + "(agents, CLI and other clients), "
-                    + "it is highly recommended to disable the deprecated protocols.", protocols);
-        } 
     }
 }


### PR DESCRIPTION
Pulled out of #3012 to try to get this merged earlier, as it has been causing test flakes and test log noise. For example,

```diff
diff --git a/test/src/test/java/jenkins/model/StartupTest.java b/test/src/test/java/jenkins/model/StartupTest.java
index aecedcf1ef..71ce0416b4 100644
--- a/test/src/test/java/jenkins/model/StartupTest.java
+++ b/test/src/test/java/jenkins/model/StartupTest.java
@@ -42,6 +42,7 @@ public class StartupTest {
 
     @Test
     public void noWarnings() throws Exception {
+        Thread.sleep(5000);
         assertEquals(Collections.emptyList(), logs.getMessages());
     }
 ```

produces a consistent failure without this patch. (The old protocols are disabled by the setup wizard, but this does not happen in normal `JenkinsRule` test executions.)

Reasoning is that there are all kinds of conditions which merit administrative monitors, including security issues, which we already display; there is no particular reason to also send something to the system log.

See also [JENKINS-48480](https://issues.jenkins-ci.org/browse/JENKINS-48480) and #3188.

@reviewbybees