### PR TITLE
[JENKINS-49906] Use more specific and less urgent message when renaming

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -284,6 +284,9 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         try {
             Jenkins.checkGoodName(newName);
             assert newName != null; // Would have thrown Failure
+            if (newName.equals(name)) {
+                return FormValidation.warning(Messages.AbstractItem_NewNameUnchanged());
+            }
             Jenkins.get().getProjectNamingStrategy().checkName(newName);
             checkIfNameIsUsed(newName);
             checkRename(newName);

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -36,6 +36,7 @@ AbstractItem.BeingDeleted={0} is currently being deleted
 AbstractItem.FailureToStopBuilds=Failed to interrupt and stop {0,choice,1#{0,number,integer} build|1<{0,number,integer} \
   builds} of {1}
 AbstractItem.NewNameInUse=The name \u201c{0}\u201d is already in use.
+AbstractItem.NewNameUnchanged=The new name is the same as the current name.
 AbstractProject.AssignedLabelString_NoMatch_DidYouMean=There\u2019s no agent/cloud that matches this assignment. Did you mean \u2018{1}\u2019 instead of \u2018{0}\u2019?
 AbstractProject.NewBuildForWorkspace=Scheduling a new build to get a workspace.
 AbstractProject.AwaitingBuildForWorkspace=Awaiting build to get a workspace.

--- a/test/src/test/java/hudson/model/AbstractItemTest.java
+++ b/test/src/test/java/hudson/model/AbstractItemTest.java
@@ -63,11 +63,13 @@ public class AbstractItemTest {
     public void checkRenameValidity() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject("foo");
         p.getBuildersList().add(new SleepBuilder(10));
+        j.createFreeStyleProject("foo-exists");
 
         assertThat(checkNameAndReturnError(p, ""), equalTo(Messages.Hudson_NoName()));
         assertThat(checkNameAndReturnError(p, ".."), equalTo(Messages.Jenkins_NotAllowedName("..")));
         assertThat(checkNameAndReturnError(p, "50%"), equalTo(Messages.Hudson_UnsafeChar('%')));
-        assertThat(checkNameAndReturnError(p, "foo"), equalTo(Messages.AbstractItem_NewNameInUse("foo")));
+        assertThat(checkNameAndReturnError(p, "foo"), equalTo(Messages.AbstractItem_NewNameUnchanged()));
+        assertThat(checkNameAndReturnError(p, "foo-exists"), equalTo(Messages.AbstractItem_NewNameInUse("foo-exists")));
 
         j.jenkins.setProjectNamingStrategy(new ProjectNamingStrategy.PatternProjectNamingStrategy("bar", "", false));
         assertThat(checkNameAndReturnError(p, "foo1"), equalTo(jenkins.model.Messages.Hudson_JobNameConventionNotApplyed("foo1", "bar")));
@@ -84,12 +86,13 @@ public class AbstractItemTest {
         mas.grant(Item.READ).everywhere().to("alice");
         j.jenkins.setAuthorizationStrategy(mas);
         FreeStyleProject p = j.createFreeStyleProject("foo");
+        j.createFreeStyleProject("foo-exists");
 
         try (ACLContext unused = ACL.as(User.getById("alice", true))) {
-            assertThat(checkNameAndReturnError(p, "foo"), equalTo(Messages.AbstractItem_NewNameInUse("foo")));
+            assertThat(checkNameAndReturnError(p, "foo-exists"), equalTo(Messages.AbstractItem_NewNameInUse("foo-exists")));
         }
         try (ACLContext unused = ACL.as(User.getById("bob", true))) {
-            assertThat(checkNameAndReturnError(p, "foo"), equalTo(Messages.Jenkins_NotAllowedName("foo")));
+            assertThat(checkNameAndReturnError(p, "foo-exists"), equalTo(Messages.Jenkins_NotAllowedName("foo-exists")));
         }
         try (ACLContext unused = ACL.as(User.getById("carol", true))) {
             try {


### PR DESCRIPTION
See [JENKINS-49906](https://issues.jenkins-ci.org/browse/JENKINS-49906).

I have changed the error to a warning and made the message more specific.

Before:
<img width="1439" alt="screen shot 2018-03-05 at 14 47 33" src="https://user-images.githubusercontent.com/1068968/37003736-157ce4ec-209c-11e8-90f5-8dece12e919c.png">

After:
<img width="1440" alt="screen shot 2018-03-05 at 14 41 05" src="https://user-images.githubusercontent.com/1068968/37003743-1acf00ba-209c-11e8-8dc9-e27030b0ffe4.png">

### Proposed changelog entries

* [JENKINS-49906](https://issues.jenkins-ci.org/browse/JENKINS-49906), Improve the error message displayed when renaming an item without changing the name.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @daniel-beck 
