### PR TITLE
[JENKINS-53401] Tie nodeProperties to the current node for save purpose

### DIFF
--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -146,8 +146,8 @@ public abstract class Slave extends Node implements Serializable {
      */
     private String label="";
 
-    private /*almost final*/ DescribableList<NodeProperty<?>,NodePropertyDescriptor> nodeProperties = 
-                                    new DescribableList<NodeProperty<?>,NodePropertyDescriptor>(Jenkins.getInstance().getNodesObject());
+    private /*almost final*/ DescribableList<NodeProperty<?>,NodePropertyDescriptor> nodeProperties =
+            new DescribableList<>(this);
 
     /**
      * Lazily computed set of labels from {@link #label}.
@@ -559,7 +559,7 @@ public abstract class Slave extends Node implements Serializable {
      */
     protected Object readResolve() {
         if(nodeProperties==null)
-            nodeProperties = new DescribableList<NodeProperty<?>,NodePropertyDescriptor>(Jenkins.getInstance().getNodesObject());
+            nodeProperties = new DescribableList<>(this);
         return this;
     }
 

--- a/test/src/test/java/hudson/slaves/NodeParallelTest.java
+++ b/test/src/test/java/hudson/slaves/NodeParallelTest.java
@@ -1,0 +1,64 @@
+package hudson.slaves;
+
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class NodeParallelTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    private static final Logger LOGGER = Logger.getLogger(NodeParallelTest.class.getName());
+
+    private final AtomicInteger count = new AtomicInteger();
+
+    @Test
+    @Issue("JENKINS-53401")
+    public void createNodesWithParallelThreads() throws InterruptedException, ExecutionException {
+        int n = 50;
+        List<Callable<Void>> tasks = Collections.nCopies(n, () -> {
+            try {
+                int i = count.incrementAndGet();
+                LOGGER.log(Level.INFO, "Creating slave " + i);
+                // JenkinsRule sync on Jenkins singleton, so this doesn't work
+                // r.createSlave();
+                DumbSlave agent = new DumbSlave("agent-"+i, "/tmp", new JNLPLauncher(true));
+                r.jenkins.addNode(agent);
+                agent.setNodeProperties(Collections.singletonList(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("foo", "" + i))));
+                return null;
+            } catch (Exception e1) {
+                throw new RuntimeException(e1);
+            }
+        });
+        ExecutorService executorService = Executors.newFixedThreadPool(n);
+        List<Future<Void>> futures = executorService.invokeAll(tasks);
+        List<Void> resultList = new ArrayList<>(futures.size());
+        // Check for exceptions
+        try {
+            for (Future<Void> future : futures) {
+                // Throws an exception if an exception was thrown by the task.
+                resultList.add(future.get());
+            }
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
See [JENKINS-53401](https://issues.jenkins-ci.org/browse/JENKINS-53401).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fixed a thread safety issue when creating several nodes in parallel.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
