### PR TITLE
Stop premature scroll bar on long build labels

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1067,6 +1067,7 @@ table.parameters > tbody:hover {
 }
 
 .build-row.multi-line .build-row-cell .pane.build-name.block {
+  padding-right: 20px;
   width: 100%;
 }
 .build-row-cell .pane.build-controls.block {


### PR DESCRIPTION
The build name width did not take into account the width/offset of the build icon. This resulted in a scroll bar being added prematurely.
Screenshot of change: https://i.imgur.com/RmercIT.png
Screenshot2: https://i.imgur.com/MW1JqZC.png