### PR TITLE
fix missing parameter in french translation of test:bar taglib

### DIFF
--- a/core/src/main/resources/lib/test/bar_fr.properties
+++ b/core/src/main/resources/lib/test/bar_fr.properties
@@ -22,5 +22,5 @@
 
 No\ tests=Pas de test
 failures={0} \u00E9checs
-skipped=Non passés
+skipped={0} non passés
 tests={0} tests


### PR DESCRIPTION
In the french translation of test:bar taglib, the total number of skipped tests is missing.

### Proposed changelog

* RFE: French localization: Print number of failing tests in the test summary bar.
