### PR TITLE
[JENKINS-48821] - Don't forget estimated duration of asynchronous jobs

### DIFF
--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -457,7 +457,6 @@ public class Executor extends Thread implements ModelObject {
             LOGGER.log(SEVERE, getName()+": Unexpected executor death", e);
         } finally {
             if (asynchronousExecution == null) {
-            	executableEstimatedDuration = DEFAULT_ESTIMATED_DURATION;
                 finish2();
             }
         }
@@ -490,6 +489,7 @@ public class Executor extends Thread implements ModelObject {
         if (this instanceof OneOffExecutor) {
             owner.remove((OneOffExecutor) this);
         }
+        executableEstimatedDuration = DEFAULT_ESTIMATED_DURATION;
         queue.scheduleMaintenance();
     }
 

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -457,9 +457,9 @@ public class Executor extends Thread implements ModelObject {
             LOGGER.log(SEVERE, getName()+": Unexpected executor death", e);
         } finally {
             if (asynchronousExecution == null) {
+            	executableEstimatedDuration = DEFAULT_ESTIMATED_DURATION;
                 finish2();
             }
-            executableEstimatedDuration = DEFAULT_ESTIMATED_DURATION;
         }
     }
 


### PR DESCRIPTION
When jobs are executed, the estimated duration is calculated, memorized
and reseted when the job is finished.

But when the job is executed asynchronously (e.g. as for pipeline
scripts), the execution is just triggered. Therefore the estimated
duration should remain - and not be reseted after triggering.

[JENKINS-48821](https://issues.jenkins-ci.org/browse/JENKINS-48821): Time remaining for all pipeline jobs is N/A
[JENKINS-49616](https://issues.jenkins-ci.org/browse/JENKINS-49616): Estimated time remaining NA

### Proposed changelog entries

* Display estimated remaining time again for pipeline jobs.

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@mention
