### PR TITLE
Add new ToolDescriptor constructor so subclasses are not required to be an inner class

### DIFF
--- a/core/src/main/java/hudson/tools/ToolDescriptor.java
+++ b/core/src/main/java/hudson/tools/ToolDescriptor.java
@@ -54,6 +54,14 @@ public abstract class ToolDescriptor<T extends ToolInstallation> extends Descrip
 
     private T[] installations;
 
+    protected ToolDescriptor() {
+        super();
+    }
+
+    protected ToolDescriptor(Class<T> clazz) {
+        super(clazz);
+    }
+
     /**
      * Configured instances of {@link ToolInstallation}s.
      *

--- a/core/src/main/java/hudson/tools/ToolDescriptor.java
+++ b/core/src/main/java/hudson/tools/ToolDescriptor.java
@@ -54,10 +54,11 @@ public abstract class ToolDescriptor<T extends ToolInstallation> extends Descrip
 
     private T[] installations;
 
-    protected ToolDescriptor() {
-        super();
-    }
+    protected ToolDescriptor() { }
 
+    /**
+     * @since FIXME
+     */
     protected ToolDescriptor(Class<T> clazz) {
         super(clazz);
     }


### PR DESCRIPTION
Allow subclasses of `ToolDescriptor` to use the `Descriptor(Class<T>)` constructor so that subclasses do not have to be an inner class of their `Describable`. Required to split out `JDK$DescriptorImpl` as part of [JENKINS-22367](https://issues.jenkins-ci.org/browse/JENKINS-22367), see #3147.

I am happy to create a JIRA ticket or tests if desired.

### Proposed changelog entries

* Developer: Add a constructor to `ToolDescriptor` so that subclasses are not required to be an inner class of their `Describable`

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees

