### PR TITLE
[JENKINS-49588] add readResolve method for 'usages' in Fingerprint.java

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -868,7 +868,7 @@ public class Fingerprint implements ModelObject, Saveable {
     /**
      * Range of builds that use this file keyed by a job full name.
      */
-    private final Hashtable<String,RangeSet> usages = new Hashtable<String,RangeSet>();
+    private Hashtable<String,RangeSet> usages = new Hashtable<String,RangeSet>();
 
     PersistedList<FingerprintFacet> facets = new PersistedList<FingerprintFacet>(this);
 
@@ -1029,6 +1029,14 @@ public class Fingerprint implements ModelObject, Saveable {
     public synchronized void add(@Nonnull String jobFullName, int n) throws IOException {
         addWithoutSaving(jobFullName, n);
         save();
+    }
+
+    // JENKINS-49588
+    protected Object readResolve() {
+        if (usages == null) {
+            usages = new Hashtable<String,RangeSet>();
+        }
+        return this;
     }
 
     void addWithoutSaving(@Nonnull String jobFullName, int n) {

--- a/core/src/test/java/hudson/model/FingerprintTest.java
+++ b/core/src/test/java/hudson/model/FingerprintTest.java
@@ -222,6 +222,13 @@ public class FingerprintTest {
                 Fingerprint.load(new File(FingerprintTest.class.getResource("fingerprint.xml").toURI())).toString());
     }
 
+    @Test public void loadFingerprintWithoutUsages() throws Exception {
+        Fingerprint fp = Fingerprint.load(new File(FingerprintTest.class.getResource("fingerprintWithoutUsages.xml").toURI()));
+        assertNotNull(fp);
+        assertEquals("test:jenkinsfile-example-1.0-SNAPSHOT.jar", fp.getFileName());
+        assertNotNull(fp.getUsages());
+    }
+
     @Test public void roundTrip() throws Exception {
         Fingerprint f = new Fingerprint(new Fingerprint.BuildPtr("foo", 13), "stuff&more.jar", SOME_MD5);
         f.addWithoutSaving("some", 1);

--- a/core/src/test/resources/hudson/model/fingerprintWithoutUsages.xml
+++ b/core/src/test/resources/hudson/model/fingerprintWithoutUsages.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<fingerprint>
+  <timestamp>2018-02-21 16:33:12.291 UTC</timestamp>
+  <original>
+    <name>maven1/test:jenkinsfile-example</name>
+    <number>4</number>
+  </original>
+  <md5sum>f003726dfd1d07868e3c1ab5aab0682d</md5sum>
+  <fileName>test:jenkinsfile-example-1.0-SNAPSHOT.jar</fileName>
+  <facets/>
+</fingerprint>


### PR DESCRIPTION
add readResolve method to ensure that <usages ../> is always initialized properly when deserializing a fingerprint

See [JENKINS-49588](https://issues.jenkins-ci.org/browse/JENKINS-49588).

- It is not clear how this situation (a Fingerprint file without any usages being serialized to disk) is occuring, but this fix will prevent it from blowing up in the event that it does happen.  

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: `Internal:` Added `readResolve` method to Fingerprint.java to ensure the `usages` field is always initialized


<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @batmat @oleg-nenashev 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
