### PR TITLE
[JENKINS-49269] Add ATH SmokeTest runs to the core build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,6 +68,8 @@ for(i = 0; i < buildTypes.size(); i++) {
 
 builds.ath = {
     node("linux") {
+        // Just to be safe
+        deleteDir()
         def fileUri
         def metadataPath
         dir("sources") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,10 @@ builds.ath = {
         def metadataPath
         dir("sources") {
             checkout scm
-            sh "mvn -DskipTests -am -pl war package -Dmaven.repo.local=${pwd tmp: true}/m2repo -s settings-azure.xml"
+            withMavenEnv(["JAVA_OPTS=-Xmx1536m -Xms512m",
+                          "MAVEN_OPTS=-Xmx1536m -Xms512m"]) {
+                sh "mvn -DskipTests -am -pl war package -Dmaven.repo.local=${pwd tmp: true}/m2repo -s settings-azure.xml"
+            }
             dir("war/target") {
                 fileUri = "file://" + pwd() + "/jenkins.war"
             }

--- a/essentials.yml
+++ b/essentials.yml
@@ -1,0 +1,4 @@
+---
+ath:
+  useLocalSnapshots: false
+  athRevision: "b36f2d27fdaa3f7ce73f0179ddbd26a6d7fa05fc"

--- a/essentials.yml
+++ b/essentials.yml
@@ -1,4 +1,4 @@
 ---
 ath:
   useLocalSnapshots: false
-  athRevision: "b36f2d27fdaa3f7ce73f0179ddbd26a6d7fa05fc"
+  athRevision: "06caf67d37d945ec5228a80d73714fac692c28d3"


### PR DESCRIPTION
Re-run of #3347 from @raul-arabaolaza because Jenkinsfile security is too smart for #3348. I've invited @raul-arabaolaza to my repo, I hope this helps.

Original PR comment below.

---

See [JENKINS-49269](https://issues.jenkins-ci.org/browse/JENKINS-49269)

There have been some [efforts](https://github.com/jenkinsci/jenkins/pull/3073) in the past to integrate a selected set of ATH tests in the builds of the core, now as a result of [INFRA-1489](https://issues.jenkins-ci.org/browse/JENKINS-49269), [JENKINS-49263](https://issues.jenkins-ci.org/browse/JENKINS-49263) and [JENKINS-50023](https://issues.jenkins-ci.org/browse/JENKINS-50023) (To be merged) is simple to do this.

This PR provides a metadata file to be used by the new `runATH` step in [pipeline-library](https://github.com/jenkins-infra/pipeline-library), see the README for details about the metadata file format, and modifies the `Jenkinsfile` so the new step is run if running on a `linux` node, as there is not yet support for ATH in windows no ATH run is executed on windows or without a `linux` node. 

As this change does not modify the code but the build process the existing PR builder should be enough to test the behavior, I have locally tested in my local instances but lack the capabilities to run this on ci.jenkins.io, any recommendation about testing is more than welcome

Note that the final commit or tag of the ATH used has to be one containing the changes in [ATH#PR420](https://github.com/jenkinsci/acceptance-test-harness/pull/420) hence I consider this Work in progress as there is one failing test and a decision about which version of the ATH to use has to be taken

I know the coverage provided by the chosen ATH tests is very small (or even symbolic) but this PR is about setting up the machinery with a fully trustable and quick set of tests, once this is merged follow up tasks will fix and add more relevant ATH tests

### Proposed changelog entries
* Internal, Run ATH subset as part of the build process 

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@batmat @rtyler as they are working in Essentials 
@jglick @oleg-nenashev @olivergondza As they have reviewed in the past a similar PR and Oliver is the maintainer of ATH 
