### PR TITLE
[JENKINS-32599] Ignore misplaced users/config.xml file

### DIFF
--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -1092,6 +1092,9 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
             File[] subdirs = getRootDir().listFiles((FileFilter) DirectoryFileFilter.INSTANCE);
             if (subdirs != null) {
                 for (File subdir : subdirs) {
+                    if (subdir.equals(getRootDir())) {
+                        continue; // ignore the parent directory in case of stray config.xml
+                    }
                     File configFile = new File(subdir, "config.xml");
                     if (configFile.exists()) {
                         String name = strategy.idFromFilename(subdir.getName());


### PR DESCRIPTION
See [JENKINS-32599](https://issues.jenkins-ci.org/browse/JENKINS-32599).

Not sure this warrants a test.

### Proposed changelog entries

* Bug: Ignore misplaced config.xml file directly in users/ directory

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
