### PR TITLE
Do not store Jenkins instance references in AdminWhitelistRule

### DIFF
--- a/core/src/main/java/jenkins/security/s2m/AdminWhitelistRule.java
+++ b/core/src/main/java/jenkins/security/s2m/AdminWhitelistRule.java
@@ -16,6 +16,8 @@ import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -52,12 +54,10 @@ public class AdminWhitelistRule implements StaplerProxy {
      */
     public final FilePathRuleConfig filePathRules;
 
-    private final Jenkins jenkins;
-
     private boolean masterKillSwitch;
 
     public AdminWhitelistRule() throws IOException, InterruptedException {
-        this.jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
 
         // while this file is not a secret, write access to this file is dangerous,
         // so put this in the better-protected part of $JENKINS_HOME, which is in secrets/
@@ -79,17 +79,21 @@ public class AdminWhitelistRule implements StaplerProxy {
                 whitelisted);
         this.filePathRules = new FilePathRuleConfig(
                 new File(jenkins.getRootDir(),"secrets/filepath-filters.d/50-gui.conf"));
-        this.masterKillSwitch = loadMasterKillSwitchFile();
+
+        File f = getMasterKillSwitchFile(jenkins);
+        this.masterKillSwitch = loadMasterKillSwitchFile(f);
     }
 
     /**
-     * Reads the master kill switch.
+     * Reads the master kill switch from a file.
      *
      * Instead of {@link FileBoolean}, we use a text file so that the admin can prevent Jenkins from
      * writing this to file.
+     * @param f File to load
+     * @return {@code true} if the file was loaded, {@code false} otherwise
      */
-    private boolean loadMasterKillSwitchFile() {
-        File f = getMasterKillSwitchFile();
+    @CheckReturnValue
+    private boolean loadMasterKillSwitchFile(@Nonnull File f) {
         try {
             if (!f.exists())    return true;
             return Boolean.parseBoolean(FileUtils.readFileToString(f).trim());
@@ -99,7 +103,8 @@ public class AdminWhitelistRule implements StaplerProxy {
         }
     }
 
-    private File getMasterKillSwitchFile() {
+    @Nonnull
+    private File getMasterKillSwitchFile(@Nonnull Jenkins jenkins) {
         return new File(jenkins.getRootDir(),"secrets/slave-to-master-security-kill-switch");
     }
 
@@ -155,7 +160,7 @@ public class AdminWhitelistRule implements StaplerProxy {
 
     @RequirePOST
     public HttpResponse doSubmit(StaplerRequest req) throws IOException {
-        jenkins.checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
 
         String whitelist = Util.fixNull(req.getParameter("whitelist"));
         if (!whitelist.endsWith("\n"))
@@ -206,11 +211,13 @@ public class AdminWhitelistRule implements StaplerProxy {
     }
 
     public void setMasterKillSwitch(boolean state) {
+        final Jenkins jenkins = Jenkins.get();
         try {
             jenkins.checkPermission(Jenkins.RUN_SCRIPTS);
-            FileUtils.writeStringToFile(getMasterKillSwitchFile(),Boolean.toString(state));
+            File f = getMasterKillSwitchFile(jenkins);
+            FileUtils.writeStringToFile(f, Boolean.toString(state));
             // treat the file as the canonical source of information in case write fails
-            masterKillSwitch = loadMasterKillSwitchFile();
+            masterKillSwitch = loadMasterKillSwitchFile(f);
         } catch (IOException e) {
             LOGGER.log(WARNING, "Failed to write master kill switch", e);
         }
@@ -221,7 +228,7 @@ public class AdminWhitelistRule implements StaplerProxy {
      */
     @Override
     public Object getTarget() {
-        jenkins.checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
         return this;
     }
 


### PR DESCRIPTION
See [JENKINS-52813](https://issues.jenkins-ci.org/browse/JENKINS-52813). The field reference was picked by memory analyzer, and most likely it has confused the reporter. The class actually does not need to store Jenkins reference at all.

### Proposed changelog entries

* RFE: AdmineWhitelistRule does not longer store references to the Jenkins instance
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/core 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
