### PR TITLE
Add parent loggers to autocompletion

### DIFF
--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -41,6 +41,7 @@ import hudson.util.RingBufferLogHandler;
 import hudson.util.XStream2;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
@@ -87,14 +88,21 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
 
     @Restricted(NoExternalUse.class)
     public AutoCompletionCandidates doAutoCompleteLoggerName(@QueryParameter String value) {
-        AutoCompletionCandidates candidates = new AutoCompletionCandidates();
+        List<String> candidateNames = new ArrayList<>();
         Enumeration<String> loggerNames = LogManager.getLogManager().getLoggerNames();
+        String lowercaseValue = value.toLowerCase(Locale.ENGLISH);
         while (loggerNames.hasMoreElements()) {
             String loggerName = loggerNames.nextElement();
-            if (loggerName.toLowerCase(Locale.ENGLISH).contains(value.toLowerCase(Locale.ENGLISH))) {
-                candidates.add(loggerName);
+            String[] loggerNameParts = loggerName.split("[.]");
+            for (int i = 0 ; i < loggerNameParts.length ; i++) {
+                String loggerNamePrefix = StringUtils.join(Arrays.copyOf(loggerNameParts, i+1), ".");
+                if (loggerNamePrefix.toLowerCase(Locale.ENGLISH).contains(lowercaseValue) && !candidateNames.contains(loggerNamePrefix)) {
+                    candidateNames.add(loggerNamePrefix);
+                }
             }
         }
+        AutoCompletionCandidates candidates = new AutoCompletionCandidates();
+        candidates.add(candidateNames.toArray(new String[0]));
         return candidates;
     }
 

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -23,6 +23,7 @@
  */
 package hudson.logging;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.thoughtworks.xstream.XStream;
 import hudson.BulkChange;
 import hudson.Extension;
@@ -87,44 +88,51 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
     }
 
     @Restricted(NoExternalUse.class)
