### PR TITLE
[JENKINS-51598] - Expose PermissionGroup IDs to API

### DIFF
--- a/core/src/main/java/hudson/security/PermissionGroup.java
+++ b/core/src/main/java/hudson/security/PermissionGroup.java
@@ -27,6 +27,7 @@ import hudson.model.Hudson;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.CheckForNull;
@@ -51,6 +52,8 @@ public final class PermissionGroup implements Iterable<Permission>, Comparable<P
      */
     public final Localizable title;
 
+    private final String id;
+
     /**
      * Both creates a registers a new permission group.
      * @param owner sets {@link #owner}
@@ -58,12 +61,32 @@ public final class PermissionGroup implements Iterable<Permission>, Comparable<P
      * @throws IllegalStateException if this group was already registered
      */
     public PermissionGroup(@Nonnull Class owner, Localizable title) throws IllegalStateException {
+        this(title.toString(Locale.ENGLISH), owner, title);
+    }
+
+    /**
+     * Both creates a registers a new permission group.
+     * @param owner sets {@link #owner}
+     * @param title sets {@link #title}
+     * @throws IllegalStateException if this group was already registered
+     * @since TODO
+     */
+    public PermissionGroup(String id, @Nonnull Class owner, Localizable title) throws IllegalStateException {
         this.owner = owner;
         this.title = title;
+        this.id = id;
         register(this);
     }
 
-    private String id() {
+    /**
+     * Gets ID of the permission group.
+     * @return Non-localizable ID of the permission group.
+     */
+    public String getId() {
+        return id;
+    }
+
+    public String getOwnerClassName() {
         return owner.getName();
     }
 
@@ -110,7 +133,7 @@ public final class PermissionGroup implements Iterable<Permission>, Comparable<P
 
         // among the permissions of the same group, just sort by their names
         // so that the sort order is consistent regardless of classloading order.
-        return id().compareTo(that.id());
+        return getOwnerClassName().compareTo(that.getOwnerClassName());
     }
 
     private int compareOrder() {
@@ -119,11 +142,11 @@ public final class PermissionGroup implements Iterable<Permission>, Comparable<P
     }
 
     @Override public boolean equals(Object o) {
-        return o instanceof PermissionGroup && id().equals(((PermissionGroup) o).id());
+        return o instanceof PermissionGroup && getOwnerClassName().equals(((PermissionGroup) o).getOwnerClassName());
     }
 
     @Override public int hashCode() {
-        return id().hashCode();
+        return getOwnerClassName().hashCode();
     }
 
     public synchronized int size() {
@@ -131,12 +154,12 @@ public final class PermissionGroup implements Iterable<Permission>, Comparable<P
     }
 
     @Override public String toString() {
-        return "PermissionGroup[" + id() + "]";
+        return "PermissionGroup[" + getOwnerClassName() + "]";
     }
 
     private static synchronized void register(PermissionGroup g) {
         if (!PERMISSIONS.add(g)) {
-            throw new IllegalStateException("attempt to register a second PermissionGroup for " + g.id());
+            throw new IllegalStateException("attempt to register a second PermissionGroup for " + g.getOwnerClassName());
         }
     }
 


### PR DESCRIPTION
See [JENKINS-51598](https://issues.jenkins-ci.org/browse/JENKINS-51598).

Currently hudson.security.PermissionGroup API offers only getName() method, but this name is localizable. In Configuration-as-Code plugin we would like to use PermissionGroup IDs in order to define permissions from YAML.

ttps://github.com/jenkinsci/configuration-as-code-plugin/blob/configuration-as-code-0.7-alpha/src/main/java/org/jenkinsci/plugins/casc/util/PermissionFinder.java#L52-L56

It was worked around in https://github.com/jenkinsci/configuration-as-code-plugin/pull/240 , but IMHO a Core API would be useful

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE - Developer: `PermissionGroup`s now expose IDs to API
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@MadsNielsen @ndeloof @ewelinawilkosz @jenkinsci/code-reviewers 
