### PR TITLE
[JENKINS-51062] Extend ClassFilterImpl.isLocationWhitelisted Maven-oriented exclusions to plugin under test during Gradle builds

### DIFF
--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -229,12 +229,12 @@ public class ClassFilterImpl extends ClassFilter {
                     LOGGER.log(Level.WARNING, "problem checking " + loc, x);
                 }
             }
-            if (loc.endsWith("/target/classes/")) {
+            if (loc.endsWith("/target/classes/") || loc.matches(".+/build/classes/[^/]+/main/")) {
                 LOGGER.log(Level.FINE, "{0} seems to be current plugin classes, OK", loc);
                 return true;
             }
             if (Main.isUnitTest) {
-                if (loc.endsWith("/target/test-classes/") || loc.endsWith("-tests.jar")) {
+                if (loc.endsWith("/target/test-classes/") || loc.endsWith("-tests.jar") || loc.matches(".+/build/classes/[^/]+/test/")) {
                     LOGGER.log(Level.FINE, "{0} seems to be test classes, OK", loc);
                     return true;
                 }


### PR DESCRIPTION
Allows test under discussion in https://github.com/jenkinsci/gradle-plugin/pull/55 by @fcojfernandez to pass. Should not affect production runs, just functional tests.

https://issues.jenkins-ci.org/browse/JENKINS-51062