### PR TITLE
[JENKINS-49387][JENKINS-49520] - Validation errors

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -67,6 +67,7 @@ import jenkins.model.Jenkins;
 import jenkins.util.ContextResettingExecutorService;
 import jenkins.security.MasterToSlaveCallable;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.kohsuke.accmod.Restricted;
@@ -1473,7 +1474,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         }
 
         String nExecutors = req.getSubmittedForm().getString("numExecutors");
-        if (Integer.parseInt(nExecutors)<=0) {
+        if (StringUtils.isBlank(nExecutors) || Integer.parseInt(nExecutors)<=0) {
             throw new FormException(Messages.Slave_InvalidConfig_Executors(nodeName), "numExecutors");
         }
 

--- a/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
+++ b/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
   </f:entry>
 
   <f:entry title="${%# of executors}" field="numExecutors">
-    <f:number clazz="positive-number" min="1" step="1" default="1"/>
+    <f:number clazz="positive-number-required" min="1" step="1" default="1"/>
   </f:entry>
 
   <f:entry title="${%Remote root directory}" field="remoteFS">

--- a/core/src/main/resources/jenkins/model/Jenkins/MasterComputer/configure.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/MasterComputer/configure.jelly
@@ -42,7 +42,7 @@ THE SOFTWARE.
         -->
 
         <f:entry title="${%# of executors}" field="numExecutors">
-          <f:number clazz="non-negative-number" min="0" step="1"/>
+          <f:number clazz="non-negative-number-required" min="0" step="1"/>
         </f:entry>
 
         <f:entry title="${%Labels}" field="labelString">

--- a/core/src/main/resources/jenkins/model/MasterBuildConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/MasterBuildConfiguration/config.groovy
@@ -3,7 +3,7 @@ package jenkins.model.MasterBuildConfiguration
 def f=namespace(lib.FormTagLib)
 
 f.entry(title:_("# of executors"), field:"numExecutors") {
-    f.number(clazz:"non-negative-number", min:0, step:1)
+    f.number(clazz:"non-negative-number-required", min:0, step:1)
 }
 f.entry(title:_("Labels"),field:"labelString") {
     f.textbox()

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -694,11 +694,17 @@ var jenkinsRules = {
     "INPUT.required" : function(e) { registerRegexpValidator(e,/./,"Field is required"); },
 
 // validate form values to be an integer
-    "INPUT.number" : function(e) { registerRegexpValidator(e,/^\-?(\d+)$/,"Not an integer"); },
-    "INPUT.non-negative-number" : function(e) {
+    "INPUT.number" : function(e) { registerRegexpValidator(e,/^(\d+|)$/,"Not an integer"); },
+    "INPUT.number-required" : function(e) { registerRegexpValidator(e,/^\-?(\d+)$/,"Not an integer"); },
+
+    "INPUT.non-negative-number-required" : function(e) {
         registerRegexpValidator(e,/^\d+$/,"Not a non-negative number");
     },
+
     "INPUT.positive-number" : function(e) {
+        registerRegexpValidator(e,/^(\d*[1-9]\d*|)$/,"Not a positive integer");
+    },
+    "INPUT.positive-number-required" : function(e) {
         registerRegexpValidator(e,/^[1-9]\d*$/,"Not a positive integer");
     },
 


### PR DESCRIPTION
See [JENKINS-49387](https://issues.jenkins-ci.org/browse/JENKINS-49387) and [JENKINS-49520](https://issues.jenkins-ci.org/browse/JENKINS-49520).

In the [PR#3141](https://github.com/jenkinsci/jenkins/pull/3141) I broke validation for some fields.
This PR:
- restores old rules for validation
- applies new rules for fields which are mandatory 

### Proposed changelog entries

* Entry 1: Prevent input validation errors in optional numeric form entries (regression in 2.105). 
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->