### PR TITLE
Add new permission for REST API

### DIFF
--- a/core/src/main/java/hudson/model/Api.java
+++ b/core/src/main/java/hudson/model/Api.java
@@ -93,6 +93,8 @@ public class Api extends AbstractModelObject {
                       @QueryParameter String wrapper,
                       @QueryParameter String tree,
                       @QueryParameter int depth) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.REST_API);
+
         setHeaders(rsp);
 
         String[] excludes = req.getParameterValues("exclude");
@@ -194,6 +196,7 @@ public class Api extends AbstractModelObject {
      * Generate schema.
      */
     public void doSchema(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.REST_API);
         setHeaders(rsp);
         rsp.setContentType("application/xml");
         StreamResult r = new StreamResult(rsp.getOutputStream());
@@ -205,6 +208,7 @@ public class Api extends AbstractModelObject {
      * Exposes the bean as JSON.
      */
     public void doJson(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.REST_API);
         if (req.getParameter("jsonp") == null || permit(req)) {
             setHeaders(rsp);
             rsp.serveExposedBean(req,bean, req.getParameter("jsonp") == null ? Flavor.JSON : Flavor.JSONP);
@@ -217,6 +221,7 @@ public class Api extends AbstractModelObject {
      * Exposes the bean as Python literal.
      */
     public void doPython(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        Jenkins.get().checkPermission(Jenkins.REST_API);
         setHeaders(rsp);
         rsp.serveExposedBean(req,bean, Flavor.PYTHON);
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5139,6 +5139,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public static final Permission ADMINISTER = Permission.HUDSON_ADMINISTER;
     public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
     public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
+    public static final Permission REST_API = new Permission(PERMISSIONS, "RestApi", Messages._Jenkins_RestApiPermission_Description(), ADMINISTER, PermissionScope.JENKINS);
 
     /**
      * Urls that are always visible without READ permission.

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -35,7 +35,7 @@ AbstractItem.TaskNoun=Build
 AbstractItem.BeingDeleted={0} is currently being deleted
 AbstractItem.FailureToStopBuilds=Failed to interrupt and stop {0,choice,1#{0,number,integer} build|1<{0,number,integer} \
   builds} of {1}
-AbstractItem.NewNameInUse=The name \u201c{0}\u201d is already in use.
+AbstractItem.NewNameInUse=The name \u201C{0}\u201D is already in use.
 AbstractItem.NewNameUnchanged=The new name is the same as the current name.
 AbstractProject.AssignedLabelString_NoMatch_DidYouMean=There\u2019s no agent/cloud that matches this assignment. Did you mean \u2018{1}\u2019 instead of \u2018{0}\u2019?
 AbstractProject.NewBuildForWorkspace=Scheduling a new build to get a workspace.
@@ -170,6 +170,9 @@ Hudson.ReadPermission.Description=\
 Hudson.RunScriptsPermission.Description=\
   Required for running scripts inside the Jenkins process, for example via the Groovy console or Groovy CLI command.
 Hudson.NodeDescription=the master Jenkins node
+Jenkins.RestApiPermission.Description=\
+  This permission allows users to use the general read-only Rest API in Jenkins, at URLs typically ending in <tt>\u2026/api/xml</tt> or <tt>\u2026/api/json</tt>. \
+  Other endpoints, typically modifying data, are not covered by this permission, and instead apply more specific permissions related to the data modification functionality provided.
 
 Item.Permissions.Title=Job
 Item.CREATE.description=Create a new job.
@@ -386,7 +389,7 @@ BuildAuthorizationToken.InvalidTokenProvided=Invalid token provided.
 Jenkins.CheckDisplayName.NameNotUniqueWarning=The display name, "{0}", is used as a name by a job and could cause confusing search results.
 Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=The display name, "{0}", is already in use by another job and could cause confusion and delay.
 
-Jenkins.NotAllowedName=\u201c{0}\u201d is not an allowed name
+Jenkins.NotAllowedName=\u201C{0}\u201D is not an allowed name
 Jenkins.IsRestarting=Jenkins is restarting
 
 User.IllegalUsername="{0}" is prohibited as a username for security reasons.


### PR DESCRIPTION
Make it easier to provide Jenkins REST API access to those who legitimately need it, while disabling it for others.

Basically, implement https://github.com/jenkins-infra/jenkins-infra/pull/1006 in core.

There's a potential scope definition problem that I tried to address in the description: `/createItem` is still accessible, and only covered by Item/Create. In fact, some endpoints, such as `/job/name/description` are pure API, and not governed by separate permissions (beyond Item/Read).

Still, I think it makes sense to add a REST API permission for the `…/api/…` URLs specifically.

WDYT?

Untested.