### PR TITLE
[JENKINS-52417] - Removing FilePath.copyFromRemotely 

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -139,7 +139,6 @@ import static hudson.Util.isSymlink;
 
 import java.util.Collections;
 import org.apache.tools.ant.BuildException;
-import org.kohsuke.accmod.restrictions.Beta;
         
 /**
  * {@link File} like object with remoting support.
@@ -969,28 +968,6 @@ public final class FilePath implements Serializable {
     public void copyFrom(URL url) throws IOException, InterruptedException {
         try (InputStream in = url.openStream()) {
             copyFrom(in);
-        }
-    }
-
-    /**
-     * Copies the content of a URL to a remote file.
-     * Unlike {@link #copyFrom} this will not transfer content over a Remoting channel.
-     * @since 2.118
-     */
-    @Restricted(Beta.class)
-    public void copyFromRemotely(URL url) throws IOException, InterruptedException {
-        act(new CopyFromRemotely(url));
-    }
-    private final class CopyFromRemotely extends MasterToSlaveFileCallable<Void> {
-        private static final long serialVersionUID = 1;
-        private final URL url;
-        CopyFromRemotely(URL url) {
-            this.url = url;
-        }
-        @Override
-        public Void invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-            copyFrom(url);
-            return null;
         }
     }
 

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -336,6 +336,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
     /**
      * Optionally obtains a URL which may be used to retrieve file contents from any process on any node.
      * For example, given cloud storage this might produce a permalink to the file.
+     * <p>Only {@code http} and {@code https} protocols are permitted.
      * <p>This is only meaningful for {@link #isFile}:
      * no ZIP etc. archiving protocol is defined to allow bulk access to directory trees.
      * <p>Any necessary authentication must be encoded somehow into the URL itself;

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -337,6 +337,8 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
      * Optionally obtains a URL which may be used to retrieve file contents from any process on any node.
      * For example, given cloud storage this might produce a permalink to the file.
      * <p>Only {@code http} and {@code https} protocols are permitted.
+     * It is recommended to use the {@code RobustHTTPClient.downloadFile} utility method
+     * from the {@code apache-httpcomponents-client-4-api} plugin to work with these URLs.
      * <p>This is only meaningful for {@link #isFile}:
      * no ZIP etc. archiving protocol is defined to allow bulk access to directory trees.
      * <p>Any necessary authentication must be encoded somehow into the URL itself;


### PR DESCRIPTION
In favor of https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin/pull/9 as picked up by https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/60 & https://github.com/jenkinsci/copyartifact-plugin/pull/104, the only places where this method had been called.

### Changelog entry

* RFE - Developer: Remove `hudson.FilePath#copyFromRemotely()` Beta API from the core