### PR TITLE
[JENKINS-20272] - Disconnected nodes should not be disconnected repeatedly

### DIFF
--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -46,20 +46,23 @@ import org.kohsuke.stapler.export.ExportedBean;
 public class ResponseTimeMonitor extends NodeMonitor {
     @Extension
     public static final AbstractNodeMonitorDescriptor<Data> DESCRIPTOR = new AbstractAsyncNodeMonitorDescriptor<Data>() {
+
         @Override
         protected Callable<Data,IOException> createCallable(Computer c) {
-            if (c.getChannel() == null) {
-                return null;
-            }
             return new Step1(get(c));
         }
 
         @Override
         protected Map<Computer, Data> monitor() throws InterruptedException {
-            Map<Computer, Data> base = super.monitor();
+            ResultMap<Data> base = (ResultMap<Data>) super.monitor();
             for (Entry<Computer, Data> e : base.entrySet()) {
                 Computer c = e.getKey();
                 Data d = e.getValue();
+                if (base.getSkipped().contains(c)) {
+                    assert d == null;
+                    continue;
+                }
+
                 if (d ==null) {
                     // if we failed to monitor, put in the special value that indicates a failure
                     e.setValue(d=new Data(get(c),-1L));

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -54,8 +54,9 @@ public class ResponseTimeMonitor extends NodeMonitor {
 
         @Override
         protected Map<Computer, Data> monitor() throws InterruptedException {
-            ResultMap<Data> base = (ResultMap<Data>) super.monitor();
-            for (Entry<Computer, Data> e : base.entrySet()) {
+            Result<Data> base = monitorDetailed();
+            Map<Computer, Data> monitoringData = base.getMonitoringData();
+            for (Entry<Computer, Data> e : monitoringData.entrySet()) {
                 Computer c = e.getKey();
                 Data d = e.getValue();
                 if (base.getSkipped().contains(c)) {
@@ -77,7 +78,7 @@ public class ResponseTimeMonitor extends NodeMonitor {
                     LOGGER.warning(Messages.ResponseTimeMonitor_MarkedOffline(c.getName()));
                 }
             }
-            return base;
+            return monitoringData;
         }
 
         public String getDisplayName() {

--- a/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
+++ b/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
@@ -58,6 +58,7 @@ public class ResponseTimeMonitorTest {
         DumbSlave slave = new DumbSlave("dummy", "dummy", j.createTmpDir().getPath(), "1", Node.Mode.NORMAL, "", new JNLPLauncher(), RetentionStrategy.NOOP, Collections.EMPTY_LIST);
         j.jenkins.addNode(slave);
         Computer c = slave.toComputer();
+        assertNotNull(c);
         OfflineCause originalOfflineCause = c.getOfflineCause();
 
         ResponseTimeMonitor rtm = ComputerSet.getMonitors().get(ResponseTimeMonitor.class);


### PR DESCRIPTION
See [JENKINS-20272](https://issues.jenkins-ci.org/browse/JENKINS-20272).

I consider the original fix fix to have no effect as [described in the jira](https://issues.jenkins-ci.org/browse/JENKINS-20272?focusedCommentId=338428&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-338428). Contrary to the original approach of skipping the check (that was not performed even before), I am focusing on the processing part that, as I was able to demonstrate, turns the absence of data caused by skipped monitoring into a failure its accumulation causes the monitor to consider the computer irresponsive.

### Proposed changelog entries

* Do not repeatedly disconnect offline computers.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

Contributors of the original PR (https://github.com/jenkinsci/jenkins/pull/2911): @oleg-nenashev, @abayer, @stephenc, @daniel-beck 
