### PR TITLE
[JENKINS-49070] - Whitelist BigDecimal and BigInteger

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -54,6 +54,8 @@ java.lang.String$CaseInsensitiveComparator
 java.lang.StringBuffer
 java.lang.StringBuilder
 java.lang.reflect.Proxy
+java.math.BigDecimal
+java.math.BigInteger
 java.net.URI
 java.net.URL
 java.security.KeyRep


### PR DESCRIPTION
See [JENKINS-49070](https://issues.jenkins-ci.org/browse/JENKINS-49070). I think we may to whitelist classes in a core plugin like Pipeline Job since snippet generator gererates BigDecimal by default.

### Proposed changelog entries

* Entry 1: Whitelist BigDecimal and BigInteger types for XStream/Remoting serialization
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jglick @abayer @svanoort (affects Pipeline)

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
