### PR TITLE
[JENKINS-51965] - Added JAXB plugin as a split dependency

### DIFF
--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -19,3 +19,4 @@ bouncycastle-api 2.16 2.16.0
 command-launcher 2.86 1.0
 # JENKINS-22367
 jdk-tool 2.112 1.0
+jaxb 2.129 1.0

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -19,4 +19,3 @@ bouncycastle-api 2.16 2.16.0
 command-launcher 2.86 1.0
 # JENKINS-22367
 jdk-tool 2.112 1.0
-jaxb 2.129 1.0

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -95,7 +95,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>2.1</version>
+      <version>2.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
@@ -412,6 +412,12 @@ THE SOFTWARE.
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>jdk-tool</artifactId>
                   <version>1.0</version>
+                  <type>hpi</type>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.jenkins-ci.plugins</groupId>
+                  <artifactId>jaxb</artifactId>
+                  <version>2.2.11-alpha-1-SNAPSHOT</version>
                   <type>hpi</type>
                 </artifactItem>
               </artifactItems>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -172,6 +172,24 @@ THE SOFTWARE.
       <artifactId>slf4j-jdk14</artifactId>
     </dependency>
 
+    <!-- Java 9+ is pushing JAXB away, so we need to bring our own -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+
+
     <!-- offline profiler API when we need it -->
     <!--dependency
       <groupId>com.yourkit.api</groupId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -95,7 +95,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>2.2-SNAPSHOT</version>
+      <version>2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
@@ -412,12 +412,6 @@ THE SOFTWARE.
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>jdk-tool</artifactId>
                   <version>1.0</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>jaxb</artifactId>
-                  <version>2.2.11-alpha-1-SNAPSHOT</version>
                   <type>hpi</type>
                 </artifactItem>
               </artifactItems>


### PR DESCRIPTION
See [JENKINS-51965](https://issues.jenkins-ci.org/browse/JENKINS-51965).

As a part of Java 9 support, we need to explicit carry around JAXB plug

https://github.com/jenkinsci/jaxb-plugin
https://github.com/jenkinsci/instance-identity-module/pull/11

### Proposed changelog entries
none
### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev 
