### PR TITLE
Prefer master for flyweight?

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1721,7 +1721,7 @@ public class Queue extends ResourceController implements Saveable {
             Map<Node, Integer> hashSource = new HashMap<Node, Integer>(h.getNodes().size());
 
             // Even if master is configured with zero executors, we may need to run a flyweight task like MatrixProject on it.
-            hashSource.put(h, Math.max(h.getNumExecutors() * 100, 1));
+            hashSource.put(h, Math.max(h.getNumExecutors() * 100, 100));
 
             for (Node n : h.getNodes()) {
                 hashSource.put(n, n.getNumExecutors() * 100);


### PR DESCRIPTION
Were looking into makeFlyWeightTaskBuildable()-> ConsistentHash.md5() slowness and found this place.
@jglick  @oleg-nenashev  @stephenc why 1 was used? When master has 0 executors it will get 1, when 1 executor, then 100. What is the logic for this magic number?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jenkins/3534)
<!-- Reviewable:end -->
