### PR TITLE
Simplified Run.writeLogTo

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1476,16 +1476,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * @since 1.349
      */
     public void writeLogTo(long offset, @Nonnull XMLOutput out) throws IOException {
-        try {
-			getLogText().writeHtmlTo(offset,out.asWriter());
-		} catch (IOException e) {
-			// try to fall back to the old getLogInputStream()
-			// mainly to support .gz compressed files
-			// In this case, console annotation handling will be turned off.
-			try (InputStream input = getLogInputStream()) {
-				IOUtils.copy(input, out.asWriter());
-			}
-		}
+        getLogText().writeHtmlTo(offset, out.asWriter());
     }
 
     /**


### PR DESCRIPTION
…by reverting https://github.com/jenkinsci/jenkins/commit/0dcf5ef64710d9c1631e8a75de3e749444104a00, which should be obsolete since `LargeText` itself has long since supported gzipped files directly.

While tracking down an exception from https://github.com/jenkinsci/workflow-api-plugin/pull/17 in a debugger, I found it being silently swallowed and the raw log dumped to HTML output instead.

### Proposed changelog entries

* Certain kinds of errors in build console display were being suppressed and ANSI escape sequences displayed instead.