+    @VisibleForTesting
+    public static Set<String> getAutoCompletionCandidates(List<String> loggerNamesList) {
+        Set<String> loggerNames = new HashSet<>(loggerNamesList);
+
+        // now look for package prefixes that make sense to offer for autocompletion:
+        // Only prefixes that match multiple loggers will be shown.
+        // Example: 'org' will show 'org', because there's org.apache, org.jenkinsci, etc.
+        // 'io' might only show 'io.jenkins.plugins' rather than 'io' if all loggers starting with 'io' start with 'io.jenkins.plugins'.
+        HashMap<String, Integer> seenPrefixes = new HashMap<>();
+        SortedSet<String> relevantPrefixes = new TreeSet<>();
+        for (String loggerName : loggerNames) {
+            String[] loggerNameParts = loggerName.split("[.]");
+
+            String longerPrefix = null;
+            for (int i = loggerNameParts.length; i > 0; i--) {
+                String loggerNamePrefix = StringUtils.join(Arrays.copyOf(loggerNameParts, i), ".");
+                seenPrefixes.put(loggerNamePrefix, seenPrefixes.getOrDefault(loggerNamePrefix, 0) + 1);
+                if (longerPrefix == null) {
+                    relevantPrefixes.add(loggerNamePrefix); // actual logger name
+                    longerPrefix = loggerNamePrefix;
+                    continue;
+                }
+
+                if (seenPrefixes.get(loggerNamePrefix) > seenPrefixes.get(longerPrefix)) {
+                    relevantPrefixes.add(loggerNamePrefix);
+                }
+                longerPrefix = loggerNamePrefix;
+            }
+        }
+        return relevantPrefixes;
+    }
+
+    @Restricted(NoExternalUse.class)
     public AutoCompletionCandidates doAutoCompleteLoggerName(@QueryParameter String value) {
         if (value == null) {
             return new AutoCompletionCandidates();
         }
 
         // get names of all actual loggers known to Jenkins
-        Set<String> candidateNames = new LinkedHashSet<>();
-        Enumeration<String> loggerNamesEnumeration = LogManager.getLogManager().getLoggerNames();
-        SortedSet<String> loggerNames = new TreeSet<>();
-        while (loggerNamesEnumeration.hasMoreElements()) {
-            loggerNames.add(loggerNamesEnumeration.nextElement());
-        }
-
-        // now look for package prefixes that make sense to offer for autocompletion:
-        // Only prefixes that match multiple loggers will be shown.
-        // Example: 'org' will show 'org', because there's org.apache, org.jenkinsci, etc.
-        // 'io' might only show 'io.jenkins.plugins' rather than 'io' if all loggers starting with 'io' start with 'io.jenkins.plugins'.
-        HashSet<String> seenPrefixes = new HashSet<>();
-        HashSet<String> relevantPrefixes = new HashSet<>();
-        for (String loggerName : loggerNames) {
-            String[] loggerNameParts = loggerName.split("[.]");
-            int prefixLength = 0;
-            for (int i = loggerNameParts.length - 1; i > 0; i--) {
-                String loggerNamePrefix = StringUtils.join(Arrays.copyOf(loggerNameParts, i + 1), ".");
-                if (seenPrefixes.contains(loggerNamePrefix)) {
-                    relevantPrefixes.add(loggerNamePrefix);
-                } else {
-                    seenPrefixes.add(loggerNamePrefix);
-                }
-            }
-        }
-        loggerNames.addAll(relevantPrefixes);
-        candidateNames.addAll(loggerNames);
+        Set<String> candidateNames = new LinkedHashSet<>(getAutoCompletionCandidates(Collections.list(LogManager.getLogManager().getLoggerNames())));
 
         for (String part : value.split("[ ]+")) {
             HashSet<String> partCandidates = new HashSet<>();
             String lowercaseValue = part.toLowerCase(Locale.ENGLISH);
-            for (String loggerName : loggerNames) {
+            for (String loggerName : candidateNames) {
                 if (loggerName.toLowerCase(Locale.ENGLISH).contains(lowercaseValue)) {
                     partCandidates.add(loggerName);
                 }

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -88,7 +88,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
 
     @Restricted(NoExternalUse.class)
     public AutoCompletionCandidates doAutoCompleteLoggerName(@QueryParameter String value) {
-        List<String> candidateNames = new ArrayList<>();
+        Set<String> candidateNames = new LinkedHashSet<>();
         Enumeration<String> loggerNames = LogManager.getLogManager().getLoggerNames();
         String lowercaseValue = value.toLowerCase(Locale.ENGLISH);
         while (loggerNames.hasMoreElements()) {
@@ -96,7 +96,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
             String[] loggerNameParts = loggerName.split("[.]");
             for (int i = 0 ; i < loggerNameParts.length ; i++) {
                 String loggerNamePrefix = StringUtils.join(Arrays.copyOf(loggerNameParts, i+1), ".");
-                if (loggerNamePrefix.toLowerCase(Locale.ENGLISH).contains(lowercaseValue) && !candidateNames.contains(loggerNamePrefix)) {
+                if (loggerNamePrefix.toLowerCase(Locale.ENGLISH).contains(lowercaseValue)) {
                     candidateNames.add(loggerNamePrefix);
                 }
             }

--- a/core/src/test/java/hudson/logging/LogRecorderTest.java
+++ b/core/src/test/java/hudson/logging/LogRecorderTest.java
@@ -25,6 +25,9 @@
 package hudson.logging;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import org.junit.Test;
@@ -124,6 +127,38 @@ public class LogRecorderTest {
     private static Boolean matches(String target, String logger, Level loggerLevel) {
         LogRecord r = createLogRecord(logger, loggerLevel, "whatever");
         return new LogRecorder.Target(target, Level.INFO).matches(r);
+    }
+
+    @Test
+    public void autocompletionTest() throws Exception {
+        List<String> loggers = Arrays.asList(
+                "com.company.whatever.Foo", "com.foo.Bar", "com.foo.Baz",
+                "org.example.app.Main", "org.example.app.impl.xml.Parser", "org.example.app.impl.xml.Validator");
+
+        Set<String> candidates = LogRecorder.getAutoCompletionCandidates(loggers);
+
+        isCandidate(candidates, "com");
+        isCandidate(candidates, "com.company.whatever.Foo");
+        isCandidate(candidates, "com.foo");
+        isCandidate(candidates, "com.foo.Bar");
+        isCandidate(candidates, "com.foo.Baz");
+        isCandidate(candidates, "org.example.app");
+        isCandidate(candidates, "org.example.app.Main");
+        isCandidate(candidates, "org.example.app.impl.xml");
+        isCandidate(candidates, "org.example.app.impl.xml.Parser");
+        isCandidate(candidates, "org.example.app.impl.xml.Validator");
+
+        isNotCandidate(candidates, "org");
+        isNotCandidate(candidates, "org.example");
+
+        assertEquals("expected number of items", 10, candidates.size());
+    }
+
+    private static void isCandidate(Set<String> candidates, String candidate) {
+        assertTrue(candidate, candidates.contains(candidate));
+    }
+    private static void isNotCandidate(Set<String> candidates, String candidate) {
+        assertFalse(candidate, candidates.contains(candidate));
     }
 
 }


### PR DESCRIPTION
> ![screen shot](https://user-images.githubusercontent.com/1831569/37295830-78f32270-2619-11e8-8a55-21e009c60693.png)

> ![screen shot](https://user-images.githubusercontent.com/1831569/37295913-b8a34c4c-2619-11e8-9a08-3e72b7f3461f.png)


Subsumes https://github.com/jenkinsci/jenkins/pull/3344 while at the same time doing a LOT more work 😆 

### Proposed changelog entries

Too minor.


### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
