### PR TITLE
[JENKINS-52781] Making a tar archive now keeps the symlinks

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -3221,18 +3221,19 @@ public final class FilePath implements Serializable {
         return f;
     }
 
-    private boolean mkdirs(File dir) throws IOException {
+    @Restricted(NoExternalUse.class)
+    boolean mkdirs(File dir) throws IOException {
         Path dirPath = fileToPath(dir);
-        if (Files.exists(dirPath)) {
+        if (Files.exists(dirPath, LinkOption.NOFOLLOW_LINKS)) {
             return false;
-        } else if (Files.notExists(dirPath)) {
+        } else if (Files.notExists(dirPath, LinkOption.NOFOLLOW_LINKS)) {
             filterNonNull().mkdirs(dir);
-            Files.createDirectories(fileToPath(dir));
+            Files.createDirectories(dirPath);
         } else {
             LOGGER.log(Level.WARNING, "unable to determine if file exists, trying to create it");
             try {
                 filterNonNull().mkdirs(dir);
-                Files.createDirectories(fileToPath(dir));
+                Files.createDirectories(dirPath);
             } catch(FileAlreadyExistsException exception) {
                 LOGGER.log(Level.WARNING, "file existed", exception);
             }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2519,7 +2519,7 @@ public final class FilePath implements Serializable {
      *      Ant file pattern mask, like "**&#x2F;*.java".
      */
     public int tar(OutputStream out, final String glob) throws IOException, InterruptedException {
-        return archive(ArchiverFactory.TAR, out, glob);
+        return archive(ArchiverFactory.TAR, out, new DirScanner.Glob(glob,null, true, false));
     }
 
     public int tar(OutputStream out, FileFilter filter) throws IOException, InterruptedException {

--- a/core/src/main/java/hudson/util/DirScanner.java
+++ b/core/src/main/java/hudson/util/DirScanner.java
@@ -39,7 +39,19 @@ public abstract class DirScanner implements Serializable {
         visitor.visit(f, relative);
     }
 
-    protected boolean scanSymlink(File f, String relative, FileVisitor visitor) throws IOException {
+
+    /**
+     * Pass the given file onto the given visitor if this visitor handles the symlinks.
+     * The file will be handled by {@link FileVisitor#visitSymlink}
+     * @param f the file to pass to the visitor.
+     * @param relative the path of the directory containing the file.
+     * @param visitor the visitor that will be used to treat the file.
+     * @return true if the given file was handled by the visitor, false otherwise
+     * @throws IOException
+     * @see FileVisitor#understandsSymlink()
+     * @since TODO
+     */
+    protected final boolean scanSymlink(File f, String relative, FileVisitor visitor) throws IOException {
         if (visitor.understandsSymlink()) {
             String target;
             try {
@@ -146,7 +158,7 @@ public abstract class DirScanner implements Serializable {
                     // useful for cases like archiving where the symlink to a directory should stay a symlink
                     // see JENKINS-52781
                     for(String f: ds.getNotFollowedSymlinks()) {
-                        File file = dir.toPath().relativize(Paths.get(f)).toFile();
+                        File file = Util.fileToPath(dir).relativize(Paths.get(f)).toFile();
                         scanSymlink(new File(f), file.getPath(), visitor);
                     }
                 }

--- a/core/src/main/java/hudson/util/FileVisitor.java
+++ b/core/src/main/java/hudson/util/FileVisitor.java
@@ -66,11 +66,17 @@ public abstract class FileVisitor {
                 visitor.visit(f,relativePath);
         }
 
-        private static final FileFilter PASS_THROUGH = new FileFilter() {
-            public boolean accept(File pathname) {
-                return true;
-            }
-        };
+        private static final FileFilter PASS_THROUGH = pathname -> true;
+
+        @Override
+        public boolean understandsSymlink() {
+            return visitor.understandsSymlink();
+        }
+
+        @Override
+        public void visitSymlink(File link, String target, String relativePath) throws IOException {
+            visitor.visitSymlink(link, target, relativePath);
+        }
 
         private static final long serialVersionUID = 1L;
     }

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -888,7 +888,7 @@ public class FilePathTest {
         Path targetDirectory = subdirectory.resolve("1");
         Files.createDirectory(targetDirectory);
         Files.createFile(targetDirectory.resolve("logs"));
-        Files.createSymbolicLink(subdirectory.resolve("lastSuccessfulBuild"), Paths.get("1"));
+        Files.createSymbolicLink(subdirectory.resolve("lastSuccessfulBuild"), targetDirectory);
         Path tarFile = temp.getRoot().toPath().resolve("archive.tar");
         FilePath tarFilePath = new FilePath(tarFile.toFile());
 
@@ -909,7 +909,7 @@ public class FilePathTest {
         Path targetDirectory = subdirectory.resolve("1");
         Files.createDirectory(targetDirectory);
         Files.createFile(targetDirectory.resolve("logs"));
-        Files.createSymbolicLink(subdirectory.resolve("lastSuccessfulBuild"), Paths.get( "1"));
+        Files.createSymbolicLink(subdirectory.resolve("lastSuccessfulBuild"), targetDirectory);
         Path tarFile = temp.getRoot().toPath().resolve("archive.tar");
         FilePath tarFilePath = new FilePath(tarFile.toFile());
 
@@ -928,7 +928,7 @@ public class FilePathTest {
         Path subdirectory = Files.createDirectory(folderToTar.resolve("build"));
         Path targetFile = subdirectory.resolve("1");
         Files.createFile(targetFile);
-        Files.createSymbolicLink(subdirectory.resolve("lastSuccessfulBuild"), Paths.get("1"));
+        Files.createSymbolicLink(subdirectory.resolve("lastSuccessfulBuild"), targetFile.resolve("1"));
         Path tarFile = temp.getRoot().toPath().resolve("archive.tar");
         FilePath tarFilePath = new FilePath(tarFile.toFile());
 
@@ -943,11 +943,15 @@ public class FilePathTest {
     }
 
     @Issue("JENKINS-52781")
-    @Test public void tryingToCreateADirectoryOnAnExistingDirectorySymlinkShouldNotFail() throws IOException, InterruptedException {
+    @Test public void tryingToCreateADirectoryOnAnExistingDirectorySymlinkShouldNotFailAndAlsoCreateTheTargetDirectory() throws IOException {
         Path testFolder = temp.newFolder().toPath();
         Path symlinkDirPath = testFolder.resolve("symlinkDir");
-        Files.createSymbolicLink(symlinkDirPath, Paths.get("nonExistingTarget"));
+        Path nonExistingTarget = testFolder.resolve("nonExistingTarget");
+        Files.createSymbolicLink(symlinkDirPath, nonExistingTarget);
 
         new FilePath(testFolder.toFile()).mkdirs(symlinkDirPath.toFile());
+
+        assertTrue("Target directory should have been created", Files.exists(nonExistingTarget));
+        assertTrue("Target directory should be a directory", Files.isDirectory(nonExistingTarget));
     }
 }

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -923,7 +923,7 @@ public class FilePathTest {
     }
 
     @Issue("JENKINS-52781")
-    @ Test public void aSymlinkToAFileIsKeptByTarArchive() throws IOException, InterruptedException {
+    @Test public void aSymlinkToAFileIsKeptByTarArchive() throws IOException, InterruptedException {
         Path folderToTar = temp.newFolder().toPath();
         Path subdirectory = Files.createDirectory(folderToTar.resolve("build"));
         Path targetFile = subdirectory.resolve("1");

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -896,9 +896,9 @@ public class FilePathTest {
             new FilePath(folderToTar.toFile()).tar(os, "**/*");
         }
 
-        Path untarredFolder = temp.getRoot().toPath().resolve("untarredFolder");
+        Path untarredFolder = temp.getRoot().toPath().resolve("untarredFolder1");
         tarFilePath.untar(new FilePath(untarredFolder.toFile()), FilePath.TarCompression.NONE);
-        assertTrue(Files.isSymbolicLink(untarredFolder.resolve("build/lastSuccessfulBuild")));
+        assertTrue("build/lastSuccessfulBuild is not a symlink", Files.isSymbolicLink(untarredFolder.resolve("build/lastSuccessfulBuild")));
     }
 
     @Issue("JENKINS-52781")
@@ -917,9 +917,9 @@ public class FilePathTest {
             new FilePath(folderToTar.toFile()).tar(os, TrueFileFilter.TRUE);
         }
 
-        Path untarredFolder = temp.getRoot().toPath().resolve("untarredFolder");
+        Path untarredFolder = temp.getRoot().toPath().resolve("untarredFolder2");
         tarFilePath.untar(new FilePath(untarredFolder.toFile()), FilePath.TarCompression.NONE);
-        assertTrue(Files.isSymbolicLink(untarredFolder.resolve("tarme/build/lastSuccessfulBuild")));
+        assertTrue("tarme/build/lastSuccessfulBuild is not a symlink", Files.isSymbolicLink(untarredFolder.resolve("tarme/build/lastSuccessfulBuild")));
     }
 
     @Issue("JENKINS-52781")
@@ -936,9 +936,9 @@ public class FilePathTest {
             new FilePath( folderToTar.toFile()).tar(os, "**/*");
         }
 
-        Path untarredFolder = temp.getRoot().toPath().resolve("untarredFolder");
+        Path untarredFolder = temp.getRoot().toPath().resolve("untarredFolder3");
         tarFilePath.untar(new FilePath(untarredFolder.toFile()), FilePath.TarCompression.NONE);
-        assertTrue(Files.isSymbolicLink(untarredFolder.resolve("build/lastSuccessfulBuild")));
+        assertTrue("build/lastSuccessfulBuild is not a symlink", Files.isSymbolicLink(untarredFolder.resolve("build/lastSuccessfulBuild")));
 
     }
 }

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -941,4 +941,13 @@ public class FilePathTest {
         assertTrue("build/lastSuccessfulBuild is not a symlink", Files.isSymbolicLink(untarredFolder.resolve("build/lastSuccessfulBuild")));
 
     }
+
+    @Issue("JENKINS-52781")
+    @Test public void tryingToCreateADirectoryOnAnExistingDirectorySymlinkShouldNotFail() throws IOException, InterruptedException {
+        Path testFolder = temp.newFolder().toPath();
+        Path symlinkDirPath = testFolder.resolve("symlinkDir");
+        Files.createSymbolicLink(symlinkDirPath, Paths.get("nonExistingTarget"));
+
+        new FilePath(testFolder.toFile()).mkdirs(symlinkDirPath.toFile());
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.9.2</version>
+        <version>1.10.2</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
See [JENKINS-52781](https://issues.jenkins-ci.org/browse/JENKINS-52781).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Internal: [JENKINS-52781] tar archives now correctly keep symlinks to directories instead of creating new directories. 
* Entry 2: Internal: [JENKINS-52781] fix an issue when trying to create a directory on a directory symlink.
* Entry 3: Internal: [JENKINS-52781] bumped the ant dependency to 1.10.2.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- ~~[ ] For dependency updates: links to external changelogs and, if possible, full diffs~~

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
