### PR TITLE
[JENKINS-52356] ZipArchiver support 64 bit files

### DIFF
--- a/core/src/main/java/hudson/util/io/ZipArchiver.java
+++ b/core/src/main/java/hudson/util/io/ZipArchiver.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import org.apache.tools.zip.ZipEntry;
+import org.apache.tools.zip.Zip64Mode;
 import org.apache.tools.zip.ZipOutputStream;
 
 import java.io.File;
@@ -49,6 +50,7 @@ final class ZipArchiver extends Archiver {
     ZipArchiver(OutputStream out) {
         zip = new ZipOutputStream(out);
         zip.setEncoding(System.getProperty("file.encoding"));
+        zip.setUseZip64(Zip64Mode.AsNeeded);
     }
 
     public void visit(final File f, final String _relativePath) throws IOException {

--- a/core/src/test/java/hudson/util/io/ZipArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/ZipArchiverTest.java
@@ -110,9 +110,13 @@ public class ZipArchiverTest {
         File hugeFile = new File(tmpDir, "huge64bitFileTest.txt");
         try {
             RandomAccessFile largeFile = new RandomAccessFile(hugeFile, "rw");
-            largeFile.setLength(4* 1024 * 1024 * 1024 + 2);
+            largeFile.setLength(4 * 1024 * 1024 * 1024 + 2);
         } catch (IOException e) {
-            fail("unable to prepare source directory for zipping", e);
+            /* We probably don't have enough free disk space
+             * That's ok, we'll skip this test...
+             */
+            LOGGER.log(Level.SEVERE, "Couldn't set up huge file for huge64bitFile test", e);
+            return;
         }
 
         // a file to store the zip archive in

--- a/core/src/test/java/hudson/util/io/ZipArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/ZipArchiverTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -100,6 +101,64 @@ public class ZipArchiverTest {
         }
 
         assertEquals("foo/bar/baz/Test.txt", zipEntryName);
+    }
+
+    @Test
+    public void huge64bitFile()  {
+        // create huge64bitFileTest.txt
+
+        File hugeFile = new File(tmpDir, "huge64bitFileTest.txt");
+        try {
+            RandomAccessFile largeFile = new RandomAccessFile(hugeFile, "rw");
+            largeFile.setLength(4* 1024 * 1024 * 1024 + 2);
+        } catch (IOException e) {
+            fail("unable to prepare source directory for zipping", e);
+        }
+
+        // a file to store the zip archive in
+        File zipFile = null;
+
+        // create zip from tmpDir
+        ZipArchiver archiver = null;
+
+        try {
+            zipFile = File.createTempFile("test", ".zip");
+            archiver = new ZipArchiver(Files.newOutputStream(zipFile.toPath()));
+
+            archiver.visit(hugeFile, "huge64bitFileTest.txt");
+        } catch (Exception e) {
+            fail("exception driving ZipArchiver", e);
+        } finally {
+            if (archiver != null) {
+                try {
+                    archiver.close();
+                } catch (IOException e) {
+                    // ignored
+                }
+            }
+        }
+
+        // examine zip contents and assert that there's an item there...
+        String zipEntryName = null;
+
+        ZipFile zipFileVerify = null;
+        try {
+            zipFileVerify = new ZipFile(zipFile);
+
+            zipEntryName = ((ZipEntry) zipFileVerify.entries().nextElement()).getName();
+        } catch (Exception e) {
+            fail("failure enumerating zip entries", e);
+        } finally {
+            if (zipFileVerify != null) {
+                try {
+                    zipFileVerify.close();
+                } catch (IOException e) {
+                    // ignored
+                }
+            }
+        }
+
+        assertEquals("huge64bitFileTest.txt", zipEntryName);
     }
 
     /**


### PR DESCRIPTION
call setUseZip64(Zip64Mode.AsNeeded)

See [JENKINS-52356](https://issues.jenkins-ci.org/browse/JENKINS-52356).

### Proposed changelog entries

* Issue, support 4+gb files in zip()

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers
