### PR TITLE
[JENKINS-51584] Actions from a TransientActionFactory should not be persisted

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2196,8 +2196,10 @@ public class Queue extends ResourceController implements Saveable {
             for (Action action: actions) addAction(action);
         }
 
+        @SuppressWarnings("deprecation") // JENKINS-51584
         protected Item(Item item) {
-        	this(item.task, new ArrayList<Action>(item.getAllActions()), item.id, item.future, item.inQueueSince);
+            // do not use item.getAllActions() here as this will persist actions from a TransientActionFactory
+            this(item.task, new ArrayList<Action>(item.getActions()), item.id, item.future, item.inQueueSince);
         }
 
         /**

--- a/core/src/main/java/hudson/model/queue/WorkUnitContext.java
+++ b/core/src/main/java/hudson/model/queue/WorkUnitContext.java
@@ -67,8 +67,8 @@ public final class WorkUnitContext {
         this.item = item;
         this.task = item.task;
         this.future = (FutureImpl)item.getFuture();
-        this.actions = new ArrayList<Action>(item.getAllActions());
-        
+        // JENKINS-51584 do not use item.getAllActions() here.
+        this.actions = new ArrayList<Action>(item.getActions());
         // +1 for the main task
         int workUnitSize = task.getSubTasks().size();
         startLatch = new Latch(workUnitSize) {

--- a/test/src/test/java/jenkins/model/TransientActionFactoryTest.java
+++ b/test/src/test/java/jenkins/model/TransientActionFactoryTest.java
@@ -155,7 +155,7 @@ public class TransientActionFactoryTest {
         FreeStyleProject p = r.createFreeStyleProject();
         FreeStyleBuild build = r.buildAndAssertSuccess(p);
         // MyProminentProjectAction is only added via the TransientActionFactory and should never be persisted.
-        assertThat(build.getActions(MyProminentProjectAction.class), hasSize(0));
+        assertThat(Util.filter(build.getActions(), MyProminentProjectAction.class), hasSize(0));
         assertThat(Util.filter(build.getAllActions(), MyProminentProjectAction.class), hasSize(1));
     }
 

--- a/test/src/test/java/jenkins/model/TransientActionFactoryTest.java
+++ b/test/src/test/java/jenkins/model/TransientActionFactoryTest.java
@@ -35,7 +35,8 @@ import hudson.model.InvisibleAction;
 import hudson.model.ProminentProjectAction;
 import hudson.model.queue.FoldableAction;
 
-import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +51,9 @@ import org.jvnet.hudson.test.TestExtension;
 
 import javax.annotation.Nonnull;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
 public class TransientActionFactoryTest {
@@ -163,7 +166,7 @@ public class TransientActionFactoryTest {
         FreeStyleProject p = r.createFreeStyleProject();
         FreeStyleBuild build = r.buildAndAssertSuccess(p);
         // MyProminentProjectAction is only added via the TransientActionFactory and should never be persisted.
-        assertThat(Util.filter(build.getActions(), MyProminentProjectAction.class), hasSize(0));
+        assertThat(Util.filter(build.getActions(), MyProminentProjectAction.class), is(empty()));
         assertThat(Util.filter(build.getAllActions(), MyProminentProjectAction.class), hasSize(1));
     }
 
@@ -182,6 +185,20 @@ public class TransientActionFactoryTest {
         }
     }
 
-    private static class MyProminentProjectAction extends InvisibleAction implements ProminentProjectAction {}
+    private static class MyProminentProjectAction extends InvisibleAction implements ProminentProjectAction {
+
+        private String allocation;
+
+        public MyProminentProjectAction() {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            new Exception("MyProminentProjectAction allocated at: ").printStackTrace(pw);
+            allocation = sw.toString();
+        }
+
+        public String toString() {
+            return allocation;
+        }
+    }
 
 }

--- a/test/src/test/java/jenkins/model/TransientActionFactoryTest.java
+++ b/test/src/test/java/jenkins/model/TransientActionFactoryTest.java
@@ -25,7 +25,14 @@
 package jenkins.model;
 
 import hudson.Util;
-import hudson.model.*;
+import hudson.model.AbstractItem;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.Actionable;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.InvisibleAction;
+import hudson.model.ProminentProjectAction;
 import hudson.model.queue.FoldableAction;
 
 import java.io.IOException;
@@ -34,8 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import org.hamcrest.Matchers;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -44,6 +49,9 @@ import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.TestExtension;
 
 import javax.annotation.Nonnull;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.*;
 
 public class TransientActionFactoryTest {
 


### PR DESCRIPTION
The Actions are created for the hudson.model.Queue$WaitingItem and
hudson.model.Queue$BuildableItem but get persisted in the actions list
of the build.

See [JENKINS-51584](https://issues.jenkins-ci.org/browse/JENKINS-51584).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Actions created from a `TransientActionFactory` that got attached to an item in the queue would be permanently persisted leading to duplicate actions shown for the a Build

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
