### PR TITLE
[JENKINS-51326] - Permit primitive types in the ClassFilterImpl

### DIFF
--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -146,6 +146,10 @@ public class ClassFilterImpl extends ClassFilter {
                 LOGGER.log(Level.FINE, "permitting {0} since it is an array", name);
                 return false;
             }
+            if (c.isPrimitive()) {
+                LOGGER.log(Level.FINE, "permitting {0} since it is a primitive data type", name);
+                return false;
+            }
             if (Throwable.class.isAssignableFrom(c)) {
                 LOGGER.log(Level.FINE, "permitting {0} since it is a throwable", name);
                 return false;

--- a/test/src/test/java/jenkins/security/ClassFilterImplTest.java
+++ b/test/src/test/java/jenkins/security/ClassFilterImplTest.java
@@ -161,6 +161,32 @@ public class ClassFilterImplTest {
         filter.check("org.jenkinsci.main.modules.instance_identity.PageDecoratorImpl");
     }
 
+    @Test
+    @Issue("JENKINS-51326")
+    public void primitivesShouldBeWhitelisted() throws Exception {
+        ClassFilterImpl filter = new ClassFilterImpl();
+
+        // ClassFilter#isBlacklisted(String) is noop now, but we check it just in case it changes
+        filter.check("long");
+        filter.check("short");
+        filter.check("int");
+        filter.check("byte");
+        filter.check("float");
+        filter.check("double");
+        filter.check("boolean");
+        filter.check("char");
+
+        // Use object check
+        filter.check(long.class);
+        filter.check(short.class);
+        filter.check(int.class);
+        filter.check(byte.class);
+        filter.check(float.class);
+        filter.check(double.class);
+        filter.check(boolean.class);
+        filter.check(char.class);
+    }
+
     @TestExtension("xstreamRequiresWhitelist")
     public static class Config extends GlobalConfiguration {
         LinkedListMultimap<?, ?> obj;


### PR DESCRIPTION
See [JENKINS-51326](https://issues.jenkins-ci.org/browse/JENKINS-51326). I am not sure why it happens in the particular reported case, because primitive classes should be boxed/unboxed by XStream. Obviously it does not happen in the reporter's case (maybe it's not XStream at all), to be investigated.

There is no sense to reject primitive classes, so I think this patch is reasonable anyway

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE: Permit primitive types in the standard Jenkins Class Filter (JEP-200)
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jglick @daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
