### PR TITLE
[JENKINS-48505] - Invoke optimistic get before computeIfAbsent to avoid contention.

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2595,7 +2595,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @SuppressWarnings({"unchecked"})
     public <T> ExtensionList<T> getExtensionList(Class<T> extensionType) {
-        return extensionLists.computeIfAbsent(extensionType, key -> ExtensionList.create(this, key));
+        ExtensionList<T> extensionList = extensionLists.get(extensionType);
+        return extensionList != null ? extensionList : extensionLists.computeIfAbsent(extensionType, key -> ExtensionList.create(this, key));
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-48505](https://issues.jenkins-ci.org/browse/JENKINS-48505) and discussion about performance concerns wrt computeIfAbsent https://github.com/jenkinsci/jenkins/pull/3091

### Proposed changelog entries

Invoke optimistic get before computeIfAbsent to avoid contention with ExtensionList.

### Desired reviewers

@oleg-nenashev 
@jglick 
