### PR TITLE
[JENKINS-53505] Remove the restriction on DownloadSettings

### DIFF
--- a/core/src/main/java/jenkins/model/DownloadSettings.java
+++ b/core/src/main/java/jenkins/model/DownloadSettings.java
@@ -50,7 +50,6 @@ import javax.annotation.Nonnull;
  * @see UpdateSite
  * @see DownloadService
  */
-@Restricted(NoExternalUse.class) // no clear reason for this to be an API
 @Extension @Symbol("downloadSettings")
 public final class DownloadSettings extends GlobalConfiguration implements PersistentDescriptor {
 


### PR DESCRIPTION
See [JENKINS-53505](https://issues.jenkins-ci.org/browse/JENKINS-53505).

### Proposed changelog entries

* JENKINS-53505: `DownloadSettings` is not restricted now.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jenkinsci/code-reviewers
