### PR TITLE
[JENKINS-51666] Polish logging for rejected classes in ClassFilterImpl

### DIFF
--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -304,7 +304,7 @@ public class ClassFilterImpl extends ClassFilter {
             Boolean r = f.permits(name);
             if (r != null) {
                 if (r) {
-                    LOGGER.log(Level.FINER, "{0} specifies a policy for {1}: {2}", new Object[] {f, name, r});
+                    LOGGER.log(Level.FINER, "{0} specifies a policy for {1}: {2}", new Object[] {f, name, true});
                 } else {
                     notifyRejected(null, name,
                             String.format("%s specifies a policy for %s: %s", f, name, r));

--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -129,7 +129,11 @@ public class ClassFilterImpl extends ClassFilter {
         for (CustomClassFilter f : ExtensionList.lookup(CustomClassFilter.class)) {
             Boolean r = f.permits(_c);
             if (r != null) {
-                LOGGER.log(Level.FINER, "{0} specifies a policy for {1}: {2}", new Object[] {f, _c.getName(), r});
+                if (r) {
+                    LOGGER.log(Level.FINER, "{0} specifies a policy for {1}: {2}", new Object[] {f, _c.getName(), true});
+                } else {
+                    notifyRejected(_c, _c.getName(), String.format("%s specifies a policy for %s: %s ", f, _c.getName(), r));
+                }
                 return !r;
             }
         }
@@ -140,6 +144,7 @@ public class ClassFilterImpl extends ClassFilter {
                 return false;
             }
             if (ClassFilter.STANDARD.isBlacklisted(c)) { // currently never true, but may issue diagnostics
+                notifyRejected(_c, _c.getName(), String.format("%s is not permitted ", _c.getName()));
                 return true;
             }
             if (c.isArray()) {


### PR DESCRIPTION
See [JENKINS-51666](https://issues.jenkins-ci.org/browse/JENKINS-51666).

This issue is fully described at link provided in ticket

### Proposed changelog entries
* Print stacktraces to logs at FINE+ level when rejecting classes in ClassFilterImpl
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
@oleg-nenashev @jglick 