### PR TITLE
Tie alt to manage object icon object class

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -54,6 +54,7 @@ THE SOFTWARE.
         <j:if test="${icon!=null}">
           <div class="manage-option">
           <j:set var="iconUrl" value="${icon.startsWith('/') ? resURL+icon : imagesURL + '/48x48/' + icon}" />
+          <j:set var="alt" value="${icon.replaceAll('\\d*\\.[^.]+$', '')} />
           ${taskTags!=null and attrs.contextMenu!='false' ? taskTags.add(m.urlName, iconUrl, m.displayName, m.requiresPOST, m.requiresConfirmation) : null}
           <j:choose>
             <j:when test="${m.requiresConfirmation}">
@@ -68,7 +69,7 @@ THE SOFTWARE.
             </j:when>
             <j:when test="${m.requiresPOST}">
               <f:link href="${m.urlName}" post="${m.requiresPOST}">
-                <img class="icon" src="${iconUrl}" alt="manage-option"/>
+                <img class="icon" src="${iconUrl}" alt="[${%alt}]"/>
                 <dl>
                   <dt>${m.displayName}</dt>
                   <dd><j:out value="${m.description}"/></dd>

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -54,7 +54,7 @@ THE SOFTWARE.
         <j:if test="${icon!=null}">
           <div class="manage-option">
           <j:set var="iconUrl" value="${icon.startsWith('/') ? resURL+icon : imagesURL + '/48x48/' + icon}" />
-          <j:set var="alt" value="${icon.replaceAll('\\d*\\.[^.]+$', '')} />
+          <j:set var="alt" value="${icon.replaceAll('\\d*\\.[^.]+$', '')}"/>
           ${taskTags!=null and attrs.contextMenu!='false' ? taskTags.add(m.urlName, iconUrl, m.displayName, m.requiresPOST, m.requiresConfirmation) : null}
           <j:choose>
             <j:when test="${m.requiresConfirmation}">


### PR DESCRIPTION
The jelly is designed to give reasonable alt text. What's present now is actually worse than nothing.

```
<a href="configure" title="Configure System"><img src="/static/f12bd9f6/images/48x48/gear2.png" alt="manage-option" class="icon" /><dl><dt>Configure System</dt><dd>Configure global settings and paths.</dd><dd></dd></dl></a></div><div class="manage-option">
  |  
  | <a href="configureSecurity" title="Configure Global Security"><img src="/static/f12bd9f6/images/48x48/secure.png" alt="manage-option" class="icon" /><dl><dt>Configure Global Security</dt><dd>Secure Jenkins; define who is allowed to access/use the system.</dd><dd></dd></dl></a></div><div class="manage-option">
```

A screen reader will offer `manage-option Configure System` and `manage-option Configure Global Security`. A human will see `gear Configure System` and `lock Configure Global Security`. Having the screen reader read `manage-option` repeatedly is actually worse than not having it read anything at all. And since the links are reasonably described...

That said, it seemed worth trying to express the spirit of the icons.