### PR TITLE
[JENKINS-51660] Correct default URL proposed for Root URL

### DIFF
--- a/core/src/main/resources/jenkins/install/SetupWizard/setupWizardConfigureInstance.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/setupWizardConfigureInstance.jelly
@@ -106,7 +106,8 @@ THE SOFTWARE.
             $('root-url').focus();
             (function setInitialRootUrlFieldValue(){
               var iframeUrl = window.location.href;
-              var iframeRelativeUrl = '/setupWizard/setupWizardConfigureInstance';
+              // will let the trailing slash in the rootUrl 
+              var iframeRelativeUrl = 'setupWizard/setupWizardConfigureInstance';
               var rootUrl = iframeUrl.substr(0, iframeUrl.length - iframeRelativeUrl.length);
               // to keep only the root url
               var rootUrlField = $('root-url');


### PR DESCRIPTION
See [JENKINS-51660](https://issues.jenkins-ci.org/browse/JENKINS-51660).

### Proposed changelog entries

* Internal: the proposed root URL now correctly ends with a slash (was only added by the server-side code previously)

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)

### Desired reviewers

@reviewbybees @jglick 

