### PR TITLE
Reduce lowerCase # of computation in doAutoCompleteLoggerName

### DIFF
--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -87,11 +87,12 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
 
     @Restricted(NoExternalUse.class)
     public AutoCompletionCandidates doAutoCompleteLoggerName(@QueryParameter String value) {
+        String lowerCasedValue = value.toLowerCase(Locale.ENGLISH);
         AutoCompletionCandidates candidates = new AutoCompletionCandidates();
         Enumeration<String> loggerNames = LogManager.getLogManager().getLoggerNames();
         while (loggerNames.hasMoreElements()) {
             String loggerName = loggerNames.nextElement();
-            if (loggerName.toLowerCase(Locale.ENGLISH).contains(value.toLowerCase(Locale.ENGLISH))) {
+            if (loggerName.toLowerCase(Locale.ENGLISH).contains(lowerCasedValue)) {
                 candidates.add(loggerName);
             }
         }


### PR DESCRIPTION
Just a small optimization on the fly. Instead of computing 350+ (increase with # of plugins) times the same `toLowerCase`, just compute it once. No change in terms of logic.

### Proposed changelog entries

* no changelog entry required

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees
