### PR TITLE
[JENKINS-46725] stop relying on jnr-posix

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,11 +107,6 @@ THE SOFTWARE.
       <version>1.0.3-jenkins-1</version>
     </dependency>
     <dependency>
-      <groupId>com.github.jnr</groupId>
-      <artifactId>jnr-posix</artifactId>
-      <version>3.0.41</version>
-    </dependency>
-    <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>trilead-putty-extension</artifactId>
       <version>1.2</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -101,11 +101,6 @@ THE SOFTWARE.
       </exclusions>
     </dependency>
 
-    <dependency> <!-- for compatibility only; all new code should use JNR -->
-      <groupId>org.jruby.ext.posix</groupId>
-      <artifactId>jna-posix</artifactId>
-      <version>1.0.3-jenkins-1</version>
-    </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>trilead-putty-extension</artifactId>

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1803,8 +1803,6 @@ public final class FilePath implements Serializable {
         Files.setPosixFilePermissions(fileToPath(f), Util.modeToPermissions(mask));
     }
 
-    private static boolean CHMOD_WARNED = false;
-
     /**
      * Gets the file permission bit mask.
      *

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -34,7 +34,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Computer;
 import hudson.model.Item;
 import hudson.model.TaskListener;
-import hudson.os.PosixAPI;
 import hudson.os.PosixException;
 import hudson.remoting.Callable;
 import hudson.remoting.Channel;
@@ -1801,11 +1800,7 @@ public final class FilePath implements Serializable {
         // Anyway the existing calls already skip this method if on Windows.
         if (File.pathSeparatorChar==';')  return; // noop
 
-        if (Util.NATIVE_CHMOD_MODE) {
-            PosixAPI.jnr().chmod(f.getAbsolutePath(), mask);
-        } else {
-            Files.setPosixFilePermissions(fileToPath(f), Util.modeToPermissions(mask));
-        }
+        Files.setPosixFilePermissions(fileToPath(f), Util.modeToPermissions(mask));
     }
 
     private static boolean CHMOD_WARNED = false;

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1637,7 +1637,7 @@ public class Util {
         int MAX_SUPPORTED_MODE = 0777;
         mode = mode & PERMISSIONS_MASK;
         if ((mode & MAX_SUPPORTED_MODE) != mode) {
-            throw new IOException("Invalid mode: " + mode);
+            throw new IOException("Invalid mode: " + Integer.toOctalString(mode));
         }
         PosixFilePermission[] allPermissions = PosixFilePermission.values();
         Set<PosixFilePermission> result = EnumSet.noneOf(PosixFilePermission.class);

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1740,5 +1740,10 @@ public class Util {
      * overwritten by Jenkins erroneously.
      */
     @Restricted(value = NoExternalUse.class)
+    @Deprecated
     public static boolean NATIVE_CHMOD_MODE = SystemProperties.getBoolean(Util.class.getName() + ".useNativeChmodAndMode");
+
+    static {
+        if (NATIVE_CHMOD_MODE) System.err.println(Util.class.getName() + ".useNativeChmodAndMode option isn't supported anymore.");
+    }
 }

--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -143,37 +143,6 @@ public class WebAppMain implements ServletContextListener {
                 throw new IncompatibleVMDetected(); // nope
             }
 
