### PR TITLE
[FIX JENKINS-51667] Move getBuildFingerprints from AbstractBuild to Run

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -803,20 +803,6 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         }
     }
 
-    /**
-     * get the fingerprints associated with this build
-     *
-     * @return never null
-     */
-    @Exported(name = "fingerprint", inline = true, visibility = -1)
-    public Collection<Fingerprint> getBuildFingerprints() {
-        FingerprintAction fingerprintAction = getAction(FingerprintAction.class);
-        if (fingerprintAction != null) {
-            return fingerprintAction.getFingerprints().values();
-        }
-        return Collections.<Fingerprint>emptyList();
-    }
-
 	/*
      * No need to lock the entire AbstractBuild on change set calculation
      */

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -830,16 +830,14 @@ public class Fingerprint implements ModelObject, Saveable {
             if (item instanceof AbstractProject) {
                 AbstractProject p = Jenkins.getInstance().getItemByFullName(newName, AbstractProject.class);
                 if (p != null) {
-                    RunList builds = p.getBuilds();
-                    for (Object build : builds) {
-                        if (build instanceof AbstractBuild) {
-                            Collection<Fingerprint> fingerprints = ((AbstractBuild)build).getBuildFingerprints();
-                            for (Fingerprint f : fingerprints) {
-                                try {
-                                    f.rename(oldName, newName);
-                                } catch (IOException e) {
-                                    logger.log(Level.WARNING, "Failed to update fingerprint record " + f.getFileName() + " when " + oldName + " was renamed to " + newName, e);
-                                }
+                    RunList<? extends Run> builds = p.getBuilds();
+                    for (Run build : builds) {
+                        Collection<Fingerprint> fingerprints = build.getBuildFingerprints();
+                        for (Fingerprint f : fingerprints) {
+                            try {
+                                f.rename(oldName, newName);
+                            } catch (IOException e) {
+                                logger.log(Level.WARNING, "Failed to update fingerprint record " + f.getFileName() + " when " + oldName + " was renamed to " + newName, e);
                             }
                         }
                     }

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -827,8 +827,8 @@ public class Fingerprint implements ModelObject, Saveable {
             }
         }
         private void locationChanged(Item item, String oldName, String newName) {
-            if (item instanceof AbstractProject) {
-                AbstractProject p = Jenkins.getInstance().getItemByFullName(newName, AbstractProject.class);
+            if (item instanceof Job) {
+                Job p = Jenkins.getInstance().getItemByFullName(newName, Job.class);
                 if (p != null) {
                     RunList<? extends Run> builds = p.getBuilds();
                     for (Run build : builds) {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1406,8 +1406,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     /**
      * get the fingerprints associated with this build
      *
-     * @return never null
+     * @return The fingerprints
      */
+    @Nonnull
     @Exported(name = "fingerprint", inline = true, visibility = -1)
     public Collection<Fingerprint> getBuildFingerprints() {
         FingerprintAction fingerprintAction = getAction(FingerprintAction.class);

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -59,6 +59,7 @@ import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.security.PermissionScope;
 import hudson.tasks.BuildWrapper;
+import hudson.tasks.Fingerprinter.FingerprintAction;
 import hudson.util.FormApply;
 import hudson.util.LogTaskListener;
 import hudson.util.ProcessTree;
@@ -80,6 +81,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -1401,6 +1403,20 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         }
     }
 
+    /**
+     * get the fingerprints associated with this build
+     *
+     * @return never null
+     */
+    @Exported(name = "fingerprint", inline = true, visibility = -1)
+    public Collection<Fingerprint> getBuildFingerprints() {
+        FingerprintAction fingerprintAction = getAction(FingerprintAction.class);
+        if (fingerprintAction != null) {
+            return fingerprintAction.getFingerprints().values();
+        }
+        return Collections.<Fingerprint>emptyList();
+    }
+    
     /**
      * Returns the log file.
      * @return The file may reference both uncompressed or compressed logs


### PR DESCRIPTION
See [JENKINS-51667](https://issues.jenkins-ci.org/browse/JENKINS-51667).

Will enable Jenkins API to serve fingerprints for all build even if they do not inherit from AbstractBuild

### Proposed changelog entries

* Jenkins API allows reading fingerprints for builds which do not derive from AbstractBuild e.g. Pipeline builds

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests: I could not find any tests related to this existing functionality, just a small rework
- [X] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@oleg-nenashev 
