### PR TITLE
[JENKINS-52771] Bump up jna.jar version to 4.5.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -535,7 +535,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>4.2.1</version>
+      <version>4.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -535,7 +535,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>4.5.1</version>
+      <version>4.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-52771.
JNA support for s390x is missing in 4.2.1. The support is added in 4.5.1 version as part of issue 845
Issue: https://github.com/java-native-access/jna/issues/845
Commit : https://github.com/matthiasblaesing/jna/commit/1fef4a20a031d91dce6d37e6ef809c9d38708bd2

See [JENKINS-52771](https://issues.jenkins-ci.org/browse/JENKINS-52771).

Changes: Bumped up version of jna to 4.5.1 in core/pom.xml

@oleg-nenashev - Please help review and merge.
