### PR TITLE
[JENKINS-50616] - Add org.jruby.RubyNil to the whitelist

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -174,7 +174,13 @@ org.jenkinsci.jruby.JRubyMapper$DynamicProxy
 org.jenkinsci.lib.xtrigger.XTriggerCause
 org.jenkinsci.lib.xtrigger.XTriggerCauseAction
 
-# TODO remove (also XStream2.BlacklistedTypesConverter.JRUBY_PROXY) when https://github.com/jenkinsci/ruby-runtime-plugin/pull/5 is widely adopted
+# TODO remove (also XStream2.BlacklistedTypesConverter.JRUBY_PROXY) when Ruby Runtime is fixed
+# Related PRs:
+#   - https://github.com/jenkinsci/ruby-runtime-plugin/pull/5,
+#   - https://github.com/jenkinsci/ruby-runtime-plugin/pull/6
+#
+# oleg:nenashev in PR#6 we are trying to get help from last maintainers due to the plugin codebase splitbrain.
+#               It is required to fix JENKINS-50616 in a proper way for 2.107.x
 org.jruby.RubyArray
 org.jruby.RubyBignum
 org.jruby.RubyBoolean
@@ -182,6 +188,7 @@ org.jruby.RubyBoolean$False
 org.jruby.RubyBoolean$True
 org.jruby.RubyFixnum
 org.jruby.RubyHash
+org.jruby.RubyNil
 org.jruby.RubyObject
 org.jruby.RubyString
 org.jruby.RubySymbol

--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -179,7 +179,7 @@ org.jenkinsci.lib.xtrigger.XTriggerCauseAction
 #   - https://github.com/jenkinsci/ruby-runtime-plugin/pull/5,
 #   - https://github.com/jenkinsci/ruby-runtime-plugin/pull/6
 #
-# oleg:nenashev in PR#6 we are trying to get help from last maintainers due to the plugin codebase splitbrain.
+# oleg-nenashev in PR#6 we are trying to get help from last maintainers due to the plugin codebase splitbrain.
 #               It is required to fix JENKINS-50616 in a proper way for 2.107.x
 org.jruby.RubyArray
 org.jruby.RubyBignum


### PR DESCRIPTION
See [JENKINS-50616](https://issues.jenkins-ci.org/browse/JENKINS-50616). It is a workaround, because we're stuck in https://github.com/jenkinsci/ruby-runtime-plugin/pull/6 due to the lack of response from plugin maintainers.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Bug: Add org.jruby.RubyNil to the built-in whitelist ( JEP-200 regression in the CI Skip plugin)
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
