### PR TITLE
[JENKINS-50217] Defend against buggy ComputerListener.onConfigurationChange implementations

### DIFF
--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -227,8 +227,13 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
             killComputer(c);
         }
         getQueue().scheduleMaintenance();
-        for (ComputerListener cl : ComputerListener.all())
-            cl.onConfigurationChange();
+        for (ComputerListener cl : ComputerListener.all()) {
+            try {
+                cl.onConfigurationChange();
+            } catch (Throwable t) {
+                LOGGER.log(Level.WARNING, null, t);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
See [JENKINS-50217](https://issues.jenkins-ci.org/browse/JENKINS-50217). Not a fix for the root cause, just a robustness defense.

### Proposed changelog entries

* A buggy `ComputerListener.onConfigurationChange` implementation should not block Jenkins startup.