### PR TITLE
JENKINS-52159: Queue.maintain - tolerate misbehaving sorter.sortBuild…

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1567,8 +1567,15 @@ public class Queue extends ResourceController implements Saveable {
                 }
             }
 
-            if (s != null)
-                s.sortBuildableItems(buildables);
+            if (s != null) {
+                try {
+                    s.sortBuildableItems(buildables);
+                } catch (Throwable e) {
+                    // We don't really care if the sort doesn't sort anything, we still should
+                    // continue to do our job. We'll complain about it and continue.
+                    LOGGER.log(Level.WARNING, "s.sortBuildableItems() threw Throwable: {0}", e);
+                }
+            }
             
             // Ensure that identification of blocked tasks is using the live state: JENKINS-27708 & JENKINS-27871
             updateSnapshot();


### PR DESCRIPTION
…ableItems()

The accelerated-build-now-plugin plugin breaks the maintain() step when called to handle sorting.
As sorting is really an optional step, it really should not be fatal.

Instead, we wrap the step in a try block, log it, and move on with life.

See [JENKINS-52159](https://issues.jenkins-ci.org/browse/JENKINS-52159).

### Proposed changelog entries

* Entry 1: JENKINS-52159 tolerate misbehaving plugins that break the Queue sorter

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests

This is a proposal. Another approach would be to blacklist the plugin, or try to fix it -- note that its maintainers no longer use it -- https://github.com/Terracotta-OSS/accelerated-build-now-plugin/issues/3#issuecomment-374920842 -- and it per @daniel-beck "that plugin could never have worked with any non abstractprojects".

### Desired reviewers