### PR TITLE
[JENKINS-49543] Old versions of Tomcat also failed to serialize classes from Jenkins modules

### DIFF
--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -273,6 +273,10 @@ public class ClassFilterImpl extends ClassFilter {
                 r = r.substring(0, r.length() - suffix.length());
             }
         }
+        if (r.startsWith("jar:file:/") && r.endsWith(".jar!/")) {
+            // JENKINS-49543: also an old behavior of Tomcat. Legal enough, but unexpected by isLocationWhitelisted.
+            r = r.substring(4, r.length() - 2);
+        }
         return r;
     }
 


### PR DESCRIPTION
See [JENKINS-49543](https://issues.jenkins-ci.org/browse/JENKINS-49543). Amends #3264.

### Proposed changelog entries

* JENKINS-49543: fix for JEP-200 issues in old versions of Tomcat was not complete; known to cause errors at least when saving user configurations.

### Desired reviewers

@reviewbybees @jenkinsci/code-reviewers