### PR TITLE
[JENKINS-51834] - Docker build runs smoke tests in the batch mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY licenseCompleter.groovy /jenkins/src/licenseCompleter.groovy
 COPY show-pom-version.rb /jenkins/src/show-pom-version.rb
 
 WORKDIR /jenkins/src/
-RUN mvn clean install -DskipTests -Plight-test
+RUN mvn clean install --batch-mode -Psmoke-test
 
 # The image is based on https://github.com/jenkinsci/docker/tree/java10
 # All documentation is applicable


### PR DESCRIPTION
See [JENKINS-51834](https://issues.jenkins-ci.org/browse/JENKINS-51834).

Since #3491 is in place, we can run some smoke tests during the Docker build.
