### PR TITLE
[JENKINS-5076] avoid running flyweight tasks on exclusive nodes

### DIFF
--- a/core/src/test/java/hudson/model/NodeTest.java
+++ b/core/src/test/java/hudson/model/NodeTest.java
@@ -1,0 +1,204 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import hudson.remoting.Callable;
+import jenkins.model.Jenkins;
+import hudson.model.Node.Mode;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodeDescriptor;
+import hudson.slaves.NodePropertyDescriptor;
+import hudson.security.Permission;
+import hudson.XmlFile;
+import hudson.Launcher;
+import hudson.FilePath;
+import hudson.model.labels.LabelAtom;
+import hudson.util.ClockDifference;
+import hudson.util.DescribableList;
+
+import org.acegisecurity.Authentication;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.any;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+import java.util.Set;
+import java.util.Collections;
+import java.util.Calendar;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jacob Keller
+ */
+@PrepareForTest(Jenkins.class)
+@RunWith(PowerMockRunner.class)
+public class NodeTest {
+
+    static class DummyNode extends Node {
+        String nodeName = Long.toString(new Random().nextLong());
+        public String getNodeName() {
+            return nodeName;
+        }
+
+        public void setNodeName(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        public String getNodeDescription() {
+            throw new UnsupportedOperationException();
+        }
+
+        public Launcher createLauncher(TaskListener listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        public int getNumExecutors() {
+            throw new UnsupportedOperationException();
+        }
+
+        public Mode getMode() {
+            throw new UnsupportedOperationException();
+        }
+
+        public Computer createComputer() {
+            throw new UnsupportedOperationException();
+        }
+
+        public Set<LabelAtom> getAssignedLabels() {
+            throw new UnsupportedOperationException();
+        }
+
+        public String getLabelString() {
+            throw new UnsupportedOperationException();
+        }
+
+        public void setLabelString(String labelString) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        public FilePath getWorkspaceFor(TopLevelItem item) {
+            throw new UnsupportedOperationException();
+        }
+
+        public FilePath getRootPath() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Callable<ClockDifference, IOException> getClockDifferenceCallable() {
+            throw new UnsupportedOperationException();
+        }
+
+        public NodeDescriptor getDescriptor() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DescribableList<NodeProperty<?>, NodePropertyDescriptor> getNodeProperties() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class EphemeralNode extends DummyNode implements hudson.slaves.EphemeralNode {
+        public Node asNode() {
+            return this;
+        }
+    }
+
+    @Mock private Jenkins jenkins;
+
+    @Before public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        /* Setup mocked Jenkins static */
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.when(Jenkins.getActiveInstance()).thenReturn(jenkins);
+
+        /* Make sure the jenkins instance is marked exclusive */
+        when(jenkins.getMode()).thenReturn(Mode.EXCLUSIVE);
+    }
+
+    @Test
+    public void testExclusiveNodeCantTakeFlyweight() throws Exception {
+        Node node = new DummyNode();
+        Node spyNode = spy(node);
+
+        /* Set up our node properties */
+        doReturn(true).when(spyNode).hasPermission(any(), any());
+
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> propList = null;
+        Saveable owner = mock(Saveable.class);
+        propList = new DescribableList(owner, Collections.emptyList());
+
+        doReturn(propList).when(spyNode).getNodeProperties();
+        doReturn(true).when(spyNode).isAcceptingTasks();
+        doReturn(Mode.EXCLUSIVE).when(spyNode).getMode();
+
+        /* Setup a buildable item */
+        Calendar timestamp = mock(Calendar.class);
+        Queue.FlyweightTask project = mock(Queue.FlyweightTask.class);
+        when(project.getAssignedLabel()).thenReturn(null);
+        List<Action> actions = Collections.<Action>emptyList();
+        Queue.WaitingItem wItem = new Queue.WaitingItem(timestamp, project, actions);
+        Queue.BuildableItem item = new Queue.BuildableItem(wItem);
+
+        /* No other nodes, master is exclusive */
+        when(jenkins.getNodes()).thenReturn(Collections.<Node>emptyList());
+        assertEquals(null, spyNode.canTake(item));
+
+        /* One other node, not exclusive */
+        Node normalNode = mock(Node.class);
+        when(normalNode.getMode()).thenReturn(Mode.NORMAL);
+        when(jenkins.getNodes()).thenReturn(Collections.singletonList(normalNode));
+        assertNotEquals(null, spyNode.canTake(item));
+
+        /* One other node, exclusive */
+        Node exclusiveNode = mock(Node.class);
+        when(exclusiveNode.getMode()).thenReturn(Mode.EXCLUSIVE);
+        when(jenkins.getNodes()).thenReturn(Collections.singletonList(exclusiveNode));
+        assertEquals(null, spyNode.canTake(item));
+    }
+}


### PR DESCRIPTION
Since commit 55bf88329027 ("If every node is restricted to tied jobs
only, Matrix build jobs can never start.", 2013-07-03) we've had
a workaround which enables flyweight tasks to run even on nodes marked
as exclusive.

This patch was included because of a possibility that a Jenkins
administrator configured all slaves and the master as exclusive, which
prevented workflow or matrix job flyweight tasks from starting.

Unfortunately, the original solution was too naive. Essentially, if the
master node was marked as exclusive, and had zero executors, then it
would bypass the restriction and allow the flyweight task to run despite
the node being marked as restricted.

Since we cannot simply revert the original change, expand the check so
that we only bypass the restriction if (a) the master is exclusive *and*
(b) every other slave node is also exclusive. Additionally, drop the
check on whether the master node has enough executors, since flyweight
tasks do not consume any executors anyways.

In other words, abide by the exclusivity restrictions for flyweight
tasks unless there is no other option available.

Add a NodeTest class with a couple of tests to verify our assumptions
and prevent future regressions.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
