### PR TITLE
CSRF Admin monitor warnings for Bootstrap

### DIFF
--- a/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-    <div class="warning">
+    <div class="alert alert-warning">
         ${%warningMessage(rootURL)}
     </div>
 </j:jelly>


### PR DESCRIPTION
- use Bootstrap css class for the warning
- after the change of [new UI blog post](https://jenkins.io/blog/2018/01/21/overhaul-of-manage-jenkins-page/)

No ticket associated.

@reviewbybees @daniel-beck @recena
