### PR TITLE
i18n/a11y: provide alt text for the jenkins logo and masthead

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -184,7 +184,7 @@ ${h.initPageVariables(context)}
       <div id="header">
         <div class="logo">
           <a id="jenkins-home-link" href="${rootURL}/">
-            <img id="jenkins-head-icon" src="${imagesURL}/headshot.png" alt="title" />
+            <img id="jenkins-head-icon" src="${imagesURL}/headshot.png" alt="[${%jenkinshead.alt}]" />
             <img id="jenkins-name-icon" src="${imagesURL}/title.png" alt="${%title}" width="139" height="34" />
           </a>
         </div>

--- a/core/src/main/resources/lib/layout/layout.properties
+++ b/core/src/main/resources/lib/layout/layout.properties
@@ -23,3 +23,4 @@
 # do not localize unless a localized wiki page really exists.
 searchBox.url=https://jenkins.io/redirect/search-box
 logout=log out
+title=Jenkins

--- a/core/src/main/resources/lib/layout/layout.properties
+++ b/core/src/main/resources/lib/layout/layout.properties
@@ -24,3 +24,4 @@
 searchBox.url=https://jenkins.io/redirect/search-box
 logout=log out
 title=Jenkins
+jenkinshead.alt=Jenkins


### PR DESCRIPTION
### Proposed changelog entries

* i18n/a11y: providing alt text for the jenkins logo and masthead

### Submitter checklist

- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)

### Desired reviewers

@daniel-beck 