### PR TITLE
Do not search for last build if concurrent build is allowed

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1068,7 +1068,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     @Override
     public CauseOfBlockage getCauseOfBlockage() {
         // Block builds until they are done with post-production
-        if (isLogUpdated() && !isConcurrentBuild()) {
+        if (!isConcurrentBuild() && isLogUpdated()) {
             final R lastBuild = getLastBuild();
             if (lastBuild != null) {
                 return new BlockedBecauseOfBuildInProgress(lastBuild);


### PR DESCRIPTION
The switch of order in check allows to reduce memory consumption in high
loaded systems.

### Proposed changelog entries

* Internal: Reduce memory consumption for concurrent jobs

### Submitter checklist

- [-] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests
- [-] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@svanoort @oleg-nenashev @jglick 

`jenkins.model.lazy.AbstractLazyLoadRunMap#search` is not optimised for searching from end (DESC order), because it copies array every time. Will address it in another PR.

![screen shot 2018-01-11 at 13 34 14](https://user-images.githubusercontent.com/4785672/34826654-b541fefc-f6d7-11e7-907b-fb089b8cdf28.png)