### PR TITLE
Exclude UI screw

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -192,6 +192,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     /**
      * Gets all the items in this collection in a read-only view.
      */
+    @Nonnull
     @Exported(name="jobs")
     public abstract Collection<TopLevelItem> getItems();
 


### PR DESCRIPTION
Small tip. 
There is no docs on what it should exactly return, but if it return null, then the whole jenkins UI will be screwed (when filter nodes/build queue is enabled and view is set by default)

```
org.apache.commons.jelly.JellyTagException: jar:file:/jenkins/WEB-INF/lib/jenkins-core-2.73.3.jar!/hudson/model/View/sidepanel.jelly:75:50: &lt;st:include> java.lang.NullPointerException
	at org.apache.commons.jelly.impl.TagScript.handleException(TagScript.java:726)
	at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:281)
	at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
	at org.apache.commons.jelly.TagSupport.invokeBody(TagSupport.java:161)
......
Caused by: java.lang.NullPointerException
	at hudson.model.View.getComputers(View.java:434)
	at sun.reflect.GeneratedMethodAccessor887.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jenkins/3646)
<!-- Reviewable:end -->


# Proposed Changelog

* N/A