### PR TITLE
[JENKINS-53511] Improve discovery and readability of WebClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.6</version>
       </dependency>
 
       <dependency>

--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -54,7 +54,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2.41.1</version>
+      <version>2.42</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test/src/test/java/hudson/AboutJenkinsTest.java
+++ b/test/src/test/java/hudson/AboutJenkinsTest.java
@@ -33,6 +33,8 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.SmokeTest;
 
+import java.net.HttpURLConnection;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -55,19 +57,19 @@ public class AboutJenkinsTest {
                 .grant(Jenkins.READ).everywhere().to(USER)
         );
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         
         { // user cannot see it
             wc.login(USER);
             HtmlPage page = wc.goTo("about/");
-            assertEquals(403, page.getWebResponse().getStatusCode());
+            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, page.getWebResponse().getStatusCode());
         }
         
         { // admin can access it
             wc.login(ADMIN);
             HtmlPage page = wc.goTo("about/");
-            assertEquals(200, page.getWebResponse().getStatusCode());
+            assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
             assertThat(page.getWebResponse().getContentAsString(), containsString("Mavenized dependencies"));
         }
     }

--- a/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
+++ b/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
@@ -1,34 +1,20 @@
 package hudson;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import hudson.remoting.Base64;
 
-import java.io.IOException;
-import java.security.KeyFactory;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.X509Certificate;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import javax.annotation.Nullable;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import jenkins.model.Jenkins;
-import jenkins.model.identity.InstanceIdentityProvider;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
-import org.jvnet.hudson.test.TestExtension;
 
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 public class TcpSlaveAgentListenerTest {
 
@@ -37,15 +23,15 @@ public class TcpSlaveAgentListenerTest {
 
     @Test
     public void headers() throws Exception {
+        WebClient wc = r.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
+
         r.getInstance().setSlaveAgentPort(-1);
-        try {
-            r.createWebClient().goTo("tcpSlaveAgentListener");
-            fail("Should get 404");
-        } catch (FailingHttpStatusCodeException e) {
-            assertThat(e.getStatusCode(), is(404));
-        }
+        wc.assertFails("tcpSlaveAgentListener", HttpURLConnection.HTTP_NOT_FOUND);
+
         r.getInstance().setSlaveAgentPort(0);
-        Page p = r.createWebClient().goTo("tcpSlaveAgentListener", "text/plain");
+        Page p = wc.goTo("tcpSlaveAgentListener", "text/plain");
+        assertEquals(HttpURLConnection.HTTP_OK, p.getWebResponse().getStatusCode());
         assertThat(p.getWebResponse().getResponseHeaderValue("X-Instance-Identity"), notNullValue());
     }
 
@@ -54,15 +40,13 @@ public class TcpSlaveAgentListenerTest {
         r.getInstance().setSlaveAgentPort(0);
         int p = r.jenkins.getTcpSlaveAgentListener().getPort();
         WebClient wc = r.createWebClient();
-        TextPage text = (TextPage) wc.getPage("http://localhost:"+p+"/");
-        String c = text.getContent();
-        assertThat(c,containsString(Jenkins.VERSION));
 
-        try {
-            wc.getPage("http://localhost:"+p+"/xxx");
-            fail("Expected 404");
-        } catch (FailingHttpStatusCodeException e) {
-            assertThat(e.getStatusCode(),equalTo(404));
-        }
+        TextPage text = wc.getPage(new URL("http://localhost:" + p + "/"));
+        String c = text.getContent();
+        assertThat(c, containsString(Jenkins.VERSION));
+
+        wc.setThrowExceptionOnFailingStatusCode(false);
+        Page page = wc.getPage(new URL("http://localhost:" + p + "/xxx"));
+        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, page.getWebResponse().getStatusCode());
     }
 }

