### PR TITLE
Fixing nullability annotations on Util.escape

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1094,8 +1094,8 @@ public class Util {
     /**
      * Escapes HTML unsafe characters like &lt;, &amp; to the respective character entities.
      */
-    @Nonnull
-    public static String escape(@Nonnull String text) {
+    @Nullable
+    public static String escape(@CheckForNull String text) {
         if (text==null)     return null;
         StringBuilder buf = new StringBuilder(text.length()+64);
         for( int i=0; i<text.length(); i++ ) {


### PR DESCRIPTION
Two annotations were added to this method, both wrong, at least if we wish to keep its original behavior. Was causing me grief from FindBugs.

### Proposed changelog entries

N/A

### Desired reviewers

@reviewbybees