### PR TITLE
[JENKINS-51994,JENKINS-46622] - Update Extras Executable WAR from 1.40 to 1.41

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -49,7 +49,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>executable-war</artifactId>
-      <version>1.40</version>
+      <version>1.41</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
See [JENKINS-51994](https://issues.jenkins-ci.org/browse/JENKINS-51994) and [JENKINS-46622](https://issues.jenkins-ci.org/browse/JENKINS-46622).

### Changelog:

1 entry for 2 issues:

* RFE, Update Extras Executable WAR from 1.40 to 1.41 in order to link the Jenkins Java support policy and to fix reflection warnings when running on Java 9+ (experimental support)
  * Changelog: https://github.com/jenkinsci/extras-executable-war/blob/master/CHANGELOG.md#141 

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/java10-support @tracymiranda

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
