### PR TITLE
Amends #3211: Restore Source compatibility of hudson.util.TextFile#lines()

### DIFF
--- a/core/src/main/java/hudson/util/TextFile.java
+++ b/core/src/main/java/hudson/util/TextFile.java
@@ -23,7 +23,6 @@
  */
 package hudson.util;
 
-import com.google.common.collect.AbstractIterator;
 import edu.umd.cs.findbugs.annotations.CreatesObligation;
 
 import hudson.Util;
@@ -41,7 +40,6 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
 
 /**
  * Represents a text file.
@@ -83,44 +81,17 @@ public class TextFile {
     }
 
     /**
-     * @throws RuntimeException in the case of {@link IOException} in {@link #readLines()}
+     * @throws RuntimeException in the case of {@link IOException} in {@link #linesStream()}
      * @deprecated This method does not properly propagate errors and may lead to file descriptor leaks
-     *             if the collection is not fully iterated. Use {@link #readLines()} instead.
+     *             if the collection is not fully iterated. Use {@link #linesStream()} instead.
      */
     @Deprecated
     public @Nonnull Iterable<String> lines() {
-        return new Iterable<String>() {
-            @Override
-            public Iterator<String> iterator() {
-                final LinesStream stream;
-                try {
-                    stream = readLines();
-                } catch (IOException ex) {
-                    throw new RuntimeException(ex);
-                }
-                final Iterator<String> it = stream.iterator();
-
-                return new Iterator<String>() {
-                    @Override
-                    public boolean hasNext() {
-                        boolean res = it.hasNext();
-                        if (!it.hasNext()) {
-                            try {
-                                stream.close();
-                            } catch (IOException ex) {
-                                throw new RuntimeException(ex);
-                            }
-                        }
-                        return res;
-                    }
-
-                    @Override
-                    public String next() {
-                        return it.next();
-                    }
-                };
-            }
-        };
+        try {
+            return linesStream();
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     /**
@@ -133,7 +104,7 @@ public class TextFile {
      * @since TODO
      */
     @CreatesObligation
-    public @Nonnull LinesStream readLines() throws IOException {
+    public @Nonnull LinesStream linesStream() throws IOException {
         return new LinesStream(Util.fileToPath(file));
     }
 

--- a/core/src/main/java/jenkins/security/s2m/ConfigFile.java
+++ b/core/src/main/java/jenkins/security/s2m/ConfigFile.java
@@ -56,7 +56,7 @@ abstract class ConfigFile<T,COL extends Collection<T>> extends TextFile {
         COL result = create();
 
         if (exists()) {
-            try (LinesStream stream = lines()) {
+            try (LinesStream stream = readLines()) {
                 for (String line : stream) {
                     if (line.startsWith("#")) continue;   // comment
                     T r = parse(line);

--- a/core/src/main/java/jenkins/security/s2m/ConfigFile.java
+++ b/core/src/main/java/jenkins/security/s2m/ConfigFile.java
@@ -56,7 +56,7 @@ abstract class ConfigFile<T,COL extends Collection<T>> extends TextFile {
         COL result = create();
 
         if (exists()) {
-            try (LinesStream stream = readLines()) {
+            try (LinesStream stream = linesStream()) {
                 for (String line : stream) {
                     if (line.startsWith("#")) continue;   // comment
                     T r = parse(line);


### PR DESCRIPTION
In #3211 @dtrebbien retained the binary comatibility, but not a source compatibility. It would cause failures in tools like PCT for plugins using the method.

### Proposed changelog entries

* RFE: Developer: Introduce the `hudson.util.TextFile#linesStream()` method for file stream processing with proper error propagation

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist
N/A

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck @jenkinsci/code-reviewers 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
