### PR TITLE
[JENKINS-51965] - Update Instance Identity module from 2.1 to 2.2

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -95,7 +95,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>instance-identity</artifactId>
-      <version>2.1</version>
+      <version>2.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
The change picks the [JENKINS-51965](https://issues.jenkins-ci.org/browse/JENKINS-51965) release and old changes created by @stephenc . Changelog https://github.com/jenkinsci/instance-identity-module/blob/master/CHANGELOG.md#22

Full diff: https://github.com/jenkinsci/instance-identity-module/compare/instance-identity-2.1...instance-identity-2.2

### Proposed changelog entries

* RFE: Update Instance Identity module from 2.1 to 2.2 to use new Java API instead of java.xml.bind classes (removed in Java 11+)
  * Full changelog https://github.com/jenkinsci/instance-identity-module/blob/master/CHANGELOG.md#22

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/java10-support @kohsuke 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
