### PR TITLE
[JENKINS-50291] Customize where Async[A]PeriodicWork tasks are logged

### DIFF
--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -200,7 +200,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
      * Determines the log file that records the result of this task.
      */
     protected File getLogFile() {
-        return new File(Jenkins.getActiveInstance().getRootDir(),"logs/tasks/"+name+".log");
+        return new File(getLogsRoot(), "/tasks/" + name + ".log");
     }
 
     /**

--- a/core/src/main/java/hudson/model/AsyncPeriodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncPeriodicWork.java
@@ -183,7 +183,7 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
      * Determines the log file that records the result of this task.
      */
     protected File getLogFile() {
-        return new File(Jenkins.getActiveInstance().getRootDir(),"logs/tasks/"+name+".log");
+        return new File(getLogsRoot(), "/tasks/" + name + ".log");
     }
     
     /**

--- a/core/src/main/java/hudson/triggers/SafeTimerTask.java
+++ b/core/src/main/java/hudson/triggers/SafeTimerTask.java
@@ -52,11 +52,11 @@ import org.acegisecurity.context.SecurityContextHolder;
 public abstract class SafeTimerTask extends TimerTask {
 
     /**
-     * System property to change the location where tasks logging should be sent.
+     * System property to change the location where (tasks) logging should be sent.
      * <p><strong>Beware: changing it while Jenkins is running gives no guarantee logs will be sent to the new location
      * until it is restarted.</strong></p>
      */
-    static final String TASKS_LOGS_ROOT_PATH_PROPERTY = SafeTimerTask.class.getName()+".TASKS_LOGS_ROOT_PATH";
+    static final String LOGS_ROOT_PATH_PROPERTY = SafeTimerTask.class.getName()+".logsTargetDir";
 
     public final void run() {
         // background activity gets system credential,
@@ -83,13 +83,13 @@ public abstract class SafeTimerTask extends TimerTask {
      * @since TODO
      */
     public static File getLogsRoot() {
-        String tagsLogsPath = SystemProperties.getString(TASKS_LOGS_ROOT_PATH_PROPERTY);
+        String tagsLogsPath = SystemProperties.getString(LOGS_ROOT_PATH_PROPERTY);
         if (tagsLogsPath == null) {
             return new File(Jenkins.get().getRootDir(), "logs");
         } else {
             LOGGER.log(Level.INFO,
                        "Using non default root path for tasks logging: {0}. (Beware: no automated migration if you change or remove it again)",
-                       TASKS_LOGS_ROOT_PATH_PROPERTY);
+                       LOGS_ROOT_PATH_PROPERTY);
             return new File(tagsLogsPath);
         }
     }

--- a/core/src/main/java/hudson/triggers/SafeTimerTask.java
+++ b/core/src/main/java/hudson/triggers/SafeTimerTask.java
@@ -24,11 +24,18 @@
 package hudson.triggers;
 
 import hudson.model.AperiodicWork;
+import hudson.model.AsyncAperiodicWork;
+import hudson.model.AsyncPeriodicWork;
 import hudson.model.PeriodicWork;
 import hudson.security.ACL;
+
+import java.io.File;
 import java.util.TimerTask;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 import jenkins.util.Timer;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
@@ -43,6 +50,14 @@ import org.acegisecurity.context.SecurityContextHolder;
  * @since 1.124
  */
 public abstract class SafeTimerTask extends TimerTask {
+
+    /**
+     * System property to change the location where tasks logging should be sent.
+     * <p><strong>Beware: changing it while Jenkins is running gives no guarantee logs will be sent to the new location
+     * until it is restarted.</strong></p>
+     */
+    static final String TASKS_LOGS_ROOT_PATH_PROPERTY = SafeTimerTask.class.getName()+".TASKS_LOGS_ROOT_PATH";
+
     public final void run() {
         // background activity gets system credential,
         // just like executors get it.
@@ -57,6 +72,27 @@ public abstract class SafeTimerTask extends TimerTask {
     }
 
     protected abstract void doRun() throws Exception;
+
+
+    /**
+     * The root path that should be used to put logs related to the tasks running in Jenkins.
+     *
+     * @see AsyncAperiodicWork#getLogFile()
+     * @see AsyncPeriodicWork#getLogFile()
+     * @return the path where the logs should be put.
+     * @since TODO
+     */
+    public static File getLogsRoot() {
+        String tagsLogsPath = SystemProperties.getString(TASKS_LOGS_ROOT_PATH_PROPERTY);
+        if (tagsLogsPath == null) {
+            return new File(Jenkins.get().getRootDir(), "logs");
+        } else {
+            LOGGER.log(Level.INFO,
+                       "Using non default root path for tasks logging: {0}. (Beware: no automated migration if you change or remove it again)",
+                       TASKS_LOGS_ROOT_PATH_PROPERTY);
+            return new File(tagsLogsPath);
+        }
+    }
 
     private static final Logger LOGGER = Logger.getLogger(SafeTimerTask.class.getName());
 }

--- a/test/src/test/java/hudson/triggers/SafeTimerTaskTest.java
+++ b/test/src/test/java/hudson/triggers/SafeTimerTaskTest.java
@@ -1,0 +1,76 @@
+package hudson.triggers;
+
+import hudson.model.AsyncPeriodicWork;
+import hudson.model.TaskListener;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class SafeTimerTaskTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public LoggerRule loggerRule = new LoggerRule();
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty(SafeTimerTask.TASKS_LOGS_ROOT_PATH_PROPERTY);
+    }
+
+    @Issue("JENKINS-50291")
+    @Test
+    public void changeLogsRoot() throws Exception {
+        assertNull(System.getProperty(SafeTimerTask.TASKS_LOGS_ROOT_PATH_PROPERTY));
+
+        File temporaryFolder = folder.newFolder();
+
+        // Check historical default value
+        final File logsRoot = new File(j.jenkins.getRootDir(), "logs/tasks");
+
+        // Give some time for the logs to arrive
+        Thread.sleep(3 * LogSpammer.RECURRENCE_PERIOD);
+
+        assertTrue(logsRoot.exists());
+        assertTrue(logsRoot.isDirectory());
+
+        System.setProperty(SafeTimerTask.TASKS_LOGS_ROOT_PATH_PROPERTY, temporaryFolder.toString());
+        assertEquals(temporaryFolder.toString(), SafeTimerTask.getLogsRoot().toString());
+    }
+
+    @TestExtension
+    public static class LogSpammer extends AsyncPeriodicWork {
+
+        public static final long RECURRENCE_PERIOD = 50L;
+
+        public LogSpammer() {
+            super("wut");
+        }
+
+        @Override
+        protected void execute(TaskListener listener) throws IOException, InterruptedException {
+            listener.getLogger().println("blah");
+        }
+
+        @Override
+        public long getRecurrencePeriod() {
+            return RECURRENCE_PERIOD;
+        }
+    }
+}

