### PR TITLE
[JENKINS-53549] Remove wrong notice since these options are not available anymore

### DIFF
--- a/war/src/main/webapp/help/system-config/homeDirectory.html
+++ b/war/src/main/webapp/help/system-config/homeDirectory.html
@@ -1,9 +1,6 @@
 <div>
-  By default, Jenkins stores all of its data in this directory on the file
-  system.
-  <br>
-  Under the <i>Advanced</i> section, you can choose to store build workspaces
-  and build records elsewhere.
+  <p>By default, Jenkins stores all of its data in this directory on the file
+    system.</p>
   <p>
   There are a few ways to change the Jenkins home directory:
   <ul>

--- a/war/src/main/webapp/help/system-config/homeDirectory_it.html
+++ b/war/src/main/webapp/help/system-config/homeDirectory_it.html
@@ -2,8 +2,6 @@
   Per impostazione predefinita, Jenkins salva tutti i propri dati in questa
   directory sul filesystem.
   <br>
-  Nella sezione <i>Avanzate</i> è possibile scegliere di salvare gli spazi di
-  lavoro e i registri delle compilazioni in un'altra posizione.
   <p>
   Ci sono modi differenti di modificare la directory home di Jenkins:
   <ul>


### PR DESCRIPTION
This documentation is wrong since https://issues.jenkins-ci.org/browse/JENKINS-50164, hence since
Jenkins 2.119 (merged as https://github.com/jenkinsci/jenkins/commit/a363f2e33cfd7c35a812dca12566e537b3650750).

See [JENKINS-53549](https://issues.jenkins-ci.org/browse/JENKINS-53549).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* _N/A: small fix not worth a changelog entry IMO_

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
