### PR TITLE
[JENKINS-52019] - Update Groovy from 2.4.11 to 2.4.12 to pick up fixes towards Java 11 support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <staplerFork>true</staplerFork>
     <stapler.version>1.254.1</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
-    <groovy.version>2.4.11</groovy.version>
+    <groovy.version>2.4.12</groovy.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION

See [JENKINS-52019](https://issues.jenkins-ci.org/browse/JENKINS-52019), it is a core counterpart for https://github.com/jenkinsci/workflow-support-plugin/pull/68. Requires sign-off from @svanoort before going forward

Testing:

* Spot-check during the Java 10+ hackathon (on Java 8, 10, 11)
* Soak testing on @oleg-nenashev's environment (~2 weeks, Java 8)
* Testing for memory leaks by @svanoort . Originally we suspected a memory leak, but according to tests there is no evidence of that which would block the change upstreaming

<img width="1163" alt="foo" src="https://user-images.githubusercontent.com/3000480/45912558-3be13280-bdd8-11e8-9b16-3842a79055ff.png">


<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE Update Groovy from 2.4.11 to 2.4.12 to pick up fixes towards Java 11 support
  * http://groovy-lang.org/changelogs/changelog-2.4.12.html

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/sig-platform @svanoort 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
