### PR TITLE
[JENKINS-46248] - Fix potential deadlock between queue maintenance and asynchronous execution

### DIFF
--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -431,11 +431,12 @@ public class Executor extends Thread implements ModelObject {
             } catch (AsynchronousExecution x) {
                 lock.writeLock().lock();
                 try {
-                    x.setExecutor(this);
+                    x.setExecutorWithoutCompleting(this);
                     this.asynchronousExecution = x;
                 } finally {
                     lock.writeLock().unlock();
                 }
+                x.maybeComplete();
             } catch (Throwable e) {
                 problems = e;
             } finally {

--- a/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
+++ b/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
@@ -39,6 +39,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
@@ -110,15 +111,10 @@ public abstract class AsynchronousExecution extends RuntimeException {
      * Use {@link #setExecutorWithoutCompleting(Executor)} and {@link #maybeComplete()}
      * instead. For this method, locking behaviour is problematic.
      */
-    @Restricted(NoExternalUse.class) @Deprecated()
+    @Restricted(DoNotUse.class) @Deprecated()
     public synchronized final void setExecutor(@Nonnull Executor executor) {
-        assert this.executor==null;
-
-        this.executor = executor;
-        if (result!=null) {
-            executor.completedAsynchronous( result!=NULL ? result : null );
-            result = null;
-        }
+        setExecutorWithoutCompleting(executor);
+        maybeComplete();
     }
 
     /**

--- a/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
+++ b/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
@@ -62,7 +62,7 @@ public abstract class AsynchronousExecution extends RuntimeException {
 
     /**
      * Initially null, and usually stays null.
-     * If {@link #completed} is called before {@link #setExecutor}, then either {@link #NULL} for success, or the error.
+     * If {@link #completed} is called before {@link #setExecutorWithoutCompleting}, then either {@link #NULL} for success, or the error.
      */
     @GuardedBy("this")
     private @CheckForNull Throwable result;
@@ -99,7 +99,7 @@ public abstract class AsynchronousExecution extends RuntimeException {
 
     /**
      * Obtains the associated executor.
-     * @return Associated Executor. May be {@code null} if {@link #setExecutor(hudson.model.Executor)} 
+     * @return Associated Executor. May be {@code null} if {@link #setExecutorWithoutCompleting(hudson.model.Executor)} 
      * has not been called yet.
      */
     @CheckForNull

--- a/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
+++ b/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
@@ -108,16 +108,6 @@ public abstract class AsynchronousExecution extends RuntimeException {
     }
 
     /**
-     * Use {@link #setExecutorWithoutCompleting(Executor)} and {@link #maybeComplete()}
-     * instead. For this method, locking behaviour is problematic.
-     */
-    @Restricted(DoNotUse.class) @Deprecated()
-    public synchronized final void setExecutor(@Nonnull Executor executor) {
-        setExecutorWithoutCompleting(executor);
-        maybeComplete();
-    }
-
-    /**
      * Set the executor without notifying it about task completion.
      * The caller <b>must</b> also call {@link #maybeComplete()}
      * after releasing any problematic locks.


### PR DESCRIPTION
See [JENKINS-46248](https://issues.jenkins-ci.org/browse/JENKINS-46248), [JENKINS-50020](https://issues.jenkins-ci.org/browse/JENKINS-50020).

This patch works around a deadlock between periodic queue maintenance and the asynchronous completion of an executor. Our deadlock stacktraces involve the Azure VM Agent plugin (see [Sam's second bullet point on JENKINS-50020](https://issues.jenkins-ci.org/browse/JENKINS-50020?focusedCommentId=331498&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-331498)), but the problem is not limited to that plugin, as shown by the stack trace in JENKINS-46248.

Here's what happens:

 1. Many common operations (including executors starting and finishing, configuration updates, entering or exiting "pending shutdown" state, slaves coming online and various queue-internal operations) call `hudson.model.Queue::scheduleMaintenance`.
    - This will run in a separate thread, calling `Queue::maintain`.
    - The queue lock is acquired in `Queue::maintain`, and will be held for the entire duration of the call.
    - Among other things, queue maintenance will poll the executors for their state, for example by calling `Executor::isParking`, which tries to acquire the executor's read lock.
    - **Summary:** At any point, an executor's read lock may be required while also holding the queue lock.
 2. The `hudson.model.Executor::run` method does some setup and then invokes an `Executable`, which may be implemented asynchronously.
    - In that situation, it will throw a subtype of `AsynchronousExecution`, which is caught by `Executor::run`.
    - The executor registers itself with the caught `AsynchronousExecution` by calling its `setExecutor` method, while holding its own write lock.
    - `AsynchronousExecution` is a kind of completable future. It will be notified by the `Executable` of its completion via its `completed` method.
    - If `setExecutor` is called before `completed`, then the executor will be notified of completion as soon as `completed` is called.
    - If `setExecutor` is called after `completed`, then the executor will be notified immediately, within the `setExecutor` method.
    - **Summary:** If an `Executable` throws `AsynchronousExecution`, but its execution completes before the executor catches it and registers itself, then `Executor::completedAsynchronous` will be called during `AsynchronousExecution::setExecutor`, while holding the executor write lock.

It seems like there are numerous plugins (perhaps commonly cloud-based agent provisioning plugins like the Azure VM agent plugin) that perform operations like winding down executors when they complete. These operations inherently require the queue lock, and so deadlock when (a) running under the executor write lock, and (b) a queue maintenance happens to be scheduled at the same time.

While it could be argued that it is a bug in a plugin to require the queue lock during executor completion, I think arguably the problem is in the core code touched by this PR. In particular:

 - If `AsynchronousExecution::setExecutor` is called **before** `AsynchronousExecution::completed`, then the callback to `Executor::completedAsynchronous` will happen in a context that *does not* hold the executor's write lock.
 - If `AsynchronousExecution::setExecutor` is called **after** `AsynchronousExecution::completed`, then currently the call to `Executor::completedAsynchronous` will happen in a context that *does* hold the executor write lock.

This discrepancy seems undesirable. The proposed patch slightly complicates the contract of `AsynchronousExecution` to ensure that the callback to `completedAsynchronous` always happens after the executor write lock has been released. In particular, it keeps the old (risky) `setExecutor` method to avoid breaking client code -- while it is marked as "internal use only", I did not want to make that assumption without understanding how enforced this restriction is.

We have been running for a few days with this patch applied, and have not observed deadlocks or ill-effects.

Note that the same risk applies any other time the executor write lock is taken: If any operation performed within the locked region requires the queue lock, it will deadlock if queue maintenance happens at the same time. This possibly imposes constraints on plugin code that may be invoked from those regions.

### Alternative solutions

A number of alternative changes would avoid the potential deadlock, which are presented here for completeness.

 - **Always take the queue lock.** One way to completely avoid the risk of mismatched lock order acquisitions is to insist that any time the executor write lock is taken, the queue lock should be held. This seems quite draconian, but perhaps the write-locked regions are intended to be short enough to justify it.
 - **Use a weaker lock for `AsynchronousExecution::setExecutor`.** Currently, the executor is set under its executor write lock. This makes sense for assigning the `AsynchronousExecution` to its field of the same name, but perhaps it is not necessary for the actual call to `setExecutor`. That call could be moved out of the lock, or it could be moved out of the write-locked region into a read-locked region. I do not have a good enough understanding of the concurrency model to judge whether that would be acceptable.
 - **Refactor `AsynchronousExecution`.** An `Executable` could return a `CompletableFuture` or similar instead of throwing `AsynchronousExecution` in order to achieve asynchronous behaviour. This would remove the need to register the executor with the `AsynchronousExecution` instance, and it could simply wait for the future's completion without holding any locks. This seems like it could be quite invasive for plugins.

### Proposed changelog entries

* JENKINS-46248: Fixed a potential deadlock between queue maintenance and executor task completion.
