### PR TITLE
LegacySecurityRealm should follow the databinding pattern

### DIFF
--- a/core/src/main/java/hudson/security/LegacySecurityRealm.java
+++ b/core/src/main/java/hudson/security/LegacySecurityRealm.java
@@ -29,13 +29,12 @@ import org.acegisecurity.AuthenticationException;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.springframework.web.context.WebApplicationContext;
-import org.kohsuke.stapler.StaplerRequest;
 import groovy.lang.Binding;
 import hudson.model.Descriptor;
 import hudson.util.spring.BeanBuilder;
 import hudson.Extension;
-import net.sf.json.JSONObject;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterConfig;
@@ -48,6 +47,10 @@ import javax.servlet.FilterConfig;
  * @author Kohsuke Kawaguchi
  */
 public final class LegacySecurityRealm extends SecurityRealm implements AuthenticationManager {
+    @DataBoundConstructor
+    public LegacySecurityRealm() {
+    }
+
     public SecurityComponents createSecurityComponents() {
         return new SecurityComponents(this);
     }
@@ -102,10 +105,6 @@ public final class LegacySecurityRealm extends SecurityRealm implements Authenti
     public static class DescriptorImpl extends  Descriptor<SecurityRealm> {
         public DescriptorImpl() {
             DESCRIPTOR = this;
-        }
-
-        public SecurityRealm newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return new LegacySecurityRealm();
         }
 
         public String getDisplayName() {


### PR DESCRIPTION
In order for this to behave more uniformly with other systems like CaC,
it's preferrable not to override the newInstance method and instead use
the standard annotation.

Issue: https://github.com/jenkinsci/configuration-as-code-plugin/issues/24