### PR TITLE
Fix the CLI test failure

### DIFF
--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -268,7 +268,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
             sc.setAuthentication(getTransportAuthentication());
             new ClassParser().parse(authenticator,p);
 
-            if (!(this instanceof LoginCommand || this instanceof LogoutCommand || this instanceof HelpCommand))
+            if (!(this instanceof LoginCommand || this instanceof LogoutCommand || this instanceof HelpCommand || this instanceof WhoAmICommand))
                 Jenkins.getActiveInstance().checkPermission(Jenkins.READ);
             p.parseArgument(args.toArray(new String[args.size()]));
             Authentication auth = authenticator.authenticate();


### PR DESCRIPTION
Small fix to avoid a test to fail. Initially due to an invisible merge conflict (new feature + separate correction, the correction was not aware of the new feature).

@reviewbybees 