### PR TITLE
[JENKINS-52534] - Add java.time.Ser to security whitelisted classes 

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -59,6 +59,7 @@ java.math.BigInteger
 java.net.URI
 java.net.URL
 java.security.KeyRep
+java.time.Ser
 java.util.ArrayDeque
 java.util.ArrayList
 java.util.Arrays$ArrayList


### PR DESCRIPTION
When transmitting objects of the new time api (introduced with Java 8) between slave and master, java.time.Ser is used in the serialization process.
