### PR TITLE
[JENKINS-52409] Add PARENT_ITEM_NAME env var

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -360,6 +360,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         env.put("HUDSON_SERVER_COOKIE",SERVER_COOKIE.get()); // Legacy compatibility
         env.put("JOB_NAME",getFullName());
         env.put("JOB_BASE_NAME", getName());
+        env.put("PARENT_ITEM_NAME", getParent().getFullName());
         return env;
     }
 

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
@@ -3,7 +3,7 @@ package jenkins.model.CoreEnvironmentContributor;
 def l = namespace(lib.JenkinsTagLib)
 
 // also advertises those contributed by Run.getCharacteristicEnvVars()
-["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME", "JOB_BASE_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
+["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME","JOB_BASE_NAME","PARENT_ITEM_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
@@ -3,6 +3,7 @@ BUILD_ID.blurb=The current build ID, identical to BUILD_NUMBER for builds create
 BUILD_DISPLAY_NAME.blurb=The display name of the current build, which is something like "#153" by default.
 JOB_NAME.blurb=Name of the project of this build, such as "foo" or "foo/bar".
 JOB_BASE_NAME.blurb=Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".
+PARENT_ITEM_NAME.blurb=Full name of the parent folder of this build, such as "" (empty string) for "foo", "bar" for "bar/foo" or "baz/bar" for "baz/bar/foo".
 BUILD_TAG.blurb=String of "jenkins-<i>$'{'JOB_NAME}</i>-<i>$'{'BUILD_NUMBER}</i>". All forward slashes ("/") in the JOB_NAME are replaced with dashes ("-"). Convenient to put into a resource file, a jar file, etc for easier identification.
 EXECUTOR_NUMBER.blurb=\
   The unique number that identifies the current executor \


### PR DESCRIPTION
Symmetric to the addition of the JOB_BASE_NAME env var in
4bab3630efcc2fa, this change adds the PARENT_ITEM_NAME
env var.

Folder names usually represent organisational structure that
is useful to have exposed in builds.
