### PR TITLE
Ignoring newly failing test

### DIFF
--- a/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
+++ b/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
@@ -28,6 +28,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
 import com.google.common.collect.ImmutableMap;
+import org.junit.Ignore;
 
 
 public class ProcessTreeKillerTest {
@@ -110,7 +111,8 @@ public class ProcessTreeKillerTest {
             return true;
         }
     }
-    
+
+    @Ignore("TODO abruptly started failing on Linux on ci.jenkins.io")
     @Test
     @Issue("JENKINS-9104")
     public void considersKillingVetos() throws Exception {


### PR DESCRIPTION
As noted in #3394, this test started failing in CI for no visible reason, so I suspect some infrastructural change. Anyway the test comment

> on some platforms where we fail to list any processes, this test will just not work

hardly inspires confidence. Best to get clean builds so unrelated PRs are not falsely marked as failing due to this.