### PR TITLE
[JENKINS-17116] - When aborting a build, wait up to 2min for process termination

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -515,7 +515,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jvnet.winp</groupId>
       <artifactId>winp</artifactId>
-      <version>1.26</version>
+      <version>1.27</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -144,6 +144,8 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
      */
     public abstract void killAll(Map<String, String> modelEnvVars) throws InterruptedException;
 
+    private final int softkillWaitSeconds = 2 * 60; // processes get at most 2 minutes to respond to SIGTERM (JENKINS-17116)
+
     /**
      * Convenience method that does {@link #killAll(Map)} and {@link OSProcess#killRecursively()}.
      * This is necessary to reliably kill the process and its descendants, as some OS
@@ -501,6 +503,8 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 return;
 
             LOGGER.log(FINER, "Killing recursively {0}", getPid());
+            // Firstly try to kill the root process gracefully, then do a forcekill if it does not help (algorithm is described in JENKINS-17116)
+            killSoftly();
             p.killRecursively();
             killByKiller();
         }
@@ -512,8 +516,37 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             }
             
             LOGGER.log(FINER, "Killing {0}", getPid());
+            // Firstly try to kill it gracefully, then do a forcekill if it does not help (algorithm is described in JENKINS-17116)
+            killSoftly();
             p.kill();
             killByKiller();
+        }
+
+        private void killSoftly() throws InterruptedException {
+            // send Ctrl+C to the process
+            try {
+                if (!p.sendCtrlC()) {
+                    return;
+                }
+            }
+            catch (WinpException e) {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, "Failed to send CTRL+C to pid=" + getPid(), e);
+                }
+                return;
+            }
+
+            // after that wait for it to cease to exist
+            long deadline = System.nanoTime() + softkillWaitSeconds * 1000000000;
+            int sleepTime = 10; // initially we sleep briefly, then sleep up to 1sec
+            do {
+                if (!p.isRunning()) {
+                    break;
+                }
+
+                Thread.sleep(sleepTime);
+                sleepTime = Math.min(sleepTime * 2, 1000);
+            } while (System.nanoTime() < deadline);
         }
 
         @Override
@@ -724,6 +757,18 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 int pid = getPid();
                 LOGGER.fine("Killing pid="+pid);
                 UnixReflection.destroy(pid);
+                // after sending SIGTERM, wait for the process to cease to exist
+                long deadline = System.nanoTime() + softkillWaitSeconds * 1000000000;
+                int sleepTime = 10; // initially we sleep briefly, then sleep up to 1sec
+                do {
+                    File f = getFile("status");
+                    if (!f.exists()) {
+                        break; // status is gone, process therefore as well
+                    }
+
+                    Thread.sleep(sleepTime);
+                    sleepTime = Math.min(sleepTime * 2, 1000);
+                } while (System.nanoTime() < deadline);
             } catch (IllegalAccessException e) {
                 // this is impossible
                 IllegalAccessError x = new IllegalAccessError();


### PR DESCRIPTION
See [JENKINS-17116](https://issues.jenkins-ci.org/browse/JENKINS-17116).

When a build is aborted by the user, Jenkins will now gracefully terminate involved processes by giving it up to 30 seconds time to exit after having received SIGTERM (on Linux) or Ctrl+C on Windows.

## Proposed Changelog entries

* RFE: Update WinP library from 1.26 to 1.27 to pick up new API and stability fixes. Jenkins now requires Windows XP or above
  * Full changelog: https://github.com/kohsuke/winp/blob/master/CHANGELOG.md#127
* Major RFE: JENKINS-17116: Introduce support of graceful process termination on Windows. Feature is controlled by the `SoftKillWaitSeconds ` system property, the default value is 2 minutes (for the entire process tree)
  * https://wiki.jenkins.io/display/JENKINS/Features+controlled+by+system+properties

@jenkinsci/code-reviewers