### PR TITLE
Address quiet period edge case (???)

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2487,7 +2487,7 @@ public class Queue extends ResourceController implements Saveable {
 
         public CauseOfBlockage getCauseOfBlockage() {
             long diff = timestamp.getTimeInMillis() - System.currentTimeMillis();
-            if (diff > 0)
+            if (diff >= 0)
                 return CauseOfBlockage.fromMessage(Messages._Queue_InQuietPeriod(Util.getTimeSpanString(diff)));
             else
                 return CauseOfBlockage.fromMessage(Messages._Queue_Unknown());

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2490,7 +2490,7 @@ public class Queue extends ResourceController implements Saveable {
             if (diff >= 0)
                 return CauseOfBlockage.fromMessage(Messages._Queue_InQuietPeriod(Util.getTimeSpanString(diff)));
             else
-                return CauseOfBlockage.fromMessage(Messages._Queue_Unknown());
+                return CauseOfBlockage.fromMessage(Messages._Queue_FinishedWaiting());
         }
 
         @Override

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -200,6 +200,7 @@ Queue.InProgress=A build is already in progress
 Queue.InQuietPeriod=In the quiet period. Expires in {0}
 Queue.NodeOffline=\u2018{0}\u2019 is offline
 Queue.Unknown=???
+Queue.FinishedWaiting=Finished waiting
 Queue.WaitingForNextAvailableExecutor=Waiting for next available executor
 Queue.WaitingForNextAvailableExecutorOn=Waiting for next available executor on \u2018{0}\u2019
 Queue.init=Restoring the build queue


### PR DESCRIPTION
In #3436, I started gathering queue API statistics.

Currently:
```
1122 / 7087 jenkins.queue.log
      3 ???
     68 All nodes of label ‘LABEL’ are offline
    765 Build # is already in progress (...)
     31 Executor slot already in use
     11 In the quiet period. Expires in # sec
   1203 NODE doesn’t have label LABEL
   2848 NODE is offline
     22 NODE is reserved for jobs with matching label expression
    554 Upstream project PROJECT is already building.
    560 Waiting for next available executor on LABEL
   4575 Waiting for next available executor on NODE
```

For each of the three times that I hit this edge `public CauseOfBlockage getCauseOfBlockage() -> CauseOfBlockage.fromMessage(Messages._Queue_Unknown())`, the difference between `inQueueSince` and `timestamp` was "-5000". Here's an example:
```js
{ _class: 'hudson.model.Queue',
  discoverableItems: [],
  items:
   [ { _class: 'hudson.model.Queue$WaitingItem',
       actions: [Array],
       blocked: false,
       buildable: false,
       id: 30826,
       inQueueSince: 1525984983231,
       params: '',
       stuck: false,
       task: [Object],
       url: 'queue/item/30826/',
       why: '???',
       timestamp: 1525984988231 } ] }
```

I'm making two changes:
1. Getting the time first instead of second because time ticks forward which means that the later we get it, the more likely it is to be negative and thus "confusing".
2. Including 10,000 milliseconds (10 seconds) of tolerance.

For my system, 5,000 milliseconds (5 seconds) would be enough for each of the three times I've hit this edge, but picking the exact count that makes my edge pass makes me queasy.