### PR TITLE
Plugin manager time machine

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -337,6 +337,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         }
 
         timeMachine = new PluginManagerTimeMachine(rootDir);
+        timeMachine.loadSnapshotManifests();
     }
 
     public Transformer getCompatibilityTransformer() {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -887,6 +887,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
             if (pluginManager==null)
                 pluginManager = PluginManager.createDefault(this);
+
+            // Apply plugin rollbacks before we init the plugin system.
+            pluginManager.getTimeMachine().doRollback();
+
             this.pluginManager = pluginManager;
             // JSON binding needs to be able to see all the classes from all the plugins
             WebApp.get(servletContext).setClassLoader(pluginManager.uberClassLoader);

--- a/core/src/main/java/jenkins/timemachine/PluginChanges.java
+++ b/core/src/main/java/jenkins/timemachine/PluginChanges.java
@@ -1,0 +1,89 @@
+package jenkins.timemachine;
+
+import hudson.util.VersionNumber;
+import jenkins.timemachine.pluginchange.Disabled;
+import jenkins.timemachine.pluginchange.Downgraded;
+import jenkins.timemachine.pluginchange.Enabled;
+import jenkins.timemachine.pluginchange.PluginChange;
+import jenkins.timemachine.pluginchange.Installed;
+import jenkins.timemachine.pluginchange.Uninstalled;
+import jenkins.timemachine.pluginchange.Upgraded;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Restricted(NoExternalUse.class)
+public class PluginChanges {
+
+    private final PluginSnapshot fromPlugin;
+    private final PluginSnapshot toPlugin;
+    private final List<PluginChange> pluginChanges = new ArrayList<>();
+
+    PluginChanges(@Nonnull String pluginId, @Nonnull PluginSnapshotManifest from, @Nonnull PluginSnapshotManifest to) {
+        this.fromPlugin = from.find(pluginId);
+        this.toPlugin = to.find(pluginId);
+        if (this.fromPlugin == null && this.toPlugin == null) {
+            throw new IllegalArgumentException("Plugin " + pluginId + " not found in either manifest.");
+        }
+        initChanges();
+    }
+
+    private void initChanges() {
+        if (fromPlugin == null && toPlugin != null) {
+            pluginChanges.add(new Installed(toPlugin));
+        } else if (fromPlugin != null && toPlugin == null) {
+            pluginChanges.add(new Uninstalled(fromPlugin));
+        } else {
+            // Plugin is in both manifests
+
+            // Version change ...
+            VersionNumber fromVersion = fromPlugin.getVersion();
+            VersionNumber toVersion = toPlugin.getVersion();
+            if (toVersion.isNewerThan(fromVersion)) {
+                pluginChanges.add(new Upgraded(fromPlugin, toPlugin));
+            } else if (toVersion.isOlderThan(fromVersion)) {
+                pluginChanges.add(new Downgraded(fromPlugin, toPlugin));
+            }
+
+            // Enabled/disabled ...
+            if (fromPlugin.isEnabled() && !toPlugin.isEnabled()) {
+                pluginChanges.add(new Disabled(toPlugin));
+            } else if (!fromPlugin.isEnabled() && toPlugin.isEnabled()) {
+                pluginChanges.add(new Enabled(toPlugin));
+            }
+        }
+    }
+
+    public List<PluginChange> getPluginChanges() {
+        return pluginChanges;
+    }
+
+    public boolean hasChanges() {
+        return !pluginChanges.isEmpty();
+    }
+
+    public static List<PluginChanges> changes(@Nonnull PluginSnapshotManifest from, @Nonnull PluginSnapshotManifest to) {
+        List<PluginChanges> changes = new ArrayList<>();
+        Set<String> allPluginIds = new LinkedHashSet<>();
+
+        allPluginIds.addAll(from.getPluginIds());
+        allPluginIds.addAll(to.getPluginIds());
+
+        for (String pluginId : allPluginIds) {
+            PluginChanges pluginChanges = new PluginChanges(pluginId, from, to);
+            if (pluginChanges.hasChanges()) {
+                changes.add(pluginChanges);
+            }
+        }
+
+        return changes;
+    }
+}

--- a/core/src/main/java/jenkins/timemachine/PluginChanges.java
+++ b/core/src/main/java/jenkins/timemachine/PluginChanges.java
@@ -8,6 +8,8 @@ import jenkins.timemachine.pluginchange.PluginChange;
 import jenkins.timemachine.pluginchange.Installed;
 import jenkins.timemachine.pluginchange.Uninstalled;
 import jenkins.timemachine.pluginchange.Upgraded;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -23,11 +25,13 @@ import java.util.Set;
 @Restricted(NoExternalUse.class)
 public class PluginChanges {
 
+    private final String pluginId;
     private final PluginSnapshot fromPlugin;
     private final PluginSnapshot toPlugin;
     private final List<PluginChange> pluginChanges = new ArrayList<>();
 
     PluginChanges(@Nonnull String pluginId, @Nonnull PluginSnapshotManifest from, @Nonnull PluginSnapshotManifest to) {
+        this.pluginId = pluginId;
         this.fromPlugin = from.find(pluginId);
         this.toPlugin = to.find(pluginId);
         if (this.fromPlugin == null && this.toPlugin == null) {
@@ -85,5 +89,19 @@ public class PluginChanges {
         }
 
         return changes;
+    }
+
+    public JSONObject toJSONObject() {
+        JSONObject jsonObject = new JSONObject();
+        JSONArray changesArray = new JSONArray();
+
+        jsonObject.put("pluginId", pluginId);
+        for (PluginChange pluginChange : pluginChanges) {
+            JSONObject changeObject = pluginChange.toJSONObject();
+            changesArray.add(changeObject);
+        }
+        jsonObject.put("changes", changesArray);
+
+        return jsonObject;
     }
 }

--- a/core/src/main/java/jenkins/timemachine/PluginManagerTimeMachine.java
+++ b/core/src/main/java/jenkins/timemachine/PluginManagerTimeMachine.java
@@ -89,6 +89,8 @@ public class PluginManagerTimeMachine {
 
     @RequirePOST
     public void doSetRollback(StaplerRequest request) {
+        // TODO: Enable jenkins security
+
         try {
             String toSnapshotTakenAt = request.getParameter("toSnapshotTakenAt");
             if (toSnapshotTakenAt != null) {
@@ -102,6 +104,8 @@ public class PluginManagerTimeMachine {
     }
 
     public HttpResponse doResetRollback(StaplerRequest request) {
+        // TODO: Enable jenkins security
+
         if (!"DELETE".equalsIgnoreCase(request.getMethod())) {
             return HttpResponses.error(HttpURLConnection.HTTP_BAD_METHOD, "Wrong method.");
         }
@@ -110,6 +114,8 @@ public class PluginManagerTimeMachine {
     }
 
     public HttpResponse doRollbackConfig() {
+        // TODO: Enable jenkins security
+
         try {
             JSONObject responseObject = new JSONObject();
             if (rollbackFile.exists()) {
@@ -122,6 +128,8 @@ public class PluginManagerTimeMachine {
     }
 
     public HttpResponse doRollback() throws IOException {
+        // TODO: Enable jenkins security
+
         if (!rollbackFile.exists()) {
             LOGGER.log(Level.INFO, "No plugins rollback registered. Continue using the current plugin set.");
             return HttpResponses.error(HttpURLConnection.HTTP_BAD_REQUEST, "Rollback snapshot not configured.");

--- a/core/src/main/java/jenkins/timemachine/PluginManagerTimeMachine.java
+++ b/core/src/main/java/jenkins/timemachine/PluginManagerTimeMachine.java
@@ -1,0 +1,65 @@
+package jenkins.timemachine;
+
+import hudson.PluginManager;
+import org.apache.commons.io.FileUtils;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class PluginManagerTimeMachine {
+
+    private static final Logger LOGGER = Logger.getLogger(PluginManagerTimeMachine.class.getName());
+
+    private final File pluginsDir;
+    private final File pluginsTimeMachineDir;
+    private final File rollbackFile;
+
+    public PluginManagerTimeMachine(@Nonnull File pluginsDir) {
+        this.pluginsDir = pluginsDir;
+        this.pluginsTimeMachineDir = new File(pluginsDir, "../time-machine/plugins");
+        this.rollbackFile = new File(pluginsTimeMachineDir, ".rollback");
+
+        if (!pluginsTimeMachineDir.exists()) {
+            if (!pluginsTimeMachineDir.mkdirs()) {
+                throw new IllegalStateException("Unexpected error creating plugins Time Machine directory: " + pluginsTimeMachineDir.getAbsolutePath());
+            }
+        }
+    }
+
+    public void setRollback(String toVersion) {
+        try {
+            FileUtils.write(rollbackFile, toVersion);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unexpected error creating rollback marker file.");
+        }
+    }
+
+    public void doRollback() throws IOException {
+        if (!rollbackFile.exists()) {
+            LOGGER.log(Level.INFO, "No plugins rollback registered. Continue using the current plugin set.");
+            return;
+        }
+
+        String rollbackToVersion = FileUtils.readFileToString(rollbackFile);
+
+        LOGGER.log(Level.INFO, "Rolling plugins back to " + rollbackToVersion);
+
+        FileUtils.deleteDirectory(pluginsDir);
+        FileUtils.copyDirectory(new File(pluginsTimeMachineDir, rollbackToVersion), pluginsDir);
+
+        // Rollback worked. Okay to delete the marker file now...
+        if (!rollbackFile.delete()) {
+            LOGGER.log(Level.SEVERE, "Failed to delete the rollback marker file: " + rollbackFile.getAbsolutePath());
+        }
+    }
+
+    public void takeSnapshot(@Nonnull PluginManager pluginManager) {
+        PluginSnapshotManifest nowSnapshot = PluginSnapshotManifest.takeSnapshot(pluginManager);
+    }
+}

--- a/core/src/main/java/jenkins/timemachine/PluginManagerTimeMachine.java
+++ b/core/src/main/java/jenkins/timemachine/PluginManagerTimeMachine.java
@@ -2,16 +2,21 @@ package jenkins.timemachine;
 
 import hudson.PluginManager;
 import org.apache.commons.io.FileUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
+@Restricted(NoExternalUse.class)
 public class PluginManagerTimeMachine {
 
     private static final Logger LOGGER = Logger.getLogger(PluginManagerTimeMachine.class.getName());
@@ -19,10 +24,11 @@ public class PluginManagerTimeMachine {
     private final File pluginsDir;
     private final File pluginsTimeMachineDir;
     private final File rollbackFile;
+    private final List<PluginSnapshotManifest> snapshotManifests;
 
     public PluginManagerTimeMachine(@Nonnull File pluginsDir) {
         this.pluginsDir = pluginsDir;
-        this.pluginsTimeMachineDir = new File(pluginsDir, "../time-machine/plugins");
+        this.pluginsTimeMachineDir = new File(pluginsDir.getParentFile(), "time-machine/plugins");
         this.rollbackFile = new File(pluginsTimeMachineDir, ".rollback");
 
         if (!pluginsTimeMachineDir.exists()) {
@@ -30,6 +36,51 @@ public class PluginManagerTimeMachine {
                 throw new IllegalStateException("Unexpected error creating plugins Time Machine directory: " + pluginsTimeMachineDir.getAbsolutePath());
             }
         }
+        snapshotManifests = new ArrayList<>();
+    }
+
+    public void loadSnapshotManifests() {
+        File[] timeMachineDirFiles = this.pluginsTimeMachineDir.listFiles();
+
+        if (timeMachineDirFiles != null) {
+            for (File timeMachineDirFile : timeMachineDirFiles) {
+                if (timeMachineDirFile.isDirectory()) {
+                    File manifestFile = new File(timeMachineDirFile, PluginSnapshotManifest.MANIFEST_FILE_NAME);
+                    if (manifestFile.exists()) {
+                        try {
+                            addSnapshotManifest(PluginSnapshotManifest.load(manifestFile));
+                        } catch (IOException e) {
+                            LOGGER.log(Level.SEVERE, "Error loading PluginSnapshotManifest file " + manifestFile.getAbsolutePath(), e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    synchronized void addSnapshotManifest(PluginSnapshotManifest snapshotManifest) {
+        snapshotManifests.add(snapshotManifest);
+        // sort them by snapshot time
+        snapshotManifests.sort((o1, o2) -> {
+            if (o1.getTakenAt() < o2.getTakenAt()) {
+                return 1;
+            } else if (o1.getTakenAt() > o2.getTakenAt()) {
+                return -1;
+            } else {
+                return 0;
+            }
+        });
+    }
+
+    File getPluginsTimeMachineDir() {
+        return pluginsTimeMachineDir;
+    }
+
+    public synchronized PluginSnapshotManifest getLatestSnapshot() {
+        if (snapshotManifests.isEmpty()) {
+            return null;
+        }
+        return snapshotManifests.get(0);
     }
 
     public void setRollback(String toVersion) {

--- a/core/src/main/java/jenkins/timemachine/PluginSnapshot.java
+++ b/core/src/main/java/jenkins/timemachine/PluginSnapshot.java
@@ -1,12 +1,15 @@
 package jenkins.timemachine;
 
 import hudson.util.VersionNumber;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
+@Restricted(NoExternalUse.class)
 public class PluginSnapshot {
 
     private String pluginId;

--- a/core/src/main/java/jenkins/timemachine/PluginSnapshot.java
+++ b/core/src/main/java/jenkins/timemachine/PluginSnapshot.java
@@ -1,0 +1,67 @@
+package jenkins.timemachine;
+
+import hudson.util.VersionNumber;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class PluginSnapshot {
+
+    private String pluginId;
+    private VersionNumber version;
+    private boolean enabled;
+
+    public String getPluginId() {
+        return pluginId;
+    }
+
+    public @Nonnull PluginSnapshot setPluginId(@Nonnull String pluginId) {
+        this.pluginId = pluginId;
+        return this;
+    }
+
+    public VersionNumber getVersion() {
+        return version;
+    }
+
+    public @Nonnull PluginSnapshot setVersion(@Nonnull VersionNumber version) {
+        this.version = version;
+        return this;
+    }
+
+    public @Nonnull PluginSnapshot setVersion(@Nonnull String version) {
+        this.version = new VersionNumber(version);
+        return this;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public PluginSnapshot setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PluginSnapshot that = (PluginSnapshot) o;
+
+        if (enabled != that.enabled) return false;
+        if (pluginId != null ? !pluginId.equals(that.pluginId) : that.pluginId != null) return false;
+        return version != null ? version.equals(that.version) : that.version == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = pluginId != null ? pluginId.hashCode() : 0;
+        result = 31 * result + (version != null ? version.hashCode() : 0);
+        result = 31 * result + (enabled ? 1 : 0);
+        return result;
+    }
+}

--- a/core/src/main/java/jenkins/timemachine/PluginSnapshotManifest.java
+++ b/core/src/main/java/jenkins/timemachine/PluginSnapshotManifest.java
@@ -10,8 +10,11 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -56,6 +59,23 @@ public class PluginSnapshotManifest {
                 .setVersion(pluginWrapper.getVersion())
                 .setEnabled(pluginWrapper.isEnabled())
         );
+    }
+
+    public PluginSnapshot find(@Nonnull String pluginId) {
+        for (PluginSnapshot plugin : plugins) {
+            if (pluginId.equals(plugin.getPluginId())) {
+                return plugin;
+            }
+        }
+        return null;
+    }
+
+    public Set<String> getPluginIds() {
+        Set<String> pluginIds = new LinkedHashSet<>();
+        for (PluginSnapshot plugin : plugins) {
+            pluginIds.add(plugin.getPluginId());
+        }
+        return pluginIds;
     }
 
     @Override

--- a/core/src/main/java/jenkins/timemachine/PluginSnapshotManifest.java
+++ b/core/src/main/java/jenkins/timemachine/PluginSnapshotManifest.java
@@ -1,0 +1,79 @@
+package jenkins.timemachine;
+
+import hudson.PluginManager;
+import hudson.PluginWrapper;
+
+import javax.annotation.Nonnull;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class PluginSnapshotManifest {
+
+    private long takenAt;
+    private List<PluginSnapshot> plugins = new CopyOnWriteArrayList<>();
+
+    public long getTakenAt() {
+        return takenAt;
+    }
+
+    public PluginSnapshotManifest setTakenAt(long takenAt) {
+        this.takenAt = takenAt;
+        return this;
+    }
+
+    public List<PluginSnapshot> getPlugins() {
+        return plugins;
+    }
+
+    public PluginSnapshotManifest setPlugins(List<PluginSnapshot> plugins) {
+        this.plugins = plugins;
+        return this;
+    }
+
+    synchronized void addSnapshot(PluginSnapshot snapshot) {
+        plugins.add(snapshot);
+        // Sort them by pluginId so the equals can work off the
+        // List#equals() impl.
+        plugins.sort(Comparator.comparing(PluginSnapshot::getPluginId));
+    }
+
+    void addSnapshot(PluginWrapper pluginWrapper) {
+        addSnapshot(new PluginSnapshot()
+                .setPluginId(pluginWrapper.getShortName())
+                .setVersion(pluginWrapper.getVersion())
+                .setEnabled(pluginWrapper.isEnabled())
+        );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PluginSnapshotManifest that = (PluginSnapshotManifest) o;
+
+        return plugins.equals(that.plugins);
+    }
+
+    @Override
+    public int hashCode() {
+        return plugins.hashCode();
+    }
+
+    static @Nonnull
+    PluginSnapshotManifest takeSnapshot(@Nonnull PluginManager pluginManager) {
+        PluginSnapshotManifest manifest = new PluginSnapshotManifest();
+        List<PluginWrapper> plugins = pluginManager.getPlugins();
+
+        for (PluginWrapper pluginWrapper : plugins) {
+            manifest.addSnapshot(pluginWrapper);
+        }
+        manifest.takenAt = System.currentTimeMillis();
+
+        return manifest;
+    }
+}

--- a/core/src/main/java/jenkins/timemachine/pluginchange/Disabled.java
+++ b/core/src/main/java/jenkins/timemachine/pluginchange/Disabled.java
@@ -1,0 +1,15 @@
+package jenkins.timemachine.pluginchange;
+
+import jenkins.timemachine.PluginSnapshot;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Restricted(NoExternalUse.class)
+public class Disabled extends PluginChange {
+    public Disabled(PluginSnapshot plugin) {
+        super(plugin);
+    }
+}

--- a/core/src/main/java/jenkins/timemachine/pluginchange/Downgraded.java
+++ b/core/src/main/java/jenkins/timemachine/pluginchange/Downgraded.java
@@ -2,6 +2,7 @@ package jenkins.timemachine.pluginchange;
 
 import hudson.util.VersionNumber;
 import jenkins.timemachine.PluginSnapshot;
+import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -26,5 +27,13 @@ public class Downgraded extends PluginChange {
 
     public VersionNumber getTo() {
         return to;
+    }
+
+    @Override
+    public JSONObject toJSONObject() {
+        JSONObject jsonObject = super.toJSONObject();
+        jsonObject.put("from", from.toString());
+        jsonObject.put("to", to.toString());
+        return jsonObject;
     }
 }

--- a/core/src/main/java/jenkins/timemachine/pluginchange/Downgraded.java
+++ b/core/src/main/java/jenkins/timemachine/pluginchange/Downgraded.java
@@ -1,0 +1,30 @@
+package jenkins.timemachine.pluginchange;
+
+import hudson.util.VersionNumber;
+import jenkins.timemachine.PluginSnapshot;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Restricted(NoExternalUse.class)
+public class Downgraded extends PluginChange {
+
+    private VersionNumber from;
+    private VersionNumber to;
+
+    public Downgraded(PluginSnapshot from, PluginSnapshot to) {
+        super(to);
+        this.from = from.getVersion();
+        this.to = to.getVersion();
+    }
+
+    public VersionNumber getFrom() {
+        return from;
+    }
+
+    public VersionNumber getTo() {
+        return to;
+    }
+}

--- a/core/src/main/java/jenkins/timemachine/pluginchange/Enabled.java
+++ b/core/src/main/java/jenkins/timemachine/pluginchange/Enabled.java
@@ -1,0 +1,15 @@
+package jenkins.timemachine.pluginchange;
+
+import jenkins.timemachine.PluginSnapshot;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Restricted(NoExternalUse.class)
+public class Enabled extends PluginChange {
+    public Enabled(PluginSnapshot plugin) {
+        super(plugin);
+    }
+}

--- a/core/src/main/java/jenkins/timemachine/pluginchange/Installed.java
+++ b/core/src/main/java/jenkins/timemachine/pluginchange/Installed.java
@@ -1,0 +1,15 @@
+package jenkins.timemachine.pluginchange;
+
+import jenkins.timemachine.PluginSnapshot;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Restricted(NoExternalUse.class)
+public class Installed extends PluginChange {
+    public Installed(PluginSnapshot plugin) {
+        super(plugin);
+    }
+}

--- a/core/src/main/java/jenkins/timemachine/pluginchange/PluginChange.java
+++ b/core/src/main/java/jenkins/timemachine/pluginchange/PluginChange.java
@@ -1,6 +1,7 @@
 package jenkins.timemachine.pluginchange;
 
 import jenkins.timemachine.PluginSnapshot;
+import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -17,5 +18,11 @@ public abstract class PluginChange {
 
     public PluginSnapshot getPlugin() {
         return plugin;
+    }
+
+    public JSONObject toJSONObject() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("type", getClass().getSimpleName().toLowerCase());
+        return jsonObject;
     }
 }

--- a/core/src/main/java/jenkins/timemachine/pluginchange/PluginChange.java
+++ b/core/src/main/java/jenkins/timemachine/pluginchange/PluginChange.java
@@ -1,0 +1,21 @@
+package jenkins.timemachine.pluginchange;
+
+import jenkins.timemachine.PluginSnapshot;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Restricted(NoExternalUse.class)
+public abstract class PluginChange {
+    private final PluginSnapshot plugin;
+
+    public PluginChange(PluginSnapshot plugin) {
+        this.plugin = plugin;
+    }
+
+    public PluginSnapshot getPlugin() {
+        return plugin;
+    }
+}

--- a/core/src/main/java/jenkins/timemachine/pluginchange/Uninstalled.java
+++ b/core/src/main/java/jenkins/timemachine/pluginchange/Uninstalled.java
@@ -1,0 +1,15 @@
+package jenkins.timemachine.pluginchange;
+
+import jenkins.timemachine.PluginSnapshot;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Restricted(NoExternalUse.class)
+public class Uninstalled extends PluginChange {
+    public Uninstalled(PluginSnapshot plugin) {
+        super(plugin);
+    }
+}

--- a/core/src/main/java/jenkins/timemachine/pluginchange/Upgraded.java
+++ b/core/src/main/java/jenkins/timemachine/pluginchange/Upgraded.java
@@ -2,6 +2,7 @@ package jenkins.timemachine.pluginchange;
 
 import hudson.util.VersionNumber;
 import jenkins.timemachine.PluginSnapshot;
+import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -26,5 +27,13 @@ public class Upgraded extends PluginChange {
 
     public VersionNumber getTo() {
         return to;
+    }
+
+    @Override
+    public JSONObject toJSONObject() {
+        JSONObject jsonObject = super.toJSONObject();
+        jsonObject.put("from", from.toString());
+        jsonObject.put("to", to.toString());
+        return jsonObject;
     }
 }

--- a/core/src/main/java/jenkins/timemachine/pluginchange/Upgraded.java
+++ b/core/src/main/java/jenkins/timemachine/pluginchange/Upgraded.java
@@ -1,0 +1,30 @@
+package jenkins.timemachine.pluginchange;
+
+import hudson.util.VersionNumber;
+import jenkins.timemachine.PluginSnapshot;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Restricted(NoExternalUse.class)
+public class Upgraded extends PluginChange {
+
+    private VersionNumber from;
+    private VersionNumber to;
+
+    public Upgraded(PluginSnapshot from, PluginSnapshot to) {
+        super(to);
+        this.from = from.getVersion();
+        this.to = to.getVersion();
+    }
+
+    public VersionNumber getFrom() {
+        return from;
+    }
+
+    public VersionNumber getTo() {
+        return to;
+    }
+}

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -167,8 +167,6 @@ THE SOFTWARE.
         </form>
       </div>
 
-      <st:include page="timemachine.jelly"/>
-
       <script>
         <!-- function to toggle the enable/disable state -->
         function flip(o) {

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -167,6 +167,7 @@ THE SOFTWARE.
         </form>
       </div>
 
+      <st:include page="timemachine.jelly"/>
 
       <script>
         <!-- function to toggle the enable/disable state -->

--- a/core/src/main/resources/hudson/PluginManager/tabBar.jelly
+++ b/core/src/main/resources/hudson/PluginManager/tabBar.jelly
@@ -31,6 +31,7 @@ THE SOFTWARE.
     <l:tab name="${%Updates}" active="${page=='updates'}" href="." />
     <l:tab name="${%Available}" active="${page=='available'}" href="./available" />
     <l:tab name="${%Installed}" active="${page=='installed'}" href="./installed" />
+    <l:tab name="${%Time Machine}" active="${page=='timemachine'}" href="./timemachine" />
     <!--<l:tab name="${%Sites}" active="${page=='sites'}" href="./sites" />-->
   <j:if test="${h.hasPermission(app.pluginManager.UPLOAD_PLUGINS) || h.hasPermission(app.pluginManager.CONFIGURE_UPDATECENTER)}"> 
     <l:tab name="${%Advanced}" active="${page=='advanced'}" href="./advanced" />

--- a/core/src/main/resources/hudson/PluginManager/timemachine.jelly
+++ b/core/src/main/resources/hudson/PluginManager/timemachine.jelly
@@ -1,0 +1,32 @@
+<!--
+The MIT License
+
+Copyright (c) 2017, CloudBees Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+
+    <div id="plugin-time-machine"></div>
+
+    <l:js src="jsbundles/plugin-time-machine.js" />
+    <l:css src="jsbundles/plugin-time-machine.css" />
+
+</j:jelly>

--- a/core/src/main/resources/hudson/PluginManager/timemachine.jelly
+++ b/core/src/main/resources/hudson/PluginManager/timemachine.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2017, CloudBees Inc.
+Copyright (c) 2018, CloudBees Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -21,12 +21,21 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+    <l:layout title="${%Update Center}" permission="${app.ADMINISTER}" norefresh="true">
+        <st:include page="sidepanel.jelly"/>
+        <l:main-panel>
+            <local:tabBar page="timemachine" xmlns:local="/hudson/PluginManager" />
 
-    <div id="plugin-time-machine"></div>
+            <div class="pane-frame">
+                <div id="plugin-time-machine"></div>
 
-    <l:js src="jsbundles/plugin-time-machine.js" />
-    <l:css src="jsbundles/plugin-time-machine.css" />
+                <l:js src="jsbundles/plugin-time-machine.js" />
+                <l:css src="jsbundles/plugin-time-machine.css" />
+            </div>
 
+        </l:main-panel>
+    </l:layout>
 </j:jelly>

--- a/core/src/test/java/jenkins/timemachine/PluginChangesTest.java
+++ b/core/src/test/java/jenkins/timemachine/PluginChangesTest.java
@@ -1,0 +1,142 @@
+package jenkins.timemachine;
+
+import jenkins.timemachine.pluginchange.Disabled;
+import jenkins.timemachine.pluginchange.Downgraded;
+import jenkins.timemachine.pluginchange.Enabled;
+import jenkins.timemachine.pluginchange.Installed;
+import jenkins.timemachine.pluginchange.PluginChange;
+import jenkins.timemachine.pluginchange.Uninstalled;
+import jenkins.timemachine.pluginchange.Upgraded;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class PluginChangesTest {
+
+    @Test
+    public void test_no_changes() {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+
+        List<PluginChanges> changes = PluginChanges.changes(manifest1, manifest2);
+        Assert.assertTrue(changes.isEmpty());
+    }
+
+    @Test
+    public void test_installed_uninstalled() {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+
+        // Installed ...
+        List<PluginChanges> changes_1_to_2 = PluginChanges.changes(manifest1, manifest2);
+        Assert.assertEquals(1, changes_1_to_2.size());
+        Assert.assertEquals(1, changes_1_to_2.get(0).getPluginChanges().size());
+
+        Installed installed = (Installed) changes_1_to_2.get(0).getPluginChanges().get(0);
+        Assert.assertEquals("b", installed.getPlugin().getPluginId());
+        Assert.assertEquals("1.0", installed.getPlugin().getVersion().toString());
+
+        // Uninstalled (just compare in the other direction) ...
+        List<PluginChanges> changes_2_to_1 = PluginChanges.changes(manifest2, manifest1);
+        Assert.assertEquals(1, changes_2_to_1.size());
+        Assert.assertEquals(1, changes_2_to_1.get(0).getPluginChanges().size());
+
+        Uninstalled uninstalled = (Uninstalled) changes_2_to_1.get(0).getPluginChanges().get(0);
+        Assert.assertEquals("b", uninstalled.getPlugin().getPluginId());
+        Assert.assertEquals("1.0", uninstalled.getPlugin().getVersion().toString());
+    }
+
+    @Test
+    public void test_upgraded_downgraded() {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.1").setEnabled(true));
+
+        // Upgrade ...
+        List<PluginChanges> changes_1_to_2 = PluginChanges.changes(manifest1, manifest2);
+        Assert.assertEquals(1, changes_1_to_2.size());
+        Assert.assertEquals(1, changes_1_to_2.get(0).getPluginChanges().size());
+
+        Upgraded upgraded = (Upgraded) changes_1_to_2.get(0).getPluginChanges().get(0);
+        Assert.assertEquals("a", upgraded.getPlugin().getPluginId());
+        Assert.assertEquals("1.0", upgraded.getFrom().toString());
+        Assert.assertEquals("1.1", upgraded.getTo().toString());
+
+        // Downgraded (just compare in the other direction) ...
+        List<PluginChanges> changes_2_to_1 = PluginChanges.changes(manifest2, manifest1);
+        Assert.assertEquals(1, changes_2_to_1.size());
+        Assert.assertEquals(1, changes_2_to_1.get(0).getPluginChanges().size());
+
+        Downgraded downgraded = (Downgraded) changes_2_to_1.get(0).getPluginChanges().get(0);
+        Assert.assertEquals("a", downgraded.getPlugin().getPluginId());
+        Assert.assertEquals("1.1", downgraded.getFrom().toString());
+        Assert.assertEquals("1.0", downgraded.getTo().toString());
+    }
+
+    @Test
+    public void test_disabled_enabled() {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(false));
+
+        // Disabled ...
+        List<PluginChanges> changes_1_to_2 = PluginChanges.changes(manifest1, manifest2);
+        Assert.assertEquals(1, changes_1_to_2.size());
+        Assert.assertEquals(1, changes_1_to_2.get(0).getPluginChanges().size());
+
+        Disabled disabled = (Disabled) changes_1_to_2.get(0).getPluginChanges().get(0);
+        Assert.assertEquals("a", disabled.getPlugin().getPluginId());
+
+        // Enabled (just compare in the other direction) ...
+        List<PluginChanges> changes_2_to_1 = PluginChanges.changes(manifest2, manifest1);
+        Assert.assertEquals(1, changes_2_to_1.size());
+        Assert.assertEquals(1, changes_2_to_1.get(0).getPluginChanges().size());
+
+        Enabled enabled = (Enabled) changes_2_to_1.get(0).getPluginChanges().get(0);
+        Assert.assertEquals("a", enabled.getPlugin().getPluginId());
+    }
+
+    @Test
+    public void test_upgraded_and_disabled() {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.1").setEnabled(false));
+
+        // Upgrade & disabled ...
+        List<PluginChanges> changes_1_to_2 = PluginChanges.changes(manifest1, manifest2);
+        Assert.assertEquals(1, changes_1_to_2.size());
+        Assert.assertEquals(2, changes_1_to_2.get(0).getPluginChanges().size());
+
+        Upgraded upgraded = (Upgraded) changes_1_to_2.get(0).getPluginChanges().get(0);
+        Assert.assertEquals("a", upgraded.getPlugin().getPluginId());
+        Assert.assertEquals("1.0", upgraded.getFrom().toString());
+        Assert.assertEquals("1.1", upgraded.getTo().toString());
+
+        Disabled disabled = (Disabled) changes_1_to_2.get(0).getPluginChanges().get(1);
+        Assert.assertEquals("a", disabled.getPlugin().getPluginId());
+    }
+}

--- a/core/src/test/java/jenkins/timemachine/PluginChangesTest.java
+++ b/core/src/test/java/jenkins/timemachine/PluginChangesTest.java
@@ -4,7 +4,6 @@ import jenkins.timemachine.pluginchange.Disabled;
 import jenkins.timemachine.pluginchange.Downgraded;
 import jenkins.timemachine.pluginchange.Enabled;
 import jenkins.timemachine.pluginchange.Installed;
-import jenkins.timemachine.pluginchange.PluginChange;
 import jenkins.timemachine.pluginchange.Uninstalled;
 import jenkins.timemachine.pluginchange.Upgraded;
 import org.junit.Assert;

--- a/core/src/test/java/jenkins/timemachine/PluginManagerTimeMachineTest.java
+++ b/core/src/test/java/jenkins/timemachine/PluginManagerTimeMachineTest.java
@@ -1,0 +1,53 @@
+package jenkins.timemachine;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class PluginManagerTimeMachineTest {
+
+    private File testRootDir = new File("./target/" + PluginManagerTimeMachineTest.class.getSimpleName());
+    private File testPluginRootDir = new File(testRootDir, "/plugins");
+    private PluginManagerTimeMachine pluginManagerTimeMachine;
+
+    @Before
+    public void setup() throws IOException {
+        FileUtils.deleteDirectory(testRootDir);
+        testRootDir.mkdirs();
+        pluginManagerTimeMachine = new PluginManagerTimeMachine(testPluginRootDir);
+    }
+
+    @Test
+    public void test_load() throws IOException {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
+        PluginSnapshotManifest manifest3 = new PluginSnapshotManifest().setTakenAt(3L);
+
+        // Save them...
+        save(manifest1);
+        save(manifest2);
+        save(manifest3);
+
+        // Load them into the time machine instance...
+        pluginManagerTimeMachine.loadSnapshotManifests();
+
+        // The "latest" snapshot should be the one that has the most
+        // recent "takenAt" timestamp i.e. manifest3 ...
+        PluginSnapshotManifest latest = pluginManagerTimeMachine.getLatestSnapshot();
+        Assert.assertNotEquals(manifest1.getTakenAt(), latest.getTakenAt());
+        Assert.assertNotEquals(manifest2.getTakenAt(), latest.getTakenAt());
+        Assert.assertEquals(manifest3.getTakenAt(), latest.getTakenAt());
+    }
+
+    private void save(PluginSnapshotManifest manifest) throws IOException {
+        File manifestFile = new File(pluginManagerTimeMachine.getPluginsTimeMachineDir(), String.format("%d/%s", manifest.getTakenAt(), PluginSnapshotManifest.MANIFEST_FILE_NAME));
+        manifest.save(manifestFile);
+    }
+}

--- a/core/src/test/java/jenkins/timemachine/PluginSnapshotManifestTest.java
+++ b/core/src/test/java/jenkins/timemachine/PluginSnapshotManifestTest.java
@@ -1,17 +1,30 @@
 package jenkins.timemachine;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 public class PluginSnapshotManifestTest {
 
+    private File testPluginRootDir = new File("./target/" + PluginSnapshotManifestTest.class.getSimpleName() + "/plugins");
+
+    @Before
+    public void setup() {
+        if (!testPluginRootDir.exists()) {
+            testPluginRootDir.mkdirs();
+        }
+    }
+
     @Test
     public void test_equals_same() {
-        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest();
-        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest();
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
 
         manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
         manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
@@ -24,8 +37,8 @@ public class PluginSnapshotManifestTest {
 
     @Test
     public void test_not_equals_enabled() {
-        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest();
-        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest();
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
 
         manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
         manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
@@ -39,8 +52,8 @@ public class PluginSnapshotManifestTest {
 
     @Test
     public void test_not_equals_version() {
-        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest();
-        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest();
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
 
         manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
         manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
@@ -54,8 +67,8 @@ public class PluginSnapshotManifestTest {
 
     @Test
     public void test_not_equals_num_plugins() {
-        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest();
-        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest();
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
 
         manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
         manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
@@ -70,8 +83,8 @@ public class PluginSnapshotManifestTest {
 
     @Test
     public void test_not_equals_diff_plugins() {
-        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest();
-        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest();
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
 
         manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
         manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
@@ -81,5 +94,25 @@ public class PluginSnapshotManifestTest {
         manifest2.addSnapshot(new PluginSnapshot().setPluginId("c") .setVersion("1.0").setEnabled(true));
 
         Assert.assertNotEquals(manifest1, manifest2);
+    }
+
+    @Test
+    public void test_save_load() throws IOException {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(System.currentTimeMillis());
+        PluginSnapshotManifest manifest2;
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+
+        // Save it ...
+        File manifestFile = new File(testPluginRootDir, PluginSnapshotManifest.MANIFEST_FILE_NAME);
+        manifest1.save(manifestFile);
+
+        // Load it ...
+        manifest2 = PluginSnapshotManifest.load(manifestFile);
+
+        // Should be the same ...
+        Assert.assertEquals(manifest1, manifest2);
+        Assert.assertEquals(manifest1.getTakenAt(), manifest2.getTakenAt());
     }
 }

--- a/core/src/test/java/jenkins/timemachine/PluginSnapshotManifestTest.java
+++ b/core/src/test/java/jenkins/timemachine/PluginSnapshotManifestTest.java
@@ -1,0 +1,85 @@
+package jenkins.timemachine;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class PluginSnapshotManifestTest {
+
+    @Test
+    public void test_equals_same() {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest();
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest();
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+
+        Assert.assertEquals(manifest1, manifest2);
+    }
+
+    @Test
+    public void test_not_equals_enabled() {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest();
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest();
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+
+        // Set one of the plugins to be disabled
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(false));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+
+        Assert.assertNotEquals(manifest1, manifest2);
+    }
+
+    @Test
+    public void test_not_equals_version() {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest();
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest();
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+
+        // Set one of the plugins to a new version
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("2.1").setEnabled(true));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+
+        Assert.assertNotEquals(manifest1, manifest2);
+    }
+
+    @Test
+    public void test_not_equals_num_plugins() {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest();
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest();
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+
+        // Add another plugin e.g. after an install
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("c") .setVersion("1.0").setEnabled(true));
+
+        Assert.assertNotEquals(manifest1, manifest2);
+    }
+
+    @Test
+    public void test_not_equals_diff_plugins() {
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest();
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest();
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+
+        // Add plugin "c" and remove plugin "b". So same number of plugins, but different plugins.
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("c") .setVersion("1.0").setEnabled(true));
+
+        Assert.assertNotEquals(manifest1, manifest2);
+    }
+}

--- a/test/src/test/java/jenkins/timemachine/PluginManagerTimeMachineTest.java
+++ b/test/src/test/java/jenkins/timemachine/PluginManagerTimeMachineTest.java
@@ -1,0 +1,99 @@
+package jenkins.timemachine;
+
+import hudson.PluginManagerUtil;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class PluginManagerTimeMachineTest {
+
+    @Rule
+    public JenkinsRule jenkinsRule = PluginManagerUtil.newJenkinsRule();
+
+    @Test
+    public void test_doSnapshots() throws IOException {
+        JSONObject response = jenkinsRule.getJSON("pluginManager/timeMachine/snapshots").getJSONObject();
+
+        Assert.assertEquals("ok", response.get("status"));
+        Assert.assertEquals(1, response.getJSONArray("data").size());
+    }
+
+    @Test
+    public void test_doSnapshotChanges() throws IOException {
+        PluginManagerTimeMachine timeMachine = jenkinsRule.getInstance().getPluginManager().getTimeMachine();
+        List<PluginSnapshotManifest> snapshots = timeMachine.getSnapshotManifests();
+
+        // clear the real one manifest (easier for the test) and add a
+        // few test ones.
+        snapshots.clear();
+
+        PluginSnapshotManifest manifest1 = new PluginSnapshotManifest().setTakenAt(1L);
+        PluginSnapshotManifest manifest2 = new PluginSnapshotManifest().setTakenAt(2L);
+
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("c") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("d") .setVersion("1.0").setEnabled(true));
+        manifest1.addSnapshot(new PluginSnapshot().setPluginId("e") .setVersion("1.0").setEnabled(true));
+
+        // Disable b
+        // Upgrade c
+        // Downgrade d
+        // Uninstall e
+        // Install f
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("a") .setVersion("1.0").setEnabled(true));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("b") .setVersion("1.0").setEnabled(false));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("c") .setVersion("1.1").setEnabled(true));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("d") .setVersion("0.9").setEnabled(true));
+        manifest2.addSnapshot(new PluginSnapshot().setPluginId("f") .setVersion("1.0").setEnabled(true));
+
+        timeMachine.addSnapshotManifest(manifest1);
+        timeMachine.addSnapshotManifest(manifest2);
+
+        JSONObject response = jenkinsRule.getJSON("pluginManager/timeMachine/snapshotChanges?from=1&to=2").getJSONObject();
+        JSONArray pluginChangesJson = response.getJSONArray("data");
+        List<PluginChanges> pluginChanges = new ArrayList<>();
+
+        Assert.assertEquals(5, pluginChangesJson.size());
+
+        JSONObject bChanges = pluginChangesJson.getJSONObject(0);
+        Assert.assertEquals("b", bChanges.getString("pluginId"));
+        Assert.assertEquals(1, bChanges.getJSONArray("changes").size());
+        Assert.assertEquals("disabled", bChanges.getJSONArray("changes").getJSONObject(0).getString("type"));
+
+        JSONObject cChanges = pluginChangesJson.getJSONObject(1);
+        Assert.assertEquals("c", cChanges.getString("pluginId"));
+        Assert.assertEquals(1, cChanges.getJSONArray("changes").size());
+        Assert.assertEquals("upgraded", cChanges.getJSONArray("changes").getJSONObject(0).getString("type"));
+        Assert.assertEquals("1.0", cChanges.getJSONArray("changes").getJSONObject(0).getString("from"));
+        Assert.assertEquals("1.1", cChanges.getJSONArray("changes").getJSONObject(0).getString("to"));
+
+        JSONObject dChanges = pluginChangesJson.getJSONObject(2);
+        System.out.println(dChanges);
+        Assert.assertEquals("d", dChanges.getString("pluginId"));
+        Assert.assertEquals(1, dChanges.getJSONArray("changes").size());
+        Assert.assertEquals("downgraded", dChanges.getJSONArray("changes").getJSONObject(0).getString("type"));
+        Assert.assertEquals("1.0", dChanges.getJSONArray("changes").getJSONObject(0).getString("from"));
+        Assert.assertEquals("0.9", dChanges.getJSONArray("changes").getJSONObject(0).getString("to"));
+
+        JSONObject eChanges = pluginChangesJson.getJSONObject(3);
+        Assert.assertEquals("e", eChanges.getString("pluginId"));
+        Assert.assertEquals(1, eChanges.getJSONArray("changes").size());
+        Assert.assertEquals("uninstalled", eChanges.getJSONArray("changes").getJSONObject(0).getString("type"));
+
+        JSONObject fChanges = pluginChangesJson.getJSONObject(4);
+        Assert.assertEquals("f", fChanges.getString("pluginId"));
+        Assert.assertEquals(1, fChanges.getJSONArray("changes").size());
+        Assert.assertEquals("installed", fChanges.getJSONArray("changes").getJSONObject(0).getString("type"));
+    }
+}

--- a/war/gulpfile.js
+++ b/war/gulpfile.js
@@ -56,6 +56,7 @@ builder.bundle('src/main/js/add-item.js')
 
 builder.bundle('src/main/js/plugin-time-machine.js')
     .withExternalModuleMapping('jquery-detached', 'core-assets/jquery-detached:jquery2')
-    .withExternalModuleMapping('bootstrap', 'core-assets/bootstrap:bootstrap3')
+    .withExternalModuleMapping('bootstrap', 'core-assets/bootstrap:bootstrap3', {addDefaultCSS: true})
+    .withExternalModuleMapping('handlebars', 'core-assets/handlebars:handlebars3')
     .less('src/main/js/plugin-time-machine.less')
     .inDir('src/main/webapp/jsbundles');

--- a/war/gulpfile.js
+++ b/war/gulpfile.js
@@ -53,3 +53,9 @@ builder.bundle('src/main/js/add-item.js')
     .withExternalModuleMapping('jquery-detached', 'core-assets/jquery-detached:jquery2')
     .less('src/main/js/add-item.less')
     .inDir('src/main/webapp/jsbundles');
+
+builder.bundle('src/main/js/plugin-time-machine.js')
+    .withExternalModuleMapping('jquery-detached', 'core-assets/jquery-detached:jquery2')
+    .withExternalModuleMapping('bootstrap', 'core-assets/bootstrap:bootstrap3')
+    .less('src/main/js/plugin-time-machine.less')
+    .inDir('src/main/webapp/jsbundles');

--- a/war/package.json
+++ b/war/package.json
@@ -8,6 +8,10 @@
     "email": "tom.fennelly@gmail.com",
     "url": "https://github.com/tfennelly"
   },
+  "scripts": {
+    "bundle": "gulp bundle",
+    "bundle:watch": "gulp rebundle"
+  },
   "private": true,
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -135,19 +135,19 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>jquery-detached</artifactId>
-      <version>1.2.1</version>
+      <version>2.0.0-SNAPSHOT</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>bootstrap</artifactId>
-      <version>1.3.2</version>
+      <version>2.0.0-SNAPSHOT</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>handlebars</artifactId>
-      <version>1.1.1</version>
+      <version>2.0.0-SNAPSHOT</version>
       <classifier>core-assets</classifier>
     </dependency>
     <dependency>

--- a/war/src/main/js/api/pluginTimeMachine.js
+++ b/war/src/main/js/api/pluginTimeMachine.js
@@ -1,0 +1,17 @@
+/**
+ * Plugin Time Machine API.
+ */
+
+var jenkins = require('../util/jenkins');
+var HTTP_TIMEOUT = 10 * 1000; // 10 seconds
+
+exports.getSnapshotList = function (handler) {
+    jenkins.get('/pluginManager/timeMachine/snapshots', function (response) {
+        handler.call({isError: (response.status !== 'ok')}, response.data);
+    }, {
+        timeout: HTTP_TIMEOUT,
+        error: function (xhr, textStatus, errorThrown) {
+            handler.call({isError: true}, errorThrown);
+        }
+    });
+};

--- a/war/src/main/js/api/pluginTimeMachine.js
+++ b/war/src/main/js/api/pluginTimeMachine.js
@@ -6,7 +6,15 @@ var jenkins = require('../util/jenkins');
 var HTTP_TIMEOUT = 10 * 1000; // 10 seconds
 
 exports.getSnapshotList = function (handler) {
-    jenkins.get('/pluginManager/timeMachine/snapshots', function (response) {
+    doGET('/pluginManager/timeMachine/snapshots', handler);
+};
+
+exports.getSnapshotDiff = function (from, to, handler) {
+    doGET('/pluginManager/timeMachine/snapshotChanges?from=' + from + '&to=' + to, handler);
+};
+
+function doGET(url, handler) {
+    jenkins.get(url, function (response) {
         handler.call({isError: (response.status !== 'ok')}, response.data);
     }, {
         timeout: HTTP_TIMEOUT,
@@ -14,4 +22,4 @@ exports.getSnapshotList = function (handler) {
             handler.call({isError: true}, errorThrown);
         }
     });
-};
+}

--- a/war/src/main/js/api/pluginTimeMachine.js
+++ b/war/src/main/js/api/pluginTimeMachine.js
@@ -4,6 +4,7 @@
 
 var jenkins = require('../util/jenkins');
 var HTTP_TIMEOUT = 10 * 1000; // 10 seconds
+var $ = require('jquery-detached').getJQuery();
 
 exports.getSnapshotList = function (handler) {
     doGET('/pluginManager/timeMachine/snapshots', handler);
@@ -11,6 +12,12 @@ exports.getSnapshotList = function (handler) {
 
 exports.getSnapshotDiff = function (from, to, handler) {
     doGET('/pluginManager/timeMachine/snapshotChanges?from=' + from + '&to=' + to, handler);
+};
+
+exports.setSnapshotRollback = function (to) {
+    doPOST('/pluginManager/timeMachine/setRollback?toSnapshotTakenAt=' + to);
+    doPOST('/restart');
+    location.replace(jenkins.baseUrl());
 };
 
 function doGET(url, handler) {
@@ -21,5 +28,15 @@ function doGET(url, handler) {
         error: function (xhr, textStatus, errorThrown) {
             handler.call({isError: true}, errorThrown);
         }
+    });
+}
+
+function doPOST(url) {
+    $.ajax({
+        url: jenkins.baseUrl() + url,
+        type: 'POST',
+        cache: false,
+        dataType: 'json',
+        contentType: "application/json"
     });
 }

--- a/war/src/main/js/plugin-time-machine.js
+++ b/war/src/main/js/plugin-time-machine.js
@@ -1,7 +1,20 @@
 var $ = require('jquery-detached').getJQuery();
+var api = require('./api/pluginTimeMachine');
+var PluginTimeMachine = require('./plugin-time-machne/PluginTimeMachine');
 
 $(function() {
-    $('#plugin-time-machine').each(function () {
-        $(this).text('*** Hello !!!!');
+    var timeMachineDiv = $('#plugin-time-machine');
+
+    // We'll be using bootstrap 3 so add the class so the
+    // styles get applied.
+    timeMachineDiv.addClass('bootstrap-3');
+
+    api.getSnapshotList(function(data) {
+        if (!this.isError) {
+            var pluginTimeMachine = new PluginTimeMachine(timeMachineDiv, data);
+            pluginTimeMachine.render();
+        } else {
+            timeMachineDiv.text('Error loading snapshots: ' + timeMachineDiv.text(JSON.stringify(data, undefined, 4)));
+        }
     });
 });

--- a/war/src/main/js/plugin-time-machine.js
+++ b/war/src/main/js/plugin-time-machine.js
@@ -1,0 +1,7 @@
+var $ = require('jquery-detached').getJQuery();
+
+$(function() {
+    $('#plugin-time-machine').each(function () {
+        $(this).text('*** Hello !!!!');
+    });
+});

--- a/war/src/main/js/plugin-time-machine.less
+++ b/war/src/main/js/plugin-time-machine.less
@@ -1,0 +1,11 @@
+#plugin-time-machine {
+  margin: 20px;
+
+  #snapshot-list {
+    margin-top: 10px;
+
+    .panel-title {
+      font-weight: bold;
+    }
+  }
+}

--- a/war/src/main/js/plugin-time-machine.less
+++ b/war/src/main/js/plugin-time-machine.less
@@ -7,5 +7,30 @@
     .panel-title {
       font-weight: bold;
     }
+
+    .snapshot-diff {
+      button.rollback {
+        margin-bottom: 10px;
+      }
+
+      td:first-child {
+        white-space: nowrap;
+        width: 2%;
+      }
+
+      .change {
+        margin-right: 3px;
+        padding: 3px 5px;
+        border-radius: 2px;
+
+        &.installed, &.enabled {
+          background-color: #00f100;
+        }
+        &.uninstalled, &.disabled {
+          background-color: #ff5a00;
+          color: #ffffff;
+        }
+      }
+    }
   }
 }

--- a/war/src/main/js/plugin-time-machine.less
+++ b/war/src/main/js/plugin-time-machine.less
@@ -23,10 +23,10 @@
         padding: 3px 5px;
         border-radius: 2px;
 
-        &.installed, &.enabled {
+        &.installed, &.enabled, &.upgraded {
           background-color: #00f100;
         }
-        &.uninstalled, &.disabled {
+        &.uninstalled, &.disabled, &.downgraded {
           background-color: #ff5a00;
           color: #ffffff;
         }

--- a/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
+++ b/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
@@ -1,0 +1,44 @@
+var $ = require('bootstrap-detached').getBootstrap();
+var snapshotListTemplate = require('./snapshotList.hbs');
+
+function PluginTimeMachine(target, snapshotIds) {
+    this.target = target;
+    this.snapshotList = toSnapshotList(snapshotIds);
+}
+PluginTimeMachine.prototype = {
+    render: function() {
+        this.target.empty();
+        this.target.append(snapshotListTemplate({snapshots: this.snapshotList}));
+
+        $('#snapshot-list').collapse();
+
+        this.collapseAll();
+    },
+    collapseAll: function() {
+        $('#snapshot-list .panel-collapse.in').collapse('hide');
+    }
+};
+
+function toSnapshotList(snapshotIds) {
+    var snapshotList = [];
+    for (var i = 0; i < snapshotIds.length; i++) {
+        var previousIdx = i + 1;
+
+        if (previousIdx < snapshotIds.length) {
+            var snapshot = {};
+
+            snapshotList.push(snapshot);
+
+            snapshot.idx = i;
+            snapshot.id = snapshotIds[i];
+            snapshot.takenAt = new Date(snapshot.id).toLocaleDateString();
+
+            snapshot.latest = (i === 0);
+            snapshot.previous = snapshotIds[previousIdx];
+            snapshot.previousTakenAt = new Date(snapshot.previous).toLocaleDateString();
+        }
+    }
+    return snapshotList;
+}
+
+module.exports = PluginTimeMachine;

--- a/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
+++ b/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
@@ -2,6 +2,8 @@ var $ = require('bootstrap-detached').getBootstrap();
 var api = require('../api/pluginTimeMachine');
 var snapshotListTemplate = require('./snapshotList.hbs');
 var snapshotDiffTemplate = require('./snapshotDiff.hbs');
+var doRollbackTemplate = require('./doRollback.hbs');
+var Modal = require('../widgets/Modal');
 
 function PluginTimeMachine(target, snapshotIds) {
     this.target = target;
@@ -42,8 +44,14 @@ PluginTimeMachine.prototype = {
 
         $("#snapshot-list").on('click', '.rollback', function(e) {
             var rollbackButton = $(e.target);
-            var snapshotId = rollbackButton.attr('data-snapshot-id');
-            console.log('Rollback to ' + snapshotId);
+            var snapshotId = parseInt(rollbackButton.attr('data-snapshot-id'));
+
+            var modal = new Modal('Plugin Rollback');
+            modal.body(doRollbackTemplate({takenAt: new Date(snapshotId)}));
+            modal.yes(function() {
+                console.log('*** do rollback');
+            });
+            modal.render();
         });
     },
 

--- a/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
+++ b/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
@@ -40,12 +40,10 @@ PluginTimeMachine.prototype = {
             timeMachine.loadSnapshotDiff(snapshotId, panelBody);
         });
 
-        $("#snapshot-list").click(function(e) {
-            var target = $(e.target);
-            if (target.hasClass('rollback')) {
-                var snapshotId = target.attr('data-snapshot-id');
-                console.log('Rollback to ' + snapshotId);
-            }
+        $("#snapshot-list").on('click', '.rollback', function(e) {
+            var rollbackButton = $(e.target);
+            var snapshotId = rollbackButton.attr('data-snapshot-id');
+            console.log('Rollback to ' + snapshotId);
         });
     },
 

--- a/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
+++ b/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
@@ -6,16 +6,31 @@ function PluginTimeMachine(target, snapshotIds) {
     this.snapshotList = toSnapshotList(snapshotIds);
 }
 PluginTimeMachine.prototype = {
+
     render: function() {
         this.target.empty();
         this.target.append(snapshotListTemplate({snapshots: this.snapshotList}));
 
-        $('#snapshot-list').collapse();
-
         this.collapseAll();
+        this.onSelect();
     },
+
     collapseAll: function() {
+        $('#snapshot-list').collapse();
         $('#snapshot-list .panel-collapse.in').collapse('hide');
+    },
+
+    onSelect: function() {
+        $("#snapshot-list").on('show.bs.collapse', function(e) {
+            var panel = $(e.target);
+            var snapshotId = panel.attr('data-snapshot-id');
+            var isLatest = (panel.attr('data-snapshot-latest') === 'true');
+            var previousSnapshotId = panel.attr('data-snapshot-previous');
+            var panelBody = $('.panel-body', panel);
+
+            panelBody.empty();
+            panelBody.text('snapshotId: ' + snapshotId);
+        });
     }
 };
 

--- a/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
+++ b/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
@@ -39,6 +39,14 @@ PluginTimeMachine.prototype = {
 
             timeMachine.loadSnapshotDiff(snapshotId, panelBody);
         });
+
+        $("#snapshot-list").click(function(e) {
+            var target = $(e.target);
+            if (target.hasClass('rollback')) {
+                var snapshotId = target.attr('data-snapshot-id');
+                console.log('Rollback to ' + snapshotId);
+            }
+        });
     },
 
     loadSnapshotDiff: function(snapshotId, panelBody) {
@@ -49,7 +57,10 @@ PluginTimeMachine.prototype = {
                 if (data.length === 0) {
                     panelBody.append('<div class="same-as-latest">This snapshot matches the current plugin state. Rolling back to this snapshot will have no effect.</div>');
                 } else {
-                    panelBody.append(snapshotDiffTemplate(data));
+                    panelBody.append(snapshotDiffTemplate({
+                        snapshotId: snapshotId,
+                        changes: data
+                    }));
                 }
             } else {
                 panelBody.text('Error loading snapshot diff: ' + JSON.stringify(data, undefined, 4));

--- a/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
+++ b/war/src/main/js/plugin-time-machne/PluginTimeMachine.js
@@ -49,7 +49,7 @@ PluginTimeMachine.prototype = {
             var modal = new Modal('Plugin Rollback');
             modal.body(doRollbackTemplate({takenAt: new Date(snapshotId)}));
             modal.yes(function() {
-                console.log('*** do rollback');
+                api.setSnapshotRollback(snapshotId);
             });
             modal.render();
         });

--- a/war/src/main/js/plugin-time-machne/doRollback.hbs
+++ b/war/src/main/js/plugin-time-machne/doRollback.hbs
@@ -1,7 +1,13 @@
 <div>
-    <p>Are you sure you want to Rollback to the plugin snapshot from {{takenAt}}?</p>
+    <p style="font-size: larger"><strong><code>{{takenAt}}</code></strong></p>
+    <p style="font-size: larger"><strong>Are you sure you want to rollback to this plugin snapshot?</strong></p>
+    <p style="opacity: 0.8">Jenking will automatically restart.</p>
     <div class="alert alert-warning">
-        Note that Jenkins configuration changes made by plugins involved in this
-        rollback may result in problems when restarting this Jenkins instance.
+        <strong>Plugin rollbacks are not without risk!</strong>
+        <p/>
+        Jenkins configuration changes (Jobs etc) made by plugins changed in a
+        rollback may result in problems when restarting the Jenkins instance.
+        Configurations may no longer be compatible with the plugin set after the
+        rollback. The older the snapshot, the higher the risk.
     </div>
 </div>

--- a/war/src/main/js/plugin-time-machne/doRollback.hbs
+++ b/war/src/main/js/plugin-time-machne/doRollback.hbs
@@ -1,0 +1,7 @@
+<div>
+    <p>Are you sure you want to Rollback to the plugin snapshot from {{takenAt}}?</p>
+    <div class="alert alert-warning">
+        Note that Jenkins configuration changes made by plugins involved in this
+        rollback may result in problems when restarting this Jenkins instance.
+    </div>
+</div>

--- a/war/src/main/js/plugin-time-machne/snapshotDiff.hbs
+++ b/war/src/main/js/plugin-time-machne/snapshotDiff.hbs
@@ -1,8 +1,8 @@
 <div class="snapshot-diff">
     <button type="button" class="btn btn-warning rollback" data-snapshot-id="{{this.snapshotId}}">Rollback</button>
-    <div class="alert alert-warning">
-        Rolling back to this Snapshot will result in the following plugin changes.
-    </div>
+    <p>
+        <strong>Rolling back to this Snapshot will result in the following plugin changes.</strong>
+    </p>
     <table class="table table-striped">
         <thead>
             <tr>

--- a/war/src/main/js/plugin-time-machne/snapshotDiff.hbs
+++ b/war/src/main/js/plugin-time-machne/snapshotDiff.hbs
@@ -18,10 +18,10 @@
                     {{#each this.changes}}
                         <span class="change {{this.type}}" title="Rolling back will result in this plugin being {{this.type}}.">{{this.type}}
                             {{#if this.from}}
-                                <span class="from">{{this.from}}</span>
+                                (<span class="from">{{this.from}}</span> <span class="glyphicon glyphicon-arrow-right"></span>
                             {{/if}}
                             {{#if this.to}}
-                                <span class="to">{{this.to}}</span>
+                                <span class="to">{{this.to}}</span>)
                             {{/if}}
                         </span>
                     {{/each}}

--- a/war/src/main/js/plugin-time-machne/snapshotDiff.hbs
+++ b/war/src/main/js/plugin-time-machne/snapshotDiff.hbs
@@ -1,0 +1,33 @@
+<div class="snapshot-diff">
+    <button type="button" class="btn btn-warning rollback">Rollback</button>
+    <div class="alert alert-warning">
+        Rolling back to this Snapshot will result in the following plugin changes.
+    </div>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Plugin</th>
+                <th>Change</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{#each this}}
+            <tr>
+                <td>{{this.pluginId}}</td>
+                <td>
+                    {{#each this.changes}}
+                        <span class="change {{this.type}}" title="Rolling back will result in this plugin being {{this.type}}.">{{this.type}}
+                            {{#if this.from}}
+                                <span class="from">{{this.from}}</span>
+                            {{/if}}
+                            {{#if this.to}}
+                                <span class="to">{{this.to}}</span>
+                            {{/if}}
+                        </span>
+                    {{/each}}
+                </td>
+            </tr>
+            {{/each}}
+        </tbody>
+    </table>
+</div>

--- a/war/src/main/js/plugin-time-machne/snapshotDiff.hbs
+++ b/war/src/main/js/plugin-time-machne/snapshotDiff.hbs
@@ -1,5 +1,5 @@
 <div class="snapshot-diff">
-    <button type="button" class="btn btn-warning rollback">Rollback</button>
+    <button type="button" class="btn btn-warning rollback" data-snapshot-id="{{this.snapshotId}}">Rollback</button>
     <div class="alert alert-warning">
         Rolling back to this Snapshot will result in the following plugin changes.
     </div>
@@ -11,7 +11,7 @@
             </tr>
         </thead>
         <tbody>
-            {{#each this}}
+            {{#each this.changes}}
             <tr>
                 <td>{{this.pluginId}}</td>
                 <td>

--- a/war/src/main/js/plugin-time-machne/snapshotList.hbs
+++ b/war/src/main/js/plugin-time-machne/snapshotList.hbs
@@ -11,7 +11,7 @@
                             </a>
                         </h4>
                     </div>
-                    <div id="collapse{{this.idx}}" class="panel-collapse collapse in" data-snapshot-id="{{this.id}}" data-snapshot-previous="{{this.previous}}" data-snapshot-latest="{{this.latest}}">
+                    <div id="collapse{{this.idx}}" class="panel-collapse collapse in" data-snapshot-id="{{this.id}}">
                         <div class="panel-body"></div>
                     </div>
                 </div>

--- a/war/src/main/js/plugin-time-machne/snapshotList.hbs
+++ b/war/src/main/js/plugin-time-machne/snapshotList.hbs
@@ -1,0 +1,25 @@
+<div>
+    <h3>Plugin Time Machine</h3>
+    {{#if snapshots}}
+        <div class="panel-group" id="snapshot-list">
+            {{#each snapshots}}
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h4 class="panel-title">
+                            <a data-toggle="collapse" data-parent="#snapshot-list" href="#collapse{{this.idx}}">
+                                {{this.takenAt}}
+                            </a>
+                        </h4>
+                    </div>
+                    <div id="collapse{{this.idx}}" class="panel-collapse collapse in">
+                        <div class="panel-body">
+
+                        </div>
+                    </div>
+                </div>
+            {{/each}}
+        </div>
+    {{else}}
+        No saved plugin changes. Entries will appear once plugin changes are made and Jenkins is restarted.
+    {{/if}}
+</div>

--- a/war/src/main/js/plugin-time-machne/snapshotList.hbs
+++ b/war/src/main/js/plugin-time-machne/snapshotList.hbs
@@ -11,10 +11,8 @@
                             </a>
                         </h4>
                     </div>
-                    <div id="collapse{{this.idx}}" class="panel-collapse collapse in">
-                        <div class="panel-body">
-
-                        </div>
+                    <div id="collapse{{this.idx}}" class="panel-collapse collapse in" data-snapshot-id="{{this.id}}" data-snapshot-previous="{{this.previous}}" data-snapshot-latest="{{this.latest}}">
+                        <div class="panel-body"></div>
                     </div>
                 </div>
             {{/each}}

--- a/war/src/main/js/plugin-time-machne/snapshotList.hbs
+++ b/war/src/main/js/plugin-time-machne/snapshotList.hbs
@@ -1,5 +1,5 @@
 <div>
-    <h3>Plugin Time Machine</h3>
+    Rollback to an earlier Jenkins Plugin Snapshot.
     {{#if snapshots}}
         <div class="panel-group" id="snapshot-list">
             {{#each snapshots}}

--- a/war/src/main/js/templates/Modal.hbs
+++ b/war/src/main/js/templates/Modal.hbs
@@ -1,0 +1,15 @@
+<div class="modal fade" id="{{id}}" tabindex="-1" role="dialog" aria-labelledby="modalLabel{{id}}" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title" id="modalLabel{{id}}">{{title}}</h4>
+            </div>
+            <div class="modal-body"></div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default noBtn" data-dismiss="modal">{{noLabel}}</button>
+                <button type="button" class="btn btn-primary yesBtn" data-dismiss="modal">{{yesLabel}}</button>
+            </div>
+        </div><!-- /.modal-content -->
+    </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->

--- a/war/src/main/js/widgets/Modal.js
+++ b/war/src/main/js/widgets/Modal.js
@@ -1,0 +1,65 @@
+var $ = require('bootstrap-detached').getBootstrap();
+var template = require('../templates/Modal.hbs');
+var id = 0;
+
+function Modal(title) {
+    this.id = 'modal_' + nextId();
+    this.title = title;
+    this.bodyConetnt = '<div>No body content set.</div>';
+    this.yesLabel = 'Yes';
+    this.noLabel = 'No';
+    this.wrapper = $('<div class="bootstrap-3"></div>');
+}
+
+Modal.prototype = {
+    yes: function (handler, label) {
+        this.yesHandler = handler;
+        if (label) {
+            this.yesLabel = label;
+        }
+    },
+    no: function (handler, label) {
+        this.noHandler = handler;
+        if (label) {
+            this.noLabel = label;
+        }
+    },
+    body: function (body) {
+        this.bodyConetnt = body;
+    },
+    render: function () {
+        var self = this;
+        var modalContent = template({
+            id: this.id,
+            title: this.title,
+            yesLabel: this.yesLabel,
+            noLabel: this.noLabel
+        });
+
+        this.wrapper.empty();
+        this.wrapper.append(modalContent);
+
+        $('body').append(this.wrapper);
+        var theModal = $('#' + this.id);
+
+        $('.modal-body', theModal).append(this.bodyConetnt);
+
+        theModal.modal();
+        theModal.on('hidden.bs.modal', function () {
+            self.wrapper.remove();
+        });
+
+        if (this.yesHandler) {
+            $('.yesBtn', theModal).click(this.yesHandler);
+        }
+        if (this.noHandler) {
+            $('.noBtn', theModal).click(this.noHandler);
+        }
+    }
+};
+
+function nextId() {
+    return ++id;
+}
+
+module.exports = Modal;


### PR DESCRIPTION
An idea I was experimenting with over xmas break.

Plugin Manager takes plugin "snapshots" and provides a UI to allow rollback.

So it's hoped it helps in those situations where you install a plugin that drags in X other plugins (transitive deps) that cause issues. Same wrt plugin updates.

**Video ....**
[![Video](https://i.ytimg.com/vi_webp/bX2Mvpo3IPc/maxresdefault.webp "Video")](https://youtu.be/bX2Mvpo3IPc)