### PR TITLE
JENKINS-27329 Less aggressive WorkspaceCleanupThread

### DIFF
--- a/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
+++ b/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
@@ -139,6 +139,13 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
             }
         }
 
+        if (item instanceof Job<?,?>) {
+            Job<?,?> j = (Job<?,?>) item;
+            if (item.isBuilding()) {
+                return false;
+            }
+        }
+
         LOGGER.log(Level.FINER, "Going to delete directory {0}", dir);
         return true;
     }

--- a/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
+++ b/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
@@ -143,6 +143,7 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
         if (item instanceof Job<?,?>) {
             Job<?,?> j = (Job<?,?>) item;
             if (j.isBuilding()) {
+                LOGGER.log(Level.FINE, "Job {0} is building, so not deleting", item.getFullDisplayName());
                 return false;
             }
         }

--- a/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
+++ b/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
@@ -141,7 +141,7 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
 
         if (item instanceof Job<?,?>) {
             Job<?,?> j = (Job<?,?>) item;
-            if (item.isBuilding()) {
+            if (j.isBuilding()) {
                 return false;
             }
         }

--- a/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
+++ b/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
@@ -139,6 +139,7 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
             }
         }
 
+        // TODO this may only check the last build in fact:
         if (item instanceof Job<?,?>) {
             Job<?,?> j = (Job<?,?>) item;
             if (j.isBuilding()) {


### PR DESCRIPTION
See JENKINS-27329 (https://issues.jenkins-ci.org/browse/JENKINS-27329).

I dare to claim that the default behaviour of WorkspaceCleanupThread is too aggressive => this little change is by no means perfect (or admittedly even far from perfect), but IMHO a saner or slightly more defensive default behaviour.

Mind that according to https://github.com/jenkinsci/jenkins/blob/9e64bcdcb4a2cf12d59dfa334e09ffb448d361e9/core/src/main/java/hudson/model/Job.java#L301 this "only" checks whether or not the last build of a job is in progress, while the JavaDoc says "Returns true if a build of this project is in progress." (cf. http://javadoc.jenkins-ci.org/hudson/model/Job.html#isBuilding--)


### Proposed changelog entries

* Internal: Less aggressive WorkspaceCleanupThread