### PR TITLE
[JENKINS-50296] Run ThreadPoolForRemoting as SYSTEM

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -30,7 +30,6 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher.ProcStarter;
 import hudson.slaves.Cloud;
-import jenkins.util.SystemProperties;
 import hudson.Util;
 import hudson.cli.declarative.CLIResolver;
 import hudson.console.AnnotatedLargeText;
@@ -65,7 +64,9 @@ import hudson.util.Futures;
 import hudson.util.NamingThreadFactory;
 import jenkins.model.Jenkins;
 import jenkins.util.ContextResettingExecutorService;
+import jenkins.util.SystemProperties;
 import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ImpersonatingExecutorService;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.Icon;
@@ -1352,9 +1353,11 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     public static final ExecutorService threadPoolForRemoting = new ContextResettingExecutorService(
+        new ImpersonatingExecutorService(
             Executors.newCachedThreadPool(
-                    new ExceptionCatchingThreadFactory(
-                            new NamingThreadFactory(new DaemonThreadFactory(), "Computer.threadPoolForRemoting"))));
+                new ExceptionCatchingThreadFactory(
+                    new NamingThreadFactory(
+                        new DaemonThreadFactory(), "Computer.threadPoolForRemoting"))), ACL.SYSTEM));
 
 //
 //

--- a/core/src/test/java/hudson/model/ComputerTest.java
+++ b/core/src/test/java/hudson/model/ComputerTest.java
@@ -38,7 +38,7 @@ public class ComputerTest {
         }
     }
 
-    @Issue("JENKINS-42556")
+    @Issue("JENKINS-50296")
     @Test
     public void testThreadPoolForRemotingActsAsSystemUser() throws InterruptedException, ExecutionException {
         Future<Authentication> job = Computer.threadPoolForRemoting.submit(Jenkins::getAuthentication);

--- a/core/src/test/java/hudson/model/ComputerTest.java
+++ b/core/src/test/java/hudson/model/ComputerTest.java
@@ -1,9 +1,18 @@
 package hudson.model;
 
 import hudson.FilePath;
+import hudson.security.ACL;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.File;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -27,5 +36,12 @@ public class ComputerTest {
         } finally {
             dir.deleteRecursive();
         }
+    }
+
+    @Issue("JENKINS-42556")
+    @Test
+    public void testThreadPoolForRemotingActsAsSystemUser() throws InterruptedException, ExecutionException {
+        Future<Authentication> job = Computer.threadPoolForRemoting.submit(Jenkins::getAuthentication);
+        assertThat(job.get(), is(ACL.SYSTEM));
     }
 }


### PR DESCRIPTION
See [JENKINS-50296](https://issues.jenkins-ci.org/browse/JENKINS-50296).

Changed the `threadPoolForRemoting` to run in the context of the `SYSTEM` user (at present, it runs as `ANONYMOUS`) to keep the code consistent with executors - see #2792 

@reviewbybees 