### PR TITLE
[JENKINS-48773] - Limit which section headers are added to the breadcrumb config outline

### DIFF
--- a/core/src/main/resources/lib/form/section_.js
+++ b/core/src/main/resources/lib/form/section_.js
@@ -38,7 +38,7 @@ var section = (function (){
             root = $(root||document.body);
 
             /**
-             * Recursively visit elements and find all section headers.
+             * Recursively visit elements and find all section headers that are not inside f:repeatable elements.
              *
              * @param {HTMLElement} dom
              *      Parent element
@@ -52,7 +52,7 @@ var section = (function (){
                             var child = new SectionNode(e);
                             parent.children.push(child);
                             visitor(e,child);
-                        } else {
+                        } else if (!e.classList.contains("repeated-container")) {
                             visitor(e,parent);
                         }
                     }

--- a/core/src/main/resources/lib/form/section_.js
+++ b/core/src/main/resources/lib/form/section_.js
@@ -38,7 +38,7 @@ var section = (function (){
             root = $(root||document.body);
 
             /**
-             * Recursively visit elements and find all section headers that are not inside f:repeatable elements.
+             * Recursively visit elements and find all visible section headers that are not inside f:repeatable elements.
              *
              * @param {HTMLElement} dom
              *      Parent element
@@ -46,11 +46,17 @@ var section = (function (){
              *      Function that returns the array to which discovered section headers and child elements are added.
              */
             function visitor(dom,parent) {
+                function isVisible(elem) {
+                    return !!( elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length );
+                }
+
                 for (var e=dom.firstChild; e!=null; e=e.nextSibling) {
                     if (e.nodeType==1) {
-                        if (e.className=="section-header") {
+                        if (e.className=="section-header" && isVisible(e)) {
                             var child = new SectionNode(e);
                             parent.children.push(child);
+                            // The next line seems to be unnecessary, as there are no children inside the section header itself.
+                            // So this code will always returns a flat list of section headers.
                             visitor(e,child);
                         } else if (!e.classList.contains("repeated-container")) {
                             visitor(e,parent);

--- a/core/src/main/resources/lib/form/section_.js
+++ b/core/src/main/resources/lib/form/section_.js
@@ -47,7 +47,7 @@ var section = (function (){
              */
             function visitor(dom,parent) {
                 function isVisible(elem) {
-                    return !!( elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length );
+                    return !!( elem.offsetWidth || elem.offsetHeight || elem.getClientRects && elem.getClientRects().length );
                 }
 
                 for (var e=dom.firstChild; e!=null; e=e.nextSibling) {


### PR DESCRIPTION
See [JENKINS-48773](https://issues.jenkins-ci.org/browse/JENKINS-48773).

This implements two independent changes:

* Do not add section headers inside `f:repeatable` elements to the outline, as that'll just make a mess of things (see Jira issue).
* Do not add section headers that are invisible (such as "Strategy" in the global config, when there's no job naming strategy selected) to the outline.

The second one has the problem that we do not check for DOM changes, so once a section header becomes visible, it still won't show in the outline. I still consider not showing initially invisible section headers preferable to showing them. My JS-fu isn't sufficient to figure out how to edit (probably) `lib/form/breadcrumb-config-outline/init.js` to do that (perhaps @kzantow knows?).

An argument could be made that any section headers that aren't on the top level shouldn't be included anyway, given that this is supposed to be a tree, and `init.js` only looks at children of the root. But I didn't bother to figure out how to determine whether a section is at the top level or not, and don't plan to.

### Proposed changelog entries

* RFE: Limit which section headers are added to the breadcrumb config outline

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

FYI @rtyler (and @abayer who edited the issue)