### PR TITLE
[JENKINS-53729] - Restore computed serialVersionUID for HyperlinkNote

### DIFF
--- a/core/src/main/java/hudson/console/HyperlinkNote.java
+++ b/core/src/main/java/hudson/console/HyperlinkNote.java
@@ -107,4 +107,5 @@ public class HyperlinkNote extends ConsoleNote {
     }
 
     private static final Logger LOGGER = Logger.getLogger(HyperlinkNote.class.getName());
+    private static final long serialVersionUID = 3908468829358026949L;
 }


### PR DESCRIPTION
See [JENKINS-53729](https://issues.jenkins-ci.org/browse/JENKINS-53729) and https://github.com/jenkinsci/jenkins/pull/3580#discussion_r216047927.

#3580 changed the computed `serialVersionUID` for HyperlinkNote, which caused errors in new versions of Jenkins when viewing build logs from HyperlinkNotes serialized by older versions of Jenkins. 

I am happy to try to create a regression test if desired.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Bug: Hyperlinks in build logs for builds run using Jenkins 2.138 or older were not displayed correctly in newer versions of Jenkins.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees 