### PR TITLE
[JENKINS-28683] (A)PeriodicWork suuport for dynamically loaded plugins.

### DIFF
--- a/core/src/main/java/hudson/model/AperiodicWork.java
+++ b/core/src/main/java/hudson/model/AperiodicWork.java
@@ -24,12 +24,15 @@
 package hudson.model;
 
 import hudson.ExtensionList;
+import hudson.ExtensionListListener;
 import hudson.ExtensionPoint;
 import hudson.init.Initializer;
 import hudson.triggers.SafeTimerTask;
 import jenkins.util.Timer;
 
+import java.util.HashSet;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -92,9 +95,15 @@ public abstract class AperiodicWork extends SafeTimerTask implements ExtensionPo
     @Initializer(after= JOB_LOADED)
     public static void init() {
         // start all AperidocWorks
+        ExtensionList<AperiodicWork> extensionList = all();
+        extensionList.addListener(new AperiodicWorkExtensionListListener(extensionList));
         for (AperiodicWork p : AperiodicWork.all()) {
-            Timer.get().schedule(p, p.getInitialDelay(), TimeUnit.MILLISECONDS);
+            scheduleAperiodWork(p);
         }
+    }
+
+    public static void scheduleAperiodWork(AperiodicWork ap) {
+        Timer.get().schedule(ap, ap.getInitialDelay(), TimeUnit.MILLISECONDS);
     }
 
     protected abstract void doAperiodicRun();
@@ -107,4 +116,31 @@ public abstract class AperiodicWork extends SafeTimerTask implements ExtensionPo
     }
 
     private static final Random RANDOM = new Random();
