### PR TITLE
[JENKINS-50056] - Do not copy all build numbers in case of descending search

### DIFF
--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -29,10 +29,9 @@ import hudson.model.RunMap;
 import java.io.File;
 import java.io.IOException;
 import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -336,9 +335,9 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
             return null;
         case DESC:
             // TODO again could be made more efficient
-            List<Integer> reversed = new ArrayList<Integer>(numberOnDisk);
-            Collections.reverse(reversed);
-            for (int m : reversed) {
+            ListIterator<Integer> iterator = numberOnDisk.listIterator(numberOnDisk.size());
+            while(iterator.hasPrevious()) {
+                int m = iterator.previous();
                 if (m > n) {
                     continue;
                 }


### PR DESCRIPTION
Follow-up on https://github.com/jenkinsci/jenkins/pull/3227. Not sure that this is the best solution, because we will have boxing-unboxing (in best case - once, in worst case - of all elements).
But for sure it's fastest :)

Another possible solution - custom method in `SortedIntList` that returns [PrimitiveIterator.OfInt
](https://docs.oracle.com/javase/8/docs/api/java/util/PrimitiveIterator.html) for both directions.

### Proposed changelog entries

* Entry 1: Internal, Reduce memory footprint for `jenkins.model.lazy.AbstractLazyLoadRunMap#search` in case of DESC order

### Submitter checklist

- [-] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [X] Appropriate autotests or explanation to why this change has no tests
- [-] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers
@svanoort  @oleg-nenashev @jglick 