### PR TITLE
[JENKINS-48407] Re-enable test

### DIFF
--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -25,6 +25,7 @@ import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
 import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
@@ -187,10 +188,6 @@ public class AtomicFileWriterTest {
         assertFalse(w.getTemporaryPath().toFile().exists());
         assertTrue(filePath.toFile().exists());
 
-        final Set<PosixFilePermission> posixFilePermissions = Files.getPosixFilePermissions(filePath);
-
-        for (PosixFilePermission perm : DEFAULT_GIVEN_PERMISSIONS) {
-            assertTrue("missing expected permission: " + perm, posixFilePermissions.contains(perm));
-        }
+        assertThat(Files.getPosixFilePermissions(filePath), equalTo(DEFAULT_GIVEN_PERMISSIONS));
     }
 }

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -17,14 +17,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
-import java.util.EnumSet;
 import java.util.Set;
 
-import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
-import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
-import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ;
-import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
-import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -3,6 +3,7 @@ package hudson.util;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -37,15 +38,15 @@ public class AtomicFileWriterTest {
      */
     @Nullable
     private static Set<PosixFilePermission> DEFAULT_GIVEN_PERMISSIONS;
-    @Rule
-    public TemporaryFolder tmp = new TemporaryFolder();
+    @ClassRule
+    public static TemporaryFolder tmp = new TemporaryFolder();
     File af;
     AtomicFileWriter afw;
     String expectedContent = "hello world";
 
     @BeforeClass
     public static void computePermissions() throws IOException {
-        final File tempDir = com.google.common.io.Files.createTempDir();
+        final File tempDir = tmp.newFolder();
         final File newFile = new File(tempDir, "blah");
         assertThat(newFile.createNewFile(), is(true));
         if (!isPosixSupported(newFile)) {

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -1,14 +1,14 @@
 package hudson.util;
 
 import org.apache.commons.io.FileUtils;
-import org.hamcrest.core.StringContains;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -20,17 +20,13 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.Set;
 
-import static org.hamcrest.core.StringContains.*;
-import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
 import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
 import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
-import static java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE;
 import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ;
-import static java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE;
-import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -40,11 +36,39 @@ import static org.junit.Assume.assumeThat;
 
 public class AtomicFileWriterTest {
     private static final String PREVIOUS = "previous value \n blah";
+    /**
+     * Provides access to the default permissions given to a new file. (i.e. indirect way to get umask settings).
+     * <p><strong>BEWARE: null on non posix systems</strong></p>
+     */
+    @Nullable
+    private static Set<PosixFilePermission> DEFAULT_GIVEN_PERMISSIONS;
     @Rule
     public TemporaryFolder tmp = new TemporaryFolder();
     File af;
     AtomicFileWriter afw;
     String expectedContent = "hello world";
+
+    @BeforeClass
+    public static void computePermissions() throws IOException {
+        final File tempDir = com.google.common.io.Files.createTempDir();
+        final File newFile = new File(tempDir, "blah");
+        assertThat(newFile.createNewFile(), is(true));
+        if (!isPosixSupported(newFile)) {
+            return;
+        }
+        DEFAULT_GIVEN_PERMISSIONS = Files.getPosixFilePermissions(newFile.toPath());
+    }
+
+    private static boolean isPosixSupported(File newFile) throws IOException {
+        // Check Posix calls are supported (to avoid running this test on Windows for instance)
+        boolean posixSupported = true;
+        try {
+            Files.getPosixFilePermissions(newFile.toPath());
+        } catch (UnsupportedOperationException e) {
+            posixSupported = false;
+        }
+        return posixSupported;
+    }
 
     @Before
     public void setUp() throws IOException {
@@ -142,36 +166,16 @@ public class AtomicFileWriterTest {
         }
     }
 
-    @Ignore // Need to fix the testing done here, since it assumes umask=002, which is wrong... Including on Kohsuke's release envt :-\.
     @Issue("JENKINS-48407")
     @Test
-    public void checkPermissions() throws IOException, InterruptedException {
+    public void checkPermissionsRespectUmask() throws IOException, InterruptedException {
 
         final File newFile = tmp.newFile();
+        boolean posixSupported = isPosixSupported(newFile);
 
-        // Check Posix calls are supported (to avoid running this test on Windows for instance)
-        boolean posixSupported = true;
-        try {
-            Files.getPosixFilePermissions(newFile.toPath());
-        } catch (UnsupportedOperationException e) {
-            posixSupported = false;
-        }
         assumeThat(posixSupported, is(true));
 
         // given
-        final Set<PosixFilePermission> givenPermissions = EnumSet.of(OWNER_READ,
-                                                                     OWNER_WRITE,
-                                                                     GROUP_READ,
-                                                                     GROUP_WRITE,
-                                                                     OTHERS_READ
-        );
-
-        final Set<PosixFilePermission> notGivenPermissions = EnumSet.of(OWNER_EXECUTE,
-                                                                        GROUP_EXECUTE,
-                                                                        OTHERS_WRITE,
-                                                                        OTHERS_EXECUTE);
-
-        Files.setPosixFilePermissions(newFile.toPath(), givenPermissions);
         Path filePath = newFile.toPath();
 
         // when
@@ -185,12 +189,8 @@ public class AtomicFileWriterTest {
 
         final Set<PosixFilePermission> posixFilePermissions = Files.getPosixFilePermissions(filePath);
 
-        for (PosixFilePermission perm : givenPermissions) {
-            assertTrue("missing: " + perm, posixFilePermissions.contains(perm));
-        }
-
-        for (PosixFilePermission perm : notGivenPermissions) {
-            assertFalse("should not be allowed: " + perm, posixFilePermissions.contains(perm));
+        for (PosixFilePermission perm : DEFAULT_GIVEN_PERMISSIONS) {
+            assertTrue("missing expected permission: " + perm, posixFilePermissions.contains(perm));
         }
     }
 }


### PR DESCRIPTION
Followup of https://github.com/jenkinsci/jenkins/pull/3274

The previous test assumed permissions would always be the same, when they actually depend on umask settings.

This change creates a file *not* using the temporary API, gets its permissions then compares it to the ones obtained using `AtomicFileWriter`.

Note: we now only check the given permissions, not the "non-given".

See [JENKINS-48407](https://issues.jenkins-ci.org/browse/JENKINS-48407).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

_N/A_: changes only under src/test.

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees esp. @daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
