### PR TITLE
[JENKINS-51835] - Create a Docker image for the Java 10 branch CD flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Build on Java 10 is not supported/tested so far
+FROM maven:3.5.3-jdk-8 as builder
+
+COPY .mvn/ /jenkins/src/.mvn/
+COPY cli/ /jenkins/src/cli/
+COPY core/ /jenkins/src/core/
+COPY src/ /jenkins/src/src/
+COPY test/ /jenkins/src/test/
+COPY war/ /jenkins/src/war/
+COPY *.xml /jenkins/src/
+COPY LICENSE.txt /jenkins/src/LICENSE.txt
+COPY licenseCompleter.groovy /jenkins/src/licenseCompleter.groovy
+COPY show-pom-version.rb /jenkins/src/show-pom-version.rb
+
+WORKDIR /jenkins/src/
+RUN mvn clean install -DskipTests -Plight-test
+
+# The image is based on https://github.com/jenkinsci/docker/tree/java10
+# All documentation is applicable
+FROM jenkins/jenkins-experimental:2.127-jdk10
+
+LABEL Description="This is an experimental image for Jenkins on Java 10"
+
+COPY --from=builder /jenkins/src/war/target/jenkins.war /usr/share/jenkins/jenkins.war
+COPY docker/jenkins2.sh /usr/local/bin/jenkins2.sh
+ENTRYPOINT ["tini", "--", "/usr/local/bin/jenkins2.sh"]

--- a/docker/jenkins2.sh
+++ b/docker/jenkins2.sh
@@ -1,0 +1,21 @@
+#! /bin/bash -e
+# Additional wrapper, which adds custom environment options for the run (if needed)
+
+# Lazy debug
+extra_java_opts=()
+if [[ "$DEBUG" ]] ; then
+  extra_java_opts+=( \
+    '-Xdebug' \
+    '-Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=y' \
+  )
+fi
+
+if [ ${#extra_java_opts[@]} -eq 0 ]; then
+  if [  -n "$JAVA_OPTS" ] ; then
+    export JAVA_OPTS="$JAVA_OPTS ${extra_java_opts[@]}"
+  else
+    export JAVA_OPTS="${extra_java_opts[@]}"
+  fi
+fi
+
+exec /usr/local/bin/jenkins.sh "$@"


### PR DESCRIPTION
See [JENKINS-51835](https://issues.jenkins-ci.org/browse/JENKINS-51835).

This is a base image for Jenkins with Java 10 in Jenkins. Once the pull request is integrated, I will setup a continuous delivery flow for the [jenkins/jenkins-experimental](https://hub.docker.com/r/jenkins/jenkins-experimental/) Docker image, a tag would be 'latest-jdk10'.

The image is based on the https://github.com/jenkinsci/docker/tree/java10 created by @carlossg in the official Docker repo

Once #3491 is integrated, I will also add some smoke testing to the image

### Proposed changelog entries

* N/A
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Desired reviewers

@carlossg @MarkEWaite @dwnusbaum @svanoort 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
