### PR TITLE
[JENKINS-50405] Run the entire thing in docker && highmem node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ for(i = 0; i < buildTypes.size(); i++) {
 }
 
 builds.ath = {
-    node("linux") {
+    node("docker&&highmem") {
         // Just to be safe
         deleteDir()
         def fileUri


### PR DESCRIPTION
See [JENKINS-50405](https://issues.jenkins-ci.org/browse/JENKINS-50405).

Check [pipeline-library#33](https://github.com/jenkins-infra/pipeline-library/pull/33)

Make sure the runATH step is not blocking the linux nodes

### Proposed changelog entries

N/A

### Submitter checklist

- [X] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

