### PR TITLE
[JENKINS-51807] - Create a branch for Java 11 support and Jenkins CD

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,5 @@
 See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).
 
-<!-- Comment: 
-If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
-
- * We do not require JIRA issues for minor improvements.
- * Bugfixes should have a JIRA issue (backporting process).
- * Major new features should have a JIRA issue reference.
--->
-
 ### Proposed changelog entries
 
 * Entry 1: Issue, Human-readable Text
@@ -19,9 +11,6 @@ The changelogs will be integrated by the core maintainers after the merge.  See 
 ### Submitter checklist
 
 - [ ] JIRA issue is well described
-- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
-      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
-- [ ] Appropriate autotests or explanation to why this change has no tests
 - [ ] For dependency updates: links to external changelogs and, if possible, full diffs
 
 <!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
@@ -30,6 +19,3 @@ The changelogs will be integrated by the core maintainers after the merge.  See 
 
 @mention
 
-<!-- Comment:
-If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
--->

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Build on Java 10 is not supported/tested so far
+FROM maven:3.5.3-jdk-8 as builder
+
+COPY .mvn/ /jenkins/src/.mvn/
+COPY cli/ /jenkins/src/cli/
+COPY core/ /jenkins/src/core/
+COPY src/ /jenkins/src/src/
+COPY test/ /jenkins/src/test/
+COPY war/ /jenkins/src/war/
+COPY *.xml /jenkins/src/
+COPY LICENSE.txt /jenkins/src/LICENSE.txt
+COPY licenseCompleter.groovy /jenkins/src/licenseCompleter.groovy
+COPY show-pom-version.rb /jenkins/src/show-pom-version.rb
+
+WORKDIR /jenkins/src/
+RUN mvn clean install -DskipTests -Plight-test
+
+# The image is based on https://github.com/jenkinsci/docker/tree/java10
+# All documentation is applicable
+FROM jenkins/jenkins-experimental:2.127-jdk10
+
+LABEL Description="This is an experimental image for Jenkins on Java 10"
+
+COPY --from=builder /jenkins/src/war/target/jenkins.war /usr/share/jenkins/jenkins.war
+COPY docker/jenkins2.sh /usr/local/bin/jenkins2.sh
+ENTRYPOINT ["tini", "--", "/usr/local/bin/jenkins2.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY licenseCompleter.groovy /jenkins/src/licenseCompleter.groovy
 COPY show-pom-version.rb /jenkins/src/show-pom-version.rb
 
 WORKDIR /jenkins/src/
-RUN mvn clean install -DskipTests -Plight-test
+RUN mvn clean install --batch-mode -Psmoke-test
 
 # The image is based on https://github.com/jenkinsci/docker/tree/java10
 # All documentation is applicable

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Build on Java 10 is not supported/tested so far
+# Build on Java 11 is not supported/tested so far
 FROM maven:3.5.3-jdk-8 as builder
 
 COPY .mvn/ /jenkins/src/.mvn/
@@ -15,11 +15,11 @@ COPY show-pom-version.rb /jenkins/src/show-pom-version.rb
 WORKDIR /jenkins/src/
 RUN mvn clean install --batch-mode -Psmoke-test
 
-# The image is based on https://github.com/jenkinsci/docker/tree/java10
+# The image is based on https://github.com/jenkinsci/docker/tree/java11
 # All documentation is applicable
-FROM jenkins/jenkins-experimental:2.127-jdk10
+FROM jenkins/jenkins-experimental:2.127-jdk11
 
-LABEL Description="This is an experimental image for Jenkins on Java 10"
+LABEL Description="This is an experimental image for Jenkins on Java 11"
 
 COPY --from=builder /jenkins/src/war/target/jenkins.war /usr/share/jenkins/jenkins.war
 COPY docker/jenkins2.sh /usr/local/bin/jenkins2.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,9 @@ def failFast = false
 
 properties([buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '20')), durabilityHint('PERFORMANCE_OPTIMIZED')])
 
+//TODO: Run tests on Java 10
+//TODO: Do we really need Windows for smoke tests
+
 // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc for information on what node types are available
 def buildTypes = ['Linux', 'Windows']
 
@@ -42,7 +45,8 @@ for(i = 0; i < buildTypes.size(); i++) {
                                     "MAVEN_OPTS=-Xmx1536m -Xms512m"]) {
                             // Actually run Maven!
                             // -Dmaven.repo.local=… tells Maven to create a subdir in the temporary directory for the local Maven repository
-                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
+                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -Dmaven.repo.local=$m2repo -s settings-azure.xml -e -Psmoke-test"
+
                             if(isUnix()) {
                                 sh mvnCmd
                                 sh 'test `git status --short | tee /dev/stderr | wc --bytes` -eq 0'
@@ -73,6 +77,7 @@ for(i = 0; i < buildTypes.size(); i++) {
     }
 }
 
+/* TODO: disabled for the Java 10 branch
 builds.ath = {
     node("docker&&highmem") {
         // Just to be safe
@@ -95,6 +100,7 @@ builds.ath = {
         }
     }
 }
+*/
 
 builds.failFast = failFast
 parallel builds

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -212,7 +212,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>bytecode-compatibility-transformer</artifactId>
-      <version>1.8</version>
+      <version>2.0-alpha-3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/docker/jenkins2.sh
+++ b/docker/jenkins2.sh
@@ -1,0 +1,21 @@
+#! /bin/bash -e
+# Additional wrapper, which adds custom environment options for the run (if needed)
+
+# Lazy debug
+extra_java_opts=()
+if [[ "$DEBUG" ]] ; then
+  extra_java_opts+=( \
+    '-Xdebug' \
+    '-Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=y' \
+  )
+fi
+
+if [ ${#extra_java_opts[@]} -eq 0 ]; then
+  if [  -n "$JAVA_OPTS" ] ; then
+    export JAVA_OPTS="$JAVA_OPTS ${extra_java_opts[@]}"
+  else
+    export JAVA_OPTS="${extra_java_opts[@]}"
+  fi
+fi
+
+exec /usr/local/bin/jenkins.sh "$@"

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -307,6 +307,12 @@ THE SOFTWARE.
       </properties>
     </profile>
     <profile>
+      <id>smoke-test</id>
+      <properties>
+        <test>jenkins.model.StartupTest,jenkins.model.JenkinsTest,jenkins.install.*,jenkins.security.CustomClassFilterTest,hudson.AboutJenkinsTest,hudson.ClassicPluginStrategyTest,hudson.LauncherTest,hudson.slaves.JNLPLauncherTest,hudson.model.RunTest,hudson.model.UserTest,hudson.model.FreeStyleProjectTest,hudson.model.HudsonTest,hudson.model.ComputerTest,hudson.CLI.BuildCommandTest#sync,*.smokes</test>
+      </properties>
+    </profile>
+    <profile>
       <id>all-tests</id>
       <activation>
         <property>


### PR DESCRIPTION
See [JENKINS-51807](https://issues.jenkins-ci.org/browse/JENKINS-51807). This PR takes https://github.com/jenkinsci/jenkins/tree/java10-support branch and replaces Docker image by the Java 11 version.

A separate branch is needed to support Docker Image CD in DockerHub, but **for now** the codebase is similar to Java 11. In the future I anticipate the branches to be merged somehow (e.g. when Java 11 gets released)

It's a downstream of https://github.com/jenkinsci/docker/pull/690

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* N/A
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@carlossg @ndeloof 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
