### PR TITLE
[JENKINS-52028] - Update Java 11 Docker image baseline to 2.128 to pick Incrementals support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mvn clean install --batch-mode -Plight-test
 
 # The image is based on https://github.com/jenkinsci/docker/tree/java10
 # All documentation is applicable
-FROM jenkins/jenkins-experimental:2.127-jdk10
+FROM jenkins/jenkins-experimental:2.128-jdk10
 
 LABEL Description="This is an experimental image for Jenkins on Java 10"
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <staplerFork>true</staplerFork>
     <stapler.version>1.254</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
-    <groovy.version>2.4.11</groovy.version>
+    <groovy.version>2.4.12</groovy.version>
   </properties>
 
   <dependencies>

--- a/docker/jenkins2.sh
+++ b/docker/jenkins2.sh
@@ -1,21 +1,6 @@
 #! /bin/bash -e
 # Additional wrapper, which adds custom environment options for the run (if needed)
 
-# Lazy debug
-extra_java_opts=()
-if [[ "$DEBUG" ]] ; then
-  extra_java_opts+=( \
-    '-Xdebug' \
-    '-Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=y' \
-  )
-fi
-
-if [ ${#extra_java_opts[@]} -eq 0 ]; then
-  if [  -n "$JAVA_OPTS" ] ; then
-    export JAVA_OPTS="$JAVA_OPTS ${extra_java_opts[@]}"
-  else
-    export JAVA_OPTS="${extra_java_opts[@]}"
-  fi
-fi
+# Just a placeholder so that we can quickly add extra options if needed
 
 exec /usr/local/bin/jenkins.sh "$@"


### PR DESCRIPTION
See [JENKINS-52028](https://issues.jenkins-ci.org/browse/JENKINS-52028). Same as #3507 , but based on https://github.com/jenkinsci/docker/pull/695

@jenkinsci/java10-support 
