### PR TITLE
[JENKINS-49129] Manage Jenkins dropdown menu no longer works

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -53,10 +53,11 @@ THE SOFTWARE.
         <j:set var="icon" value="${m.iconClassName != null ? m.iconClassName : m.iconFileName}" />
         <j:if test="${icon!=null}">
           <div class="manage-option">
+          <j:set var="iconUrl" value="${icon.startsWith('/') ? resURL+icon : imagesURL + '/48x48/' + icon}" />
+          ${taskTags!=null and attrs.contextMenu!='false' ? taskTags.add(m.urlName, iconUrl, m.displayName, m.requiresPOST, m.requiresConfirmation) : null}
           <j:choose>
             <j:when test="${m.requiresConfirmation}">
               <l:confirmationLink href="${m.urlName}" post="${m.requiresPOST}" message="${%are.you.sure(m.displayName)}">
-                <j:set var="iconUrl" value="${icon.startsWith('/') ? resURL+icon : imagesURL + '/48x48/' + icon}" />
                 <img class="icon" src="${iconUrl}" />
                 <dl>
                   <dt>${m.displayName}</dt>
@@ -67,7 +68,6 @@ THE SOFTWARE.
             </j:when>
             <j:when test="${m.requiresPOST}">
               <f:link href="${m.urlName}" post="${m.requiresPOST}">
-                <j:set var="iconUrl" value="${icon.startsWith('/') ? resURL+icon : imagesURL + '/48x48/' + icon}" />
                 <img class="icon" src="${iconUrl}" alt="manage-option"/>
                 <dl>
                   <dt>${m.displayName}</dt>
@@ -78,7 +78,6 @@ THE SOFTWARE.
             </j:when>
             <j:otherwise>
               <a href="${m.urlName}" title="${m.displayName}">
-                <j:set var="iconUrl" value="${icon.startsWith('/') ? resURL+icon : imagesURL + '/48x48/' + icon}" />
                 <img class="icon" src="${iconUrl}" alt="manage-option"/>
                 <dl>
                   <dt>${m.displayName}</dt>


### PR DESCRIPTION
See [JENKINS-49129](https://issues.jenkins-ci.org/browse/JENKINS-49129).

These changes were tested manually through smoke tests.

### Proposed changelog entries

* [JENKINS-43786](https://issues.jenkins-ci.org/browse/JENKINS-43786) (released on `2.103`) introduced a regression. In the breadcrumb, the dropdown menu for the option *Manage Jenkins* stopped working.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@jenkinsci/code-reviewers, esp @daniel-beck (since he found the bug)