### PR TITLE
[DO NOT MERGE] Add test failing on one platform only

### DIFF
--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -45,6 +45,7 @@ import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
+import hudson.Functions;
 import hudson.init.Initializer;
 import hudson.maven.MavenModuleSet;
 import hudson.maven.MavenModuleSetBuild;
@@ -186,6 +187,11 @@ public class JenkinsTest {
         
         Jenkins jenkins = Jenkins.getInstance();
         assertFalse(jenkins.isNameUnique(jobName, curJobName));
+    }
+
+    @Test
+    public void testPlatformFlake() throws Exception {
+        assertTrue(Functions.isWindows());
     }
 
     @Test


### PR DESCRIPTION
@oleg-nenashev and I discovered that we have failing builds in this repo without recorded test failures, but tests failing.

For example, in https://ci.jenkins.io/job/Core/job/jenkins/job/master/941, `hudson.slaves.PingThreadTest` failed on Linux, in build 938, `jenkins.model.JenkinsBuildsAndWorkspacesDirectoriesTest` failed on Linux.

Testing a hypothesis that tests that fail on one platform only are not considered failing by JUnit plugin.