### PR TITLE
[JENKINS-32778] - Prevent extracting archived plugins outside of target path

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -598,6 +598,10 @@ public final class FilePath implements Serializable {
             while (entries.hasMoreElements()) {
                 ZipEntry e = entries.nextElement();
                 File f = new File(dir, e.getName());
+                if (!f.toPath().normalize().startsWith(dir.toPath())) {
+                    throw new IOException(
+                        "Zip " + zipFile.getPath() + " contains illegal file name that breaks out of the target directory: " + e.getName());
+                }
                 if (e.isDirectory()) {
                     mkdirs(f);
                 } else {


### PR DESCRIPTION
See [JENKINS-32778](https://issues.jenkins-ci.org/browse/JENKINS-32778), or [details](#details) below.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE: Ensure there is no path traversal during Jenkins plugin installation

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). 
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] ~For dependency updates: links to external changelogs and, if possible, full diffs~

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

###  <a name="details"></a> Details
This PR is meant to fix an arbitrary file write vulnerability, that can be achieved using a specially crafted zip archive, that holds path traversal filenames. When the filename gets concatenated to the target extraction directory, the final path ends up outside of the target folder. 

A sample malicious zip file (see [this gist](https://gist.github.com/grnd/2992cc4d968386ae277123bad9e7f00a)) or jar file can cause arbitrary files to be written outside of the directory intended.

There are various possible ways to avoid this issue, some include checking for `..` (dot dot) characters in the filename, but the best solution in our opinion is to check if the final target filename, starts with the target folder (after both are resolved to their absolute path).

Stay secure,
Snyk Team