### PR TITLE
Javadoc: Cleanup obsolete <tt> tags from package.html

### DIFF
--- a/core/src/main/java/hudson/model/package.html
+++ b/core/src/main/java/hudson/model/package.html
@@ -23,5 +23,5 @@ THE SOFTWARE.
 -->
 
 <html><head/><body>
-Core object model that are bound to URLs via stapler, rooted at <a href="Hudson.html"><tt>Hudson</tt></a>.
+Core object model that are bound to URLs via stapler, rooted at <a href="Hudson.html"><code>Hudson</code></a>.
 </body></html>

--- a/core/src/main/java/hudson/scm/package.html
+++ b/core/src/main/java/hudson/scm/package.html
@@ -23,5 +23,5 @@ THE SOFTWARE.
 -->
 
 <html><head/><body>
-Hudson's interface with source code management systems. Start with <a href="SCM.html"><tt>SCM</tt></a>
+Hudson's interface with source code management systems. Start with <a href="SCM.html"><code>SCM</code></a>
 </body></html>

--- a/core/src/main/java/hudson/tasks/package.html
+++ b/core/src/main/java/hudson/tasks/package.html
@@ -23,6 +23,6 @@ THE SOFTWARE.
 -->
 
 <html><head/><body>
-Built-in <a href="Builder.html"><code>Builder</code></a>s and <a href="Publisher.html"><tt>Publisher</tt></a>s
+Built-in <a href="Builder.html"><code>Builder</code></a>s and <a href="Publisher.html"><code>Publisher</code></a>s
 that perform the actual heavy-lifting of a build. 
 </body></html>

--- a/core/src/main/java/hudson/tasks/package.html
+++ b/core/src/main/java/hudson/tasks/package.html
@@ -23,6 +23,6 @@ THE SOFTWARE.
 -->
 
 <html><head/><body>
-Built-in <a href="Builder.html"><tt>Builder</tt></a>s and <a href="Publisher.html"><tt>Publisher</tt></a>s
+Built-in <a href="Builder.html"><code>Builder</code></a>s and <a href="Publisher.html"><tt>Publisher</tt></a>s
 that perform the actual heavy-lifting of a build. 
 </body></html>

--- a/core/src/main/java/hudson/triggers/package.html
+++ b/core/src/main/java/hudson/triggers/package.html
@@ -23,5 +23,5 @@ THE SOFTWARE.
 -->
 
 <html><head/><body>
-Built-in <a href="Trigger.html"><tt>Trigger</tt></a>s that run periodically to kick a new build.
+Built-in <a href="Trigger.html"><code>Trigger</code></a>s that run periodically to kick a new build.
 </body></html>

--- a/core/src/main/java/hudson/util/spring/package.html
+++ b/core/src/main/java/hudson/util/spring/package.html
@@ -32,10 +32,10 @@ but modifications are made since then to make the syntax more consistent.
 <h2>Changes to the original code</h2>
 <p>
     Our version has support for getting rid of surrounding "bb.beans { ... }" if the script
-    is parsed via the <tt>BeanBuilder.parse()</tt> method.
+    is parsed via the <code>BeanBuilder.parse()</code> method.
 </p>
 <p>
-    Anonymous bean definition syntax is changed to <tt>bean(CLASS) {...}</tt> from
-    <tt>{CLASS _ -> ...}</tt> to increase consistency with named bean definition.
+    Anonymous bean definition syntax is changed to <code>bean(CLASS) {...}</code> from
+    <code>{CLASS _ -> ...}</code> to increase consistency with named bean definition.
 </p>
 </body></html>


### PR DESCRIPTION
`<tt>` tags are not longer supported in HTML5: https://www.w3schools.com/tags/tag_tt.asp . JDK11 generates HTML5 by default, so it makes sense to cleanup tags so that we can run build on JDK11

# Changelog

* N/A

@jenkinsci/sig-platform 