### PR TITLE
[JENKINS-50599] Make Nodes#addNode fail atomically

### DIFF
--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -142,7 +142,7 @@ public class Nodes implements Saveable {
             // TODO there is a theoretical race whereby the node instance is updated/removed after lock release
             try {
                 persistNode(node);
-            } catch (IOException e) {
+            } catch (IOException | RuntimeException e) {
                 // JENKINS-50599: If persisting the node throws an exception, we need to remove the node from
                 // memory before propagating the exception.
                 Queue.withLock(new Runnable() {

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -148,7 +148,7 @@ public class Nodes implements Saveable {
                 Queue.withLock(new Runnable() {
                     @Override
                     public void run() {
-                        nodes.compute(node.getNodeName(), (nodeName, node) -> oldNode);
+                        nodes.compute(node.getNodeName(), (ignoredNodeName, ignoredNode) -> oldNode);
                         jenkins.updateComputerList();
                         jenkins.trimLabels();
                     }

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -148,11 +148,7 @@ public class Nodes implements Saveable {
                 Queue.withLock(new Runnable() {
                     @Override
                     public void run() {
-                        if (oldNode == null) {
-                            nodes.remove(node.getNodeName());
-                        } else {
-                            nodes.put(node.getNodeName(), oldNode);
-                        }
+                        nodes.compute(node.getNodeName(), (nodeName, node) -> oldNode);
                         jenkins.updateComputerList();
                         jenkins.trimLabels();
                     }

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -144,7 +144,7 @@ public class Nodes implements Saveable {
                 persistNode(node);
             } catch (IOException e) {
                 // JENKINS-50599: If persisting the node throws an exception, we need to remove the node from
-                // memory before propogating the exception.
+                // memory before propagating the exception.
                 Queue.withLock(new Runnable() {
                     @Override
                     public void run() {

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -127,7 +127,8 @@ public class Nodes implements Saveable {
      * @throws IOException if the list of nodes could not be persisted.
      */
     public void addNode(final @Nonnull Node node) throws IOException {
-        if (node != nodes.get(node.getNodeName())) {
+        Node oldNode = nodes.get(node.getNodeName());
+        if (node != oldNode) {
             // TODO we should not need to lock the queue for adding nodes but until we have a way to update the
             // computer list for just the new node
             Queue.withLock(new Runnable() {
@@ -139,7 +140,25 @@ public class Nodes implements Saveable {
                 }
             });
             // TODO there is a theoretical race whereby the node instance is updated/removed after lock release
-            persistNode(node);
+            try {
+                persistNode(node);
+            } catch (IOException e) {
+                // JENKINS-50599: If persisting the node throws an exception, we need to remove the node from
+                // memory before propogating the exception.
+                Queue.withLock(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (oldNode == null) {
+                            nodes.remove(node.getNodeName());
+                        } else {
+                            nodes.put(node.getNodeName(), oldNode);
+                        }
+                        jenkins.updateComputerList();
+                        jenkins.trimLabels();
+                    }
+                });
+                throw e;
+            }
             NodeListener.fireOnCreated(node);
         }
     }

--- a/test/src/test/java/jenkins/model/NodesTest.java
+++ b/test/src/test/java/jenkins/model/NodesTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model;
+
+import hudson.model.Descriptor;
+import hudson.model.Slave;
+import hudson.slaves.ComputerLauncher;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class NodesTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-50599")
+    public void addNodeShouldFailAtomically() throws Exception {
+        InvalidNode node = new InvalidNode("foo", "temp", r.createComputerLauncher(null));
+        try {
+            r.jenkins.addNode(node);
+            fail("Adding the node should have thrown an exception during serialization");
+        } catch (IOException e) {
+            String className = InvalidNode.class.getName();
+            assertThat("The exception should be from failing to serialize the node",
+                    e.getMessage(), containsString("Failed to serialize " + className + "#cl for class " + className));
+        }
+        assertThat("The node should not exist since #addNode threw an exception",
+                r.jenkins.getNode("foo"), nullValue());
+    }
+
+    private static class InvalidNode extends Slave {
+        private ClassLoader cl; // JEP-200 whitelist changes prevent this field from being serialized.
+
+        public InvalidNode(String name, String remoteFS, ComputerLauncher launcher) throws Descriptor.FormException, IOException {
+            super(name, remoteFS, launcher);
+            cl = InvalidNode.class.getClassLoader();
+        }
+    }
+}


### PR DESCRIPTION
See [JENKINS-50599](https://issues.jenkins-ci.org/browse/JENKINS-50599).

### Proposed changelog entries

* Bugfix: Make the logic for adding nodes atomic, so that if a newly added node fails to be persisted it will not exist in a partly-initialized state.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees 