### PR TITLE
[JENKINS-52153] - Check SlaveComputer.getChannelToMaster() before use

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -396,7 +396,10 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         // Check for the existance of vetoers if I don't know already
         if (vetoersExist == null) {
             try {
-                vetoersExist = SlaveComputer.getChannelToMaster().call(new DoVetoersExist());
+                VirtualChannel channelToMaster = SlaveComputer.getChannelToMaster();
+                if (channelToMaster != null) {
+                    vetoersExist = channelToMaster.call(new DoVetoersExist());
+                }
             }
             catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Error while determining if vetoers exist", e);


### PR DESCRIPTION
Avoid a null pointer exception when running tests on Windows.

No separate bug report has been filed since this is a test failure only.

Prior to this change, a null pointer exception is reported on Windows when I run:

`mvn clean -Dtest=hudson.util.ProcessTreeTest test`

The null pointer exception stack trace is:

```
[INFO] Running hudson.util.ProcessTreeTest
Jun 10, 2018 8:32:43 PM hudson.util.ProcessTree get
WARNING: Error while determining if vetoers exist
java.lang.NullPointerException
        at hudson.util.ProcessTree.get(ProcessTree.java:399)
        at hudson.util.ProcessTreeTest.remoting(ProcessTreeTest.java:31)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:272)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:236)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:386)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:323)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:143)

Jun 10, 2018 8:32:43 PM hudson.util.ProcessTree get
WARNING: Error while determining if vetoers exist
java.lang.NullPointerException
        at hudson.util.ProcessTree.get(ProcessTree.java:399)
        at hudson.util.ProcessTreeTest$MyCallable.call(ProcessTreeTest.java:50)
        at hudson.util.ProcessTreeTest$MyCallable.call(ProcessTreeTest.java:47)
        at hudson.remoting.UserRequest.perform(UserRequest.java:212)
        at hudson.remoting.UserRequest.perform(UserRequest.java:54)
        at hudson.remoting.Request$2.run(Request.java:369)
        at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.512 s - in hudson.util.ProcessTreeTest
```

### Proposed changelog entries (Mark)

* Internal: Avoid ProcessTree null pointer exception when running tests on Windows

### Proposed changelog entries (Oleg)

* Prevent NPE in the process termination veto caching when there is no Remoting channel to the master. 

### Submitter checklist

- [x] JIRA issue is well described (N/A)
- [x] Changelog entry appropriate for the audience affected by the change
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jenkinsci/code-reviewers 