### PR TITLE
[JENKINS-51483] Remove erroneous entry in split-plugin-cycles.txt

### DIFF
--- a/core/src/main/resources/jenkins/split-plugin-cycles.txt
+++ b/core/src/main/resources/jenkins/split-plugin-cycles.txt
@@ -10,5 +10,3 @@ script-security command-launcher
 script-security matrix-auth
 script-security matrix-project
 script-security windows-slaves
-
-apache-httpcomponents-client-4-api jdk-tool


### PR DESCRIPTION
See [JENKINS-51483](https://issues.jenkins-ci.org/browse/JENKINS-51483).

This entry should have been removed before #3301 was merged. ~Here is the jdk-tool:1.0 pom that shows that it does not depend on apache-httpcomponents-client-4-api: https://github.com/jenkinsci/jdk-tool-plugin/blob/jdk-tool-1.0/pom.xml.~ EDIT: jdk-tool is the wrong place to justify this. The actual justification is that apache-httpcomponents-client-4-api used JDKInstaller in [some tests](https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin/blob/db063eece700bcb435bb8b502360f57601392f37/src/test/java/org/jenkinsci/plugins/apachehttpclient4api/Client4JDKInstaller.java#L34) and the entry should never have been added.

### Proposed changelog entries

* Bug: Restore implied dependency on JDK Tool Plugin from Apache HttpComponents Client 4 API Plugin

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
