### PR TITLE
[Jenkins-24846] UI Improvement: Update Center

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/check.jelly
+++ b/core/src/main/resources/hudson/PluginManager/check.jelly
@@ -28,6 +28,23 @@ THE SOFTWARE.
     ${%lastUpdated(app.updateCenter.lastUpdatedString)}
   </div>
   <div>
+    <j:set var="lastCheck" value="0" />
+    <j:forEach var="s" items="${app.updateCenter.sites}">
+      <j:choose>
+        <j:set var="siteLastCheck" value="${s.dataTimestamp}" />
+        <j:when test="${lastCheck==0}">
+          <j:set var="lastCheck" value="${siteLastCheck}" />
+        </j:when>
+        <j:when test="${lastCheck gt siteLastCheck}">
+          <j:set var="lastCheck" value="${siteLastCheck}" />
+        </j:when>
+      </j:choose>
+    </j:forEach>
+    <j:if test="${lastCheck + 2 * 3600000 lt System.currentTimeMillis()}">
+      ${%lastUpdatedIsStale}
+    </j:if>
+  </div>
+  <div>
     <f:link href="${ds.useBrowser ? 'checkUpdates' : 'checkUpdatesServer'}" post="true" clazz="yui-button yui-submit-button submit-button primary">
       <button>${%Check now}</button>
     </f:link>

--- a/core/src/main/resources/hudson/PluginManager/check.jelly
+++ b/core/src/main/resources/hudson/PluginManager/check.jelly
@@ -23,15 +23,16 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-
   <j:invokeStatic var="ds" className="jenkins.model.DownloadSettings" method="get"/>
-  ${%lastUpdated(app.updateCenter.lastUpdatedString)}
-  <f:link href="${ds.useBrowser ? 'checkUpdates' : 'checkUpdatesServer'}" post="true" clazz="yui-button yui-submit-button submit-button primary">
-    <button>${%Check now}</button>
-  </f:link>
-  <j:if test="${app.pluginManager.lastErrorCheckUpdateCenters != null}">
-    <div class="error">
-      ${app.pluginManager.lastErrorCheckUpdateCenters}
-    </div>
-  </j:if>
+  <div>
+    ${%lastUpdated(app.updateCenter.lastUpdatedString)}
+    <f:link href="${ds.useBrowser ? 'checkUpdates' : 'checkUpdatesServer'}" post="true" clazz="yui-button yui-submit-button submit-button primary">
+      <button>${%Check now}</button>
+    </f:link>
+    <j:if test="${app.pluginManager.lastErrorCheckUpdateCenters != null}">
+      <div class="error">
+        ${app.pluginManager.lastErrorCheckUpdateCenters}
+      </div>
+    </j:if>
+  </div>
 </j:jelly>

--- a/core/src/main/resources/hudson/PluginManager/check.jelly
+++ b/core/src/main/resources/hudson/PluginManager/check.jelly
@@ -26,6 +26,8 @@ THE SOFTWARE.
   <j:invokeStatic var="ds" className="jenkins.model.DownloadSettings" method="get"/>
   <div>
     ${%lastUpdated(app.updateCenter.lastUpdatedString)}
+  </div>
+  <div>
     <f:link href="${ds.useBrowser ? 'checkUpdates' : 'checkUpdatesServer'}" post="true" clazz="yui-button yui-submit-button submit-button primary">
       <button>${%Check now}</button>
     </f:link>

--- a/core/src/main/resources/hudson/PluginManager/check.properties
+++ b/core/src/main/resources/hudson/PluginManager/check.properties
@@ -21,3 +21,4 @@
 # THE SOFTWARE.
 
 lastUpdated=Update information obtained: {0} ago
+lastUpdatedIsStale=Last checked for plugin updates more than 2 hours ago. You should check again before updating.

--- a/core/src/main/resources/hudson/PluginManager/index.jelly
+++ b/core/src/main/resources/hudson/PluginManager/index.jelly
@@ -27,11 +27,13 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <local:table page="updates" list="${app.updateCenter.updates}" xmlns:local="/hudson/PluginManager">
-    <div style="margin-top:1em">
+  <div>
       ${%Select}: <a href="javascript:toggleCheckboxes(true);">${%All}</a>,
                   <a href="javascript:checkPluginsWithoutWarnings();">${%Compatible}</a>,
                   <a href="javascript:toggleCheckboxes(false);">${%None}</a><br/>
+  </div>
+  <local:table page="updates" list="${app.updateCenter.updates}" xmlns:local="/hudson/PluginManager">
+    <div style="margin-top:1em">
       ${%UpdatePageDescription}
       <j:if test="${!empty(app.updateCenter.jobs)}">
         <br/> ${%UpdatePageLegend(rootURL+'/updateCenter/')}

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -167,8 +167,8 @@ THE SOFTWARE.
               <f:submit value="${%Download now and install after restart}" />
             </j:if>
             <st:include page="check.jelly"/>
-            </div>
           </div>
+        </div>
         <d:invokeBody />
       </form>
     </l:main-panel>

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -58,6 +58,19 @@ THE SOFTWARE.
       <form method="post" action="install">
         <j:set var="isUpdates" value="${attrs.page=='updates'}" />
         <local:tabBar page="${attrs.page}" xmlns:local="/hudson/PluginManager" />
+
+        <div id="top-sticker" >
+          <div class="top-sticker-inner">
+            <j:if test="${!empty(list)}">
+              <j:if test="${!isUpdates}">
+                <f:submit value="${%Install without restart}" name="dynamicLoad" />
+                <span style="margin-left:2em;"></span>
+              </j:if>
+              <f:submit value="${%Download now and install after restart}" />
+            </j:if>
+          </div>
+        </div>
+
         <div class="pane-frame">
           <table id="plugins" class="sortable pane bigtable stripped-odd">
             <tr>
@@ -159,13 +172,6 @@ THE SOFTWARE.
 
         <div id="bottom-sticker" >
           <div class="bottom-sticker-inner">
-            <j:if test="${!empty(list)}">
-              <j:if test="${!isUpdates}">
-                <f:submit value="${%Install without restart}" name="dynamicLoad" />
-                <span style="margin-left:2em;"></span>
-              </j:if>
-              <f:submit value="${%Download now and install after restart}" />
-            </j:if>
             <st:include page="check.jelly"/>
           </div>
         </div>


### PR DESCRIPTION
See [JENKINS-24846](https://issues.jenkins-ci.org/browse/JENKINS-24846).

### Proposed changelog entries

* Move select all/none to top of update center
* Split check for updates to its own line
* Include a note when the last update check is more than 2 hours stale
* Move Select All/None above the box

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

### Before
![image](https://user-images.githubusercontent.com/2119212/45459402-28421780-b6c6-11e8-899f-6cec833a6423.png)

### After (no updates)
![image](https://user-images.githubusercontent.com/2119212/45459740-d13d4200-b6c7-11e8-9ea6-5d16688839bb.png)

Note: We may want to colorize the select all/none row. It's also possible that the right thing to do would be to make it a component and include it both at the top and bottom.