### PR TITLE
Javadoc: cleanup `tt` tags from Javadoc (prohibited in JDK11)

### DIFF
--- a/cli/src/main/java/hudson/cli/PrivateKeyProvider.java
+++ b/cli/src/main/java/hudson/cli/PrivateKeyProvider.java
@@ -71,7 +71,7 @@ public class PrivateKeyProvider {
     /**
      * Read keys from default keyFiles
      *
-     * <tt>.ssh/id_rsa</tt>, <tt>.ssh/id_dsa</tt> and <tt>.ssh/identity</tt>.
+     * {@code .ssh/id_rsa}, {@code .ssh/id_dsa} and {@code .ssh/identity}.
      *
      * @return true if some key was read successfully.
      */

--- a/core/src/main/java/hudson/CopyOnWrite.java
+++ b/core/src/main/java/hudson/CopyOnWrite.java
@@ -43,7 +43,7 @@ import java.lang.annotation.Target;
  *
  * <p>
  * The field marked with this annotation usually needs to be marked as
- * <tt>volatile</tt>.
+ * {@code volatile}.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/EnvVars.java
+++ b/core/src/main/java/hudson/EnvVars.java
@@ -54,7 +54,7 @@ import javax.annotation.Nonnull;
  * but case <b>insensitive</b> way (that is, cmd.exe can get both FOO and foo as environment variables
  * when it's launched, and the "set" command will display it accordingly, but "echo %foo%" results in
  * echoing the value of "FOO", not "foo" &mdash; this is presumably caused by the behavior of the underlying
- * Win32 API <tt>GetEnvironmentVariable</tt> acting in case insensitive way.) Windows users are also
+ * Win32 API {@code GetEnvironmentVariable} acting in case insensitive way.) Windows users are also
  * used to write environment variable case-insensitively (like %Path% vs %PATH%), and you can see many
  * documents on the web that claims Windows environment variables are case insensitive.
  *
@@ -65,10 +65,10 @@ import javax.annotation.Nonnull;
  * <p>
  * In Jenkins, often we need to build up "environment variable overrides"
  * on master, then to execute the process on agents. This causes a problem
- * when working with variables like <tt>PATH</tt>. So to make this work,
- * we introduce a special convention <tt>PATH+FOO</tt> &mdash; all entries
- * that starts with <tt>PATH+</tt> are merged and prepended to the inherited
- * <tt>PATH</tt> variable, on the process where a new process is executed. 
+ * when working with variables like {@code PATH}. So to make this work,
+ * we introduce a special convention {@code PATH+FOO} &mdash; all entries
+ * that starts with {@code PATH+} are merged and prepended to the inherited
+ * {@code PATH} variable, on the process where a new process is executed.
  *
  * @author Kohsuke Kawaguchi
  */
