### PR TITLE
[JENKINS-48770] Quiet period is in milliseconds

### DIFF
--- a/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
+++ b/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
@@ -133,7 +133,9 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
      * This method is supposed to be invoked from {@link ParameterizedJobMixIn#doBuild(StaplerRequest, StaplerResponse, TimeDuration)}.
      */
     public void _doBuild(StaplerRequest req, StaplerResponse rsp, @QueryParameter TimeDuration delay) throws IOException, ServletException {
-        if (delay==null)    delay=new TimeDuration(getJob().getQuietPeriod());
+        if (delay==null)
+            // time set in UI is in seconds. Changing it into milliseconds
+            delay=new TimeDuration(getJob().getQuietPeriod() * 1000);
 
 
         List<ParameterValue> values = new ArrayList<ParameterValue>();
@@ -182,7 +184,9 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
         		values.add(value);
         	}
         }
-        if (delay==null)    delay=new TimeDuration(getJob().getQuietPeriod());
+        if (delay==null)
+            // time set in UI is in seconds. Changing it into milliseconds
+            delay=new TimeDuration(getJob().getQuietPeriod() * 1000);
 
         Queue.Item item = Jenkins.getInstance().getQueue().schedule2(
                 getJob(), delay.getTimeInSeconds(), new ParametersAction(values), ParameterizedJobMixIn.getBuildCause(getJob(), req)).getItem();

--- a/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
+++ b/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
@@ -134,8 +135,7 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
      */
     public void _doBuild(StaplerRequest req, StaplerResponse rsp, @QueryParameter TimeDuration delay) throws IOException, ServletException {
         if (delay==null)
-            // time set in UI is in seconds. Changing it into milliseconds
-            delay=new TimeDuration(getJob().getQuietPeriod() * 1000);
+            delay=new TimeDuration(TimeUnit.MILLISECONDS.convert(getJob().getQuietPeriod(), TimeUnit.SECONDS));
 
 
         List<ParameterValue> values = new ArrayList<ParameterValue>();
@@ -185,8 +185,7 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
         	}
         }
         if (delay==null)
-            // time set in UI is in seconds. Changing it into milliseconds
-            delay=new TimeDuration(getJob().getQuietPeriod() * 1000);
+            delay=new TimeDuration(TimeUnit.MILLISECONDS.convert(getJob().getQuietPeriod(), TimeUnit.SECONDS));
 
         Queue.Item item = Jenkins.getInstance().getQueue().schedule2(
                 getJob(), delay.getTimeInSeconds(), new ParametersAction(values), ParameterizedJobMixIn.getBuildCause(getJob(), req)).getItem();

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -190,7 +190,8 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
     @SuppressWarnings("deprecation")
     public final void doBuild(StaplerRequest req, StaplerResponse rsp, @QueryParameter TimeDuration delay) throws IOException, ServletException {
         if (delay == null) {
-            delay = new TimeDuration(asJob().getQuietPeriod());
+            // time set in UI is in seconds. Changing it into milliseconds
+            delay = new TimeDuration(asJob().getQuietPeriod() * 1000);
         }
 
         if (!asJob().isBuildable()) {

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -54,6 +54,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 import static javax.servlet.http.HttpServletResponse.SC_CREATED;
@@ -190,8 +191,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
     @SuppressWarnings("deprecation")
     public final void doBuild(StaplerRequest req, StaplerResponse rsp, @QueryParameter TimeDuration delay) throws IOException, ServletException {
         if (delay == null) {
-            // time set in UI is in seconds. Changing it into milliseconds
-            delay = new TimeDuration(asJob().getQuietPeriod() * 1000);
+            delay=new TimeDuration(TimeUnit.MILLISECONDS.convert(asJob().getQuietPeriod(), TimeUnit.SECONDS));
         }
 
         if (!asJob().isBuildable()) {


### PR DESCRIPTION
See [JENKINS-48770](https://issues.jenkins-ci.org/browse/JENKINS-48770).

Detected a regression in how the Quiet Period value from the UI was used. This issue and PR try to fix it.

### Proposed changelog entries

* JENKINS-48770: Fix regression in Quiet Period value that was considering the value as milliseconds instead of seconds

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs


### Desired reviewers

@reviewbybees @oleg-nenashev @daniel-beck @batmat 
