### PR TITLE
[JENKINS-51779] Avoid com.google.common.collect.Iterators.skip

### DIFF
--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -37,6 +37,8 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.HashSet;
 import javax.annotation.Nonnull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Varios {@link Iterator} implementations.
@@ -410,8 +412,8 @@ public class Iterators {
      * Similar to {@link com.google.common.collect.Iterators#skip} except not {@link Beta}.
      * @param iterator some iterator
      * @param count a nonnegative count
-     * @since FIXME
      */
+    @Restricted(NoExternalUse.class)
     public static void skip(@Nonnull Iterator<?> iterator, int count) {
         if (count < 0) {
             throw new IllegalArgumentException();

--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -23,6 +23,7 @@
  */
 package hudson.util;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 
@@ -35,6 +36,7 @@ import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.HashSet;
+import javax.annotation.Nonnull;
 
 /**
  * Varios {@link Iterator} implementations.
@@ -403,4 +405,20 @@ public class Iterators {
     public interface CountingPredicate<T> {
         boolean apply(int index, T input);
     }
+
+    /**
+     * Similar to {@link com.google.common.collect.Iterators#skip} except not {@link Beta}.
+     * @param iterator some iterator
+     * @param count a nonnegative count
+     * @since FIXME
+     */
+    public static void skip(@Nonnull Iterator<?> iterator, int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException();
+        }
+        while (iterator.hasNext() && count-- > 0) {
+            iterator.next();
+        }
+    }
+
 }

--- a/core/src/main/java/hudson/util/RunList.java
+++ b/core/src/main/java/hudson/util/RunList.java
@@ -150,7 +150,7 @@ public class RunList<R extends Run> extends AbstractList<R> {
     public List<R> subList(int fromIndex, int toIndex) {
         List<R> r = new ArrayList<R>();
         Iterator<R> itr = iterator();
-        Iterators.skip(itr,fromIndex);
+        hudson.util.Iterators.skip(itr, fromIndex);
         for (int i=toIndex-fromIndex; i>0; i--) {
             r.add(itr.next());
         }

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -24,7 +24,6 @@
 package jenkins.widgets;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import hudson.model.AbstractBuild;
 import hudson.model.Job;
 import hudson.model.ParameterValue;
@@ -32,6 +31,7 @@ import hudson.model.ParametersAction;
 import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.search.UserSearchProperty;
+import hudson.util.Iterators;
 import hudson.widgets.HistoryWidget;
 
 import javax.annotation.Nonnull;

--- a/core/src/test/java/hudson/util/IteratorsTest.java
+++ b/core/src/test/java/hudson/util/IteratorsTest.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -77,9 +78,27 @@ public class IteratorsTest {
         assertEquals("[]", com.google.common.collect.Iterators.toString(Iterators.limit(asList(1,2,4,6).iterator(), EVEN)));
     }
 
-    public static final CountingPredicate<Integer> EVEN = new CountingPredicate<Integer>() {
-        public boolean apply(int index, Integer input) {
-            return input % 2 == 0;
-        }
-    };
+    public static final CountingPredicate<Integer> EVEN = (index, input) -> input % 2 == 0;
+
+    @Issue("JENKINS-51779")
+    @Test
+    public void skip() {
+        List<Integer> lst = Iterators.sequence(1, 4);
+        Iterator<Integer> it = lst.iterator();
+        Iterators.skip(it, 0);
+        assertEquals("[1, 2, 3]", com.google.common.collect.Iterators.toString(it));
+        it = lst.iterator();
+        Iterators.skip(it, 1);
+        assertEquals("[2, 3]", com.google.common.collect.Iterators.toString(it));
+        it = lst.iterator();
+        Iterators.skip(it, 2);
+        assertEquals("[3]", com.google.common.collect.Iterators.toString(it));
+        it = lst.iterator();
+        Iterators.skip(it, 3);
+        assertEquals("[]", com.google.common.collect.Iterators.toString(it));
+        it = lst.iterator();
+        Iterators.skip(it, 4);
+        assertEquals("[]", com.google.common.collect.Iterators.toString(it));
+    }
+
 }


### PR DESCRIPTION
See [JENKINS-51779](https://issues.jenkins-ci.org/browse/JENKINS-51779).

I attempted to use [this tool](http://overstock.github.io/library-detectors/):

```diff
diff --git a/core/pom.xml b/core/pom.xml
index 0d5c3f2c27..24fbed17e7 100644
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -812,6 +812,15 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+            <plugins>
+                <plugin>
+                    <groupId>com.overstock.findbugs</groupId>
+                    <artifactId>library-detectors</artifactId>
+                    <version>1.2.0</version>
+                </plugin>
+            </plugins>
+        </configuration>
       </plugin>
     </plugins>
   </build>
```

but no warnings were reported, perhaps because core still suppresses most FindBugs warnings? @oleg-nenashev knows most about this.

Anyway, it was easy enough to catch uses of methods which were _actually_ deleted in later Guava versions:

```diff
diff --git a/pom.xml b/pom.xml
index 6a4a504cd9..a768842f7d 100644
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@ THE SOFTWARE.
     <project.patchManagement.url>https://api.github.com</project.patchManagement.url>
     <patch.tracker.serverId>jenkins-jira</patch.tracker.serverId>
 
-    <guavaVersion>11.0.1</guavaVersion>
+    <guavaVersion>23.0</guavaVersion>
     <slf4jVersion>1.7.25</slf4jVersion>
     <maven-plugin.version>2.14</maven-plugin.version>
     <matrix-project.version>1.4.1</matrix-project.version>
```

### Proposed changelog entries

* Removing use of a Guava method deleted in later versions, which could cause problems for plugins running functional tests.