### PR TITLE
[JENKINS-48467] - Updated UserIdCause.print() to use ModelHyperlinkNote

### DIFF
--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -453,9 +453,9 @@ public abstract class Cause {
 
         @Override
         public void print(TaskListener listener) {
+
             listener.getLogger().println(Messages.Cause_UserIdCause_ShortDescription(
-                    // TODO JENKINS-48467 - better to use ModelHyperlinkNote.encodeTo(User), or User.getUrl, since it handles URL escaping
-                    ModelHyperlinkNote.encodeTo("/user/"+getUserIdOrUnknown(), getUserName())));
+                    ModelHyperlinkNote.encodeTo(User.getOrCreateByIdOrFullName(getUserIdOrUnknown()))));
         }
 
         @Override

--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -454,8 +454,7 @@ public abstract class Cause {
         @Override
         public void print(TaskListener listener) {
             User user = getUserId() == null ? null : User.getById(getUserId(), false);
-            if(user != null)
-            {
+            if (user != null) {
                 listener.getLogger().println(Messages.Cause_UserIdCause_ShortDescription(
                         ModelHyperlinkNote.encodeTo(user)));
             } else {

--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -453,9 +453,12 @@ public abstract class Cause {
 
         @Override
         public void print(TaskListener listener) {
-
-            listener.getLogger().println(Messages.Cause_UserIdCause_ShortDescription(
-                    ModelHyperlinkNote.encodeTo(User.getOrCreateByIdOrFullName(getUserIdOrUnknown()))));
+            User user = getUserId() == null ? null : User.getById(getUserId(), false);
+            if(user != null)
+            {
+                listener.getLogger().println(Messages.Cause_UserIdCause_ShortDescription(
+                        ModelHyperlinkNote.encodeTo(user)));
+            }
         }
 
         @Override

--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -458,6 +458,9 @@ public abstract class Cause {
             {
                 listener.getLogger().println(Messages.Cause_UserIdCause_ShortDescription(
                         ModelHyperlinkNote.encodeTo(user)));
+            } else {
+                listener.getLogger().println(Messages.Cause_UserIdCause_ShortDescription(
+                        "unknown or anonymous"));
             }
         }
 

--- a/test/src/test/java/hudson/model/CauseTest.java
+++ b/test/src/test/java/hudson/model/CauseTest.java
@@ -33,7 +33,9 @@ import java.util.regex.Pattern;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.*;
 
+import hudson.security.*;
 import hudson.util.StreamTaskListener;
+import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -87,14 +89,26 @@ public class CauseTest {
 
     @Issue("JENKINS-48467")
     @Test public void userIdCausePrintTest() throws Exception {
+//        JenkinsRule.DummySecurityRealm realm = j.createDummySecurityRealm();
+//        realm.addGroups("administrator", "admins");
+//        realm.addGroups("alice", "users");
+//        realm.addGroups("bob", "users", "lpadmin", "bob");
+//
+//        j.jenkins.setSecurityRealm(realm);
+//        GlobalMatrixAuthorizationStrategy auth = new GlobalMatrixAuthorizationStrategy();
+//        auth.add(Jenkins.ADMINISTER, "admins");
+//        auth.add(Permission.READ, "users");
+//        j.jenkins.setAuthorizationStrategy(auth);
+
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TaskListener listener = new StreamTaskListener(baos);
 
-        //null userId - dont print anything
+        //null userId - print unknown or anonymous
         Cause causeA = new Cause.UserIdCause(null);
         causeA.print(listener);
 
-        assertTrue(baos.toString().isEmpty());
+        assertEquals(baos.toString().trim(),"Started by user unknown or anonymous");
         baos.reset();
 
         //SYSTEM userid  - getDisplayName() should be SYSTEM
@@ -104,16 +118,16 @@ public class CauseTest {
         assertThat(baos.toString(), containsString("SYSTEM"));
         baos.reset();
 
-        //unknown userid - dont print anything
+        //unknown userid - print unknown or anonymous
         Cause causeC = new Cause.UserIdCause("abc123");
         causeC.print(listener);
 
-        assertTrue(baos.toString().isEmpty());
+        assertEquals(baos.toString().trim(),"Started by user unknown or anonymous");
         baos.reset();
 
-        //Standard operation
-        //user userid  - getDisplayName() should be user
-        User user = User.getById("user", true);
+        //More or less standard operation
+        //user userid  - getDisplayName() should be foo
+        User user = User.getById("foo", true);
         Cause causeD = new Cause.UserIdCause(user.getId());
         causeD.print(listener);
 

--- a/test/src/test/java/hudson/model/CauseTest.java
+++ b/test/src/test/java/hudson/model/CauseTest.java
@@ -110,5 +110,14 @@ public class CauseTest {
 
         assertTrue(baos.toString().isEmpty());
         baos.reset();
+
+        //Standard operation
+        //user userid  - getDisplayName() should be user
+        User user = User.getById("user", true);
+        Cause causeD = new Cause.UserIdCause(user.getId());
+        causeD.print(listener);
+
+        assertThat(baos.toString(), containsString(user.getDisplayName()));
+        baos.reset();
     }
 }

--- a/test/src/test/java/hudson/model/CauseTest.java
+++ b/test/src/test/java/hudson/model/CauseTest.java
@@ -25,14 +25,20 @@
 package hudson.model;
 
 import hudson.XmlFile;
-import java.io.File;
+
+import java.io.*;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.apache.tools.ant.taskdefs.Parallel;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import javax.annotation.Nonnull;
 
 public class CauseTest {
 
@@ -79,4 +85,22 @@ public class CauseTest {
         //j.interactiveBreak();
     }
 
+
+    @Issue("JENKINS-48467")
+    @Test public void userIdCause() throws Exception {
+        TaskListener mockListener = mock(TaskListener.class);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        when(mockListener.getLogger()).thenReturn(new PrintStream(baos));
+
+        Cause.UserIdCause userIdCauseWithNullId = new Cause.UserIdCause(null);
+        Cause.UserIdCause userIdCause = new Cause.UserIdCause("123321");
+
+        userIdCauseWithNullId.print(mockListener);
+        userIdCause.print(mockListener);
+
+        assertTrue(new String(baos.toByteArray()).contains("unknown"));
+        assertTrue(new String(baos.toByteArray()).contains("123321"));
+
+    }
 }

--- a/test/src/test/java/hudson/model/CauseTest.java
+++ b/test/src/test/java/hudson/model/CauseTest.java
@@ -89,18 +89,6 @@ public class CauseTest {
 
     @Issue("JENKINS-48467")
     @Test public void userIdCausePrintTest() throws Exception {
-//        JenkinsRule.DummySecurityRealm realm = j.createDummySecurityRealm();
-//        realm.addGroups("administrator", "admins");
-//        realm.addGroups("alice", "users");
-//        realm.addGroups("bob", "users", "lpadmin", "bob");
-//
-//        j.jenkins.setSecurityRealm(realm);
-//        GlobalMatrixAuthorizationStrategy auth = new GlobalMatrixAuthorizationStrategy();
-//        auth.add(Jenkins.ADMINISTER, "admins");
-//        auth.add(Permission.READ, "users");
-//        j.jenkins.setAuthorizationStrategy(auth);
-
-
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TaskListener listener = new StreamTaskListener(baos);
 


### PR DESCRIPTION
See [JENKINS-48467](https://issues.jenkins-ci.org/browse/JENKINS-48467).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Updated UserCauseId.print() to use ModelHyperlinkNote.encodeTo(User) to handle URL escaping. 

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ X ] JIRA issue is well described
- [ X ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ X ] Appropriate autotests or explanation to why this change has no tests
- [ N/A ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
