### PR TITLE
Try to prevent NullPointerException’s during Jenkins shutdown

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -904,6 +904,9 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     private void addNewExecutorIfNecessary() {
+        if (Jenkins.getInstanceOrNull() == null) {
+            return;
+        }
         Set<Integer> availableNumbers  = new HashSet<Integer>();
         for (int i = 0; i < numExecutors; i++)
             availableNumbers.add(i);

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -144,7 +144,7 @@ public class Executor extends Thread implements ModelObject {
     public Executor(@Nonnull Computer owner, int n) {
         super("Executor #"+n+" for "+owner.getDisplayName());
         this.owner = owner;
-        this.queue = Jenkins.getInstance().getQueue();
+        this.queue = Jenkins.get().getQueue();
         this.number = n;
     }
 

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -459,6 +459,9 @@ public class Queue extends ResourceController implements Saveable {
      */
     public void save() {
         if(BulkChange.contains(this))  return;
+        if (Jenkins.getInstanceOrNull() == null) {
+            return;
+        }
 
         XmlFile queueFile = new XmlFile(XSTREAM, getXMLQueueFile());
         lock.lock();
@@ -504,11 +507,11 @@ public class Queue extends ResourceController implements Saveable {
     }
 
     private File getQueueFile() {
-        return new File(Jenkins.getInstance().getRootDir(), "queue.txt");
+        return new File(Jenkins.get().getRootDir(), "queue.txt");
     }
 
     /*package*/ File getXMLQueueFile() {
-        return new File(Jenkins.getInstance().getRootDir(), "queue.xml");
+        return new File(Jenkins.get().getRootDir(), "queue.xml");
     }
 
     /**
@@ -1450,6 +1453,10 @@ public class Queue extends ResourceController implements Saveable {
      * and it also gets invoked periodically (see {@link Queue.MaintainTask}.)
      */
     public void maintain() {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins == null) {
+            return;
+        }
         lock.lock();
         try { try {
 
@@ -1460,7 +1467,7 @@ public class Queue extends ResourceController implements Saveable {
 
             {// update parked (and identify any pending items whose executor has disappeared)
                 List<BuildableItem> lostPendings = new ArrayList<BuildableItem>(pendings);
-                for (Computer c : Jenkins.getInstance().getComputers()) {
+                for (Computer c : jenkins.getComputers()) {
                     for (Executor e : c.getExecutors()) {
                         if (e.isInterrupted()) {
                             // JENKINS-28840 we will deadlock if we try to touch this executor while interrupt flag set

--- a/core/src/main/java/hudson/util/PluginServletFilter.java
+++ b/core/src/main/java/hudson/util/PluginServletFilter.java
@@ -166,7 +166,11 @@ public class PluginServletFilter implements Filter, ExtensionPoint {
 
     @Restricted(NoExternalUse.class)
     public static void cleanUp() {
-        PluginServletFilter instance = getInstance(Jenkins.getInstance().servletContext);
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins == null) {
+            return;
+        }
+        PluginServletFilter instance = getInstance(jenkins.servletContext);
         if (instance != null) {
             // While we could rely on the current implementation of list being a CopyOnWriteArrayList
             // safer to just take an explicit copy of the list and operate on the copy


### PR DESCRIPTION
During some functional tests, I think in Pipeline-related code and perhaps only when using `RestartableJenkinsRule`, I have seen various random exceptions printed (without seeming to affect the test result). There look to be cases of `Jenkins.instance == null` momentarily. This patch should just disable code which cannot sensibly run at that point, and would not be accomplishing anything anyway—queue and executor adjustments.

```
java.lang.NullPointerException
	at hudson.model.Queue.maintain(Queue.java:1461)
```

and

```
java.lang.RuntimeException: Unexpected issues encountered during cleanUp: null; null; null
	at jenkins.model.Jenkins.cleanUp(Jenkins.java:3277)
	at …
	Suppressed: java.lang.NullPointerException
		at hudson.model.Queue.getXMLQueueFile(Queue.java:510)
		at hudson.model.Queue.save(Queue.java:462)
		at jenkins.model.Jenkins._cleanUpPersistQueue(Jenkins.java:3545)
		at jenkins.model.Jenkins.cleanUp(Jenkins.java:3256)
		... 6 more
	Suppressed: java.lang.NullPointerException
		at hudson.util.PluginServletFilter.cleanUp(PluginServletFilter.java:150)
		at jenkins.model.Jenkins._cleanUpPluginServletFilters(Jenkins.java:3609)
		at jenkins.model.Jenkins.cleanUp(Jenkins.java:3262)
		... 6 more
Caused by: java.lang.NullPointerException
	at hudson.model.Executor.<init>(Executor.java:138)
	at hudson.model.Computer.addNewExecutorIfNecessary(Computer.java:923)
	at hudson.model.Computer.access$100(Computer.java:150)
	at hudson.model.Computer$2.run(Computer.java:1079)
	at hudson.model.Queue.tryWithLock(Queue.java:1278)
	at hudson.model.Computer.removeExecutor(Computer.java:1089)
	at hudson.model.Executor.interrupt(Executor.java:213)
	at hudson.model.Executor.interrupt(Executor.java:190)
	at hudson.model.Executor.interruptForShutdown(Executor.java:175)
	at hudson.model.Computer$3.run(Computer.java:1116)
	at hudson.model.Queue.withLock(Queue.java:1217)
	at hudson.model.Computer.interrupt(Computer.java:1112)
	at jenkins.model.Jenkins$22.run(Jenkins.java:3369)
	at hudson.model.Queue.withLock(Queue.java:1217)
	at jenkins.model.Jenkins._cleanUpDisconnectComputers(Jenkins.java:3364)
	at jenkins.model.Jenkins.cleanUp(Jenkins.java:3240)
	... 6 more
```

(`cleanUp` does not set `theInstance = null` until the very end, so I am not sure exactly what was going on here. Do not have a reproduction case handy in order to study it further.)

@reviewbybees