### PR TITLE
[JENKINS-51889,JENKINS-51955,JENKINS-51971] - Stop using Guava’s NullOutputStream, document setChannel API

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -389,21 +389,8 @@ public class SlaveComputer extends Computer {
     /**
      * Creates a {@link Channel} from the given stream and sets that to this agent.
      *
-     * @param in
-     *      Stream connected to the remote agent. It's the caller's responsibility to do
-     *      buffering on this stream, if that's necessary.
-     * @param out
-     *      Stream connected to the remote peer. It's the caller's responsibility to do
-     *      buffering on this stream, if that's necessary.
-     * @param taskListener
-     *      Receives the portion of data in <tt>is</tt> before
-     *      the data goes into the "binary mode". This is useful
-     *      when the established communication channel might include some data that might
-     *      be useful for debugging/trouble-shooting.
-     * @param listener
-     *      Gets a notification when the channel closes, to perform clean up. Can be null.
-     *      By the time this method is called, the cause of the termination is reported to the user,
-     *      so the implementation of the listener doesn't need to do that again.
+     * Same as {@link #setChannel(InputStream, OutputStream, OutputStream, Channel.Listener)}, but for
+     * {@link TaskListener}.
      */
     public void setChannel(@Nonnull InputStream in, @Nonnull OutputStream out,
                            @Nonnull TaskListener taskListener,

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -578,14 +578,18 @@ public class SlaveComputer extends Computer {
 
     /**
      * Sets up the connection through an existing channel.
-     * @param channel the channel to use; <strong>warning:</strong> callers are expected to have called {@link ChannelConfigurator} already
+     * @param channel the channel to use; <strong>warning:</strong> callers are expected to have called {@link ChannelConfigurator} already.
+     * @param launchLog Launch log. If not {@code null}, will receive launch log messages
+     * @param listener Channel event listener to be attached (if not {@code null})
      * @since 1.444
      */
-    public void setChannel(Channel channel, OutputStream launchLog, Channel.Listener listener) throws IOException, InterruptedException {
+    public void setChannel(@Nonnull Channel channel,
+                           @CheckForNull OutputStream launchLog,
+                           @CheckForNull Channel.Listener listener) throws IOException, InterruptedException {
         if(this.channel!=null)
             throw new IllegalStateException("Already connected");
 
-        final TaskListener taskListener = new StreamTaskListener(launchLog);
+        final TaskListener taskListener = launchLog != null ? new StreamTaskListener(launchLog) : TaskListener.NULL;
         PrintStream log = taskListener.getLogger();
 
         channel.setProperty(SlaveComputer.class, this);

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -44,6 +44,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.kohsuke.stapler.framework.io.WriterOutputStream;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 // TODO: AbstractTaskListener is empty now, but there are dependencies on that e.g. Ruby Runtime - JENKINS-48116)
 // The change needs API deprecation policy or external usages cleanup.
 
@@ -56,7 +59,9 @@ import org.kohsuke.stapler.framework.io.WriterOutputStream;
  * @author Kohsuke Kawaguchi
  */
 public class StreamTaskListener extends AbstractTaskListener implements TaskListener, Closeable {
+    @Nonnull
     private PrintStream out;
+    @CheckForNull
     private Charset charset;
 
     /**
@@ -66,15 +71,15 @@ public class StreamTaskListener extends AbstractTaskListener implements TaskList
      *      or use {@link #fromStdout()} or {@link #fromStderr()}.
      */
     @Deprecated
-    public StreamTaskListener(PrintStream out) {
+    public StreamTaskListener(@Nonnull PrintStream out) {
         this(out,null);
     }
 
-    public StreamTaskListener(OutputStream out) {
+    public StreamTaskListener(@Nonnull OutputStream out) {
         this(out,null);
     }
 
-    public StreamTaskListener(OutputStream out, Charset charset) {
+    public StreamTaskListener(@Nonnull OutputStream out, @CheckForNull Charset charset) {
         try {
             if (charset == null)
                 this.out = (out instanceof PrintStream) ? (PrintStream)out : new PrintStream(out, false);
@@ -87,18 +92,18 @@ public class StreamTaskListener extends AbstractTaskListener implements TaskList
         }
     }
 
-    public StreamTaskListener(File out) throws IOException {
+    public StreamTaskListener(@Nonnull File out) throws IOException {
         this(out,null);
     }
 
-    public StreamTaskListener(File out, Charset charset) throws IOException {
+    public StreamTaskListener(@Nonnull File out, @CheckForNull Charset charset) throws IOException {
         // don't do buffering so that what's written to the listener
         // gets reflected to the file immediately, which can then be
         // served to the browser immediately
         this(Files.newOutputStream(asPath(out)), charset);
     }
 
-    private static Path asPath(File out) throws IOException {
+    private static Path asPath(@Nonnull File out) throws IOException {
         try {
             return out.toPath();
         } catch (InvalidPathException e) {
@@ -115,7 +120,7 @@ public class StreamTaskListener extends AbstractTaskListener implements TaskList
      * @throws IOException if the file could not be opened.
      * @since 1.651
      */
-    public StreamTaskListener(File out, boolean append, Charset charset) throws IOException {
+    public StreamTaskListener(@Nonnull File out, boolean append, @CheckForNull Charset charset) throws IOException {
         // don't do buffering so that what's written to the listener
         // gets reflected to the file immediately, which can then be
         // served to the browser immediately
@@ -127,7 +132,7 @@ public class StreamTaskListener extends AbstractTaskListener implements TaskList
         );
     }
 
-    public StreamTaskListener(Writer w) throws IOException {
+    public StreamTaskListener(@Nonnull Writer w) throws IOException {
         this(new WriterOutputStream(w));
     }
 

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -160,7 +160,7 @@ public class StreamTaskListener extends AbstractTaskListener implements TaskList
 
     @Override
     public Charset getCharset() {
-        return charset;
+        return charset != null ? charset : Charset.defaultCharset();
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {


### PR DESCRIPTION
…

See [JENKINS-51889](https://issues.jenkins-ci.org/browse/JENKINS-51889) and [JENKINS-51955](https://issues.jenkins-ci.org/browse/JENKINS-51955). It also picks a small patch for valid FindBugs warnings in [JENKINS-51971](https://issues.jenkins-ci.org/browse/JENKINS-51971). Follow-up to https://github.com/jenkinsci/jenkins/pull/3455#discussion_r194793508

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Bug, JENKINS-51889: Stop using deprecated `com.google.common.io.NullOutputStream` from Guava to avoid binary conflicts with plugins bundling newer Guava versions, e.g. Mesos plugin (regression in 2.127)
* Bug, JENKINS-51955: - Prevent NPE in `SlaveComputer#setChannel(Channel,OutputStream launchLog,Channel.Listener)` when `null` `launchLog` is passed from API
* JENKINS-51971 - `StreamTaskListener#getCharset()` now returns default charset when it is not configured

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jglick @jtnord 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
