### PR TITLE
[JENKINS-46911] - Revert trimming of name in Jenkins#checkGoodName()

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3850,7 +3850,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *      if the given name is not good
      */
     public static void checkGoodName(String name) throws Failure {
-        if(name==null || name.trim().length()==0)
+        if(name==null || name.length()==0)
             throw new Failure(Messages.Hudson_NoName());
 
         if(".".equals(name.trim()))


### PR DESCRIPTION
Reverts change of the method in #3057 by @godfath3r, according to comments from @dwnusbaum and @jtnord . My bad, I should carefully read conversations before merging

@jenkinsci/code-reviewers 