--- a/test/src/test/java/hudson/cli/CLITest.java
+++ b/test/src/test/java/hudson/cli/CLITest.java
@@ -37,6 +37,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.HttpURLConnection;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
@@ -234,11 +235,12 @@ public class CLITest {
         sshd.start();
 
         // Sanity check
-        JenkinsRule.WebClient wc = r.createWebClient();
-        wc.getOptions().setRedirectEnabled(false);
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = r.createWebClient()
+                .withRedirectEnabled(false)
+                .withThrowExceptionOnFailingStatusCode(false);
+        
         WebResponse rsp = wc.goTo("cli-proxy/").getWebResponse();
-        assertEquals(rsp.getContentAsString(), 302, rsp.getStatusCode());
+        assertEquals(rsp.getContentAsString(), HttpURLConnection.HTTP_MOVED_TEMP, rsp.getStatusCode());
         assertEquals(rsp.getContentAsString(), null, rsp.getResponseHeaderValue("X-Jenkins"));
         assertEquals(rsp.getContentAsString(), null, rsp.getResponseHeaderValue("X-Jenkins-CLI-Port"));
         assertEquals(rsp.getContentAsString(), null, rsp.getResponseHeaderValue("X-SSH-Endpoint"));
@@ -308,7 +310,7 @@ public class CLITest {
                 public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
                     rsp.setHeader("Location", url);
                     rsp.setContentType("text/html");
-                    rsp.setStatus(302);
+                    rsp.setStatus(HttpURLConnection.HTTP_MOVED_TEMP);
                     PrintWriter w = rsp.getWriter();
                     w.append("Redirect to ").append(url);
                 }

--- a/test/src/test/java/hudson/diagnosis/HudsonHomeDiskUsageMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/HudsonHomeDiskUsageMonitorTest.java
@@ -5,14 +5,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import hudson.model.User;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
-import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
 import jenkins.security.apitoken.ApiTokenTestHelper;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,6 +23,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Collections;
 
@@ -63,7 +63,8 @@ public class HudsonHomeDiskUsageMonitorTest {
     public void noAccessForNonAdmin() throws Exception {
         ApiTokenTestHelper.enableLegacyBehavior();
         
-        JenkinsRule.WebClient wc = j.createWebClient();
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
 
         // TODO: Use MockAuthorizationStrategy in later versions
         JenkinsRule.DummySecurityRealm realm = j.createDummySecurityRealm();
@@ -85,26 +86,19 @@ public class HudsonHomeDiskUsageMonitorTest {
         HudsonHomeDiskUsageMonitor mon = HudsonHomeDiskUsageMonitor.get();
 
         wc.withBasicApiToken(bob);
-        try {
-            wc.getPage(request);
-            fail();
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(403, e.getStatusCode());
-        }
+        Page p = wc.getPage(request);
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, p.getWebResponse().getStatusCode());
+
         assertTrue(mon.isEnabled());
 
         WebRequest requestReadOnly = new WebRequest(new URL(wc.getContextPath() + "administrativeMonitor/hudsonHomeIsFull"), HttpMethod.GET);
-        try {
-            wc.getPage(requestReadOnly);
-            fail();
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(403, e.getStatusCode());
-        }
+        p = wc.getPage(requestReadOnly);
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, p.getWebResponse().getStatusCode());
 
         wc.withBasicApiToken(administrator);
-        wc.getPage(request);
+        p = wc.getPage(request);
+        assertEquals(HttpURLConnection.HTTP_OK, p.getWebResponse().getStatusCode());
         assertFalse(mon.isEnabled());
-
     }
 
     /**

--- a/test/src/test/java/hudson/model/AbstractItemTest.java
+++ b/test/src/test/java/hudson/model/AbstractItemTest.java
@@ -1,7 +1,7 @@
 package hudson.model;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import hudson.security.ACL;
@@ -9,6 +9,7 @@ import hudson.security.ACLContext;
 import hudson.security.AccessDeniedException2;
 import hudson.util.FormValidation;
 import java.io.File;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Arrays;
 import jenkins.model.Jenkins;
@@ -117,18 +118,17 @@ public class AbstractItemTest {
         WebRequest wr = new WebRequest(w.createCrumbedUrl(p.getUrl() + "confirmRename"), HttpMethod.POST);
         wr.setRequestParameters(Arrays.asList(new NameValuePair("newName", "bar")));
         w.login("alice", "alice");
-        assertThat(getPath(w.getPage(wr).getUrl()), equalTo(p.getUrl()));
+        Page page = w.getPage(wr);
+        assertThat(getPath(page.getUrl()), equalTo(p.getUrl()));
         assertThat(p.getName(), equalTo("bar"));
 
         wr = new WebRequest(w.createCrumbedUrl(p.getUrl() + "confirmRename"), HttpMethod.POST);
         wr.setRequestParameters(Arrays.asList(new NameValuePair("newName", "baz")));
         w.login("bob", "bob");
-        try {
-            assertThat(getPath(w.getPage(wr).getUrl()), equalTo(p.getUrl()));
-            fail("Expecting HTTP 403 Forbidden");
-        } catch (FailingHttpStatusCodeException e) {
-            assertThat(e.getStatusCode(), equalTo(403));
-        }
+
+        w.setThrowExceptionOnFailingStatusCode(false);
+        page = w.getPage(wr);
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, page.getWebResponse().getStatusCode());
         assertThat(p.getName(), equalTo("bar"));
     }
 

--- a/test/src/test/java/hudson/model/AsynchPeopleTest.java
+++ b/test/src/test/java/hudson/model/AsynchPeopleTest.java
@@ -24,7 +24,6 @@
 
 package hudson.model;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.html.DomElement;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import static org.junit.Assert.*;
@@ -41,16 +40,10 @@ public class AsynchPeopleTest {
 
     @Issue("JENKINS-18641")
     @Test public void display() throws Exception {
-        User.get("bob");
+        User.getById(  "bob", true);
         JenkinsRule.WebClient wc = j.createWebClient();
-        HtmlPage page;
-        try {
-            page = wc.goTo("asynchPeople");
-        } catch (FailingHttpStatusCodeException x) {
-            System.err.println(x.getResponse().getResponseHeaders());
-            System.err.println(x.getResponse().getContentAsString());
-            throw x;
-        }
+
+        HtmlPage page = wc.goTo("asynchPeople");
         assertEquals(0, wc.waitForBackgroundJavaScript(120000));
         boolean found = false;
         for (DomElement table : page.getElementsByTagName("table")) {

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -34,6 +34,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.xml.XmlPage;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 import jenkins.model.Jenkins;
 import hudson.slaves.DumbSlave;
@@ -109,7 +110,7 @@ public class ComputerTest {
 
     private void verifyOfflineCause(Computer computer) throws Exception {
         XmlPage page = j.createWebClient().goToXml("computer/" + computer.getName() + "/config.xml");
-        String content = page.getWebResponse().getContentAsString("UTF-8");
+        String content = page.getWebResponse().getContentAsString(StandardCharsets.UTF_8);
         assertThat(content, containsString("temporaryOfflineCause"));
         assertThat(content, containsString("<userId>username</userId>"));
         assertThat(content, not(containsString("ApiTokenProperty")));

--- a/test/src/test/java/hudson/model/DirectlyModifiableViewTest.java
+++ b/test/src/test/java/hudson/model/DirectlyModifiableViewTest.java
@@ -184,8 +184,8 @@ public class DirectlyModifiableViewTest {
     }
 
     private Page doPost(View view, String path) throws Exception {
-        WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         WebRequest req = new WebRequest(
                 new URL(j.jenkins.getRootUrl() + view.getUrl() + path),
                 HttpMethod.POST

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -23,7 +23,6 @@
  */
 package hudson.model;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -243,13 +242,8 @@ public class DirectoryBrowserSupportTest {
         p.getPublishersList().add(new ArtifactArchiver("f"));
         j.buildAndAssertSuccess(p);
         HtmlPage page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/");
-        try {
-            Page download = page.getAnchorByText("f").click();
-            assertEquals("Hello world!", download.getWebResponse().getContentAsString());
-        } catch (FailingHttpStatusCodeException x) {
-            IOUtils.copy(x.getResponse().getContentAsStream(), System.err);
-            throw x;
-        }
+        Page download = page.getAnchorByText("f").click();
+        assertEquals("Hello world!", download.getWebResponse().getContentAsString());
     }
     /** Simulation of a storage service with URLs unrelated to {@link Run#doArtifact}. */
     @TestExtension("externalURLDownload")

--- a/test/src/test/java/hudson/model/HudsonTest.java
+++ b/test/src/test/java/hudson/model/HudsonTest.java
@@ -25,7 +25,6 @@ package hudson.model;
 
 import static org.junit.Assert.*;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
@@ -169,20 +168,19 @@ public class HudsonTest {
     public void deleteHudsonComputer() throws Exception {
         WebClient wc = j.createWebClient();
         HtmlPage page = wc.goTo("computer/(master)/");
-        for (HtmlAnchor a : page.getAnchors())
-            assertFalse(a.getHrefAttribute(),a.getHrefAttribute().endsWith("delete"));
-
-        // try to delete it by hitting the final URL directly
-        WebRequest req = new WebRequest(new URL(wc.getContextPath()+"computer/(master)/doDelete"), HttpMethod.POST);
-        try {
-            wc.getPage(wc.addCrumb(req));
-            fail("Error code expected");
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, e.getStatusCode());
+        for (HtmlAnchor a : page.getAnchors()) {
+            assertFalse(a.getHrefAttribute(), a.getHrefAttribute().endsWith("delete"));
         }
 
+        wc.setThrowExceptionOnFailingStatusCode(false);
+        // try to delete it by hitting the final URL directly
+        WebRequest req = new WebRequest(new URL(wc.getContextPath()+"computer/(master)/doDelete"), HttpMethod.POST);
+        page = wc.getPage(wc.addCrumb(req));
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, page.getWebResponse().getStatusCode());
+
         // the master computer object should be still here
-        wc.goTo("computer/(master)/");
+        page = wc.goTo("computer/(master)/");
+        assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
     }
 
     /**

--- a/test/src/test/java/hudson/model/ItemsTest.java
+++ b/test/src/test/java/hudson/model/ItemsTest.java
@@ -191,9 +191,10 @@ public class ItemsTest {
         /** Use the REST command to create an empty project (normally used only from the UI in the New Item dialog). */
         REST_EMPTY {
             @Override void run(JenkinsRule r, String target) throws Exception {
-                JenkinsRule.WebClient wc = wc(r);
-                wc.getOptions().setRedirectEnabled(false);
-                wc.getOptions().setThrowExceptionOnFailingStatusCode(false); // redirect perversely counts as a failure
+                JenkinsRule.WebClient wc = wc(r)
+                        // redirect perversely counts as a failure
+                        .withRedirectEnabled(false)
+                        .withThrowExceptionOnFailingStatusCode(false);
                 WebResponse webResponse = wc.getPage(new WebRequest(new URL(wc.getContextPath() + "createItem?name=" + target + "&mode=hudson.model.FreeStyleProject"), HttpMethod.POST)).getWebResponse();
                 if (webResponse.getStatusCode() != HttpStatus.SC_MOVED_TEMPORARILY) {
                     throw new FailingHttpStatusCodeException(webResponse);
@@ -204,9 +205,9 @@ public class ItemsTest {
         REST_COPY {
             @Override void run(JenkinsRule r, String target) throws Exception {
                 r.createFreeStyleProject("dupe");
-                JenkinsRule.WebClient wc = wc(r);
-                wc.getOptions().setRedirectEnabled(false);
-                wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+                JenkinsRule.WebClient wc = wc(r)
+                        .withRedirectEnabled(false)
+                        .withThrowExceptionOnFailingStatusCode(false);
                 WebResponse webResponse = wc.getPage(new WebRequest(new URL(wc.getContextPath() + "createItem?name=" + target + "&mode=copy&from=dupe"), HttpMethod.POST)).getWebResponse();
                 r.jenkins.getItem("dupe").delete();
                 if (webResponse.getStatusCode() != HttpStatus.SC_MOVED_TEMPORARILY) {
@@ -228,9 +229,9 @@ public class ItemsTest {
         REST_RENAME {
             @Override void run(JenkinsRule r, String target) throws Exception {
                 r.createFreeStyleProject("dupe");
-                JenkinsRule.WebClient wc = wc(r);
-                wc.getOptions().setRedirectEnabled(false);
-                wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+                JenkinsRule.WebClient wc = wc(r)
+                        .withRedirectEnabled(false)
+                        .withThrowExceptionOnFailingStatusCode(false);
                 WebResponse webResponse = wc.getPage(new WebRequest(new URL(wc.getContextPath() + "job/dupe/doRename?newName=" + target), HttpMethod.POST)).getWebResponse();
                 if (webResponse.getStatusCode() != HttpStatus.SC_MOVED_TEMPORARILY) {
                     r.jenkins.getItem("dupe").delete();

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -24,7 +24,7 @@
  */
 package hudson.model;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebAssert;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlFormUtil;
@@ -52,7 +52,6 @@ import java.util.concurrent.CountDownLatch;
 
 import jenkins.model.ProjectNamingStrategy;
 
-import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
 import jenkins.security.apitoken.ApiTokenTestHelper;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -221,14 +220,19 @@ public class JobTest {
         try {
             wc.assertFails("job/testJob/config.xml", HttpURLConnection.HTTP_FORBIDDEN);
 
-            wc.withBasicApiToken(User.getById("alice", true));  // Has CONFIGURE and EXTENDED_READ permission
-            tryConfigDotXml(wc, 500, "Both perms; should get 500");
+            wc.setThrowExceptionOnFailingStatusCode(false);
+            
+            // Has CONFIGURE and EXTENDED_READ permission
+            wc.withBasicApiToken(User.getById("alice", true));  
+            tryConfigDotXml(wc, HttpURLConnection.HTTP_INTERNAL_ERROR, "Both perms; should get 500");
 
-            wc.withBasicApiToken(User.getById("bob", true));  // Has only CONFIGURE permission (this should imply EXTENDED_READ)
-            tryConfigDotXml(wc, 500, "Config perm should imply EXTENDED_READ");
+            // Has only CONFIGURE permission (this should imply EXTENDED_READ)
+            wc.withBasicApiToken(User.getById("bob", true));  
+            tryConfigDotXml(wc, HttpURLConnection.HTTP_INTERNAL_ERROR, "Config perm should imply EXTENDED_READ");
 
-            wc.withBasicApiToken(User.getById("charlie", true));  // Has only EXTENDED_READ permission
-            tryConfigDotXml(wc, 403, "No permission, should get 403");
+            // Has only EXTENDED_READ permission
+            wc.withBasicApiToken(User.getById("charlie", true));  
+            tryConfigDotXml(wc, HttpURLConnection.HTTP_FORBIDDEN, "No permission, should get 403");
         } finally {
             Item.EXTENDED_READ.setEnabled(saveEnabled);
         }
@@ -236,17 +240,17 @@ public class JobTest {
 
     private static void tryConfigDotXml(JenkinsRule.WebClient wc, int status, String msg) throws Exception {
         // Verify we can GET the config.xml:
-        wc.goTo("job/testJob/config.xml", "application/xml");
+        Page p = wc.goTo("job/testJob/config.xml", "application/xml");
+        assertEquals("Retrieving config.xml should be ok", HttpURLConnection.HTTP_OK, p.getWebResponse().getStatusCode());
+        
         // This page is a simple form to POST to /job/testJob/config.xml
         // But it posts invalid data so we expect 500 if we have permission, 403 if not
         HtmlPage page = wc.goTo("userContent/post.html");
-        try {
-            HtmlFormUtil.submit(page.getForms().get(0));
-            fail("Expected exception: " + msg);
-        } catch (FailingHttpStatusCodeException expected) {
-            assertEquals(msg, status, expected.getStatusCode());
-        }
-        wc.goTo("logout");
+        p = HtmlFormUtil.submit(page.getForms().get(0));
+        assertEquals(msg, status, p.getWebResponse().getStatusCode());
+        
+        p = wc.goTo("logout");
+        assertEquals("To logout should be ok", HttpURLConnection.HTTP_OK, p.getWebResponse().getStatusCode());
     }
 
     @LocalData @Issue("JENKINS-6371")

--- a/test/src/test/java/hudson/model/NodeTest.java
+++ b/test/src/test/java/hudson/model/NodeTest.java
@@ -23,7 +23,6 @@
  */
 package hudson.model;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
@@ -448,12 +447,10 @@ public class NodeTest {
         WebRequest settings = new WebRequest(wc.createCrumbedUrl("computer/(master)/config.xml"));
         settings.setHttpMethod(HttpMethod.POST);
         settings.setRequestBody("<hudson/>");
-        try {
-            Page page = wc.getPage(settings);
-            fail(page.getWebResponse().getContentAsString());
-        } catch (FailingHttpStatusCodeException x) {
-            assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, x.getStatusCode());
-        }
+
+        wc.setThrowExceptionOnFailingStatusCode(false);
+        Page page = wc.getPage(settings);
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, page.getWebResponse().getStatusCode());
     }
 
     /**

--- a/test/src/test/java/hudson/model/ParametersTest.java
+++ b/test/src/test/java/hudson/model/ParametersTest.java
@@ -51,22 +51,22 @@ public class ParametersTest {
         CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
         project.getBuildersList().add(builder);
 
-        WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage page = wc.goTo("job/" + project.getName() + "/build?delay=0sec");
 
         HtmlForm form = page.getFormByName("parameters");
 
-        HtmlElement element = (HtmlElement) DomNodeUtil.selectSingleNode(form, "//tr[td/div/input/@value='string']");
+        HtmlElement element = DomNodeUtil.selectSingleNode(form, "//tr[td/div/input/@value='string']");
         assertNotNull(element);
         assertEquals("string description", ((HtmlElement) DomNodeUtil.selectSingleNode(element.getNextSibling().getNextSibling(), "td[@class='setting-description']")).getTextContent());
 
-        HtmlTextInput stringParameterInput = (HtmlTextInput) DomNodeUtil.selectSingleNode(element, ".//input[@name='value']");
+        HtmlTextInput stringParameterInput = DomNodeUtil.selectSingleNode(element, ".//input[@name='value']");
         assertEquals("defaultValue", stringParameterInput.getAttribute("value"));
         assertEquals("string", ((HtmlElement) DomNodeUtil.selectSingleNode(element, "td[@class='setting-name']")).getTextContent());
         stringParameterInput.setAttribute("value", "newValue");
 
-        element = (HtmlElement) DomNodeUtil.selectSingleNode(form, "//tr[td/div/input/@value='boolean']");
+        element = DomNodeUtil.selectSingleNode(form, "//tr[td/div/input/@value='boolean']");
         assertNotNull(element);
         assertEquals("boolean description", ((HtmlElement) DomNodeUtil.selectSingleNode(element.getNextSibling().getNextSibling(), "td[@class='setting-description']")).getTextContent());
         Object o = DomNodeUtil.selectSingleNode(element, ".//input[@name='value']");
@@ -75,12 +75,12 @@ public class ParametersTest {
         assertEquals(true, booleanParameterInput.isChecked());
         assertEquals("boolean", ((HtmlElement) DomNodeUtil.selectSingleNode(element, "td[@class='setting-name']")).getTextContent());
 
-        element = (HtmlElement) DomNodeUtil.selectSingleNode(form, ".//tr[td/div/input/@value='choice']");
+        element = DomNodeUtil.selectSingleNode(form, ".//tr[td/div/input/@value='choice']");
         assertNotNull(element);
         assertEquals("choice description", ((HtmlElement) DomNodeUtil.selectSingleNode(element.getNextSibling().getNextSibling(), "td[@class='setting-description']")).getTextContent());
         assertEquals("choice", ((HtmlElement) DomNodeUtil.selectSingleNode(element, "td[@class='setting-name']")).getTextContent());
 
-        element = (HtmlElement) DomNodeUtil.selectSingleNode(form, ".//tr[td/div/input/@value='run']");
+        element = DomNodeUtil.selectSingleNode(form, ".//tr[td/div/input/@value='run']");
         assertNotNull(element);
         assertEquals("run description", ((HtmlElement) DomNodeUtil.selectSingleNode(element.getNextSibling().getNextSibling(), "td[@class='setting-description']")).getTextContent());
         assertEquals("run", ((HtmlElement) DomNodeUtil.selectSingleNode(element, "td[@class='setting-name']")).getTextContent());
@@ -105,16 +105,16 @@ public class ParametersTest {
         CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
         project.getBuildersList().add(builder);
 
-        WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage page = wc.goTo("job/" + project.getName() + "/build?delay=0sec");
         HtmlForm form = page.getFormByName("parameters");
 
-        HtmlElement element = (HtmlElement) DomNodeUtil.selectSingleNode(form, ".//tr[td/div/input/@value='choice']");
+        HtmlElement element = DomNodeUtil.selectSingleNode(form, ".//tr[td/div/input/@value='choice']");
         assertNotNull(element);
         assertEquals("choice description", ((HtmlElement) DomNodeUtil.selectSingleNode(element.getNextSibling().getNextSibling(), "td[@class='setting-description']")).getTextContent());
         assertEquals("choice", ((HtmlElement) DomNodeUtil.selectSingleNode(element, "td[@class='setting-name']")).getTextContent());
-        HtmlOption opt = (HtmlOption)DomNodeUtil.selectSingleNode(element, "td/div/select/option[@value='Choice <2>']");
+        HtmlOption opt = DomNodeUtil.selectSingleNode(element, "td/div/select/option[@value='Choice <2>']");
         assertNotNull(opt);
         assertEquals("Choice <2>", opt.asText());
         opt.setSelected(true);
@@ -192,8 +192,8 @@ public class ParametersTest {
                 new FileParameterDefinition("filename", "description"));
         project.addProperty(pdp);
 
-        WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage page = wc.goTo("job/" + project.getName() + "/build?delay=0sec");
         HtmlForm form = page.getFormByName("parameters");
 
@@ -215,12 +215,13 @@ public class ParametersTest {
         );
         p.addProperty(pdb);
 
-        WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false); // Ignore 405
+        WebClient wc = j.createWebClient()
+                // Ignore 405
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage page = wc.getPage(p, "build");
 
         // java.lang.IllegalArgumentException: No such parameter definition: <gibberish>.
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(true);
+        wc.setThrowExceptionOnFailingStatusCode(true);
         final HtmlForm form = page.getFormByName("parameters");
         HtmlFormUtil.submit(form, HtmlFormUtil.getButtonByCaption(form, "Build"));
     }
@@ -233,8 +234,8 @@ public class ParametersTest {
         StringParameterDefinition param = new StringParameterDefinition("<param name>", "<param default>", "<param description>");
         assertEquals("<b>[</b>param description<b>]</b>", param.getFormattedDescription());
         p.addProperty(new ParametersDefinitionProperty(param));
-        WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage page = wc.getPage(p, "build?delay=0sec");
         collector.checkThat(page.getWebResponse().getStatusCode(), is(HttpStatus.SC_METHOD_NOT_ALLOWED)); // 405 to dissuade scripts from thinking this triggered the build
         String text = page.getWebResponse().getContentAsString();

--- a/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
@@ -71,8 +71,9 @@ public class PasswordParameterDefinitionTest {
         User admin = User.getById("admin", true);
         User dev = User.getById("dev", true);
 
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false); // ParametersDefinitionProperty/index.jelly sends a 405 but really it is OK
+        JenkinsRule.WebClient wc = j.createWebClient()
+                // ParametersDefinitionProperty/index.jelly sends a 405 but really it is OK
+                .withThrowExceptionOnFailingStatusCode(false);
         // Control case: admin can use default value.
         j.submit(wc.withBasicApiToken(admin).getPage(p, "build?delay=0sec").getFormByName("parameters"));
         j.waitUntilNoActivity();

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.javascript.host.event.Event;
 import hudson.*;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.security.AccessDeniedException2;
@@ -252,7 +253,8 @@ public class ProjectTest {
         assertEquals("Scm retry count should be the same as global scm retry count.", 6, p.getScmCheckoutRetryCount());
         HtmlForm form = j.createWebClient().goTo(p.getUrl() + "/configure").getFormByName("config");
         ((HtmlElement)form.getByXPath("//div[@class='advancedLink']//button").get(0)).click();
-        form.getInputByName("hasCustomScmCheckoutRetryCount").click();
+        // required due to the new default behavior of click
+        form.getInputByName("hasCustomScmCheckoutRetryCount").click(new Event(), true);
         form.getInputByName("scmCheckoutRetryCount").setValueAttribute("7");
         j.submit(form);
         assertEquals("Scm retry count was set.", 7, p.getScmCheckoutRetryCount());

--- a/test/src/test/java/hudson/model/QueueSEC891Test.java
+++ b/test/src/test/java/hudson/model/QueueSEC891Test.java
@@ -59,9 +59,9 @@ public class QueueSEC891Test {
         WebRequest request = new WebRequest(new URL(r.getURL() + urlProvider.apply(currentOne)), HttpMethod.POST);
         
         { // user without right cannot cancel
-            JenkinsRule.WebClient wc = r.createWebClient();
-            wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
-            wc.getOptions().setRedirectEnabled(false);
+            JenkinsRule.WebClient wc = r.createWebClient()
+                    .withRedirectEnabled(false)
+                    .withThrowExceptionOnFailingStatusCode(false);
             wc.login("user");
             Page p = wc.getPage(request);
             // currently the endpoint return a redirection to the previously visited page, none in our case 
@@ -71,9 +71,9 @@ public class QueueSEC891Test {
             assertFalse(currentOne.getFuture().isCancelled());
         }
         { // user with right can
-            JenkinsRule.WebClient wc = r.createWebClient();
-            wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
-            wc.getOptions().setRedirectEnabled(false);
+            JenkinsRule.WebClient wc = r.createWebClient()
+                    .withRedirectEnabled(false)
+                    .withThrowExceptionOnFailingStatusCode(false);
             wc.login("admin");
             Page p = wc.getPage(request);
             assertThat(p.getWebResponse().getStatusCode(), lessThan(400));

--- a/test/src/test/java/hudson/model/UserRestartSEC897Test.java
+++ b/test/src/test/java/hudson/model/UserRestartSEC897Test.java
@@ -32,16 +32,16 @@ public class UserRestartSEC897Test {
                 User.getById("admin", true).save();
                 
                 { // attempt with ".."
-                    JenkinsRule.WebClient wc = rr.j.createWebClient();
-                    wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+                    JenkinsRule.WebClient wc = rr.j.createWebClient()
+                            .withThrowExceptionOnFailingStatusCode(false);
                     
                     WebRequest request = new WebRequest(new URL(rr.j.jenkins.getRootUrl() + "whoAmI/api/xml"));
                     request.setAdditionalHeader("Authorization", base64("..", "any-password"));
                     wc.getPage(request);
                 }
                 { // attempt with "../users/.."
-                    JenkinsRule.WebClient wc = rr.j.createWebClient();
-                    wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+                    JenkinsRule.WebClient wc = rr.j.createWebClient()
+                            .withThrowExceptionOnFailingStatusCode(false);
                     
                     WebRequest request = new WebRequest(new URL(rr.j.jenkins.getRootUrl() + "whoAmI/api/xml"));
                     request.setAdditionalHeader("Authorization", base64("../users/..", "any-password"));

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -24,6 +24,7 @@
 package hudson.model;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
+import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
@@ -31,7 +32,6 @@ import jenkins.model.Jenkins;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.jvnet.hudson.test.Issue;
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
@@ -56,6 +56,7 @@ import hudson.util.FormValidation;
 import hudson.util.HudsonIsLoading;
 import java.io.File;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -120,19 +121,19 @@ public class ViewTest {
     @Test public void conflictingName() throws Exception {
         assertNull(j.jenkins.getView("foo"));
 
-        HtmlForm form = j.createWebClient().goTo("newView").getFormByName("createItem");
+        WebClient wc = j.createWebClient();
+        HtmlForm form = wc.goTo("newView").getFormByName("createItem");
         form.getInputByName("name").setValueAttribute("foo");
         form.getRadioButtonsByName("mode").get(0).setChecked(true);
         j.submit(form);
         assertNotNull(j.jenkins.getView("foo"));
 
+        wc.setThrowExceptionOnFailingStatusCode(false);
         // do it again and verify an error
-        try {
-            j.submit(form);
-            fail("shouldn't be allowed to create two views of the same name.");
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(400, e.getStatusCode());
-        }
+        Page page = j.submit(form);
+        assertEquals("shouldn't be allowed to create two views of the same name.", 
+                HttpURLConnection.HTTP_BAD_REQUEST, 
+                page.getWebResponse().getStatusCode());
     }
 
     @Test public void privateView() throws Exception {
@@ -209,23 +210,24 @@ public class ViewTest {
             IconSet.icons.addIcon(new Icon("icon-folder icon-md", "24x24/folder.gif", "width: 24px; height: 24px;"));
         }
         
-        WebClient webClient = j.createWebClient();
+        WebClient webClient = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         webClient.getOptions().setJavaScriptEnabled(false);
         j.assertAllImageLoadSuccessfully(webClient.goTo("asynchPeople"));
     }
 
     @Issue("JENKINS-16608")
     @Test public void notAllowedName() throws Exception {
-        HtmlForm form = j.createWebClient().goTo("newView").getFormByName("createItem");
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
+        HtmlForm form = wc.goTo("newView").getFormByName("createItem");
         form.getInputByName("name").setValueAttribute("..");
         form.getRadioButtonsByName("mode").get(0).setChecked(true);
 
-        try {
-            j.submit(form);
-            fail("\"..\" should not be allowed.");
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(400, e.getStatusCode());
-        }
+        HtmlPage page = j.submit(form);
+        assertEquals("\"..\" should not be allowed.",
+                HttpURLConnection.HTTP_BAD_REQUEST, 
+                page.getWebResponse().getStatusCode());
     }
 
     @Ignore("verified manually in Winstone but org.mortbay.JettyResponse.sendRedirect (6.1.26) seems to mangle the location")

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -246,7 +246,7 @@ public class ViewTest {
         ListView view = listView("v");
         view.description = "one";
         WebClient wc = j.createWebClient();
-        String xml = wc.goToXml("view/v/config.xml").getContent();
+        String xml = wc.goToXml("view/v/config.xml").getWebResponse().getContentAsString();
         assertTrue(xml, xml.contains("<description>one</description>"));
         xml = xml.replace("<description>one</description>", "<description>two</description>");
         WebRequest req = new WebRequest(wc.createCrumbedUrl("view/v/config.xml"), HttpMethod.POST);

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -27,12 +27,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.FreeStyleProject;
 import hudson.model.ListView;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URL;
 
 import java.util.ArrayList;
@@ -43,7 +44,6 @@ import hudson.model.User;
 import hudson.model.View;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
-import hudson.security.AuthorizationStrategy;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
@@ -58,8 +58,6 @@ import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockFolder;
 
-import com.gargoylesoftware.htmlunit.AlertHandler;
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.Page;
 
 /**
@@ -74,12 +72,10 @@ public class SearchTest {
      */
     @Test
     public void testFailure() throws Exception {
-        try {
-            j.search("no-such-thing");
-            fail("404 expected");
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(404,e.getResponse().getStatusCode());
-        }
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
+        HtmlPage resultPage = wc.search("no-such-thing");
+        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, resultPage.getWebResponse().getStatusCode());
     }
 
     /**
@@ -88,18 +84,13 @@ public class SearchTest {
     @Issue("JENKINS-3415")
     @Test
     public void testXSS() throws Exception {
-        try {
-            WebClient wc = j.createWebClient();
-            wc.setAlertHandler(new AlertHandler() {
-                public void handleAlert(Page page, String message) {
-                    throw new AssertionError();
-                }
-            });
-            wc.search("<script>alert('script');</script>");
-            fail("404 expected");
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(404,e.getResponse().getStatusCode());
-        }
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
+        wc.setAlertHandler((page, message) -> {
+            throw new AssertionError();
+        });
+        HtmlPage resultPage = wc.search("<script>alert('script');</script>");
+        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, resultPage.getWebResponse().getStatusCode());
     }
     
     @Test

--- a/test/src/test/java/hudson/tools/ZipExtractionInstallerTest.java
+++ b/test/src/test/java/hudson/tools/ZipExtractionInstallerTest.java
@@ -24,7 +24,6 @@
 package hudson.tools;
 
 import com.gargoylesoftware.htmlunit.HttpMethod;
-import com.gargoylesoftware.htmlunit.InteractivePage;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
@@ -148,7 +147,7 @@ public class ZipExtractionInstallerTest {
         }
         
         @Override
-        public Object callFunction(InteractivePage page, Function function, Scriptable scope, Scriptable thisObject, Object[] args) {
+        public Object callFunction(HtmlPage page, Function function, Scriptable scope, Scriptable thisObject, Object[] args) {
             if (thisObject instanceof XMLHttpRequest) {
                 try {
                     WebRequest request = getPrivateWebRequestField((XMLHttpRequest) thisObject);

--- a/test/src/test/java/hudson/tools/ZipExtractionInstallerTest.java
+++ b/test/src/test/java/hudson/tools/ZipExtractionInstallerTest.java
@@ -45,6 +45,7 @@ import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -87,12 +88,12 @@ public class ZipExtractionInstallerTest {
         
         JenkinsRule.WebClient adminWc = j.createWebClient();
         adminWc.login(ADMIN);
-        assertEquals(200, adminWc.getPage(request).getWebResponse().getStatusCode());
+        assertEquals(HttpURLConnection.HTTP_OK, adminWc.getPage(request).getWebResponse().getStatusCode());
         
-        JenkinsRule.WebClient userWc = j.createWebClient();
-        userWc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient userWc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         userWc.login(USER);
-        assertEquals(403, userWc.getPage(request).getWebResponse().getStatusCode());
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, userWc.getPage(request).getWebResponse().getStatusCode());
     }
     
     @Test

--- a/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -24,6 +24,7 @@
 
 package hudson.util;
 
+import com.gargoylesoftware.htmlunit.Page;
 import hudson.cli.CLICommandInvoker;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.AbstractDescribableImpl;
@@ -38,6 +39,7 @@ import hudson.model.User;
 import hudson.security.ACL;
 
 import java.io.ByteArrayInputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
@@ -45,7 +47,6 @@ import java.util.Map;
 import jenkins.model.Jenkins;
 import static org.junit.Assert.*;
 
-import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
 import jenkins.security.apitoken.ApiTokenTestHelper;
 import net.sf.json.JSONObject;
 
@@ -59,7 +60,6 @@ import org.jvnet.hudson.test.recipes.LocalData;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.WebRequest;
 
@@ -236,18 +236,17 @@ public class RobustReflectionConverterTest {
             
             // Configure a bad keyword via REST.
             r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
-            WebClient wc = r.createWebClient();
+            WebClient wc = r.createWebClient()
+                    .withThrowExceptionOnFailingStatusCode(false);
             wc.withBasicApiToken(test);
             WebRequest req = new WebRequest(new URL(wc.getContextPath() + String.format("%s/config.xml", p.getUrl())), HttpMethod.POST);
             req.setEncodingType(null);
             req.setRequestBody(String.format(CONFIGURATION_TEMPLATE, AcceptOnlySpecificKeyword.ACCEPT_KEYWORD, "badvalue"));
             
-            try {
-                wc.getPage(req);
-                fail("Submitting unacceptable configuration via REST should fail.");
-            } catch (FailingHttpStatusCodeException e) {
-                // pass
-            }
+            Page page = wc.getPage(req);
+            assertEquals("Submitting unacceptable configuration via REST should fail.", 
+                    HttpURLConnection.HTTP_INTERNAL_ERROR,
+                    page.getWebResponse().getStatusCode());
             
             // Configuration should not be updated for a failure of the critical field,
             assertNotEquals("badvalue", p.getProperty(KeywordProperty.class).getCriticalField().getKeyword());

--- a/test/src/test/java/jenkins/bugs/Jenkins19124Test.java
+++ b/test/src/test/java/jenkins/bugs/Jenkins19124Test.java
@@ -41,7 +41,10 @@ public class Jenkins19124Test {
         JenkinsRule.WebClient wc = j.createWebClient();
         HtmlPage c = wc.getPage(p, "configure");
         HtmlTextInput alpha = c.getElementByName("_.alpha");
+        // the fireEvent is required as setValueAttribute's new behavior is not triggering the onChange event anymore
         alpha.setValueAttribute("hello");
+        alpha.fireEvent("change");
+
         WebClientUtil.waitForJSExec(wc);
         assertEquals("hello", d.alpha);
         assertEquals("2", d.bravo);

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -337,33 +337,30 @@ public class JenkinsTest {
             grant(Jenkins.READ).everywhere().to("bob").
             grantWithoutImplication(Jenkins.ADMINISTER, Jenkins.READ).everywhere().to("charlie"));
 
-        WebClient wc = j.createWebClient();
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false)
+                .withBasicApiToken(User.getById("alice", true));
 
-        wc.withBasicApiToken(User.getById("alice", true));
         wc.assertFails("eval", HttpURLConnection.HTTP_BAD_METHOD);
-        assertEquals("3", eval(wc));
+        assertEquals("3", eval(wc).getWebResponse().getContentAsString());
 
         wc.withBasicApiToken(User.getById("bob", true));
-        try {
-            eval(wc);
-            fail("bob has only READ");
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, e.getStatusCode());
-        }
+        Page page = eval(wc);
+        assertEquals("bob has only READ", 
+                HttpURLConnection.HTTP_FORBIDDEN, 
+                page.getWebResponse().getStatusCode());
 
         wc.withBasicApiToken(User.getById("charlie", true));
-        try {
-            eval(wc);
-            fail("charlie has ADMINISTER but not RUN_SCRIPTS");
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, e.getStatusCode());
-        }
+        page = eval(wc);
+        assertEquals("charlie has ADMINISTER but not RUN_SCRIPTS", 
+                HttpURLConnection.HTTP_FORBIDDEN,
+                page.getWebResponse().getStatusCode());
     }
-    private String eval(WebClient wc) throws Exception {
+    private Page eval(WebClient wc) throws Exception {
         WebRequest req = new WebRequest(new URL(wc.getContextPath() + "eval"), HttpMethod.POST);
         req.setEncodingType(null);
         req.setRequestBody("<j:jelly xmlns:j='jelly:core'>${1+2}</j:jelly>");
-        return wc.getPage(req).getWebResponse().getContentAsString();
+        return wc.getPage(req);
     }
 
     @TestExtension("testUnprotectedRootAction")
@@ -411,13 +408,13 @@ public class JenkinsTest {
         j.jenkins.setAuthorizationStrategy(auth);
 
         // no anonymous read access
-        assertTrue(!Jenkins.getInstance().hasPermission(Jenkins.ANONYMOUS,Jenkins.READ));
+        assertTrue(!Jenkins.get().hasPermission(Jenkins.ANONYMOUS, Jenkins.READ));
 
-        WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("error/reportError");
 
-        assertEquals(p.asText(), 400, p.getWebResponse().getStatusCode());  // not 403 forbidden
+        assertEquals(p.asText(), HttpURLConnection.HTTP_BAD_REQUEST, p.getWebResponse().getStatusCode());  // not 403 forbidden
         assertTrue(p.getWebResponse().getContentAsString().contains("My car is black"));
     }
 
@@ -462,8 +459,8 @@ public class JenkinsTest {
 
         URL url = new URL(j.getURL(), "computer/" + slave.getNodeName() + "/scriptText?script=println(42)");
 
-        WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
 
         WebRequest req = new WebRequest(url, HttpMethod.POST);
         Page page = wc.getPage(wc.addCrumb(req));

--- a/test/src/test/java/jenkins/security/ApiTokenPropertyTest.java
+++ b/test/src/test/java/jenkins/security/ApiTokenPropertyTest.java
@@ -24,6 +24,8 @@ import hudson.model.FreeStyleProject;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+
+import java.net.HttpURLConnection;
 import java.net.URL;
 
 import jenkins.model.Jenkins;
@@ -139,12 +141,14 @@ public class ApiTokenPropertyTest {
         final ApiTokenProperty.DescriptorImpl descriptor = (ApiTokenProperty.DescriptorImpl) t.getDescriptor();
         
         // Make sure that Admin can reset a token of another user
-        WebClient wc = createClientForUser("bar");
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        WebClient wc = createClientForUser("bar")
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage requirePOST = wc.goTo(foo.getUrl() + "/" + descriptor.getDescriptorUrl()+ "/changeToken");
-        assertEquals("method should not be allowed", 405, requirePOST.getWebResponse().getStatusCode());
+        assertEquals("method should not be allowed", 
+                HttpURLConnection.HTTP_BAD_METHOD, 
+                requirePOST.getWebResponse().getStatusCode());
 
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(true);
+        wc.setThrowExceptionOnFailingStatusCode(true);
         WebRequest request = new WebRequest(new URL(j.getURL().toString() + foo.getUrl() + "/" + descriptor.getDescriptorUrl()+ "/changeToken"), HttpMethod.POST);
         HtmlPage res = wc.getPage(request);
 
@@ -163,7 +167,7 @@ public class ApiTokenPropertyTest {
         WebClient wc = createClientForUser("foo");
         WebRequest wr = new WebRequest(new URL(j.getURL(), "job/bar/build"), HttpMethod.POST);
 
-        assertEquals(201, wc.getPage(wr).getWebResponse().getStatusCode());
+        assertEquals(HttpURLConnection.HTTP_CREATED, wc.getPage(wr).getWebResponse().getStatusCode());
 
         j.waitUntilNoActivity();
 

--- a/test/src/test/java/jenkins/security/RekeySecretAdminMonitorTest.java
+++ b/test/src/test/java/jenkins/security/RekeySecretAdminMonitorTest.java
@@ -11,7 +11,6 @@ import hudson.Util;
 import hudson.util.Secret;
 import hudson.util.SecretHelper;
 import org.apache.commons.io.FileUtils;
-import org.hamcrest.CoreMatchers;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.recipes.Recipe.Runner;
 import org.xml.sax.SAXException;
@@ -22,8 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.regex.Pattern;
-
-import static org.junit.Assert.assertThat;
+import java.util.stream.Stream;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -132,7 +130,18 @@ public class RekeySecretAdminMonitorTest extends HudsonTestCase {
     }
 
     private HtmlButton getButton(HtmlForm form, int index) {
-        return form.<HtmlButton>getHtmlElementsByTagName("button").get(index);
+        // due to the removal of method HtmlElement.getHtmlElementsByTagName
+        Stream<HtmlButton> buttonStream = form.getElementsByTagName("button").stream()
+                .filter(HtmlButton.class::isInstance)
+                .map(HtmlButton.class::cast);
+
+        if (index > 0) {
+            buttonStream = buttonStream.skip(index - 1);
+        }
+        
+        return buttonStream
+                .findFirst()
+                .orElse(null);
     }
 
     public void testScanOnBoot() throws Exception {

--- a/test/src/test/java/jenkins/security/Security177Test.java
+++ b/test/src/test/java/jenkins/security/Security177Test.java
@@ -19,8 +19,8 @@ public class Security177Test {
     
     @Test
     public void nosniff() throws Exception {
-        WebClient wc = jenkins.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        WebClient wc = jenkins.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
 
         URL u = jenkins.getURL();
         verifyNoSniff(wc.getPage(new URL(u, "adjuncts/507db12b/nosuch/adjunct.js")));

--- a/test/src/test/java/jenkins/security/apitoken/ApiTokenStatsTest.java
+++ b/test/src/test/java/jenkins/security/apitoken/ApiTokenStatsTest.java
@@ -67,8 +67,9 @@ public class ApiTokenStatsTest {
         assertNotNull(t.getTokenStats());
         
         // test the authentication via Token
-        WebClient wc = j.createWebClient().withBasicCredentials(u.getId());
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        WebClient wc = j.createWebClient()
+                .withBasicCredentials(u.getId())
+                .withThrowExceptionOnFailingStatusCode(false);
         
         final String TOKEN_NAME = "New Token Name";
         

--- a/test/src/test/java/jenkins/security/stapler/Security914Test.java
+++ b/test/src/test/java/jenkins/security/stapler/Security914Test.java
@@ -33,6 +33,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestPluginManager;
 
+import java.net.HttpURLConnection;
 import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
@@ -53,8 +54,8 @@ public class Security914Test {
         }
         j.createWebClient().goTo("plugin/credentials/images/24x24/credentials.png", "image/png");
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         WebRequest request = new WebRequest(new URL(j.getURL() + "plugin/credentials/.xml"));
         // plugin deployed in: test\target\jenkins7375296945862059919tmp
         // rootDir is in     : test\target\jenkinsTests.tmp\jenkins1274934531848159942test
@@ -62,7 +63,7 @@ public class Security914Test {
         request.setAdditionalHeader("Accept-Language", "../../../../jenkinsTests.tmp/" + j.jenkins.getRootDir().getName() + "/config");
         
         Page p = wc.getPage(request);
-        assertEquals(p.getWebResponse().getStatusCode(), 404);
+        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, p.getWebResponse().getStatusCode());
         assertNotEquals(p.getWebResponse().getContentType(), "application/xml");
     }
     
@@ -75,14 +76,14 @@ public class Security914Test {
         }
         j.createWebClient().goTo("plugin/credentials/images/24x24/credentials.png", "image/png");
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         WebRequest request = new WebRequest(new URL(j.getURL() + "plugin/credentials/.ini"));
         // ../ can be multiply to infinity, no impact, we just need to have enough to reach the root
         request.setAdditionalHeader("Accept-Language", "../../../../../../../../../../../../windows/win");
         
         Page p = wc.getPage(request);
-        assertEquals(p.getWebResponse().getStatusCode(), 404);
+        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, p.getWebResponse().getStatusCode());
         assertEquals(p.getWebResponse().getContentType(), "text/html");
     }
 }

--- a/test/src/test/java/lib/form/ExpandableTextboxTest.java
+++ b/test/src/test/java/lib/form/ExpandableTextboxTest.java
@@ -99,8 +99,8 @@ public class ExpandableTextboxTest {
     private void checkRegularCase(TestRootAction testParams) throws Exception {
         testParams.paramName = "testName";
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
         
         HtmlElementUtil.click(getExpandButton(p));
@@ -110,8 +110,8 @@ public class ExpandableTextboxTest {
     private void checkInjectionInName(TestRootAction testParams) throws Exception {
         testParams.paramName = "testName',document.title='hacked'+'";
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
         
         HtmlElementUtil.click(getExpandButton(p));

--- a/test/src/test/java/lib/form/PasswordTest.java
+++ b/test/src/test/java/lib/form/PasswordTest.java
@@ -148,7 +148,7 @@ public class PasswordTest {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             String pName = p.getFullName();
             getJobCommand.main(Collections.singletonList(pName), Locale.ENGLISH, System.in, new PrintStream(baos), System.err);
-            assertEquals(xmlAdmin, baos.toString(configXml.getWebResponse().getContentCharset()));
+            assertEquals(xmlAdmin, baos.toString(configXml.getWebResponse().getContentCharset().name()));
             CopyJobCommand copyJobCommand = new CopyJobCommand();
             copyJobCommand.setTransportAuth(adminAuth);
             String pAdminName = pName + "-admin";
@@ -171,7 +171,7 @@ public class PasswordTest {
             getJobCommand.setTransportAuth(devAuth);
             baos = new ByteArrayOutputStream();
             getJobCommand.main(Collections.singletonList(pName), Locale.ENGLISH, System.in, new PrintStream(baos), System.err);
-            assertEquals(xmlDev, baos.toString(configXml.getWebResponse().getContentCharset()));
+            assertEquals(xmlDev, baos.toString(configXml.getWebResponse().getContentCharset().name()));
             copyJobCommand = new CopyJobCommand();
             copyJobCommand.setTransportAuth(devAuth);
             String pDevName = pName + "-dev";
@@ -194,7 +194,9 @@ public class PasswordTest {
         }
         VulnerableProperty.DescriptorImpl.incomingURL = null;
         String secret = "s3cr3t";
+        // the fireEvent is required as setText's new behavior is not triggering the onChange event anymore
         field.setText(secret);
+        field.fireEvent("change");
         while (VulnerableProperty.DescriptorImpl.incomingURL == null) {
             Thread.sleep(100); // form validation of edited value
         }

--- a/test/src/test/java/lib/form/ValidateButtonTest.java
+++ b/test/src/test/java/lib/form/ValidateButtonTest.java
@@ -128,8 +128,8 @@ public class ValidateButtonTest {
         descriptor.paramMethod = "validateInjection";
         descriptor.paramWith = "a,b";
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
         
         descriptor.wasCalled = false;
@@ -142,8 +142,8 @@ public class ValidateButtonTest {
         descriptor.paramMethod = "validateInjection',document.title='hacked'+'";
         descriptor.paramWith = "a,b";
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
         
         // no check on wasCalled because the button that is expected by the method is not passed (arguments are shifted due to the injection)
@@ -156,8 +156,8 @@ public class ValidateButtonTest {
         descriptor.paramMethod = "validateInjection";
         descriptor.paramWith = "a,b',document.title='hacked'+'";
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
         
         descriptor.wasCalled = false;

--- a/test/src/test/java/lib/layout/ConfirmationLinkTest.java
+++ b/test/src/test/java/lib/layout/ConfirmationLinkTest.java
@@ -41,6 +41,8 @@ import org.kohsuke.stapler.WebMethod;
 
 import javax.annotation.CheckForNull;
 
+import java.net.HttpURLConnection;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -111,8 +113,8 @@ public class ConfirmationLinkTest {
     }
     
     private Page getPageAfterClick() throws Exception {
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
     
         return HtmlElementUtil.click(getClickableLink(p));
@@ -124,15 +126,15 @@ public class ConfirmationLinkTest {
         testParams.paramClass = null;
         testParams.paramPost = null;
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
         
         Page pageAfterClick = HtmlElementUtil.click(getClickableLink(p));
         assertNotEquals("hacked", p.getTitleText());
         assertTrue(p.getWebResponse().getContentAsString().contains("Message to confirm the click"));
         // the url it clicks on is escaped and so does not exist
-        assertEquals(404, pageAfterClick.getWebResponse().getStatusCode());
+        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, pageAfterClick.getWebResponse().getStatusCode());
     }
     
     private void checkInjectionInMessage(TestRootAction testParams) throws Exception {
@@ -141,14 +143,14 @@ public class ConfirmationLinkTest {
         testParams.paramClass = null;
         testParams.paramPost = null;
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
     
         Page pageAfterClick = HtmlElementUtil.click(getClickableLink(p));
         assertNotEquals("hacked", p.getTitleText());
         // the url is normally the same page so it's ok
-        assertEquals(200, pageAfterClick.getWebResponse().getStatusCode());
+        assertEquals(HttpURLConnection.HTTP_OK, pageAfterClick.getWebResponse().getStatusCode());
     }
     
     private void checkInjectionInPost(TestRootAction testParams) throws Exception {
@@ -157,15 +159,15 @@ public class ConfirmationLinkTest {
         testParams.paramClass = null;
         testParams.paramPost = postPayload;
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
         
         Page pageAfterClick = HtmlElementUtil.click(getClickableLink(p));
         assertNotEquals("hacked", p.getTitleText());
         assertTrue(p.getWebResponse().getContentAsString().contains("Message to confirm the click"));
         // the url is normally the same page so it's ok
-        assertEquals(200, pageAfterClick.getWebResponse().getStatusCode());
+        assertEquals(HttpURLConnection.HTTP_OK, pageAfterClick.getWebResponse().getStatusCode());
     }
     
     private HtmlAnchor getClickableLink(HtmlPage page){

--- a/test/src/test/java/lib/layout/StopButtonTest.java
+++ b/test/src/test/java/lib/layout/StopButtonTest.java
@@ -77,8 +77,8 @@ public class StopButtonTest {
         testParams.paramAlt = "Alternative text for icon";
         testParams.paramConfirm = null;
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
     
         HtmlElementUtil.click(getStopLink(p));
@@ -91,8 +91,8 @@ public class StopButtonTest {
         testParams.paramAlt = "Alternative text for icon";
         testParams.paramConfirm = "Confirm message";
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
     
         HtmlElementUtil.click(getStopLink(p));
@@ -105,8 +105,8 @@ public class StopButtonTest {
         testParams.paramAlt = "Alternative text for icon";
         testParams.paramConfirm = postPayload;
         
-        JenkinsRule.WebClient wc = j.createWebClient();
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
         HtmlPage p = wc.goTo("test");
     
         HtmlElementUtil.click(getStopLink(p));


### PR DESCRIPTION
- downstream of https://github.com/jenkinsci/jenkins-test-harness/pull/109
- update of commons-io from 2.4 to 2.6 to be ok with JTH:2.42. It's fully compatible with 2.4 cf [upgrade to 2.5](https://commons.apache.org/proper/commons-io/upgradeto2_5.html) and [upgrade to 2.6](https://commons.apache.org/proper/commons-io/upgradeto2_6.html).

See [JENKINS-53511](https://issues.jenkins-ci.org/browse/JENKINS-53511).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Developer: Improve discovery and readability of WebClient most popular options.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
