### PR TITLE
[JENKINS-50237/JENKINS-49618] Pick up Remoting 3.19 with automatic ProxyException; and avoid BuildException to begin with

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -138,6 +138,7 @@ import static hudson.Util.fixEmpty;
 import static hudson.Util.isSymlink;
 
 import java.util.Collections;
+import org.apache.tools.ant.BuildException;
         
 /**
  * {@link File} like object with remoting support.
@@ -1829,7 +1830,12 @@ public final class FilePath implements Serializable {
             throw new IOException("Expecting Ant GLOB pattern, but saw '"+includes+"'. See http://ant.apache.org/manual/Types/fileset.html for syntax");
         FileSet fs = Util.createFileSet(dir,includes,excludes);
         fs.setDefaultexcludes(defaultExcludes);
-        DirectoryScanner ds = fs.getDirectoryScanner(new Project());
+        DirectoryScanner ds;
+        try {
+            ds = fs.getDirectoryScanner(new Project());
+        } catch (BuildException x) {
+            throw new IOException(x.getMessage());
+        }
         String[] files = ds.getIncludedFiles();
         return files;
     }

--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -152,6 +152,7 @@ net.bull.javamelody.internal.model.TomcatInformations
 org.acegisecurity.userdetails.User
 org.apache.commons.fileupload.disk.DiskFileItem
 org.apache.commons.fileupload.util.FileItemHeadersImpl
+org.apache.tools.ant.Location
 
 # TODO remove when git-client 2.7.1+ is widely adopted
 org.eclipse.jgit.lib.ObjectId

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
 
     <!-- Minimum Remoting version, which is tested for API compatibility -->
-    <remoting.version>3.19-20180320.212209-2</remoting.version> <!-- TODO https://github.com/jenkinsci/remoting/pull/263 -->
+    <remoting.version>3.19</remoting.version>
     <remoting.minimum.supported.version>2.60</remoting.minimum.supported.version>
 
     <!-- TODO: JENKINS-36716 - Switch to Medium once FindBugs is cleaned up, 430 issues on Mar 10, 2018 -->

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
 
     <!-- Minimum Remoting version, which is tested for API compatibility -->
-    <remoting.version>3.18</remoting.version>
+    <remoting.version>3.19-20180319.205443-1</remoting.version> <!-- TODO https://github.com/jenkinsci/remoting/pull/263 -->
     <remoting.minimum.supported.version>2.60</remoting.minimum.supported.version>
 
     <!-- TODO: JENKINS-36716 - Switch to Medium once FindBugs is cleaned up, 430 issues on Mar 10, 2018 -->

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
 
     <!-- Minimum Remoting version, which is tested for API compatibility -->
-    <remoting.version>3.19-20180319.205443-1</remoting.version> <!-- TODO https://github.com/jenkinsci/remoting/pull/263 -->
+    <remoting.version>3.19-20180320.212209-2</remoting.version> <!-- TODO https://github.com/jenkinsci/remoting/pull/263 -->
     <remoting.minimum.supported.version>2.60</remoting.minimum.supported.version>
 
     <!-- TODO: JENKINS-36716 - Switch to Medium once FindBugs is cleaned up, 430 issues on Mar 10, 2018 -->

--- a/test/src/test/java/hudson/FilePathTest.java
+++ b/test/src/test/java/hudson/FilePathTest.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson;
+
+import hudson.model.Node;
+import org.apache.tools.ant.DirectoryScanner;
+import static org.hamcrest.Matchers.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class FilePathTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Issue("JENKINS-50237")
+    @Test
+    public void listGlob() throws Exception {
+        for (Node n : new Node[] {r.jenkins, r.createOnlineSlave()}) {
+            FilePath d = n.getRootPath().child("globbing");
+            FilePath exists = d.child("dir/exists");
+            exists.write("", null);
+            assertThat(d.list("**/exists"), arrayContainingInAnyOrder(exists));
+            assertThat(d.list("**/nonexistent"), emptyArray());
+            FilePath nonexistentDir = d.child("nonexistentDir");
+            try {
+                assertThat("if it works at all, should be empty", nonexistentDir.list("**"), emptyArray());
+            } catch (Exception x) {
+                assertThat(x.toString(), containsString(nonexistentDir.getRemote() + DirectoryScanner.DOES_NOT_EXIST_POSTFIX));
+            }
+        }
+    }
+
+}

--- a/test/src/test/java/jenkins/security/s2m/DefaultFilePathFilterTest.java
+++ b/test/src/test/java/jenkins/security/s2m/DefaultFilePathFilterTest.java
@@ -25,13 +25,13 @@
 package jenkins.security.s2m;
 
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.model.Slave;
 import hudson.remoting.Callable;
 import java.io.File;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 import org.jenkinsci.remoting.RoleChecker;
+import static org.hamcrest.Matchers.*;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -67,9 +67,7 @@ public class DefaultFilePathFilterTest {
             // good
 
             // make sure that the stack trace contains the call site info to help assist diagnosis
-            StringWriter sw = new StringWriter();
-            x.printStackTrace(new PrintWriter(sw));
-            assertTrue(sw.toString().contains(DefaultFilePathFilterTest.class.getName()+".remotePath"));
+            assertThat(Functions.printThrowable(x), containsString(DefaultFilePathFilterTest.class.getName()+".remotePath"));
         }
         assertFalse(reverse.exists());
         DefaultFilePathFilter.BYPASS = true;


### PR DESCRIPTION
See [JENKINS-50237](https://issues.jenkins-ci.org/browse/JENKINS-50237) and [JENKINS-49618](https://issues.jenkins-ci.org/browse/JENKINS-49618) .

* Changelog: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#319
* Full diff: https://github.com/jenkinsci/remoting/compare/remoting-3.18...remoting-3.19

Jesse: Changelog as in #3358, but this fixes the underlying problem rather than papering over it with a new whitelist addition. Downstream of https://github.com/jenkinsci/remoting/pull/263.

Without the `FilePath` patch, the test passes, but with a warning.

### Changelog entries

* JENKINS-50237 - BUG - Whitelist `org.apache.tools.ant.Location` to prevent deserialization exception when listing agent files in non-existent directory or invalid filter (JEP-200).
* JENKINS-50237 - Major RFE - Remoting 3.19: Always send `ProxyException` over the channel along with original exceptions, so that Jenkins core can always deserialize exceptions even if the original type is not whitelisted (JEP-200). This change requires update of Remoting versions on the agent side
  *  Full Changelog: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#319
* JENKINS-49618 - RFE - Remoting 3.19: Display Remoting version in the agent log when starting up the agent

### Desired reviewers

@reviewbybees @jenkinsci/code-reviewers 
