### PR TITLE
[JENKINS-37599] Fix handling of "minimum" in f:repeatable and f:repeatableProperty

### DIFF
--- a/core/src/main/resources/lib/form/repeatable.jelly
+++ b/core/src/main/resources/lib/form/repeatable.jelly
@@ -107,6 +107,7 @@ THE SOFTWARE.
     </st:attribute>
     <st:attributeConstraints expr="((var,items,name?)|field),varStatus?,noAddButton?,enableTopButton?,add?,minimum?,header?"/>
   </st:documentation>
+  <j:set var="minimum" value="${attrs.minimum ?: 0}" />
 
 
   <st:adjunct includes="lib.form.repeatable.repeatable"/>

--- a/core/src/main/resources/lib/form/repeatableProperty.jelly
+++ b/core/src/main/resources/lib/form/repeatableProperty.jelly
@@ -67,7 +67,7 @@ THE SOFTWARE.
   </st:documentation>
 
 
-  <f:repeatable field="${attrs.field}" default="${attrs.default}" noAddButton="${attrs.noAddButton}" header="${attrs.header}" add="${attrs.add}" enableTopButton="${attrs.enableTopButton}">
+  <f:repeatable field="${attrs.field}" default="${attrs.default}" noAddButton="${attrs.noAddButton}" header="${attrs.header}" add="${attrs.add}" minimum="${attrs.minimum ?: 0}" enableTopButton="${attrs.enableTopButton}">
     <table style="width:100%">
       <st:include page="config.jelly" class="${descriptor.clazz}" />
       <d:invokeBody/>

--- a/test/src/test/java/lib/form/RepeatablePropertyTest.java
+++ b/test/src/test/java/lib/form/RepeatablePropertyTest.java
@@ -29,14 +29,20 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
 import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.Issue;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class RepeatablePropertyTest extends HudsonTestCase implements Describable<RepeatablePropertyTest> {
@@ -46,6 +52,7 @@ public class RepeatablePropertyTest extends HudsonTestCase implements Describabl
     
     public ArrayList<ExcitingObject> testRepeatable;
     public ArrayList<ExcitingObject> defaults;
+    public List<ExcitingObjectContainer> testRepeatableContainer;
     
     public void testSimple() throws Exception {
         testRepeatable = createRepeatable();
@@ -68,6 +75,32 @@ public class RepeatablePropertyTest extends HudsonTestCase implements Describabl
            new ExcitingObject("Ignore me too")
         ));
         assertFormContents(VIEW_WITH_DEFAULT, testRepeatable);
+    }
+
+    @Issue("JENKINS-37599")
+    public void testNestedRepeatableProperty() throws Exception {
+        testRepeatableContainer = Collections.emptyList();
+        // minimum="1" is set for the upper one,
+        // the form should be:
+        // * 1 ExcitingObjectCotainer
+        // * no ExcitingObject
+        final HtmlForm form = getForm("nested");
+        List<HtmlTextInput> containerNameInputs = form.getElementsByAttribute("input", "type", "text");
+        CollectionUtils.filter(containerNameInputs, new Predicate<HtmlTextInput>() {
+            @Override
+            public boolean evaluate(HtmlTextInput input) {
+                return input.getNameAttribute().endsWith(".containerName");
+            }
+        });
+        List<HtmlTextInput> greatPropertyInputs = form.getElementsByAttribute("input", "type", "text");
+        CollectionUtils.filter(greatPropertyInputs, new Predicate<HtmlTextInput>() {
+            @Override
+            public boolean evaluate(HtmlTextInput input) {
+                return input.getNameAttribute().endsWith(".greatProperty");
+            }
+        });
+        assertEquals(1, containerNameInputs.size());
+        assertEquals(0, greatPropertyInputs.size());
     }
         
     private void assertFormContents(final String viewName, final ArrayList<ExcitingObject> expected) throws Exception {
@@ -147,4 +180,23 @@ public class RepeatablePropertyTest extends HudsonTestCase implements Describabl
         }
     }
 
+    public static final class ExcitingObjectContainer extends AbstractDescribableImpl<ExcitingObjectContainer> {
+        String containerName;
+        List<ExcitingObject> excitingObjectList;
+
+        @DataBoundConstructor
+        public ExcitingObjectContainer(String containerName, List<ExcitingObject> excitingObjectList) {
+            this.containerName = containerName;
+            this.excitingObjectList = excitingObjectList;
+        }
+        public String getContainerName() {
+            return containerName;
+        }
+        public List<ExcitingObject> getExcitingObjectList() {
+            return excitingObjectList;
+        }
+        @Extension
+        public static final class DescriptorImpl extends Descriptor<ExcitingObjectContainer> {
+        }
+    }
 }

--- a/test/src/test/resources/lib/form/RepeatablePropertyTest/ExcitingObjectContainer/config.jelly
+++ b/test/src/test/resources/lib/form/RepeatablePropertyTest/ExcitingObjectContainer/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry field="containerName">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="Exciting Objects">
+        <f:repeatableProperty field="excitingObjectList"/>
+    </f:entry>
+</j:jelly>

--- a/test/src/test/resources/lib/form/RepeatablePropertyTest/nested.jelly
+++ b/test/src/test/resources/lib/form/RepeatablePropertyTest/nested.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <l:layout title="Testing nested repeatableProperty">
+        <l:main-panel>
+            <f:form method="post" name="config" action="thisFormIsOnlyInspectedInTheTests">
+                <j:set var="instance" value="${it}" />
+                <j:set var="descriptor" value="${it.descriptor}" />
+                <f:entry title="Nested Exciting Objects">
+                    <f:repeatableProperty field="testRepeatableContainer" minimum="1" />
+                </f:entry>
+            </f:form>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>


### PR DESCRIPTION
See [JENKINS-37599](https://issues.jenkins-ci.org/browse/JENKINS-37599), [JENKINS-44824](https://issues.jenkins-ci.org/browse/JENKINS-44824)

### Proposed changelog entries
```
    - type: bug
      message: Internal: "minimum" should default to 0 in <f:repeatable> and <f:repeatableProperty> especially even when they are nested.
      issue: 37599
```

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers
