### PR TITLE
JENKINS-53353 Do not cache results of View.getActions()

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -552,6 +552,14 @@ public abstract class View extends AbstractModelObject implements AccessControll
         return result;
     }
 
+    /**
+     * No-op. Included to maintain backwards compatibility.
+     * @deprecated This method does nothing and should not be used
+     */
+    @Restricted(DoNotUse.class)
+    @Deprecated
+    public void updateTransientActions() {}
+
     public Object getDynamic(String token) {
         for (Action a : getActions()) {
             String url = a.getUrlName();

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -546,11 +546,9 @@ public abstract class View extends AbstractModelObject implements AccessControll
      * @see Jenkins#getActions()
      */
     public List<Action> getActions() {
-    	List<Action> result = new ArrayList<Action>();
+    	List<Action> result = new ArrayList<>();
     	result.addAll(getOwner().getViewActions());
-    	synchronized (this) {
-            result.addAll(TransientViewActionFactory.createAllFor(this));
-    	}
+        result.addAll(TransientViewActionFactory.createAllFor(this));
     	return result;
     }
 

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -546,10 +546,10 @@ public abstract class View extends AbstractModelObject implements AccessControll
      * @see Jenkins#getActions()
      */
     public List<Action> getActions() {
-    	List<Action> result = new ArrayList<>();
-    	result.addAll(getOwner().getViewActions());
+        List<Action> result = new ArrayList<>();
+        result.addAll(getOwner().getViewActions());
         result.addAll(TransientViewActionFactory.createAllFor(this));
-    	return result;
+        return result;
     }
 
     public Object getDynamic(String token) {

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -116,7 +116,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static jenkins.scm.RunWithSCM.*;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -172,8 +171,6 @@ public abstract class View extends AbstractModelObject implements AccessControll
      */
     protected boolean filterQueue;
     
-    protected transient List<Action> transientActions;
-
     /**
      * List of {@link ViewProperty}s configured for this view.
      * @since 1.406
@@ -552,18 +549,11 @@ public abstract class View extends AbstractModelObject implements AccessControll
     	List<Action> result = new ArrayList<Action>();
     	result.addAll(getOwner().getViewActions());
     	synchronized (this) {
-    		if (transientActions == null) {
-                updateTransientActions();
-    		}
-    		result.addAll(transientActions);
+            result.addAll(TransientViewActionFactory.createAllFor(this));
     	}
     	return result;
     }
-    
-    public synchronized void updateTransientActions() {
-        transientActions = TransientViewActionFactory.createAllFor(this); 
-    }
-    
+
     public Object getDynamic(String token) {
         for (Action a : getActions()) {
             String url = a.getUrlName();
@@ -993,7 +983,6 @@ public abstract class View extends AbstractModelObject implements AccessControll
         rename(req.getParameter("name"));
 
         getProperties().rebuild(req, req.getSubmittedForm(), getApplicablePropertyDescriptors());
-        updateTransientActions();  
 
         save();
 


### PR DESCRIPTION
See [JENKINS-53353](https://issues.jenkins-ci.org/browse/JENKINS-53353).

Plugins that may affect the view, eg via TransientViewActionFactory
that get installed _after_ a `view` has been initally viewed
will not be able to add anything to the view if the results
of getActions() are cached.

### Proposed changelog entries

* Entry 1: Removed caching in Views - Plugins that affected the View, but are installed _after_ the initial rendering/viewing of the `View` will not be called again and do not contribute to the `View`.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
      * No existing tests present for the caching. Code is simplistic enough and removes functionality so unnecessary to add tests.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

@reviewbybees @jtnord
