### PR TITLE
[JENKINS-50237] - Fix error propagation and JEP-200 issue when FilePath#list() is invoked for non-existent directory

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -120,6 +120,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.input.CountingInputStream;
 import org.apache.commons.lang.StringUtils;
+import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
@@ -1827,11 +1828,14 @@ public final class FilePath implements Serializable {
     private static String[] glob(File dir, String includes, String excludes, boolean defaultExcludes) throws IOException {
         if(isAbsolute(includes))
             throw new IOException("Expecting Ant GLOB pattern, but saw '"+includes+"'. See http://ant.apache.org/manual/Types/fileset.html for syntax");
-        FileSet fs = Util.createFileSet(dir,includes,excludes);
-        fs.setDefaultexcludes(defaultExcludes);
-        DirectoryScanner ds = fs.getDirectoryScanner(new Project());
-        String[] files = ds.getIncludedFiles();
-        return files;
+        try {
+            FileSet fs = Util.createFileSet(dir, includes, excludes);
+            fs.setDefaultexcludes(defaultExcludes);
+            DirectoryScanner ds = fs.getDirectoryScanner(new Project());
+            return ds.getIncludedFiles();
+        } catch (BuildException ex) {
+            throw new IOException(String.format("Failed to scan directory %s with [excludes=%s. includes=%s]", dir, excludes, includes), ex);
+        }
     }
 
     /**

--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -152,6 +152,7 @@ net.bull.javamelody.internal.model.TomcatInformations
 org.acegisecurity.userdetails.User
 org.apache.commons.fileupload.disk.DiskFileItem
 org.apache.commons.fileupload.util.FileItemHeadersImpl
+org.apache.tools.ant.Location
 
 # TODO remove when git-client 2.7.1+ is widely adopted
 org.eclipse.jgit.lib.ObjectId

--- a/test/src/test/java/hudson/FilePathTest.java
+++ b/test/src/test/java/hudson/FilePathTest.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson;
+
+import hudson.model.Node;
+import hudson.slaves.DumbSlave;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.For;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+@For(FilePath.class)
+public class FilePathTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void shouldListFilesOnAgent() throws Exception {
+        final DumbSlave agent = j.createOnlineSlave();
+        FilePath p = agent.getRootPath();
+        FilePath foo = p.child("foo.txt");
+        foo.write("Hello, JEP-200!", "UTF-8");
+        FilePath[] paths = p.list("*.txt");
+        assertThat("1 file should be found", paths.length, equalTo(1));
+        assertThat(paths[0].getRemote(), containsString("foo.txt"));
+    }
+
+    @Test
+    public void shouldListFilesOnMaster_nonExistentPath() throws Exception {
+        assertFailsToReadNonExistetDir(j.jenkins);
+    }
+
+    @Test
+    @Issue("JENKINS-50237")
+    public void shouldListFilesOnAgent_nonExistentPath() throws Exception {
+        final DumbSlave agent = j.createOnlineSlave();
+        assertFailsToReadNonExistetDir(agent);
+    }
+
+    private void assertFailsToReadNonExistetDir(Node agent) throws AssertionError, InterruptedException {
+        try {
+            FilePath p = agent.getRootPath();
+            FilePath[] paths = p.child("/non/existent/path").list("*.txt");
+        } catch (IOException ex) {
+            assertThat("FilePath#list() should have failed with standard error",
+                    ex.getMessage(), containsString("Failed to scan directory"));
+            return;
+        }
+        fail("Expected IOException");
+    }
+
+}


### PR DESCRIPTION
See [JENKINS-50237](https://issues.jenkins-ci.org/browse/JENKINS-50237).

FilePath#glob() may throw runtime `BuildException` when the underlying Ant logic fails to construct directory scanner for the specified data. Although the default ClassFilter allows serialization of exceptions, it does not allow non-whitelisted fields. BuildException handles `org.apache.tools.ant.Location`, so... FilePath#list() response cannot be deserialized without whitelisting.

I could have reworked logic to prevent serialization over the channel, but Location is safe:

```
public class Location implements Serializable {
    private static final long serialVersionUID = 1L;
    private final String fileName;
    private final int lineNumber;
    private final int columnNumber;
    public static final Location UNKNOWN_LOCATION = new Location();
    private static final FileUtils FILE_UTILS = FileUtils.getFileUtils();
...
```

So I just whitelisted it

### Proposed changelog entries

* Bug: Jenkins does not longer fail with ClassFilter deserialization exception when listing agent files in non-existent directory or invalid filter (JEP-200).
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
