### PR TITLE
[JENKINS-34712] Always show the master node when it is offline

### DIFF
--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -129,7 +129,7 @@ THE SOFTWARE.
       <j:forEach var="c" items="${computers}">
         <j:set var="cDisplayExecutors" value="${c.displayExecutors}"/>
         <tr>
-          <j:if test="${computersSize gt 1 and !cDisplayExecutors.isEmpty()}">
+          <j:if test="${(computersSize gt 1 and !cDisplayExecutors.isEmpty()) or (c.node == app and c.offline)}">
             <th class="pane" colspan="3">
               <local:computerCaption title="${c.displayName}" />
             </th>


### PR DESCRIPTION
See [JENKINS-34712](https://issues.jenkins-ci.org/browse/JENKINS-34712).

Here are some screenshots:

* Master is offline with 0 executors and there are no other nodes.
  * Before: 
     <img width="361" alt="master-any-either" src="https://user-images.githubusercontent.com/1068968/36264077-ce9e3e88-1239-11e8-9d89-376e8d4052b2.png">
  * After: 
     <img width="363" alt="master-single-any-offline" src="https://user-images.githubusercontent.com/1068968/36264016-9baefa8a-1239-11e8-9d83-4458f3360927.png">
* Master is offline with 0 executors and there is another node (Foo).
  * Before:
     <img width="359" alt="master-0-online" src="https://user-images.githubusercontent.com/1068968/36264102-e08962a8-1239-11e8-9078-261031f9e268.png">
  * After:
     <img width="360" alt="master-any-offline" src="https://user-images.githubusercontent.com/1068968/36264130-f75ec9be-1239-11e8-8aa3-48714ae4813d.png">

### Proposed changelog entries

* Always show the `master` node in the executors widget when it is offline.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees
