### PR TITLE
Try to handle enums that fail isEnum

### DIFF
--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -164,12 +164,15 @@ public class ClassFilterImpl extends ClassFilter {
             {
                 // Class.isEnum seems to be false for, e.g., java.util.concurrent.TimeUnit$6
                 // https://www.logicbig.com/how-to/code-snippets/jcode-reflection-field-isenumconstant.html
-                Field[] declaredFields = c.getDeclaredFields();
-                for (int i = 0; i < declaredFields.length; i++) {
-                    Field f = declaredFields[i];
-                    if (f.isEnumConstant() && name == f.getName()) {
-                        LOGGER.log(Level.FINE, "permitting {0} since it is an enum", name);
-                        return false;
+                Class declaringClass = c.getDeclaringClass();
+                if (declaringClass.isEnum()) {
+                    Field[] declaredFields = c.getDeclaredFields();
+                    for (int i = 0; i < declaredFields.length; i++) {
+                        Field f = declaredFields[i];
+                        if (f.isEnumConstant() && c == declaringClass.values()[i]) {
+                            LOGGER.log(Level.FINE, "permitting {0} since it is an enum (albeit somewhat special)", name);
+                            return false;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
https://www.logicbig.com/how-to/code-snippets/jcode-reflection-field-isenumconstant.html

Current code, conceptually:
```Groovy
d=java.util.concurrent.TimeUnit.DAYS
[d.class.isEnum(),d.getDeclaringClass().class.isEnum()]

Result: [false, false]
```

Attempted conceptual supplement:
```Groovy
declaredFields = java.util.concurrent.TimeUnit.class.getDeclaredFields();
declaredFields.collect { [it.getName(), it.isEnumConstant()] }

Result: [[NANOSECONDS, true], [MICROSECONDS, true], [MILLISECONDS, true], [SECONDS, true], [MINUTES, true], [HOURS, true], [DAYS, true], [C0, false], [C1, false], [C2, false], [C3, false], [C4, false], [C5, false], [C6, false], [MAX, false], [$VALUES, false]]
```


See [JENKINS-52945](https://issues.jenkins-ci.org/browse/JENKINS-52945).

### Proposed changelog entries

* Relax JEP-200 to handle enums (like `java.util.concurrent.TimeUnit`) that fail `class.isEnum()`

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@jglick 

Note:
* I haven't actually compiled this, and I'm not really a Java 8 person (more like java 5). I /think/ this might do what I want.
* This definitely should have tests (since it's relaxing JEP-200)
* This should have multiple reviewers once it actually vaguely works
* Assuming someone added a special whitelist for TimeUnit, that should be removed once this goes in