### PR TITLE
[JENKINS-50124] restore AbstractTaskListeners serialVersionUID.

### DIFF
--- a/core/src/main/java/hudson/util/AbstractTaskListener.java
+++ b/core/src/main/java/hudson/util/AbstractTaskListener.java
@@ -13,4 +13,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 @RestrictedSince("2.91")
 public abstract class AbstractTaskListener implements TaskListener {
+
+    private static final long serialVersionUID = 7217626701881006422L;
+
 }


### PR DESCRIPTION
If a subclass was serialized (default java serialization) then the
changes do push down the method to the interface would break
deserialization when in reality the classes are still compatible.

Restoring the compatibility by hard coding the `serialVersionUID` to what
it was before the change.

See [JENKINS-50124](https://issues.jenkins-ci.org/browse/JENKINS-50124).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: restore serialVersionUID of AbstractTaskListener

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @recena

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