@@ -107,7 +107,7 @@ public class EnvVars extends TreeMap<String,String> {
     }
 
     /**
-     * Builds an environment variables from an array of the form <tt>"key","value","key","value"...</tt>
+     * Builds an environment variables from an array of the form {@code "key","value","key","value"...}
      */
     public EnvVars(String... keyValuePairs) {
         this();
@@ -121,7 +121,7 @@ public class EnvVars extends TreeMap<String,String> {
      * Overrides the current entry by the given entry.
      *
      * <p>
-     * Handles <tt>PATH+XYZ</tt> notation.
+     * Handles {@code PATH+XYZ} notation.
      */
     public void override(String key, String value) {
         if(value==null || value.length()==0) {

--- a/core/src/main/java/hudson/FileSystemProvisionerDescriptor.java
+++ b/core/src/main/java/hudson/FileSystemProvisionerDescriptor.java
@@ -50,12 +50,12 @@ public abstract class FileSystemProvisionerDescriptor extends Descriptor<FileSys
      * This method is called to do this, after Hudson determines that the workspace should be deleted
      * to reclaim disk space. The implementation of this method is expected to sniff the contents of
      * the workspace, and if it looks like the one created by {@link FileSystemProvisioner#prepareWorkspace(AbstractBuild, FilePath, TaskListener)},
-     * perform the necessary deletion operation, and return <tt>true</tt>.
+     * perform the necessary deletion operation, and return {@code true}.
      *
      * <p>
      * If the workspace isn't the one created by this {@link FileSystemProvisioner}, or if the
      * workspace can be simply deleted by {@link FilePath#deleteRecursive()}, then simply
-     * return <tt>false</tt> to give other {@link FileSystemProvisionerDescriptor}s a chance to
+     * return {@code false} to give other {@link FileSystemProvisionerDescriptor}s a chance to
      * discard them.
      *
      * @param ws

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -396,11 +396,11 @@ public class Functions {
      * is chosen, this part remains intact.
      *
      * <p>
-     * The <tt>524</tt> is the path from {@link Job} to {@link Run}.
+     * The {@code 524} is the path from {@link Job} to {@link Run}.
      *
      * <p>
-     * The <tt>bbb</tt> portion is the path after that till the last
-     * {@link Run} subtype. The <tt>ccc</tt> portion is the part
+     * The {@code bbb} portion is the path after that till the last
+     * {@link Run} subtype. The {@code ccc} portion is the part
      * after that.
      */
     public static final class RunUrl {
@@ -618,7 +618,7 @@ public class Functions {
     private static final SimpleFormatter formatter = new SimpleFormatter();
 
     /**
-     * Used by <tt>layout.jelly</tt> to control the auto refresh behavior.
+     * Used by {@code layout.jelly} to control the auto refresh behavior.
      *
      * @param noAutoRefresh
      *      On certain pages, like a page with forms, will have annoying interference
@@ -772,7 +772,7 @@ public class Functions {
     }
 
     /**
-     * This version is so that the 'checkPermission' on <tt>layout.jelly</tt>
+     * This version is so that the 'checkPermission' on {@code layout.jelly}
      * degrades gracefully if "it" is not an {@link AccessControlled} object.
      * Otherwise it will perform no check and that problem is hard to notice.
      */
@@ -1693,7 +1693,7 @@ public class Functions {
     /**
      * Obtains the host name of the Hudson server that clients can use to talk back to.
      * <p>
-     * This is primarily used in <tt>slave-agent.jnlp.jelly</tt> to specify the destination
+     * This is primarily used in {@code slave-agent.jnlp.jelly} to specify the destination
      * that the agents talk to.
      */
     public String getServerName() {
@@ -1746,7 +1746,7 @@ public class Functions {
     /**
      * If the given href link is matching the current page, return true.
      *
-     * Used in <tt>task.jelly</tt> to decide if the page should be highlighted.
+     * Used in {@code task.jelly} to decide if the page should be highlighted.
      */
     public boolean hyperlinkMatchesCurrentPage(String href) throws UnsupportedEncodingException {
         String url = Stapler.getCurrentRequest().getRequestURL().toString();

--- a/core/src/main/java/hudson/Indenter.java
+++ b/core/src/main/java/hudson/Indenter.java
@@ -26,7 +26,7 @@ package hudson;
 import hudson.model.Job;
 
 /**
- * Used by <tt>projectView.jelly</tt> to indent modules.
+ * Used by {@code projectView.jelly} to indent modules.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -282,7 +282,7 @@ public abstract class Launcher {
          * Sets STDOUT destination.
          * 
          * @param out Output stream. 
-         *            Use {@code null} to send STDOUT to <tt>/dev/null</tt>.
+         *            Use {@code null} to send STDOUT to {@code /dev/null}.
          * @return {@code this}
          */
         public ProcStarter stdout(@CheckForNull OutputStream out) {
@@ -334,7 +334,7 @@ public abstract class Launcher {
 
         /**
          * Controls where the stdin of the process comes from.
-         * By default, <tt>/dev/null</tt>.
+         * By default, {@code /dev/null}.
          * 
          * @return {@code this}
          */

--- a/core/src/main/java/hudson/Plugin.java
+++ b/core/src/main/java/hudson/Plugin.java
@@ -62,20 +62,20 @@ import jenkins.model.GlobalConfiguration;
  * to plugin functionality.
  *
  * <p>
- * A plugin is bound to URL space of Hudson as <tt>${rootURL}/plugin/foo/</tt>,
+ * A plugin is bound to URL space of Hudson as {@code ${rootURL}/plugin/foo/},
  * where "foo" is taken from your plugin name "foo.jpi". All your web resources
  * in src/main/webapp are visible from this URL, and you can also define Jelly
  * views against your Plugin class, and those are visible in this URL, too.
  *
  * <p>
- * {@link Plugin} can have an optional <tt>config.jelly</tt> page. If present,
+ * {@link Plugin} can have an optional {@code config.jelly} page. If present,
  * it will become a part of the system configuration page (http://server/hudson/configure).
  * This is convenient for exposing/maintaining configuration that doesn't
  * fit any {@link Descriptor}s.
  *
  * <p>
  * Up until Hudson 1.150 or something, subclasses of {@link Plugin} required
- * <tt>@plugin</tt> javadoc annotation, but that is no longer a requirement.
+ * {@code @plugin} javadoc annotation, but that is no longer a requirement.
  *
  * @author Kohsuke Kawaguchi
  * @since 1.42
@@ -194,11 +194,11 @@ public abstract class Plugin implements Saveable {
      * Handles the submission for the system configuration.
      *
      * <p>
-     * If this class defines <tt>config.jelly</tt> view, be sure to
+     * If this class defines {@code config.jelly} view, be sure to
      * override this method and persists the submitted values accordingly.
      *
      * <p>
-     * The following is a sample <tt>config.jelly</tt> that you can start yours with:
+     * The following is a sample {@code config.jelly} that you can start yours with:
      * <pre>{@code <xmp>
      * <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
      *   <f:section title="Locale">
@@ -222,7 +222,7 @@ public abstract class Plugin implements Saveable {
     }
 
     /**
-     * This method serves static resources in the plugin under <tt>hudson/plugin/SHORTNAME</tt>.
+     * This method serves static resources in the plugin under {@code hudson/plugin/SHORTNAME}.
      */
     public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         String path = req.getRestOfPath();

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1216,7 +1216,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     /**
      * Discover all the service provider implementations of the given class,
-     * via <tt>META-INF/services</tt>.
+     * via {@code META-INF/services}.
      * @deprecated Use {@link ServiceLoader} instead, or (more commonly) {@link ExtensionList}.
      */
     @Deprecated

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -81,7 +81,7 @@ import static org.apache.commons.io.FilenameUtils.getBaseName;
  * for Jenkins to control {@link Plugin}.
  *
  * <p>
- * A plug-in is packaged into a jar file whose extension is <tt>".jpi"</tt> (or <tt>".hpi"</tt> for backward compatibility),
+ * A plug-in is packaged into a jar file whose extension is {@code ".jpi"} (or {@code ".hpi"} for backward compatibility),
  * A plugin needs to have a special manifest entry to identify what it is.
  *
  * <p>
@@ -126,7 +126,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     /**
      * Base URL for loading static resources from this plugin.
      * Null if disabled. The static resources are mapped under
-     * <tt>CONTEXTPATH/plugin/SHORTNAME/</tt>.
+     * {@code CONTEXTPATH/plugin/SHORTNAME/}.
      */
     public final URL baseResourceURL;
 
@@ -151,7 +151,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * True if this plugin is activated for this session.
-     * The snapshot of <tt>disableFile.exists()</tt> as of the start up.
+     * The snapshot of {@code disableFile.exists()} as of the start up.
      */
     private final boolean active;
     

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -138,7 +138,7 @@ public class Util {
     private static final Pattern VARIABLE = Pattern.compile("\\$([A-Za-z0-9_]+|\\{[A-Za-z0-9_.]+\\}|\\$)");
 
     /**
-     * Replaces the occurrence of '$key' by <tt>properties.get('key')</tt>.
+     * Replaces the occurrence of '$key' by {@code properties.get('key')}.
      *
      * <p>
      * Unlike shell, undefined variables are left as-is (this behavior is the same as Ant.)
@@ -150,7 +150,7 @@ public class Util {
     }
 
     /**
-     * Replaces the occurrence of '$key' by <tt>resolver.get('key')</tt>.
+     * Replaces the occurrence of '$key' by {@code resolver.get('key')}.
      *
      * <p>
      * Unlike shell, undefined variables are left as-is (this behavior is the same as Ant.)

--- a/core/src/main/java/hudson/XmlFile.java
+++ b/core/src/main/java/hudson/XmlFile.java
@@ -72,12 +72,12 @@ import org.apache.commons.io.IOUtils;
  * not have any data, the newly added field is left to the VM-default
  * value (if you let XStream create the object, such as
  * {@link #read()} &mdash; which is the majority), or to the value initialized by the
- * constructor (if the object is created via <tt>new</tt> and then its
+ * constructor (if the object is created via {@code new} and then its
  * value filled by XStream, such as {@link #unmarshal(Object)}.)
  *
  * <p>
  * Removing a field requires that you actually leave the field with
- * <tt>transient</tt> keyword. When you read the old XML, XStream
+ * {@code transient} keyword. When you read the old XML, XStream
  * will set the value to this field. But when the data is saved,
  * the field will no longer will be written back to XML.
  * (It might be possible to tweak XStream so that we can simply
@@ -85,13 +85,13 @@ import org.apache.commons.io.IOUtils;
  *
  * <p>
  * Changing the data structure is usually a combination of the two
- * above. You'd leave the old data store with <tt>transient</tt>,
+ * above. You'd leave the old data store with {@code transient},
  * and then add the new data. When you are reading the old XML,
  * only the old field will be set. When you are reading the new XML,
  * only the new field will be set. You'll then need to alter the code
  * so that it will be able to correctly handle both situations,
  * and that as soon as you see data in the old field, you'll have to convert
- * that into the new data structure, so that the next <tt>save</tt> operation
+ * that into the new data structure, so that the next {@code save} operation
  * will write the new data (otherwise you'll end up losing the data, because
  * old fields will be never written back.)
  *
@@ -154,7 +154,7 @@ public final class XmlFile {
      * Loads the contents of this file into an existing object.
      *
      * @return
-     *      The unmarshalled object. Usually the same as <tt>o</tt>, but would be different
+     *      The unmarshalled object. Usually the same as {@code o}, but would be different
      *      if the XML representation is completely new.
      */
     public Object unmarshal( Object o ) throws IOException {

--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -84,7 +84,7 @@ import javax.annotation.Nonnull;
  * <h2>How does a CLI command work</h2>
  * <p>
  * The users starts {@linkplain CLI the "CLI agent"} on a remote system, by specifying arguments, like
- * <tt>"java -jar jenkins-cli.jar command arg1 arg2 arg3"</tt>. The CLI agent creates
+ * {@code "java -jar jenkins-cli.jar command arg1 arg2 arg3"}. The CLI agent creates
  * a remoting channel with the server, and it sends the entire arguments to the server, along with
  * the remoted stdin/out/err.
  *
@@ -183,7 +183,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
      * Gets the command name.
      *
      * <p>
-     * For example, if the CLI is invoked as <tt>java -jar cli.jar foo arg1 arg2 arg4</tt>,
+     * For example, if the CLI is invoked as {@code java -jar cli.jar foo arg1 arg2 arg4},
      * on the server side {@link CLICommand} that returns "foo" from {@link #getName()}
      * will be invoked.
      *

--- a/core/src/main/java/hudson/cli/declarative/CLIMethod.java
+++ b/core/src/main/java/hudson/cli/declarative/CLIMethod.java
@@ -38,8 +38,8 @@ import java.lang.annotation.Target;
  * Annotates methods on model objects to expose them as CLI commands.
  *
  * <p>
- * You need to have <tt>Messages.properties</tt> in the same package with the
- * <tt>CLI.<i>command-name</i>.shortDescription</tt> key to describe the command.
+ * You need to have {@code Messages.properties} in the same package with the
+ * {@code CLI.<i>command-name</i>.shortDescription} key to describe the command.
  * This is used for the same purpose as {@link CLICommand#getShortDescription()}.
  *
  * <p>

--- a/core/src/main/java/hudson/cli/declarative/CLIResolver.java
+++ b/core/src/main/java/hudson/cli/declarative/CLIResolver.java
@@ -40,12 +40,12 @@ import java.lang.annotation.Target;
  * <p>
  * Hudson uses the return type of the resolver method
  * to pick the resolver method to use, of all the resolver methods it discovers. That is,
- * if Hudson is looking to find an instance of type <tt>T</tt> for the current command, it first
- * looks for the resolver method whose return type is <tt>T</tt>, then it checks for the base type of <tt>T</tt>,
+ * if Hudson is looking to find an instance of type {@code T} for the current command, it first
+ * looks for the resolver method whose return type is {@code T}, then it checks for the base type of {@code T},
  * and so on.
  *
  * <p>
- * If the chosen resolver method is an instance method on type <tt>S</tt>, the "parent resolver" is then
+ * If the chosen resolver method is an instance method on type {@code S}, the "parent resolver" is then
  * located to resolve an instance of type 'S'. This process repeats until a static resolver method is discovered
  * (since most of Hudson's model objects are anchored to the root {@link jenkins.model.Jenkins} object, normally that would become
  * the top-most resolver method.)

--- a/core/src/main/java/hudson/cli/handlers/ViewOptionHandler.java
+++ b/core/src/main/java/hudson/cli/handlers/ViewOptionHandler.java
@@ -48,7 +48,7 @@ import javax.annotation.CheckForNull;
  * For example:
  * <dl>
  *   <dt>my_view_name</dt><dd>refers to a top level view with given name.</dd>
- *   <dt>nested/inner</dt><dd>refers to a view named <tt>inner</tt> inside of a top level view group named <tt>nested</tt>.</dd>
+ *   <dt>nested/inner</dt><dd>refers to a view named {@code inner} inside of a top level view group named {@code nested}.</dd>
  * </dl>
  *
  * <p>

--- a/core/src/main/java/hudson/console/ConsoleAnnotatorFactory.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotatorFactory.java
@@ -58,7 +58,7 @@ import java.net.URL;
  *
  * <h2>Behaviour, JavaScript, and CSS</h2>
  * <p>
- * {@link ConsoleNote} can have associated <tt>script.js</tt> and <tt>style.css</tt> (put them
+ * {@link ConsoleNote} can have associated {@code script.js} and {@code style.css} (put them
  * in the same resource directory that you normally put Jelly scripts), which will be loaded into
  * the HTML page whenever the console notes are used. This allows you to use minimal markup in
  * code generation, and do the styling in CSS and perform the rest of the interesting work as a CSS behaviour/JavaScript.

--- a/core/src/main/java/hudson/console/ConsoleNote.java
+++ b/core/src/main/java/hudson/console/ConsoleNote.java
@@ -109,7 +109,7 @@ import org.jenkinsci.remoting.util.AnonymousClassWarnings;
  *
  * <h2>Behaviour, JavaScript, and CSS</h2>
  * <p>
- * {@link ConsoleNote} can have associated <tt>script.js</tt> and <tt>style.css</tt> (put them
+ * {@link ConsoleNote} can have associated {@code script.js} and {@code style.css} (put them
  * in the same resource directory that you normally put Jelly scripts), which will be loaded into
  * the HTML page whenever the console notes are used. This allows you to use minimal markup in
  * code generation, and do the styling in CSS and perform the rest of the interesting work as a CSS behaviour/JavaScript.

--- a/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageChecker.java
+++ b/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageChecker.java
@@ -31,7 +31,7 @@ import org.jenkinsci.Symbol;
 import java.util.logging.Logger;
 
 /**
- * Periodically checks the disk usage of <tt>JENKINS_HOME</tt>,
+ * Periodically checks the disk usage of {@code JENKINS_HOME},
  * and activate {@link HudsonHomeDiskUsageMonitor} if necessary.
  *
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageMonitor.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Monitors the disk usage of <tt>JENKINS_HOME</tt>, and if it's almost filled up, warn the user.
+ * Monitors the disk usage of {@code JENKINS_HOME}, and if it's almost filled up, warn the user.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/init/Initializer.java
+++ b/core/src/main/java/hudson/init/Initializer.java
@@ -92,7 +92,7 @@ public @interface Initializer {
     String[] attains() default {};
 
     /**
-     * Key in <tt>Messages.properties</tt> that represents what this task is about. Used for rendering the progress.
+     * Key in {@code Messages.properties} that represents what this task is about. Used for rendering the progress.
      * Defaults to "${short class name}.${method Name}".
      */
     String displayName() default "";

--- a/core/src/main/java/hudson/init/Terminator.java
+++ b/core/src/main/java/hudson/init/Terminator.java
@@ -52,7 +52,7 @@ public @interface Terminator {
     String[] attains() default {};
 
     /**
-     * Key in <tt>Messages.properties</tt> that represents what this task is about. Used for rendering the progress.
+     * Key in {@code Messages.properties} that represents what this task is about. Used for rendering the progress.
      * Defaults to "${short class name}.${method Name}".
      */
     String displayName() default "";

--- a/core/src/main/java/hudson/init/package-info.java
+++ b/core/src/main/java/hudson/init/package-info.java
@@ -33,7 +33,7 @@
  *
  * <p>
  * Such micro-scopic dependencies are organized into a bigger directed acyclic graph, which is then executed
- * via <tt>Session</tt>. During execution of the reactor, additional tasks can be discovered and added to
+ * via {@code Session}. During execution of the reactor, additional tasks can be discovered and added to
  * the DAG. We use this additional indirection to:
  *
  * <ol>

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -112,7 +112,7 @@ public abstract class Lifecycle implements ExtensionPoint {
     }
 
     /**
-     * If the location of <tt>jenkins.war</tt> is known in this life cycle,
+     * If the location of {@code jenkins.war} is known in this life cycle,
      * return it location. Otherwise return null to indicate that it is unknown.
      *
      * <p>
@@ -131,7 +131,7 @@ public abstract class Lifecycle implements ExtensionPoint {
      *
      * <p>
      * On some system, most notably Windows, a file being in use cannot be changed,
-     * so rewriting <tt>jenkins.war</tt> requires some special trick. Override this method
+     * so rewriting {@code jenkins.war} requires some special trick. Override this method
      * to do so.
      */
     public void rewriteHudsonWar(File by) throws IOException {

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -54,7 +54,7 @@ public class WindowsServiceLifecycle extends Lifecycle {
     }
 
     /**
-     * If <tt>jenkins.exe</tt> is old compared to our copy,
+     * If {@code jenkins.exe} is old compared to our copy,
      * schedule an overwrite (except that since it's currently running,
      * we can only do it when Jenkins restarts next time.)
      */

--- a/core/src/main/java/hudson/markup/MarkupFormatter.java
+++ b/core/src/main/java/hudson/markup/MarkupFormatter.java
@@ -51,7 +51,7 @@ import org.kohsuke.stapler.QueryParameter;
  *   
  * <h2>Views</h2>
  * <p>
- * This extension point must have a valid <tt>config.jelly</tt> that feeds the constructor.
+ * This extension point must have a valid {@code config.jelly} that feeds the constructor.
  *
  * TODO: allow {@link MarkupFormatter} to control the UI that the user uses to edit.
  *

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -297,7 +297,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     /**
      * Returns the root directory of the checked-out module.
      * <p>
-     * This is usually where <tt>pom.xml</tt>, <tt>build.xml</tt>
+     * This is usually where {@code pom.xml}, {@code build.xml}
      * and so on exists.
      */
     public final FilePath getModuleRoot() {

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -790,7 +790,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     }
 
     /**
-     * Accepts <tt>config.xml</tt> submission, as well as serve it.
+     * Accepts {@code config.xml} submission, as well as serve it.
      */
     @WebMethod(name = "config.xml")
     public void doConfigDotXml(StaplerRequest req, StaplerResponse rsp)

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -573,7 +573,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     /**
      * Returns the root directory of the checked-out module.
      * <p>
-     * This is usually where <tt>pom.xml</tt>, <tt>build.xml</tt>
+     * This is usually where {@code pom.xml}, {@code build.xml}
      * and so on exists.
      *
      * @deprecated as of 1.319
@@ -642,7 +642,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     }
 
     /**
-     * Used in <tt>sidepanel.jelly</tt> to decide whether to display
+     * Used in {@code sidepanel.jelly} to decide whether to display
      * the config/delete/build links.
      */
     public boolean isConfigurable() {
@@ -751,7 +751,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * Returns the live list of all {@link Publisher}s configured for this project.
      *
      * <p>
-     * This method couldn't be called <tt>getPublishers()</tt> because existing methods
+     * This method couldn't be called {@code getPublishers()} because existing methods
      * in sub-classes return different inconsistent types.
      */
     public abstract DescribableList<Publisher,Descriptor<Publisher>> getPublishersList();

--- a/core/src/main/java/hudson/model/Action.java
+++ b/core/src/main/java/hudson/model/Action.java
@@ -38,12 +38,12 @@ import javax.annotation.CheckForNull;
  *
  * <p>
  * Some actions use the latter without the former (for example, to add a link to an external website),
- * while others do the former without the latter (for example, to just draw some graphs in <tt>floatingBox.jelly</tt>),
+ * while others do the former without the latter (for example, to just draw some graphs in {@code floatingBox.jelly}),
  * and still some others do both.
  *
  * <h2>Views</h2>
  * <p>
- * If an action has a view named <tt>floatingBox.jelly</tt>,
+ * If an action has a view named {@code floatingBox.jelly},
  * it will be displayed as a floating box on the top page of
  * the target {@link ModelObject}. (For example, this is how
  * the JUnit test result trend shows up in the project top page.
@@ -82,7 +82,7 @@ public interface Action extends ModelObject {
      *
      * @return
      *      If just a file name (like "abc.gif") is returned, it will be
-     *      interpreted as a file name inside <tt>/images/24x24</tt>.
+     *      interpreted as a file name inside {@code /images/24x24}.
      *      This is useful for using one of the stock images.
      *      <p>
      *      If an absolute file name that starts from '/' is returned (like
@@ -91,7 +91,7 @@ public interface Action extends ModelObject {
      *      image files from a plugin.
      *      <p>
      *      Finally, return null to hide it from the task list. This is normally not very useful,
-     *      but this can be used for actions that only contribute <tt>floatBox.jelly</tt>
+     *      but this can be used for actions that only contribute {@code floatBox.jelly}
      *      and no task list item. The other case where this is useful is
      *      to avoid showing links that require a privilege when the user is anonymous.
      * @see Functions#isAnonymous()

--- a/core/src/main/java/hudson/model/AdministrativeMonitor.java
+++ b/core/src/main/java/hudson/model/AdministrativeMonitor.java
@@ -65,9 +65,9 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  * <dl>
  * <dt>message.jelly</dt>
  * <dd>
- * If {@link #isActivated()} returns true, Jenkins will use the <tt>message.jelly</tt>
+ * If {@link #isActivated()} returns true, Jenkins will use the {@code message.jelly}
  * view of this object to render the warning text. This happens in the
- * <tt>http://SERVER/jenkins/manage</tt> page. This view should typically render
+ * {@code http://SERVER/jenkins/manage} page. This view should typically render
  * a DIV box with class='error' or class='warning' with a human-readable text
  * inside it. It often also contains a link to a page that provides more details
  * about the problem.

--- a/core/src/main/java/hudson/model/Api.java
+++ b/core/src/main/java/hudson/model/Api.java
@@ -60,7 +60,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * Used to expose remote access API for ".../api/"
  *
  * <p>
- * If the parent object has a <tt>_api.jelly</tt> view, it will be included
+ * If the parent object has a {@code _api.jelly} view, it will be included
  * in the api index page.
  *
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/hudson/model/BuildBadgeAction.java
+++ b/core/src/main/java/hudson/model/BuildBadgeAction.java
@@ -32,7 +32,7 @@ package hudson.model;
  * with {@link Run}. 
  *
  * <p>
- * Actions with this marker should have a view <tt>badge.jelly</tt>,
+ * Actions with this marker should have a view {@code badge.jelly},
  * which will be called to render the badges. The expected visual appearance
  * of a badge is a 16x16 icon.
  *

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1493,7 +1493,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     /**
-     * Accepts <tt>config.xml</tt> submission, as well as serve it.
+     * Accepts {@code config.xml} submission, as well as serve it.
      */
     @WebMethod(name = "config.xml")
     public void doConfigDotXml(StaplerRequest req, StaplerResponse rsp)

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -538,7 +538,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      * Creates a configured instance from the submitted form.
      *
      * <p>
-     * Hudson only invokes this method when the user wants an instance of <tt>T</tt>.
+     * Hudson only invokes this method when the user wants an instance of {@code T}.
      * So there's no need to check that in the implementation.
      *
      * <p>
@@ -714,9 +714,9 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      *
      * <p>
      * This value is relative to the context root of Hudson, so normally
-     * the values are something like <tt>"/plugin/emma/help.html"</tt> to
-     * refer to static resource files in a plugin, or <tt>"/publisher/EmmaPublisher/abc"</tt>
-     * to refer to Jelly script <tt>abc.jelly</tt> or a method <tt>EmmaPublisher.doAbc()</tt>.
+     * the values are something like {@code "/plugin/emma/help.html"} to
+     * refer to static resource files in a plugin, or {@code "/publisher/EmmaPublisher/abc"}
+     * to refer to Jelly script {@code abc.jelly} or a method {@code EmmaPublisher.doAbc()}.
      *
      * @return
      *      null to indicate that there's no help.
@@ -915,7 +915,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
     }
 
     /**
-     * Serves <tt>help.html</tt> from the resource of {@link #clazz}.
+     * Serves {@code help.html} from the resource of {@link #clazz}.
      */
     public void doHelp(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         String path = req.getRestOfPath();

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -811,7 +811,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     /**
-     * Gets the youngest build #m that satisfies <tt>n&lt;=m</tt>.
+     * Gets the youngest build #m that satisfies {@code n&lt;=m}.
      * 
      * This is useful when you'd like to fetch a build but the exact build might
      * be already gone (deleted, rotated, etc.)
@@ -826,7 +826,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     /**
-     * Gets the latest build #m that satisfies <tt>m&lt;=n</tt>.
+     * Gets the latest build #m that satisfies {@code m&lt;=n}.
      * 
      * This is useful when you'd like to fetch a build but the exact build might
      * be already gone (deleted, rotated, etc.)

--- a/core/src/main/java/hudson/model/JobProperty.java
+++ b/core/src/main/java/hudson/model/JobProperty.java
@@ -53,9 +53,9 @@ import javax.annotation.Nonnull;
  * configuration screen, and they are persisted with the job object.
  *
  * <p>
- * Configuration screen should be defined in <tt>config.jelly</tt>.
+ * Configuration screen should be defined in {@code config.jelly}.
  * Within this page, the {@link JobProperty} instance is available
- * as <tt>instance</tt> variable (while <tt>it</tt> refers to {@link Job}.
+ * as {@code instance} variable (while {@code it} refers to {@link Job}.
  *
  * <p>
  * Starting 1.150, {@link JobProperty} implements {@link BuildStep},

--- a/core/src/main/java/hudson/model/ManagementLink.java
+++ b/core/src/main/java/hudson/model/ManagementLink.java
@@ -37,7 +37,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
- * Extension point to add icon to <tt>http://server/hudson/manage</tt> page.
+ * Extension point to add icon to {@code http://server/hudson/manage} page.
  *
  * <p>
  * This is a place for exposing features that are only meant for system admins

--- a/core/src/main/java/hudson/model/ModelObject.java
+++ b/core/src/main/java/hudson/model/ModelObject.java
@@ -27,7 +27,7 @@ package hudson.model;
  * A model object has a human readable name.
  *
  * And it normally has URL, but this interface doesn't define one.
- * (Since there're so many classes that define the <tt>getUrl</tt> method
+ * (Since there're so many classes that define the {@code getUrl} method
  * we should have such one.)
  *
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/hudson/model/ParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ParameterDefinition.java
@@ -75,18 +75,18 @@ import org.kohsuke.stapler.export.ExportedBean;
  *
  * <h2>Persistence</h2>
  * <p>
- * Instances of {@link ParameterDefinition}s are persisted into job <tt>config.xml</tt>
+ * Instances of {@link ParameterDefinition}s are persisted into job {@code config.xml}
  * through XStream.
  *
  *
  * <h2>Associated Views</h2>
  * <h3>config.jelly</h3>
- * {@link ParameterDefinition} class uses <tt>config.jelly</tt> to contribute a form
+ * {@link ParameterDefinition} class uses {@code config.jelly} to contribute a form
  * fragment in the job configuration screen. Values entered there are fed back to
  * {@link ParameterDescriptor#newInstance(StaplerRequest, JSONObject)} to create {@link ParameterDefinition}s.
  *
  * <h3>index.jelly</h3>
- * The <tt>index.jelly</tt> view contributes a form fragment in the page where the user
+ * The {@code index.jelly} view contributes a form fragment in the page where the user
  * enters actual values of parameters for a build. The result of this form submission
  * is then fed to {@link ParameterDefinition#createValue(StaplerRequest, JSONObject)} to
  * create {@link ParameterValue}s.

--- a/core/src/main/java/hudson/model/ParameterValue.java
+++ b/core/src/main/java/hudson/model/ParameterValue.java
@@ -56,12 +56,12 @@ import org.kohsuke.stapler.export.ExportedBean;
  *
  * <h2>Persistence</h2>
  * <p>
- * Instances of {@link ParameterValue}s are persisted into build's <tt>build.xml</tt>
+ * Instances of {@link ParameterValue}s are persisted into build's {@code build.xml}
  * through XStream (via {@link ParametersAction}), so instances need to be persistable.
  *
  * <h2>Associated Views</h2>
  * <h3>value.jelly</h3>
- * The <tt>value.jelly</tt> view contributes a UI fragment to display the parameter
+ * The {@code value.jelly} view contributes a UI fragment to display the parameter
  * values used for a build.
  *
  * <h2>Notes</h2>

--- a/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
+++ b/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
@@ -59,7 +59,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  * Keeps a list of the parameters defined for a project.
  *
  * <p>
- * This class also implements {@link Action} so that <tt>index.jelly</tt> provides
+ * This class also implements {@link Action} so that {@code index.jelly} provides
  * a form to enter build parameters.
  * <p>The owning job needs a {@code sidepanel.jelly} and should have web methods delegating to {@link ParameterizedJobMixIn#doBuild} and {@link ParameterizedJobMixIn#doBuildWithParameters}.
  * The builds also need a {@code sidepanel.jelly}.

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2004,7 +2004,7 @@ public class Queue extends ResourceController implements Saveable {
      *
      * <h2>Views</h2>
      * <p>
-     * Implementation must have <tt>executorCell.jelly</tt>, which is
+     * Implementation must have {@code executorCell.jelly}, which is
      * used to render the HTML that indicates this executable is executing.
      */
     public interface Executable extends Runnable {
@@ -3036,7 +3036,7 @@ public class Queue extends ResourceController implements Saveable {
     }
 
     /**
-     * Schedule <tt>Queue.save()</tt> call for near future once items change. Ignore all changes until the time the save
+     * Schedule {@code Queue.save()} call for near future once items change. Ignore all changes until the time the save
      * takes place.
      *
      * Once queue is restored after a crash, items stages might not be accurate until the next #maintain() - this is not

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1471,7 +1471,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     }
 
     /**
-     * Used from <tt>console.jelly</tt> to write annotated log to the given output.
+     * Used from {@code console.jelly} to write annotated log to the given output.
      *
      * @since 1.349
      */

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -84,7 +84,7 @@ import org.kohsuke.stapler.StaplerResponse;
  * Information about a Hudson agent node.
  *
  * <p>
- * Ideally this would have been in the <tt>hudson.slaves</tt> package,
+ * Ideally this would have been in the {@code hudson.slaves} package,
  * but for compatibility reasons, it can't.
  *
  * <p>

--- a/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
+++ b/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
@@ -125,7 +125,7 @@ public abstract class TopLevelItemDescriptor extends Descriptor<TopLevelItem> im
      *
      * <p>
      * Used as the caption when the user chooses what item type to create.
-     * The descriptor implementation also needs to have <tt>newInstanceDetail.jelly</tt>
+     * The descriptor implementation also needs to have {@code newInstanceDetail.jelly}
      * script, which will be used to render the text below the caption
      * that explains the item type.
      */

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -574,7 +574,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     }
 
     /**
-     * Gets the {@link UpdateSite} from which we receive updates for <tt>jenkins.war</tt>.
+     * Gets the {@link UpdateSite} from which we receive updates for {@code jenkins.war}.
      *
      * @return
      *      {@code null} if no such update center is provided.
@@ -1218,8 +1218,8 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
          *
          * @deprecated as of 1.333
          *      With the introduction of multiple update center capability, this information
-         *      is now a part of the <tt>update-center.json</tt> file. See
-         *      <tt>http://jenkins-ci.org/update-center.json</tt> as an example.
+         *      is now a part of the {@code update-center.json} file. See
+         *      {@code http://jenkins-ci.org/update-center.json} as an example.
          */
         @Deprecated
         public String getConnectionCheckUrl() {
@@ -1245,7 +1245,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
          * Returns the URL of the server that hosts plugins and core updates.
          *
          * @deprecated as of 1.333
-         *      <tt>update-center.json</tt> is now signed, so we don't have to further make sure that
+         *      {@code update-center.json} is now signed, so we don't have to further make sure that
          *      we aren't downloading from anywhere unsecure.
          */
         @Deprecated
@@ -1279,7 +1279,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     /**
      * Things that {@link UpdateCenter#installerService} executes.
      *
-     * This object will have the <tt>row.jelly</tt> which renders the job on UI.
+     * This object will have the {@code row.jelly} which renders the job on UI.
      */
     @ExportedBean
     public abstract class UpdateCenterJob implements Runnable {

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -131,7 +131,7 @@ public class UpdateSite {
     private final String id;
 
     /**
-     * Path to <tt>update-center.json</tt>, like <tt>http://jenkins-ci.org/update-center.json</tt>.
+     * Path to {@code update-center.json}, like {@code http://jenkins-ci.org/update-center.json}.
      */
     private final String url;
 

--- a/core/src/main/java/hudson/model/UserProperty.java
+++ b/core/src/main/java/hudson/model/UserProperty.java
@@ -41,10 +41,10 @@ import org.kohsuke.stapler.export.ExportedBean;
  * configuration screen, and they are persisted with the user object.
  *
  * <p>
- * Configuration screen should be defined in <tt>config.jelly</tt>.
+ * Configuration screen should be defined in {@code config.jelly}.
  * Within this page, the {@link UserProperty} instance is available
- * as <tt>instance</tt> variable (while <tt>it</tt> refers to {@link User}.
- * See {@link hudson.search.UserSearchProperty}'s <tt>config.jelly</tt> for an example.
+ * as {@code instance} variable (while {@code it} refers to {@link User}.
+ * See {@link hudson.search.UserSearchProperty}'s {@code config.jelly} for an example.
  * <p>A property may also define a {@code summary.jelly} view to show in the main user screen.
  *
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -134,7 +134,7 @@ import org.xml.sax.SAXException;
  * <h2>Note for implementers</h2>
  * <ul>
  * <li>
- * {@link View} subtypes need the <tt>newViewDetail.jelly</tt> page,
+ * {@link View} subtypes need the {@code newViewDetail.jelly} page,
  * which is included in the "new view" page. This page should have some
  * description of what the view is about. 
  * </ul>
@@ -1154,7 +1154,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     }
 
     /**
-     * Accepts <tt>config.xml</tt> submission, as well as serve it.
+     * Accepts {@code config.xml} submission, as well as serve it.
      */
     @WebMethod(name = "config.xml")
     public HttpResponse doConfigDotXml(StaplerRequest req) throws IOException {
@@ -1367,7 +1367,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     /**
      * Instantiate View subtype from XML stream.
      *
-     * @param name Alternative name to use or <tt>null</tt> to keep the one in xml.
+     * @param name Alternative name to use or {@code null} to keep the one in xml.
      */
     public static View createViewFromXML(String name, InputStream xml) throws IOException {
 

--- a/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
+++ b/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
@@ -19,7 +19,7 @@ import org.jvnet.localizer.Localizable;
  * has expanded beyond queues.
  *
  * <h2>View</h2>
- * <tt>summary.jelly</tt> should do one-line HTML rendering to be used showing the cause
+ * {@code summary.jelly} should do one-line HTML rendering to be used showing the cause
  * to the user. By default it simply renders {@link #getShortDescription()} text.
  *
  * <p>

--- a/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
@@ -134,16 +134,16 @@ public abstract class AbstractAsyncNodeMonitorDescriptor<T> extends AbstractNode
      * returned in the future.
      *
      * The {@link #getMonitoringData()} provides the results of the monitoring as {@link #monitor()} does. Note the value
-     * in the map can be <tt>null</tt> for several reasons:
+     * in the map can be {@code null} for several reasons:
      * <ul>
-     *     <li>The monitoring {@link Callable} returned <tt>null</tt> as a provisioning result.</li>
+     *     <li>The monitoring {@link Callable} returned {@code null} as a provisioning result.</li>
      *     <li>Creating or evaluating that callable has thrown an exception.</li>
      *     <li>The computer was not monitored as it was offline.</li>
      *     <li>The {@link AbstractAsyncNodeMonitorDescriptor#createCallable} has returned null.</li>
      * </ul>
      *
      * Clients can distinguishing among these states based on the additional data attached to this object. {@link #getSkipped()}
-     * returns computers that was not monitored as they ware either offline or monitor produced <tt>null</tt> {@link Callable}.
+     * returns computers that was not monitored as they ware either offline or monitor produced {@code null} {@link Callable}.
      */
     protected static final class Result<T> {
         private static final long serialVersionUID = -7671448355804481216L;

--- a/core/src/main/java/hudson/node_monitors/NodeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/NodeMonitor.java
@@ -48,7 +48,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  * <dl>
  * <dt>column.jelly</dt>
  * <dd>
- * Invoked from {@link ComputerSet} <tt>index.jelly</tt> to render a column.
+ * Invoked from {@link ComputerSet} {@code index.jelly} to render a column.
  * The {@link NodeMonitor} instance is accessible through the "from" variable.
  * Also see {@link #getColumnCaption()}.
  *

--- a/core/src/main/java/hudson/scheduler/RareOrImpossibleDateException.java
+++ b/core/src/main/java/hudson/scheduler/RareOrImpossibleDateException.java
@@ -35,7 +35,7 @@ import java.util.Calendar;
  * <p>This can typically have a few different reasons:</p>
  *
  * <ul>
- *   <li>The date is impossible. For example, June 31 does never happen, so <tt>0 0 31 6 *</tt> will never happen</li>
+ *   <li>The date is impossible. For example, June 31 does never happen, so {@code 0 0 31 6 *} will never happen</li>
  *   <li>The date happens only rarely
  *     <ul>
  *       <li>February 29 being the obvious one</li>

--- a/core/src/main/java/hudson/scm/AbstractScmTagAction.java
+++ b/core/src/main/java/hudson/scm/AbstractScmTagAction.java
@@ -37,11 +37,11 @@ import java.io.IOException;
 import jenkins.model.RunAction2;
 
 /**
- * Common part of <tt>CVSSCM.TagAction</tt> and <tt>SubversionTagAction</tt>.
+ * Common part of {@code CVSSCM.TagAction} and {@code SubversionTagAction}.
  *
  * <p>
  * This class implements the action that tags the modules. Derived classes
- * need to provide <tt>tagForm.jelly</tt> view that displays a form for
+ * need to provide {@code tagForm.jelly} view that displays a form for
  * letting user start tagging.
  *
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/hudson/scm/SCM.java
+++ b/core/src/main/java/hudson/scm/SCM.java
@@ -572,7 +572,7 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
      * <p>
      * Many builders, like Ant or Maven, works off the specific user file
      * at the top of the checked out module (in the above case, that would
-     * be <tt>xyz/build.xml</tt>), yet the builder doesn't know the "xyz"
+     * be {@code xyz/build.xml}), yet the builder doesn't know the "xyz"
      * part; that comes from SCM.
      *
      * <p>
@@ -678,7 +678,7 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
     }
 
     /**
-     * The returned object will be used to parse <tt>changelog.xml</tt>.
+     * The returned object will be used to parse {@code changelog.xml}.
      */
     public abstract ChangeLogParser createChangeLogParser();
 

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -334,7 +334,7 @@ public class Search implements StaplerProxy {
         public int length() { return tokens.length; }
 
         /**
-         * Returns {@link List} such that its <tt>get(end)</tt>
+         * Returns {@link List} such that its {@code get(end)}
          * returns the concatenation of [token_start,...,token_end]
          * (both end inclusive.)
          */

--- a/core/src/main/java/hudson/security/AuthenticationProcessingFilter2.java
+++ b/core/src/main/java/hudson/security/AuthenticationProcessingFilter2.java
@@ -39,7 +39,7 @@ import org.acegisecurity.ui.webapp.AuthenticationProcessingFilter;
 
 /**
  * {@link AuthenticationProcessingFilter} with a change for Jenkins so that
- * we can pick up the hidden "from" form field defined in <tt>login.jelly</tt>
+ * we can pick up the hidden "from" form field defined in {@code login.jelly}
  * to send the user back to where he came from, after a successful authentication.
  * 
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
+++ b/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
@@ -58,14 +58,14 @@ import java.net.URLEncoder;
  *
  * <p>
  * When an HTTP request arrives with an HTTP basic auth header, this filter detects
- * that and emulate an invocation of <tt>/j_security_check</tt>
+ * that and emulate an invocation of {@code /j_security_check}
  * (see <a href="http://mail-archives.apache.org/mod_mbox/tomcat-users/200105.mbox/%3C9005C0C9C85BD31181B20060085DAC8B10C8EF@tuvi.andmevara.ee%3E">this page</a> for the original technique.)
  *
  * <p>
  * This causes the container to perform authentication, but there's no way
  * to find out whether the user has been successfully authenticated or not.
  * So to find this out, we then redirect the user to
- * {@link jenkins.model.Jenkins#doSecured(StaplerRequest, StaplerResponse) <tt>/secured/...</tt> page}.
+ * {@link jenkins.model.Jenkins#doSecured(StaplerRequest, StaplerResponse) {@code /secured/...} page}.
  *
  * <p>
  * The handler of the above URL checks if the user is authenticated,
@@ -79,7 +79,7 @@ import java.net.URLEncoder;
  * <h2>Notes</h2>
  * <ul>
  * <li>
- * The technique of getting a request dispatcher for <tt>/j_security_check</tt> may not
+ * The technique of getting a request dispatcher for {@code /j_security_check} may not
  * work for all containers, but so far that seems like the only way to make this work.
  * <li>
  * This A → B → A redirect is a cyclic redirection, so we need to watch out for clients

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -730,7 +730,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
      *
      * <p>
      * The salt is prepended to the hashed password and returned. So the encoded password is of the form
-     * <tt>SALT ':' hash(PASSWORD,SALT)</tt>.
+     * {@code SALT ':' hash(PASSWORD,SALT)}.
      *
      * <p>
      * This abbreviates the need to store the salt separately, which in turn allows us to hide the salt handling

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -75,7 +75,7 @@ import java.util.logging.Logger;
  *
  * <p>
  * If additional views/URLs need to be exposed,
- * an active {@link SecurityRealm} is bound to <tt>CONTEXT_ROOT/securityRealm/</tt>
+ * an active {@link SecurityRealm} is bound to {@code CONTEXT_ROOT/securityRealm/}
  * through {@link jenkins.model.Jenkins#getSecurityRealm()}, so you can define additional pages and
  * operations on your {@link SecurityRealm}.
  *
@@ -143,7 +143,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
      * {@link AuthenticationManager} instantiation often depends on the user-specified parameters
      * (for example, if the authentication is based on LDAP, the user needs to specify
      * the host name of the LDAP server.) Such configuration is expected to be
-     * presented to the user via <tt>config.jelly</tt> and then
+     * presented to the user via {@code config.jelly} and then
      * captured as instance variables inside the {@link SecurityRealm} implementation.
      *
      * <p>
@@ -205,8 +205,8 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
      *
      * <p>
      * {@link SecurityRealm} is a singleton resource in Hudson, and therefore
-     * it's always configured through <tt>config.jelly</tt> and never with
-     * <tt>global.jelly</tt>. 
+     * it's always configured through {@code config.jelly} and never with
+     * {@code global.jelly}.
      */
     @Override
     public Descriptor<SecurityRealm> getDescriptor() {
@@ -225,7 +225,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
      * Gets the target URL of the "login" link.
      * There's no need to override this, except for {@link LegacySecurityRealm}.
      * On legacy implementation this should point to {@code loginEntry}, which
-     * is protected by <tt>web.xml</tt>, so that the user can be eventually authenticated
+     * is protected by {@code web.xml}, so that the user can be eventually authenticated
      * by the container.
      *
      * <p>
@@ -315,12 +315,12 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
 
     /**
      * Returns true if this {@link SecurityRealm} allows online sign-up.
-     * This creates a hyperlink that redirects users to <tt>CONTEXT_ROOT/signUp</tt>,
-     * which will be served by the <tt>signup.jelly</tt> view of this class.
+     * This creates a hyperlink that redirects users to {@code CONTEXT_ROOT/signUp},
+     * which will be served by the {@code signup.jelly} view of this class.
      *
      * <p>
      * If the implementation needs to redirect the user to a different URL
-     * for signing up, use the following jelly script as <tt>signup.jelly</tt>
+     * for signing up, use the following jelly script as {@code signup.jelly}
      *
      * <pre>{@code <xmp>
      * <st:redirect url="http://www.sun.com/" xmlns:st="jelly:stapler"/>

--- a/core/src/main/java/hudson/security/captcha/CaptchaSupport.java
+++ b/core/src/main/java/hudson/security/captcha/CaptchaSupport.java
@@ -38,7 +38,7 @@ import jenkins.model.Jenkins;
  * Extension point for adding Captcha Support to User Registration Page {@link CaptchaSupport}.
  *
  * <p>
- * This object can have an optional <tt>config.jelly</tt> to configure the Captcha Support
+ * This object can have an optional {@code config.jelly} to configure the Captcha Support
  * <p>
  * A default constructor is needed to create CaptchaSupport in
  * the default configuration.

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -67,7 +67,7 @@ import java.util.concurrent.Future;
  * <p>
  * To do this, have your {@link Slave} subtype remember the necessary handle (such as EC2 instance ID)
  * as a field. Such fields need to survive the user-initiated re-configuration of {@link Slave}, so you'll need to
- * expose it in your {@link Slave} <tt>configure-entries.jelly</tt> and read it back in through {@link DataBoundConstructor}.
+ * expose it in your {@link Slave} {@code configure-entries.jelly} and read it back in through {@link DataBoundConstructor}.
  *
  * <p>
  * You then implement your own {@link Computer} subtype, override {@link Slave#createComputer()}, and instantiate
@@ -80,9 +80,9 @@ import java.util.concurrent.Future;
  *
  * <h3>Views</h3>
  *
- * Since version 2.64, Jenkins clouds are visualized in UI. Implementations can provide <tt>top</tt> or <tt>main</tt> view
- * to be presented at the top of the page or at the bottom respectively. In the middle, actions have their <tt>summary</tt>
- * views displayed. Actions further contribute to <tt>sidepanel</tt> with <tt>box</tt> views. All mentioned views are
+ * Since version 2.64, Jenkins clouds are visualized in UI. Implementations can provide {@code top} or {@code main} view
+ * to be presented at the top of the page or at the bottom respectively. In the middle, actions have their {@code summary}
+ * views displayed. Actions further contribute to {@code sidepanel} with {@code box} views. All mentioned views are
  * optional to preserve backward compatibility.
  *
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/hudson/slaves/NodeDescriptor.java
+++ b/core/src/main/java/hudson/slaves/NodeDescriptor.java
@@ -50,8 +50,8 @@ import javax.servlet.ServletException;
  *
  * <h2>Views</h2>
  * <p>
- * This object needs to have <tt>newInstanceDetail.jelly</tt> view, which shows up in
- * <tt>http://server/hudson/computers/new</tt> page as an explanation of this job type.
+ * This object needs to have {@code newInstanceDetail.jelly} view, which shows up in
+ * {@code http://server/hudson/computers/new} page as an explanation of this job type.
  *
  * <h2>Other Implementation Notes</h2>
  *

--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -44,7 +44,7 @@ import java.util.Date;
  *
  * <h2>Views</h2>
  * <p>
- * {@link OfflineCause} must have <tt>cause.jelly</tt> that renders a cause
+ * {@link OfflineCause} must have {@code cause.jelly} that renders a cause
  * into HTML. This is used to tell users why the node is put offline.
  * This view should render a block element like DIV.
  *

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -408,7 +408,7 @@ public class SlaveComputer extends Computer {
      *      Stream connected to the remote peer. It's the caller's responsibility to do
      *      buffering on this stream, if that's necessary.
      * @param launchLog
-     *      If non-null, receive the portion of data in <tt>is</tt> before
+     *      If non-null, receive the portion of data in {@code is} before
      *      the data goes into the "binary mode". This is useful
      *      when the established communication channel might include some data that might
      *      be useful for debugging/trouble-shooting.

--- a/core/src/main/java/hudson/tasks/BuildStep.java
+++ b/core/src/main/java/hudson/tasks/BuildStep.java
@@ -65,7 +65,7 @@ import jenkins.model.Jenkins;
  * So generally speaking, derived classes should use instance variables
  * only for keeping configuration. You can still store objects you use
  * for processing, like a parser of some sort, but they need to be marked
- * as <tt>transient</tt>, and the code needs to be aware that they might
+ * as {@code transient}, and the code needs to be aware that they might
  * be null (which is the case when you access the field for the first time
  * the object is restored.)
  *
@@ -145,7 +145,7 @@ public interface BuildStep {
      * it owns when the rendering is requested.
      *
      * <p>
-     * This action can have optional <tt>jobMain.jelly</tt> view, which will be
+     * This action can have optional {@code jobMain.jelly} view, which will be
      * aggregated into the main panel of the job top page. The jelly file
      * should have an {@code <h2>} tag that shows the section title, followed by some
      * block elements to render the details of the section.

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -246,7 +246,7 @@ public class Maven extends Builder {
     }
 
     /**
-     * Looks for <tt>pom.xlm</tt> or <tt>project.xml</tt> to determine the maven executable
+     * Looks for {@code pom.xlm} or {@code project.xml} to determine the maven executable
      * name.
      */
     private static final class DecideDefaultMavenCommand extends MasterToSlaveFileCallable<String> {
@@ -779,7 +779,7 @@ public class Maven extends Builder {
          * If the Maven installation can not be uniquely determined,
          * it's often better to return just one of them, rather than returning
          * null, since this method is currently ultimately only used to
-         * decide where to parse <tt>conf/settings.xml</tt> from.
+         * decide where to parse {@code conf/settings.xml} from.
          */
         MavenInstallation inferMavenInstallation();
     }

--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -108,7 +108,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
      *
      * @return
      *      Return the real top directory inside {@code root} that contains the meat. In the above example,
-     *      <tt>root.child("jakarta-ant")</tt> should be returned. If there's no directory to pull up,
+     *      {@code root.child("jakarta-ant")} should be returned. If there's no directory to pull up,
      *      return null. 
      */
     protected FilePath findPullUpDirectory(FilePath root) throws IOException, InterruptedException {

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -471,7 +471,7 @@ public class SCMTrigger extends Trigger<Item> {
         }
         
         /**
-         * Used from <tt>polling.jelly</tt> to write annotated polling log to the given output.
+         * Used from {@code polling.jelly} to write annotated polling log to the given output.
          */
         public void writePollingLogTo(long offset, XMLOutput out) throws IOException {
             // TODO: resurrect compressed log file support

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -165,7 +165,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
     /**
      * Adds key value pairs as "-Dkey=value -Dkey=value ..."
      *
-     * <tt>-D</tt> portion is configurable as the 'prefix' parameter.
+     * {@code -D} portion is configurable as the 'prefix' parameter.
      * @since 1.114
      */
     public ArgumentListBuilder addKeyValuePairs(String prefix, Map<String,String> props) {

--- a/core/src/main/java/hudson/util/DoubleLaunchChecker.java
+++ b/core/src/main/java/hudson/util/DoubleLaunchChecker.java
@@ -47,7 +47,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
 
 /**
- * Makes sure that no other Hudson uses our <tt>JENKINS_HOME</tt> directory,
+ * Makes sure that no other Hudson uses our {@code JENKINS_HOME} directory,
  * to forestall the problem of running multiple instances of Hudson that point to the same data directory.
  *
  * <p>

--- a/core/src/main/java/hudson/util/ErrorObject.java
+++ b/core/src/main/java/hudson/util/ErrorObject.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  * Basis for error model objects.
  *
  * This implementation serves error pages for any requests under its domain. Subclasses are responsible for providing
- * <tt>index</tt> view.
+ * {@code index} view.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/util/FormFieldValidator.java
+++ b/core/src/main/java/hudson/util/FormFieldValidator.java
@@ -170,8 +170,8 @@ public abstract class FormFieldValidator {
      * Sends out a string error message that indicates an error.
      *
      * @param message
-     *      Human readable message to be sent. <tt>error(null)</tt>
-     *      can be used as <tt>ok()</tt>.
+     *      Human readable message to be sent. {@code error(null)}
+     *      can be used as {@code ok()}.
      */
     public void error(String message) throws IOException, ServletException {
         errorWithMarkup(message==null?null:Util.escape(message));
@@ -209,8 +209,8 @@ public abstract class FormFieldValidator {
      * attack.
      *
      * @param message
-     *      Human readable message to be sent. <tt>error(null)</tt>
-     *      can be used as <tt>ok()</tt>.
+     *      Human readable message to be sent. {@code error(null)}
+     *      can be used as {@code ok()}.
      */
     public void errorWithMarkup(String message) throws IOException, ServletException {
         _errorWithMarkup(message,"error");

--- a/core/src/main/java/hudson/util/FormFillFailure.java
+++ b/core/src/main/java/hudson/util/FormFillFailure.java
@@ -40,7 +40,7 @@ import org.kohsuke.stapler.StaplerResponse;
  * Represents a failure in a form field doFillXYZ method.
  *
  * <p>
- * Use one of the factory methods to create an instance, then throw it from your <tt>doFillXyz</tt>
+ * Use one of the factory methods to create an instance, then throw it from your {@code doFillXyz}
  * method.
  *
  * @since 2.50
@@ -117,8 +117,8 @@ public abstract class FormFillFailure extends IOException implements HttpRespons
      * This method must be used with care to avoid cross-site scripting
      * attack.
      *
-     * @param message Human readable message to be sent. <tt>error(null)</tt>
-     *                can be used as <tt>ok()</tt>.
+     * @param message Human readable message to be sent. {@code error(null)}
+     *                can be used as {@code ok()}.
      */
     public static FormFillFailure errorWithMarkup(String message) {
         return _errorWithMarkup(message, FormValidation.Kind.ERROR);

--- a/core/src/main/java/hudson/util/FormValidation.java
+++ b/core/src/main/java/hudson/util/FormValidation.java
@@ -66,7 +66,7 @@ import static hudson.Util.*;
  * Represents the result of the form field validation.
  *
  * <p>
- * Use one of the factory methods to create an instance, then return it from your <tt>doCheckXyz</tt>
+ * Use one of the factory methods to create an instance, then return it from your {@code doCheckXyz}
  * method. (Via {@link HttpResponse}, the returned object will render the result into {@link StaplerResponse}.)
  * This way of designing form field validation allows you to reuse {@code doCheckXyz()} methods
  * programmatically as well (by using {@link #kind}.
@@ -77,7 +77,7 @@ import static hudson.Util.*;
  * that you may be able to reuse.
  *
  * <p>
- * Also see <tt>doCheckCvsRoot</tt> in <tt>CVSSCM</tt> as an example.
+ * Also see {@code doCheckCvsRoot} in {@code CVSSCM} as an example.
  *
  * <p>
  * This class extends {@link IOException} so that it can be thrown from a method. This allows one to reuse
@@ -136,8 +136,8 @@ public abstract class FormValidation extends IOException implements HttpResponse
      * Sends out a string error message that indicates an error.
      *
      * @param message
-     *      Human readable message to be sent. <tt>error(null)</tt>
-     *      can be used as <tt>ok()</tt>.
+     *      Human readable message to be sent. {@code error(null)}
+     *      can be used as {@code ok()}.
      */
     public static FormValidation error(String message) {
         return errorWithMarkup(message==null?null: Util.escape(message));
@@ -245,8 +245,8 @@ public abstract class FormValidation extends IOException implements HttpResponse
      * attack.
      *
      * @param message
-     *      Human readable message to be sent. <tt>error(null)</tt>
-     *      can be used as <tt>ok()</tt>.
+     *      Human readable message to be sent. {@code error(null)}
+     *      can be used as {@code ok()}.
      */
     public static FormValidation errorWithMarkup(String message) {
         return _errorWithMarkup(message,Kind.ERROR);

--- a/core/src/main/java/hudson/util/Function1.java
+++ b/core/src/main/java/hudson/util/Function1.java
@@ -24,7 +24,7 @@
 package hudson.util;
 
 /**
- * Unary function <tt>y=f(x)</tt>.
+ * Unary function {@code y=f(x)}.
  * 
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/util/HudsonFailedToLoad.java
+++ b/core/src/main/java/hudson/util/HudsonFailedToLoad.java
@@ -30,7 +30,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * Model object used to display the generic error when Jenkins start up fails fatally during initialization.
  *
  * <p>
- * <tt>index.jelly</tt> would display a nice friendly error page.
+ * {@code index.jelly} would display a nice friendly error page.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/util/IncompatibleAntVersionDetected.java
+++ b/core/src/main/java/hudson/util/IncompatibleAntVersionDetected.java
@@ -33,7 +33,7 @@ import java.net.URL;
  * we find out that the container is picking up its own Ant and that's not 1.7.
  *
  * <p>
- * <tt>index.jelly</tt> would display a nice friendly error page.
+ * {@code index.jelly} would display a nice friendly error page.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/util/IncompatibleServletVersionDetected.java
+++ b/core/src/main/java/hudson/util/IncompatibleServletVersionDetected.java
@@ -33,7 +33,7 @@ import java.net.URL;
  * we find out that the container doesn't support servlet 2.4.
  *
  * <p>
- * <tt>index.jelly</tt> would display a nice friendly error page.
+ * {@code index.jelly} would display a nice friendly error page.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/util/IncompatibleVMDetected.java
+++ b/core/src/main/java/hudson/util/IncompatibleVMDetected.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * we find out that XStream is running in pure-java mode.
  *
  * <p>
- * <tt>index.jelly</tt> would display a nice friendly error page.
+ * {@code index.jelly} would display a nice friendly error page.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/util/InsufficientPermissionDetected.java
+++ b/core/src/main/java/hudson/util/InsufficientPermissionDetected.java
@@ -31,7 +31,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * we find that we don't have enough permissions to run.
  *
  * <p>
- * <tt>index.jelly</tt> would display a nice friendly error page.
+ * {@code index.jelly} would display a nice friendly error page.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/util/KeyedDataStorage.java
+++ b/core/src/main/java/hudson/util/KeyedDataStorage.java
@@ -254,7 +254,7 @@ public abstract class KeyedDataStorage<T,P> {
      * Among cache misses, number of times when we had {@link SoftReference}
      * but lost its value due to GC.
      *
-     * <tt>totalQuery-cacheHit-weakRefLost</tt> means cache miss.
+     * {@code totalQuery-cacheHit-weakRefLost} means cache miss.
      */
     public final AtomicInteger weakRefLost = new AtomicInteger();
     /**

--- a/core/src/main/java/hudson/util/LineEndNormalizingWriter.java
+++ b/core/src/main/java/hudson/util/LineEndNormalizingWriter.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * Finds the lone LF and converts that to CR+LF.
  *
  * <p>
- * Internet Explorer's <tt>XmlHttpRequest.responseText</tt> seems to
+ * Internet Explorer's {@code XmlHttpRequest.responseText} seems to
  * normalize the line end, and if we only send LF without CR, it will
  * not recognize that as a new line. To work around this problem,
  * we use this filter to always convert LF to CR+LF.

--- a/core/src/main/java/hudson/util/ListBoxModel.java
+++ b/core/src/main/java/hudson/util/ListBoxModel.java
@@ -62,7 +62,7 @@ import java.util.Collection;
  *
  * <p>
  * Other parts of the HTML can initiate the SELECT element update by using the "updateListBox"
- * function, defined in <tt>hudson-behavior.js</tt>. The following example does it
+ * function, defined in {@code hudson-behavior.js}. The following example does it
  * when the value of the textbox changes:
  *
  * <pre>{@code <xmp>
@@ -70,11 +70,11 @@ import java.util.Collection;
  * </xmp>}</pre>
  *
  * <p>
- * The first argument is the SELECT element or the ID of it (see Prototype.js <tt>$(...)</tt> function.)
+ * The first argument is the SELECT element or the ID of it (see Prototype.js {@code $(...)} function.)
  * The second argument is the URL that returns the options list.
  *
  * <p>
- * The URL usually maps to the <tt>doXXX</tt> method on the server, which uses {@link ListBoxModel}
+ * The URL usually maps to the {@code doXXX} method on the server, which uses {@link ListBoxModel}
  * for producing option values. See the following example:
  *
  * <pre>

--- a/core/src/main/java/hudson/util/NoHomeDir.java
+++ b/core/src/main/java/hudson/util/NoHomeDir.java
@@ -30,7 +30,7 @@ import java.io.File;
  * we couldn't create the home directory.
  *
  * <p>
- * <tt>index.jelly</tt> would display a nice friendly error page.
+ * {@code index.jelly} would display a nice friendly error page.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/util/NoTempDir.java
+++ b/core/src/main/java/hudson/util/NoTempDir.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * there appears to be no temporary directory.
  *
  * <p>
- * <tt>index.jelly</tt> would display a nice friendly error page.
+ * {@code index.jelly} would display a nice friendly error page.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -969,7 +969,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
     }
 
     /**
-     * Implementation for Solaris that uses <tt>/proc</tt>.
+     * Implementation for Solaris that uses {@code /proc}.
      *
      * /proc/PID/psinfo contains a psinfo_t struct. We use it to determine where the
      *     process arguments and environment are located in PID's address space.

--- a/core/src/main/java/hudson/util/Service.java
+++ b/core/src/main/java/hudson/util/Service.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
 import static java.util.logging.Level.WARNING;
 
 /**
- * Load classes by looking up <tt>META-INF/services</tt>.
+ * Load classes by looking up {@code META-INF/services}.
  *
  * @author Kohsuke Kawaguchi
  * @deprecated use {@link ServiceLoader} instead.
@@ -76,7 +76,7 @@ public class Service {
     }
 
     /**
-     * Look up <tt>META-INF/service/<i>SPICLASSNAME</i></tt> from the classloader
+     * Look up {@code META-INF/service/<i>SPICLASSNAME</i>} from the classloader
      * and all the discovered classes into the given collection.
      */
     public static <T> void load(Class<T> spi, ClassLoader cl, Collection<Class<? extends T>> result) {

--- a/core/src/main/java/hudson/util/TimeUnit2.java
+++ b/core/src/main/java/hudson/util/TimeUnit2.java
@@ -36,10 +36,10 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A <tt>TimeUnit</tt> represents time durations at a given unit of
+ * A {@code TimeUnit} represents time durations at a given unit of
  * granularity and provides utility methods to convert across units,
  * and to perform timing and delay operations in these units.  A
- * <tt>TimeUnit</tt> does not maintain time information, but only
+ * {@code TimeUnit} does not maintain time information, but only
  * helps organize and use time representations that may be maintained
  * separately across various contexts.  A nanosecond is defined as one
  * thousandth of a microsecond, a microsecond as one thousandth of a
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
  * as sixty seconds, an hour as sixty minutes, and a day as twenty four
  * hours.
  *
- * <p>A <tt>TimeUnit</tt> is mainly used to inform time-based methods
+ * <p>A {@code TimeUnit} is mainly used to inform time-based methods
  * how a given timing parameter should be interpreted. For example,
  * the following code will timeout in 50 milliseconds if the {@link
  * java.util.concurrent.locks.Lock lock} is not available:
@@ -63,7 +63,7 @@ import java.util.concurrent.TimeUnit;
  *
  * Note however, that there is no guarantee that a particular timeout
  * implementation will be able to notice the passage of time at the
- * same granularity as the given <tt>TimeUnit</tt>.
+ * same granularity as the given {@code TimeUnit}.
  *
  * @author Doug Lea
  * @deprecated use {@link TimeUnit}. (Java 5 did not have all the units required, so {@link TimeUnit2} was introduced
@@ -188,20 +188,20 @@ public enum TimeUnit2 {
      * Convert the given time duration in the given unit to this
      * unit.  Conversions from finer to coarser granularities
      * truncate, so lose precision. For example converting
-     * <tt>999</tt> milliseconds to seconds results in
-     * <tt>0</tt>. Conversions from coarser to finer granularities
+     * {@code 999} milliseconds to seconds results in
+     * {@code 0}. Conversions from coarser to finer granularities
      * with arguments that would numerically overflow saturate to
-     * <tt>Long.MIN_VALUE</tt> if negative or <tt>Long.MAX_VALUE</tt>
+     * {@code Long.MIN_VALUE} if negative or {@code Long.MAX_VALUE}
      * if positive.
      *
      * <p>For example, to convert 10 minutes to milliseconds, use:
-     * <tt>TimeUnit.MILLISECONDS.convert(10L, TimeUnit.MINUTES)</tt>
+     * {@code TimeUnit.MILLISECONDS.convert(10L, TimeUnit.MINUTES)}
      *
-     * @param sourceDuration the time duration in the given <tt>sourceUnit</tt>
-     * @param sourceUnit the unit of the <tt>sourceDuration</tt> argument
+     * @param sourceDuration the time duration in the given {@code sourceUnit}
+     * @param sourceUnit the unit of the {@code sourceDuration} argument
      * @return the converted duration in this unit,
-     * or <tt>Long.MIN_VALUE</tt> if conversion would negatively
-     * overflow, or <tt>Long.MAX_VALUE</tt> if it would positively overflow.
+     * or {@code Long.MIN_VALUE} if conversion would negatively
+     * overflow, or {@code Long.MAX_VALUE} if it would positively overflow.
      */
     public long convert(long sourceDuration, TimeUnit2 sourceUnit) {
         throw new AbstractMethodError();
@@ -211,31 +211,31 @@ public enum TimeUnit2 {
      * Convert the given time duration in the given unit to this
      * unit.  Conversions from finer to coarser granularities
      * truncate, so lose precision. For example converting
-     * <tt>999</tt> milliseconds to seconds results in
-     * <tt>0</tt>. Conversions from coarser to finer granularities
+     * {@code 999} milliseconds to seconds results in
+     * {@code 0}. Conversions from coarser to finer granularities
      * with arguments that would numerically overflow saturate to
-     * <tt>Long.MIN_VALUE</tt> if negative or <tt>Long.MAX_VALUE</tt>
+     * {@code Long.MIN_VALUE} if negative or {@code Long.MAX_VALUE}
      * if positive.
      *
      * <p>For example, to convert 10 minutes to milliseconds, use:
-     * <tt>TimeUnit.MILLISECONDS.convert(10L, TimeUnit.MINUTES)</tt>
+     * {@code TimeUnit.MILLISECONDS.convert(10L, TimeUnit.MINUTES)}
      *
-     * @param sourceDuration the time duration in the given <tt>sourceUnit</tt>
-     * @param sourceUnit the unit of the <tt>sourceDuration</tt> argument
+     * @param sourceDuration the time duration in the given {@code sourceUnit}
+     * @param sourceUnit the unit of the {@code sourceDuration} argument
      * @return the converted duration in this unit,
-     * or <tt>Long.MIN_VALUE</tt> if conversion would negatively
-     * overflow, or <tt>Long.MAX_VALUE</tt> if it would positively overflow.
+     * or {@code Long.MIN_VALUE} if conversion would negatively
+     * overflow, or {@code Long.MAX_VALUE} if it would positively overflow.
      */
     public long convert(long sourceDuration, TimeUnit sourceUnit) {
         throw new AbstractMethodError();
     }
 
     /**
-     * Equivalent to <tt>NANOSECONDS.convert(duration, this)</tt>.
+     * Equivalent to {@code NANOSECONDS.convert(duration, this)}.
      * @param duration the duration
      * @return the converted duration,
-     * or <tt>Long.MIN_VALUE</tt> if conversion would negatively
-     * overflow, or <tt>Long.MAX_VALUE</tt> if it would positively overflow.
+     * or {@code Long.MIN_VALUE} if conversion would negatively
+     * overflow, or {@code Long.MAX_VALUE} if it would positively overflow.
      * @see #convert
      */
     public long toNanos(long duration) {
@@ -243,11 +243,11 @@ public enum TimeUnit2 {
     }
 
     /**
-     * Equivalent to <tt>MICROSECONDS.convert(duration, this)</tt>.
+     * Equivalent to {@code MICROSECONDS.convert(duration, this)}.
      * @param duration the duration
      * @return the converted duration,
-     * or <tt>Long.MIN_VALUE</tt> if conversion would negatively
-     * overflow, or <tt>Long.MAX_VALUE</tt> if it would positively overflow.
+     * or {@code Long.MIN_VALUE} if conversion would negatively
+     * overflow, or {@code Long.MAX_VALUE} if it would positively overflow.
      * @see #convert
      */
     public long toMicros(long duration) {
@@ -255,11 +255,11 @@ public enum TimeUnit2 {
     }
 
     /**
-     * Equivalent to <tt>MILLISECONDS.convert(duration, this)</tt>.
+     * Equivalent to {@code MILLISECONDS.convert(duration, this)}.
      * @param duration the duration
      * @return the converted duration,
-     * or <tt>Long.MIN_VALUE</tt> if conversion would negatively
-     * overflow, or <tt>Long.MAX_VALUE</tt> if it would positively overflow.
+     * or {@code Long.MIN_VALUE} if conversion would negatively
+     * overflow, or {@code Long.MAX_VALUE} if it would positively overflow.
      * @see #convert
      */
     public long toMillis(long duration) {
@@ -267,11 +267,11 @@ public enum TimeUnit2 {
     }
 
     /**
-     * Equivalent to <tt>SECONDS.convert(duration, this)</tt>.
+     * Equivalent to {@code SECONDS.convert(duration, this)}.
      * @param duration the duration
      * @return the converted duration,
-     * or <tt>Long.MIN_VALUE</tt> if conversion would negatively
-     * overflow, or <tt>Long.MAX_VALUE</tt> if it would positively overflow.
+     * or {@code Long.MIN_VALUE} if conversion would negatively
+     * overflow, or {@code Long.MAX_VALUE} if it would positively overflow.
      * @see #convert
      */
     public long toSeconds(long duration) {
@@ -279,11 +279,11 @@ public enum TimeUnit2 {
     }
 
     /**
-     * Equivalent to <tt>MINUTES.convert(duration, this)</tt>.
+     * Equivalent to {@code MINUTES.convert(duration, this)}.
      * @param duration the duration
      * @return the converted duration,
-     * or <tt>Long.MIN_VALUE</tt> if conversion would negatively
-     * overflow, or <tt>Long.MAX_VALUE</tt> if it would positively overflow.
+     * or {@code Long.MIN_VALUE} if conversion would negatively
+     * overflow, or {@code Long.MAX_VALUE} if it would positively overflow.
      * @see #convert
      */
     public long toMinutes(long duration) {
@@ -291,11 +291,11 @@ public enum TimeUnit2 {
     }
 
     /**
-     * Equivalent to <tt>HOURS.convert(duration, this)</tt>.
+     * Equivalent to {@code HOURS.convert(duration, this)}.
      * @param duration the duration
      * @return the converted duration,
-     * or <tt>Long.MIN_VALUE</tt> if conversion would negatively
-     * overflow, or <tt>Long.MAX_VALUE</tt> if it would positively overflow.
+     * or {@code Long.MIN_VALUE} if conversion would negatively
+     * overflow, or {@code Long.MAX_VALUE} if it would positively overflow.
      * @see #convert
      */
     public long toHours(long duration) {
@@ -303,7 +303,7 @@ public enum TimeUnit2 {
     }
 
     /**
-     * Equivalent to <tt>DAYS.convert(duration, this)</tt>.
+     * Equivalent to {@code DAYS.convert(duration, this)}.
      * @param duration the duration
      * @return the converted duration
      * @see #convert
@@ -322,11 +322,11 @@ public enum TimeUnit2 {
     abstract int excessNanos(long d, long m);
 
     /**
-     * Performs a timed <tt>Object.wait</tt> using this time unit.
+     * Performs a timed {@code Object.wait} using this time unit.
      * This is a convenience method that converts timeout arguments
-     * into the form required by the <tt>Object.wait</tt> method.
+     * into the form required by the {@code Object.wait} method.
      *
-     * <p>For example, you could implement a blocking <tt>poll</tt>
+     * <p>For example, you could implement a blocking {@code poll}
      * method (see {@link java.util.concurrent.BlockingQueue#poll BlockingQueue.poll})
      * using:
      *
@@ -353,9 +353,9 @@ public enum TimeUnit2 {
     }
 
     /**
-     * Performs a timed <tt>Thread.join</tt> using this time unit.
+     * Performs a timed {@code Thread.join} using this time unit.
      * This is a convenience method that converts time arguments into the
-     * form required by the <tt>Thread.join</tt> method.
+     * form required by the {@code Thread.join} method.
      * @param thread the thread to wait for
      * @param timeout the maximum time to wait. If less than
      * or equal to zero, do not wait at all.
@@ -372,9 +372,9 @@ public enum TimeUnit2 {
     }
 
     /**
-     * Performs a <tt>Thread.sleep</tt> using this unit.
+     * Performs a {@code Thread.sleep} using this unit.
      * This is a convenience method that converts time arguments into the
-     * form required by the <tt>Thread.sleep</tt> method.
+     * form required by the {@code Thread.sleep} method.
      * @param timeout the minimum time to sleep. If less than
      * or equal to zero, do not sleep at all.
      * @throws InterruptedException if interrupted while sleeping.

--- a/core/src/main/java/hudson/views/ListViewColumn.java
+++ b/core/src/main/java/hudson/views/ListViewColumn.java
@@ -48,13 +48,13 @@ import net.sf.json.JSONObject;
  * Extension point for adding a column to a table rendering of {@link Item}s, such as {@link ListView}.
  *
  * <p>
- * This object must have the <tt>column.jelly</tt>. This view
+ * This object must have the {@code column.jelly}. This view
  * is called for each cell of this column. The {@link Item} object
  * is passed in the "job" variable. The view should render
  * the {@code <td>} tag.
  *
  * <p>
- * This object may have an additional <tt>columnHeader.jelly</tt>. The default ColumnHeader
+ * This object may have an additional {@code columnHeader.jelly}. The default ColumnHeader
  * will render {@link #getColumnCaption()}.
  *
  * <p>

--- a/core/src/main/java/hudson/views/MyViewsTabBar.java
+++ b/core/src/main/java/hudson/views/MyViewsTabBar.java
@@ -47,7 +47,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * Extension point for adding a MyViewsTabBar header to Projects {@link MyViewsProperty}.
  *
  * <p>
- * This object must have the <tt>myViewTabs.jelly</tt>. This view
+ * This object must have the {@code myViewTabs.jelly}. This view
  * is called once when the My Views main panel is built.
  * The "views" attribute is set to the "Collection of views".
  *

--- a/core/src/main/java/hudson/views/ViewsTabBar.java
+++ b/core/src/main/java/hudson/views/ViewsTabBar.java
@@ -48,7 +48,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * Extension point for adding a ViewsTabBar header to Projects {@link ListView}.
  *
  * <p>
- * This object must have the <tt>viewTabs.jelly</tt>. This view
+ * This object must have the {@code viewTabs.jelly}. This view
  * is called once when the project views main panel is built.
  * The "views" attribute is set to the "Collection of views".
  *

--- a/core/src/main/java/jenkins/model/CauseOfInterruption.java
+++ b/core/src/main/java/jenkins/model/CauseOfInterruption.java
@@ -39,7 +39,7 @@ import javax.annotation.Nonnull;
  * Records why an {@linkplain Executor#interrupt() executor is interrupted}.
  *
  * <h2>View</h2>
- * <tt>summary.groovy/.jelly</tt> should do one-line HTML rendering to be used while rendering
+ * {@code summary.groovy/.jelly} should do one-line HTML rendering to be used while rendering
  * "build history" widget, next to the blocking build. By default it simply renders
  * {@link #getShortDescription()} text.
  *

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -797,7 +797,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     /**
      * Secret key generated once and used for a long time, beyond
-     * container start/stop. Persisted outside <tt>config.xml</tt> to avoid
+     * container start/stop. Persisted outside {@code config.xml} to avoid
      * accidental exposure.
      */
     private transient final String secretKey;
@@ -1557,7 +1557,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     /**
      * Gets the plugin object from its short name.
-     * This allows URL <tt>hudson/plugin/ID</tt> to be served by the views
+     * This allows URL {@code hudson/plugin/ID} to be served by the views
      * of the plugin class.
      * @param shortName Short name of the plugin
      * @return The plugin singleton or {@code null} if for some reason the plugin is not loaded.
@@ -4618,7 +4618,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
     
     /**
-     * Exposes the current user to <tt>/me</tt> URL.
+     * Exposes the current user to {@code /me} URL.
      */
     public User getMe() {
         User u = User.current();

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -157,7 +157,7 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration implements
     }
 
     /**
-     * Checks the URL in <tt>global.jelly</tt>
+     * Checks the URL in {@code global.jelly}
      */
     public FormValidation doCheckUrl(@QueryParameter String value) {
         if(value.startsWith("http://localhost"))

--- a/core/src/main/java/jenkins/security/BasicHeaderProcessor.java
+++ b/core/src/main/java/jenkins/security/BasicHeaderProcessor.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
 import static java.util.logging.Level.*;
 
 /**
- * Takes "username:password" given in the <tt>Authorization</tt> HTTP header and authenticates
+ * Takes "username:password" given in the {@code Authorization} HTTP header and authenticates
  * the request.
  *
  * <p>

--- a/core/src/main/java/jenkins/security/ExceptionTranslationFilter.java
+++ b/core/src/main/java/jenkins/security/ExceptionTranslationFilter.java
@@ -53,13 +53,13 @@ import java.util.logging.Logger;
  * <p>
  * If an {@link AuthenticationException} is detected, the filter will launch the <code>authenticationEntryPoint</code>.
  * This allows common handling of authentication failures originating from any subclass of
- * <tt>AbstractSecurityInterceptor</tt>.
+ * {@code AbstractSecurityInterceptor}.
  * </p>
  * <p>
  * If an {@link AccessDeniedException} is detected, the filter will determine whether or not the user is an anonymous
  * user. If they are an anonymous user, the <code>authenticationEntryPoint</code> will be launched. If they are not
- * an anonymous user, the filter will delegate to the <tt>AccessDeniedHandler</tt>.
- * By default the filter will use <tt>AccessDeniedHandlerImpl</tt>.
+ * an anonymous user, the filter will delegate to the {@code AccessDeniedHandler}.
+ * By default the filter will use {@code AccessDeniedHandlerImpl}.
  * </p>
  * <p>
  * To use this filter, it is necessary to specify the following properties:
@@ -74,7 +74,7 @@ import java.util.logging.Logger;
  * </ul>
  * <P>
  * <B>Do not use this class directly.</B> Instead configure
- * <code>web.xml</code> to use the <tt>FilterToBeanProxy</tt>.
+ * <code>web.xml</code> to use the {@code FilterToBeanProxy}.
  * </p>
  *
  * @author Ben Alex

--- a/core/src/main/java/jenkins/security/HMACConfidentialKey.java
+++ b/core/src/main/java/jenkins/security/HMACConfidentialKey.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 
 /**
  * {@link ConfidentialKey} that's used for creating a token by hashing some information with secret
- * (such as <tt>hash(msg|secret)</tt>).
+ * (such as {@code hash(msg|secret)}).
  *
  * <p>
  * This provides more secure version of it by using HMAC.

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol.java
@@ -31,11 +31,11 @@ import org.jenkinsci.remoting.engine.JnlpProtocol1Handler;
  *
  * <p>
  * We do this by computing HMAC of the agent name.
- * This code is sent to the agent inside the <tt>.jnlp</tt> file
+ * This code is sent to the agent inside the {@code .jnlp} file
  * (this file itself is protected by HTTP form-based authentication that
  * we use everywhere else in Jenkins), and the agent sends this
  * token back when it connects to the master.
- * Unauthorized agents can't access the protected <tt>.jnlp</tt> file,
+ * Unauthorized agents can't access the protected {@code .jnlp} file,
  * so it can't impersonate a valid agent.
  *
  * <p>

--- a/core/src/main/java/jenkins/slaves/systemInfo/SlaveSystemInfo.java
+++ b/core/src/main/java/jenkins/slaves/systemInfo/SlaveSystemInfo.java
@@ -8,7 +8,7 @@ import hudson.model.Computer;
  * Extension point that contributes to the system information page of {@link Computer}.
  *
  * <h2>Views</h2>
- * Subtypes must have <tt>systemInfo.groovy/.jelly</tt> view.
+ * Subtypes must have {@code systemInfo.groovy/.jelly} view.
  * This view will have the "it" variable that refers to {@link Computer} object, and "instance" variable
  * that refers to {@link SlaveSystemInfo} object.
  *

--- a/core/src/main/java/jenkins/util/groovy/AbstractGroovyViewModule.java
+++ b/core/src/main/java/jenkins/util/groovy/AbstractGroovyViewModule.java
@@ -12,9 +12,9 @@ import lib.JenkinsTagLib;
  * <p>
  * Usage from script of a subclass, say ViewHelper:
  * <p>
- * <tt>new ViewHelper(delegate).method();</tt>
+ * {@code new ViewHelper(delegate).method();}
  * <p>
- * see <tt>ModularizeViewScript</tt> in ui-samples for an example how to use
+ * see {@code ModularizeViewScript} in ui-samples for an example how to use
  * this class.
  */
 public abstract class AbstractGroovyViewModule extends GroovyObjectSupport {

--- a/core/src/main/java/jenkins/util/groovy/GroovyHookScript.java
+++ b/core/src/main/java/jenkins/util/groovy/GroovyHookScript.java
@@ -31,8 +31,8 @@ import jenkins.model.Jenkins;
  * </ol>
  *
  * <p>
- * Scripts inside <tt>/WEB-INF</tt> is meant for OEM distributions of Jenkins. Files inside
- * <tt>$JENKINS_HOME</tt> are for installation local settings. Use of <tt>HOOK.groovy.d</tt>
+ * Scripts inside {@code /WEB-INF} is meant for OEM distributions of Jenkins. Files inside
+ * {@code $JENKINS_HOME} are for installation local settings. Use of {@code HOOK.groovy.d}
  * allows configuration management tools to control scripts easily.
  *
  * @author Kohsuke Kawaguchi


### PR DESCRIPTION
In #3634 the pull requests fail due to the `tt` tags which are rejected by JDK11 on ci.jenkins.io. I applied bulk refactoring so that we get rid of the deprecated tags

# Changelog

* Not required

@jenkinsci/sig-platform 