### PR TITLE
[WIP] Introduced a permission to read system configuration.

### DIFF
--- a/core/src/main/java/hudson/AboutJenkins.java
+++ b/core/src/main/java/hudson/AboutJenkins.java
@@ -3,6 +3,7 @@ package hudson;
 import hudson.model.ManagementLink;
 import java.net.URL;
 
+import hudson.security.Permission;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -38,4 +39,11 @@ public class AboutJenkins extends ManagementLink {
         return AboutJenkins.class.getResource("/META-INF/licenses.xml");
     }
 
+    /**
+     * Nothing sensitive about this information.
+     */
+    @Override
+    public Permission getRequiredPermission() {
+        return null;
+    }
 }

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -56,6 +56,8 @@ import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+import static jenkins.model.Jenkins.ADMINISTER;
+
 /**
  * Records a selected set of logs so that the system administrator
  * can diagnose a specific aspect of the system.
@@ -281,6 +283,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
      */
     @RequirePOST
     public synchronized void doConfigSubmit( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
+        Jenkins.get().checkPermission(ADMINISTER);
         JSONObject src = req.getSubmittedForm();
 
         String newName = src.getString("name"), redirect = ".";
@@ -307,6 +310,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
 
     @RequirePOST
     public HttpResponse doClear() throws IOException {
+        Jenkins.get().checkPermission(ADMINISTER);
         handler.clear();
         return HttpResponses.redirectToDot();
     }
@@ -334,6 +338,8 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
      */
     @RequirePOST
     public synchronized void doDoDelete(StaplerResponse rsp) throws IOException, ServletException {
+        Jenkins.get().checkPermission(ADMINISTER);
+
         getConfigFile().delete();
         getParent().logRecorders.remove(name);
         // Disable logging for all our targets,

--- a/core/src/main/java/hudson/model/ManagementLink.java
+++ b/core/src/main/java/hudson/model/ManagementLink.java
@@ -112,10 +112,10 @@ public abstract class ManagementLink implements ExtensionPoint, Action {
     }
 
     /**
-     * @return permission required for user to access this management link, in addition to {@link Jenkins#ADMINISTER}
+     * Permission required for user to access this management link. By default, {@link Jenkins#ADMINISTER}
      */
     public @CheckForNull Permission getRequiredPermission() {
-        return null;
+        return Jenkins.ADMINISTER;
     }
 
     /**

--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -109,7 +109,7 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
 
     public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException {
         // for compatibility reasons, the actual value is stored in Jenkins
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         j.checkPermission(Jenkins.ADMINISTER);
         if (json.has("useSecurity")) {
             JSONObject security = json.getJSONObject("useSecurity");
@@ -186,7 +186,7 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
     
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.ADMINISTER;
+        return Jenkins.EXTENDED_READ;
     }
 
     public static Predicate<GlobalConfigurationCategory> FILTER = new Predicate<GlobalConfigurationCategory>() {

--- a/core/src/main/java/jenkins/management/ConfigureLink.java
+++ b/core/src/main/java/jenkins/management/ConfigureLink.java
@@ -26,6 +26,8 @@ package jenkins.management;
 
 import hudson.Extension;
 import hudson.model.ManagementLink;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
 /**
@@ -46,6 +48,11 @@ public class ConfigureLink extends ManagementLink {
     @Override
     public String getDescription() {
         return Messages.ConfigureLink_Description();
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.EXTENDED_READ;
     }
 
     @Override

--- a/core/src/main/java/jenkins/management/PluginsLink.java
+++ b/core/src/main/java/jenkins/management/PluginsLink.java
@@ -26,6 +26,8 @@ package jenkins.management;
 
 import hudson.Extension;
 import hudson.model.ManagementLink;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
 /**

--- a/core/src/main/java/jenkins/management/PluginsLink.java
+++ b/core/src/main/java/jenkins/management/PluginsLink.java
@@ -54,4 +54,9 @@ public class PluginsLink extends ManagementLink {
     public String getUrlName() {
         return "pluginManager";
     }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.EXTENDED_READ;
+    }
 }

--- a/core/src/main/java/jenkins/management/StatisticsLink.java
+++ b/core/src/main/java/jenkins/management/StatisticsLink.java
@@ -26,6 +26,8 @@ package jenkins.management;
 
 import hudson.Extension;
 import hudson.model.ManagementLink;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
 /**
@@ -51,5 +53,10 @@ public class StatisticsLink extends ManagementLink {
     @Override
     public String getUrlName() {
         return "load-statistics";
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.EXTENDED_READ;
     }
 }

--- a/core/src/main/java/jenkins/management/SystemInfoLink.java
+++ b/core/src/main/java/jenkins/management/SystemInfoLink.java
@@ -26,6 +26,8 @@ package jenkins.management;
 
 import hudson.Extension;
 import hudson.model.ManagementLink;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
 /**
@@ -51,5 +53,10 @@ public class SystemInfoLink extends ManagementLink {
     @Override
     public String getUrlName() {
         return "systemInfo";
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.EXTENDED_READ;
     }
 }

--- a/core/src/main/java/jenkins/management/SystemLogLink.java
+++ b/core/src/main/java/jenkins/management/SystemLogLink.java
@@ -26,6 +26,8 @@ package jenkins.management;
 
 import hudson.Extension;
 import hudson.model.ManagementLink;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
 /**
@@ -51,5 +53,10 @@ public class SystemLogLink extends ManagementLink {
     @Override
     public String getUrlName() {
         return "log";
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.EXTENDED_READ;
     }
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2458,7 +2458,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Everything below here is admin-only, so do the check here.
      */
     public LogRecorderManager getLog() {
-        checkPermission(ADMINISTER);
+        checkPermission(EXTENDED_READ);
         return log;
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5064,6 +5064,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     public static final PermissionGroup PERMISSIONS = Permission.HUDSON_PERMISSIONS;
     public static final Permission ADMINISTER = Permission.HUDSON_ADMINISTER;
+    /**
+     * Permission to read configuration.
+     * @see Item#EXTENDED_READ
+     */
+    public static final Permission EXTENDED_READ = new Permission(PERMISSIONS,"ExtendedRead", Messages._Hudson_ExtendedReadPermission_Description(), ADMINISTER, PermissionScope.JENKINS);
     public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
     public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
 

--- a/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
+++ b/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
@@ -71,7 +71,7 @@ public class GlobalToolConfiguration extends ManagementLink {
 
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.ADMINISTER;
+        return Jenkins.EXTENDED_READ;
     }
 
     @RequirePOST
@@ -82,7 +82,7 @@ public class GlobalToolConfiguration extends ManagementLink {
     }
 
     private boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException, IOException {
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.get();
         j.checkPermission(Jenkins.ADMINISTER);
 
         boolean result = true;

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-  <l:layout title="${%Update Center}" permission="${app.ADMINISTER}" norefresh="true">
+  <l:layout title="${%Update Center}" permission="${app.EXTENDED_READ}" norefresh="true">
     <st:include page="sidepanel.jelly"/>
     <l:main-panel>
         <st:adjunct includes="hudson.PluginManager._table"/>
@@ -63,8 +63,10 @@ THE SOFTWARE.
                 <th width="32" tooltip="${%Uncheck to disable the plugin}">${%Enabled}</th>
                 <th initialSortDir="down">${%Name}</th>
                 <th width="1">${%Version}</th>
-                <th width="1">${%Previously installed version}</th>
-                <th width="1">${%Uninstall}</th>
+                <l:hasPermission permission="${app.ADMINISTER}">
+                  <th width="1">${%Previously installed version}</th>
+                  <th width="1">${%Uninstall}</th>
+                </l:hasPermission>
               </tr>
               <j:forEach var="p" items="${app.pluginManager.plugins}">
                 <tr class="plugin ${p.hasDependants()?'has-dependants':''} ${(p.hasDependants() &amp;&amp; !p.enabled)?'has-dependants-but-disabled':''} ${p.isDeleted()?'deleted':''}" data-plugin-id="${p.shortName}" data-plugin-name="${p.displayName}">
@@ -105,39 +107,41 @@ THE SOFTWARE.
                       ${p.version}
                     </a>
                   </td>
-                  <td class="pane">
-                    <j:if test="${p.downgradable}">
-                      <form method="post" action="${rootURL}/updateCenter/plugin/${p.shortName}/downgrade">
-                        <s:submit value="${%downgradeTo(p.backupVersion)}"/>
-                      </form>
-                    </j:if>
-                  </td>
-                  <td class="center pane uninstall">
-                    <j:choose>
-                      <j:when test="${p.isDeleted()}">
-                        <p>${%Uninstallation pending}</p>
-                      </j:when>
-                      <j:otherwise>
-                          <j:if test="${p.hasDependants()}">
-                            <div class="dependant-list">
-                              <j:forEach var="dependant" items="${p.dependants}">
-                                <span data-plugin-id="${dependant}"></span>
-                              </j:forEach>
-                            </div>
-                          </j:if>
-                          <j:if test="${p.hasDependencies()}">
-                            <div class="dependency-list">
-                              <j:forEach var="dependency" items="${p.dependencies}">
-                                <span data-plugin-id="${dependency.shortName}"></span>  
-                              </j:forEach>
-                            </div>
-                          </j:if>
-                          <form method="post" action="plugin/${p.shortName}/uninstall">
-                              <input class="uninstall" type="submit" value="${%Uninstall}"/>
-                          </form>
-                      </j:otherwise>
-                    </j:choose>
-                  </td>
+                  <l:hasPermission permission="${app.ADMINISTER}">
+                    <td class="pane">
+                      <j:if test="${p.downgradable}">
+                        <form method="post" action="${rootURL}/updateCenter/plugin/${p.shortName}/downgrade">
+                          <s:submit value="${%downgradeTo(p.backupVersion)}"/>
+                        </form>
+                      </j:if>
+                    </td>
+                    <td class="center pane uninstall">
+                      <j:choose>
+                        <j:when test="${p.isDeleted()}">
+                          <p>${%Uninstallation pending}</p>
+                        </j:when>
+                        <j:otherwise>
+                            <j:if test="${p.hasDependants()}">
+                              <div class="dependant-list">
+                                <j:forEach var="dependant" items="${p.dependants}">
+                                  <span data-plugin-id="${dependant}"></span>
+                                </j:forEach>
+                              </div>
+                            </j:if>
+                            <j:if test="${p.hasDependencies()}">
+                              <div class="dependency-list">
+                                <j:forEach var="dependency" items="${p.dependencies}">
+                                  <span data-plugin-id="${dependency.shortName}"></span>
+                                </j:forEach>
+                              </div>
+                            </j:if>
+                            <form method="post" action="plugin/${p.shortName}/uninstall">
+                                <input class="uninstall" type="submit" value="${%Uninstall}"/>
+                            </form>
+                        </j:otherwise>
+                      </j:choose>
+                    </td>
+                  </l:hasPermission>
                 </tr>
               </j:forEach>
               <!-- failed ones -->

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout title="${%Update Center}" permission="${app.ADMINISTER}" norefresh="true">
+  <l:layout title="${%Update Center}" permission="${app.EXTENDED_READ}" norefresh="true">
     <l:header>
       <script type="text/javascript">
       <![CDATA[
@@ -61,9 +61,11 @@ THE SOFTWARE.
         <div class="pane-frame">
           <table id="plugins" class="sortable pane bigtable stripped-odd">
             <tr>
-              <th initialSortDir="${isUpdates?null:'down'}"
-                  tooltip="${%Check to install the plugin}${isUpdates?'':'&lt;br/&gt;'+'%Click this heading to sort by category'}"
-                  width="32" onclick="showhideCategories(this,1)">${%Install}</th>
+              <l:hasPermission permission="${app.ADMINISTER}">
+                <th initialSortDir="${isUpdates?null:'down'}"
+                    tooltip="${%Check to install the plugin}${isUpdates?'':'&lt;br/&gt;'+'%Click this heading to sort by category'}"
+                    width="32" onclick="showhideCategories(this,1)">${%Install}</th>
+              </l:hasPermission>
               <th initialSortDir="${isUpdates?'down':null}"
                   onclick="showhideCategories(this,0)">${%Name}</th>
               <th onclick="showhideCategories(this,0)">${%Version}</th>
@@ -87,11 +89,13 @@ THE SOFTWARE.
                   <j:set var="installedOk"
                          value="${installJob.status.success and installJob.plugin.version==p.version}" />
                   <tr class="${installJob!=null ? 'already-upgraded' : ''} plugin" name="${p.displayName}">
-                    <td class="pane" align="center" data="${thisCat}_">
-                      <input type="checkbox" name="plugin.${p.name}.${p.sourceId}"
-                             checked="${installedOk ? 'checked' : null}"
-                             disabled="${installedOk ? 'disabled' : null}" onClick="flip(this);"/>
-                    </td>
+                    <l:hasPermission permission="${app.ADMINISTER}">
+                      <td class="pane" align="center" data="${thisCat}_">
+                        <input type="checkbox" name="plugin.${p.name}.${p.sourceId}"
+                               checked="${installedOk ? 'checked' : null}"
+                               disabled="${installedOk ? 'disabled' : null}" onClick="flip(this);"/>
+                      </td>
+                    </l:hasPermission>
                     <td class="pane" data="${h.xmlEscape(p.displayName)}">
                       <div>
                         <a href="${p.wiki}"><st:out value="${p.displayName}"/></a>
@@ -149,18 +153,20 @@ THE SOFTWARE.
           </table>
         </div>
 
-        <div id="bottom-sticker" >
-          <div class="bottom-sticker-inner">
-            <j:if test="${!empty(list)}">
-              <j:if test="${!isUpdates}">
-                <f:submit value="${%Install without restart}" name="dynamicLoad" />
-                <span style="margin-left:2em;"></span>
+        <l:hasPermission permission="${app.ADMINISTER}">
+          <div id="bottom-sticker" >
+            <div class="bottom-sticker-inner">
+              <j:if test="${!empty(list)}">
+                <j:if test="${!isUpdates}">
+                  <f:submit value="${%Install without restart}" name="dynamicLoad" />
+                  <span style="margin-left:2em;"></span>
+                </j:if>
+                <f:submit value="${%Download now and install after restart}" />
               </j:if>
-              <f:submit value="${%Download now and install after restart}" />
-            </j:if>
-            <st:include page="check.jelly"/>
+              <st:include page="check.jelly"/>
+              </div>
             </div>
-          </div>
+        </l:hasPermission>
         <d:invokeBody />
       </form>
     </l:main-panel>

--- a/core/src/main/resources/hudson/logging/LogRecorder/configure.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/configure.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:layout norefresh="true">
+<l:layout norefresh="true" permission="${app.ADMINISTER}">
   <st:include page="sidepanel.jelly" />
   <l:main-panel>
     <f:form method="post" name="config" action="configSubmit">

--- a/core/src/main/resources/hudson/logging/LogRecorder/delete.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/delete.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout>
+  <l:layout permission="${app.ADMINISTER}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <form method="post" action="doDelete">

--- a/core/src/main/resources/hudson/logging/LogRecorder/sidepanel.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/sidepanel.jelly
@@ -32,8 +32,10 @@ THE SOFTWARE.
     <l:tasks>
       <l:task href=".." icon="icon-up icon-md" title="${%Back to Loggers}"/>
       <l:task href="." icon="icon-notepad icon-md" title="${%Log records}"/>
-      <l:task href="configure" icon="icon-gear2 icon-md" title="${%Configure}"/>
-      <l:task href="delete" icon="icon-edit-delete icon-md" title="${%Delete}"/>
+      <l:hasPermission permission="${app.ADMINISTER}">
+        <l:task href="configure" icon="icon-gear2 icon-md" title="${%Configure}"/>
+        <l:task href="delete" icon="icon-edit-delete icon-md" title="${%Delete}"/>
+      </l:hasPermission>
     </l:tasks>
   </l:side-panel>
 </j:jelly>

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
@@ -58,15 +58,19 @@ THE SOFTWARE.
       <local:row href="all" name="${%All Jenkins Logs}" />
       <j:forEach var="lr" items="${it.logRecorders.values()}">
         <local:row name="${lr.name}" href="${lr.searchUrl}/">
-          <a href="${lr.searchUrl}/configure">
-            <l:icon class="icon-gear2 icon-lg" tooltip="Configure"/>
-          </a>
+          <l:hasPermission permission="${app.ADMINISTER}">
+            <a href="${lr.searchUrl}/configure">
+              <l:icon class="icon-gear2 icon-lg" tooltip="Configure"/>
+            </a>
+          </l:hasPermission>
         </local:row>
       </j:forEach>
     </table>
-    <form method="get" action="new">
-      <f:submit value="${%Add new log recorder}" />
-    </form>
+    <l:hasPermission permission="${app.ADMINISTER}">
+      <form method="get" action="new">
+        <f:submit value="${%Add new log recorder}" />
+      </form>
+    </l:hasPermission>
   </l:main-panel>
 </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/sidepanel.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/sidepanel.jelly
@@ -34,7 +34,9 @@ THE SOFTWARE.
       <l:task href="${rootURL}/manage" icon="icon-gear2 icon-md" title="${%Manage Jenkins}"/>
       <l:task href="." icon="icon-clipboard icon-md" title="${%Logger List}"/>
       <l:task href="all" icon="icon-notepad icon-md" title="${%All Logs}"/>
-      <l:task href="new" icon="icon-new-package icon-md" title="${%New Log Recorder}"/>
+      <l:hasPermission permission="${app.ADMINISTER}">
+        <l:task href="new" icon="icon-new-package icon-md" title="${%New Log Recorder}"/>
+      </l:hasPermission>
       <l:task href="levels" icon="icon-gear icon-md" title="${%Log Levels}"/>
     </l:tasks>
   </l:side-panel>

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -167,6 +167,10 @@ Hudson.ReadPermission.Description=\
   add "authenticated" pseudo-user and grant the read access.
 Hudson.RunScriptsPermission.Description=\
   Required for running scripts inside the Jenkins process, for example via the Groovy console or Groovy CLI command.
+Hudson.ExtendedReadPermission.Description=\
+  This permission grants read-only access to Jenkins configurations. Please be \
+  aware that sensitive information, such as presence of credentials, will be \
+  exposed to a wider audience by granting this permission.
 Hudson.NodeDescription=the master Jenkins node
 
 Item.Permissions.Title=Job

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
@@ -12,7 +12,7 @@ def f=namespace(lib.FormTagLib)
 def l=namespace(lib.LayoutTagLib)
 def st=namespace("jelly:stapler")
 
-l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName, cssclass:request.getParameter('decorate')) {
+l.layout(norefresh:true, permission:app.EXTENDED_READ, title:my.displayName, cssclass:request.getParameter('decorate')) {
     l.main_panel {
         h1 {
             l.icon(class: 'icon-secure icon-xlg')
@@ -95,9 +95,11 @@ l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName, csscla
                 }
             }
 
-            f.bottomButtonBar {
-                f.submit(value:_("Save"))
-                f.apply()
+            l.hasPermission(permission:app.ADMINISTER) {
+                f.bottomButtonBar {
+                    f.submit(value:_("Save"))
+                    f.apply()
+                }
             }
         }
 

--- a/core/src/main/resources/hudson/security/Messages.properties
+++ b/core/src/main/resources/hudson/security/Messages.properties
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-GlobalSecurityConfiguration.DisplayName=Configure Global Security
+GlobalSecurityConfiguration.DisplayName=Global Security Configuration
 GlobalSecurityConfiguration.Description=Secure Jenkins; define who is allowed to access/use the system.
 
 HudsonPrivateSecurityRealm.WouldYouLikeToSignUp=This {0} {1} is new to Jenkins. Would you like to sign up?

--- a/core/src/main/resources/jenkins/management/Messages.properties
+++ b/core/src/main/resources/jenkins/management/Messages.properties
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 
-ConfigureLink.DisplayName=Configure System
+ConfigureLink.DisplayName=System Configuration
 ConfigureLink.Description=Configure global settings and paths.
 
 ConfigureTools.DisplayName=Global Tool Configuration

--- a/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:layout norefresh="true" permission="${it.ADMINISTER}" title="${%Configure System}">
+<l:layout norefresh="true" permission="${it.EXTENDED_READ}" title="${%Configure System}">
   <st:include page="sidepanel.jelly" />
   <f:breadcrumb-config-outline />
   <l:main-panel>
@@ -60,10 +60,12 @@ THE SOFTWARE.
         </f:rowSet>
       </j:forEach>
 
-      <f:bottomButtonBar>
-        <f:submit value="${%Save}" />
-        <f:apply value="${%Apply}"/>
-      </f:bottomButtonBar>
+      <j:if test="${h.hasPermission(it,it.ADMINISTER)}">
+        <f:bottomButtonBar>
+          <f:submit value="${%Save}" />
+          <f:apply value="${%Apply}"/>
+        </f:bottomButtonBar>
+      </j:if>
     </f:form>
     <st:adjunct includes="lib.form.confirm" />
   </l:main-panel>

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:layout title="${%Manage Jenkins}" xmlns:local="local" permission="${app.ADMINISTER}">
+<l:layout title="${%Manage Jenkins}" xmlns:local="local" permission="${app.EXTENDED_READ}">
 
   <l:header>
      <link rel="stylesheet" href="${resURL}/bootstrap/css/bootstrap.min.css" type="text/css" />

--- a/core/src/main/resources/jenkins/tools/GlobalToolConfiguration/index.groovy
+++ b/core/src/main/resources/jenkins/tools/GlobalToolConfiguration/index.groovy
@@ -7,7 +7,7 @@ def f=namespace(lib.FormTagLib)
 def l=namespace(lib.LayoutTagLib)
 def st=namespace("jelly:stapler")
 
-l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
+l.layout(norefresh:true, permission:app.EXTENDED_READ, title:my.displayName) {
     l.side_panel {
         l.tasks {
             l.task(icon:"icon-up icon-md", href:rootURL+'/', title:_("Back to Dashboard"))
@@ -33,9 +33,11 @@ l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
                 }
             }
 
-            f.bottomButtonBar {
-                f.submit(value:_("Save"))
-                f.apply(value:_("Apply"))
+            l.hasPermission(permission:app.ADMINISTER) {
+                f.bottomButtonBar {
+                    f.submit(value:_("Save"))
+                    f.apply(value:_("Apply"))
+                }
             }
         }
 


### PR DESCRIPTION
... similar to that of Item.EXTENDED_READ.

This is useful for Jenkins whose configuration is managed externally,
such as configuration as code.

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

### Proposed changelog entries

* Introduced a new permission that can read system configuration but not overwrite it

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

@jenkinsci/code-reviewers
