### PR TITLE
[JENKINS-51603] - Relax workDirectory requirements for a JNLPLauncher constructor

### DIFF
--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -31,7 +31,6 @@ import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.TaskListener;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import jenkins.model.Jenkins;
 import jenkins.slaves.RemotingWorkDirSettings;
@@ -81,7 +80,7 @@ public class JNLPLauncher extends ComputerLauncher {
      * @since 2.68
      */
     @DataBoundConstructor
-    public JNLPLauncher(@CheckForNull String tunnel, @CheckForNull String vmargs, @Nullable RemotingWorkDirSettings workDirSettings) {
+    public JNLPLauncher(@CheckForNull String tunnel, @CheckForNull String vmargs, @CheckForNull RemotingWorkDirSettings workDirSettings) {
         this.tunnel = Util.fixEmptyAndTrim(tunnel);
         this.vmargs = Util.fixEmptyAndTrim(vmargs);
         this.workDirSettings = workDirSettings != null ? workDirSettings :

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -31,6 +31,8 @@ import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.TaskListener;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import jenkins.model.Jenkins;
 import jenkins.slaves.RemotingWorkDirSettings;
 import org.jenkinsci.Symbol;
@@ -68,12 +70,22 @@ public class JNLPLauncher extends ComputerLauncher {
 
     @Nonnull
     private RemotingWorkDirSettings workDirSettings;
-    
+
+    /**
+     * Constructor.
+     * @param tunnel Tunnel settings
+     * @param vmargs JVM arguments
+     * @param workDirSettings Settings for Work Directory management in Remoting.
+     *                        If {@code null}, {@link RemotingWorkDirSettings#getEnabledDefaults()}
+     *                        will be used to enable work directories by default in new agents.
+     * @since 2.68
+     */
     @DataBoundConstructor
-    public JNLPLauncher(@CheckForNull String tunnel, @CheckForNull String vmargs, @Nonnull RemotingWorkDirSettings workDirSettings) {
+    public JNLPLauncher(@CheckForNull String tunnel, @CheckForNull String vmargs, @Nullable RemotingWorkDirSettings workDirSettings) {
         this.tunnel = Util.fixEmptyAndTrim(tunnel);
         this.vmargs = Util.fixEmptyAndTrim(vmargs);
-        this.workDirSettings = workDirSettings;
+        this.workDirSettings = workDirSettings != null ? workDirSettings :
+                RemotingWorkDirSettings.getEnabledDefaults();
     }
     
     @Deprecated


### PR DESCRIPTION
See [JENKINS-51603](https://issues.jenkins-ci.org/browse/JENKINS-51603). The current API causes incompatibility between agent configurations 2.60.x and 2.73.1+ LTS baselines when you use Configuration-as-Code plugin. Although we are going to have a workaround fix there (https://github.com/jenkinsci/configuration-as-code-plugin/issues/233), it would be great to relax the API a bit

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Bug: Relax API requirements in Java Web Start agent Launcher so that Configuration-as-Code plugin can load old configuration format on Jenkins 2.68 and above
  * https://github.com/jenkinsci/configuration-as-code-plugin


<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@ndeloof @MadsNielsen @ewelinawilkosz @jenkinsci/code-reviewers 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
