### PR TITLE
[JENKINS-51179] - Provide diagnostics when loading corrupted fingerprint files

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1366,7 +1366,12 @@ public class Fingerprint implements ModelObject, Saveable {
             start = System.currentTimeMillis();
 
         try {
-            Fingerprint f = (Fingerprint) configFile.read();
+            Object loaded = configFile.read();
+            if (!(loaded instanceof Fingerprint)) {
+                throw new IOException("Unexpected Fingerprint type. Expected " + Fingerprint.class + " or subclass but got "
+                        + (loaded != null ? loaded.getClass() : "null"));
+            }
+            Fingerprint f = (Fingerprint) loaded;
             if(logger.isLoggable(Level.FINE))
                 logger.fine("Loading fingerprint "+file+" took "+(System.currentTimeMillis()-start)+"ms");
             if (f.facets==null)

--- a/test/src/test/java/hudson/model/FingerprintTest.java
+++ b/test/src/test/java/hudson/model/FingerprintTest.java
@@ -23,6 +23,7 @@
  */
 package hudson.model;
 
+import hudson.XmlFile;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.security.AuthorizationMatrixProperty;
@@ -30,6 +31,8 @@ import hudson.security.Permission;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import hudson.tasks.ArtifactArchiver;
 import hudson.tasks.Fingerprinter;
+
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -50,6 +53,7 @@ import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.SecuredMockFolder;
 import org.jvnet.hudson.test.WorkspaceCopyFileBuilder;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -114,6 +118,20 @@ public class FingerprintTest {
         Hashtable<String, Fingerprint.RangeSet> usages = fp.getUsages();
         assertTrue("Usages do not have a reference to " + project, usages.containsKey(project.getName()));
         assertTrue("Usages do not have a reference to " + project2, usages.containsKey(project2.getName()));       
+    }
+
+    @Test
+    @Issue("JENKINS-51179")
+    public void shouldThrowIOExceptionWhenFileIsInvalid() throws Exception {
+        XmlFile f = new XmlFile(new File(rule.jenkins.getRootDir(), "foo.xml"));
+        f.write("Hello, world!");
+        try {
+            Fingerprint.load(f.getFile());
+        } catch (IOException ex) {
+            assertThat(ex.getMessage(), containsString("Unexpected Fingerprint type"));
+            return;
+        }
+        fail("Expected IOException");
     }
     
     @Test


### PR DESCRIPTION
See [JENKINS-51179](https://issues.jenkins-ci.org/browse/JENKINS-51179). Actually this patch adds some diagnostics instead of the unchecked class cast we had here before.

### Proposed changelog entries

* JENKINS-51179, Bug, - Prevent unhandled ClassCastException when loading Fingerprints from corrupted files
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/code-reviewers 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
