### PR TITLE
Limit the size of the Queue.leftItems cache to avoid excessive memory use [scalability]

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -209,7 +209,7 @@ public class Queue extends ResourceController implements Saveable {
      *
      * This map is forgetful, since we can't remember everything that executed in the past.
      */
-    private final Cache<Long,LeftItem> leftItems = CacheBuilder.newBuilder().expireAfterWrite(5*60, TimeUnit.SECONDS).build();
+    private final Cache<Long,LeftItem> leftItems = CacheBuilder.newBuilder().maximumSize(200).expireAfterWrite(5*60, TimeUnit.SECONDS).build();
 
     /**
      * Data structure created for each idle {@link Executor}.

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -209,7 +209,7 @@ public class Queue extends ResourceController implements Saveable {
      *
      * This map is forgetful, since we can't remember everything that executed in the past.
      */
-    private final Cache<Long,LeftItem> leftItems = CacheBuilder.newBuilder().maximumSize(200).expireAfterWrite(5*60, TimeUnit.SECONDS).build();
+    private final Cache<Long,LeftItem> leftItems = CacheBuilder.newBuilder().maximumSize(200).expireAfterWrite(2, TimeUnit.MINUTES).build();
 
     /**
      * Data structure created for each idle {@link Executor}.


### PR DESCRIPTION
Covers a minor scalability issue (memory) observed in Scaling testing.   The Queue.leftItems cache stores a strong reference to Items, and thus Builds which have recently left the queue -- but there is no hard limit on how many builds can be held there, only a 5-minute time expiration. 

In recent Pipeline scalability testing, I found that if builds are completing quickly this could result in a thousand (!!!) or more WorkflowRuns held in memory and a *gigantic* memory footprint - the same is likely true of other heavier job types. 

I prefer a fixed size limit here (flexible on the size) vs. Soft Reference because we already have a time limit built in and this limits the impact of build-load spikes.

This is trivial & common-sense enough that it probably doesn't merit a JIRA, changelog entry, and it is covered by existing tests.

# TODO:

- [ ] Rewrite APIs to use something that doesn't mandate a hard reference to the leftItem / Run (reduce memory impacts)

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@olivergondza @oleg-nenashev and of course @Jimilian who probably has seen the impact in production.
