### PR TITLE
use "permanent" as canonical symbol for dumbslave

### DIFF
--- a/core/src/main/java/hudson/slaves/DumbSlave.java
+++ b/core/src/main/java/hudson/slaves/DumbSlave.java
@@ -65,8 +65,8 @@ public final class DumbSlave extends Slave {
         super(name, remoteFS, launcher);
     }
 
-    @Extension @Symbol({"dumb",
-            "slave", "agent" /*because this is in effect the canonical slave type*/})
+    @Extension @Symbol({"agent" /*because this is in effect the canonical slave type*/, 
+            "dumb", "slave"})
     public static final class DescriptorImpl extends SlaveDescriptor {
         public String getDisplayName() {
             return Messages.DumbSlave_displayName();

--- a/core/src/main/java/hudson/slaves/DumbSlave.java
+++ b/core/src/main/java/hudson/slaves/DumbSlave.java
@@ -65,7 +65,7 @@ public final class DumbSlave extends Slave {
         super(name, remoteFS, launcher);
     }
 
-    @Extension @Symbol({"agent" /*because this is in effect the canonical slave type*/, 
+    @Extension @Symbol({"permanent" /*because this is in effect the canonical slave type*/, 
             "dumb", "slave"})
     public static final class DescriptorImpl extends SlaveDescriptor {
         public String getDisplayName() {


### PR DESCRIPTION
@Symbol first value is the canonical one as identifier (see javadoc https://github.com/jenkinsci/structs-plugin/blob/master/annotation/src/main/java/org/jenkinsci/Symbol.java#L33)

### Proposed changelog entries

* use "permanent" as canonical symbol for DumbSlave

### Submitter checklist

- [x] no JIRA for minor change
- [x] Changelog entry appropriate for the audience affected by the change
- [x] metadata only, no concrete code to be tested
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs
