### PR TITLE
[JENKINS-50324] User without READ cannot logout

### DIFF
--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -273,7 +273,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
             if (auth==Jenkins.ANONYMOUS)
                 auth = loadStoredAuthentication();
             sc.setAuthentication(auth); // run the CLI with the right credential
-            if (!(this instanceof LoginCommand || this instanceof HelpCommand))
+            if (!(this instanceof LoginCommand || this instanceof LogoutCommand || this instanceof HelpCommand || this instanceof WhoAmICommand))
                 Jenkins.getActiveInstance().checkPermission(Jenkins.READ);
             return run();
         } catch (CmdLineException e) {


### PR DESCRIPTION
- if the user does not have read permission, he can login but not logout
- or even ask who they are (who-am-i)

See [JENKINS-50324](https://issues.jenkins-ci.org/browse/JENKINS-50324).

### Proposed changelog entries

* CLI over remoting: user without READ can now logout and use `who-am-i` command

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@reviewbybees @oleg-nenashev @dwnusbaum 
