### PR TITLE
Fix sortable.js to handle "Never" and null dates

### DIFF
--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -271,7 +271,7 @@ var Sortable = (function() {
      *   "03-23-99 1:30 PM also ignored content"
      *   "12-25/1979 13:45:22 always with the ignored content!"
      */
-    var date_pattern = /^(\d{1,2})[\/-](\d{1,2})[\/-](\d\d|\d\d\d\d)(?:(?:\s*(\d{1,2})?:(\d\d)?(?::(\d\d)?)?)?(?:\s*([aA][mM]|[pP][mM])?))\b/
+    var date_pattern = /^Never|(\d{1,2})[\/-](\d{1,2})[\/-](\d\d|\d\d\d\d)(?:(?:\s*(\d{1,2})?:(\d\d)?(?::(\d\d)?)?)?(?:\s*([aA][mM]|[pP][mM])?))\b/
 
     // available sort functions
     var sorter = {
@@ -284,6 +284,9 @@ var Sortable = (function() {
              */
             function toDate(x) {
                 dmatches = x.match(date_pattern);
+                if (!dmatches || dmatches[0] == "Never") {
+                    return new Date(0);
+                }
                 month = dmatches[1];
                 day = dmatches[2];
                 year = parseInt(dmatches[3]);


### PR DESCRIPTION
Build Failure Analyzer plugin can put "Never" in the "Last Seen" column,
which broke matching/sorting in sortable.js. This change handles
"Never" (so it includes it as a Date) and non-matching strings in
a column determined to be date, and treats them as equal to the Epoch,
so they sort as very old.

### Proposed changelog entries

* Improve sortable.js to handle non-date-like values in Date table columns

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@Wadeck @oleg-nenashev 

