### PR TITLE
Log the message only once in INFO level

### DIFF
--- a/core/src/main/java/hudson/triggers/SafeTimerTask.java
+++ b/core/src/main/java/hudson/triggers/SafeTimerTask.java
@@ -58,6 +58,12 @@ public abstract class SafeTimerTask extends TimerTask {
      */
     static final String LOGS_ROOT_PATH_PROPERTY = SafeTimerTask.class.getName()+".logsTargetDir";
 
+    /**
+     * Local marker to know if the information about using non default root directory for logs has already been logged at least once.
+     * @see #LOGS_ROOT_PATH_PROPERTY
+     */
+    private static boolean ALREADY_LOGGED = false;
+
     public final void run() {
         // background activity gets system credential,
         // just like executors get it.
@@ -87,9 +93,14 @@ public abstract class SafeTimerTask extends TimerTask {
         if (tagsLogsPath == null) {
             return new File(Jenkins.get().getRootDir(), "logs");
         } else {
-            LOGGER.log(Level.INFO,
+            Level logLevel = Level.INFO;
+            if (ALREADY_LOGGED) {
+                logLevel = Level.FINE;
+            }
+            LOGGER.log(logLevel,
                        "Using non default root path for tasks logging: {0}. (Beware: no automated migration if you change or remove it again)",
                        LOGS_ROOT_PATH_PROPERTY);
+            ALREADY_LOGGED = true;
             return new File(tagsLogsPath);
         }
     }


### PR DESCRIPTION
Without this, we will see this log more and more as plugins start using this to put their logs at the right place, as I realized while working on https://github.com/jenkinsci/metrics-plugin/pull/30.

This is a small followup improvement for https://github.com/jenkinsci/jenkins/pull/3367

See [JENKINS-50291](https://issues.jenkins-ci.org/browse/JENKINS-50291) for more context.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* JENKINS-50291 improvement: log only once the fact the instance is using a non default configuration.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
