### PR TITLE
[JENKINS-44402] Make cancel shutdown link work when loaded via AJAX

### DIFF
--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -46,6 +46,7 @@ THE SOFTWARE.
     </j:otherwise>
   </j:choose>
   <l:pane title="${title}" width="2" id="buildQueue">
+    <st:adjunct includes="lib.form.link.link"/>
     <j:if test="${app.quietingDown}">
       <tr>
         <td class="pane" colspan="2" style="white-space: normal;">


### PR DESCRIPTION
See [JENKINS-44402](https://issues.jenkins-ci.org/browse/JENKINS-44402). 

This is currently just a workaround that loads the link library unconditionally (so its script tag has already been processed when the link appears via AJAX) because I do not know the best way to fix the root cause.

The real fix would be to load script tags in `refreshPart` when setting `innerHtml` in [hudson-behavior.js](https://github.com/jenkinsci/jenkins/blob/master/war/src/main/webapp/scripts/hudson-behavior.js#L1521), but I'm not sure about the security implications of doing that.

### Proposed changelog entries

* Make cancel shutdown link work without requiring the page to be reloaded.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees 
