### PR TITLE
Update Winstone to 4.4 in order to pick Jetty 9.4.11

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -89,7 +89,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>4.3</version>
+      <version>4.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Picks up the Jetty update by @olamy : https://github.com/jenkinsci/winstone/pull/49

Full diff: https://github.com/jenkinsci/winstone/compare/winstone-4.3...winstone-4.4

### Proposed changelog entries

* RFE, Winstone 4.4: Update Jetty from `9.4.8.v20171121` to `9.4.11.v20180605`
  * Winstone changelog: https://github.com/jenkinsci/winstone/blob/master/CHANGELOG.md#44
  * 9.4.11 changelog - https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.11.v20180605
  * 9.4.10 changelog - https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.10.v20180503
  * 9.4.9 changelog - https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.9.v20180320
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@olamy @daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
