### PR TITLE
[JENKINS-51966] - Move XmlFile into hierarchy XmlFileStorage -> FileStorage -> Storage.

### DIFF
--- a/core/src/main/java/hudson/FileStorage.java
+++ b/core/src/main/java/hudson/FileStorage.java
@@ -1,0 +1,7 @@
+package hudson;
+
+public interface FileStorage extends Storage {
+    boolean exists();
+
+    void delete();
+}

--- a/core/src/main/java/hudson/Plugin.java
+++ b/core/src/main/java/hudson/Plugin.java
@@ -258,7 +258,7 @@ public abstract class Plugin implements Saveable {
      * @since 1.245
      */
     protected void load() throws IOException {
-        XmlFile xml = getConfigXml();
+        XmlFileStorage xml = getConfigXml();
         if(xml.exists())
             xml.unmarshal(this);
     }
@@ -270,7 +270,7 @@ public abstract class Plugin implements Saveable {
      */
     public void save() throws IOException {
         if(BulkChange.contains(this))   return;
-        XmlFile config = getConfigXml();
+        Storage config = getConfigXml();
         config.write(this);
         SaveableListener.fireOnChange(this, config);
     }
@@ -284,8 +284,8 @@ public abstract class Plugin implements Saveable {
      *
      * @since 1.245
      */
-    protected XmlFile getConfigXml() {
-        return new XmlFile(Jenkins.XSTREAM,
+    protected XmlFileStorage getConfigXml() {
+        return new XmlFileStorage(Jenkins.XSTREAM,
                 new File(Jenkins.getInstance().getRootDir(),wrapper.getShortName()+".xml"));
     }
 

--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -199,7 +199,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
 
     public void save() throws IOException {
         if(BulkChange.contains(this))   return;
-        XmlFile config = getXmlFile();
+        Storage config = getXmlFile();
         config.write(this);
         SaveableListener.fireOnChange(this, config);
     }
@@ -212,12 +212,12 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
         return this;
     }
 
-    public static XmlFile getXmlFile() {
-        return new XmlFile(XSTREAM, new File(Jenkins.getInstance().getRootDir(), "proxy.xml"));
+    public static XmlFileStorage getXmlFile() {
+        return new XmlFileStorage(XSTREAM, new File(Jenkins.getInstance().getRootDir(), "proxy.xml"));
     }
 
     public static ProxyConfiguration load() throws IOException {
-        XmlFile f = getXmlFile();
+        FileStorage f = getXmlFile();
         if(f.exists())
             return (ProxyConfiguration) f.read();
         else

--- a/core/src/main/java/hudson/Storage.java
+++ b/core/src/main/java/hudson/Storage.java
@@ -1,0 +1,9 @@
+package hudson;
+
+import java.io.IOException;
+
+public interface Storage {
+    Object read() throws IOException;
+
+    void write(Object o) throws IOException;
+}

--- a/core/src/main/java/hudson/XmlFileStorage.java
+++ b/core/src/main/java/hudson/XmlFileStorage.java
@@ -113,17 +113,17 @@ import org.apache.commons.io.IOUtils;
  * @see <a href="https://wiki.jenkins-ci.org/display/JENKINS/Architecture#Architecture-Persistence">Architecture » Persistence</a>
  * @author Kohsuke Kawaguchi
  */
-public final class XmlFile {
+public final class XmlFileStorage implements FileStorage {
     private final XStream xs;
     private final File file;
     private static final Map<Object, Void> beingWritten = Collections.synchronizedMap(new IdentityHashMap<>());
     private static final ThreadLocal<File> writing = new ThreadLocal<>();
 
-    public XmlFile(File file) {
+    public XmlFileStorage(File file) {
         this(DEFAULT_XSTREAM,file);
     }
 
-    public XmlFile(XStream xs, File file) {
+    public XmlFileStorage(XStream xs, File file) {
         this.xs = xs;
         this.file = file;
     }
@@ -182,7 +182,8 @@ public final class XmlFile {
         }
     }
 
-    public void write( Object o ) throws IOException {
+    @Override
+    public void write(Object o) throws IOException {
         mkdirs();
         AtomicFileWriter w = new AtomicFileWriter(file);
         try {
@@ -352,7 +353,7 @@ public final class XmlFile {
      * {@link XStream} instance is supposed to be thread-safe.
      */
 
-    private static final Logger LOGGER = Logger.getLogger(XmlFile.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(XmlFileStorage.class.getName());
 
     private static final SAXParserFactory JAXP = SAXParserFactory.newInstance();
 

--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -26,7 +26,7 @@ package hudson.diagnosis;
 import com.google.common.base.Predicate;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import hudson.Extension;
-import hudson.XmlFile;
+import hudson.Storage;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -127,7 +127,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
     @Extension
     public static final SaveableListener changeListener = new SaveableListener() {
         @Override
-        public void onChange(Saveable obj, XmlFile file) {
+        public void onChange(Saveable obj, Storage file) {
             remove(obj, false);
         }
     };

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -29,7 +29,7 @@ import hudson.BulkChange;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.model.*;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
@@ -330,7 +330,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
         JSONObject src = req.getSubmittedForm();
 
         String newName = src.getString("name"), redirect = ".";
-        XmlFile oldFile = null;
+        XmlFileStorage oldFile = null;
         if(!name.equals(newName)) {
             Jenkins.checkGoodName(newName);
             oldFile = getConfigFile();
@@ -402,8 +402,8 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
     /**
      * The file we save our configuration.
      */
-    private XmlFile getConfigFile() {
-        return new XmlFile(XSTREAM, new File(LogRecorderManager.configDir(), name + ".xml"));
+    private XmlFileStorage getConfigFile() {
+        return new XmlFileStorage(XSTREAM, new File(LogRecorderManager.configDir(), name + ".xml"));
     }
 
     /**

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -26,7 +26,7 @@ package hudson.model;
 
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import hudson.AbortException;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.Util;
 import hudson.Functions;
 import hudson.BulkChange;
@@ -38,7 +38,6 @@ import hudson.model.queue.Tasks;
 import hudson.model.queue.WorkUnit;
 import hudson.security.ACLContext;
 import hudson.security.AccessControlled;
-import hudson.security.Permission;
 import hudson.security.ACL;
 import hudson.util.AlternativeUiTextProvider;
 import hudson.util.AlternativeUiTextProvider.Message;
@@ -598,12 +597,12 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         SaveableListener.fireOnChange(this, getConfigFile());
     }
 
-    public final XmlFile getConfigFile() {
+    public final XmlFileStorage getConfigFile() {
         return Items.getConfigFile(this);
     }
 
     private Object writeReplace() {
-        return XmlFile.replaceIfNotAtTopLevel(this, () -> new Replacer(this));
+        return XmlFileStorage.replaceIfNotAtTopLevel(this, () -> new Replacer(this));
     }
     private static class Replacer {
         private final String fullName;
@@ -819,7 +818,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     @Restricted(NoExternalUse.class)
     public void writeConfigDotXml(OutputStream os) throws IOException {
         checkPermission(EXTENDED_READ);
-        XmlFile configFile = getConfigFile();
+        XmlFileStorage configFile = getConfigFile();
         if (hasPermission(CONFIGURE)) {
             IOUtils.copy(configFile.getFile(), os);
         } else {
@@ -855,7 +854,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      */
     public void updateByXml(Source source) throws IOException {
         checkPermission(CONFIGURE);
-        XmlFile configXmlFile = getConfigFile();
+        XmlFileStorage configXmlFile = getConfigFile();
         final AtomicFileWriter out = new AtomicFileWriter(configXmlFile.getFile());
         try {
             try {
@@ -866,7 +865,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
             }
 
             // try to reflect the changes by reloading
-            Object o = new XmlFile(Items.XSTREAM, out.getTemporaryFile()).unmarshalNullingOut(this);
+            Object o = new XmlFileStorage(Items.XSTREAM, out.getTemporaryFile()).unmarshalNullingOut(this);
             if (o!=this) {
                 // ensure that we've got the same job type. extending this code to support updating
                 // to different job type requires destroying & creating a new job type

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -26,8 +26,9 @@ package hudson.model;
 import hudson.BulkChange;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
+import hudson.FileStorage;
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.init.Initializer;
 import hudson.model.Descriptor.FormException;
 import hudson.model.listeners.SaveableListener;
@@ -371,8 +372,8 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     /**
      * {@link NodeMonitor}s are persisted in this file.
      */
-    private static XmlFile getConfigFile() {
-        return new XmlFile(new File(Jenkins.getInstance().getRootDir(),"nodeMonitors.xml"));
+    private static XmlFileStorage getConfigFile() {
+        return new XmlFileStorage(new File(Jenkins.getInstance().getRootDir(),"nodeMonitors.xml"));
     }
 
     public Api getApi() {
@@ -438,7 +439,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
                     = new DescribableList<NodeMonitor, Descriptor<NodeMonitor>>(Saveable.NOOP);
 
             // load persisted monitors
-            XmlFile xf = getConfigFile();
+            FileStorage xf = getConfigFile();
             if(xf.exists()) {
                 DescribableList<NodeMonitor,Descriptor<NodeMonitor>> persisted =
                         (DescribableList<NodeMonitor,Descriptor<NodeMonitor>>) xf.read();

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -26,7 +26,7 @@ package hudson.model;
 import hudson.DescriptorExtensionList;
 import hudson.PluginWrapper;
 import hudson.RelativePath;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.BulkChange;
 import hudson.ExtensionList;
 import hudson.Util;
@@ -885,7 +885,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      * get a chance to set default values.)
      */
     public synchronized void load() {
-        XmlFile file = getConfigFile();
+        XmlFileStorage file = getConfigFile();
         if(!file.exists())
             return;
 
@@ -896,8 +896,8 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
         }
     }
 
-    protected XmlFile getConfigFile() {
-        return new XmlFile(new File(Jenkins.getInstance().getRootDir(),getId()+".xml"));
+    protected XmlFileStorage getConfigFile() {
+        return new XmlFileStorage(new File(Jenkins.getInstance().getRootDir(),getId()+".xml"));
     }
 
     /**

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -32,8 +32,10 @@ import com.thoughtworks.xstream.converters.basic.DateConverter;
 import com.thoughtworks.xstream.converters.collections.CollectionConverter;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+import hudson.FileStorage;
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.BulkChange;
 import hudson.Extension;
 import hudson.model.listeners.ItemListener;
@@ -1335,8 +1337,9 @@ public class Fingerprint implements ModelObject, Saveable {
     /**
      * The file we save our configuration.
      */
-    private static @Nonnull XmlFile getConfigFile(@Nonnull File file) {
-        return new XmlFile(XSTREAM,file);
+    private static @Nonnull
+    XmlFileStorage getConfigFile(@Nonnull File file) {
+        return new XmlFileStorage(XSTREAM,file);
     }
 
     /**
@@ -1357,7 +1360,7 @@ public class Fingerprint implements ModelObject, Saveable {
         return load(getFingerprintFile(md5sum));
     }
     /*package*/ static @CheckForNull Fingerprint load(@Nonnull File file) throws IOException {
-        XmlFile configFile = getConfigFile(file);
+        FileStorage configFile = getConfigFile(file);
         if(!configFile.exists())
             return null;
 

--- a/core/src/main/java/hudson/model/ItemGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ItemGroupMixIn.java
@@ -24,7 +24,7 @@
 package hudson.model;
 
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.model.listeners.ItemListener;
 import hudson.security.AccessControlled;
 import hudson.util.CopyOnWriteMap;
@@ -111,7 +111,7 @@ public abstract class ItemGroupMixIn {
                 // Try to retain the identity of an existing child object if we can.
                 V item = (V) parent.getItem(subdir.getName());
                 if (item == null) {
-                    XmlFile xmlFile = Items.getConfigFile(subdir);
+                    XmlFileStorage xmlFile = Items.getConfigFile(subdir);
                     if (xmlFile.exists()) {
                         item = (V) Items.load(parent, subdir);
                     } else {
@@ -222,7 +222,7 @@ public abstract class ItemGroupMixIn {
     public synchronized <T extends TopLevelItem> T copy(T src, String name) throws IOException {
         acl.checkPermission(Item.CREATE);
         src.checkPermission(Item.EXTENDED_READ);
-        XmlFile srcConfigFile = Items.getConfigFile(src);
+        XmlFileStorage srcConfigFile = Items.getConfigFile(src);
         if (!src.hasPermission(Item.CONFIGURE)) {
             Matcher matcher = AbstractItem.SECRET_PATTERN.matcher(srcConfigFile.asString());
             while (matcher.find()) {

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -26,7 +26,7 @@ package hudson.model;
 import com.thoughtworks.xstream.XStream;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.model.listeners.ItemListener;
 import hudson.remoting.Callable;
 import hudson.security.ACL;
@@ -376,14 +376,14 @@ public class Items {
     /**
      * The file we save our configuration.
      */
-    public static XmlFile getConfigFile(File dir) {
-        return new XmlFile(XSTREAM,new File(dir,"config.xml"));
+    public static XmlFileStorage getConfigFile(File dir) {
+        return new XmlFileStorage(XSTREAM,new File(dir,"config.xml"));
     }
 
     /**
      * The file we save our configuration.
      */
-    public static XmlFile getConfigFile(Item item) {
+    public static XmlFileStorage getConfigFile(Item item) {
         return getConfigFile(item.getRootDir());
     }
     

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -32,8 +32,9 @@ import hudson.BulkChange;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.Storage;
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.init.Initializer;
 import static hudson.init.InitMilestone.JOB_LOADED;
 import static hudson.util.Iterators.reverse;
@@ -394,7 +395,7 @@ public class Queue extends ResourceController implements Saveable {
             } else {
                 queueFile = getXMLQueueFile();
                 if (queueFile.exists()) {
-                    Object unmarshaledObj = new XmlFile(XSTREAM, queueFile).read();
+                    Object unmarshaledObj = new XmlFileStorage(XSTREAM, queueFile).read();
                     List items;
 
                     if (unmarshaledObj instanceof State) {
@@ -463,7 +464,7 @@ public class Queue extends ResourceController implements Saveable {
             return;
         }
 
-        XmlFile queueFile = new XmlFile(XSTREAM, getXMLQueueFile());
+        Storage queueFile = new XmlFileStorage(XSTREAM, getXMLQueueFile());
         lock.lock();
         try {
             // write out the queue state we want to save

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -46,7 +46,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.StandardOpenOption;
 import jenkins.util.SystemProperties;
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.cli.declarative.CLIMethod;
 import hudson.model.Descriptor.FormException;
 import hudson.model.listeners.RunListener;
@@ -1924,12 +1924,13 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         SaveableListener.fireOnChange(this, getDataFile());
     }
 
-    private @Nonnull XmlFile getDataFile() {
-        return new XmlFile(XSTREAM,new File(getRootDir(),"build.xml"));
+    private @Nonnull
+    XmlFileStorage getDataFile() {
+        return new XmlFileStorage(XSTREAM,new File(getRootDir(),"build.xml"));
     }
 
     private Object writeReplace() {
-        return XmlFile.replaceIfNotAtTopLevel(this, () -> new Replacer(this));
+        return XmlFileStorage.replaceIfNotAtTopLevel(this, () -> new Replacer(this));
     }
     private static class Replacer {
         private final String id;

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -35,7 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import jenkins.util.SystemProperties;
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import static hudson.init.InitMilestone.PLUGINS_STARTED;
 import static java.util.logging.Level.WARNING;
 
@@ -849,7 +849,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      * Loads the data from the disk into this object.
      */
     public synchronized void load() throws IOException {
-        XmlFile file = getConfigFile();
+        XmlFileStorage file = getConfigFile();
         if(file.exists()) {
             try {
                 sites.replaceBy(((PersistedList)file.unmarshal(sites)).toList());
@@ -881,8 +881,8 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         return new UpdateSite(PREDEFINED_UPDATE_SITE_ID, config.getUpdateCenterUrl() + "update-center.json");
     }
 
-    private XmlFile getConfigFile() {
-        return new XmlFile(XSTREAM,new File(Jenkins.getInstance().root,
+    private XmlFileStorage getConfigFile() {
+        return new XmlFileStorage(XSTREAM,new File(Jenkins.getInstance().root,
                                     UpdateCenter.class.getName()+".xml"));
     }
 

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -33,14 +33,13 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.FeedAdapter;
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.model.Descriptor.FormException;
 import hudson.model.listeners.SaveableListener;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
-import hudson.security.Permission;
 import hudson.security.SecurityRealm;
 import hudson.security.UserMayOrMayNotExistException;
 import hudson.util.FormApply;
@@ -188,7 +187,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     private synchronized void load() {
         properties.clear();
 
-        XmlFile config = getConfigFile();
+        XmlFileStorage config = getConfigFile();
         try {
             if(config.exists())
                 config.unmarshal(this);
@@ -768,8 +767,8 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     /**
      * The file we save our configuration.
      */
-    protected final XmlFile getConfigFile() {
-        return new XmlFile(XSTREAM,getConfigFileFor(id));
+    protected final XmlFileStorage getConfigFile() {
+        return new XmlFileStorage(XSTREAM,getConfigFileFor(id));
     }
 
     private static final File getConfigFileFor(String id) {
@@ -829,7 +828,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     }
 
     private Object writeReplace() {
-        return XmlFile.replaceIfNotAtTopLevel(this, () -> new Replacer(this));
+        return XmlFileStorage.replaceIfNotAtTopLevel(this, () -> new Replacer(this));
     }
     private static class Replacer {
         private final String id;

--- a/core/src/main/java/hudson/model/labels/LabelAtom.java
+++ b/core/src/main/java/hudson/model/labels/LabelAtom.java
@@ -29,7 +29,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import hudson.BulkChange;
 import hudson.CopyOnWrite;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.model.Action;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Failure;
@@ -161,8 +161,8 @@ public class LabelAtom extends Label implements Saveable {
         return LabelOperatorPrecedence.ATOM;
     }
 
-    /*package*/ XmlFile getConfigFile() {
-        return new XmlFile(XSTREAM, new File(Jenkins.getInstance().root, "labels/"+name+".xml"));
+    /*package*/ XmlFileStorage getConfigFile() {
+        return new XmlFileStorage(XSTREAM, new File(Jenkins.getInstance().root, "labels/"+name+".xml"));
     }
 
     public void save() throws IOException {
@@ -176,7 +176,7 @@ public class LabelAtom extends Label implements Saveable {
     }
 
     public void load() {
-        XmlFile file = getConfigFile();
+        XmlFileStorage file = getConfigFile();
         if(file.exists()) {
             try {
                 file.unmarshal(this);

--- a/core/src/main/java/hudson/model/listeners/SaveableListener.java
+++ b/core/src/main/java/hudson/model/listeners/SaveableListener.java
@@ -27,7 +27,8 @@ package hudson.model.listeners;
 import hudson.ExtensionPoint;
 import hudson.Extension;
 import hudson.ExtensionList;
-import hudson.XmlFile;
+import hudson.Storage;
+import hudson.XmlFileStorage;
 import hudson.model.Saveable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -49,9 +50,9 @@ public abstract class SaveableListener implements ExtensionPoint {
      * @param o
      *      The saveable object.
      * @param file
-     *      The {@link XmlFile} for this saveable object.
+     *      The {@link XmlFileStorage} for this saveable object.
      */
-    public void onChange(Saveable o, XmlFile file) {}
+    public void onChange(Saveable o, Storage file) {}
 
     /**
      * Registers this object as an active listener so that it can start getting
@@ -75,7 +76,7 @@ public abstract class SaveableListener implements ExtensionPoint {
     /**
      * Fires the {@link #onChange} event.
      */
-    public static void fireOnChange(Saveable o, XmlFile file) {
+    public static void fireOnChange(Saveable o, Storage file) {
         for (SaveableListener l : all()) {
             try {
                 l.onChange(o,file);

--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -49,7 +49,7 @@ import com.thoughtworks.xstream.mapper.CannotResolveClassException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.PluginManager;
 import hudson.PluginWrapper;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.remoting.ClassFilter;
 import hudson.util.xstream.ImmutableSetConverter;
@@ -143,7 +143,7 @@ public class XStream2 extends XStream {
      * which it expects to be {@link Nonnull} unless you are prepared to restore default values for those fields.
      * @param nullOut whether to perform this special behavior;
      *                false to use the stock XStream behavior of leaving unmentioned {@code root} fields untouched
-     * @see XmlFile#unmarshalNullingOut
+     * @see XmlFileStorage#unmarshalNullingOut
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-21017">JENKINS-21017</a>
      * @since 2.99
      */

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2984,8 +2984,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * The file we save our configuration.
      */
-    private XmlFile getConfigFile() {
-        return new XmlFile(XSTREAM, new File(root,"config.xml"));
+    private XmlFileStorage getConfigFile() {
+        return new XmlFileStorage(XSTREAM, new File(root,"config.xml"));
     }
 
     public int getNumExecutors() {
@@ -3023,7 +3023,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     private void loadConfig() throws IOException {
-        XmlFile cfg = getConfigFile();
+        XmlFileStorage cfg = getConfigFile();
         if (cfg.exists()) {
             // reset some data that may not exist in the disk file
             // so that we can take a proper compensation action later.

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -2,7 +2,7 @@ package jenkins.model;
 
 import hudson.Extension;
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.util.FormValidation;
 import hudson.util.XStream2;
 import org.jenkinsci.Symbol;
@@ -59,11 +59,11 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
     public synchronized void load() {
         // for backward compatibility, if we don't have our own data yet, then
         // load from Mailer.
-        XmlFile file = getConfigFile();
+        XmlFileStorage file = getConfigFile();
         if(!file.exists()) {
             XStream2 xs = new XStream2();
             xs.addCompatibilityAlias("hudson.tasks.Mailer$DescriptorImpl",JenkinsLocationConfiguration.class);
-            file = new XmlFile(xs,new File(Jenkins.getInstance().getRootDir(),"hudson.tasks.Mailer.xml"));
+            file = new XmlFileStorage(xs,new File(Jenkins.getInstance().getRootDir(),"hudson.tasks.Mailer.xml"));
             if (file.exists()) {
                 try {
                     file.unmarshal(this);

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -24,8 +24,10 @@
 package jenkins.model;
 
 import hudson.BulkChange;
+import hudson.FileStorage;
+import hudson.Storage;
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.model.Queue;
@@ -155,7 +157,7 @@ public class Nodes implements Saveable {
         if (node instanceof EphemeralNode) {
             Util.deleteRecursive(new File(getNodesDir(), node.getNodeName()));
         } else {
-            XmlFile xmlFile = new XmlFile(Jenkins.XSTREAM,
+            Storage xmlFile = new XmlFileStorage(Jenkins.XSTREAM,
                     new File(new File(getNodesDir(), node.getNodeName()), "config.xml"));
             xmlFile.write(node);
             SaveableListener.fireOnChange(this, xmlFile);
@@ -270,7 +272,7 @@ public class Nodes implements Saveable {
                 continue;
             }
             existing.add(n.getNodeName());
-            XmlFile xmlFile = new XmlFile(Jenkins.XSTREAM, new File(new File(nodesDir, n.getNodeName()), "config.xml"));
+            Storage xmlFile = new XmlFileStorage(Jenkins.XSTREAM, new File(new File(nodesDir, n.getNodeName()), "config.xml"));
             xmlFile.write(n);
             SaveableListener.fireOnChange(this, xmlFile);
         }
@@ -311,7 +313,7 @@ public class Nodes implements Saveable {
         if (subdirs != null) {
             for (File subdir : subdirs) {
                 try {
-                    XmlFile xmlFile = new XmlFile(Jenkins.XSTREAM, new File(subdir, "config.xml"));
+                    FileStorage xmlFile = new XmlFileStorage(Jenkins.XSTREAM, new File(subdir, "config.xml"));
                     if (xmlFile.exists()) {
                         Node node = (Node) xmlFile.read();
                         newNodes.put(node.getNodeName(), node);

--- a/core/src/test/java/hudson/XmlFileStorageTest.java
+++ b/core/src/test/java/hudson/XmlFileStorageTest.java
@@ -9,13 +9,12 @@ import java.net.URL;
 import jenkins.model.Jenkins;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.xml.sax.SAXParseException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class XmlFileTest {
+public class XmlFileStorageTest {
 
     @Test
     public void canReadXml1_0Test() throws IOException {
@@ -23,7 +22,7 @@ public class XmlFileTest {
         XStream2  xs = new XStream2();
         xs.alias("hudson", Jenkins.class);
 
-        XmlFile xmlFile =  new XmlFile(xs, new File(configUrl.getFile()));
+        XmlFileStorage xmlFile =  new XmlFileStorage(xs, new File(configUrl.getFile()));
         if (xmlFile.exists()) {
             Node n = (Node) xmlFile.read();
             assertThat(n.getNumExecutors(), is(2));
@@ -40,7 +39,7 @@ public class XmlFileTest {
         XStream2  xs = new XStream2();
         xs.alias("hudson", Jenkins.class);
 
-        XmlFile xmlFile =  new XmlFile(xs, new File(configUrl.getFile()));
+        XmlFileStorage xmlFile =  new XmlFileStorage(xs, new File(configUrl.getFile()));
         if (xmlFile.exists()) {
             Node n = (Node) xmlFile.read();
             assertThat(n.getNumExecutors(), is(2));
@@ -54,7 +53,7 @@ public class XmlFileTest {
         XStream2  xs = new XStream2();
         xs.alias("hudson", Jenkins.class);
 
-        XmlFile xmlFile =  new XmlFile(xs, new File(configUrl.getFile()));
+        XmlFileStorage xmlFile =  new XmlFileStorage(xs, new File(configUrl.getFile()));
         if (xmlFile.exists()) {
             Node n = (Node) xmlFile.read();
             assertThat(n.getNumExecutors(), is(2));
@@ -68,7 +67,7 @@ public class XmlFileTest {
         XStream2  xs = new XStream2();
         xs.alias("hudson", Jenkins.class);
 
-        XmlFile xmlFile =  new XmlFile(xs, new File(configUrl.getFile()));
+        XmlFileStorage xmlFile =  new XmlFileStorage(xs, new File(configUrl.getFile()));
         if (xmlFile.exists()) {
             Node n = (Node) xmlFile.read();
             assertThat(n.getNumExecutors(), is(2));

--- a/core/src/test/java/hudson/slaves/NodeListTest.java
+++ b/core/src/test/java/hudson/slaves/NodeListTest.java
@@ -25,13 +25,14 @@ package hudson.slaves;
 
 import static org.junit.Assert.assertEquals;
 
+import hudson.FileStorage;
 import hudson.remoting.Callable;
 import jenkins.model.Jenkins;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.model.Computer;
 import hudson.model.TopLevelItem;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.Launcher;
 import hudson.FilePath;
 import hudson.model.labels.LabelAtom;
@@ -128,7 +129,7 @@ public class NodeListTest {
 
         File tmp = File.createTempFile("test","test");
         try {
-            XmlFile x = new XmlFile(Jenkins.XSTREAM, tmp);
+            FileStorage x = new XmlFileStorage(Jenkins.XSTREAM, tmp);
             x.write(nl);
 
             String xml = FileUtils.readFileToString(tmp);

--- a/test/src/test/java/hudson/XmlFileStorageTest.java
+++ b/test/src/test/java/hudson/XmlFileStorageTest.java
@@ -11,7 +11,7 @@ import org.jvnet.hudson.test.recipes.LocalData;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class XMLFileTest {
+public class XmlFileStorageTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();

--- a/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
@@ -24,7 +24,7 @@
 
 package hudson.diagnosis;
 
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.InvisibleAction;
@@ -136,7 +136,7 @@ public class OldDataMonitorTest {
         xml.deleteOnExit();
         OldDataMonitor.changeListener
                 .onChange(new Saveable() {public void save() throws IOException {}},
-                        new XmlFile(xml));
+                        new XmlFileStorage(xml));
 
         preventExit.countDown();
         discardFuture.get();

--- a/test/src/test/java/hudson/model/AbstractItem2Test.java
+++ b/test/src/test/java/hudson/model/AbstractItem2Test.java
@@ -23,7 +23,7 @@
  */
 package hudson.model;
 
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import java.util.logging.Level;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -41,7 +41,7 @@ public class AbstractItem2Test {
     public RestartableJenkinsRule rr = new RestartableJenkinsRule();
 
     @Rule
-    public LoggerRule logging = new LoggerRule().record(XmlFile.class, Level.WARNING).capture(100);
+    public LoggerRule logging = new LoggerRule().record(XmlFileStorage.class, Level.WARNING).capture(100);
 
     @Issue("JENKINS-45892")
     @Test

--- a/test/src/test/java/hudson/model/CauseTest.java
+++ b/test/src/test/java/hudson/model/CauseTest.java
@@ -24,7 +24,7 @@
 
 package hudson.model;
 
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 
 import java.io.*;
 import java.util.concurrent.Future;
@@ -33,9 +33,8 @@ import java.util.regex.Pattern;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.*;
 
-import hudson.security.*;
 import hudson.util.StreamTaskListener;
-import jenkins.model.Jenkins;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -57,9 +56,9 @@ public class CauseTest {
                 early = last;
             }
         }
-        String buildXml = new XmlFile(Run.XSTREAM, new File(early.getRootDir(), "build.xml")).asString();
+        String buildXml = new XmlFileStorage(Run.XSTREAM, new File(early.getRootDir(), "build.xml")).asString();
         assertTrue("keeps full history:\n" + buildXml, buildXml.contains("<upstreamBuild>1</upstreamBuild>"));
-        buildXml = new XmlFile(Run.XSTREAM, new File(last.getRootDir(), "build.xml")).asString();
+        buildXml = new XmlFileStorage(Run.XSTREAM, new File(last.getRootDir(), "build.xml")).asString();
         assertFalse("too big:\n" + buildXml, buildXml.contains("<upstreamBuild>1</upstreamBuild>"));
     }
 
@@ -81,7 +80,7 @@ public class CauseTest {
             c.scheduleBuild2(0, cause);
             last = next3.get();
         }
-        int count = new XmlFile(Run.XSTREAM, new File(last.getRootDir(), "build.xml")).asString().split(Pattern.quote("<hudson.model.Cause_-UpstreamCause")).length;
+        int count = new XmlFileStorage(Run.XSTREAM, new File(last.getRootDir(), "build.xml")).asString().split(Pattern.quote("<hudson.model.Cause_-UpstreamCause")).length;
         assertFalse("too big at " + count, count > 100);
         //j.interactiveBreak();
     }

--- a/test/src/test/java/hudson/model/ParametersAction2Test.java
+++ b/test/src/test/java/hudson/model/ParametersAction2Test.java
@@ -2,7 +2,7 @@ package hudson.model;
 
 import hudson.Functions;
 import hudson.Launcher;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.tasks.Builder;
 import java.io.File;
 import java.io.IOException;
@@ -317,7 +317,7 @@ public class ParametersAction2Test {
         FreeStyleProject p = j.createFreeStyleProject();
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("key", "sensible-default")));
         FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("key", "value"))));
-        assertThat(new XmlFile(Run.XSTREAM, new File(b.getRootDir(), "build.xml")).asString(), not(containsString("sensible-default")));
+        assertThat(new XmlFileStorage(Run.XSTREAM, new File(b.getRootDir(), "build.xml")).asString(), not(containsString("sensible-default")));
         assertEquals(Collections.emptyList(), logs.getMessages());
     }
 

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -32,7 +32,8 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.xml.XmlPage;
 import hudson.Functions;
 import hudson.Launcher;
-import hudson.XmlFile;
+import hudson.Storage;
+import hudson.XmlFileStorage;
 import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
 import hudson.matrix.LabelAxis;
@@ -218,7 +219,7 @@ public class QueueTest {
      */
     private void resetQueueState() throws IOException {
         File queueFile = r.jenkins.getQueue().getXMLQueueFile();
-        XmlFile xmlFile = new XmlFile(Queue.XSTREAM, queueFile);
+        Storage xmlFile = new XmlFileStorage(Queue.XSTREAM, queueFile);
         xmlFile.write(new Queue.State());
         r.jenkins.getQueue().load();
     }
@@ -379,7 +380,7 @@ public class QueueTest {
                         + "Started by remote host 1.2.3.4 with note: test (2 times) "
                         + "Started by remote host 4.3.2.1 with note: test "
                         + "Started by remote host 1.2.3.4 with note: foo"));
-        System.out.println(new XmlFile(new File(build.getRootDir(), "build.xml")).asString());
+        System.out.println(new XmlFileStorage(new File(build.getRootDir(), "build.xml")).asString());
     }
 
     @Issue("JENKINS-8790")
@@ -1031,7 +1032,7 @@ public class QueueTest {
     @TestExtension("load_queue_xml")
     public static final class QueueSaveSniffer extends SaveableListener {
         private static int count = 0;
-        @Override public void onChange(Saveable o, XmlFile file) {
+        @Override public void onChange(Saveable o, Storage file) {
             if (o instanceof Queue) {
                 count++;
             }

--- a/test/src/test/java/hudson/model/RunActionTest.java
+++ b/test/src/test/java/hudson/model/RunActionTest.java
@@ -24,7 +24,7 @@
 
 package hudson.model;
 
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import java.io.File;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
@@ -50,7 +50,7 @@ public class RunActionTest {
                 FreeStyleBuild b2 = rr.j.buildAndAssertSuccess(p);
                 b2.addAction(new BadAction(b1));
                 b2.save();
-                String text = new XmlFile(new File(b2.getRootDir(), "build.xml")).asString();
+                String text = new XmlFileStorage(new File(b2.getRootDir(), "build.xml")).asString();
                 assertThat(text, not(containsString("<owner class=\"build\">")));
                 assertThat(text, containsString("<id>p#1</id>"));
             }

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -35,7 +35,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlLabel;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlRadioButtonInput;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.matrix.AxisList;
 import hudson.matrix.LabelAxis;
 import hudson.matrix.MatrixProject;
@@ -239,7 +239,7 @@ public class ViewTest {
         req.setEncodingType(null);
         wc.getPage(req);
         assertEquals("two", view.getDescription());
-        xml = new XmlFile(Jenkins.XSTREAM, new File(j.jenkins.getRootDir(), "config.xml")).asString();
+        xml = new XmlFileStorage(Jenkins.XSTREAM, new File(j.jenkins.getRootDir(), "config.xml")).asString();
         assertTrue(xml, xml.contains("<description>two</description>"));
     }
     
@@ -256,7 +256,7 @@ public class ViewTest {
         req.setEncodingType(null);
         wc.getPage(req);
         assertEquals(null, view.getDescription()); // did not work
-        xml = new XmlFile(Jenkins.XSTREAM, new File(j.jenkins.getRootDir(), "config.xml")).asString();
+        xml = new XmlFileStorage(Jenkins.XSTREAM, new File(j.jenkins.getRootDir(), "config.xml")).asString();
         assertThat(xml, not(containsString("<description>"))); // did not work
         assertEquals(j.jenkins, view.getOwner());
     }

--- a/test/src/test/java/hudson/tasks/FingerprinterTest.java
+++ b/test/src/test/java/hudson/tasks/FingerprinterTest.java
@@ -29,7 +29,7 @@ import com.google.common.collect.ImmutableSet;
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.Util;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
 import hudson.matrix.MatrixProject;
@@ -310,7 +310,7 @@ public class FingerprinterTest {
         job._getRuns().purgeCache(); // force build records to be reloaded
         build = job.getBuildByNumber(3);
         assertNotNull(build);
-        System.out.println(new XmlFile(new File(build.getRootDir(), "build.xml")).asString());
+        System.out.println(new XmlFileStorage(new File(build.getRootDir(), "build.xml")).asString());
         action = build.getAction(Fingerprinter.FingerprintAction.class);
         assertNotNull(action);
         assertEquals(build, action.getBuild());

--- a/test/src/test/java/jenkins/security/ClassFilterImplTest.java
+++ b/test/src/test/java/jenkins/security/ClassFilterImplTest.java
@@ -28,7 +28,7 @@ import com.google.common.collect.LinkedListMultimap;
 import com.thoughtworks.xstream.XStream;
 import hudson.ExtensionList;
 import hudson.Launcher;
-import hudson.XmlFile;
+import hudson.XmlFileStorage;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -36,7 +36,6 @@ import hudson.model.BuildListener;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.model.Saveable;
-import hudson.remoting.ClassFilter;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import java.io.IOException;
@@ -166,7 +165,7 @@ public class ClassFilterImplTest {
         LinkedListMultimap<?, ?> obj;
         String unrelated;
         @Override
-        protected XmlFile getConfigFile() {
+        protected XmlFileStorage getConfigFile() {
             return super.getConfigFile();
         }
     }


### PR DESCRIPTION
### Proposed changelog entries

* Moves some XmlFile methods to into the interfaces FileStorage and Storage.
This is to provide a foundation to start adding an extension point for storage.

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs