### PR TITLE
TextFileTest.tail failed on Windows when using a source checkout with Unix newlines

### DIFF
--- a/core/src/test/java/hudson/util/TextFileTest.java
+++ b/core/src/test/java/hudson/util/TextFileTest.java
@@ -40,10 +40,9 @@ public class TextFileTest {
     public void tail() throws Exception {
         File f = tmp.newFile();
         FileUtils.copyURLToFile(getClass().getResource("ascii.txt"), f);
-
+        String whole = FileUtils.readFileToString(f);
         TextFile t = new TextFile(f);
-        String tailStr = "la, vitae interdum quam rutrum id." + System.lineSeparator();
-        assertEquals(34 + System.lineSeparator().length(), tailStr.length());
+        String tailStr = whole.substring(whole.length() - 34);
         assertEquals(tailStr, t.fastTail(tailStr.length()));
     }
 


### PR DESCRIPTION
Not sure what CI environment change started making this fail—I saw it in #3254 but apparently _every_ core PR build is now failing—but at any rate I could reproduce this locally on Windows 10 sharing a checkout of `jenkinsci/jenkins` from Linux:

```
org.junit.ComparisonFailure: 
expected:<l[a, vitae interdum quam rutrum id.
]
> but was:<l[la, vitae interdum quam rutrum id.]
>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at hudson.util.TextFileTest.tail(TextFileTest.java:47)
```

@reviewbybees @jenkinsci/code-reviewers