### PR TITLE
Fix test failure by cleaning up static state after tests

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -382,7 +382,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
     }
 
 
-    private static Boolean vetoersExist;
+    /* package */ static Boolean vetoersExist;
     
     /**
      * Gets the {@link ProcessTree} of the current system

--- a/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
+++ b/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
@@ -38,6 +38,7 @@ public class ProcessTreeKillerTest {
     
     @After
     public void tearDown() throws Exception {
+        ProcessTree.vetoersExist = null;
         if (null != process)
             process.destroy();
     }    


### PR DESCRIPTION
#3357 introduced a static field to hold some state for process tree related code. Previously, the test fails consistently for me locally, but clearing the static field in an `@TearDown` method causes them to pass. This could be an alternative to #3418, or we could go ahead and merge that PR while this is being reviewed to get the build passing.

I don't know if we should do any further refactoring to avoid the static state in the first place.

CC @andne

@reviewbybees 