### PR TITLE
[JENKINS-52325] - If copy of artifact with attributes throws error, retry without attributes

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2495,8 +2495,8 @@ public final class FilePath implements Serializable {
                         if (exceptionEncountered) {
                             Files.copy(fileToPath(f), targetPath, StandardCopyOption.REPLACE_EXISTING);
                             if (!logMessageShown) {
-                                LOGGER.log(Level.WARNING, 
-                                    "Attributes removed when copying to {0}, please make sure Jenkins process owns the directory.", 
+                                LOGGER.log(Level.INFO, 
+                                    "JENKINS-52325: Jenkins failed to retain attributes when copying to {0}, so proceeding without attributes.", 
                                     dest.getAbsolutePath());
                                 logMessageShown = true;
                             }


### PR DESCRIPTION
See [JENKINS-52325](https://issues.jenkins-ci.org/browse/JENKINS-52325).
Catch error when copying files. After first file fails, retry this file without COPY_ATTRIBUTES flag and copy further files also without this flag (to avoid copy - fail - rollback - retry cycles)

### Proposed changelog entries

* Entry 1: Internal: when archiving artifacts, handle the case when Jenkins can copy files but cannot change attributes like modification time (regression in TODO)

### Desired reviewers

@jvz 

