### PR TITLE
Solving a release blocker problem from FindBugs

### DIFF
--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
@@ -75,7 +75,7 @@ public class ApiTokenStore {
         this.init();
     }
     
-    private ApiTokenStore readResolve() {
+    private Object readResolve() {
         this.init();
         return this;
     }


### PR DESCRIPTION
Not sure why this didn't get caught, as this code seems to have been around for quite a while. Maybe findbugs version change?

Steps to reproduce: mvn -DskipTests install

> [INFO] The method jenkins.security.apitoken.ApiTokenStore$HashedToken.readResolve() must be declared with a return type of Object rather than ApiTokenStore$HashedToken [jenkins.security.apitoken.ApiTokenStore$HashedToken] At ApiTokenStore.java:[lines 360-361] SE_READ_RESOLVE_MUST_RETURN_OBJECT