### PR TITLE
Remove jcifs dependency from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,11 +233,6 @@ THE SOFTWARE.
         <scope>provided</scope><!-- by log4j-over-slf4j -->
       </dependency>
       <dependency>
-        <groupId>org.samba.jcifs</groupId>
-        <artifactId>jcifs</artifactId>
-        <version>1.3.17-kohsuke-1</version>
-      </dependency>
-      <dependency>
         <groupId>org.kohsuke</groupId>
         <artifactId>access-modifier-annotation</artifactId>
         <version>${access-modifier-annotation.version}</version>


### PR DESCRIPTION
Jenkins core has a dependency on jcifs, but it doesn't seem to be used anywhere in core. I ran the full test suite after removing this dependency and all the tests passed. Removing this will make it easier to use newer versions or non-conflicting versions in plugins as necessary. There are no additional tests needed as this is just a dependency cleanup.

### Proposed changelog entries

* Internal: Remove unused dependency on jcifs from core

### Submitter checklist

- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@daniel-beck @oleg-nenashev 
