### PR TITLE
Source fork fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 target
-.flattened-pom.xml
 work
 
 # IntelliJ project files 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.44</version>
+    <version>1.46-20180514.183442-1</version> <!-- TODO https://github.com/jenkinsci/pom/pull/25 -->
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.46-20180514.183442-1</version> <!-- TODO https://github.com/jenkinsci/pom/pull/25 -->
+    <version>1.46</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
See discussion in [JENKINS-51247](https://issues.jenkins-ci.org/browse/JENKINS-51247).

Reverts temporary #3441 and tries to fix it properly using https://github.com/jenkinsci/pom/pull/25.

Basically, it seems that `release:perform` was always running a forked execution just to generate a sources JAR, leading to a bunch of mojos being run twice for no good reason. And that broke after #3431 due to [MNG-6405](https://issues.apache.org/jira/browse/MNG-6405). This works around the Maven bug by getting rid of the forked executions, which should also speed up the release a bit and generally simplify things.