### PR TITLE
Add missing javadoc for second parameter

### DIFF
--- a/core/src/main/java/jenkins/ExtensionFilter.java
+++ b/core/src/main/java/jenkins/ExtensionFilter.java
@@ -63,8 +63,9 @@ public abstract class ExtensionFilter implements ExtensionPoint {
      * @param type
      *      The type of the extension that we are discovering. This is not the actual instance
      *      type, but the contract type, such as {@link Descriptor}, {@link AdministrativeMonitor}, etc.
+     * @param component the actual discovered {@link hudson.Extension} object.
      * @return
-     *      true to let the component into Jenkins. false to drop it and pretend
+     *      <code>true</code> to let the component into Jenkins. <code>false</code> to drop it and pretend
      *      as if it didn't exist. When any one of {@link ExtensionFilter}s veto
      *      a component, it gets dropped.
      */


### PR DESCRIPTION
No Jenkins JIRA, trivial and developer-only fix.

### Proposed changelog entries

* Internal: _N/A_

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- ~~[ ] JIRA issue is well described N/A~~
- ~~[ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)~~
- [x] Appropriate autotests or explanation to why this change has no tests
- ~~[ ] For dependency updates: links to external changelogs and, if possible, full diffs~~

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers



<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
