### PR TITLE
Another use of ExtensionList.lookupSingleton

### DIFF
--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -241,7 +241,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     @Extension public static final class RunListenerImpl extends RunListener<Run> {
 
         static RunListenerImpl get() {
-            return ExtensionList.lookup(RunListener.class).get(RunListenerImpl.class);
+            return ExtensionList.lookupSingleton(RunListenerImpl.class);
         }
 
         private Map<Job,Collection<ReverseBuildTrigger>> upstream2Trigger;


### PR DESCRIPTION
Observed a user getting an NPE from `ReverseBuildTrigger.start` suggesting that `RunListenerImpl.get()` is returning null for unknown reasons. May as well take advantage of #3021 to get a better error message.

@reviewbybees