### PR TITLE
Fix typo in the private Slave#reportLauncherCreateError() method name

### DIFF
--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -493,19 +493,19 @@ public abstract class Slave extends Node implements Serializable {
             // RemoteLauncher requires an active Channel instance to operate correctly
             final Channel channel = c.getChannel();
             if (channel == null) { 
-                reportLauncerCreateError("The agent has not been fully initialized yet",
+                reportLauncherCreateError("The agent has not been fully initialized yet",
                                          "No remoting channel to the agent OR it has not been fully initialized yet", listener);
                 return new Launcher.DummyLauncher(listener);
             }
             if (channel.isClosingOrClosed()) {
-                reportLauncerCreateError("The agent is being disconnected",
+                reportLauncherCreateError("The agent is being disconnected",
                                          "Remoting channel is either in the process of closing down or has closed down", listener);
                 return new Launcher.DummyLauncher(listener);
             }
             final Boolean isUnix = c.isUnix();
             if (isUnix == null) {
                 // isUnix is always set when the channel is not null, so it should never happen
-                reportLauncerCreateError("The agent has not been fully initialized yet",
+                reportLauncherCreateError("The agent has not been fully initialized yet",
                                          "Cannot determing if the agent is a Unix one, the System status request has not completed yet. " +
                                          "It is an invalid channel state, please report a bug to Jenkins if you see it.", 
                                          listener);
@@ -516,7 +516,7 @@ public abstract class Slave extends Node implements Serializable {
         }
     }
     
-    private void reportLauncerCreateError(@Nonnull String humanReadableMsg, @CheckForNull String exceptionDetails, @Nonnull TaskListener listener) {
+    private void reportLauncherCreateError(@Nonnull String humanReadableMsg, @CheckForNull String exceptionDetails, @Nonnull TaskListener listener) {
         String message = "Issue with creating launcher for agent " + name + ". " + humanReadableMsg;
         listener.error(message);
         if (LOGGER.isLoggable(Level.WARNING)) {


### PR DESCRIPTION
It is a follow-up to the comment from @jglick which I missed somehow: https://github.com/jenkinsci/jenkins/commit/78a42d5a4a5d545324c2d3230de6947e1ec8806e#r24180690 

### Proposed changelog entries

* N/A
* ...


### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
