### PR TITLE
Update triggerRemotely documentation

### DIFF
--- a/war/src/main/webapp/help/project-config/triggerRemotely.html
+++ b/war/src/main/webapp/help/project-config/triggerRemotely.html
@@ -9,4 +9,10 @@
   <p>You'll need to provide an authorization token in the form of
   a string so that only those who know it would be able to remotely
   trigger this project's builds.</p>
+  <p>Your script will not be able to reach the trigger URL if your
+  Jenkins instance is configured without the read permission for
+  anonymous users. To circumvent this limitation please install the
+  <a href="https://wiki.jenkins.io/display/JENKINS/Build+Token+Root+Plugin" target="_blank">
+  Build Token Root Plugin
+  </a></p>
 </div>

--- a/war/src/main/webapp/help/project-config/triggerRemotely.html
+++ b/war/src/main/webapp/help/project-config/triggerRemotely.html
@@ -12,7 +12,7 @@
   <p>Your script will not be able to reach the trigger URL if your
   Jenkins instance is configured without the read permission for
   anonymous users. To circumvent this limitation please install the
-  <a href="https://wiki.jenkins.io/display/JENKINS/Build+Token+Root+Plugin" target="_blank">
+  <a href="https://plugins.jenkins.io/build-token-root" target="_blank">
   Build Token Root Plugin
   </a></p>
 </div>


### PR DESCRIPTION
It took me quite a while to find out that the trigger endpoint doesn't work when anonymous users don't have read access, even though you use a special authentication token. With this update to the docs I hope to prevent others from falling into this trap.