### PR TITLE
Apparently #3431 broke the Maven release?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
+.flattened-pom.xml
 work
 
 # IntelliJ project files 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.45</version>
+    <version>1.44</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Reverting the critical bits of #3431 since it apparently caused problems for the Maven release, presumably due to the use of a forked execution.