### PR TITLE
[JENKINS-22088] - Upgrade Extras Executable War from 1.36 to 1.37

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -49,7 +49,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>executable-war</artifactId>
-      <version>1.36</version>
+      <version>1.37</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bumps the extra executable war and pulls in 2 notable changes.

* https://github.com/jenkinsci/extras-executable-war/blob/master/CHANGELOG.md#137
* Full diff: https://github.com/jenkinsci/extras-executable-war/compare/executable-war-1.36...executable-war-1.37

### Proposed changelog entries

* RFE - Extras Executable WAR 1.37: Add ability to supply WAR command-line arguments via STDIN using the `--paramsFromStdIn` parameter
  * Documentation: https://github.com/jenkinsci/extras-executable-war#parameters-from-stdin
* BUG - [JENKINS-22088](https://issues.jenkins-ci.org/browse/JENKINS-22088) - Extras Executable WAR 1.37:  Prevent the disk space leak due to multiple copies of `winstone-XXXX.jar` in the TEMP folder.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
