### PR TITLE
Separate original and downstream dependency errors

### DIFF
--- a/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/message.jelly
@@ -4,14 +4,31 @@
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="correct" value="${%Correct}"/>
     </form>
-    ${%Dependency errors}
+    <p><strong>${%Dependency errors}:</strong></p>
+    <p>${%blurbOriginal}</p>
     <j:forEach items="${it.plugins}" var="plugin">
-    <dl>
-      <dt>${plugin.longName} v${plugin.version}</dt>
-      <j:forEach items="${plugin.dependencyErrors}" var="d">
-        <dd>${d}</dd>
-      </j:forEach>
-    </dl>
+      <j:if test="${plugin.hasOriginalDependencyErrors()}">
+        <dl>
+          <dt>${plugin.longName} version ${plugin.version}</dt>
+          <j:forEach items="${plugin.originalDependencyErrors}" var="d">
+            <dd>${d}</dd>
+          </j:forEach>
+        </dl>
+      </j:if>
     </j:forEach>
+    <j:if test="${it.hasAnyDerivedDependencyErrors()}">
+      <p><strong>${%Downstream dependency errors}:</strong></p>
+      <p>${%blurbDerived}</p>
+      <dl>
+        <j:forEach items="${it.plugins}" var="plugin">
+          <j:if test="${plugin.hasDerivedDependencyErrors()}">
+            <dt>${plugin.displayName} version ${plugin.version}</dt>
+            <j:forEach items="${plugin.derivedDependencyErrors}" var="d">
+              <dd>${d}</dd>
+            </j:forEach>
+          </j:if>
+        </j:forEach>
+      </dl>
+    </j:if>
   </div>
 </j:jelly>

--- a/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/message.properties
+++ b/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/message.properties
@@ -19,4 +19,5 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-Dependency\ errors=There are dependency errors loading some plugins.
+blurbOriginal=Some plugins could not be loaded due to unsatisfied dependencies. Fix these issues and restart Jenkins to restore the functionality provided by these plugins.
+blurbDerived=These plugins failed to load because of one or more of the errors above. Fix those and these plugins will load again.


### PR DESCRIPTION
Nobody understands 'fix this plugin first', so separate those from the actual issues that need fixing.

# Before

![screen shot 2018-01-23 at 13 44 09](https://user-images.githubusercontent.com/1831569/35276394-8abdf95e-0043-11e8-964d-98701a5fa066.png)

# After

![screen shot 2018-01-23 at 13 43 32](https://user-images.githubusercontent.com/1831569/35276402-8f491954-0043-11e8-9d10-8715f13cce3e.png)


@Vlatombe @fbelzunc WDYT?