### PR TITLE
[JENKINS-49017] - Whitelist java.util.Sublist and java.util.RandomAccessSublist

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -109,8 +109,10 @@ java.util.LinkedList
 java.util.Locale
 java.util.Optional
 java.util.Properties
+java.util.RandomAccessSublist
 java.util.RegularEnumSet
 java.util.Stack
+java.util.Sublist
 java.util.TreeMap
 java.util.TreeMap$KeySet
 java.util.TreeSet


### PR DESCRIPTION
See [JENKINS-49017](https://issues.jenkins-ci.org/browse/JENKINS-49017). A workaround for the plugin has been applied here: https://github.com/jenkinsci/extensible-choice-parameter-plugin/pull/33

Actually it should allow using objects created by `ArrayList#sublist()` & Co

### Proposed changelog entries

* Entry 1: Whitelist java.util.Sublist and java.util.RandomAccessSublist for XStream/Remoting serialization
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
