### PR TITLE
Avoid CI failures pending reincrementalifization

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,7 @@ for(i = 0; i < buildTypes.size(); i++) {
                         dir(m2repo) {
                             archiveArtifacts artifacts: "**/*$changelist/*$changelist*",
                                              excludes: '**/*.lastUpdated,**/jenkins-test/',
+                                             allowEmptyArchive: true, // in case we forgot to reincrementalify
                                              fingerprint: true
                         }
                     }


### PR DESCRIPTION
Follows up #3426: we do not want builds like [this one](https://ci.jenkins.io/job/Core/job/jenkins/view/change-requests/job/PR-3425/1/console) to fail merely because there are no eligible incremental artifacts. The deployment function [should simply return early](https://github.com/jenkins-infra/community-functions/blob/5ac5d3f33c6a0bc8503bd484b0835c5748be674e/incrementals-publisher/index.js#L156-L160) in this case.