### PR TITLE
[JENKINS-49795] Fix bad serialization of ParametersAction.parameterDefinitionNames and make sure this kind of mistake produces a warning in the future

### DIFF
--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -296,7 +296,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
     public void onAttached(Run<?, ?> r) {
         ParametersDefinitionProperty p = r.getParent().getProperty(ParametersDefinitionProperty.class);
         if (p != null) {
-            this.parameterDefinitionNames = p.getParameterDefinitionNames();
+            this.parameterDefinitionNames = new ArrayList<>(p.getParameterDefinitionNames());
         } else {
             this.parameterDefinitionNames = Collections.emptyList();
         }

--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -156,6 +156,13 @@ public class ClassFilterImpl extends ClassFilter {
             }
             String location = codeSource(c);
             if (location != null) {
+                if (c.isAnonymousClass()) { // e.g., pkg.Outer$1
+                    LOGGER.warning("JENKINS-49573: attempt to serialize anonymous " + c + " in " + location);
+                } else if (c.isLocalClass()) { // e.g., pkg.Outer$1Local
+                    LOGGER.warning("JENKINS-49573: attempt to serialize local " + c + " in " + location);
+                } else if (c.isSynthetic()) { // e.g., pkg.Outer$$Lambda$1/12345678
+                    LOGGER.warning("JENKINS-49573: attempt to serialize synthetic " + c + " in " + location);
+                }
                 if (isLocationWhitelisted(location)) {
                     LOGGER.log(Level.FINE, "permitting {0} due to its location in {1}", new Object[] {name, location});
                     return false;

--- a/test/src/test/java/hudson/model/ParametersAction2Test.java
+++ b/test/src/test/java/hudson/model/ParametersAction2Test.java
@@ -2,28 +2,30 @@ package hudson.model;
 
 import hudson.Functions;
 import hudson.Launcher;
-import hudson.model.queue.QueueTaskFuture;
-import hudson.tasks.BatchFile;
+import hudson.XmlFile;
 import hudson.tasks.Builder;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.recipes.LocalData;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class ParametersAction2Test {
     @Rule
     public JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public LoggerRule logs = new LoggerRule().record("", Level.WARNING).capture(100);
 
     @Test
     @Issue("SECURITY-170")
@@ -307,6 +309,16 @@ public class ParametersAction2Test {
         assertEquals(1, p2.getLastBuild().getAction(ParametersAction.class).getParameters().size());
         assertEquals(p1.getLastBuild().getAction(ParametersAction.class).getParameter("foo").getValue(), "for p1");
         assertEquals(p2.getLastBuild().getAction(ParametersAction.class).getParameter("foo").getValue(), "for p2");
+    }
+
+    @Issue("JENKINS-49573")
+    @Test
+    public void noInnerClasses() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("key", "sensible-default")));
+        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("key", "value"))));
+        assertThat(new XmlFile(Run.XSTREAM, new File(b.getRootDir(), "build.xml")).asString(), not(containsString("sensible-default")));
+        assertEquals(Collections.emptyList(), logs.getMessages());
     }
 
     public static boolean hasParameterWithName(Iterable<ParameterValue> values, String name) {


### PR DESCRIPTION
See [JENKINS-49795](https://issues.jenkins-ci.org/browse/JENKINS-49795). The mistake corrected in https://github.com/jenkinsci/matrix-combinations-plugin/pull/25 was aggravated by the surprising fact that a parameter _definition_ was being serialized to a _build_ record, due to an innocent-looking change by @amuniz 0ce2a1ae3a4abfa2ef43d1bd90c685dd27172562 for SECURITY-170 which for almost two years has saved junk to the `build.xml` of every project with parameters.

Before:

```xml
<parameterDefinitionNames class="hudson.model.ParametersDefinitionProperty$1">
  <outer-class>
    <parameterDefinitions class="java.util.Arrays$ArrayList">
      <a class="hudson.model.ParameterDefinition-array">
        <hudson.model.StringParameterDefinition>
          <name>key</name>
          <defaultValue>sensible-default</defaultValue>
          <trim>false</trim>
        </hudson.model.StringParameterDefinition>
      </a>
    </parameterDefinitions>
  </outer-class>
</parameterDefinitionNames>
```

After:

```xml
<parameterDefinitionNames>
  <string>key</string>
</parameterDefinitionNames>
```

### Proposed changelog entries

* Cleaning up the format of `build.xml` files from parameterized projects.
* Issuing warnings to the system log when attempts are made to use classes with unpredictable names and serial forms (such as anonymous classes) in Remoting or XStream serialization or deserialization.

@reviewbybees @jenkinsci/code-reviewers