### PR TITLE
access-modifier.version=1.13

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -809,9 +809,14 @@ public class CLI implements AutoCloseable {
         return authenticate(Collections.singleton(key));
     }
 
+    /** For access from {@code HelpCommand}. */
+    static String usage() {
+        return Messages.CLI_Usage();
+    }
+
     private static void printUsage(String msg) {
         if(msg!=null)   System.out.println(msg);
-        System.err.println(Messages.CLI_Usage());
+        System.err.println(usage());
     }
 
     static final Logger LOGGER = Logger.getLogger(CLI.class.getName());

--- a/core/src/main/java/hudson/cli/DeleteBuildsCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteBuildsCommand.java
@@ -31,14 +31,14 @@ import java.io.PrintStream;
 import java.util.HashSet;
 import java.util.List;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Deletes builds records in a bulk.
  *
  * @author Kohsuke Kawaguchi
  */
-@Restricted(DoNotUse.class) // command implementation only
+@Restricted(NoExternalUse.class) // command implementation only
 @Extension
 public class DeleteBuildsCommand extends RunRangeCommand {
     @Override

--- a/core/src/main/java/hudson/cli/HelpCommand.java
+++ b/core/src/main/java/hudson/cli/HelpCommand.java
@@ -53,7 +53,7 @@ public class HelpCommand extends CLICommand {
     protected int run() throws Exception {
         if (!Jenkins.getActiveInstance().hasPermission(Jenkins.READ)) {
             throw new AccessDeniedException("You must authenticate to access this Jenkins.\n"
-                    + hudson.cli.client.Messages.CLI_Usage());
+                    + CLI.usage());
         }
 
         if (command != null)

--- a/core/src/main/java/hudson/cli/ListChangesCommand.java
+++ b/core/src/main/java/hudson/cli/ListChangesCommand.java
@@ -15,14 +15,14 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Retrieves a change list for the specified builds.
  *
  * @author Kohsuke Kawaguchi
  */
-@Restricted(DoNotUse.class) // command implementation only
+@Restricted(NoExternalUse.class) // command implementation only
 @Extension
 public class ListChangesCommand extends RunRangeCommand {
     @Override

--- a/core/src/main/java/jenkins/model/NewViewLink.java
+++ b/core/src/main/java/jenkins/model/NewViewLink.java
@@ -9,10 +9,10 @@ import java.util.Collections;
 import java.util.List;
 
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 @Extension
-@Restricted(DoNotUse.class)
+@Restricted(NoExternalUse.class)
 public class NewViewLink extends TransientViewActionFactory {
 
     @VisibleForTesting

--- a/core/src/main/java/jenkins/security/CustomClassFilter.java
+++ b/core/src/main/java/jenkins/security/CustomClassFilter.java
@@ -44,7 +44,6 @@ import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
@@ -83,7 +82,7 @@ public interface CustomClassFilter extends ExtensionPoint {
      * Entries may also be preceded by {@code !} to blacklist.
      * Example: {@code -Dhudson.remoting.ClassFilter=com.google.common.collect.LinkedListMultimap,!com.acme.illadvised.YoloReflectionFactory$Handle}
      */
-    @Restricted(DoNotUse.class)
+    @Restricted(NoExternalUse.class)
     @Extension
     public class Static implements CustomClassFilter {
 

--- a/core/src/main/java/jenkins/security/s2m/DefaultFilePathFilter.java
+++ b/core/src/main/java/jenkins/security/s2m/DefaultFilePathFilter.java
@@ -30,7 +30,7 @@ import hudson.remoting.ChannelBuilder;
 import jenkins.ReflectiveFilePathFilter;
 import jenkins.security.ChannelConfigurator;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.File;
 import java.util.logging.Level;
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
 /**
  * Blocks agents from writing to files on the master by default (and also provide the kill switch.)
  */
-@Restricted(DoNotUse.class) // impl
+@Restricted(NoExternalUse.class) // impl
 @Extension public class DefaultFilePathFilter extends ChannelConfigurator {
 
     /**

--- a/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
+++ b/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
@@ -52,7 +52,7 @@ import jenkins.model.DependencyDeclarer;
 import jenkins.model.RunAction2;
 import jenkins.model.TransientActionFactory;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * A build step (like a {@link Builder} or {@link Publisher}) which may be called at an arbitrary time during a build (or multiple times), run, and be done.
@@ -103,7 +103,7 @@ public interface SimpleBuildStep extends BuildStep {
     }
 
     @SuppressWarnings("rawtypes")
-    @Restricted(DoNotUse.class)
+    @Restricted(NoExternalUse.class)
     @Extension
     public static final class LastBuildActionFactory extends TransientActionFactory<Job> {
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@ THE SOFTWARE.
     <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <findbugs.failOnError>true</findbugs.failOnError>
-    <access-modifier.version>1.12</access-modifier.version>
+    <access-modifier.version>1.13</access-modifier.version>
     <access-modifier-annotation.version>${access-modifier.version}</access-modifier-annotation.version> <!-- differing only where needed for timestamped snapshots -->
     <access-modifier-checker.version>${access-modifier.version}</access-modifier-checker.version>
 


### PR DESCRIPTION
Mainly picks up https://github.com/kohsuke/access-modifier/pull/7. Just for completeness; probably not very relevant since the important aspect is https://github.com/jenkinsci/plugin-pom/pull/97. No changelog required I think.

@jenkinsci/code-reviewers @reviewbybees