### PR TITLE
[JENKINS-46725] Update jnr-posix to 3.0.45

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -109,7 +109,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.0.41</version>
+      <version>3.0.45</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
See [JENKINS-46725](https://issues.jenkins-ci.org/browse/JENKINS-46725).

I cannot find changelogs for jnr-posix, but here is the full diff: https://github.com/jnr/jnr-posix/compare/jnr-posix-3.0.41...jnr-posix-3.0.45. The most interesting change to me is jnr/jnr-posix#109 which makes some reflective accesses lazy, which would get rid of the warnings if we don't use that code.

### Proposed changelog entries

* Update jnr-posix to 3.0.45. ([Full diff](https://github.com/jnr/jnr-posix/compare/jnr-posix-3.0.41...jnr-posix-3.0.45))

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs