### PR TITLE
[JENKINS-51355] - Print stacktraces to logs at FINE+ level when rejecting classes in ClassFilterImpl

### DIFF
--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -172,10 +172,13 @@ public class ClassFilterImpl extends ClassFilter {
                 return false;
             }
             if (SUPPRESS_WHITELIST || SUPPRESS_ALL) {
-                LOGGER.log(Level.WARNING, "{0} in {1} might be dangerous, so would normally be rejected; see https://jenkins.io/redirect/class-filter/", new Object[] {name, location != null ? location : "JRE"});
+                notifyRejected(_c, null,
+                        String.format("%s in %s might be dangerous, so would normally be rejected; see https://jenkins.io/redirect/class-filter/", name, location != null ?location : "JRE"));
+
                 return false;
             }
-            LOGGER.log(Level.WARNING, "{0} in {1} might be dangerous, so rejecting; see https://jenkins.io/redirect/class-filter/", new Object[] {name, location != null ? location : "JRE"});
+            notifyRejected(_c, null,
+                    String.format("%s in %s might be dangerous, so rejecting; see https://jenkins.io/redirect/class-filter/", name, location != null ?location : "JRE"));
             return true;
         });
     }
@@ -295,7 +298,13 @@ public class ClassFilterImpl extends ClassFilter {
         for (CustomClassFilter f : ExtensionList.lookup(CustomClassFilter.class)) {
             Boolean r = f.permits(name);
             if (r != null) {
-                LOGGER.log(Level.FINER, "{0} specifies a policy for {1}: {2}", new Object[] {f, name, r});
+                if (r) {
+                    LOGGER.log(Level.FINER, "{0} specifies a policy for {1}: {2}", new Object[] {f, name, r});
+                } else {
+                    notifyRejected(null, name,
+                            String.format("%s specifies a policy for %s: %s", f, name, r));
+                }
+
                 return !r;
             }
         }
@@ -305,11 +314,22 @@ public class ClassFilterImpl extends ClassFilter {
                 LOGGER.log(Level.WARNING, "would normally reject {0} according to standard blacklist; see https://jenkins.io/redirect/class-filter/", name);
                 return false;
             }
-            LOGGER.log(Level.WARNING, "rejecting {0} according to standard blacklist; see https://jenkins.io/redirect/class-filter/", name);
+            notifyRejected(null, name,
+                    String.format("rejecting %s according to standard blacklist; see https://jenkins.io/redirect/class-filter/", name));
             return true;
         } else {
             return false;
         }
     }
 
+    private void notifyRejected(@CheckForNull Class<?> clazz, @CheckForNull String clazzName, String message) {
+        Throwable cause = null;
+        if (LOGGER.isLoggable(Level.INFO)) {
+            cause = new SecurityException("Class rejected by the class filter: " +
+                    (clazz != null ? clazz.getName() : clazzName));
+        }
+        LOGGER.log(Level.WARNING, message, cause);
+
+        // TODO: Integrate with Telemetry API (JEP-304) once it is available in the core
+    }
 }

--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -311,7 +311,8 @@ public class ClassFilterImpl extends ClassFilter {
         // could apply a cache if the pattern search turns out to be slow
         if (ClassFilter.STANDARD.isBlacklisted(name)) {
             if (SUPPRESS_ALL) {
-                LOGGER.log(Level.WARNING, "would normally reject {0} according to standard blacklist; see https://jenkins.io/redirect/class-filter/", name);
+                notifyRejected(null, name,
+                        String.format("would normally reject %s according to standard blacklist; see https://jenkins.io/redirect/class-filter/", name));
                 return false;
             }
             notifyRejected(null, name,

--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -325,7 +325,7 @@ public class ClassFilterImpl extends ClassFilter {
 
     private void notifyRejected(@CheckForNull Class<?> clazz, @CheckForNull String clazzName, String message) {
         Throwable cause = null;
-        if (LOGGER.isLoggable(Level.INFO)) {
+        if (LOGGER.isLoggable(Level.FINE)) {
             cause = new SecurityException("Class rejected by the class filter: " +
                     (clazz != null ? clazz.getName() : clazzName));
         }


### PR DESCRIPTION
See [JENKINS-51355](https://issues.jenkins-ci.org/browse/JENKINS-51355) and [JENKINS-51326](https://issues.jenkins-ci.org/browse/JENKINS-51326) which is the original issue. In some cases we see ClassFilter errors without stacktraces for Remoting (and XStream?) when there is no reporting in class filter callers. 

I propose logging invocation stacktraces when the logging level is above `INFO`

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE: Log stacktraces in JEP-200 rejection messages when `jenkins.security.ClassFilterImpl` logging level is `FINE` or above
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jglick @dwnusbaum @jeffret-b 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
