### PR TITLE
MessageFormat treats ' as a special character

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.properties
+++ b/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.properties
@@ -1,2 +1,2 @@
 blurb=There appears to be a large number of jobs. Did you know that you can organize your jobs to different views? \
-  You can click '+' in the top page to create a new view any time.
+  You can click ''+'' in the top page to create a new view any time.

--- a/core/src/main/resources/hudson/model/LoadStatistics/main.properties
+++ b/core/src/main/resources/hudson/model/LoadStatistics/main.properties
@@ -51,7 +51,7 @@ blurb=\
     <dd>\
       This is the number of jobs that are in the build queue, waiting for an \
       available executor (of this computer, of this label, or in this Jenkins, respectively.) \
-      This doesn't include jobs that are in the quiet period, nor does it include \
+      This doesn''t include jobs that are in the quiet period, nor does it include \
       jobs that are in the queue because earlier builds are still in progress. \
       If this line ever goes above 0, that means your Jenkins will run more builds by \
       adding more computers.\

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -67,7 +67,7 @@ AbstractProject.ExtendedReadPermission.Description=\
 AbstractProject.DiscoverPermission.Description=\
   This permission grants discover access to jobs. Lower than read permissions, it allows you to \
   redirect anonymous users to the login page when they try to access a job url. \
-  Without it they would get a 404 error and wouldn't be able to discover project names.
+  Without it they would get a 404 error and wouldn''t be able to discover project names.
 # WipeOutPermission is only visible in the security configuration if the system property
 # hudson.security.WipeOutPermission is set to true
 AbstractProject.WipeOutPermission.Description=\
@@ -77,7 +77,7 @@ AbstractProject.CancelPermission.Description=\
 AbstractProject.AssignedLabelString.InvalidBooleanExpression=\
   Invalid boolean expression: {0}
 AbstractProject.AssignedLabelString.NoMatch=\
