### PR TITLE
JDK-11 support: refactor code to avoid underscore variable names

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -778,19 +778,20 @@ public class ClassicPluginStrategy implements PluginStrategy {
                         Class<?> c = ClassLoaderReflectionToolkit._findLoadedClass(pw.classLoader, name);
                         if (c!=null)    return c;
                         return ClassLoaderReflectionToolkit._findClass(pw.classLoader, name);
-                    } catch (ClassNotFoundException e) {
+                    } catch (ClassNotFoundException ignored) {
                         //not found. try next
                     }
                 }
             } else {
                 for (Dependency dep : dependencies) {
                     PluginWrapper p = pluginManager.getPlugin(dep.shortName);
-                    if(p!=null)
+                    if(p!=null) {
                         try {
                             return p.classLoader.loadClass(name);
-                        } catch (ClassNotFoundException ex) {
-                            // try next
+                        } catch (ClassNotFoundException ignored) {
+                            // OK, try next
                         }
+                    }
                 }
             }
 

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -788,7 +788,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
                     if(p!=null)
                         try {
                             return p.classLoader.loadClass(name);
-                        } catch (ClassNotFoundException _) {
+                        } catch (ClassNotFoundException ex) {
                             // try next
                         }
                 }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2309,7 +2309,7 @@ public final class FilePath implements Serializable {
             // legacy agent.jar. Handle this gracefully
             try {
                 LOGGER.log(Level.WARNING,"Looks like an old agent.jar. Please update "+ Which.jarFile(Channel.class)+" to the new version",e);
-            } catch (IOException _) {
+            } catch (IOException ex) {
                 // really ignore this time
             }
         }
@@ -2427,7 +2427,7 @@ public final class FilePath implements Serializable {
                     // report both errors
                     e.addSuppressed(x);
                     throw e;
-                } catch (TimeoutException _) {
+                } catch (TimeoutException ex) {
                     // remote is hanging
                     throw e;
                 }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2309,7 +2309,7 @@ public final class FilePath implements Serializable {
             // legacy agent.jar. Handle this gracefully
             try {
                 LOGGER.log(Level.WARNING,"Looks like an old agent.jar. Please update "+ Which.jarFile(Channel.class)+" to the new version",e);
-            } catch (IOException ex) {
+            } catch (IOException ignored) {
                 // really ignore this time
             }
         }
