### PR TITLE
Fix Korean translation in the login page

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/login_ko.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/login_ko.properties
@@ -20,8 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Password=\uC554&nbsp;&nbsp;&nbsp;&nbsp;\uD638
-Remember\ me\ on\ this\ computer=\uAE30\uC5B5\uD558\uAE30
-User=\uACC4\uC815
-login=\uB85C\uADF8\uC778
+Username=\uC0AC\uC6A9\uC790 \uC774\uB984
+Password=\uBE44\uBC00\uBC88\uD638
+signIn=\uB85C\uADF8\uC778
 signUp=<a href="signup">\uACC4\uC815 \uC0DD\uC131</a>
+Keep\ me\ signed\ in=\uB85C\uADF8\uC778 \uC0C1\uD0DC \uC720\uC9C0
+Invalid\ username\ or\ password=\uC0AC\uC6A9\uC790 \uC774\uB984 \uB610\uB294 \uC554\uD638\uAC00 \uC798\uBABB\uB418\uC5C8\uC2B5\uB2C8\uB2E4.


### PR DESCRIPTION

### Proposed changelog entries

* Fix malformed character of the password form
* Update other strings along with the newest login page 

#### before
<img width="415" alt="2018-06-19 9 23 58" src="https://user-images.githubusercontent.com/5208632/41597492-92dca476-7408-11e8-8ac3-30d8e180a122.png">

#### after
![2018-06-19 7 50 15](https://user-images.githubusercontent.com/5208632/41597491-92a7a3d4-7408-11e8-8a94-8e2070a52fd3.png)
