### PR TITLE
Accept SHA-256 without complaint in logs

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1887,7 +1887,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         VerificationResult result512 = verifyChecksums(entry.getSha512(), job.getComputedSHA512(), false);
         switch (result512) {
             case PASS:
-                // this has passed so no reason not to check the weaker checksums
+                // this has passed so no reason to check the weaker checksums
                 return;
             case FAIL:
                 throwVerificationFailure(entry.getSha512(), job.getComputedSHA512(), file, "SHA-512");

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1887,7 +1887,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         VerificationResult result512 = verifyChecksums(entry.getSha512(), job.getComputedSHA512(), false);
         switch (result512) {
             case PASS:
-                // this has passed but no real reason not to check the others
+                // this has passed so no reason not to check the weaker checksums
                 return;
             case FAIL:
                 throwVerificationFailure(entry.getSha512(), job.getComputedSHA512(), file, "SHA-512");

--- a/test/src/test/java/hudson/model/UpdateCenter2Test.java
+++ b/test/src/test/java/hudson/model/UpdateCenter2Test.java
@@ -66,7 +66,7 @@ public class UpdateCenter2Test {
         String wrongChecksum = "ABCDEFG1234567890";
 
         // usually the problem is the file having a wrong checksum, but changing the expected one works just the same
-        j.jenkins.getUpdateCenter().getSite("default").getPlugin("changelog-history").sha1 = wrongChecksum;
+        j.jenkins.getUpdateCenter().getSite("default").getPlugin("changelog-history").sha512 = wrongChecksum;
         DownloadJob job = (DownloadJob) j.jenkins.getUpdateCenter().getPlugin("changelog-history").deploy().get();
         assertTrue(job.status instanceof Failure);
         assertTrue("error message references checksum", ((Failure) job.status).problem.getMessage().contains(wrongChecksum));


### PR DESCRIPTION
We may need to scale down the requirement for SHA-512 checksums a bit here due to performance considerations in our infra. TBD.

Followup to #3356. Motivated by https://github.com/jenkins-infra/update-center2/pull/198.

### Proposed changelog entries

* Don't log warnings when SHA-256 checksums are provided but SHA-512 are not for plugin downloads.

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@dwnusbaum 