### PR TITLE
Fix the FindBugs issue in the test

### DIFF
--- a/core/src/test/java/hudson/model/JobTest.java
+++ b/core/src/test/java/hudson/model/JobTest.java
@@ -74,7 +74,7 @@ public class JobTest {
         Node node = PowerMockito.mock(Node.class);
         PowerMockito.doReturn(c).when(node).toComputer();
 
-        EnvVars env = job.getEnvironment(node, null);
+        EnvVars env = job.getEnvironment(node, TaskListener.NULL);
         String path = "/test";
         env.override("PATH+TEST", path);
 


### PR DESCRIPTION
The test was not passing non-Null task listener as `job.getEnvironment` expects. It is okay for the current versions, but it becomes a problem when Mockito is updated in #3637  