### PR TITLE
[FIX JENKINS-50748] Handle null arg to jsStringEscape

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1379,6 +1379,7 @@ public class Functions {
     }
 
     public static String jsStringEscape(String s) {
+        if (s == null) return null;
         StringBuilder buf = new StringBuilder();
         for( int i=0; i<s.length(); i++ ) {
             char ch = s.charAt(i);


### PR DESCRIPTION
See [JENKINS-50748](https://issues.jenkins-ci.org/browse/JENKINS-50748).

### Proposed changelog entries

* Bug: Don't log null pointer exceptions on some forms with validation button (regression in 2.116).

@Wadeck @oleg-nenashev @dwnusbaum 