### PR TITLE
Reincrementalify core.

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.main</groupId>
     <artifactId>jenkins-parent</artifactId>
-    <version>2.121-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
 
   <artifactId>cli</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.main</groupId>
     <artifactId>jenkins-parent</artifactId>
-    <version>2.121-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
 
   <artifactId>jenkins-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.44-20180507.021652-1</version> <!-- TODO https://github.com/jenkinsci/pom/pull/22 -->
+    <version>1.44</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,13 +28,13 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.43</version>
+    <version>1.44-20180507.021652-1</version> <!-- TODO https://github.com/jenkinsci/pom/pull/22 -->
     <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.main</groupId>
   <artifactId>jenkins-parent</artifactId>
-  <version>2.121-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>pom</packaging>
 
   <name>Jenkins main module</name>
@@ -75,7 +75,7 @@ THE SOFTWARE.
   </issueManagement>
 
   <properties>
-    <revision>2.120</revision>
+    <revision>2.121</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <!-- *.html files are in UTF-8, and *.properties are in iso-8859-1, so this configuration is actually incorrect,

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.main</groupId>
     <artifactId>jenkins-parent</artifactId>
-    <version>2.121-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
 
   <artifactId>jenkins-test</artifactId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.main</groupId>
     <artifactId>jenkins-parent</artifactId>
-    <version>2.121-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
 
   <artifactId>jenkins-war</artifactId>


### PR DESCRIPTION
Reapplies a bit of #3394. As [noted in the guide](https://github.com/jenkinsci/pom/blob/master/incrementals.md#running-maven-releases), this needs to happen after releases. Picks up https://github.com/jenkinsci/pom/pull/22 to make that command work. Now `git diff HEAD^^^` displays the expected result:

```diff
diff --git a/pom.xml b/pom.xml
index 4ba3d3469a..7f0607b4af 100644
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.43</version>
+    <version>1.44-20180507.021652-1</version> <!-- TODO https://github.com/jenkinsci/pom/pull/22 -->
     <relativePath />
   </parent>
 
@@ -75,7 +75,7 @@ THE SOFTWARE.
   </issueManagement>
 
   <properties>
-    <revision>2.120</revision>
+    <revision>2.121</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <!-- *.html files are in UTF-8, and *.properties are in iso-8859-1, so this configuration is actually incorrect,
```