### PR TITLE
[JENKINS-52794] - offer symetrical getter for databound constructor parameter "env"

### DIFF
--- a/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
+++ b/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
@@ -39,6 +39,9 @@ import org.kohsuke.stapler.Stapler;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * {@link NodeProperty} that sets additional environment variables.
@@ -63,6 +66,10 @@ public class EnvironmentVariablesNodeProperty extends NodeProperty<Node> {
 	
     public EnvVars getEnvVars() {
     	return envVars;
+    }
+
+    public List<Entry> getEnv() {
+        return envVars.entrySet().stream().map(Entry::new).collect(Collectors.toList());
     }
 
     @Override
@@ -99,6 +106,10 @@ public class EnvironmentVariablesNodeProperty extends NodeProperty<Node> {
 	
 	public static class Entry {
 		public String key, value;
+
+		public Entry(Map.Entry<String,String> e) {
+		    this(e.getKey(), e.getValue());
+        }
 
 		@DataBoundConstructor
 		public Entry(String key, String value) {

--- a/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
+++ b/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
@@ -68,6 +68,10 @@ public class EnvironmentVariablesNodeProperty extends NodeProperty<Node> {
     	return envVars;
     }
 
+    /**
+     * @return environment variables using same data type as constructor parameter.
+     * @since TODO
+     */
     public List<Entry> getEnv() {
         return envVars.entrySet().stream().map(Entry::new).collect(Collectors.toList());
     }
@@ -107,7 +111,7 @@ public class EnvironmentVariablesNodeProperty extends NodeProperty<Node> {
 	public static class Entry {
 		public String key, value;
 
-		public Entry(Map.Entry<String,String> e) {
+		private Entry(Map.Entry<String,String> e) {
 		    this(e.getKey(), e.getValue());
         }
 

--- a/core/src/main/resources/hudson/slaves/EnvironmentVariablesNodeProperty/config.jelly
+++ b/core/src/main/resources/hudson/slaves/EnvironmentVariablesNodeProperty/config.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%List of variables}" help="${descriptor.getHelpPage()}">
-    <f:repeatable var="env" items="${instance.envVars.entrySet()}">
+    <f:repeatable var="env" items="${instance.env}">
       <table width="100%">
         <f:entry title="${%Name}">
           <f:textbox name="env.key" value="${env.key}" />


### PR DESCRIPTION
Signed-off-by: Nicolas De Loof <nicolas.deloof@gmail.com>

See [JENKINS-52794](https://issues.jenkins-ci.org/browse/JENKINS-52794).
offer a getter for constructor parameter "env" as a List of key,value Entries

### Proposed changelog entries

* fix export of EnvironmentVariablesNodeProperty by configuration-as-code

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). 
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@oleg-nenashev 