### PR TITLE
[JENKINS-49322] Add an optional prefix parameter to artifact archiver

### DIFF
--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -110,6 +110,11 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
     @Nonnull
     private Boolean caseSensitive = true;
 
+    /**
+     * The target parent directory.
+     */
+    private String targetDirectory;
+
     @DataBoundConstructor public ArtifactArchiver(String artifacts) {
         this.artifacts = artifacts.trim();
         allowEmptyArchive = false;
@@ -214,6 +219,14 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
         this.caseSensitive = caseSensitive;
     }
 
+    public @CheckForNull String getTargetDirectory() {
+        return targetDirectory;
+    }
+
+    @DataBoundSetter public final void setTargetDirectory(@CheckForNull String targetDirectory) {
+        this.targetDirectory = Util.fixEmptyAndTrim(targetDirectory);
+    }
+
     private void listenerWarnOrError(TaskListener listener, String message) {
     	if (allowEmptyArchive) {
     		listener.getLogger().println(String.format("WARN: %s", message));
@@ -242,7 +255,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
 
             Map<String,String> files = ws.act(new ListFiles(artifacts, excludes, defaultExcludes, caseSensitive));
             if (!files.isEmpty()) {
-                build.pickArtifactManager().archive(ws, launcher, BuildListenerAdapter.wrap(listener), files);
+                build.pickArtifactManager().archive(ws, launcher, BuildListenerAdapter.wrap(listener), files, targetDirectory);
                 if (fingerprint) {
                     new Fingerprinter(artifacts).perform(build, ws, launcher, listener);
                 }

--- a/core/src/main/java/jenkins/model/ArtifactManager.java
+++ b/core/src/main/java/jenkins/model/ArtifactManager.java
@@ -60,11 +60,12 @@ public abstract class ArtifactManager {
      * @param launcher a launcher to use if external processes need to be forked
      * @param listener a way to print messages about progress or problems
      * @param artifacts map from paths in the archive area to paths relative to {@code workspace} (all paths {@code /}-separated)
+     * @param targetDirectory the target parent directory
      * @throws IOException if transfer or copying failed in any way
      * @throws InterruptedException if transfer was interrupted
      * @see ArtifactArchiver#perform(Run, FilePath, Launcher, TaskListener)
      */
-    public abstract void archive(FilePath workspace, Launcher launcher, BuildListener listener, Map<String,String> artifacts) throws IOException, InterruptedException;
+    public abstract void archive(FilePath workspace, Launcher launcher, BuildListener listener, Map<String,String> artifacts, String targetDirectory) throws IOException, InterruptedException;
 
     /**
      * Delete all artifacts associated with an earlier build (if any).

--- a/core/src/main/java/jenkins/model/StandardArtifactManager.java
+++ b/core/src/main/java/jenkins/model/StandardArtifactManager.java
@@ -55,8 +55,8 @@ public class StandardArtifactManager extends ArtifactManager {
         this.build = build;
     }
 
-    @Override public void archive(FilePath workspace, Launcher launcher, BuildListener listener, final Map<String,String> artifacts) throws IOException, InterruptedException {
-        File dir = getArtifactsDir();
+    @Override public void archive(FilePath workspace, Launcher launcher, BuildListener listener, final Map<String,String> artifacts, String targetDirectory) throws IOException, InterruptedException {
+        File dir = buildTarget(targetDirectory);
         String description = "transfer of " + artifacts.size() + " files"; // TODO improve when just one file
         workspace.copyRecursiveTo(new FilePath.ExplicitlySpecifiedDirScanner(artifacts), new FilePath(dir), description);
     }
@@ -81,4 +81,11 @@ public class StandardArtifactManager extends ArtifactManager {
         return build.getArtifactsDir();
     }
 
+    private File buildTarget(String prefix) {
+        if (prefix != null) {
+            return new File(getArtifactsDir(), prefix);
+        } else {
+            return getArtifactsDir();
+        }
+    }
 }

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
@@ -31,6 +31,9 @@ THE SOFTWARE.
     <f:entry title="${%Excludes}" field="excludes">
       <f:textbox />
     </f:entry>
+    <f:entry title="${%targetDirectory}" field="targetDirectory">
+      <f:textbox />
+    </f:entry>
     <f:entry field="allowEmptyArchive" >
       <f:checkbox title="${%allowEmptyArchive}"/>
     </f:entry>

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.properties
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.properties
@@ -24,3 +24,4 @@ allowEmptyArchive=Do not fail build if archiving returns nothing
 onlyIfSuccessful=Archive artifacts only if build is successful
 defaultExcludes=Use default excludes
 caseSensitive=Treat include and exclude patterns as case sensitive
+targetDirectory=Target directory

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-targetDirectory.html
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-targetDirectory.html
@@ -1,0 +1,3 @@
+<div>
+    Optionally specify the parent directory for the archived files, such as "foo".
+</div>


### PR DESCRIPTION
Add targetDirectory parameter for the artifact archiver
No test added, I can add some if needed.

See [JENKINS-49322](https://issues.jenkins-ci.org/browse/JENKINS-49322).

### Proposed changelog entries

* Add an optional parent directory parameter to the artifact archiver

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

no idea, sorry 😉 
