### PR TITLE
Fix revision after bad merge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@ THE SOFTWARE.
   </issueManagement>
 
   <properties>
-    <revision>2.121</revision>
+    <revision>2.122</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <!-- *.html files are in UTF-8, and *.properties are in iso-8859-1, so this configuration is actually incorrect,


### PR DESCRIPTION
@kohsuke’s https://github.com/jenkinsci/jenkins/commit/91e1cf2d3e0fa1c4766c62f2db54cd3a28cd9d32 seems to have been a bad merge, as it took one parent at `2.121-SNAPSHOT` and another at `2.122-SNAPSHOT` and would up merging to be `2.121-SNAPSHOT`:

```diff
-  <version>2.122-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
…
-    <revision>2.120</revision>
+    <revision>2.121</revision>
```

So, fixing.