### PR TITLE
CSS fix to prevent table content from breaking out of table and align small images for Google Chrome.

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -446,7 +446,12 @@ table.pane {
   width: 100%;
   border-collapse: collapse;
   border: 1px #bbb solid;
-  hyphens: auto;
+   /* Adds a hyphen where the word breaks, if supported (No Blink) */
+   -ms-hyphens: auto;
+   -moz-hyphens: auto;
+   -webkit-hyphens: auto;
+   hyphens: auto;
+ 
 }
 
 td.pane {

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -446,6 +446,7 @@ table.pane {
   width: 100%;
   border-collapse: collapse;
   border: 1px #bbb solid;
+  hyphens: auto;
 }
 
 td.pane {
@@ -1897,6 +1898,7 @@ body.no-sticker #bottom-sticker {
 .icon-sm {
     width: 16px;
     height: 16px;
+    float: left;
 }
 
 .icon-md {


### PR DESCRIPTION
We noticed an issue on our Jenkins instances where long build server names were breaking out of the left hand side tables for build status on Google Chrome. Firefox and IE appeared correct. 

### Proposed changelog entries

* Entry 1: Change the style.css to prevent content from breaking out of tables in CSS and align images to left so text aligns with image in Chrome. 
