### PR TITLE
Add support for SHA-256/512 in update site metadata

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -65,7 +65,6 @@ import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContext;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.input.CountingInputStream;
 import org.apache.commons.io.output.NullOutputStream;
 import org.jenkinsci.Symbol;
@@ -1169,11 +1168,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 }
                 if (sha256 != null) {
                     byte[] digest = sha256.digest();
-                    job.computedSHA256 = Hex.encodeHexString(digest);
+                    job.computedSHA256 = Base64.encodeBase64String(digest);
                 }
                 if (sha512 != null) {
                     byte[] digest = sha512.digest();
-                    job.computedSHA512 = Hex.encodeHexString(digest);
+                    job.computedSHA512 = Base64.encodeBase64String(digest);
                 }
                 return tmp;
             } catch (IOException e) {
@@ -1655,7 +1654,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         private String computedSHA1;
 
         /**
-         * Hex encoded SHA-256 checksum of the downloaded file, if it could be computed.
+         * Base64 encoded SHA-256 checksum of the downloaded file, if it could be computed.
          *
          * @since TODO
          */
@@ -1667,7 +1666,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         private String computedSHA256;
 
         /**
-         *Hex encoded SHA-512 checksum of the downloaded file, if it could be computed.
+         * Base64 encoded SHA-512 checksum of the downloaded file, if it could be computed.
          *
          * @since TODO
          */

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -658,7 +658,7 @@ public class UpdateSite {
         }
 
         /**
-         * The hex string encoded SHA-256 checksum of the file.
+         * The base64 encoded SHA-256 checksum of the file.
          * Can be null if not provided by the update site.
          * @since TODO
          */
@@ -667,7 +667,7 @@ public class UpdateSite {
         }
 
         /**
-         * The hex string encoded SHA-512 checksum of the file.
+         * The base64 encoded SHA-512 checksum of the file.
          * Can be null if not provided by the update site.
          * @since TODO
          */

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -616,6 +616,12 @@ public class UpdateSite {
         @Restricted(NoExternalUse.class)
         /* final */ String sha1;
 
+        @Restricted(NoExternalUse.class)
+        /* final */ String sha256;
+
+        @Restricted(NoExternalUse.class)
+        /* final */ String sha512;
+
         public Entry(String sourceId, JSONObject o) {
             this(sourceId, o, null);
         }
@@ -628,6 +634,8 @@ public class UpdateSite {
             // Trim this to prevent issues when the other end used Base64.encodeBase64String that added newlines
             // to the end in old commons-codec. Not the case on updates.jenkins-ci.org, but let's be safe.
             this.sha1 = Util.fixEmptyAndTrim(o.optString("sha1"));
+            this.sha256 = Util.fixEmptyAndTrim(o.optString("sha256"));
+            this.sha512 = Util.fixEmptyAndTrim(o.optString("sha512"));
 
             String url = o.getString("url");
             if (!URI.create(url).isAbsolute()) {
@@ -647,6 +655,24 @@ public class UpdateSite {
         // TODO @Exported assuming we want this in the API
         public String getSha1() {
             return sha1;
+        }
+
+        /**
+         * The hex string encoded SHA-256 checksum of the file.
+         * Can be null if not provided by the update site.
+         * @since TODO
+         */
+        public String getSha256() {
+            return sha256;
+        }
+
+        /**
+         * The hex string encoded SHA-512 checksum of the file.
+         * Can be null if not provided by the update site.
+         * @since TODO
+         */
+        public String getSha512() {
+            return sha512;
         }
 
         /**

--- a/core/src/test/java/hudson/model/UpdateCenterTest.java
+++ b/core/src/test/java/hudson/model/UpdateCenterTest.java
@@ -1,9 +1,17 @@
 package hudson.model;
 
+import net.sf.json.JSONObject;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class UpdateCenterTest {
 
@@ -40,5 +48,140 @@ public class UpdateCenterTest {
         assertThat(UpdateCenter.UpdateCenterConfiguration.toUpdateCenterCheckUrl(
                 "file://./foo.jar!update-center.json").toExternalForm(),
                 is("file://./foo.jar!update-center.json"));
+    }
+
+    @Test
+    public void noChecksums() {
+        try {
+            UpdateCenter.verifyChecksums(new MockDownloadJob(null, null, null), buildEntryWithExpectedChecksums(null, null, null), new File("example"));
+            fail();
+        } catch (IOException ex) {
+            assertEquals("Unable to confirm integrity of downloaded file, refusing installation", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void sha1Match() throws Exception {
+        UpdateCenter.verifyChecksums(
+                new MockDownloadJob(EMPTY_SHA1, null, null),
+                buildEntryWithExpectedChecksums(EMPTY_SHA1, null, null), new File("example"));
+    }
+
+    @Test
+    public void sha1Mismatch() {
+        try {
+            UpdateCenter.verifyChecksums(
+                    new MockDownloadJob(EMPTY_SHA1.replace('k', 'f'), null, null),
+                    buildEntryWithExpectedChecksums(EMPTY_SHA1, null, null), new File("example"));
+            fail();
+        } catch (IOException ex) {
+            assertTrue(ex.getMessage().contains("does not match expected SHA-1, expected '2jmj7l5rSw0yVb/vlWAYkK/YBwk=', actual '2jmj7l5rSw0yVb/vlWAYfK/YBwf='"));
+        }
+    }
+
+    @Test
+    public void sha512ProvidedOnly() throws IOException {
+        UpdateCenter.verifyChecksums(
+                new MockDownloadJob(EMPTY_SHA1, EMPTY_SHA256, EMPTY_SHA512),
+                buildEntryWithExpectedChecksums(null, null, EMPTY_SHA512), new File("example"));
+    }
+
+    @Test
+    public void sha512and256IgnoreCase() throws IOException {
+        UpdateCenter.verifyChecksums(
+                new MockDownloadJob(EMPTY_SHA1, EMPTY_SHA256.toUpperCase(Locale.US), EMPTY_SHA512.toUpperCase(Locale.US)),
+                buildEntryWithExpectedChecksums(null, EMPTY_SHA256, EMPTY_SHA512), new File("example"));
+    }
+
+    @Test
+    public void sha1DoesNotIgnoreCase() {
+        try {
+            UpdateCenter.verifyChecksums(
+                    new MockDownloadJob(EMPTY_SHA1, EMPTY_SHA256, EMPTY_SHA512),
+                    buildEntryWithExpectedChecksums(EMPTY_SHA1.toUpperCase(Locale.US), null, null), new File("example"));
+            fail();
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("does not match expected SHA-1, expected '2JMJ7L5RSW0YVB/VLWAYKK/YBWK=', actual '2jmj7l5rSw0yVb/vlWAYkK/YBwk='"));
+        }
+
+    }
+
+    @Test
+    public void noOverlapForComputedAndProvidedChecksums() {
+        try {
+            UpdateCenter.verifyChecksums(
+                    new MockDownloadJob(EMPTY_SHA1, EMPTY_SHA256, null),
+                    buildEntryWithExpectedChecksums(null, null, EMPTY_SHA512), new File("example"));
+            fail();
+        } catch (Exception e) {
+            assertTrue(e.getMessage().equals("Unable to confirm integrity of downloaded file, refusing installation"));
+        }
+    }
+
+    @Test
+    public void noOverlapForComputedAndProvidedChecksumsForSpecIncompliantJVM() {
+        try {
+            UpdateCenter.verifyChecksums(
+                    new MockDownloadJob(EMPTY_SHA1, null, null),
+                    buildEntryWithExpectedChecksums(null, EMPTY_SHA256, EMPTY_SHA512), new File("example"));
+            fail();
+        } catch (Exception e) {
+            assertTrue(e.getMessage().equals("Unable to confirm integrity of downloaded file, refusing installation"));
+        }
+    }
+
+
+    private static String EMPTY_SHA1 = "2jmj7l5rSw0yVb/vlWAYkK/YBwk=";
+    private static String EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    private static String EMPTY_SHA512 = "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+
+    private static UpdateSite.Entry buildEntryWithExpectedChecksums(String expectedSHA1, String expectedSHA256, String expectedSHA512) {
+        JSONObject o = new JSONObject();
+        o.put("name", "unnamed");
+        o.put("version", "unspecified");
+        o.put("url", "https://example.invalid");
+        if (expectedSHA1 != null) {
+            o.put("sha1", expectedSHA1);
+        }
+        if (expectedSHA256 != null) {
+            o.put("sha256", expectedSHA256);
+        }
+        if (expectedSHA512 != null) {
+            o.put("sha512", expectedSHA512);
+        }
+        return new MockEntry(o);
+    }
+
+    private static class MockEntry extends UpdateSite.Entry {
+
+        MockEntry(JSONObject o) {
+            // needs name, version, url, optionally sha1, sha256, sha512
+            super("default", o);
+        }
+    }
+
+    private static class MockDownloadJob implements UpdateCenter.WithComputedChecksums {
+
+        private final String computedSHA1;
+        private final String computedSHA256;
+        private final String computedSHA512;
+
+        public MockDownloadJob(String computedSHA1, String computedSHA256, String computedSHA512) {
+            this.computedSHA1 = computedSHA1;
+            this.computedSHA256 = computedSHA256;
+            this.computedSHA512 = computedSHA512;
+        }
+
+        public String getComputedSHA1() {
+            return this.computedSHA1;
+        }
+
+        public String getComputedSHA256() {
+            return computedSHA256;
+        }
+
+        public String getComputedSHA512() {
+            return computedSHA512;
+        }
     }
 }


### PR DESCRIPTION
If the update site metadata provides SHA-512 or SHA-256 checksums, check those.

This is intended as a security hardening. SHA-1 isn't a good choice anymore.

Companion PR in infra: https://github.com/jenkins-infra/update-center2/pull/191. As Jenkins will continue to support update sites that only provide SHA-1 (for now, and with a warning), they could be merged independently, but probably should not be.

### Proposed changelog entries

* RFE: Check SHA-512 or SHA-256 checksums of update site metadata and core and plugin downloads if the update site provides them.

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
