### PR TITLE
[JENKINS-48957] Prevent wildfly to deliver old jackson for blue ocean and other plugins

### DIFF
--- a/war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.jboss.resteasy.resteasy-jackson-provider" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/war/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -2,7 +2,13 @@
 <jboss-deployment-structure>
     <deployment>
         <exclusions>
+            <module name="com.fasterxml.jackson.core.jackson-core" />
+            <module name="com.fasterxml.jackson.core.jackson-annotations" />
+            <module name="com.fasterxml.jackson.core.jackson-databind" />
             <module name="org.jboss.resteasy.resteasy-jackson-provider" />
         </exclusions>
+	<exclude-subsystems>
+	    <subsystem name="jaxrs" />
+	</exclude-subsystems>    
     </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
See [JENKINS-48957](https://issues.jenkins-ci.org/browse/JENKINS-48957).

This change has no test cases because it is a system issue and it would require to have test cases for every application server jenkins is running on.

### Proposed changelog entries

* JENKINS-48957 isolated Jenkins from JAX-RS classes shipped with wildfly (former JBoss) implementation to make blue ocean works (Jackson 2.7 vs 2.8) 

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [X] Appropriate autotests or explanation to why this change has no tests
- [X] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@michaelneale 

