### PR TITLE
[JENKINS-52665] Treat plugin dependency mismatches involving snapshots as nonfatal

### DIFF
--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -15,9 +15,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+import org.jvnet.hudson.test.Issue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -180,4 +179,16 @@ public class PluginWrapperTest {
             );
         }
     }
+
+    @Issue("JENKINS-52665")
+    @Test
+    public void isSnapshot() {
+        assertFalse(PluginWrapper.isSnapshot("1.0"));
+        assertFalse(PluginWrapper.isSnapshot("1.0-alpha-1"));
+        assertFalse(PluginWrapper.isSnapshot("1.0-rc9999.abc123def456"));
+        assertTrue(PluginWrapper.isSnapshot("1.0-SNAPSHOT"));
+        assertTrue(PluginWrapper.isSnapshot("1.0-20180719.153600-1"));
+        assertTrue(PluginWrapper.isSnapshot("1.0-SNAPSHOT (private-abcd1234-jqhacker)"));
+    }
+
 }


### PR DESCRIPTION
See [JENKINS-52665](https://issues.jenkins-ci.org/browse/JENKINS-52665).

Before, an `InjectedTest` failure might look like

```
java.io.IOException: Pipeline: Nodes and Processes v2.20-rc333.74dc7c303e6d failed to load.
 - Pipeline: Supporting APIs v2.19-SNAPSHOT (private-3e5e4aee-jglick) is older than required. To fix, install v2.19-rc254.98b83d2c6e7e or later.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:655)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:515)
	at …
```

This example is of a plugin depending on a build of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/21 & https://github.com/jenkinsci/workflow-job-plugin/pull/27 after switching to a snapshot dependency on local modifications to https://github.com/jenkinsci/workflow-support-plugin/pull/15. With the core patch, the test passes, just printing something like

```
… hudson.PluginWrapper versionDependencyError
WARNING: Suppressing dependency error in Pipeline: Nodes and Processes v2.20-rc333.74dc7c303e6d: Pipeline: Supporting APIs v2.19-SNAPSHOT (private-3e5e4aee-jglick) is older than required. To fix, install v2.19-rc254.98b83d2c6e7e or later.
… hudson.PluginWrapper versionDependencyError
WARNING: Suppressing dependency error in Pipeline: Job v2.22-rc311.5616213fbed0: Pipeline: Supporting APIs v2.19-SNAPSHOT (private-3e5e4aee-jglick) is older than required. To fix, install v2.19-rc265.3e5e4aeecfff or later.
```

Alleviates the pressure to finish and integrate https://github.com/jenkinsci/lib-version-number/pull/6.

### Proposed changelog entries

* Downgrading plugin manager errors about dependency version mismatches to warnings when Maven snapshot versions are involved. Typically only relevant for developers, especially when using Incrementals.

@jenkinsci/code-reviewers