### PR TITLE
[JENKINS-41127] Prevent flyweight tasks for jobs with concurrent execution disabled from running concurrently

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1470,7 +1470,7 @@ public class Queue extends ResourceController implements Saveable {
             {// update parked (and identify any pending items whose executor has disappeared)
                 List<BuildableItem> lostPendings = new ArrayList<BuildableItem>(pendings);
                 for (Computer c : jenkins.getComputers()) {
-                    for (Executor e : c.getExecutors()) {
+                    for (Executor e : c.getAllExecutors()) {
                         if (e.isInterrupted()) {
                             // JENKINS-28840 we will deadlock if we try to touch this executor while interrupt flag set
                             // we need to clear lost pendings as we cannot know what work unit was on this executor


### PR DESCRIPTION
See [JENKINS-41127](https://issues.jenkins-ci.org/browse/JENKINS-41127).

Previously, if a flyweight task was in `Queue.pendings` at the start of a call to `Queue#maintain`, then it would be removed from `pendings` as part of the `lostPending` logic because tasks running on a `OneOffExecutor` (flyweight tasks) were not tracked, and after being removed, it is not added back to the queue. (which appears incorrect as previously noted, though I'm not sure exactly how it should be fixed (as simple as just adding the return value to the queue as in the other parts of `Queue#maintain`?)): https://github.com/jenkinsci/jenkins/blob/1a11fa39b567fd7ff64e61fab23aa18a123f2d97/core/src/main/java/hudson/model/Queue.java#L1503

Because of this, if there were two builds in the queue for a pipeline with concurrent execution disabled, one still in `blocked`, and the other in `pendings` at the start of `Queue#maintain`, then the pending build would be removed from the queue (but would continue executing), and the previously blocked build would no longer be blocked and would start executing concurrently.

I was only able to reproduce the bug with Pipeline, but the issue should in theory affect other job types that use flyweight executors such as matrix projects.

I am not sure if there is a good way to create a regression test for the change, but am looking into it.

### Proposed changelog entries

* Bug: Some types of builds, like pipelines, would sometimes run concurrently even when that was disabled.

  (Suggestions to improve the changelog entry are very welcome)

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jennbriden
