### PR TITLE
[JENKINS-52822] Add CLI command to enable a plugin

### DIFF
--- a/core/src/main/java/hudson/cli/EnablePluginCommand.java
+++ b/core/src/main/java/hudson/cli/EnablePluginCommand.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 Matt Sicker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package hudson.cli;
 
 import hudson.Extension;

--- a/core/src/main/java/hudson/cli/EnablePluginCommand.java
+++ b/core/src/main/java/hudson/cli/EnablePluginCommand.java
@@ -1,20 +1,28 @@
 package hudson.cli;
 
 import hudson.Extension;
-import hudson.Plugin;
+import hudson.PluginManager;
+import hudson.PluginWrapper;
 import jenkins.model.Jenkins;
 import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.Option;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
- * Enables an installed plugin by name.
+ * Enables one or more installed plugins. The listed plugins
  *
  * @since TODO
  */
 @Extension
 public class EnablePluginCommand extends CLICommand {
 
-    @Argument(required = true, usage = "Enables the plugin with the given name if it's installed.")
-    private String pluginName;
+    @Argument(required = true, usage = "Enables the plugins with the given short names and their dependencies.")
+    private List<String> pluginNames;
+
+    @Option(name = "-restart", usage = "Restart Jenkins after enabling plugins.")
+    private boolean restart;
 
     @Override
     public String getShortDescription() {
@@ -25,11 +33,23 @@ public class EnablePluginCommand extends CLICommand {
     protected int run() throws Exception {
         Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.ADMINISTER);
-        Plugin plugin = jenkins.getPlugin(pluginName);
-        if (plugin == null) {
-            throw new IllegalArgumentException(Messages.EnablePluginCommand_NoSuchPlugin(pluginName));
+        PluginManager manager = jenkins.getPluginManager();
+        for (String pluginName : pluginNames) {
+            enablePlugin(manager, pluginName);
         }
-        plugin.getWrapper().enable();
+        if (restart) {
+            jenkins.safeRestart();
+        }
         return 0;
+    }
+
+    private static void enablePlugin(PluginManager manager, String shortName) throws IOException {
+        PluginWrapper plugin = manager.getPlugin(shortName);
+        if (plugin == null) throw new IllegalArgumentException(Messages.EnablePluginCommand_NoSuchPlugin(shortName));
+        if (plugin.isEnabled()) return;
+        for (PluginWrapper.Dependency dependency : plugin.getDependencies()) {
+            enablePlugin(manager, dependency.shortName);
+        }
+        plugin.enable();
     }
 }

--- a/core/src/main/java/hudson/cli/EnablePluginCommand.java
+++ b/core/src/main/java/hudson/cli/EnablePluginCommand.java
@@ -35,7 +35,8 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Enables one or more installed plugins. The listed plugins
+ * Enables one or more installed plugins. The listed plugins must already be installed along with its dependencies.
+ * Any listed plugin with disabled dependencies will have its dependencies enabled transitively.
  *
  * @since TODO
  */

--- a/core/src/main/java/hudson/cli/EnablePluginCommand.java
+++ b/core/src/main/java/hudson/cli/EnablePluginCommand.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2018 Matt Sicker
+ * Copyright (c) 2018 CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/main/java/hudson/cli/EnablePluginCommand.java
+++ b/core/src/main/java/hudson/cli/EnablePluginCommand.java
@@ -1,0 +1,35 @@
+package hudson.cli;
+
+import hudson.Extension;
+import hudson.Plugin;
+import jenkins.model.Jenkins;
+import org.kohsuke.args4j.Argument;
+
+/**
+ * Enables an installed plugin by name.
+ *
+ * @since TODO
+ */
+@Extension
+public class EnablePluginCommand extends CLICommand {
+
+    @Argument(required = true, usage = "Enables the plugin with the given name if it's installed.")
+    private String pluginName;
+
+    @Override
+    public String getShortDescription() {
+        return Messages.EnablePluginCommand_ShortDescription();
+    }
+
+    @Override
+    protected int run() throws Exception {
+        Jenkins jenkins = Jenkins.get();
+        jenkins.checkPermission(Jenkins.ADMINISTER);
+        Plugin plugin = jenkins.getPlugin(pluginName);
+        if (plugin == null) {
+            throw new IllegalArgumentException(Messages.EnablePluginCommand_NoSuchPlugin(pluginName));
+        }
+        plugin.getWrapper().enable();
+        return 0;
+    }
+}

--- a/core/src/main/resources/hudson/cli/Messages.properties
+++ b/core/src/main/resources/hudson/cli/Messages.properties
@@ -28,7 +28,7 @@ DeleteViewCommand.ShortDescription=\
 DeleteJobCommand.ShortDescription=\
  Deletes job(s).
 EnablePluginCommand.ShortDescription=\
- Enables an installed plugin.
+ Enables one or more installed plugins transitively.
 GroovyCommand.ShortDescription=\
  Executes the specified Groovy script. 
 GroovyshCommand.ShortDescription=\

--- a/core/src/main/resources/hudson/cli/Messages.properties
+++ b/core/src/main/resources/hudson/cli/Messages.properties
@@ -8,6 +8,7 @@ InstallPluginCommand.NoUpdateDataRetrieved=No update center data is retrieved ye
 InstallPluginCommand.NotAValidSourceName={0} is neither a valid file, URL, nor a plugin artifact name in the update center
 
 EnablePluginCommand.NoSuchPlugin=No such plugin found with the name {0}
+EnablePluginCommand.MissingDependencies=Cannot enable plugin {0} as it is missing the dependency {1}
 
 AddJobToViewCommand.ShortDescription=\
  Adds jobs to view.

--- a/core/src/main/resources/hudson/cli/Messages.properties
+++ b/core/src/main/resources/hudson/cli/Messages.properties
@@ -7,6 +7,8 @@ InstallPluginCommand.NoUpdateCenterDefined=Note that no update center is defined
 InstallPluginCommand.NoUpdateDataRetrieved=No update center data is retrieved yet from: {0}
 InstallPluginCommand.NotAValidSourceName={0} is neither a valid file, URL, nor a plugin artifact name in the update center
 
+EnablePluginCommand.NoSuchPlugin=No such plugin found with the name {0}
+
 AddJobToViewCommand.ShortDescription=\
  Adds jobs to view.
 BuildCommand.ShortDescription=\
@@ -25,6 +27,8 @@ DeleteViewCommand.ShortDescription=\
  Deletes view(s).
 DeleteJobCommand.ShortDescription=\
  Deletes job(s).
+EnablePluginCommand.ShortDescription=\
+ Enables an installed plugin.
 GroovyCommand.ShortDescription=\
  Executes the specified Groovy script. 
 GroovyshCommand.ShortDescription=\

--- a/test/src/test/java/hudson/cli/EnablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/EnablePluginCommandTest.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 Matt Sicker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package hudson.cli;
 
 import hudson.PluginManager;

--- a/test/src/test/java/hudson/cli/EnablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/EnablePluginCommandTest.java
@@ -1,0 +1,52 @@
+package hudson.cli;
+
+import hudson.Plugin;
+import hudson.PluginWrapper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+
+import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
+import static hudson.cli.CLICommandInvoker.Matcher.succeeded;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class EnablePluginCommandTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void enableSinglePlugin() throws IOException {
+        String name = "token-macro";
+        assertThat(j.jenkins.getPlugin(name), is(nullValue()));
+        assertThat(
+                new CLICommandInvoker(j, "install-plugin")
+                        .withStdin(InstallPluginCommandTest.class.getResourceAsStream("/plugins/token-macro.hpi"))
+                        .invokeWithArgs("-name", name, "-deploy", "="),
+                succeeded());
+        Plugin plugin = j.jenkins.getPlugin(name);
+        assertThat(plugin, is(notNullValue()));
+        PluginWrapper wrapper = plugin.getWrapper();
+        assertTrue(wrapper.isEnabled());
+        wrapper.disable();
+        assertFalse(wrapper.isEnabled());
+
+        assertThat(
+                new CLICommandInvoker(j, "enable-plugin").invokeWithArgs(name),
+                succeeded()
+        );
+        assertTrue(wrapper.isEnabled());
+    }
+
+    @Test
+    public void enableInvalidPluginFails() {
+        assertThat(
+                new CLICommandInvoker(j, "enable-plugin").invokeWithArgs("foobar"), failedWith(3)
+        );
+    }
+}

--- a/test/src/test/java/hudson/cli/EnablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/EnablePluginCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2018 Matt Sicker
+ * Copyright (c) 2018 CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
See [JENKINS-52822](https://issues.jenkins-ci.org/browse/JENKINS-52822).


* Added a new CLI command `enable-plugin` to enable one or more installed plugins and optionally restart Jenkins.


- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->


@tracymiranda @daniel-beck @varyvol @reviewbybees