### PR TITLE
[JENKINS-52441] Care about user with id = 'null'

### DIFF
--- a/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
+++ b/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
@@ -161,6 +161,10 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
     @RequirePOST
     public HttpResponse doRevokeAllSelected(@JsonBody RevokeAllSelectedModel content) throws IOException {
         for (RevokeAllSelectedUserAndUuid value : content.values) {
+            if(value.userId == null){
+                // special case not managed by JSONObject
+                value.userId = "null";
+            }
             User user = User.getById(value.userId, false);
             if (user == null) {
                 LOGGER.log(Level.INFO, "User not found id={0}", value.userId);

--- a/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
+++ b/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
@@ -100,7 +100,7 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
     @Restricted(NoExternalUse.class)
     public @Nullable ApiTokenProperty.TokenInfoAndStats getLegacyStatsOf(@Nonnull User user, @Nullable ApiTokenStore.HashedToken legacyToken) {
         ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);
-        if(legacyToken != null){
+        if (legacyToken != null) {
             ApiTokenStats.SingleTokenStats legacyStats = apiTokenProperty.getTokenStats().findTokenStatsById(legacyToken.getUuid());
             ApiTokenProperty.TokenInfoAndStats tokenInfoAndStats = new ApiTokenProperty.TokenInfoAndStats(legacyToken, legacyStats);
             return tokenInfoAndStats;
@@ -116,7 +116,7 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
     // used by Jelly view
     @Restricted(NoExternalUse.class)
     public boolean hasFreshToken(@Nonnull User user, @Nullable ApiTokenProperty.TokenInfoAndStats legacyStats) {
-        if(legacyStats == null){
+        if (legacyStats == null) {
             return false;
         }
         
@@ -140,12 +140,12 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
     // used by Jelly view
     @Restricted(NoExternalUse.class)
     public boolean hasMoreRecentlyUsedToken(@Nonnull User user, @Nullable ApiTokenProperty.TokenInfoAndStats legacyStats) {
-        if(legacyStats == null){
+        if (legacyStats == null) {
             return false;
         }
         
         ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);
-    
+        
         return apiTokenProperty.getTokenList().stream()
                 .filter(token -> !token.isLegacy)
                 .anyMatch(token -> {
@@ -161,7 +161,7 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
     @RequirePOST
     public HttpResponse doRevokeAllSelected(@JsonBody RevokeAllSelectedModel content) throws IOException {
         for (RevokeAllSelectedUserAndUuid value : content.values) {
-            if(value.userId == null){
+            if (value.userId == null) {
                 // special case not managed by JSONObject
                 value.userId = "null";
             }
@@ -170,13 +170,13 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
                 LOGGER.log(Level.INFO, "User not found id={0}", value.userId);
             } else {
                 ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);
-                if(apiTokenProperty == null){
+                if (apiTokenProperty == null) {
                     LOGGER.log(Level.INFO, "User without apiTokenProperty found id={0}", value.userId);
-                }else{
+                } else {
                     ApiTokenStore.HashedToken revokedToken = apiTokenProperty.getTokenStore().revokeToken(value.uuid);
-                    if(revokedToken == null){
+                    if (revokedToken == null) {
                         LOGGER.log(Level.INFO, "User without selected token id={0}, tokenUuid={1}", new Object[]{value.userId, value.uuid});
-                    }else{
+                    } else {
                         apiTokenProperty.deleteApiToken();
                         user.save();
                         LOGGER.log(Level.INFO, "Revocation success for user id={0}, tokenUuid={1}", new Object[]{value.userId, value.uuid});

--- a/test/src/test/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitorTest.java
+++ b/test/src/test/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitorTest.java
@@ -58,8 +58,8 @@ public class LegacyApiTokenAdministrativeMonitorTest {
         ONLY_RECENT(2);
         
         int index;
-    
-        SelectFilter(int index){
+        
+        SelectFilter(int index) {
             this.index = index;
         }
     }
@@ -106,10 +106,10 @@ public class LegacyApiTokenAdministrativeMonitorTest {
         
         apiTokenProperty.changeApiToken();
         assertTrue(monitor.isActivated());
-    
+        
         {//revoke the legacy token
             JenkinsRule.WebClient wc = j.createWebClient();
-    
+            
             HtmlPage page = wc.goTo(monitor.getUrl() + "/manage");
             {// select all (only one user normally)
                 HtmlAnchor filterAll = getFilterByIndex(page, SelectFilter.ALL);
@@ -388,7 +388,7 @@ public class LegacyApiTokenAdministrativeMonitorTest {
     private void createUserWithToken(boolean legacy, boolean fresh, boolean recent) throws Exception {
         User user = User.getById(String.format("user %b %b %b %d", legacy, fresh, recent, nextId++), true);
         if (!legacy) {
-            return ;
+            return;
         }
         
         ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);


### PR DESCRIPTION
- add a special condition for user with id = `"null"`
- in our patched version of json-lib, it seems that the code that manage the value `"null"` was removed long time ago by [that PR](https://github.com/jenkinsci/json-lib/commit/71809a892de86906299898c9cae8ced6bf278141).

See [JENKINS-52441](https://issues.jenkins-ci.org/browse/JENKINS-52441).

### Proposed changelog entries

* Support user with id "null" in Legacy API token monitoring page

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

@reviewbybees @cloudbees/team-foundation
