### PR TITLE
Add content doc for split plugins resource file

### DIFF
--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -1,5 +1,9 @@
 # See ClassicPluginStrategy.DETACHED_LIST. As of JENKINS-47634 also used by plugin-compat-tester.
-# Columns are: plugin ID, first core release without the plugins' functionality, plugin version that's implied
+
+# Columns are: plugin ID, last core release still containing the plugin's functionality, plugin version that's implied.
+
+# Note that all split plugins between and including matrix-auth and jdk-tool incorrectly use the first
+# core release without the plugin's functionality when they should use the immediately prior release.
 
 maven-plugin 1.296 1.296
 subversion 1.310 1.0

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -1,4 +1,5 @@
 # See ClassicPluginStrategy.DETACHED_LIST. As of JENKINS-47634 also used by plugin-compat-tester.
+# Columns are: plugin ID, first core release without the plugins' functionality, plugin version that's implied
 
 maven-plugin 1.296 1.296
 subversion 1.310 1.0

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -4,6 +4,7 @@
 
 # Note that all split plugins between and including matrix-auth and jdk-tool incorrectly use the first
 # core release without the plugin's functionality when they should use the immediately prior release.
+# Fixing these retroactively won't help, as the difference only matters to those specific versions.
 
 maven-plugin 1.296 1.296
 subversion 1.310 1.0


### PR DESCRIPTION
Written based on https://jenkins.io/changelog/#v2.112 and https://jenkins.io/changelog/#v2.86

Weirdly enough, https://github.com/jenkinsci/jenkins/blob/d041df95f9e6844e530192c12e626506d514e3b8/core/src/main/java/hudson/ClassicPluginStrategy.java#L387 seems to contradict that. AFAIUI, those plugins were split off when core was 2.86-SNAPSHOT and 2.112-SNAPSHOT, respectively, so seem to be one off in the resource file (as the linked comment seems to say these should be 2.85 and 2.111 per https://github.com/jenkinsci/jenkins/blob/d041df95f9e6844e530192c12e626506d514e3b8/core/src/main/java/hudson/ClassicPluginStrategy.java#L440)?

Hoping to get some clarity from reviewers here.