### PR TITLE
[JENKINS-51818,JENKINS-51841] - Update Remoting from 3.21 to 3.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3.21</remoting.version>
+    <remoting.version>3.22</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.4</remoting.minimum.supported.version>
 


### PR DESCRIPTION
Updates Remoting to 3.22 with some stability and extensibility updates.

### Proposed changelog entries

* JENKINS-51818, RFE - Remoting 3.22: When connecting over TCP, agents will check availability of the master's TCP Agent Listener port
  * https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#322
* JENKINS-51841., RFE - Developer API: Remoting 3.22 now offers a new `Channel#readFrom(Channel, byte[] payload)` method for a standardized command deserialization from the channel 

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/code-reviewers @pvtuan10 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
