### PR TITLE
Strip referer when following links to other origins

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -59,6 +59,7 @@ THE SOFTWARE.
 <st:setHeader name="Expires" value="0" />
 <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate" />
 <st:setHeader name="X-Hudson-Theme" value="default" />
+<st:setHeader name="Referrer-Policy" value="same-origin" />
 <st:contentType value="text/html;charset=UTF-8" />
 
   <j:new var="h" className="hudson.Functions" /><!-- instead of JSP functions -->


### PR DESCRIPTION
https://www.w3.org/TR/referrer-policy/#referrer-policy-same-origin

### Proposed changelog entries

* RFE: Instruct browsers to not send referrer headers when following links to other sites.

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