+
+    /**
+     * ExtensionListener that will kick off any new AperiodWork extensions from plugins that are dynamically
+     * loaded.
+     */
+    private static class AperiodicWorkExtensionListListener extends ExtensionListListener {
+
+        private final Set<AperiodicWork> registered = new HashSet<>();
+
+        AperiodicWorkExtensionListListener(ExtensionList<AperiodicWork> initiallyRegistered) {
+            for (AperiodicWork p : initiallyRegistered) {
+                registered.add(p);
+            }
+        }
+
+        @Override
+        public void onChange() {
+            synchronized (registered) {
+                for (AperiodicWork p : AperiodicWork.all()) {
+                    if (!registered.contains(p)) {
+                        scheduleAperiodWork(p);
+                        registered.add(p);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/core/src/main/java/hudson/model/AperiodicWork.java
+++ b/core/src/main/java/hudson/model/AperiodicWork.java
@@ -102,7 +102,7 @@ public abstract class AperiodicWork extends SafeTimerTask implements ExtensionPo
         }
     }
 
-    public static void scheduleAperiodWork(AperiodicWork ap) {
+    private static void scheduleAperiodWork(AperiodicWork ap) {
         Timer.get().schedule(ap, ap.getInitialDelay(), TimeUnit.MILLISECONDS);
     }
 

--- a/test/src/test/java/hudson/model/APeriodicWorkTest.java
+++ b/test/src/test/java/hudson/model/APeriodicWorkTest.java
@@ -23,7 +23,7 @@ public class APeriodicWorkTest {
     public void newExtensionsAreScheduled() throws Exception {
         TestAperiodicWork tapw = new TestAperiodicWork();
 
-        int size = PeriodicWork.all().size();
+        int size = AperiodicWork.all().size();
         ExtensionList.lookup(AperiodicWork.class).add(tapw);
 
         assertThat("we have one new AperiodicWork", AperiodicWork.all(), hasSize(size+1));

--- a/test/src/test/java/hudson/model/APeriodicWorkTest.java
+++ b/test/src/test/java/hudson/model/APeriodicWorkTest.java
@@ -1,0 +1,59 @@
+package hudson.model;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.ExtensionList;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class APeriodicWorkTest {
+
+    @Rule
+    public JenkinsRule jr = new JenkinsRule();
+
+
+    @Test
+    public void newExtensionsAreScheduled() throws Exception {
+        TestAperiodicWork tapw = new TestAperiodicWork();
+
+        int size = PeriodicWork.all().size();
+        ExtensionList.lookup(AperiodicWork.class).add(tapw);
+
+        assertThat("we have one new AperiodicWork", AperiodicWork.all(), hasSize(size+1));
+        assertThat("The task was not run within 15 seconds",tapw.doneSignal.await(15, TimeUnit.SECONDS), is(true));
+    }
+
+    private static class TestAperiodicWork extends AperiodicWork {
+
+        CountDownLatch doneSignal = new CountDownLatch(1);
+
+        @Override
+        public long getRecurrencePeriod() {
+            // should make this only ever run once initially for testing.
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public long getInitialDelay() {
+            // Don't delay just run it!
+            return 0L;
+        }
+
+        @Override
+        public AperiodicWork getNewInstance() {
+            return this;
+        }
+
+        @Override
+        protected void doAperiodicRun() {
+            doneSignal.countDown();
+        }
+    }
+}

--- a/test/src/test/java/hudson/model/AperiodicWorkTest.java
+++ b/test/src/test/java/hudson/model/AperiodicWorkTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-public class APeriodicWorkTest {
+public class AperiodicWorkTest {
 
     @Rule
     public JenkinsRule jr = new JenkinsRule();
@@ -27,7 +27,7 @@ public class APeriodicWorkTest {
         ExtensionList.lookup(AperiodicWork.class).add(tapw);
 
         assertThat("we have one new AperiodicWork", AperiodicWork.all(), hasSize(size+1));
-        assertThat("The task was not run within 15 seconds",tapw.doneSignal.await(15, TimeUnit.SECONDS), is(true));
+        assertThat("The task was run within 15 seconds", tapw.doneSignal.await(15, TimeUnit.SECONDS), is(true));
     }
 
     private static class TestAperiodicWork extends AperiodicWork {

--- a/test/src/test/java/hudson/model/PeriodicWorkTest.java
+++ b/test/src/test/java/hudson/model/PeriodicWorkTest.java
@@ -2,7 +2,6 @@ package hudson.model;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/test/src/test/java/hudson/model/PeriodicWorkTest.java
+++ b/test/src/test/java/hudson/model/PeriodicWorkTest.java
@@ -27,7 +27,7 @@ public class PeriodicWorkTest {
         ExtensionList.lookup(PeriodicWork.class).add(tpw);
 
         assertThat("we have one new PeriodicWork", PeriodicWork.all(), hasSize(size+1));
-        assertThat("The task was not run within 15 seconds",tpw.doneSignal.await(15, TimeUnit.SECONDS), is(true));
+        assertThat("The task was run within 15 seconds", tpw.doneSignal.await(15, TimeUnit.SECONDS), is(true));
     }
 
     private static class TestPeriodicWork extends PeriodicWork {

--- a/test/src/test/java/hudson/model/PeriodicWorkTest.java
+++ b/test/src/test/java/hudson/model/PeriodicWorkTest.java
@@ -1,0 +1,55 @@
+package hudson.model;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.ExtensionList;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class PeriodicWorkTest {
+
+    @Rule
+    public JenkinsRule jr = new JenkinsRule();
+
+
+    @Test
+    public void newExtensionsAreScheduled() throws Exception {
+        TestPeriodicWork tpw = new TestPeriodicWork();
+
+        int size = PeriodicWork.all().size();
+        ExtensionList.lookup(PeriodicWork.class).add(tpw);
+
+        assertThat("we have one new PeriodicWork", PeriodicWork.all(), hasSize(size+1));
+        assertThat("The task was not run within 15 seconds",tpw.doneSignal.await(15, TimeUnit.SECONDS), is(true));
+    }
+
+    private static class TestPeriodicWork extends PeriodicWork {
+
+        CountDownLatch doneSignal = new CountDownLatch(1);
+
+        @Override
+        public long getRecurrencePeriod() {
+            // should make this only ever run once initially for testing.
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public long getInitialDelay() {
+            // Don't delay just run it!
+            return 0L;
+        }
+
+        @Override
+        protected void doRun() throws Exception {
+            doneSignal.countDown();
+        }
+    }
+}


### PR DESCRIPTION
If a new PeriodicWork or AperiodicWork extension is loaded then schedule
the task.

See [JENKINS-28683](https://issues.jenkins-ci.org/browse/JENKINS-28683).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Dynamically loaded plugins now have any PeriodicWork/AperiodicWork extensions scheduled

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers



<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
