### PR TITLE
Add the checkMethod attribute to textbox

### DIFF
--- a/core/src/main/resources/lib/form/textarea.jelly
+++ b/core/src/main/resources/lib/form/textarea.jelly
@@ -52,9 +52,8 @@ THE SOFTWARE.
       which is the recommended approach.
     </st:attribute>
     <st:attribute name="checkMethod" use="optional" type="String">
-      If specified, the HTTP method to use for input field will be checked (via AJAX).
-    
-      'post' is the only value (in lowercase) that is supported to change the default GET method into a POST
+      Specify 'post' (must be lowercase) to change the HTTP method used for the AJAX requests to @checkUrl from a GET to a POST.
+      If any other value is specified then requests will use GET.
     </st:attribute>
     <st:attribute name="codemirror-mode">
       Turns this text area into CodeMirror-assisted code editing text area.

--- a/core/src/main/resources/lib/form/textarea.jelly
+++ b/core/src/main/resources/lib/form/textarea.jelly
@@ -51,8 +51,10 @@ THE SOFTWARE.
       If @field is specified, this will be inferred automatically,
       which is the recommended approach.
     </st:attribute>
-    <st:attribute name="checkMethod">
-      If specified, the HTTP method to use for input field will be checked (via AJAX)
+    <st:attribute name="checkMethod" use="optional" type="String">
+      If specified, the HTTP method to use for input field will be checked (via AJAX).
+    
+      'post' is the only value (in lowercase) that is supported to change the default GET method into a POST
     </st:attribute>
     <st:attribute name="codemirror-mode">
       Turns this text area into CodeMirror-assisted code editing text area.

--- a/core/src/main/resources/lib/form/textbox.jelly
+++ b/core/src/main/resources/lib/form/textbox.jelly
@@ -64,8 +64,10 @@ THE SOFTWARE.
       If @field is specified, this will be inferred automatically,
       which is the recommended approach.
     </st:attribute>
-    <st:attribute name="checkMethod">
-      If specified, the HTTP method to use for input field will be checked (via AJAX)
+    <st:attribute name="checkMethod" use="optional" type="String">
+      If specified, the HTTP method to use for input field will be checked (via AJAX).
+      
+      'post' is the only value (in lowercase) that is supported to change the default GET method into a POST
     </st:attribute>
     <st:attribute name="autoCompleteDelimChar">
       A single character that can be used as a delimiter for autocompletion. Normal

--- a/core/src/main/resources/lib/form/textbox.jelly
+++ b/core/src/main/resources/lib/form/textbox.jelly
@@ -64,6 +64,9 @@ THE SOFTWARE.
       If @field is specified, this will be inferred automatically,
       which is the recommended approach.
     </st:attribute>
+    <st:attribute name="checkMethod">
+      If specified, the HTTP method to use for input field will be checked (via AJAX)
+    </st:attribute>
     <st:attribute name="autoCompleteDelimChar">
       A single character that can be used as a delimiter for autocompletion. Normal
       autocomplete will replace the entire content of the text box with the autocomplete

--- a/core/src/main/resources/lib/form/textbox.jelly
+++ b/core/src/main/resources/lib/form/textbox.jelly
@@ -65,9 +65,8 @@ THE SOFTWARE.
       which is the recommended approach.
     </st:attribute>
     <st:attribute name="checkMethod" use="optional" type="String">
-      If specified, the HTTP method to use for input field will be checked (via AJAX).
-      
-      'post' is the only value (in lowercase) that is supported to change the default GET method into a POST
+      Specify 'post' (must be lowercase) to change the HTTP method used for the AJAX requests to @checkUrl from a GET to a POST. 
+      If any other value is specified then requests will use GET.
     </st:attribute>
     <st:attribute name="autoCompleteDelimChar">
       A single character that can be used as a delimiter for autocompletion. Normal


### PR DESCRIPTION
- better discovery capability for the plugin maintainers and core developers
- to find the the associated documentation in the code, you need to navigate to `MorphTagLibrary`, understand what it does, then look at hudson-behavior.js to see there is such an option. After a search you see that `textarea.jelly` already provide the same kind of documentation. (i.e. there is no direct documentation)
- current usage: [~13 usages](https://github.com/search?l=XML&q=org%3Ajenkinsci+checkMethod&type=Code)

### Desired reviewers

@reviewbybees