### PR TITLE
[JENKINS-49737 ] - Update Extras Executable WAR to 1.38

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -49,7 +49,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>executable-war</artifactId>
-      <version>1.37</version>
+      <version>1.38-20180310.154259-1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -49,7 +49,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>executable-war</artifactId>
-      <version>1.38-20180310.154259-1</version>
+      <version>1.38</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Just a minor facelift + [JENKINS-49737](https://issues.jenkins-ci.org/browse/JENKINS-49737) from @AmitJMagar:

* Changelog: https://github.com/jenkinsci/extras-executable-war/blob/master/CHANGELOG.md#138
* Full diff: https://github.com/jenkinsci/extras-executable-war/compare/executable-war-1.37...executable-war-1.38

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* JENKINS-49737: Extras Executable War 1.38: Show startup warnings when running Jenkins on Java 9 or above.
  * Full changelog: https://github.com/jenkinsci/extras-executable-war/blob/master/CHANGELOG.md#138
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/code-reviewers 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
