### PR TITLE
Adding an AnchorNote to allow redirects directly to a place in the co…

### DIFF
--- a/core/src/main/java/hudson/console/AnchorNote.java
+++ b/core/src/main/java/hudson/console/AnchorNote.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010-2011, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.console;
+
+import hudson.Extension;
+import hudson.MarkupText;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+import java.util.function.BiFunction;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Turns a text into a anchor link by specifying the anchor separately.
+ * Allows to create links directly into a longer log.
+ *
+ * @author RB based on HyperlinkNote by Kohsuke Kawaguchi
+ * @since ???
+ */
+public class AnchorNote extends ConsoleNote {
+    private final String anchor;
+    private final int length;
+
+    public AnchorNote(String anchor, int length) {
+        this.anchor = anchor;
+        this.length = length;
+    }
+
+    @Override
+    public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
+        if (length == 0) {
+            text.addMarkup(charPos, charPos + length, "<a name='" + anchor + "'"+extraAttributes()+"></a>", "");
+        }
+        else {
+            text.addMarkup(charPos, charPos + length, "<a name='" + anchor + "'"+extraAttributes()+">", "</a>");
+        }
+        return null;
+    }
+
+    protected String extraAttributes() {
+        return "";
+    }
+
+    public static String encodeTo(String anchor, String text) {
+        return encodeTo(anchor, text, AnchorNote::new);
+    }
+
+    @Restricted(NoExternalUse.class)
+    static String encodeTo(String anchor, String text, BiFunction<String, Integer, ConsoleNote> constructor) {
+        // If text contains newlines, then its stored length will not match its length when being
+        // displayed, since the display length will only include text up to the first newline,
+        // which will cause an IndexOutOfBoundsException in MarkupText#rangeCheck when
+        // ConsoleAnnotationOutputStream converts the note into markup. That stream treats '\n' as
+        // the sole end-of-line marker on all platforms, so we ignore '\r' because it will not
+        // break the conversion.
+        text = text.replace('\n', ' ');
+
+        try {
+            return constructor.apply(anchor,text.length()).encode()+text;
+        } catch (IOException e) {
+            // impossible, but don't make this a fatal problem
+            LOGGER.log(Level.WARNING, "Failed to serialize "+AnchorNote.class,e);
+            return text;
+        }
+    }
+
+    @Extension @Symbol("anchor")
+    public static class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        public String getDisplayName() {
+            return "Anchor";
+        }
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(AnchorNote.class.getName());
+}

--- a/core/src/main/java/hudson/console/AnchorNote.java
+++ b/core/src/main/java/hudson/console/AnchorNote.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2010-2011, CloudBees, Inc.
+ * Copyright (c) 2018, Tenable, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
  * Turns a text into a anchor link by specifying the anchor separately.
  * Allows to create links directly into a longer log.
  *
- * @author RB based on HyperlinkNote by Kohsuke Kawaguchi
+ * @author Ralph Boerger based on HyperlinkNote by Kohsuke Kawaguchi
  * @since ???
  */
 public class AnchorNote extends ConsoleNote {

--- a/core/src/main/java/hudson/console/AnchorNote.java
+++ b/core/src/main/java/hudson/console/AnchorNote.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
  * Allows to create links directly into a longer log.
  *
  * @author Ralph Boerger based on HyperlinkNote by Kohsuke Kawaguchi
- * @since ???
+ * @since TODO
  */
 public class AnchorNote extends ConsoleNote {
     private final String anchor;

--- a/test/src/test/java/hudson/console/AnchorNoteTest.java
+++ b/test/src/test/java/hudson/console/AnchorNoteTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 CloudBees, Inc.
+ * Copyright 2018 Tenable, Inc
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/test/java/hudson/console/AnchorNoteTest.java
+++ b/test/src/test/java/hudson/console/AnchorNoteTest.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.console;
+
+import hudson.model.FreeStyleProject;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class AnchorNoteTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void textWithNewlines() throws Exception {
+        String anchor = "anchor";
+        String noteText = "\nthis string\nhas newline\r\ncharacters\n\r";
+        String input = AnchorNote.encodeTo(anchor, noteText);
+        String noteTextSanitized = input.substring(input.length() - noteText.length());
+        String output = annotate(input);
+        assertThat(output, allOf(
+                containsString("name='" + anchor + "'"),
+                containsString(">" + noteTextSanitized + "</a>")));
+    }
+
+    @Test
+    public void textIsEmpty() throws Exception {
+        String anchor = "anchor";
+        String noteText = "";
+        String input = AnchorNote.encodeTo(anchor, noteText);
+        String noteTextSanitized = input.substring(input.length() - noteText.length());
+        // Throws IndexOutOfBoundsException before https://github.com/jenkinsci/jenkins/pull/3580.
+        String output = annotate(input);
+        assertThat(output, allOf(
+                containsString("name='" + anchor + "'"),
+                containsString("></a>")));
+    }
+
+    private static String annotate(String text) throws IOException {
+        StringWriter writer = new StringWriter();
+        try (ConsoleAnnotationOutputStream out = new ConsoleAnnotationOutputStream(writer, null, null, StandardCharsets.UTF_8)) {
+            IOUtils.copy(new StringReader(text), out);
+        }
+        return writer.toString();
+    }
+}


### PR DESCRIPTION
No JIRA ticket for this small new feature.

Similar to the *HyperlinkNote class(es) this allows the easy insertion of a html anchor in to the Console log. This could be called from plugin, Jenkins Library code or pipeline code directly.

i.e. Example

`node {
   echo 'Hello World'
   
   for(def i = 0; i < 100; i++) {
       echo i.toString()
   }
   
   echo hudson.console.AnchorNote.encodeTo('myachor', '')
}` 

this allows to reference the anchor "myanchor" directly from a link of the form <job>/consoleFull#myanchor thus allowing us to reference this in mail/slack/... notification.

This avoids uses having to search for certain places in long logs.

**Proposed changelog entries**

- Additional Class AnchorNote to allow to insert HTML Anchors into the console log

**Desired reviewers**

@daniel-beck 