### PR TITLE
[JENKINS-51777] Don't let tar entries escape target dir

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2452,6 +2452,10 @@ public final class FilePath implements Serializable {
             TarArchiveEntry te;
             while ((te = t.getNextTarEntry()) != null) {
                 File f = new File(baseDir, te.getName());
+                if (!f.toPath().normalize().startsWith(baseDir.toPath())) {
+                    throw new IOException(
+                            "Tar " + name + " contains illegal file name that breaks out of the target directory: " + te.getName());
+                }
                 if (te.isDirectory()) {
                     mkdirs(f);
                 } else {


### PR DESCRIPTION
See [JENKINS-51777](https://issues.jenkins-ci.org/browse/JENKINS-51777).

Basically complete the half of https://snyk.io/research/zip-slip-vulnerability in core that #3402 left out. We don't currently consider this to be exploitable, so this is hardening, and we had to hold it back due to the embargo until this week.

### Proposed changelog entries

* Security hardening: Prevent tar archives from escaping their base directory.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@Wadeck 