### PR TITLE
[FIX JENKINS-48407] Permission issue after upgrade to 2.93

### DIFF
--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -138,7 +138,8 @@ public class AtomicFileWriter extends Writer {
         }
 
         try {
-            tmpPath = Files.createTempFile(dir, "atomic", "tmp");
+            // JENKINS-48407: NIO's createTempFile creates file with 0600 permissions, so we use pre-NIO for this...
+            tmpPath = File.createTempFile("atomic", "tmp", dir.toFile()).toPath();
         } catch (IOException e) {
             throw new IOException("Failed to create a temporary file in "+ dir,e);
         }

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -6,20 +6,36 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Set;
 
 import static org.hamcrest.core.StringContains.*;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 
 public class AtomicFileWriterTest {
     private static final String PREVIOUS = "previous value \n blah";
@@ -122,6 +138,57 @@ public class AtomicFileWriterTest {
         } catch (IOException e) {
             assertThat(e.getMessage(),
                        containsString("exists and is neither a directory nor a symlink to a directory"));
+        }
+    }
+
+    @Issue("JENKINS-48407")
+    @Test
+    public void checkPermissions() throws IOException, InterruptedException {
+
+        final File newFile = tmp.newFile();
+
+        // Check Posix calls are supported (to avoid running this test on Windows for instance)
+        boolean posixSupported = true;
+        try {
+            Files.getPosixFilePermissions(newFile.toPath());
+        } catch (UnsupportedOperationException e) {
+            posixSupported = false;
+        }
+        assumeThat(posixSupported, is(true));
+
+        // given
+        final Set<PosixFilePermission> givenPermissions = EnumSet.of(OWNER_READ,
+                                                                     OWNER_WRITE,
+                                                                     GROUP_READ,
+                                                                     GROUP_WRITE,
+                                                                     OTHERS_READ
+        );
+
+        final Set<PosixFilePermission> notGivenPermissions = EnumSet.of(OWNER_EXECUTE,
+                                                                        GROUP_EXECUTE,
+                                                                        OTHERS_WRITE,
+                                                                        OTHERS_EXECUTE);
+
+        Files.setPosixFilePermissions(newFile.toPath(), givenPermissions);
+        Path filePath = newFile.toPath();
+
+        // when
+        AtomicFileWriter w = new AtomicFileWriter(filePath, StandardCharsets.UTF_8);
+        w.write("whatever");
+        w.commit();
+
+        // then
+        assertFalse(w.getTemporaryPath().toFile().exists());
+        assertTrue(filePath.toFile().exists());
+
+        final Set<PosixFilePermission> posixFilePermissions = Files.getPosixFilePermissions(filePath);
+
+        for (PosixFilePermission perm : givenPermissions) {
+            assertTrue("missing: " + perm, posixFilePermissions.contains(perm));
+        }
+
+        for (PosixFilePermission perm : notGivenPermissions) {
+            assertFalse("should not be allowed: " + perm, posixFilePermissions.contains(perm));
         }
     }
 }


### PR DESCRIPTION
Simply revert to using pre-NIO createTempFile for backward compatibility.
There is no simple way to restore a similar way using NIO's createTempFile.

This supersedes https://github.com/jenkinsci/jenkins/pull/3181 where I tried to be smart, to no avail (as one could have expected)

See [JENKINS-48407](https://issues.jenkins-ci.org/browse/JENKINS-48407).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* [JENKINS-48407](https://issues.jenkins-ci.org/browse/JENKINS-48407): files in `JENKINS_HOME` written through `AtomicFileWriter` were writable **and** readable by nobody but the owner.

Tested manually (running with the current PR on the left, on the right with a pristine 2.101):

![image](https://user-images.githubusercontent.com/223853/34921018-7c8926a6-f97c-11e7-9237-7c7bb4849084.png)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees esp. @jtnord @dwnusbaum 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
