### PR TITLE
[JENKINS-53016] Harden (Model)HyperlinkNote against display names containing newlines

### DIFF
--- a/core/src/main/java/hudson/console/HyperlinkNote.java
+++ b/core/src/main/java/hudson/console/HyperlinkNote.java
@@ -79,7 +79,7 @@ public class HyperlinkNote extends ConsoleNote {
         return encodeTo(url, text, HyperlinkNote::new);
     }
 
-    static String encodeTo(String url, String text, BiFunction<String, Integer, ? extends ConsoleNote> constructor) {
+    static String encodeTo(String url, String text, BiFunction<String, Integer, ConsoleNote> constructor) {
         // If text contains newlines, then its stored length will not match its length when being
         // displayed, since the display length will only include text up to the first newline,
         // which will cause an IndexOutOfBoundsException in MarkupText#rangeCheck when

--- a/core/src/main/java/hudson/console/HyperlinkNote.java
+++ b/core/src/main/java/hudson/console/HyperlinkNote.java
@@ -27,6 +27,8 @@ import hudson.Extension;
 import hudson.MarkupText;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -79,6 +81,7 @@ public class HyperlinkNote extends ConsoleNote {
         return encodeTo(url, text, HyperlinkNote::new);
     }
 
+    @Restricted(NoExternalUse.class)
     static String encodeTo(String url, String text, BiFunction<String, Integer, ConsoleNote> constructor) {
         // If text contains newlines, then its stored length will not match its length when being
         // displayed, since the display length will only include text up to the first newline,

--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -59,7 +59,10 @@ public class ModelHyperlinkNote extends HyperlinkNote {
     public static String encodeTo(String url, String text) {
         // If text contains newlines, then its stored length will not match its length when being
         // displayed, since the display length will only include text up to the first newline,
-        // which will cause an IndexOutOfBoundsException in MarkupText#rangeCheck when viewing the note.
+        // which will cause an IndexOutOfBoundsException in MarkupText#rangeCheck when
+        // ConsoleAnnotationOutputStream converts the note into markup. That stream treats '\n' as
+        // the sole end-of-line marker on all platforms, so we ignore '\r' because it will not
+        // break the conversion.
         text = text.replace('\n', ' ');
         try {
             return new ModelHyperlinkNote(url,text.length()).encode()+text;

--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -57,6 +57,10 @@ public class ModelHyperlinkNote extends HyperlinkNote {
     }
 
     public static String encodeTo(String url, String text) {
+        // If text contains newlines, then its stored length will not match its length when being
+        // displayed, since the display length will only include text up to the first newline,
+        // which will cause an IndexOutOfBoundsException in MarkupText#rangeCheck when viewing the note.
+        text = text.replace('\n', ' ');
         try {
             return new ModelHyperlinkNote(url,text.length()).encode()+text;
         } catch (IOException e) {

--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -5,8 +5,6 @@ import hudson.model.*;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
-import java.io.IOException;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
@@ -57,20 +55,7 @@ public class ModelHyperlinkNote extends HyperlinkNote {
     }
 
     public static String encodeTo(String url, String text) {
-        // If text contains newlines, then its stored length will not match its length when being
-        // displayed, since the display length will only include text up to the first newline,
-        // which will cause an IndexOutOfBoundsException in MarkupText#rangeCheck when
-        // ConsoleAnnotationOutputStream converts the note into markup. That stream treats '\n' as
-        // the sole end-of-line marker on all platforms, so we ignore '\r' because it will not
-        // break the conversion.
-        text = text.replace('\n', ' ');
-        try {
-            return new ModelHyperlinkNote(url,text.length()).encode()+text;
-        } catch (IOException e) {
-            // impossible, but don't make this a fatal problem
-            LOGGER.log(Level.WARNING, "Failed to serialize "+ModelHyperlinkNote.class,e);
-            return text;
-        }
+        return HyperlinkNote.encodeTo(url, text, ModelHyperlinkNote::new);
     }
 
     @Extension @Symbol("hyperlinkToModels")

--- a/test/src/test/java/hudson/console/ModelHyperlinkNoteTest.java
+++ b/test/src/test/java/hudson/console/ModelHyperlinkNoteTest.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.console;
+
+import hudson.model.FreeStyleProject;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class ModelHyperlinkNoteTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void textWithNewlines() throws Exception {
+        FreeStyleProject p = r.createFreeStyleProject();
+        String noteText = "\nthis string\nhas newline\r\ncharacters\n";
+        String input = ModelHyperlinkNote.encodeTo(p, noteText);
+        String noteTextSanitized = input.substring(input.length() - noteText.length());
+        // Throws IndexOutOfBoundsException before https://github.com/jenkinsci/jenkins/pull/3580.
+        String output = annotate(input);
+        assertThat(output, allOf(
+                containsString("href='" + r.getURL().toString()+p.getUrl() + "'"),
+                containsString(">" + noteTextSanitized + "</a>")));
+    }
+
+    private String annotate(String text) throws IOException {
+        StringWriter writer = new StringWriter();
+        try (ConsoleAnnotationOutputStream out = new ConsoleAnnotationOutputStream(writer, null, null, StandardCharsets.UTF_8)) {
+            IOUtils.copy(new StringReader(text), out);
+        }
+        return writer.toString();
+    }
+}


### PR DESCRIPTION
See [JENKINS-53016](https://issues.jenkins-ci.org/browse/JENKINS-53016).

This fix seems less likely to cause regressions than trying to add validation to display names for model objects (and that wouldn't fix bare use of HyperlinkNote).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Bugfix: Fix issue preventing build logs from being displayed when they contain hyperlinks whose link text contains newline characters.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees 