### PR TITLE
Update Remoting to 3.20 in order to refresh the code signing certificate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
 
     <!-- Minimum Remoting version, which is tested for API compatibility -->
-    <remoting.version>3.19</remoting.version>
+    <remoting.version>3.20</remoting.version>
     <remoting.minimum.supported.version>2.60</remoting.minimum.supported.version>
 
     <!-- TODO: JENKINS-36716 - Switch to Medium once FindBugs is cleaned up, 430 issues on Mar 10, 2018 -->

--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,9 @@ THE SOFTWARE.
 
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
 
-    <!-- Minimum Remoting version, which is tested for API compatibility -->
+    <!-- Bundled Remoting version -->
     <remoting.version>3.20</remoting.version>
+    <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>2.60</remoting.minimum.supported.version>
 
     <!-- TODO: JENKINS-36716 - Switch to Medium once FindBugs is cleaned up, 430 issues on Mar 10, 2018 -->


### PR DESCRIPTION
My current Code Signing certificate expires on April 27. It should not block Remoting users from running versions with old certificates, but I decided to refresh it in order to avoid issues with releases in the future.

There is no code changes inside, full diff: https://github.com/jenkinsci/remoting/compare/remoting-3.19...remoting-3.20

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE: Update Remoting from 3.19 to 3.20 in order to refresh the code signing certificate
  * Full changelog: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#320
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @dwnusbaum @jeffret-b 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
