### PR TITLE
[JENKINS-52818] support @Postconstruct on extensions

### DIFF
--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -565,6 +565,9 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                 if (instance == null) return;
                 List<Method> methods = new LinkedList<>();
                 Class c = instance.getClass();
+                // find PostConstruct methods in class hierarchy, the one from parent class being first in list
+                // so that we invoke them before derived class one. This isn't specified in JSR-250 but implemented
+                // this way in Spring and what most developers would expect to happen.
                 while (c != Object.class) {
                     Arrays.stream(c.getDeclaredMethods())
                             .filter(m -> m.getAnnotation(PostConstruct.class) != null)

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -567,7 +567,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                 Class c = instance.getClass();
                 while (c != Object.class) {
                     Arrays.stream(c.getDeclaredMethods())
-                            .filter(m -> m.getDeclaredAnnotation(PostConstruct.class) != null)
+                            .filter(m -> m.getAnnotation(PostConstruct.class) != null)
                             .findFirst()
                             .ifPresent(method -> methods.add(0, method));
                     c = c.getSuperclass();

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -578,6 +578,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
 
                 for (Method postConstruct : methods) {
                     try {
+                        postConstruct.setAccessible(true);
                         postConstruct.invoke(instance);
                     } catch (final Exception e) {
                         throw new RuntimeException(String.format("@PostConstruct %s", postConstruct), e);

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -118,7 +118,9 @@ import javax.annotation.Nullable;
  * <p>
  * {@link Descriptor} can persist data just by storing them in fields.
  * However, it is the responsibility of the derived type to properly
- * invoke {@link #save()}. {@link #load()} is automatically invoked as a JSR-250 lifecycle method.
+ * invoke {@link #save()} and {@link #load()}.
+ * {@link #load()} is automatically invoked as a JSR-250 lifecycle method if derived class
+ * do implement {@link PersistentDescriptor}.
  *
  * <h2>Reflection Enhancement</h2>
  * {@link Descriptor} defines addition to the standard Java reflection
@@ -886,7 +888,6 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      * (If we do that in the base class, the derived class won't
      * get a chance to set default values.)
      */
-    @PostConstruct
     public synchronized void load() {
         XmlFile file = getConfigFile();
         if(!file.exists())

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -51,6 +51,8 @@ import org.apache.commons.io.IOUtils;
 
 import static hudson.util.QuotedStringTokenizer.*;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+
+import javax.annotation.PostConstruct;
 import javax.servlet.ServletException;
 import javax.servlet.RequestDispatcher;
 import java.io.File;
@@ -116,7 +118,7 @@ import javax.annotation.Nullable;
  * <p>
  * {@link Descriptor} can persist data just by storing them in fields.
  * However, it is the responsibility of the derived type to properly
- * invoke {@link #save()} and {@link #load()}.
+ * invoke {@link #save()}. {@link #load()} is automatically invoked as a JSR-250 lifecycle method.
  *
  * <h2>Reflection Enhancement</h2>
  * {@link Descriptor} defines addition to the standard Java reflection
@@ -884,6 +886,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      * (If we do that in the base class, the derived class won't
      * get a chance to set default values.)
      */
+    @PostConstruct
     public synchronized void load() {
         XmlFile file = getConfigFile();
         if(!file.exists())

--- a/core/src/main/java/hudson/model/PersistentDescriptor.java
+++ b/core/src/main/java/hudson/model/PersistentDescriptor.java
@@ -1,0 +1,16 @@
+package hudson.model;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Marker interface for Descriptors which use xml persistent data, and as such need to load from disk when instantiated.
+ * <p>
+ * {@link Descriptor#load()} method is annotated as {@link PostConstruct} so it get autmatically invoked after
+ * constructor and field injection.
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public interface PersistentDescriptor extends Saveable {
+
+    @PostConstruct
+    void load();
+}

--- a/core/src/main/java/hudson/model/PersistentDescriptor.java
+++ b/core/src/main/java/hudson/model/PersistentDescriptor.java
@@ -5,7 +5,7 @@ import javax.annotation.PostConstruct;
 /**
  * Marker interface for Descriptors which use xml persistent data, and as such need to load from disk when instantiated.
  * <p>
- * {@link Descriptor#load()} method is annotated as {@link PostConstruct} so it get autmatically invoked after
+ * {@link Descriptor#load()} method is annotated as {@link PostConstruct} so it get automatically invoked after
  * constructor and field injection.
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -88,7 +88,6 @@ public class UsageStatistics extends PageDecorator {
      */
     public UsageStatistics(String keyImage) {
         this.keyImage = keyImage;
-        load();
     }
 
     /**

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -66,7 +66,7 @@ import jenkins.util.SystemProperties;
  * @author Kohsuke Kawaguchi
  */
 @Extension
-public class UsageStatistics extends PageDecorator {
+public class UsageStatistics extends PageDecorator implements PersistentDescriptor {
     private final String keyImage;
 
     /**

--- a/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
@@ -12,6 +12,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import hudson.Extension;
+import hudson.model.PersistentDescriptor;
 import jenkins.util.SystemProperties;
 import hudson.Util;
 import jenkins.model.Jenkins;
@@ -121,7 +122,7 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
     }
     
     @Extension @Symbol("standard")
-    public static final class DescriptorImpl extends CrumbIssuerDescriptor<DefaultCrumbIssuer> implements ModelObject {
+    public static final class DescriptorImpl extends CrumbIssuerDescriptor<DefaultCrumbIssuer> implements ModelObject, PersistentDescriptor {
 
         private final static HexStringConfidentialKey CRUMB_SALT = new HexStringConfidentialKey(Jenkins.class,"crumbSalt",16);
         

--- a/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
@@ -127,7 +127,6 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
         
         public DescriptorImpl() {
             super(CRUMB_SALT.get(), SystemProperties.getString("hudson.security.csrf.requestfield", CrumbIssuer.DEFAULT_CRUMB_NAME));
-            load();
         }
 
         @Override

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -430,7 +430,6 @@ public class Maven extends Builder {
 
         public DescriptorImpl() {
             DESCRIPTOR = this;
-            load();
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -24,6 +24,7 @@
 package hudson.tasks;
 
 import hudson.Extension;
+import hudson.model.PersistentDescriptor;
 import jenkins.MasterToSlaveFileCallable;
 import hudson.Launcher;
 import hudson.Functions;
@@ -424,7 +425,7 @@ public class Maven extends Builder {
     public static DescriptorImpl DESCRIPTOR;
 
     @Extension @Symbol("maven")
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> implements PersistentDescriptor {
         @CopyOnWrite
         private volatile MavenInstallation[] installations = new MavenInstallation[0];
 

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -137,10 +137,6 @@ public class Shell extends CommandInterpreter {
          */
         private String shell;
 
-        public DescriptorImpl() {
-            load();
-        }
-
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
         }

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -27,6 +27,7 @@ import hudson.FilePath;
 import hudson.Util;
 import hudson.Extension;
 import hudson.model.AbstractProject;
+import hudson.model.PersistentDescriptor;
 import hudson.remoting.VirtualChannel;
 import hudson.util.FormValidation;
 import java.io.IOException;
@@ -131,7 +132,7 @@ public class Shell extends CommandInterpreter {
     }
 
     @Extension @Symbol("shell")
-    public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+    public static class DescriptorImpl extends BuildStepDescriptor<Builder> implements PersistentDescriptor {
         /**
          * Shell executable, or null to default.
          */

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -37,6 +37,7 @@ import hudson.model.AdministrativeMonitor;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Item;
+import hudson.model.PersistentDescriptor;
 import hudson.model.Run;
 import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
@@ -213,7 +214,7 @@ public class SCMTrigger extends Trigger<Item> {
     }
 
     @Extension @Symbol("pollSCM")
-    public static class DescriptorImpl extends TriggerDescriptor {
+    public static class DescriptorImpl extends TriggerDescriptor implements PersistentDescriptor {
 
         private static ThreadFactory threadFactory() {
             return new NamingThreadFactory(Executors.defaultThreadFactory(), "SCMTrigger");

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -84,6 +84,8 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+import javax.annotation.PostConstruct;
+
 import static java.util.logging.Level.WARNING;
 
 
@@ -242,11 +244,6 @@ public class SCMTrigger extends Trigger<Item> {
         private static final int THREADS_UPPER_BOUND = 100;
         private static final int THREADS_DEFAULT= 10;
 
-        public DescriptorImpl() {
-            load();
-            resizeThreadPool();
-        }
-
         private void readResolve() {
             if (maximumThreads == 0) {
                 maximumThreads = THREADS_DEFAULT;
@@ -347,6 +344,7 @@ public class SCMTrigger extends Trigger<Item> {
         /**
          * Update the {@link ExecutorService} instance.
          */
+        @PostConstruct
         /*package*/ synchronized void resizeThreadPool() {
             queue.setExecutors(Executors.newFixedThreadPool(maximumThreads, threadFactory()));
         }

--- a/core/src/main/java/jenkins/CLI.java
+++ b/core/src/main/java/jenkins/CLI.java
@@ -39,10 +39,6 @@ public class CLI extends GlobalConfiguration {
     
     private boolean enabled = true; // historical default, but overridden in SetupWizard
 
-    public CLI() {
-        load();
-    }
-
     @Override
     public @Nonnull GlobalConfigurationCategory getCategory() {
         return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);

--- a/core/src/main/java/jenkins/CLI.java
+++ b/core/src/main/java/jenkins/CLI.java
@@ -4,6 +4,8 @@ import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import java.io.IOException;
 import javax.annotation.Nonnull;
+
+import hudson.model.PersistentDescriptor;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import org.jenkinsci.Symbol;
@@ -23,7 +25,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  */
 @Restricted(NoExternalUse.class)
 @Extension @Symbol("remotingCLI")
-public class CLI extends GlobalConfiguration {
+public class CLI extends GlobalConfiguration implements PersistentDescriptor {
 
     /**
      * Supersedes {@link #isEnabled} if set.

--- a/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java
+++ b/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java
@@ -46,10 +46,6 @@ public class ArtifactManagerConfiguration extends GlobalConfiguration {
 
     private final DescribableList<ArtifactManagerFactory,ArtifactManagerFactoryDescriptor> artifactManagerFactories = new DescribableList<ArtifactManagerFactory,ArtifactManagerFactoryDescriptor>(this);
 
-    public ArtifactManagerConfiguration() {
-        load();
-    }
-
     private Object readResolve() {
         artifactManagerFactories.setOwner(this);
         return this;

--- a/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java
+++ b/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java
@@ -25,6 +25,7 @@
 package jenkins.model;
 
 import hudson.Extension;
+import hudson.model.PersistentDescriptor;
 import hudson.util.DescribableList;
 import java.io.IOException;
 import net.sf.json.JSONObject;
@@ -38,7 +39,7 @@ import javax.annotation.Nonnull;
  * @since 1.532
  */
 @Extension @Symbol("artifactManager")
-public class ArtifactManagerConfiguration extends GlobalConfiguration {
+public class ArtifactManagerConfiguration extends GlobalConfiguration implements PersistentDescriptor {
     
     public static @Nonnull ArtifactManagerConfiguration get() {
         return GlobalConfiguration.all().getInstance(ArtifactManagerConfiguration.class);

--- a/core/src/main/java/jenkins/model/DownloadSettings.java
+++ b/core/src/main/java/jenkins/model/DownloadSettings.java
@@ -59,10 +59,6 @@ public final class DownloadSettings extends GlobalConfiguration {
 
     private boolean useBrowser = false;
     
-    public DownloadSettings() {
-        load();
-    }
-
     public boolean isUseBrowser() {
         return useBrowser;
     }

--- a/core/src/main/java/jenkins/model/DownloadSettings.java
+++ b/core/src/main/java/jenkins/model/DownloadSettings.java
@@ -30,6 +30,7 @@ import hudson.model.AdministrativeMonitor;
 import hudson.model.AsyncPeriodicWork;
 import hudson.model.DownloadService;
 import hudson.model.DownloadService.Downloadable;
+import hudson.model.PersistentDescriptor;
 import hudson.model.TaskListener;
 import hudson.model.UpdateSite;
 import hudson.util.FormValidation;
@@ -51,7 +52,7 @@ import javax.annotation.Nonnull;
  */
 @Restricted(NoExternalUse.class) // no clear reason for this to be an API
 @Extension @Symbol("downloadSettings")
-public final class DownloadSettings extends GlobalConfiguration {
+public final class DownloadSettings extends GlobalConfiguration implements PersistentDescriptor {
 
     public static @Nonnull DownloadSettings get() {
         return GlobalConfiguration.all().getInstance(DownloadSettings.class);

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -59,10 +59,6 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration {
         return config;
     }
 
-    public JenkinsLocationConfiguration() {
-        load();
-    }
-
     @Override
     public synchronized void load() {
         // for backward compatibility, if we don't have our own data yet, then

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -3,6 +3,7 @@ package jenkins.model;
 import hudson.Extension;
 import hudson.Util;
 import hudson.XmlFile;
+import hudson.model.PersistentDescriptor;
 import hudson.util.FormValidation;
 import hudson.util.XStream2;
 import org.jenkinsci.Symbol;
@@ -31,7 +32,7 @@ import javax.annotation.Nonnull;
  * @since 1.494
  */
 @Extension @Symbol("location")
-public class JenkinsLocationConfiguration extends GlobalConfiguration {
+public class JenkinsLocationConfiguration extends GlobalConfiguration implements PersistentDescriptor {
     /**
      * @deprecated replaced by {@link #jenkinsUrl}
      */

--- a/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java
+++ b/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java
@@ -1,6 +1,7 @@
 package jenkins.mvn;
 
 import hudson.Extension;
+import hudson.model.PersistentDescriptor;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.tools.ToolConfigurationCategory;
@@ -11,7 +12,7 @@ import javax.annotation.Nonnull;
 
 //as close as it gets to the global Maven Project configuration
 @Extension(ordinal = 50) @Symbol("maven")
-public class GlobalMavenConfig extends GlobalConfiguration {
+public class GlobalMavenConfig extends GlobalConfiguration  implements PersistentDescriptor {
     private SettingsProvider settingsProvider;
     private GlobalSettingsProvider globalSettingsProvider;
 

--- a/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java
+++ b/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java
@@ -15,10 +15,6 @@ public class GlobalMavenConfig extends GlobalConfiguration {
     private SettingsProvider settingsProvider;
     private GlobalSettingsProvider globalSettingsProvider;
 
-    public GlobalMavenConfig() {
-        load();
-    }
-
     @Override
     public @Nonnull ToolConfigurationCategory getCategory() {
         return GlobalConfigurationCategory.get(ToolConfigurationCategory.class);

--- a/core/src/main/java/jenkins/security/QueueItemAuthenticatorConfiguration.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticatorConfiguration.java
@@ -25,10 +25,6 @@ public class QueueItemAuthenticatorConfiguration extends GlobalConfiguration {
     private final DescribableList<QueueItemAuthenticator,QueueItemAuthenticatorDescriptor> authenticators
         = new DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor>(this);
 
-    public QueueItemAuthenticatorConfiguration() {
-        load();
-    }
-
     private Object readResolve() {
         authenticators.setOwner(this);
         return this;

--- a/core/src/main/java/jenkins/security/QueueItemAuthenticatorConfiguration.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticatorConfiguration.java
@@ -1,6 +1,7 @@
 package jenkins.security;
 
 import hudson.Extension;
+import hudson.model.PersistentDescriptor;
 import hudson.model.queue.Tasks;
 import hudson.util.DescribableList;
 import jenkins.model.GlobalConfiguration;
@@ -21,7 +22,7 @@ import java.util.List;
  * @since 1.520
  */
 @Extension @Symbol("queueItemAuthenticator")
-public class QueueItemAuthenticatorConfiguration extends GlobalConfiguration {
+public class QueueItemAuthenticatorConfiguration extends GlobalConfiguration implements PersistentDescriptor {
     private final DescribableList<QueueItemAuthenticator,QueueItemAuthenticatorDescriptor> authenticators
         = new DescribableList<QueueItemAuthenticator, QueueItemAuthenticatorDescriptor>(this);
 

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
@@ -26,6 +26,7 @@ package jenkins.security;
 
 import hudson.Extension;
 import hudson.PluginWrapper;
+import hudson.model.PersistentDescriptor;
 import hudson.model.UpdateSite;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
@@ -50,7 +51,7 @@ import java.util.Set;
  */
 @Extension
 @Restricted(NoExternalUse.class)
-public class UpdateSiteWarningsConfiguration extends GlobalConfiguration {
+public class UpdateSiteWarningsConfiguration extends GlobalConfiguration implements PersistentDescriptor {
 
     private HashSet<String> ignoredWarnings = new HashSet<>();
 

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
@@ -59,10 +59,6 @@ public class UpdateSiteWarningsConfiguration extends GlobalConfiguration {
         return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
     }
 
-    public UpdateSiteWarningsConfiguration() {
-        load();
-    }
-
     @Nonnull
     public Set<String> getIgnoredWarnings() {
         return Collections.unmodifiableSet(ignoredWarnings);

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenPropertyConfiguration.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenPropertyConfiguration.java
@@ -58,10 +58,6 @@ public class ApiTokenPropertyConfiguration extends GlobalConfiguration {
         return GlobalConfiguration.all().get(ApiTokenPropertyConfiguration.class);
     }
 
-    public ApiTokenPropertyConfiguration() {
-        load();
-    }
-
     public boolean hasExistingConfigFile(){
         return getConfigFile().exists();
     }

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenPropertyConfiguration.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenPropertyConfiguration.java
@@ -24,6 +24,7 @@
 package jenkins.security.apitoken;
 
 import hudson.Extension;
+import hudson.model.PersistentDescriptor;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import org.jenkinsci.Symbol;
@@ -35,7 +36,7 @@ import org.jenkinsci.Symbol;
  */
 @Extension 
 @Symbol("apiToken")
-public class ApiTokenPropertyConfiguration extends GlobalConfiguration {
+public class ApiTokenPropertyConfiguration extends GlobalConfiguration implements PersistentDescriptor {
     /**
      * When a user is created, this property determines whether or not we create a legacy token for the user.
      * For security reasons, we do not recommend you enable this but we left that open to ease upgrades.


### PR DESCRIPTION
See [JENKINS-52818](https://issues.jenkins-ci.org/browse/JENKINS-52818).

Proposed changes add support for @Postconstruct on Extensions, to offer an homogeneous development model with Stapler's data-bound components. 

This change will also help fixing https://github.com/jenkinsci/configuration-as-code-plugin/issues/370 as Extension's _construction_ and _initialisation_ are then split in two distinct steps.

### Proposed changelog entries

* Extensions can now define @Postconstruct lifecycle methods
* Extensions (including Descriptors) don't need to invoke load() explicitly anymore

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). 
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

