### PR TITLE
Better fix for "Stop premature scroll bar on long build labels" (#3576)

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -1067,7 +1067,6 @@ table.parameters > tbody:hover {
 }
 
 .build-row.multi-line .build-row-cell .pane.build-name.block {
-  padding-right: 20px;
   width: 100%;
 }
 .build-row-cell .pane.build-controls.block {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1845,7 +1845,6 @@ function updateBuildHistory(ajaxUrl,nBuild) {
                     var wrap = blockWrap(buildDetails, buildControls);
                     indentMultiline(wrap);
                     Element.addClassName(wrap, "build-details-controls");
-                    $(displayName).setStyle({width: '100%'});
                     detailsOverflowParams = getElementOverflowParams(buildDetails); // recalculate
                     expandLeftWithRight(detailsOverflowParams, controlsOverflowParams);
                     setBuildControlWidths();


### PR DESCRIPTION
A better fix for the scroll bar issue I previously tried to fix in #3576. This should also work on Chrome. This also stops the caret from overflowing, which I assume is the correct behaviour.

Screenshot from chrome: [https://i.imgur.com/jQQYvdP.png](https://i.imgur.com/jQQYvdP.png)

I'm not sure why the width was being set from this function, maybe this was done before the width was managed by the css?

### Desired reviewers
@peetereczek
@daniel-beck