### PR TITLE
[JENKINS-52450] annotate onLoad build param as Nonnull

### DIFF
--- a/core/src/main/java/jenkins/model/ArtifactManager.java
+++ b/core/src/main/java/jenkins/model/ArtifactManager.java
@@ -33,7 +33,7 @@ import hudson.model.TaskListener;
 import hudson.tasks.ArtifactArchiver;
 import java.io.IOException;
 import java.util.Map;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.Nonnull;
 import jenkins.util.VirtualFile;
 
 /**
@@ -48,7 +48,7 @@ public abstract class ArtifactManager {
      * The selected manager will be persisted inside a build, so the build reference should be {@code transient} (quasi-{@code final}) and restored here.
      * @param build a historical build with which this manager was associated
      */
-    public abstract void onLoad(@NonNull Run<?,?> build);
+    public abstract void onLoad(@Nonnull Run<?,?> build);
 
     /**
      * Archive all configured artifacts from a build.

--- a/core/src/main/java/jenkins/model/ArtifactManager.java
+++ b/core/src/main/java/jenkins/model/ArtifactManager.java
@@ -33,6 +33,7 @@ import hudson.model.TaskListener;
 import hudson.tasks.ArtifactArchiver;
 import java.io.IOException;
 import java.util.Map;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.util.VirtualFile;
 
 /**
@@ -47,7 +48,7 @@ public abstract class ArtifactManager {
      * The selected manager will be persisted inside a build, so the build reference should be {@code transient} (quasi-{@code final}) and restored here.
      * @param build a historical build with which this manager was associated
      */
-    public abstract void onLoad(Run<?,?> build);
+    public abstract void onLoad(@NonNull Run<?,?> build);
 
     /**
      * Archive all configured artifacts from a build.


### PR DESCRIPTION
See [JENKINS-52450](https://issues.jenkins-ci.org/browse/JENKINS-52450).

### Proposed changelog entries

* Entry 1: do not allow null build values on ArtifactManager.onLoad(@NonNull Run<?,?> build) method

### Submitter checklist

- [X] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jglick 
@jenkinsci/code-reviewers
