### PR TITLE
[JENKINS-52718] InstallState API should not be Restricted

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1015,7 +1015,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @return The Jenkins {@link jenkins.install.InstallState install state}.
      */
     @Nonnull
-    @Restricted(NoExternalUse.class)
     public InstallState getInstallState() {
         if (installState != null) {
             installStateName = installState.name();
@@ -1029,7 +1028,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Update the current install state. This will invoke state.initializeState() 
      * when the state has been transitioned.
      */
-    @Restricted(NoExternalUse.class)
     public void setInstallState(@Nonnull InstallState newState) {
         String prior = installStateName;
         installStateName = newState.name();


### PR DESCRIPTION
See [JENKINS-52718](https://issues.jenkins-ci.org/browse/JENKINS-52718).

### Proposed changelog entries

* JENKINS-52718: Jenkins#{get,set}InstallState should not be `@Restricted`

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees @jenkinsci/code-reviewers 
