### PR TITLE
Adding test coverage for BuildAuthorisationToken

### DIFF
--- a/test/src/test/java/hudson/model/BuildAuthorizationTokenTest.java
+++ b/test/src/test/java/hudson/model/BuildAuthorizationTokenTest.java
@@ -1,0 +1,80 @@
+package hudson.model;
+
+import java.lang.reflect.Field;
+import java.net.URL;
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import jenkins.model.Jenkins;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class BuildAuthorizationTokenTest {
+
+    @Rule
+    public JenkinsRule jr = new JenkinsRule();
+
+    private static final String token = "whatever";
+
+    @Before
+    public void setupSecurity() {
+        jr.jenkins.setSecurityRealm(jr.createDummySecurityRealm());
+        jr.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                                    .grant(Jenkins.READ).everywhere().toEveryone()
+                                                    .grant(Item.READ).everywhere().toEveryone());
+    }
+
+
+    @Test
+    public void triggerJobWithTokenShouldSucceedWithPost() throws Exception {
+        FreeStyleProject project = createFreestyleProjectWithToken();
+        JenkinsRule.WebClient wc = jr.createWebClient();
+        HtmlPage page = wc.getPage(wc.addCrumb(new WebRequest(new URL(jr.getURL(), project.getUrl() +
+                                                                                   "build?delay=0&token="+token)
+                                                             ,HttpMethod.POST)));
+        jr.waitUntilNoActivity();
+        assertThat("the project should have been built", project.getBuilds(), hasSize(1));
+    }
+
+    @Test
+    public void triggerJobWithTokenShouldSucceedWithGet() throws Exception {
+        FreeStyleProject project = createFreestyleProjectWithToken();
+        JenkinsRule.WebClient wc = jr.createWebClient();
+        HtmlPage page = wc.getPage(new WebRequest(new URL(jr.getURL(), project.getUrl() + "build?delay=0&token=" + token)
+                                                  ,HttpMethod.GET));
+        jr.waitUntilNoActivity();
+        assertThat("the project should have been built", project.getBuilds(), hasSize(1));
+    }
+
+
+    @Test
+    public void triggerJobsWithoutTokenShouldFail() throws Exception {
+        FreeStyleProject project = jr.createFreeStyleProject();
+        JenkinsRule.WebClient wc = jr.createWebClient();
+        try {
+            HtmlPage page = wc.getPage(wc.addCrumb(
+                    new WebRequest(new URL(jr.getURL(), project.getUrl() + "build?delay=0"), HttpMethod.POST)));
+            fail("should not reach here as anonymous does not have Item.BUILD and token is not set");
+        }
+        catch (FailingHttpStatusCodeException fex) {
+            assertThat("Should fail with access denined", fex.getStatusCode(), is(403));
+        }
+    }
+
+    private FreeStyleProject createFreestyleProjectWithToken() throws Exception {
+        FreeStyleProject fsp = jr.createFreeStyleProject();
+        Field f = AbstractProject.class.getDeclaredField("authToken");
+        f.setAccessible(true);
+        f.set(fsp, new BuildAuthorizationToken(token));
+        return fsp;
+    }
+}

--- a/test/src/test/java/hudson/model/BuildAuthorizationTokenTest.java
+++ b/test/src/test/java/hudson/model/BuildAuthorizationTokenTest.java
@@ -33,7 +33,6 @@ public class BuildAuthorizationTokenTest {
                                                     .grant(Item.READ).everywhere().toEveryone());
     }
 
-
     @Test
     public void triggerJobWithTokenShouldSucceedWithPost() throws Exception {
         FreeStyleProject project = createFreestyleProjectWithToken();


### PR DESCRIPTION
I could not see any test coverage for BuildAuthorisationToken so added
some.

No JIRA - as this is improving test coverage.


### Proposed changelog entries

N/A test code only

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
