### PR TITLE
[JENKINS-48593] - Add getSystemProperty(key) to fix hudson.consoleTailKB system property

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -473,10 +473,8 @@ public class Functions {
      * Gets the system property indicated by the specified key.
      * 
      * Delegates to {@link SystemProperties#getString(java.lang.String)}.
-     * 
-     * @since TODO
      */
-    @Restricted(NoExternalUse.class)
+    @Restricted(DoNotUse.class)
     public static String getSystemProperty(String key) {
         return SystemProperties.getString(key);
     }

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -474,7 +474,7 @@ public class Functions {
      * 
      * Delegates to {@link SystemProperties#getString(java.lang.String)}.
      * 
-     * @since 2.96
+     * @since TODO
      */
     @Restricted(NoExternalUse.class)
     public static String getSystemProperty(String key) {

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -469,8 +469,16 @@ public class Functions {
         return new TreeMap<Object,Object>(System.getProperties());
     }
 
+    /**
+     * Gets the system property indicated by the specified key.
+     * 
+     * Delegates to {@link SystemProperties#getString(java.lang.String)}.
+     * 
+     * @since 2.96
+     */
+    @Restricted(NoExternalUse.class)
     public static String getSystemProperty(String key) {
-        return System.getProperty(key);
+        return SystemProperties.getString(key);
     }
 
     public static Map getEnvVars() {

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -469,6 +469,10 @@ public class Functions {
         return new TreeMap<Object,Object>(System.getProperties());
     }
 
+    public static String getSystemProperty(String key) {
+        return System.getProperty(key);
+    }
+
     public static Map getEnvVars() {
         return new TreeMap<String,String>(EnvVars.masterEnvVars);
     }


### PR DESCRIPTION
The system property "hudson.consoleTailKB" is supposed to control how many KB of console log is shown in the default console view.

It is used in two places:

https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/model/Run/console.jelly#L38
https://github.com/jenkinsci/workflow-support-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl/index.jelly#L39

Both jelly scripts expect a method getSystemProperty(key) on the Functions class. But that method does not exist. Therefore the default of 150 KB is always used and the system property is ignored.

This PR adds this missing method to fix the system property "hudson.consoleTailKB".
