### PR TITLE
[JENKINS-49401] Move Setup Wizard initialization logic to the init re…

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -918,9 +918,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             if(KILL_AFTER_LOAD)
                 // TODO cleanUp?
                 System.exit(0);
-
-            setupWizard = new SetupWizard();
-            getInstallState().initializeState();
+            save();
 
             launchTcpSlaveAgentListener();
 
@@ -3146,6 +3144,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 // auto register root actions
                 for (Action a : getExtensionList(RootAction.class))
                     if (!actions.contains(a)) actions.add(a);
+
+                setupWizard = new SetupWizard();
+                getInstallState().initializeState();
             }
         });
 


### PR DESCRIPTION
…actor.

This way, it is guaranteed the Jenkins version field is not persisted before
the SetupWizard is executed, and computation of the initial Setup Wizard
state will be correct.

Since the SetupWizard is now executed before reaching the COMPLETED
milestone, a Jenkins.save() call has been added in order to persist the current Jenkins version.

See [JENKINS-49401](https://issues.jenkins-ci.org/browse/JENKINS-49401).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fixed a race condition case that could lead to skip Setup Wizard on the first startup of OEM setups (with groovy scripts or pre-installed plugins).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
