### PR TITLE
Some more refinements to ClassFilterImpl shutoff during development

### DIFF
--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -130,7 +130,7 @@ public class ClassFilterImpl extends ClassFilter {
                 return true;
             }
             String name = c.getName();
-            if (Main.isUnitTest && name.contains("$$EnhancerByMockitoWithCGLIB$$")) {
+            if (Main.isUnitTest && (name.contains("$$EnhancerByMockitoWithCGLIB$$") || name.contains("$$FastClassByMockitoWithCGLIB$$") || name.startsWith("org.mockito."))) {
                 mockOff();
                 return false;
             }
@@ -222,11 +222,11 @@ public class ClassFilterImpl extends ClassFilter {
                     LOGGER.log(Level.WARNING, "problem checking " + loc, x);
                 }
             }
-            if (Main.isUnitTest || Main.isDevelopmentMode) {
-                if (loc.endsWith("/target/classes/")) {
-                    LOGGER.log(Level.FINE, "{0} seems to be current plugin classes, OK", loc);
-                    return true;
-                }
+            if (loc.endsWith("/target/classes/")) {
+                LOGGER.log(Level.FINE, "{0} seems to be current plugin classes, OK", loc);
+                return true;
+            }
+            if (Main.isUnitTest) {
                 if (loc.endsWith("/target/test-classes/") || loc.endsWith("-tests.jar")) {
                     LOGGER.log(Level.FINE, "{0} seems to be test classes, OK", loc);
                     return true;


### PR DESCRIPTION
Should not be a user-visible change.

1. Extend https://github.com/jenkinsci/jenkins/pull/3120/commits/475ef3acd04ef13d3af1bdc28d37392c318ed612 in https://github.com/jenkinsci/jenkins/pull/3120 to include `java -jar jenkins.war` (as opposed to `mvn hpi:run`) when supporting `$JENKINS_HOME/plugins/*.jpl`, as is occasionally useful.
1. Fix some cases observed in `ghprb-plugin` (after https://github.com/jenkinsci/ghprb-plugin/pull/615) where Jenkins fails to detect that Mockito is in use and the class filter needs to be disabled.

@reviewbybees