### PR TITLE
[JENKINS-53133] Add JobPropertyDescriptor#isModifiableByUser()

### DIFF
--- a/core/src/main/java/hudson/model/JobPropertyDescriptor.java
+++ b/core/src/main/java/hudson/model/JobPropertyDescriptor.java
@@ -96,6 +96,14 @@ public abstract class JobPropertyDescriptor extends Descriptor<JobProperty<?>> {
     }
 
     /**
+     * Whether this job property can be modified by the user, either through the UI or the {@code properties} step in Pipeline.
+     * @return defaults to true
+     */
+    public boolean isModifiableByUser() {
+        return true;
+    }
+
+    /**
      * Gets the {@link JobPropertyDescriptor}s applicable for a given job type.
      */
     public static List<JobPropertyDescriptor> getPropertyDescriptors(Class<? extends Job> clazz) {


### PR DESCRIPTION
See [JENKINS-53133](https://issues.jenkins-ci.org/browse/JENKINS-53133).

Downstream PR in `workflow-multibranch` incoming.

### Proposed changelog entries

* Entry 1: Internal: JENKINS-53133, add flag to `JobPropertyDescriptor` to allow ignoring a `JobProperty` in Pipeline's `properties` step.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