--- a/test/src/test/java/hudson/triggers/SafeTimerTaskTest.java
+++ b/test/src/test/java/hudson/triggers/SafeTimerTaskTest.java
@@ -31,13 +31,13 @@ public class SafeTimerTaskTest {
 
     @After
     public void tearDown() throws Exception {
-        System.clearProperty(SafeTimerTask.TASKS_LOGS_ROOT_PATH_PROPERTY);
+        System.clearProperty(SafeTimerTask.LOGS_ROOT_PATH_PROPERTY);
     }
 
     @Issue("JENKINS-50291")
     @Test
     public void changeLogsRoot() throws Exception {
-        assertNull(System.getProperty(SafeTimerTask.TASKS_LOGS_ROOT_PATH_PROPERTY));
+        assertNull(System.getProperty(SafeTimerTask.LOGS_ROOT_PATH_PROPERTY));
 
         File temporaryFolder = folder.newFolder();
 
@@ -50,7 +50,7 @@ public class SafeTimerTaskTest {
         assertTrue(logsRoot.exists());
         assertTrue(logsRoot.isDirectory());
 
-        System.setProperty(SafeTimerTask.TASKS_LOGS_ROOT_PATH_PROPERTY, temporaryFolder.toString());
+        System.setProperty(SafeTimerTask.LOGS_ROOT_PATH_PROPERTY, temporaryFolder.toString());
         assertEquals(temporaryFolder.toString(), SafeTimerTask.getLogsRoot().toString());
     }
 


### PR DESCRIPTION
See [JENKINS-50291](https://issues.jenkins-ci.org/browse/JENKINS-50291).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* [JENKINS-50291](https://issues.jenkins-ci.org/browse/JENKINS-50291): Introduce system property to send logs usually sent to `$JENKINS_HOME/logs` to another location. 

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
