### PR TITLE
[JENKINS-51834] - Simplify the CI for Java 10 branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,5 @@
 See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).
 
-<!-- Comment: 
-If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
-
- * We do not require JIRA issues for minor improvements.
- * Bugfixes should have a JIRA issue (backporting process).
- * Major new features should have a JIRA issue reference.
--->
-
 ### Proposed changelog entries
 
 * Entry 1: Issue, Human-readable Text
@@ -19,9 +11,6 @@ The changelogs will be integrated by the core maintainers after the merge.  See 
 ### Submitter checklist
 
 - [ ] JIRA issue is well described
-- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
-      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
-- [ ] Appropriate autotests or explanation to why this change has no tests
 - [ ] For dependency updates: links to external changelogs and, if possible, full diffs
 
 <!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
@@ -30,6 +19,3 @@ The changelogs will be integrated by the core maintainers after the merge.  See 
 
 @mention
 
-<!-- Comment:
-If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
--->

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,9 @@ def failFast = false
 
 properties([buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '20')), durabilityHint('PERFORMANCE_OPTIMIZED')])
 
+//TODO: Run tests on Java 10
+//TODO: Do we really need Windows for smoke tests
+
 // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc for information on what node types are available
 def buildTypes = ['Linux', 'Windows']
 
@@ -42,7 +45,8 @@ for(i = 0; i < buildTypes.size(); i++) {
                                     "MAVEN_OPTS=-Xmx1536m -Xms512m"]) {
                             // Actually run Maven!
                             // -Dmaven.repo.local=… tells Maven to create a subdir in the temporary directory for the local Maven repository
-                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
+                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -Dmaven.repo.local=$m2repo -s settings-azure.xml -e -Psmoke-test"
+
                             if(isUnix()) {
                                 sh mvnCmd
                                 sh 'test `git status --short | tee /dev/stderr | wc --bytes` -eq 0'
@@ -73,6 +77,7 @@ for(i = 0; i < buildTypes.size(); i++) {
     }
 }
 
+/* TODO: disabled for the Java 10 branch
 builds.ath = {
     node("docker&&highmem") {
         // Just to be safe
@@ -95,6 +100,7 @@ builds.ath = {
         }
     }
 }
+*/
 
 builds.failFast = failFast
 parallel builds

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -307,6 +307,12 @@ THE SOFTWARE.
       </properties>
     </profile>
     <profile>
+      <id>smoke-test</id>
+      <properties>
+        <test>jenkins.model.StartupTest,jenkins.model.JenkinsTest,jenkins.install.*,jenkins.security.CustomClassFilterTest,hudson.AboutJenkinsTest,hudson.ClassicPluginStrategyTest,hudson.LauncherTest,hudson.slaves.JNLPLauncherTest,hudson.model.RunTest,hudson.model.UserTest,hudson.model.FreeStyleProjectTest,hudson.model.HudsonTest,hudson.model.ComputerTest,hudson.CLI.BuildCommandTest#sync,*.smokes</test>
+      </properties>
+    </profile>
+    <profile>
       <id>all-tests</id>
       <activation>
         <property>


### PR DESCRIPTION
See [JENKINS-51834](https://issues.jenkins-ci.org/browse/JENKINS-51834). During Hackathon we would like to reduce load on the CI infrastructure and to speedup feedback, so I propose to simplify CI.

- [x] Disable ATH
- [x] Run only a subset of JTH tests (clean build takes ~6 minutes on my machine). Extra profile us added for that
- [x] Simplify the PR template for the branch

The current CI flow does not run on Java 10 anyway, so it's just a smoke test

### Desired reviewers

@rtyler @olblak (Infra Team) + @dwnusbaum @MarkEWaite @svanoort 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
