### PR TITLE
Remove ${build.version} property in favor of ${project.version}

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-alpha-3</version>
+    <version>1.0-beta-1</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-1</version>
+    <version>1.0-alpha-3</version>
   </extension>
 </extensions>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -99,7 +99,7 @@
                   <mainClass>hudson.cli.CLI</mainClass>
                 </manifest>
                 <manifestEntries>
-                  <Jenkins-CLI-Version>${build.version}</Jenkins-CLI-Version>
+                  <Jenkins-CLI-Version>${project.version}</Jenkins-CLI-Version>
                 </manifestEntries>
               </archive>
             </configuration>

--- a/cli/src/filter/resources/jenkins/cli/jenkins-cli-version.properties
+++ b/cli/src/filter/resources/jenkins/cli/jenkins-cli-version.properties
@@ -1,1 +1,1 @@
-version=${build.version}
+version=${project.version}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -644,6 +644,7 @@ THE SOFTWARE.
         <plugin>
          <groupId>org.codehaus.mojo</groupId>
          <artifactId>build-helper-maven-plugin</artifactId>
+         <version>1.7</version>
          <executions>
              <execution>
                  <id>add-source</id>

--- a/core/src/filter/resources/hudson/model/hudson-version.properties
+++ b/core/src/filter/resources/hudson/model/hudson-version.properties
@@ -1,1 +1,1 @@
-version=${build.version}
+version=${project.version}

--- a/core/src/filter/resources/jenkins/model/jenkins-version.properties
+++ b/core/src/filter/resources/jenkins/model/jenkins-version.properties
@@ -1,1 +1,1 @@
-version=${build.version}
+version=${project.version}

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4945,7 +4945,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
         String ver = props.getProperty("version");
         if(ver==null)   ver = UNCOMPUTED_VERSION;
-        if(Main.isDevelopmentMode && "${build.version}".equals(ver)) {
+        if(Main.isDevelopmentMode && "${project.version}".equals(ver)) {
             // in dev mode, unable to get version (ahem Eclipse)
             try {
                 File dir = new File(".").getAbsoluteFile();

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@ THE SOFTWARE.
     <!-- *.html files are in UTF-8, and *.properties are in iso-8859-1, so this configuration is actually incorrect,
     but this suppresses a warning from Maven, and as long as we don't do filtering we should be OK. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <build.type>private</build.type>
 
     <!-- configuration for patch tracker plugin  -->
     <project.patchManagement.system>github</project.patchManagement.system>
@@ -306,50 +305,6 @@ THE SOFTWARE.
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.7</version>
-          <executions>
-            <execution>
-              <id>timestamp-property</id>
-              <goals>
-                <goal>timestamp-property</goal>
-              </goals>
-              <configuration>
-                <name>now</name>
-                <pattern>MM/dd/yyyy HH:mm z</pattern>
-                <locale>en_US</locale>
-              </configuration>
-            </execution>
-            <execution>
-            <id>user.name</id>
-            <goals>
-              <goal>regex-property</goal>
-            </goals>
-            <configuration>
-              <name>user.name.escaped</name>
-              <value>${user.name}</value>
-              <regex>([$\\])</regex>
-              <replacement>\\$1</replacement>
-              <failIfNoMatch>false</failIfNoMatch>
-            </configuration>
-          </execution>
-          <execution>
-              <id>version-property</id>
-              <goals>
-                <goal>regex-property</goal>
-              </goals>
-              <configuration>
-                <name>build.version</name>
-                <value>${project.version}</value>
-                <regex>-SNAPSHOT</regex>
-                <replacement>-SNAPSHOT (${build.type}-${now}-${user.name.escaped})</replacement>
-                <failIfNoMatch>false</failIfNoMatch>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.7</version>
@@ -551,10 +506,6 @@ THE SOFTWARE.
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
           <!-- enable release profile during the release, create IPS package, and sign bits. -->
@@ -660,30 +611,6 @@ THE SOFTWARE.
   </build>
 
   <profiles>
-    <profile>
-      <id>rc</id>
-      <properties>
-        <build.type>rc</build.type>
-      </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.codehaus.mojo</groupId>
-              <artifactId>build-helper-maven-plugin</artifactId>
-              <executions>
-                <execution>
-                  <id>version-property</id>
-                  <configuration>
-                    <replacement>-RC (${now})</replacement>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
     <profile>
       <id>metrics</id>
       <build>


### PR DESCRIPTION
After #3394 it is gratuitous to set a `build.version` property (apparently introduced in https://github.com/jenkinsci/jenkins/commit/5827fa97c0fe8d84c823353fbb649ae2f130daf1) to something like `2.121-SNAPSHOT (private-05/09/2018 18:05 GMT-jglick)`: snapshots are for local use, and if you wish to publish something (including an LTS RC!), JEP-305 allows you to use `-Dset.changelist` to give it a real version (if it was not already deployed for you automatically, that is). Allows us to simplify the build process a little bit.