### PR TITLE
[JENKINS-47020] - Improve job search experience

### DIFF
--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -140,7 +140,7 @@ public class Search {
     public SearchResult getSuggestions(StaplerRequest req, String query) {
         Set<String> paths = new HashSet<String>();  // paths already added, to control duplicates
         SearchResultImpl r = new SearchResultImpl();
-        int max = req.hasParameter("max") ? Integer.parseInt(req.getParameter("max")) : 20;
+        int max = req.hasParameter("max") ? Integer.parseInt(req.getParameter("max")) : 100;
         SearchableModelObject smo = findClosestSearchableModelObject(req);
         for (SuggestedItem i : suggest(makeSuggestIndex(req), query, smo)) {
             if(r.size()>=max) {

--- a/core/src/main/resources/hudson/search/Search/search-failed.jelly
+++ b/core/src/main/resources/hudson/search/Search/search-failed.jelly
@@ -48,8 +48,8 @@ THE SOFTWARE.
             </j:forEach>
           </ol>
             <j:if test="${items.hasMoreResults()}">
-                <j:set var="max" value="${request.hasParameter('max')?request.getParameter('max'):20}"/>
-                <em>result has been truncated, <a href="?q=${it.encodeQuery(q)}&amp;max=${max+20}">see 20 more</a></em>
+                <j:set var="max" value="${request.hasParameter('max')?request.getParameter('max'):100}"/>
+                <em>result has been truncated, <a href="?q=${it.encodeQuery(q)}&amp;max=${max+100}">see 100 more</a></em>
             </j:if>
         </j:otherwise>
       </j:choose>

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1493,7 +1493,7 @@ DIV.yahooTree td {
 
 #search-box-completion .yui-ac-content {
   border: 1px solid black;
-  width:25em;
+  width:35em;
   background-color: white;
   overflow: hidden;
 }

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2373,6 +2373,7 @@ function createSearchBox(searchURL) {
     ac.typeAhead = false;
     ac.autoHighlight = false;
     ac.formatResult = ac.formatEscapedResult;
+    ac.maxResultsDisplayed = 25;
 
     var box   = $("search-box");
     var sizer = $("search-box-sizer");


### PR DESCRIPTION
See [JENKINS-47020](https://issues.jenkins-ci.org/browse/JENKINS-47020).

* search screen should return 100 results instead of 20
* auto-complete search to return 20 results instead of 10
* width of auto-complete results increased from 25em to 35em

### Proposed changelog entries

* JENKINS-47020, Search user experience: Change the default Item search result pagination from 20 to 100 

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

![jenkins-search-25results-35em-width](https://user-images.githubusercontent.com/102495/36979611-5a3c4668-2088-11e8-8694-5d007209f1a4.png)
