### PR TITLE
[JENKINS-48831] New/fixed version of js-lib core-asset modules

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -41,6 +41,7 @@ THE SOFTWARE.
     <JENKINS_HOME>${basedir}/work</JENKINS_HOME>
     <contextPath>/jenkins</contextPath><!-- context path during test -->
     <port>8080</port><!-- HTTP listener port -->
+    <js.libs.version>2.0.0-SNAPSHOT</js.libs.version>
     <node.version>6.10.2</node.version>
     <yarn.version>0.24.5</yarn.version>
   </properties>
@@ -135,19 +136,19 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>jquery-detached</artifactId>
-      <version>1.2.1</version>
+      <version>${js.libs.version}</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>bootstrap</artifactId>
-      <version>1.3.2</version>
+      <version>${js.libs.version}</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>handlebars</artifactId>
-      <version>1.1.1</version>
+      <version>${js.libs.version}</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <JENKINS_HOME>${basedir}/work</JENKINS_HOME>
     <contextPath>/jenkins</contextPath><!-- context path during test -->
     <port>8080</port><!-- HTTP listener port -->
-    <js.libs.version>2.0.0-SNAPSHOT</js.libs.version>
+    <js-libs.version>2.0.0-SNAPSHOT</js-libs.version>
     <node.version>6.10.2</node.version>
     <yarn.version>0.24.5</yarn.version>
   </properties>
@@ -136,19 +136,19 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>jquery-detached</artifactId>
-      <version>${js.libs.version}</version>
+      <version>${js-libs.version}</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>bootstrap</artifactId>
-      <version>${js.libs.version}</version>
+      <version>${js-libs.version}</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>handlebars</artifactId>
-      <version>${js.libs.version}</version>
+      <version>${js-libs.version}</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>


### PR DESCRIPTION
See [JENKINS-48831](https://issues.jenkins-ci.org/browse/JENKINS-48831).

Depends on https://github.com/jenkinsci/js-libs/pull/4

@jenkinsci/code-reviewers @reviewbybees