### PR TITLE
grammar improvements for patternJobNamingStrategy

### DIFF
--- a/war/src/main/webapp/help/system-config/patternJobNamingStrategy.html
+++ b/war/src/main/webapp/help/system-config/patternJobNamingStrategy.html
@@ -1,8 +1,8 @@
 <div>
-  Define a pattern (regular expression) to check whether the job name is valid or not.
+  Define a pattern (regular expression) to check whether or not the job name is valid.
   <p>
   Forcing the check on existing jobs, will allow you to enforce a naming convention on existing jobs - e.g. even if the user does not change the name, 
-  it will be validated with the given pattern at every submit and no updates can be made until the name confirms.<br>
+  it will be validated with the given pattern at every submit and no updates can be made until the name conforms.<br>
   <i>This option does not affect the execution of jobs with non-compliant names.
   It just controls the validation process when saving job configurations.</i> 
 </div>


### PR DESCRIPTION
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
