### PR TITLE
[JENKINS-52255] Add --xml option to list-plugins command

### DIFF
--- a/test/src/test/java/hudson/cli/ListPluginsCommandTest.java
+++ b/test/src/test/java/hudson/cli/ListPluginsCommandTest.java
@@ -30,6 +30,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -60,6 +61,28 @@ public class ListPluginsCommandTest {
         ;
         assertThat(result, CLICommandInvoker.Matcher.succeeded());
         assertThat(result.stdout(), containsString("token-macro"));
+    }
+
+    @Test
+    public void listPluginsAsXML() throws Exception {
+        assertNull(j.jenkins.getPluginManager().getPlugin("token-macro"));
+        CLICommandInvoker.Result result = new CLICommandInvoker(j, new ListPluginsCommand())
+                .invokeWithArgs("--xml");
+        assertThat(result, CLICommandInvoker.Matcher.succeeded());
+        assertThat(result.stdout(), containsString("<list/>"));
+        assertThat(result.stdout(), not(containsString("token-macro")));
+
+        assertThat(new CLICommandInvoker(j, new InstallPluginCommand()).
+                        withStdin(ListPluginsCommandTest.class.getResourceAsStream("/plugins/token-macro.hpi")).
+                        invokeWithArgs("-name", "token-macro", "-deploy", "="),
+                CLICommandInvoker.Matcher.succeeded());
+        assertNotNull(j.jenkins.getPluginManager().getPlugin("token-macro"));
+
+        result = new CLICommandInvoker(j, new ListPluginsCommand()).invokeWithArgs("--xml");
+        assertThat(result, CLICommandInvoker.Matcher.succeeded());
+        assertThat(result.stdout(), containsString("token-macro"));
+        assertThat(result.stdout(), containsString("<list>"));
+        assertThat(result.stdout(), containsString("</list>"));
     }
     
     @Test


### PR DESCRIPTION
See [JENKINS-52255](https://issues.jenkins-ci.org/browse/JENKINS-52255).

### Proposed changelog entries

* [JENKINS-52255] `--xml` option in `list-plugins` CLI to generate XML output

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jenkinsci/code-reviewers
