### PR TITLE
[JENKINS-53721] - Add getter/setter to EnvVars so the envinject plugin can set Platform safely

### DIFF
--- a/core/src/main/java/hudson/EnvVars.java
+++ b/core/src/main/java/hudson/EnvVars.java
@@ -97,7 +97,8 @@ public class EnvVars extends TreeMap<String,String> {
 
     /**
      * Sets the platform for which these env vars target.
-     * @param platform 
+     * @since TODO
+     * @param platform the platform to set.
      */
     public void setPlatform(@Nonnull Platform platform) {
         this.platform = platform;

--- a/core/src/main/java/hudson/EnvVars.java
+++ b/core/src/main/java/hudson/EnvVars.java
@@ -44,6 +44,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
+import javax.annotation.CheckForNull;
 
 /**
  * Environment variables.
@@ -84,7 +85,23 @@ public class EnvVars extends TreeMap<String,String> {
      * So this property remembers that information.
      */
     private Platform platform;
+    
+    /**
+     * Gets the platform for which these env vars targeted.
+     * @since TODO
+     * @return The platform.
+     */
+    public @CheckForNull Platform getPlatform() {
+        return platform;
+    }
 
+    /**
+     * Sets the platform for which these env vars target.
+     * @param platform 
+     */
+    public void setPlatform(@Nonnull Platform platform) {
+        this.platform = platform;
+    }
     public EnvVars() {
         super(CaseInsensitiveComparator.INSTANCE);
     }
@@ -425,7 +442,7 @@ public class EnvVars extends TreeMap<String,String> {
      *
      * <p>
      * If you access this field from agents, then this is the environment
-     * variable of the agent agent.
+     * variable of the agent.
      */
     public static final Map<String,String> masterEnvVars = initMaster();
 


### PR DESCRIPTION
See [JENKINS-53721](https://issues.jenkins-ci.org/browse/JENKINS-53721).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* JENKINS-53721, RFE: Developer: Introduce `getPlatform()` and `setPlatform()` methods in `hudson.EnvVars`
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
