### PR TITLE
[JENKINS-49000] - Whitelist Extra Guava Classes (JEP-200)

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -1,11 +1,25 @@
+com.google.common.collect.AbstractListMultimap
+com.google.common.collect.AbstractMultimap
 com.google.common.collect.AbstractSetMultimap
+# Artifactory - https://issues.jenkins-ci.org/browse/JENKINS-48991
+com.google.common.collect.ArrayListMultimap
 com.google.common.collect.EmptyImmutableList
 com.google.common.collect.EmptyImmutableSet
 com.google.common.collect.EmptyImmutableSortedSet
 com.google.common.collect.HashMultimap
+# First hit: https://github.com/jenkinsci/pitmutation-plugin/
+com.google.common.collect.HashMultiset
 com.google.common.collect.ImmutableList
+# Registered in XStream2 converters
+com.google.common.collect.ImmutableMap
+# Registered in XStream2 converters
+com.google.common.collect.ImmutableSet
 com.google.common.collect.ImmutableSet$SerializedForm
 com.google.common.collect.ImmutableSortedSet
+# https://issues.jenkins-ci.org/browse/JENKINS-48989
+com.google.common.collect.Maps$TransformedEntriesMap
+# https://github.com/jenkinsci/sonar-gerrit-plugin
+com.google.common.collect.Multimap
 com.google.common.collect.RegularImmutableList
 com.google.common.collect.RegularImmutableSet
 com.google.common.collect.RegularImmutableSortedSet


### PR DESCRIPTION
See [JENKINS-49000](https://issues.jenkins-ci.org/browse/JENKINS-49000). Just started going through the GitHub search output

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: 49000 - Extend default whitelist of Guava collection classes
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
