### PR TITLE
[JENKINS-51650] RunParameterDefinition.copyWithDefaultValue() used wrong constructor

### DIFF
--- a/core/src/main/java/hudson/model/RunParameterDefinition.java
+++ b/core/src/main/java/hudson/model/RunParameterDefinition.java
@@ -92,7 +92,7 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
     public ParameterDefinition copyWithDefaultValue(ParameterValue defaultValue) {
         if (defaultValue instanceof RunParameterValue) {
             RunParameterValue value = (RunParameterValue) defaultValue;
-            return new RunParameterDefinition(getName(), value.getRunId(), getDescription(), getFilter());
+            return new RunParameterDefinition(getName(), getProjectName(), value.getRunId(), getDescription(), getFilter());
         } else {
             return this;
         }


### PR DESCRIPTION
RunParameterDefinition.copyWithDefaultValue() used wrong constructor,
essentially creating a broken RunParameterDefinition where the project name
was set to the runid and the real runid was nulled.