### PR TITLE
[JENKINS-48922] - Whitelist StringBuilder and StringBuffer for serialization

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -36,8 +36,8 @@ java.lang.Object
 java.lang.Short
 java.lang.StackTraceElement
 java.lang.String
-java.lang.StringBuilder
 java.lang.StringBuffer
+java.lang.StringBuilder
 java.lang.reflect.Proxy
 java.net.URI
 java.net.URL

--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -36,6 +36,8 @@ java.lang.Object
 java.lang.Short
 java.lang.StackTraceElement
 java.lang.String
+java.lang.StringBuilder
+java.lang.StringBuffer
 java.lang.reflect.Proxy
 java.net.URI
 java.net.URL


### PR DESCRIPTION
It has been catched by @MarkEWaite in Grooby PostBuild Plugin, see [JENKINS-48992](https://issues.jenkins-ci.org/browse/JENKINS-48992). I think this is generally a bad idea to serialize this classes, but I see no security concerns in it.

Searches like [this](https://github.com/search?l=Java&q=org%3Ajenkinsci+%22private+StringBuilder%22&type=Code) and [this](https://github.com/search?utf8=%E2%9C%93&q=org%3Ajenkinsci+%22private+StringBuffer%22&type=Code) reveal other  potential usages, so I decided to add the classes to the global whitelist

The fix has been verified in https://github.com/jenkinsci/groovy-postbuild-plugin/pull/29

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Not required

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
