### PR TITLE
[JENKINS-46602] - Update BCT to 2.0-alpha-3

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -212,7 +212,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>bytecode-compatibility-transformer</artifactId>
-      <version>1.8</version>
+      <version>2.0-alpha-3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
It is required to make Pipelines at least starting on Java 10. Originally the BCT module was update by @batmat in Sep 2017, and it is a good time to integrate it into the Java 10 development branch.

See [JENKINS-46602](https://issues.jenkins-ci.org/browse/JENKINS-46602).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Desired reviewers

@batmat @MarkEWaite 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
