### PR TITLE
[JENKINS-9104] Move process killing veto checks to master

### DIFF
--- a/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
+++ b/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 import java.io.File;
 import java.io.IOException;
+import java.io.StringWriter;
 
 import hudson.EnvVars;
 import hudson.Functions;
@@ -13,6 +14,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Slave;
 import hudson.tasks.Maven;
 import hudson.tasks.Shell;
 import hudson.util.ProcessTreeRemoting.IOSProcess;
@@ -26,6 +28,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
 import com.google.common.collect.ImmutableMap;
+
 
 public class ProcessTreeKillerTest {
 
@@ -136,8 +139,44 @@ public class ProcessTreeKillerTest {
             // Means the process is still running
         }
     }
+    
+    @Test
+    @Issue("JENKINS-9104")
+    public void considersKillingVetosOnSlave() throws Exception {
+        // on some platforms where we fail to list any processes, this test will
+        // just not work
+        assumeTrue(ProcessTree.get() != ProcessTree.DEFAULT);
+        
+        // Define a process we (shouldn't) kill
+        ProcessBuilder pb = new ProcessBuilder();
+        pb.environment().put("cookie", "testKeepDaemonsAlive");
+        
+        if (File.pathSeparatorChar == ';') {
+            pb.command("cmd");
+        } else {
+            pb.command("sleep", "5m");
+        }
+        
+        // Create a slave so we can tell it to kill the process
+        Slave s = j.createSlave();
+        s.toComputer().connect(false).get();
+        
+        // Start the process
+        process = pb.start();
+        
+        // Call killall (somewhat roundabout though) to (not) kill it
+        StringWriter out = new StringWriter();
+        s.createLauncher(new StreamTaskListener(out)).kill(ImmutableMap.of("cookie", "testKeepDaemonsAlive"));
+        
+        try {
+            process.exitValue();
+            fail("Process should have been excluded from the killing");
+        } catch (IllegalThreadStateException e) {
+            // Means the process is still running
+        }
+    }
 
-    @TestExtension("considersKillingVetos")
+    @TestExtension({"considersKillingVetos", "considersKillingVetosOnSlave"})
     public static class VetoAllKilling extends ProcessKillingVeto {
         @Override
         public VetoCause vetoProcessKilling(IOSProcess p) {


### PR DESCRIPTION
See [JENKINS-9104](https://issues.jenkins-ci.org/browse/JENKINS-9104).

I originally tried to fix this issue in #2741, but it had some issues and I couldn't get it working.  This is a different approach where the veto checks are performed on the master always so that the extension list is available.  I have the impression from the conversation in the previous PR that extension points aren't supposed to be propagate to the slaves, so this approach avoids that.  Instead I send the process object to the master and do the checks there.  As best as I can tell, `OSProcess` objects can be sent over the channel and attempts to access their properties get forwarded back and forth so that the data becomes available.

I do think it's a bit silly to send the message of the `VetoCause` across the channel, but unless it's made `Serializable`, that seemed to be the easiest option.  Shouldn't be a problem unless `VetoCause` needs additional data added to it, at which point that piece may need to be re-thought.

### Proposed changelog entries

* JENKINS-9104 - Fix issue where process-killer vetos were being ignored on agents
  * ProcessKillingVeto extension point: https://jenkins.io/doc/developer/extensions/jenkins-core/#processkillingveto