### PR TITLE
[JENKINS-50237] - Backport: Whitelist org.apache.tools.ant.Location for serialization

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -152,6 +152,7 @@ net.bull.javamelody.internal.model.TomcatInformations
 org.acegisecurity.userdetails.User
 org.apache.commons.fileupload.disk.DiskFileItem
 org.apache.commons.fileupload.util.FileItemHeadersImpl
+org.apache.tools.ant.Location
 
 # TODO remove when git-client 2.7.1+ is widely adopted
 org.eclipse.jgit.lib.ObjectId


### PR DESCRIPTION
This change backports a small fix for [JENKINS-50237](https://issues.jenkins-ci.org/browse/JENKINS-50237). It comes from https://github.com/jenkinsci/jenkins/pull/3359, but we do not backport the Remoting part of this pull request.

(cherry picked from commit 300fbc3715f1f96a67300e22ab2dc3a7f1556746)

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* JENKINS-50237 - BUG - Whitelist org.apache.tools.ant.Location to prevent deserialization exception when listing agent files in non-existent directory or invalid filter (JEP-200).

### Desired reviewers

@reviewbybees @jglick @olivergondza 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
