### PR TITLE
clarify: jnlp agent port help

### DIFF
--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/help-slaveAgentPort.html
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/help-slaveAgentPort.html
@@ -1,7 +1,10 @@
 <div>
+  If you are not using JNLP agents, it's recommended that you disable this
+  entirely, which is the default installation behavior.
   Jenkins uses a TCP port to communicate with agents launched via JNLP.
-  Normally this port is chosen randomly to avoid collisions, but this would
-  make securing the system difficult. If you are not using JNLP agents,
-  it's recommend to disable this TCP port. Alternatively, you can specify
-  the fixed port number so that you can configure your firewall accordingly.
+  If you're going to use JNLP agents, you can allow the system to randomly
+  select a port at launch (this avoids interfering with other programs,
+  including other Jenkins instances).
+  As it's hard for firewalls to secure a random port, you can instead
+  specify a fixed port number and configure your firewall accordingly.
 </div>


### PR DESCRIPTION
document default and recommended behavior first
grammar: recommended-that
explain that the system is responsible for random generation at launch

Removes mention of "default" secondary behavior because, afaict
the default is simply "disabled", but by listing random before assigned,
we're implicitly favoring that.

### Desired reviewers

@daniel-beck 