### PR TITLE
[JENKINS-46386] Make SystemProperties safe to call from agent JVMs

### DIFF
--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -24,7 +24,6 @@
 package jenkins.util;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import java.util.logging.Level;
@@ -67,34 +66,40 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  */
 //TODO: Define a correct design of this engine later. Should be accessible in libs (remoting, stapler) and Jenkins modules too
 @Restricted(NoExternalUse.class)
-public class SystemProperties implements ServletContextListener, OnMaster {
-    // this class implements ServletContextListener and is declared in WEB-INF/web.xml
+public class SystemProperties {
 
-    /**
-     * The ServletContext to get the "init" parameters from.
-     */
-    @CheckForNull
-    private static ServletContext theContext;
+    // declared in WEB-INF/web.xml
+    public static final class Listener implements ServletContextListener, OnMaster {
+
+        /**
+         * The ServletContext to get the "init" parameters from.
+         */
+        @CheckForNull
+        private static ServletContext theContext;
+
+        /**
+         * Called by the servlet container to initialize the {@link ServletContext}.
+         */
+        @Override
+        @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
+                justification = "Currently Jenkins instance may have one ond only one context")
+        public void contextInitialized(ServletContextEvent event) {
+            theContext = event.getServletContext();
+        }
+
+        @Override
+        public void contextDestroyed(ServletContextEvent event) {
+            theContext = null;
+        }
+
+    }
 
     /**
      * Logger.
      */
     private static final Logger LOGGER = Logger.getLogger(SystemProperties.class.getName());
 
-    /**
-     * Public for the servlet container.
-     */
-    public SystemProperties() {}
-
-    /**
-     * Called by the servlet container to initialize the {@link ServletContext}.
-     */
-    @Override
-    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
-            justification = "Currently Jenkins instance may have one ond only one context")
-    public void contextInitialized(ServletContextEvent event) {
-        theContext = event.getServletContext();
-    }
+    private SystemProperties() {}
 
     /**
      * Gets the system property indicated by the specified key.
@@ -373,9 +378,16 @@ public class SystemProperties implements ServletContextListener, OnMaster {
 
     @CheckForNull
     private static String tryGetValueFromContext(String key) {
-        if (StringUtils.isNotBlank(key) && theContext != null) {
+        if (!JenkinsJVM.isJenkinsJVM()) {
+            return null;
+        }
+        return doTryGetValueFromContext(key);
+    }
+
+    private static String doTryGetValueFromContext(String key) {
+        if (StringUtils.isNotBlank(key) && Listener.theContext != null) {
             try {
-                String value = theContext.getInitParameter(key);
+                String value = Listener.theContext.getInitParameter(key);
                 if (value != null) {
                     return value;
                 }
@@ -387,8 +399,4 @@ public class SystemProperties implements ServletContextListener, OnMaster {
         return null;
     }
 
-    @Override
-    public void contextDestroyed(ServletContextEvent event) {
-        // nothing to do
-    }
 }

--- a/test/src/test/java/jenkins/util/SystemPropertiesTest.java
+++ b/test/src/test/java/jenkins/util/SystemPropertiesTest.java
@@ -46,7 +46,7 @@ public class SystemPropertiesTest {
     
     @Before
     public void setUp() {
-        new SystemProperties().contextInitialized(new ServletContextEvent(j.jenkins.servletContext));
+        new SystemProperties.Listener().contextInitialized(new ServletContextEvent(j.jenkins.servletContext));
     }
     
     @Test

--- a/war/src/main/webapp/WEB-INF/web.xml
+++ b/war/src/main/webapp/WEB-INF/web.xml
@@ -153,7 +153,7 @@ THE SOFTWARE.
 
   <listener>
     <!-- Must be before WebAppMain in order to initialize the context before the first use of this class. -->
-    <listener-class>jenkins.util.SystemProperties</listener-class>
+    <listener-class>jenkins.util.SystemProperties$Listener</listener-class>
   </listener>
   <listener>
     <listener-class>hudson.WebAppMain</listener-class>


### PR DESCRIPTION
See [JENKINS-46386](https://issues.jenkins-ci.org/browse/JENKINS-46386). Tested manually using steps given in JIRA.

Accomplishes basically the same thing as #3065, but much more simply. Filing this now because the effectiveness of #3067 seems to have been lost after #3173.

### Proposed changelog entries

* Prevent some cases of linkage errors relating to Servlet classes when code is run on an agent.

### Desired reviewers

@jenkinsci/code-reviewers @reviewbybees