### PR TITLE
[JENKINS-52164] Fix rename action for AbstractItems that don't define URL when including the actions taglib

### DIFF
--- a/core/src/main/resources/jenkins/model/RenameAction/action.jelly
+++ b/core/src/main/resources/jenkins/model/RenameAction/action.jelly
@@ -26,6 +26,6 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
     <!-- TODO: Should use permission attribute after JENKINS-18649 -->
     <j:if test="${it.hasPermission(it.CONFIGURE) or (it.parent.hasPermission(it.CREATE) and it.hasPermission(it.DELETE))}">
-      <l:task href="${url}/confirm-rename" icon="icon-notepad icon-md" enabled="${it.nameEditable}" title="${%Rename}"/>
+      <l:task href="${h.getActionUrl(it.url, action)}" icon="icon-notepad icon-md" enabled="${it.nameEditable}" title="${%Rename}"/>
     </j:if>
 </j:jelly>

--- a/test/src/test/java/hudson/model/AbstractItemTest.java
+++ b/test/src/test/java/hudson/model/AbstractItemTest.java
@@ -3,8 +3,6 @@ package hudson.model;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.WebRequest;
-import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
@@ -15,17 +13,13 @@ import java.net.URL;
 import java.util.Arrays;
 import jenkins.model.Jenkins;
 import jenkins.model.ProjectNamingStrategy;
-import jenkins.model.RenameAction;
 import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
-import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.SleepBuilder;
-import org.jvnet.hudson.test.TestExtension;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -138,30 +132,6 @@ public class AbstractItemTest {
         assertThat(p.getName(), equalTo("bar"));
     }
 
-    @Test
-    @Issue("JENKINS-52164")
-    public void renameLinksShouldBeValid() throws Exception {
-        FreeStyleProject project1 = j.createFreeStyleProject("project1");
-        MockFolder folder1 = j.createProject(RenameableMockFolder.class, "folder1");
-        FreeStyleProject project2 = folder1.createProject(FreeStyleProject.class, "project2");
-
-        HtmlAnchor anchor = findRenameAnchor(project1);
-        anchor.click();
-
-        anchor = findRenameAnchor(project2);
-        anchor.click();
-
-        anchor = findRenameAnchor(folder1); // Throws ElementNotFoundException before JENKINS-52164 fix
-        anchor.click();
-    }
-
-    private HtmlAnchor findRenameAnchor(AbstractItem item) throws Exception {
-        WebClient w = j.createWebClient();
-        HtmlPage page = w.goTo(item.getUrl());
-        String relativeUrl = j.contextPath + "/" + item.getUrl() + item.getAction(RenameAction.class).getUrlName();
-        return page.getAnchorByHref(relativeUrl);
-    }
-
     private String checkNameAndReturnError(AbstractItem i, String newName) {
         FormValidation fv = i.doCheckNewName(newName);
         if (FormValidation.Kind.OK.equals(fv.kind)) {
@@ -175,27 +145,4 @@ public class AbstractItemTest {
         return u.getPath().substring(j.contextPath.length() + 1);
     }
 
-    public static class RenameableMockFolder extends MockFolder {
-        protected RenameableMockFolder(ItemGroup parent, String name) {
-            super(parent, name);
-        }
-
-        @Override
-        public boolean isNameEditable() {
-            return true;
-        }
-
-        @Override
-        public TopLevelItemDescriptor getDescriptor() {
-            return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
-        }
-
-        @TestExtension("renameLinksShouldBeValid")
-        public static class DescriptorImpl extends TopLevelItemDescriptor {
-            @Override
-            public TopLevelItem newInstance(ItemGroup parent, String name) {
-                return new RenameableMockFolder(parent, name);
-            }
-        }
-    }
 }


### PR DESCRIPTION
See [JENKINS-52164](https://issues.jenkins-ci.org/browse/JENKINS-52164).

This is a regression for any subclasses of `Job` that return `true` for `Job#isNameEditable` and do not define a variable named `url` containing the URL to the item in the Jelly file where they include `</lib/hudson:actions>`. However, I have not seen this issue reported, and it doesn't affect `WorkflowJob` which is the only subclass of `Job` but not `AbstractProject` that I could think of, so I don't know whether we want to treat it as a bug for users or developers.

The change is tested downstream in jenkinsci/cloudbees-folder-plugin#120.

### Proposed changelog entries

* Bug: Some items could not be renamed (regression in 2.110).

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @fcojfernandez 
