### PR TITLE
Interrupt all executors when node is removed.

### DIFF
--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -27,9 +27,12 @@ import hudson.BulkChange;
 import hudson.Util;
 import hudson.XmlFile;
 import hudson.model.Computer;
+import hudson.model.Executor;
 import hudson.model.Node;
 import hudson.model.Queue;
+import hudson.model.Result;
 import hudson.model.Saveable;
+import hudson.model.User;
 import hudson.model.listeners.SaveableListener;
 import hudson.slaves.EphemeralNode;
 import hudson.slaves.OfflineCause;
@@ -256,6 +259,14 @@ public class Nodes implements Saveable {
                     if (c != null) {
                         c.recordTermination();
                         c.disconnect(OfflineCause.create(hudson.model.Messages._Hudson_NodeBeingRemoved()));
+                        for(Executor executor: c.getAllExecutors()){
+                            executor.interrupt(Result.ABORTED, new CauseOfInterruption() {
+                                @Override
+                                public String getShortDescription() {
+                                    return "Node was removed by " + User.current().getId();
+                                }
+                            });
+                        }
                     }
                     if (node == nodes.remove(node.getNodeName())) {
                         jenkins.updateComputerList();

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -263,7 +263,7 @@ public class Nodes implements Saveable {
                             executor.interrupt(Result.ABORTED, new CauseOfInterruption() {
                                 @Override
                                 public String getShortDescription() {
-                                    return "Node was removed by " + User.current().getId();
+                                    return "Node was removed by " + (User.current() == null ? "(no user)" : User.current().getId());
                                 }
                             });
                         }

--- a/test/src/test/java/jenkins/model/NodesTest.java
+++ b/test/src/test/java/jenkins/model/NodesTest.java
@@ -25,14 +25,22 @@
 package jenkins.model;
 
 import hudson.model.Descriptor;
+import hudson.model.Executor;
+import hudson.model.Label;
 import hudson.model.Node;
+import hudson.model.Queue;
 import hudson.model.Slave;
+import hudson.model.queue.SubTask;
 import hudson.slaves.ComputerLauncher;
 import java.io.IOException;
+
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import javax.annotation.Nonnull;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.nullValue;
@@ -86,6 +94,92 @@ public class NodesTest {
         Node newNode = r.createSlave("foo", "", null);
         r.jenkins.addNode(newNode);
         assertThat(r.jenkins.getNode("foo"), sameInstance(newNode));
+    }
+
+    @Test
+    public void removeNodeWithNonIdleExecutorsTest() throws Exception {
+        Node node = r.createOnlineSlave();
+        r.jenkins.addNode(node);
+        TestFlyweightTask task = new TestFlyweightTask();
+        task.label = node.getSelfLabel();
+        r.jenkins.getQueue().schedule(task,0);
+        //wait for execution
+        while(!task.isBuilding){
+            Thread.sleep(100);
+        }
+        Executor executor = node.toComputer().getOneOffExecutors().get(0);
+        r.jenkins.getNodesObject().removeNode(node);
+        //wait for executing of interruption
+        Thread.sleep(1000);
+        Assert.assertFalse(executor.isActive());
+    }
+
+    static class TestFlyweightTask implements Queue.FlyweightTask, Queue.Task {
+
+        boolean isBuilding = false;
+        transient Label label;
+
+        @Override
+        public String getDisplayName() {
+            return "test";
+        }
+
+        @Override
+        public Queue.Executable createExecutable() throws IOException {
+            return new Queue.Executable() {
+                @Nonnull
+                @Override
+                public SubTask getParent() {
+                    return TestFlyweightTask.this;
+                }
+
+                @Override
+                public void run() {
+                    try {
+                        TestFlyweightTask.this.isBuilding = true;
+                        Thread.sleep(10000);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                    TestFlyweightTask.this.isBuilding=false;
+                }
+
+                @Override
+                public String toString() {
+                    return "test";
+                }
+            };
+        }
+
+        @Override
+        public String getName() {
+            return "test";
+        }
+
+        @Override
+        public String getFullDisplayName() {
+            return "test";
+        }
+
+        @Override
+        public void checkAbortPermission() {
+
+        }
+
+        @Override
+        public boolean hasAbortPermission() {
+            return true;
+        }
+
+        @Override
+        public String getUrl() {
+            return "test";
+        }
+
+        public Label getAssignedLabel(){
+            return label;
+        }
+
     }
 
     private static class InvalidNode extends Slave {


### PR DESCRIPTION
There is possibility to remove node even if there is execution of task - no matter if it is from UI or by some cloud plugin in case that connection was lost. In case of normal task, it will be interrupted in the moment it sends something through channel. But in case of flyweight task (for example matrix project), this task will stay there and it is not possible to interrupt it from UI - [doStop](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/AbstractBuild.java#L1315) method

I think that when node is removed, all executors should be interrupted.
