### PR TITLE
Fixing serialization of InstallState

### DIFF
--- a/core/src/main/java/jenkins/install/InstallState.java
+++ b/core/src/main/java/jenkins/install/InstallState.java
@@ -45,16 +45,36 @@ import org.apache.commons.lang.StringUtils;
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 public class InstallState implements ExtensionPoint {
+
+    /**
+     * Only here for XStream compatibility.
+     * @see #readResolve
+     */
+    @Deprecated
+    @SuppressWarnings("MismatchedReadAndWriteOfArray")
+    private static final InstallState[] UNUSED_INNER_CLASSES = {
+        new InstallState("UNKNOWN", false) {},
+        new InstallState("INITIAL_SETUP_COMPLETED", false) {},
+        new InstallState("CREATE_ADMIN_USER", false) {},
+        new InstallState("INITIAL_SECURITY_SETUP", false) {},
+        new InstallState("RESTART", false) {},
+        new InstallState("DOWNGRADE", false) {},
+    };
+
     /**
      * Need InstallState != NEW for tests by default
      */
     @Extension
-    public static final InstallState UNKNOWN = new InstallState("UNKNOWN", true) {
+    public static final InstallState UNKNOWN = new Unknown();
+    private static class Unknown extends InstallState {
+        Unknown() {
+            super("UNKNOWN", true);
+        }
         @Override
         public void initializeState() {
             InstallUtil.proceedToNextStateFrom(this);
         }
-    };
+    }
     
     /**
      * After any setup / restart / etc. hooks are done, states should be running
@@ -66,7 +86,11 @@ public class InstallState implements ExtensionPoint {
      * The initial set up has been completed
      */
     @Extension
-    public static final InstallState INITIAL_SETUP_COMPLETED = new InstallState("INITIAL_SETUP_COMPLETED", true) {
+    public static final InstallState INITIAL_SETUP_COMPLETED = new InitialSetupCompleted();
+    private static final class InitialSetupCompleted extends InstallState {
+        InitialSetupCompleted() {
+            super("INITIAL_SETUP_COMPLETED", true);
+        }
         public void initializeState() {
             Jenkins j = Jenkins.getInstance();
             try {
@@ -82,7 +106,11 @@ public class InstallState implements ExtensionPoint {
      * Creating an admin user for an initial Jenkins install.
      */
     @Extension
-    public static final InstallState CREATE_ADMIN_USER = new InstallState("CREATE_ADMIN_USER", false) {
+    public static final InstallState CREATE_ADMIN_USER = new CreateAdminUser();
+    private static final class CreateAdminUser extends InstallState {
+        CreateAdminUser() {
+            super("CREATE_ADMIN_USER", false);
+        }
         public void initializeState() {
             Jenkins j = Jenkins.getInstance();
             // Skip this state if not using the security defaults
@@ -104,7 +132,11 @@ public class InstallState implements ExtensionPoint {
      * Security setup for a new Jenkins install.
      */
     @Extension
-    public static final InstallState INITIAL_SECURITY_SETUP = new InstallState("INITIAL_SECURITY_SETUP", false) {
+    public static final InstallState INITIAL_SECURITY_SETUP = new InitialSecuritySetup();
+    private static final class InitialSecuritySetup extends InstallState {
+        InitialSecuritySetup() {
+            super("INITIAL_SECURITY_SETUP", false);
+        }
         public void initializeState() {
             try {
                 Jenkins.getInstance().getSetupWizard().init(true);
@@ -126,7 +158,11 @@ public class InstallState implements ExtensionPoint {
      * Restart of an existing Jenkins install.
      */
     @Extension
-    public static final InstallState RESTART = new InstallState("RESTART", true) {
+    public static final InstallState RESTART = new Restart();
+    private static final class Restart extends InstallState {
+        Restart() {
+            super("RESTART", true);
+        }
         public void initializeState() {
             InstallUtil.saveLastExecVersion();
         }
@@ -142,7 +178,11 @@ public class InstallState implements ExtensionPoint {
      * Downgrade of an existing Jenkins install.
      */
     @Extension
-    public static final InstallState DOWNGRADE = new InstallState("DOWNGRADE", true) {
+    public static final InstallState DOWNGRADE = new Downgrade();
+    private static final class Downgrade extends InstallState {
+        Downgrade() {
+            super("DOWNGRADE", true);
+        }
         public void initializeState() {
             InstallUtil.saveLastExecVersion();
         }
@@ -161,7 +201,7 @@ public class InstallState implements ExtensionPoint {
      */
     public static final InstallState DEVELOPMENT = new InstallState("DEVELOPMENT", true);
 
-    private final boolean isSetupComplete;
+    private final transient boolean isSetupComplete;
     private final String name;
 
     public InstallState(@Nonnull String name, boolean isSetupComplete) {
@@ -174,7 +214,13 @@ public class InstallState implements ExtensionPoint {
      */
     public void initializeState() {
     }
-    
+
+    /**
+     * The actual class name is irrelevant; this is functionally an enum.
+     * <p>Creating a {@code writeReplace} does not help much since XStream then just saves:
+     * {@code <installState class="jenkins.install.InstallState$CreateAdminUser" resolves-to="jenkins.install.InstallState">}
+     * @see #UNUSED_INNER_CLASSES
+     */
     public Object readResolve() {
         // If we get invalid state from the configuration, fallback to unknown
         if (StringUtils.isBlank(name)) {

--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -157,11 +157,11 @@ public class ClassFilterImpl extends ClassFilter {
             String location = codeSource(c);
             if (location != null) {
                 if (c.isAnonymousClass()) { // e.g., pkg.Outer$1
-                    LOGGER.warning("JENKINS-49573: attempt to serialize anonymous " + c + " in " + location);
+                    LOGGER.warning("JENKINS-49573: attempt to (de-)serialize anonymous " + c + " in " + location);
                 } else if (c.isLocalClass()) { // e.g., pkg.Outer$1Local
-                    LOGGER.warning("JENKINS-49573: attempt to serialize local " + c + " in " + location);
+                    LOGGER.warning("JENKINS-49573: attempt to (de-)serialize local " + c + " in " + location);
                 } else if (c.isSynthetic()) { // e.g., pkg.Outer$$Lambda$1/12345678
-                    LOGGER.warning("JENKINS-49573: attempt to serialize synthetic " + c + " in " + location);
+                    LOGGER.warning("JENKINS-49573: attempt to (de-)serialize synthetic " + c + " in " + location);
                 }
                 if (isLocationWhitelisted(location)) {
                     LOGGER.log(Level.FINE, "permitting {0} due to its location in {1}", new Object[] {name, location});


### PR DESCRIPTION
Follows up #3312. We were apparently always storing junk in `$JENKINS_HOME/config.xml` and just never noticed before; with that patch but without this one, Jenkins prints warnings during initial setup. If anyone had ever randomly inserted, say,

```java
private static void whatever() {
    Timer.get().submit(new Runnable() {
        @Override
        public void run() {
            // something unrelated
        }
    });
}
```

into `InstallState.java`, we would have broken upgrades for users—depending on the position this was added to the source file. Ouch.

Tested manually, with the help of

```diff
diff --git a/core/src/main/java/jenkins/model/Jenkins.java b/core/src/main/java/jenkins/model/Jenkins.java
index 15a4edce00..dfb49bb8c4 100644
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3166,6 +3166,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
 
         getConfigFile().write(this);
+        new Throwable(getConfigFile().asString()).printStackTrace();
         SaveableListener.fireOnChange(this, getConfigFile());
     }
 
```

Tested upgrade against an anonymous inner class install state saved from 2.107.

### Proposed changelog entries

* Making storage of the Jenkins setup wizard’s installation state simpler and more robust.

### Desired reviewers

@jenkinsci/code-reviewers @reviewbybees