### PR TITLE
Try to use a known working ath docker image

### DIFF
--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
@@ -75,9 +75,7 @@ public class ApiTokenStore {
         this.init();
     }
     
-    //TODO Properly investigate this
-    @SuppressFBWarnings("SE_READ_RESOLVE_MUST_RETURN_OBJECT")
-    private ApiTokenStore readResolve() {
+    private Object readResolve() {
         this.init();
         return this;
     }
@@ -358,9 +356,7 @@ public class ApiTokenStore {
             this.init();
         }
     
-        //TODO Properly investigate this
-        @SuppressFBWarnings("SE_READ_RESOLVE_MUST_RETURN_OBJECT")
-        private HashedToken readResolve() {
+        private Object readResolve() {
             this.init();
             return this;
         }

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
@@ -75,6 +75,8 @@ public class ApiTokenStore {
         this.init();
     }
     
+    //TODO Properly investigate this
+    @SuppressFBWarnings("SE_READ_RESOLVE_MUST_RETURN_OBJECT")
     private ApiTokenStore readResolve() {
         this.init();
         return this;
@@ -356,6 +358,8 @@ public class ApiTokenStore {
             this.init();
         }
     
+        //TODO Properly investigate this
+        @SuppressFBWarnings("SE_READ_RESOLVE_MUST_RETURN_OBJECT")
         private HashedToken readResolve() {
             this.init();
             return this;

--- a/essentials.yml
+++ b/essentials.yml
@@ -2,5 +2,6 @@
 ath:
   useLocalSnapshots: false
   athRevision: "06caf67d37d945ec5228a80d73714fac692c28d3"
+  athImage: "jenkins/ath:acceptance-test-harness-1.62"
   categories:
     - org.jenkinsci.test.acceptance.junit.SmokeTest


### PR DESCRIPTION
I have found several builds failing due to selenium errors since yesterday, including the ATH itself and several internal builds.
I suspect something has happened with the docker image, maybe the firefox ESR version has changed in the local repo or something similar

If I am right this version of the docker image should still work.

With the builds working again we can center in fixing the docker image