### PR TITLE
progress-bar: you cannot add a background to a TR

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1598,8 +1598,9 @@ table.progress-bar {
   clear: none;
 }
 
-table.progress-bar tr.unknown {
-    background-image:url(../images/progress-unknown.gif);
+table.progress-bar tr.unknown td {
+	background-image:url(../images/progress-unknown.gif);
+	background-repeat: repeat-x;
 }
 
 td.progress-bar-done {
@@ -1614,8 +1615,8 @@ table.progress-bar.red {
   border: 1px solid #cc0000;
 }
 
-table.progress-bar.red tr.unknown {
-    background-image:url(../images/progress-unknown-red.gif);
+table.progress-bar.red tr.unknown td {
+	background-image:url(../images/progress-unknown-red.gif);
 }
 table.progress-bar.red td.progress-bar-done {
   background-color: #cc0000;


### PR DESCRIPTION
In CSS, you cannot add a `background-image` (or any
background) to a TR element.

With this fix, the barber-strip "unknown" progress bark re-appears.

I found this bug when filing [JENKINS-49749](https://issues.jenkins-ci.org/browse/JENKINS-49749)