### PR TITLE
[JENKINS-14632] Use a more specific selector so we don't risk matchin…

### DIFF
--- a/core/src/main/resources/lib/form/advanced/advanced.js
+++ b/core/src/main/resources/lib/form/advanced/advanced.js
@@ -3,7 +3,7 @@ Behaviour.specify("INPUT.advanced-button", 'advanced', 0, function(e) {
             var link = $(e.target).up(".advancedLink");
             link.style.display = "none"; // hide the button
 
-            var container = link.next().down(); // TABLE -> TBODY
+            var container = link.next("table.advancedBody").down(); // TABLE -> TBODY
 
             var tr = link.up("TR");
 

--- a/test/src/test/java/lib/form/AdvancedButtonTest.java
+++ b/test/src/test/java/lib/form/AdvancedButtonTest.java
@@ -6,6 +6,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
 import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.Issue;
 import org.kohsuke.stapler.StaplerRequest;
 
 
@@ -33,6 +34,7 @@ public class AdvancedButtonTest extends HudsonTestCase {
         return FormValidation.ok();
     }
 
+    @Issue("JENKINS-14632")
     public void testSectionInsideOfAdvanced() throws Exception {
         HtmlPage p = createWebClient().goTo("self/testSectionInsideOfAdvanced");
         HtmlForm f = p.getFormByName("config");

--- a/test/src/test/java/lib/form/AdvancedButtonTest.java
+++ b/test/src/test/java/lib/form/AdvancedButtonTest.java
@@ -32,4 +32,12 @@ public class AdvancedButtonTest extends HudsonTestCase {
         assertEquals("dvalue",c.getString("d"));
         return FormValidation.ok();
     }
+
+    public void testSectionInsideOfAdvanced() throws Exception {
+        HtmlPage p = createWebClient().goTo("self/testSectionInsideOfAdvanced");
+        HtmlForm f = p.getFormByName("config");
+        assertFalse(f.getInputByName("b").isDisplayed());
+        HtmlFormUtil.getButtonByCaption(f, "Advanced...").click();
+        assertTrue(f.getInputByName("b").isDisplayed());
+    }
 }

--- a/test/src/test/resources/lib/form/AdvancedButtonTest/testSectionInsideOfAdvanced.jelly
+++ b/test/src/test/resources/lib/form/AdvancedButtonTest/testSectionInsideOfAdvanced.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<l:layout title="Testing the effect of validateButton">
+  <l:main-panel>
+    <f:form method="post" name="config" action="">
+      <f:entry title="a">
+        <f:textbox name="a" value="avalue" />
+      </f:entry>
+      <f:advanced>
+        <f:section title="foo">
+          <f:entry title="b">
+            <f:textbox name="b" value="bvalue" />
+          </f:entry>
+        </f:section>
+      </f:advanced>
+      <f:submit value="submit" />
+    </f:form>
+  </l:main-panel>
+</l:layout>
+</j:jelly>


### PR DESCRIPTION
…g an element we are not expecting

See [JENKINS-14632](https://issues.jenkins-ci.org/browse/JENKINS-14632).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fix behaviour of Advanced button when a section is nested inside

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