@@ -2427,8 +2427,8 @@ public final class FilePath implements Serializable {
                     // report both errors
                     e.addSuppressed(x);
                     throw e;
-                } catch (TimeoutException ex) {
-                    // remote is hanging
+                } catch (TimeoutException ignored) {
+                    // remote is hanging, just throw the original exception
                     throw e;
                 }
             }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1493,7 +1493,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     }
                     updateCenter.persistInstallStatus();
                     if(!failures) {
-                        try (ACLContext _ = ACL.as(currentAuth)) {
+                        try (ACLContext acl = ACL.as(currentAuth)) {
                             InstallUtil.proceedToNextStateFrom(InstallState.INITIAL_PLUGINS_INSTALLING);
                         }
                     }

--- a/core/src/main/java/hudson/cli/handlers/GenericItemOptionHandler.java
+++ b/core/src/main/java/hudson/cli/handlers/GenericItemOptionHandler.java
@@ -62,7 +62,7 @@ public abstract class GenericItemOptionHandler<T extends Item> extends OptionHan
         T s = j.getItemByFullName(src, type());
         if (s == null) {
             final Authentication who = Jenkins.getAuthentication();
-            try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+            try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
                 Item actual = j.getItemByFullName(src);
                 if (actual == null) {
                     LOGGER.log(Level.FINE, "really no item exists named {0}", src);

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -822,7 +822,7 @@ public class Fingerprint implements ModelObject, Saveable {
     public static final class ProjectRenameListener extends ItemListener {
         @Override
         public void onLocationChanged(final Item item, final String oldName, final String newName) {
-            try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+            try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
                 locationChanged(item, oldName, newName);
             }
         }
@@ -1438,7 +1438,7 @@ public class Fingerprint implements ModelObject, Saveable {
         // Probably it failed due to the missing Item.DISCOVER
         // We try to retrieve the job using SYSTEM user and to check permissions manually.
         final Authentication userAuth = Jenkins.getAuthentication();
-        try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+        try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
             final Item itemBySystemUser = jenkins.getItemByFullName(fullName);
             if (itemBySystemUser == null) {
                 return false;

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -518,7 +518,7 @@ public class ListView extends View implements DirectlyModifiableView {
     public static final class Listener extends ItemListener {
         @Override
         public void onLocationChanged(final Item item, final String oldFullName, final String newFullName) {
-            try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+            try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
                 locationChanged(oldFullName, newFullName);
             }
         }
@@ -563,7 +563,7 @@ public class ListView extends View implements DirectlyModifiableView {
 
         @Override
         public void onDeleted(final Item item) {
-            try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+            try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
                 deleted(item);
             }
         }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1401,7 +1401,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             status = new Running();
             try {
                 // safeRestart records the current authentication for the log, so set it to the managing user
-                try (ACLContext _ = ACL.as(User.get(authentication, false, Collections.emptyMap()))) {
+                try (ACLContext acl = ACL.as(User.get(authentication, false, Collections.emptyMap()))) {
                     Jenkins.getInstance().safeRestart();
                 }
             } catch (RestartNotSupportedException exception) {

--- a/core/src/main/java/hudson/model/queue/Executables.java
+++ b/core/src/main/java/hudson/model/queue/Executables.java
@@ -46,7 +46,7 @@ public class Executables {
             throws Error, RuntimeException {
         try {
             return e.getParent();
-        } catch (AbstractMethodError _) {
+        } catch (AbstractMethodError ex) {
             try {
                 Method m = e.getClass().getMethod("getParent");
                 m.setAccessible(true);

--- a/core/src/main/java/hudson/model/queue/Executables.java
+++ b/core/src/main/java/hudson/model/queue/Executables.java
@@ -46,7 +46,7 @@ public class Executables {
             throws Error, RuntimeException {
         try {
             return e.getParent();
-        } catch (AbstractMethodError ex) {
+        } catch (AbstractMethodError ignored) { // will fallback to a private implementation
             try {
                 Method m = e.getClass().getMethod("getParent");
                 m.setAccessible(true);

--- a/core/src/main/java/hudson/os/solaris/ZFSInstaller.java
+++ b/core/src/main/java/hudson/os/solaris/ZFSInstaller.java
@@ -219,7 +219,7 @@ public class ZFSInstaller extends AdministrativeMonitor implements Serializable 
                     // revert the file system creation
                     try {
                         hudson.destory();
-                    } catch (Exception _) {
+                    } catch (Exception ex) {
                         // but ignore the error and let the original error thrown
                     }
                     throw e;

--- a/core/src/main/java/hudson/os/solaris/ZFSInstaller.java
+++ b/core/src/main/java/hudson/os/solaris/ZFSInstaller.java
@@ -219,7 +219,7 @@ public class ZFSInstaller extends AdministrativeMonitor implements Serializable 
                     // revert the file system creation
                     try {
                         hudson.destory();
-                    } catch (Exception ex) {
+                    } catch (Exception ignored) {
                         // but ignore the error and let the original error thrown
                     }
                     throw e;

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -739,11 +739,11 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
     /*package*/ static final PasswordEncoder CLASSIC = new PasswordEncoder() {
         private final PasswordEncoder passwordEncoder = new ShaPasswordEncoder(256);
 
-        public String encodePassword(String rawPass, Object _) throws DataAccessException {
+        public String encodePassword(String rawPass, Object obj) throws DataAccessException {
             return hash(rawPass);
         }
 
-        public boolean isPasswordValid(String encPass, String rawPass, Object _) throws DataAccessException {
+        public boolean isPasswordValid(String encPass, String rawPass, Object obj) throws DataAccessException {
             // pull out the sale from the encoded password
             int i = encPass.indexOf(':');
             if(i<0) return false;
@@ -779,11 +779,11 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
      * {@link PasswordEncoder} that uses jBCrypt.
      */
     private static final PasswordEncoder JBCRYPT_ENCODER = new PasswordEncoder() {
-        public String encodePassword(String rawPass, Object _) throws DataAccessException {
+        public String encodePassword(String rawPass, Object obj) throws DataAccessException {
             return BCrypt.hashpw(rawPass,BCrypt.gensalt());
         }
 
-        public boolean isPasswordValid(String encPass, String rawPass, Object _) throws DataAccessException {
+        public boolean isPasswordValid(String encPass, String rawPass, Object obj) throws DataAccessException {
             return BCrypt.checkpw(rawPass,encPass);
         }
     };

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -431,7 +431,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
         public static class ItemListenerImpl extends ItemListener {
             @Override
             public void onLocationChanged(final Item item, final String oldFullName, final String newFullName) {
-                try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+                try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
                     locationChanged(item, oldFullName, newFullName);
                 }
             }

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -1253,18 +1253,18 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 kinfo_proc_ppid_offset = kinfo_proc_ppid_offset_32;
             }
             try {
-                IntByReference _ = new IntByReference(sizeOfInt);
+                IntByReference ref = new IntByReference(sizeOfInt);
                 IntByReference size = new IntByReference(sizeOfInt);
                 Memory m;
                 int nRetry = 0;
                 while(true) {
                     // find out how much memory we need to do this
-                    if(LIBC.sysctl(MIB_PROC_ALL,3, NULL, size, NULL, _)!=0)
+                    if(LIBC.sysctl(MIB_PROC_ALL,3, NULL, size, NULL, ref)!=0)
                         throw new IOException("Failed to obtain memory requirement: "+LIBC.strerror(Native.getLastError()));
 
                     // now try the real call
                     m = new Memory(size.getValue());
-                    if(LIBC.sysctl(MIB_PROC_ALL,3, m, size, NULL, _)!=0) {
+                    if(LIBC.sysctl(MIB_PROC_ALL,3, m, size, NULL, ref)!=0) {
                         if(Native.getLastError()==ENOMEM && nRetry++<16)
                             continue; // retry
                         throw new IOException("Failed to call kern.proc.all: "+LIBC.strerror(Native.getLastError()));
@@ -1324,14 +1324,14 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     arguments = new ArrayList<String>();
                     envVars = new EnvVars();
 
-                    IntByReference _ = new IntByReference();
+                    IntByReference intByRef = new IntByReference();
 
                     IntByReference argmaxRef = new IntByReference(0);
                     IntByReference size = new IntByReference(sizeOfInt);
 
                     // for some reason, I was never able to get sysctlbyname work.
 //        if(LIBC.sysctlbyname("kern.argmax", argmaxRef.getPointer(), size, NULL, _)!=0)
-                    if(LIBC.sysctl(new int[]{CTL_KERN,KERN_ARGMAX},2, argmaxRef.getPointer(), size, NULL, _)!=0)
+                    if(LIBC.sysctl(new int[]{CTL_KERN,KERN_ARGMAX},2, argmaxRef.getPointer(), size, NULL, intByRef)!=0)
                         throw new IOException("Failed to get kern.argmax: "+LIBC.strerror(Native.getLastError()));
 
                     int argmax = argmaxRef.getValue();
@@ -1369,7 +1369,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     }
                     StringArrayMemory m = new StringArrayMemory(argmax);
                     size.setValue(argmax);
-                    if(LIBC.sysctl(new int[]{CTL_KERN,KERN_PROCARGS2,pid},3, m, size, NULL, _)!=0)
+                    if(LIBC.sysctl(new int[]{CTL_KERN,KERN_PROCARGS2,pid},3, m, size, NULL, intByRef)!=0)
                         throw new IOException("Failed to obtain ken.procargs2: "+LIBC.strerror(Native.getLastError()));
 
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5030,7 +5030,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 if (idx > 0) {
                     return new VersionNumber(versionString.substring(0,idx));
                 }
-            } catch (NumberFormatException _) {
+            } catch (NumberFormatException ex) {
                 // fall through
             }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5030,7 +5030,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 if (idx > 0) {
                     return new VersionNumber(versionString.substring(0,idx));
                 }
-            } catch (NumberFormatException ex) {
+            } catch (NumberFormatException ignored) {
                 // fall through
             }
 

--- a/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
+++ b/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
@@ -77,7 +77,7 @@ public class JnlpSlaveRestarterInstaller extends ComputerListener implements Ser
 
             try {
                 Engine.class.getMethod("addListener", EngineListener.class);
-            } catch (NoSuchMethodException ex) {
+            } catch (NoSuchMethodException ignored) {
                 return null;    // running with older version of remoting that doesn't support adding listener
             }
 

--- a/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
+++ b/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
@@ -77,7 +77,7 @@ public class JnlpSlaveRestarterInstaller extends ComputerListener implements Ser
 
             try {
                 Engine.class.getMethod("addListener", EngineListener.class);
-            } catch (NoSuchMethodException _) {
+            } catch (NoSuchMethodException ex) {
                 return null;    // running with older version of remoting that doesn't support adding listener
             }
 

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -251,7 +251,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
         }
 
         private Map<Job,Collection<ReverseBuildTrigger>> calculateCache() {
-            try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+            try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
                 final Map<Job, Collection<ReverseBuildTrigger>> result = new WeakHashMap<>();
                 for (Job<?, ?> downstream : Jenkins.getInstance().allItems(Job.class)) {
                     ReverseBuildTrigger trigger =
@@ -312,7 +312,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     public static class ItemListenerImpl extends ItemListener {
         @Override
         public void onLocationChanged(Item item, final String oldFullName, final String newFullName) {
-            try (ACLContext _ = ACL.as(ACL.SYSTEM)) {
+            try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
                 for (Job<?, ?> p : Jenkins.getInstance().allItems(Job.class)) {
                     ReverseBuildTrigger t = ParameterizedJobMixIn.getTrigger(p, ReverseBuildTrigger.class);
                     if (t != null) {

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -293,7 +293,7 @@ public class PluginManagerTest {
         try {
             callDependerValue();
             fail();
-        } catch (ClassNotFoundException _) {
+        } catch (ClassNotFoundException ex) {
         }
         
         // No extensions exist.
@@ -331,7 +331,7 @@ public class PluginManagerTest {
         try {
             r.jenkins.getExtensionList("org.jenkinsci.plugins.dependencytest.dependee.DependeeExtensionPoint");
             fail();
-        } catch( ClassNotFoundException _ ){
+        } catch( ClassNotFoundException ex ){
         }
         
         // Load dependee.
@@ -380,7 +380,7 @@ public class PluginManagerTest {
         try {
             r.jenkins.getExtensionList("org.jenkinsci.plugins.dependencytest.dependee.DependeeExtensionPoint");
             fail();
-        } catch( ClassNotFoundException _ ){
+        } catch( ClassNotFoundException ex ){
         }
     }
 

--- a/test/src/test/java/hudson/cli/ComputerStateTest.java
+++ b/test/src/test/java/hudson/cli/ComputerStateTest.java
@@ -168,6 +168,6 @@ public class ComputerStateTest {
         try {
             page.getAnchorByText(text);
             fail(text + " link should not exist");
-        } catch (ElementNotFoundException _) { /*expected*/ }
+        } catch (ElementNotFoundException ex) { /*expected*/ }
     }
 }

--- a/test/src/test/java/hudson/model/FingerprintTest.java
+++ b/test/src/test/java/hudson/model/FingerprintTest.java
@@ -160,7 +160,7 @@ public class FingerprintTest {
         setJobPermissionsOnce(project1, "user1", Item.READ, Item.DISCOVER);
         setJobPermissionsOnce(project2, "user2", Item.READ, Item.DISCOVER);
 
-        try (ACLContext _ = ACL.as(user1)) {
+        try (ACLContext acl = ACL.as(user1)) {
             Fingerprint.BuildPtr original = fp.getOriginal();
             assertThat("user1 should be able to see the origin", fp.getOriginal(), notNullValue());
             assertEquals("user1 should be able to see the origin's project name", project1.getName(), original.getName());
@@ -169,13 +169,13 @@ public class FingerprintTest {
             assertEquals("Only project1 should be visible to user1", project1.getFullName(), fp._getUsages().get(0).name);
         }
 
-        try (ACLContext _ = ACL.as(user2)) {
+        try (ACLContext acl = ACL.as(user2)) {
             assertThat("user2 should be unable to see the origin", fp.getOriginal(), nullValue());
             assertEquals("Only one usage should be visible to user2", 1, fp._getUsages().size());
             assertEquals("Only project2 should be visible to user2", project2.getFullName(), fp._getUsages().get(0).name);
         }
 
-        try (ACLContext _ = ACL.as(user3)) {
+        try (ACLContext acl = ACL.as(user3)) {
             Fingerprint.BuildPtr original = fp.getOriginal();
             assertThat("user3 should be unable to see the origin", fp.getOriginal(), nullValue());
             assertEquals("All usages should be invisible for user3", 0, fp._getUsages().size());
@@ -193,7 +193,7 @@ public class FingerprintTest {
         User user1 = User.get("user1");   
         setupProjectMatrixAuthStrategy(Jenkins.READ, Item.DISCOVER);
 
-        try (ACLContext _ = ACL.as(user1)) {
+        try (ACLContext acl = ACL.as(user1)) {
             Fingerprint.BuildPtr original = fingerprint.getOriginal();
             assertThat("user1 should able to see the origin", fingerprint.getOriginal(), notNullValue());
             assertEquals("user1 sees the wrong original name with Item.DISCOVER", project.getFullName(), original.getName());
@@ -216,7 +216,7 @@ public class FingerprintTest {
         folder.setPermissions("user1", Item.READ);
         
         // Ensure we can read the original from user account
-        try (ACLContext _ = ACL.as(user1)) {
+        try (ACLContext acl = ACL.as(user1)) {
             assertTrue("Test framework issue: User1 should be able to read the folder", folder.hasPermission(Item.READ));
 
             Fingerprint.BuildPtr original = fingerprint.getOriginal();
@@ -241,7 +241,7 @@ public class FingerprintTest {
         setupProjectMatrixAuthStrategy(Jenkins.READ, Item.DISCOVER);
         
         // Ensure we can read the original from user account
-        try (ACLContext _ = ACL.as(user1)) {
+        try (ACLContext acl = ACL.as(user1)) {
             assertFalse("Test framework issue: User1 should be unable to read the folder", folder.hasPermission(Item.READ));
             assertThat("user1 should be unable to see the origin", fingerprint.getOriginal(), nullValue());
             assertEquals("No jobs should be visible to user1", 0, fingerprint._getUsages().size());
@@ -266,7 +266,7 @@ public class FingerprintTest {
         setupProjectMatrixAuthStrategy(Jenkins.READ, Item.READ, Item.DISCOVER);
         project.delete();
 
-        try (ACLContext _ = ACL.as(user1)) {
+        try (ACLContext acl = ACL.as(user1)) {
             assertThat("user1 should be unable to see the origin", fp.getOriginal(), nullValue());
             assertEquals("No jobs should be visible to user1", 0, fp._getUsages().size());
         }
@@ -284,7 +284,7 @@ public class FingerprintTest {
         setupProjectMatrixAuthStrategy(Jenkins.ADMINISTER);
         project.delete();
 
-        try (ACLContext _ = ACL.as(user1)) {
+        try (ACLContext acl = ACL.as(user1)) {
             Fingerprint.BuildPtr original = fingerprint.getOriginal();
             assertThat("user1 should able to see the origin", fingerprint.getOriginal(), notNullValue());
             assertThat("Job has been deleted, so Job reference should return null", fingerprint.getOriginal().getJob(), nullValue());

--- a/test/src/test/java/hudson/model/ListViewTest.java
+++ b/test/src/test/java/hudson/model/ListViewTest.java
@@ -234,7 +234,7 @@ public class ListViewTest {
         ListView v = new ListView("v", j.jenkins);
         v.add(p);
         j.jenkins.addView(v);
-        try (ACLContext _ = ACL.as(User.get("alice"))) {
+        try (ACLContext acl = ACL.as(User.get("alice"))) {
             p.renameTo("p2");
         }
         assertEquals(Collections.singletonList(p), v.getItems());

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -440,7 +440,7 @@ public class SearchTest {
         mas.grant(Jenkins.READ).onRoot().toEveryone();
         j.jenkins.setAuthorizationStrategy(mas);
 
-        try(ACLContext _ = ACL.as(User.get("alice"))) {
+        try(ACLContext acl = ACL.as(User.get("alice"))) {
             List<SearchItem> results = new ArrayList<>();
             j.jenkins.getSearchIndex().find("config", results);
             j.jenkins.getSearchIndex().find("manage", results);

--- a/test/src/test/java/jenkins/security/ApiTokenPropertyTest.java
+++ b/test/src/test/java/jenkins/security/ApiTokenPropertyTest.java
@@ -69,7 +69,7 @@ public class ApiTokenPropertyTest {
         final String token = t.getApiToken();
 
         // Make sure that user is able to get the token via the interface
-        try (ACLContext _ = ACL.as(u)) {
+        try (ACLContext acl = ACL.as(u)) {
             assertEquals("User is unable to get its own token", token, t.getApiToken());
         }
 


### PR DESCRIPTION
Refactoring towards Java 11. Underscore variables are not welcome in Java anymore, and IMO it makes sense to just refactor them away.

# Changelog

* Not required

@jenkinsci/sig-platform 