### PR TITLE
fix French translation of tools installations list

### DIFF
--- a/core/src/main/resources/hudson/tools/ToolInstallation/global_fr.properties
+++ b/core/src/main/resources/hudson/tools/ToolInstallation/global_fr.properties
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-description=Nombre d''installations {0} sur ce syst\u00E8me
+description=Liste des installations {0} sur ce syst\u00E8me
 label.add=Ajouter {0}
 label.delete=Supprimer {0}
 title=Installations {0}


### PR DESCRIPTION
Tools installation global page:

The french translation of 'List of {0} installations on this system' is incorrect.
The current translation is 'Nombre d'installations {0} sur ce système' (which means 'Number of {0} installation on this system' ).
The correct translation should be 'Liste des installations {0} sur ce système'.

### Proposed changelog entries

* Improve French localizations

### Desired reviewers

@aheritier 

