### PR TITLE
[JENKINS-39495] Defend against a null serialized ParametersAction.parameters

### DIFF
--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -87,7 +87,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
 
     private Set<String> safeParameters;
 
-    private final List<ParameterValue> parameters;
+    private @Nonnull List<ParameterValue> parameters;
 
     private List<String> parameterDefinitionNames;
 
@@ -99,7 +99,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
 
     private transient Run<?, ?> run;
 
-    public ParametersAction(List<ParameterValue> parameters) {
+    public ParametersAction(@Nonnull List<ParameterValue> parameters) {
         this.parameters = new ArrayList<>(parameters);
         String paramNames = SystemProperties.getString(SAFE_PARAMETERS_SYSTEM_PROPERTY_NAME);
         safeParameters = new TreeSet<>();
@@ -284,6 +284,9 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
     }
 
     private Object readResolve() {
+        if (parameters == null) { // JENKINS-39495
+            parameters = Collections.emptyList();
+        }
         if (build != null)
             OldDataMonitor.report(build, "1.283");
         if (safeParameters == null) {


### PR DESCRIPTION
See [JENKINS-39495](https://issues.jenkins-ci.org/browse/JENKINS-39495). Much simpler alternative to #2616. As of #3028, the constructor already throws a `NullPointerException` if you pass a null argument. Great—keep that, and just defend against null serial data, for which we cannot issue any kind of helpful warning anyway so why bother.

### Proposed changelog entries

* `NullPointerException` after restarts given an as-yet-undiagnosed plugin bug passing a null parameter list.

### Desired reviewers

@jenkinsci/code-reviewers @reviewbybees