### PR TITLE
[JENKINS-50939] - Whitelist java.util.EnumSet

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -102,6 +102,7 @@ java.util.Collections$UnmodifiableSortedSet
 
 java.util.Date
 java.util.EnumMap
+java.util.EnumSet
 java.util.GregorianCalendar
 java.util.HashMap
 java.util.HashSet


### PR DESCRIPTION
See [JENKINS-50939](https://issues.jenkins-ci.org/browse/JENKINS-50939), or see details [here](https://github.com/jenkinsci/jenkins/pull/3403).

As suggested in https://jenkins.io/blog/2018/01/13/jep-200/, this merge request adds java.util.EnumMap to the whitelist (as it is "defined in the Java Platform"). Because no new feature is implemented, no autotests are provided.

### Proposed changelog entries

* Whitelist java.util.EnumMap to prevent deserialization exception

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