-  There's no agent/cloud that matches this assignment
+  There''s no agent/cloud that matches this assignment
 AbstractProject.CustomWorkspaceEmpty=Custom workspace is empty.
 AbstractProject.LabelLink=<a href="{0}{2}">Label {1}</a> is serviced by {3,choice,0#no nodes|1#1 node|1<{3} nodes}{4,choice,0#|1# and 1 cloud|1< and {4} clouds}. \
   Permissions or other restrictions provided by plugins may prevent this job from running on those nodes.

--- a/core/src/main/resources/hudson/model/MyViewsProperty/config.properties
+++ b/core/src/main/resources/hudson/model/MyViewsProperty/config.properties
@@ -20,4 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-description=The view selected by default when navigating to the users' private views
+description=The view selected by default when navigating to the users'' private views

--- a/core/src/main/resources/hudson/os/solaris/ZFSInstaller/askRootPassword.properties
+++ b/core/src/main/resources/hudson/os/solaris/ZFSInstaller/askRootPassword.properties
@@ -21,4 +21,4 @@
 # THE SOFTWARE.
 
 blurb=It appears that the current user account lacks necessary permissions to create a ZFS file system. \
-  Please provide the username and the password that's capable of doing this, such as root. 
+  Please provide the username and the password that''s capable of doing this, such as root.

--- a/core/src/main/resources/hudson/security/Messages.properties
+++ b/core/src/main/resources/hudson/security/Messages.properties
@@ -33,8 +33,8 @@ HudsonPrivateSecurityRealm.Details.PasswordError=\
 HudsonPrivateSecurityRealm.ManageUserLinks.DisplayName=Manage Users
 HudsonPrivateSecurityRealm.ManageUserLinks.Description=Create/delete/modify users that can log in to this Jenkins
 
-HudsonPrivateSecurityRealm.CreateAccount.TextNotMatchWordInImage=Text didn't match the word shown in the image
-HudsonPrivateSecurityRealm.CreateAccount.PasswordNotMatch=Password didn't match
+HudsonPrivateSecurityRealm.CreateAccount.TextNotMatchWordInImage=Text didn''t match the word shown in the image
+HudsonPrivateSecurityRealm.CreateAccount.PasswordNotMatch=Password didn''t match
 HudsonPrivateSecurityRealm.CreateAccount.PasswordRequired=Password is required
 HudsonPrivateSecurityRealm.CreateAccount.UserNameRequired=User name is required
 HudsonPrivateSecurityRealm.CreateAccount.InvalidEmailAddress=Invalid e-mail address

--- a/core/src/main/resources/hudson/security/csrf/CrumbFilter/retry.properties
+++ b/core/src/main/resources/hudson/security/csrf/CrumbFilter/retry.properties
@@ -1,4 +1,4 @@
-blurb = The URL you're trying to access requires that requests be sent using POST (like a form submission). \
+blurb = The URL you''re trying to access requires that requests be sent using POST (like a form submission). \
   The button below allows you to retry accessing this URL using POST. \
   URL being accessed:
 warning = If you were sent here from an untrusted source, please proceed with caution.

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/help.properties
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/help.properties
@@ -27,5 +27,5 @@ blurb=Allows an agent to be launched using <a href="https://en.wikipedia.org/wik
   just needs to be able to reach the master. If you have enabled security via \
   the <i>Configure Global Security</i> page, you can customize the port on \
   which the Jenkins master will listen for incoming JNLP agent connections.<br>\
-  By default, the JNLP agent will launch a GUI, but it's also possible to run \
+  By default, the JNLP agent will launch a GUI, but it''s also possible to run \
   a JNLP agent without a GUI, e.g. as a Window service.

--- a/core/src/main/resources/hudson/tasks/Maven/help.properties
+++ b/core/src/main/resources/hudson/tasks/Maven/help.properties
@@ -1,6 +1,6 @@
 para1=For projects that use Maven as the build system. This causes Jenkins to invoke \
 	Maven with the given goals and options. A non-zero exit code from Maven makes Jenkins \
-	mark the build as a failure. Some Maven versions have a bug where it doesn't return \
+	mark the build as a failure. Some Maven versions have a bug where it doesn''t return \
 	the exit code correctly.
 para2=Jenkins passes <a href="{0}/env-vars.html" target="_new">various environment \
 	variables</a> to Maven, which you can access from Maven as "$&#123;env.VARIABLENAME}".

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -39,12 +39,12 @@ installWizard_installComplete_installComplete_restartRequiredNotSupportedMessage
 installWizard_installComplete_restartLabel=Restart
 installWizard_installIncomplete_title=Resume Installation
 installWizard_installIncomplete_banner=Resume Installation
-installWizard_installIncomplete_message=Jenkins was restarted during installation and some plugins didn't seem to get installed.
+installWizard_installIncomplete_message=Jenkins was restarted during installation and some plugins didn''t seem to get installed.
 installWizard_installIncomplete_resumeInstallationButtonLabel=Resume
 installWizard_saveFirstUser=Save and Finish
 installWizard_skipFirstUser=Continue as admin
 installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
-You've skipped creating an admin user. To log in, use the username: 'admin' and \
+You''ve skipped creating an admin user. To log in, use the username: "admin" and \
 the administrator password you used to access the setup wizard.\
 </div>
 installWizard_addFirstUser_title=Getting Started
@@ -63,7 +63,7 @@ installWizard_continue=Continue
 installWizard_retry=Retry
 installWizard_upgradePanel_title=Upgrade
 installWizard_upgradePanel_banner=Welcome to Jenkins {0}!
-installWizard_upgradePanel_message=Jenkins {0} includes some great new features that we think you'll love, install these additional plugins to take advantage of them!
+installWizard_upgradePanel_message=Jenkins {0} includes some great new features that we think you''ll love, install these additional plugins to take advantage of them!
 installWizard_upgradePanel_skipRecommendedPlugins=No thanks
 installWizard_upgradeComplete_title=Upgrade
 installWizard_pluginsInstalled_banner=Welcome to Jenkins {0}!

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
@@ -3,7 +3,7 @@ BUILD_ID.blurb=The current build ID, identical to BUILD_NUMBER for builds create
 BUILD_DISPLAY_NAME.blurb=The display name of the current build, which is something like "#153" by default.
 JOB_NAME.blurb=Name of the project of this build, such as "foo" or "foo/bar".
 JOB_BASE_NAME.blurb=Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".
-BUILD_TAG.blurb=String of "jenkins-<i>$'{'JOB_NAME}</i>-<i>$'{'BUILD_NUMBER}</i>". All forward slashes ('/') in the JOB_NAME are replaced with dashes ('-'). Convenient to put into a resource file, a jar file, etc for easier identification.
+BUILD_TAG.blurb=String of "jenkins-<i>$'{'JOB_NAME}</i>-<i>$'{'BUILD_NUMBER}</i>". All forward slashes ("/") in the JOB_NAME are replaced with dashes ("-"). Convenient to put into a resource file, a jar file, etc for easier identification.
 EXECUTOR_NUMBER.blurb=\
   The unique number that identifies the current executor \
   (among executors of the same machine) that\u2019s \

--- a/core/src/main/resources/jenkins/model/Jenkins/noPrincipal.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/noPrincipal.properties
@@ -21,5 +21,5 @@
 # THE SOFTWARE.
 
 blurb=\
-        The web container doesn't seem to be configured to do authentication. \
+        The web container doesn''t seem to be configured to do authentication. \
         Check the container documentation and/or also consult <tt>jenkins-users@googlegroups.com</tt>

--- a/core/src/main/resources/jenkins/model/Messages.properties
+++ b/core/src/main/resources/jenkins/model/Messages.properties
@@ -62,7 +62,7 @@ NewViewLink.NewView=New View
 
 PatternProjectNamingStrategy.DisplayName=Pattern
 PatternProjectNamingStrategy.NamePatternRequired=Name Pattern is required
-PatternProjectNamingStrategy.NamePatternInvalidSyntax=regular expression's syntax is invalid.
+PatternProjectNamingStrategy.NamePatternInvalidSyntax=regular expression''s syntax is invalid.
 ParameterizedJobMixIn.build_with_parameters=Build with Parameters
 ParameterizedJobMixIn.build_now=Build Now
 BlockedBecauseOfBuildInProgress.shortDescription=Build #{0} is already in progress{1}


### PR DESCRIPTION
https://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html

Test case is jenkins/computer/node/configure
 Help for "Launch method"

Without this fix, you will see:
Launch agent via Java Web Start
... By default, the JNLP agent will launch a GUI, but its also possible to run a JNLP agent without a GUI, e.g. as a Window service.

You should see:
... By default, the JNLP agent will launch a GUI, but it's also possible to run a JNLP agent without a GUI, e.g. as a Window service.

### Submitter checklist

- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)

### Desired reviewers