### PR TITLE
[JENKINS-46523] - Make UnixReflection class compatible with Java 11, remove pre-Java 8 reflection

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -885,7 +885,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 } else {
                     long pid = (long)JAVA9_PID_METHOD.invoke(proc);
                     if (pid > Integer.MAX_VALUE) {
-                        throw new IllegalAccessError("Java 9+ support error: PID is out of Jenkins API bounds: " + pid);
+                        throw new IllegalAccessError("Java 9+ support error (JENKINS-53799). PID is out of Jenkins API bounds: " + pid);
                     }
                     return (int)pid;
                 }

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -821,22 +821,22 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
          * Field to access the PID of the process.
          * Required for Java 8 and older JVMs.
          */
-        private static final @CheckForNull Field JAVA8_PID_FIELD;
+        private static final Field JAVA8_PID_FIELD;
 
         /**
          * Field to access the PID of the process.
          * Required for Java 9 and above until this is replaced by multi-release JAR.
          */
-        private static final @CheckForNull Method JAVA9_PID_METHOD;
+        private static final Method JAVA9_PID_METHOD;
 
         /**
          * Method to destroy a process, given pid.
          *
          * Looking at the JavaSE source code, this is using SIGTERM (15)
          */
-        private static final @CheckForNull Method JAVA8_DESTROY_PROCESS;
-        private static final @CheckForNull Method JAVA_9_PROCESSHANDLE_OF;
-        private static final @CheckForNull Method JAVA_9_PROCESSHANDLE_DESTROY;
+        private static final Method JAVA8_DESTROY_PROCESS;
+        private static final Method JAVA_9_PROCESSHANDLE_OF;
+        private static final Method JAVA_9_PROCESSHANDLE_DESTROY;
 
         static {
             try {


### PR DESCRIPTION
See [JENKINS-46523](https://issues.jenkins-ci.org/browse/JENKINS-46523). UnixReflection class didn't support Java 9+ APIs, and `java.lang.UNIXProcess` is removed from recent Java versions. Multi-release JAR is probably a way to go, but so far I would like to apply a quick patch.

This patch fixes ~100 tests in #3636 

### Proposed changelog entries

* RFE: Update Unix process management logic to support Process Tree termination in Java 11
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/sig-platform 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
