### PR TITLE
[JENKINS-49126] OldDataMonitor: Prevent escaping b-old version

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/OldDataMonitor/manage.jelly
+++ b/core/src/main/resources/hudson/diagnosis/OldDataMonitor/manage.jelly
@@ -34,15 +34,22 @@ THE SOFTWARE.
       <tr><th>${%Type}</th><th>${%Name}</th><th>${%Version}</th><th></th></tr>
       <j:forEach var="item" items="${it.data.entrySet()}">
         <j:set var="obj" value="${item.key}"/>
-        <j:set var="range" value="${item.value}"/>
         <j:choose>
-          <j:when test="${range!=''}">
-            <j:if test="${range.isOld(150)}"><j:set var="range"><b>${range}</b></j:set></j:if>
+          <j:when test="${item.value!=''}">
             <tr>
               <td>${obj.class.name}</td>
               <!-- fullName is first to avoid calling User.get(String) for User object -->
               <td>${obj.fullName?:obj.fullDisplayName?:obj.displayName?:obj.name}</td>
-              <td>${range}</td>
+              <td>
+                <j:choose>
+                  <j:when test="${item.value.isOld(150)}">
+                    <b title="${%Very old version}">${item.value}</b>
+                  </j:when>
+                  <j:otherwise>
+                    ${item.value}
+                  </j:otherwise>
+                </j:choose>
+              </td>
               <td style="white-space:normal">${item.value.extra}</td>
             </tr>
           </j:when>


### PR DESCRIPTION
- in case there is some very old data (more than 150 revisions in the past, or different major version) they should be "bolded" in the summary page. Currently the tag is escaped.
- with proposed solution, there is not unescaped value that could be displayed (manually tested with version like `1.46.<i>54</i>`)

[JENKINS-49126](https://issues.jenkins-ci.org/browse/JENKINS-49126)

@reviewbybees

<details><summary>Screenshots</summary>

Before
![before](https://user-images.githubusercontent.com/2662497/35326102-e5bc5adc-00f5-11e8-93f2-4b16559bb2e6.png)

After
![after](https://user-images.githubusercontent.com/2662497/35326104-e72c14fc-00f5-11e8-81ef-ece52fd284c2.png)

</details>
