### PR TITLE
[JENKINS-52945,JENKINS-42533] Update Remoting to 3.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3.25</remoting.version>
+    <remoting.version>3.26</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.4</remoting.minimum.supported.version>
 


### PR DESCRIPTION
[JENKINS-52945,JENKINS-42533] Update Remoting to 3.26 to remove some unhelpful warnings.

See [JENKINS-52945](https://issues.jenkins-ci.org/browse/JENKINS-52945) and [JENKINS-42533](https://issues.jenkins-ci.org/browse/JENKINS-42533)

Remoting changelog (contains the same entries as proposed below): https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#325

Remoting PRs: 
* [JENKINS-42533](https://github.com/jenkinsci/remoting/pull/283)
* [JENKINS-52945](https://github.com/jenkinsci/remoting/pull/282)

### Proposed changelog entries

* [JENKINS-52945](https://issues.jenkins-ci.org/browse/JENKINS-52945) - AnonymousClassWarnings should not warn about enums.
  * https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#325
* [JENKINS-42533](https://issues.jenkins-ci.org/browse/JENKINS-42533) - Eliminate another excessively severe warning about trying to export already unexported object.
  * https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#325

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees 
