### PR TITLE
Fix JENKINS-52181 about permission issue when using cli to get console

### DIFF
--- a/core/src/main/java/hudson/cli/ConsoleCommand.java
+++ b/core/src/main/java/hudson/cli/ConsoleCommand.java
@@ -41,7 +41,7 @@ public class ConsoleCommand extends CLICommand {
     public int n = -1;
 
     protected int run() throws Exception {
-        job.checkPermission(Item.BUILD);
+        job.checkPermission(Item.READ);
 
         Run<?,?> run;
 

--- a/test/src/test/java/hudson/cli/ConsoleCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConsoleCommandTest.java
@@ -81,19 +81,6 @@ public class ConsoleCommandTest {
         assertThat(result.stderr(), containsString("ERROR: No such job 'aProject'"));
     }
 
-    @Test public void consoleShouldFailWithoutItemBuildPermission() throws Exception {
-
-        j.createFreeStyleProject("aProject");
-
-        final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
-                .invokeWithArgs("aProject");
-
-        assertThat(result, failedWith(6));
-        assertThat(result, hasNoStandardOutput());
-        assertThat(result.stderr(), containsString("ERROR: user is missing the Job/Build permission"));
-    }
-
     @Test public void consoleShouldFailWhenProjectDoesNotExist() throws Exception {
 
         final CLICommandInvoker.Result result = command

--- a/test/src/test/java/hudson/cli/ConsoleCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConsoleCommandTest.java
@@ -38,6 +38,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.IOException;
 

--- a/test/src/test/java/hudson/cli/ConsoleCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConsoleCommandTest.java
@@ -80,6 +80,17 @@ public class ConsoleCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: No such job 'aProject'"));
     }
+    
+    @Issue("JENKINS-52181")
+    @Test public void consoleShouldBeAccessibleForUserWithRead() throws Exception {	
+        j.createFreeStyleProject("aProject");	
+        final CLICommandInvoker.Result result = command	
+                .authorizedTo(Jenkins.READ, Job.READ)	
+                .invokeWithArgs("aProject");	
+        
+        assertThat(result, succeeded());
+        assertThat(result.stdout(), containsString("echo 5"));	
+    }
 
     @Test public void consoleShouldFailWhenProjectDoesNotExist() throws Exception {
 

--- a/test/src/test/java/hudson/cli/ConsoleCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConsoleCommandTest.java
@@ -84,13 +84,20 @@ public class ConsoleCommandTest {
     
     @Issue("JENKINS-52181")
     @Test public void consoleShouldBeAccessibleForUserWithRead() throws Exception {	
-        j.createFreeStyleProject("aProject");	
+        FreeStyleProject project = j.createFreeStyleProject("aProject");	
+        if (Functions.isWindows()) {
+            project.getBuildersList().add(new BatchFile("echo 1"));
+        } else {
+            project.getBuildersList().add(new Shell("echo 1"));
+        }
+        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        
         final CLICommandInvoker.Result result = command	
                 .authorizedTo(Jenkins.READ, Job.READ)	
                 .invokeWithArgs("aProject");	
         
         assertThat(result, succeeded());
-        assertThat(result.stdout(), containsString("echo 5"));	
+        assertThat(result.stdout(), containsString("echo 1"));	
     }
 
     @Test public void consoleShouldFailWhenProjectDoesNotExist() throws Exception {


### PR DESCRIPTION
Fixed https://issues.jenkins-ci.org/browse/JENKINS-52181 about issue when using jenkins-cli to get console of a project requires user has Job/Build permission as per guidance from Oleg Nenashev.

