### PR TITLE
JenkinsFile: Use performance-optimized build mode to reduce IO a bit when Jenkins builds itself

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@
 def runTests = true
 def failFast = false
 
-properties([buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '20'))])
+properties([buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '20')), durabilityHint('PERFORMANCE_OPTIMIZED')])
 
 // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc for information on what node types are available
 def buildTypes = ['Linux', 'Windows']


### PR DESCRIPTION
Minor JenkinsFile improvement: should reduce IO needs of the Jenkins master when it's being all meta and building itself.

Docs behind the mode: https://jenkins.io/doc/book/pipeline/scaling-pipeline/

Why is it safe to use performance-optimized build?  If we somehow manage to trigger an unplanned failure of the master during a build, we can always rerun these builds (higher durability for pipelines doesn't buy us much here).

Edit: and for normal maintenance, we won't lose anything because the Pipelines auto-persist any unsaved data when the master is shutting down.

### Desired reviewers

@rtyler 