-//  JNA is no longer a hard requirement. It's just nice to have. See HUDSON-4820 for more context.
-//            // make sure JNA works. this can fail if
-//            //    - platform is unsupported
-//            //    - JNA is already loaded in another classloader
-//            // see http://wiki.jenkins-ci.org/display/JENKINS/JNA+is+already+loaded
-//            // TODO: or shall we instead modify Hudson to work gracefully without JNA?
-//            try {
-//                /*
-//                    java.lang.UnsatisfiedLinkError: Native Library /builds/apps/glassfish/domains/hudson-domain/generated/jsp/j2ee-modules/hudson-1.309/loader/com/sun/jna/sunos-sparc/libjnidispatch.so already loaded in another classloader
-//                        at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1743)
-//                        at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1674)
-//                        at java.lang.Runtime.load0(Runtime.java:770)
-//                        at java.lang.System.load(System.java:1005)
-//                        at com.sun.jna.Native.loadNativeLibraryFromJar(Native.java:746)
-//                        at com.sun.jna.Native.loadNativeLibrary(Native.java:680)
-//                        at com.sun.jna.Native.<clinit>(Native.java:108)
-//                        at hudson.util.jna.GNUCLibrary.<clinit>(GNUCLibrary.java:86)
-//                        at hudson.Util.createSymlink(Util.java:970)
-//                        at hudson.model.Run.run(Run.java:1174)
-//                        at hudson.matrix.MatrixBuild.run(MatrixBuild.java:149)
-//                        at hudson.model.ResourceController.execute(ResourceController.java:88)
-//                        at hudson.model.Executor.run(Executor.java:123)
-//                 */
-//                String.valueOf(Native.POINTER_SIZE); // this meaningless operation forces the classloading and initialization
-//            } catch (LinkageError e) {
-//                if (e.getMessage().contains("another classloader"))
-//                    context.setAttribute(APP,new JNADoublyLoaded(e));
-//                else
-//                    context.setAttribute(APP,new HudsonFailedToLoad(e));
-//            }
-
             // make sure this is servlet 2.4 container or above
             try {
                 ServletResponse.class.getMethod("setCharacterEncoding",String.class);

--- a/core/src/main/java/hudson/os/PosixAPI.java
+++ b/core/src/main/java/hudson/os/PosixAPI.java
@@ -27,7 +27,7 @@ public class PosixAPI {
     }
 
     /**
-     * @deprecated use {@link #jnr} and {@link POSIX#isNative}
+     * @deprecated
      */
     @Deprecated
     public boolean isNative() {
@@ -35,7 +35,7 @@ public class PosixAPI {
     }
 
     /**
-     * @deprecated use {@link #jnr} and {@link POSIX#isNative}
+     * @deprecated
      */
     @Deprecated
     public static boolean supportsNative() {

--- a/core/src/main/java/hudson/os/PosixAPI.java
+++ b/core/src/main/java/hudson/os/PosixAPI.java
@@ -5,20 +5,16 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.Map;
 import java.util.logging.Logger;
-import jnr.constants.platform.Errno;
-import jnr.posix.POSIX;
-import jnr.posix.POSIXFactory;
-import jnr.posix.util.DefaultPOSIXHandler;
 
 /**
  * POSIX API wrapper.
  * Formerly used the jna-posix library, but this has been superseded by jnr-posix.
  * @author Kohsuke Kawaguchi
  */
+@Deprecated
 public class PosixAPI {
 
-    private static POSIX posix;
-    
+
     /**
      * Load the JNR implementation of the POSIX APIs for the current platform.
      * Runtime exceptions will be of type {@link PosixException}.
@@ -26,25 +22,8 @@ public class PosixAPI {
      * @return some implementation (even on Windows or unsupported Unix)
      * @since 1.518
      */
-    public static synchronized POSIX jnr() {
-        if (posix == null) {
-            posix = POSIXFactory.getPOSIX(new DefaultPOSIXHandler() {
-                @Override public void error(Errno error, String extraData) {
-                    throw new PosixException("native error " + error.description() + " " + extraData, convert(error));
-                }
-                @Override public void error(Errno error, String methodName, String extraData) {
-                    throw new PosixException("native error calling " + methodName + ": " + error.description() + " " + extraData, convert(error));
-                }
-                private org.jruby.ext.posix.POSIX.ERRORS convert(Errno error) {
-                    try {
-                        return org.jruby.ext.posix.POSIX.ERRORS.valueOf(error.name());
-                    } catch (IllegalArgumentException x) {
-                        return org.jruby.ext.posix.POSIX.ERRORS.EIO; // PosixException.message has real error anyway
-                    }
-                }
-            }, true);
-        }
-        return posix;
+    public static synchronized Object jnr() {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/core/src/main/java/hudson/os/PosixAPI.java
+++ b/core/src/main/java/hudson/os/PosixAPI.java
@@ -1,10 +1,5 @@
 package hudson.os;
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.PrintStream;
-import java.util.Map;
-import java.util.logging.Logger;
 
 /**
  * POSIX API wrapper.
@@ -14,91 +9,20 @@ import java.util.logging.Logger;
 @Deprecated
 public class PosixAPI {
 
-
-    /**
-     * Load the JNR implementation of the POSIX APIs for the current platform.
-     * Runtime exceptions will be of type {@link PosixException}.
-     * {@link IllegalStateException} will be thrown for methods not implemented on this platform.
-     * @return some implementation (even on Windows or unsupported Unix)
-     * @since 1.518
-     */
     public static synchronized Object jnr() {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * @deprecated
-     */
-    @Deprecated
+    public static synchronized Object get() {
+        throw new UnsupportedOperationException();
+    }
+
     public boolean isNative() {
         return supportsNative();
     }
 
-    /**
-     * @deprecated
-     */
-    @Deprecated
     public static boolean supportsNative() {
-        return !(jnaPosix instanceof org.jruby.ext.posix.JavaPOSIX);
+        return false;
     }
 
-    private static org.jruby.ext.posix.POSIX jnaPosix;
-    /** @deprecated Use {@link #jnr} instead. */
-    @Deprecated
-    public static synchronized org.jruby.ext.posix.POSIX get() {
-        if (jnaPosix == null) {
-            jnaPosix = org.jruby.ext.posix.POSIXFactory.getPOSIX(new org.jruby.ext.posix.POSIXHandler() {
-        public void error(org.jruby.ext.posix.POSIX.ERRORS errors, String s) {
-            throw new PosixException(s,errors);
-        }
-
-        public void unimplementedError(String s) {
-            throw new UnsupportedOperationException(s);
-        }
-
-        public void warn(WARNING_ID warning_id, String s, Object... objects) {
-            LOGGER.fine(s);
-        }
-
-        public boolean isVerbose() {
-            return true;
-        }
-
-        public File getCurrentWorkingDirectory() {
-            return new File(".").getAbsoluteFile();
-        }
-
-        public String[] getEnv() {
-            Map<String,String> envs = System.getenv();
-            String[] envp = new String[envs.size()];
-            
-            int i = 0;
-            for (Map.Entry<String,String> e : envs.entrySet()) {
-                envp[i++] = e.getKey()+'+'+e.getValue();
-            }
-            return envp;
-        }
-
-        public InputStream getInputStream() {
-            return System.in;
-        }
-
-        public PrintStream getOutputStream() {
-            return System.out;
-        }
-
-        public int getPID() {
-            // TODO
-            return 0;
-        }
-
-        public PrintStream getErrorStream() {
-            return System.err;
-        }
-    }, true);
-        }
-        return jnaPosix;
-    }
-
-    private static final Logger LOGGER = Logger.getLogger(PosixAPI.class.getName());
 }

--- a/core/src/main/java/hudson/os/PosixException.java
+++ b/core/src/main/java/hudson/os/PosixException.java
@@ -6,10 +6,10 @@ package hudson.os;
  * @see PosixAPI
  * @author Kohsuke Kawaguchi
  */
-@Deprecated
 public class PosixException extends RuntimeException {
 
-    public PosixException() {
+    public PosixException(String message) {
+        super(message);
     }
 
 

--- a/core/src/main/java/hudson/os/PosixException.java
+++ b/core/src/main/java/hudson/os/PosixException.java
@@ -1,28 +1,16 @@
 package hudson.os;
 
-import org.jruby.ext.posix.POSIX.ERRORS;
 
 /**
  * Indicates an error during POSIX API call.
  * @see PosixAPI
  * @author Kohsuke Kawaguchi
  */
+@Deprecated
 public class PosixException extends RuntimeException {
-    private final ERRORS errors;
 
-    public PosixException(String message, ERRORS errors) {
-        super(message);
-        this.errors = errors;
+    public PosixException() {
     }
 
-    /** @deprecated Leaks reference to deprecated jna-posix API. */
-    @Deprecated
-    public ERRORS getErrorCode() {
-        return errors;
-    }
 
-    @Override
-    public String toString() {
-        return super.toString()+" "+errors;
-    }
 }

--- a/core/src/main/java/hudson/util/IOUtils.java
+++ b/core/src/main/java/hudson/util/IOUtils.java
@@ -124,11 +124,7 @@ public class IOUtils {
     public static int mode(File f) throws PosixException {
         if(Functions.isWindows())   return -1;
         try {
-            if (Util.NATIVE_CHMOD_MODE) {
-                return PosixAPI.jnr().stat(f.getPath()).mode();
-            } else {
-                return Util.permissionsToMode(Files.getPosixFilePermissions(fileToPath(f)));
-            }
+            return Util.permissionsToMode(Files.getPosixFilePermissions(fileToPath(f)));
         } catch (IOException cause) {
             PosixException e = new PosixException("Unable to get file permissions", null);
             e.initCause(cause);

--- a/core/src/main/java/hudson/util/IOUtils.java
+++ b/core/src/main/java/hudson/util/IOUtils.java
@@ -126,7 +126,7 @@ public class IOUtils {
         try {
             return Util.permissionsToMode(Files.getPosixFilePermissions(fileToPath(f)));
         } catch (IOException cause) {
-            PosixException e = new PosixException("Unable to get file permissions", null);
+            PosixException e = new PosixException("Unable to get file permissions");
             e.initCause(cause);
             throw e;
         }

--- a/core/src/main/java/hudson/util/jna/GNUCLibrary.java
+++ b/core/src/main/java/hudson/util/jna/GNUCLibrary.java
@@ -32,7 +32,6 @@ import com.sun.jna.NativeLong;
 import com.sun.jna.LastErrorException;
 import com.sun.jna.ptr.IntByReference;
 import hudson.os.PosixAPI;
-import jnr.posix.POSIX;
 import org.jvnet.libpam.impl.CLibrary.passwd;
 
 /**

--- a/core/src/main/java/hudson/util/jna/GNUCLibrary.java
+++ b/core/src/main/java/hudson/util/jna/GNUCLibrary.java
@@ -40,7 +40,6 @@ import org.jvnet.libpam.impl.CLibrary.passwd;
  * <p>
  * Not available on all platforms (such as Linux/PPC, IBM mainframe, etc.), so the caller should recover gracefully
  * in case of {@link LinkageError}. See HUDSON-4820.
- * <p>Consider deprecating all methods present also in {@link POSIX} (as obtained by {@link PosixAPI#jnr}).
  * @author Kohsuke Kawaguchi
  */
 public interface GNUCLibrary extends Library {

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -20,4 +20,5 @@ command-launcher 2.86 1.0
 # JENKINS-22367
 jdk-tool 2.112 1.0
 # JENKINS-46725
-jnr-posix-api 2.129 3.0.45
+jnr-posix-api 2.130 3.0.45
+jna-posix-api 2.130 1.0.3-jenkins-1

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -19,3 +19,5 @@ bouncycastle-api 2.16 2.16.0
 command-launcher 2.86 1.0
 # JENKINS-22367
 jdk-tool 2.112 1.0
+# JENKINS-46725
+jnr-posix-api 2.129 3.0.45

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -27,6 +27,7 @@ import hudson.FilePath.TarCompression;
 import hudson.model.TaskListener;
 import hudson.os.PosixAPI;
 import hudson.remoting.VirtualChannel;
+import hudson.util.IOUtils;
 import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayInputStream;
@@ -43,6 +44,7 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
@@ -485,17 +487,17 @@ public class FilePathTest {
         File original = new File(tmp,"original");
         FilePath originalP = new FilePath(channels.french, original.getPath());
         originalP.touch(0);
-        PosixAPI.jnr().chmod(original.getAbsolutePath(), 02777); // Read/write/execute for everyone and setuid.
+        originalP.chmod(02777); // Read/write/execute for everyone and setuid.
 
         File sameChannelCopy = new File(tmp,"sameChannelCopy");
         FilePath sameChannelCopyP = new FilePath(channels.french, sameChannelCopy.getPath());
         originalP.copyToWithPermission(sameChannelCopyP);
-        assertEquals("Special permissions should be copied on the same machine", 02777, PosixAPI.jnr().stat(sameChannelCopy.getAbsolutePath()).mode() & 07777);
+        assertEquals("Special permissions should be copied on the same machine", 02777, IOUtils.mode(sameChannelCopy) & 07777);
 
         File diffChannelCopy = new File(tmp,"diffChannelCopy");
         FilePath diffChannelCopyP = new FilePath(channels.british, diffChannelCopy.getPath());
         originalP.copyToWithPermission(diffChannelCopyP);
-        assertEquals("Special permissions should not be copied across machines", 00777, PosixAPI.jnr().stat(diffChannelCopy.getAbsolutePath()).mode() & 07777);
+        assertEquals("Special permissions should not be copied across machines", 00777, IOUtils.mode(diffChannelCopy) & 07777);
     }
 
     @Test public void symlinkInTar() throws Exception {

--- a/licenseCompleter.groovy
+++ b/licenseCompleter.groovy
@@ -90,12 +90,4 @@ complete {
         rewriteLicense([],ccby)
     }
 
-    //
-    // Choose from multi-licensed modules
-    //==========================================================================
-
-    match("*:jna-posix") {
-        accept("GNU Lesser General Public License Version 2.1")
-    }
-
 }

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -414,6 +414,12 @@ THE SOFTWARE.
                   <version>1.0</version>
                   <type>hpi</type>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>jnr-posix-api</artifactId>
+                  <version>3.0.45</version>
+                  <type>hpi</type>
+                </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/detached-plugins</outputDirectory>
               <stripVersion>true</stripVersion>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -420,6 +420,12 @@ THE SOFTWARE.
                   <version>3.0.45</version>
                   <type>hpi</type>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>jna-posix-api</artifactId>
+                  <version>1.0.3-jenkins-1</version>
+                  <type>hpi</type>
+                </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/detached-plugins</outputDirectory>
               <stripVersion>true</stripVersion>


### PR DESCRIPTION
See [JENKINS-46725](https://issues.jenkins-ci.org/browse/JENKINS-46725).

### Proposed changelog entries

* Removed jnr-posix as dependency, relying on plain JDK APIs for filesystem access

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)

### Desired reviewers

@jenkinsci/java10-support @oleg-nenashev 

I guess this approach will be controversial, as it **removes** stuff from jenkins-core. Way too hack-ish anyway, highly improbable jnr-posix library will survive to jigsaw.