### PR TITLE
[JENKINS-26883] Change log level to help external monitoring tools

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4191,7 +4191,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
                     // give some time for the browser to load the "reloading" page
                     Thread.sleep(5000);
-                    LOGGER.severe(String.format("Restarting VM as requested by %s",exitUser));
+                    LOGGER.info(String.format("Restarting VM as requested by %s",exitUser));
                     for (RestartListener listener : RestartListener.all())
                         listener.onRestart();
                     lifecycle.restart();
@@ -4228,7 +4228,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                         // give some time for the browser to load the "reloading" page
                         LOGGER.info("Restart in 10 seconds");
                         Thread.sleep(10000);
-                        LOGGER.severe(String.format("Restarting VM as requested by %s",exitUser));
+                        LOGGER.info(String.format("Restarting VM as requested by %s",exitUser));
                         for (RestartListener listener : RestartListener.all())
                             listener.onRestart();
                         lifecycle.restart();


### PR DESCRIPTION
See [JENKINS-26883](https://issues.jenkins-ci.org/browse/JENKINS-26883).

### Proposed changelog entries

* Entry 1: JENKINS-26883, Change log level of `Restarting VM as requested` trace to only use `SEVERE` traces when bad/critical things just happened. 

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs


This particular change doesn't contain any tests as it's just a log level change and no test cases are in place as far as I see.

### Desired reviewers

@recena , @reviewbybees 
