### PR TITLE
[JENKINS-53055] Upgrade libpam4j dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -544,11 +544,6 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>
-      <artifactId>libpam4j</artifactId>
-      <version>1.11</version>
-    </dependency>
-    <dependency>
-      <groupId>org.kohsuke</groupId>
       <artifactId>libzfs</artifactId>
       <version>0.8</version>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -545,7 +545,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>libpam4j</artifactId>
-      <version>1.8</version>
+      <version>1.11</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -544,6 +544,11 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>
+      <artifactId>libpam4j</artifactId>
+      <version>1.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
       <artifactId>libzfs</artifactId>
       <version>0.8</version>
     </dependency>


### PR DESCRIPTION
See [JENKINS-53055](https://issues.jenkins-ci.org/browse/JENKINS-53055).

The underlying code in libpam4j has remained very stable and backwards compatible and requires no additional tests written. See [libpam4j changes since 1.8](https://github.com/kohsuke/libpam4j/compare/libpam4j-1.8...libpam4j-1.11).

### Proposed changelog entries

* `Internal:` upgrade libpam4j to 1.11

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees @daniel-beck @Wadeck @oleg-nenashev @jeffret-b 