### PR TITLE
[FIXED JENKINS-51037] Add ConcurrentSkipListSet to whitelisted classes

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -125,6 +125,7 @@ java.util.Vector
 java.util.concurrent.ConcurrentHashMap
 java.util.concurrent.ConcurrentLinkedQueue
 java.util.concurrent.ConcurrentSkipListMap
+java.util.concurrent.ConcurrentSkipListSet
 java.util.concurrent.CopyOnWriteArrayList
 java.util.concurrent.CopyOnWriteArraySet
 java.util.concurrent.CountDownLatch


### PR DESCRIPTION
This adds ConcurrentSkipListSet to the list of default whitelisted classes for deserialization.

See JEP-200 and [JENKINS-51037](https://issues.jenkins-ci.org/browse/JENKINS-51037).

### Proposed changelog entries

* _Internal:_ added `java.util.concurrent.ConcurrentSkipListSet` to whitelisted classes for serialization.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees @dwnusbaum @daniel-beck 