### PR TITLE
[JENKINS-52019] Fix Declarative Pipeline failures on Java 10 with just a little Groovy bump

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <staplerFork>true</staplerFork>
     <stapler.version>1.254</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
-    <groovy.version>2.4.11</groovy.version>
+    <groovy.version>2.4.12</groovy.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
See [JENKINS-52019](https://issues.jenkins-ci.org/browse/JENKINS-52019).

Tested manually using deployed SNAPSHOT 2.129-20180618.202934-2 and a variety of simpler Declarative builds plus Scripted Pipeline builds and shared libraries.  Not covered by Pipeline unit tests *yet* because of issues with JenkinsRule in Java 10 (another thing to fix).

Groovy Changelog: http://groovy-lang.org/changelogs/changelog-2.4.12.html

### Proposed changelog entries

* Bump Groovy to 2.4.12 to pick up better modules support and fix Declarative Pipeline failures under Java 10

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@oleg-nenashev 
