### PR TITLE
Micro-optimizations to Plugin data to reduce minimum memory for Jenkins

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -26,7 +26,7 @@ package hudson;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Proc.LocalProc;
 import hudson.model.Computer;
-import hudson.util.MemoryReductionUtil;
+import jenkins.util.MemoryReductionUtil;
 import hudson.util.QuotedStringTokenizer;
 import jenkins.model.Jenkins;
 import hudson.model.TaskListener;

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -26,6 +26,7 @@ package hudson;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Proc.LocalProc;
 import hudson.model.Computer;
+import hudson.util.MemoryReductionUtil;
 import hudson.util.QuotedStringTokenizer;
 import jenkins.model.Jenkins;
 import hudson.model.TaskListener;
@@ -396,7 +397,7 @@ public abstract class Launcher {
          */
         @Nonnull
         public String[] envs() {
-            return envs != null ? envs.clone() : new String[0];
+            return envs != null ? envs.clone() : MemoryReductionUtil.EMPTY_STRING_ARRAY;
         }
 
         /**

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -188,7 +188,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     /**
      * A String error message, and a boolean indicating whether it's an original error (false) or downstream from an original one (true)
      */
-    private final transient Map<String, Boolean> dependencyErrors = new HashMap<>();
+    private final transient Map<String, Boolean> dependencyErrors = new HashMap<>(0);
 
     /**
      * Is this plugin bundled in jenkins.war?

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -256,8 +256,8 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
             int idx = s.indexOf(':');
             if(idx==-1)
                 throw new IllegalArgumentException("Illegal dependency specifier "+s);
-            this.shortName = s.substring(0,idx);
-            String version = s.substring(idx+1);
+            this.shortName = s.substring(0,idx).intern();
+            String version = s.substring(idx+1).intern();
 
             boolean isOptional = false;
             String[] osgiProperties = version.split("[;]");
@@ -300,7 +300,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 			List<Dependency> dependencies, List<Dependency> optionalDependencies) {
         this.parent = parent;
 		this.manifest = manifest;
-		this.shortName = computeShortName(manifest, archive.getName());
+		this.shortName = computeShortName(manifest, archive.getName()).intern();
 		this.baseResourceURL = baseResourceURL;
 		this.classLoader = classLoader;
 		this.disableFile = disableFile;

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -256,8 +256,8 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
             int idx = s.indexOf(':');
             if(idx==-1)
                 throw new IllegalArgumentException("Illegal dependency specifier "+s);
-            this.shortName = s.substring(0,idx).intern();
-            String version = s.substring(idx+1).intern();
+            this.shortName = Util.intern(s.substring(0,idx));
+            String version = Util.intern(s.substring(idx+1));
 
             boolean isOptional = false;
             String[] osgiProperties = version.split("[;]");
@@ -300,7 +300,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 			List<Dependency> dependencies, List<Dependency> optionalDependencies) {
         this.parent = parent;
 		this.manifest = manifest;
-		this.shortName = computeShortName(manifest, archive.getName()).intern();
+		this.shortName = Util.intern(computeShortName(manifest, archive.getName()));
 		this.baseResourceURL = baseResourceURL;
 		this.classLoader = classLoader;
 		this.disableFile = disableFile;

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -26,7 +26,7 @@ package hudson;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import hudson.model.TaskListener;
-import hudson.util.MemoryReductionUtil;
+import jenkins.util.MemoryReductionUtil;
 import hudson.util.QuotedStringTokenizer;
 import hudson.util.VariableResolver;
 import jenkins.util.SystemProperties;
@@ -93,7 +93,6 @@ import javax.annotation.Nullable;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 
 /**

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -26,6 +26,7 @@ package hudson;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import hudson.model.TaskListener;
+import hudson.util.MemoryReductionUtil;
 import hudson.util.QuotedStringTokenizer;
 import hudson.util.VariableResolver;
 import jenkins.util.SystemProperties;
@@ -1343,7 +1344,7 @@ public class Util {
             @Nonnull String symlinkPath, @Nonnull TaskListener listener) throws InterruptedException {
         try {
             Path path = fileToPath(new File(baseDir, symlinkPath));
-            Path target = Paths.get(targetPath, new String[0]);
+            Path target = Paths.get(targetPath, MemoryReductionUtil.EMPTY_STRING_ARRAY);
 
             final int maxNumberOfTries = 4;
             final int timeInMillis = 100;

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -32,6 +32,7 @@ import hudson.Util;
 import hudson.XmlFile;
 import hudson.model.*;
 import hudson.util.HttpResponses;
+import hudson.util.MemoryReductionUtil;
 import jenkins.model.Jenkins;
 import hudson.model.listeners.SaveableListener;
 import hudson.remoting.Channel;
@@ -140,7 +141,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
             candidateNames.retainAll(partCandidates);
         }
         AutoCompletionCandidates candidates = new AutoCompletionCandidates();
-        candidates.add(candidateNames.toArray(new String[0]));
+        candidates.add(candidateNames.toArray(MemoryReductionUtil.EMPTY_STRING_ARRAY));
         return candidates;
     }
 

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -32,7 +32,7 @@ import hudson.Util;
 import hudson.XmlFile;
 import hudson.model.*;
 import hudson.util.HttpResponses;
-import hudson.util.MemoryReductionUtil;
+import jenkins.util.MemoryReductionUtil;
 import jenkins.model.Jenkins;
 import hudson.model.listeners.SaveableListener;
 import hudson.remoting.Channel;

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -137,7 +137,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      */
     public transient final Class<? extends T> clazz;
 
-    private transient final Map<String,CheckMethod> checkMethods = new ConcurrentHashMap<String,CheckMethod>();
+    private transient final Map<String,CheckMethod> checkMethods = new ConcurrentHashMap<String,CheckMethod>(2);
 
     /**
      * Lazily computed list of properties on {@link #clazz} and on the descriptor itself.
@@ -233,7 +233,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      *
      * @see #getHelpFile(String) 
      */
-    private transient final Map<String,HelpRedirect> helpRedirect = new HashMap<String,HelpRedirect>();
+    private transient final Map<String,HelpRedirect> helpRedirect = new HashMap<String,HelpRedirect>(2);
 
     private static class HelpRedirect {
         private final Class<? extends Describable> owner;

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -35,7 +35,7 @@ import hudson.security.AccessControlled;
 import hudson.triggers.Trigger;
 import hudson.util.DescriptorList;
 import hudson.util.EditDistance;
-import hudson.util.MemoryReductionUtil;
+import jenkins.util.MemoryReductionUtil;
 import hudson.util.XStream2;
 import java.io.File;
 import java.io.IOException;

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -35,6 +35,7 @@ import hudson.security.AccessControlled;
 import hudson.triggers.Trigger;
 import hudson.util.DescriptorList;
 import hudson.util.EditDistance;
+import hudson.util.MemoryReductionUtil;
 import hudson.util.XStream2;
 import java.io.File;
 import java.io.IOException;
@@ -313,8 +314,8 @@ public class Items {
 
     // Had difficulty adapting the version in Functions to use no live items, so rewrote it:
     static String getRelativeNameFrom(String itemFullName, String groupFullName) {
-        String[] itemFullNameA = itemFullName.isEmpty() ? new String[0] : itemFullName.split("/");
-        String[] groupFullNameA = groupFullName.isEmpty() ? new String[0] : groupFullName.split("/");
+        String[] itemFullNameA = itemFullName.isEmpty() ? MemoryReductionUtil.EMPTY_STRING_ARRAY : itemFullName.split("/");
+        String[] groupFullNameA = groupFullName.isEmpty() ? MemoryReductionUtil.EMPTY_STRING_ARRAY : groupFullName.split("/");
         for (int i = 0; ; i++) {
             if (i == itemFullNameA.length) {
                 if (i == groupFullNameA.length) {

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -731,8 +731,8 @@ public class UpdateSite {
 
         public WarningVersionRange(JSONObject o) {
             this.name = Util.fixEmpty(o.optString("name"));
-            this.firstVersion = Util.fixEmpty(o.optString("firstVersion"));
-            this.lastVersion = Util.fixEmpty(o.optString("lastVersion"));
+            this.firstVersion = Util.intern(Util.fixEmpty(o.optString("firstVersion")));
+            this.lastVersion = Util.intern(Util.fixEmpty(o.optString("lastVersion")));
             Pattern p;
             try {
                 p = Pattern.compile(o.getString("pattern"));
@@ -834,8 +834,8 @@ public class UpdateSite {
             this.url = o.getString("url");
 
             if (o.has("versions")) {
-                List<WarningVersionRange> ranges = new ArrayList<>();
                 JSONArray versions = o.getJSONArray("versions");
+                List<WarningVersionRange> ranges = new ArrayList<>(versions.size());
                 for (int i = 0; i < versions.size(); i++) {
                     WarningVersionRange range = new WarningVersionRange(versions.getJSONObject(i));
                     ranges.add(range);

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -35,7 +35,7 @@ import hudson.model.UpdateCenter.UpdateCenterJob;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.Kind;
 import hudson.util.HttpResponses;
-import static hudson.util.MemoryReductionUtil.*;
+import static jenkins.util.MemoryReductionUtil.*;
 import hudson.util.TextFile;
 import static java.util.concurrent.TimeUnit.*;
 import hudson.util.VersionNumber;

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -990,8 +990,8 @@ public class UpdateSite {
             JSONArray ja = o.getJSONArray("dependencies");
             int depCount = (int)(ja.stream().filter(IS_DEP_PREDICATE.and(IS_OPTIONAL.negate())).count());
             int optionalDepCount = (int)(ja.stream().filter(IS_DEP_PREDICATE.and(IS_OPTIONAL)).count());
-            dependencies = getPresizedMap(depCount);
-            optionalDependencies = getPresizedMap(optionalDepCount);
+            dependencies = getPresizedMutableMap(depCount);
+            optionalDependencies = getPresizedMutableMap(optionalDepCount);
 
             for(Object jo : o.getJSONArray("dependencies")) {
                 JSONObject depObj = (JSONObject) jo;

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -976,7 +976,7 @@ public class UpdateSite {
         public final Map<String,String> optionalDependencies;
 
         final Predicate<Object> IS_DEP_PREDICATE = x -> x instanceof JSONObject && get(((JSONObject)x), "name") != null;
-        final Predicate<Object> IS_OPTIONAL = x-> "false".equals(get(((JSONObject)x), "optional"));
+        final Predicate<Object> IS_NOT_OPTIONAL = x-> "false".equals(get(((JSONObject)x), "optional"));
 
         @DataBoundConstructor
         public Plugin(String sourceId, JSONObject o) {
@@ -988,8 +988,8 @@ public class UpdateSite {
             this.requiredCore = Util.intern(get(o,"requiredCore"));
             this.categories = o.has("labels") ? internInPlace((String[])o.getJSONArray("labels").toArray(EMPTY_STRING_ARRAY)) : null;
             JSONArray ja = o.getJSONArray("dependencies");
-            int depCount = (int)(ja.stream().filter(IS_DEP_PREDICATE.and(IS_OPTIONAL.negate())).count());
-            int optionalDepCount = (int)(ja.stream().filter(IS_DEP_PREDICATE.and(IS_OPTIONAL)).count());
+            int depCount = (int)(ja.stream().filter(IS_DEP_PREDICATE.and(IS_NOT_OPTIONAL)).count());
+            int optionalDepCount = (int)(ja.stream().filter(IS_DEP_PREDICATE.and(IS_NOT_OPTIONAL.negate())).count());
             dependencies = getPresizedMutableMap(depCount);
             optionalDependencies = getPresizedMutableMap(optionalDepCount);
 

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -926,6 +926,9 @@ public class UpdateSite {
             return null;
     }
 
+    static final Predicate<Object> IS_DEP_PREDICATE = x -> x instanceof JSONObject && get(((JSONObject)x), "name") != null;
+    static final Predicate<Object> IS_NOT_OPTIONAL = x-> "false".equals(get(((JSONObject)x), "optional"));
+
     public final class Plugin extends Entry {
         /**
          * Optional URL to the Wiki page that discusses this plugin.
@@ -974,9 +977,6 @@ public class UpdateSite {
          */
         @Exported
         public final Map<String,String> optionalDependencies;
-
-        final Predicate<Object> IS_DEP_PREDICATE = x -> x instanceof JSONObject && get(((JSONObject)x), "name") != null;
-        final Predicate<Object> IS_NOT_OPTIONAL = x-> "false".equals(get(((JSONObject)x), "optional"));
 
         @DataBoundConstructor
         public Plugin(String sourceId, JSONObject o) {

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -35,7 +35,7 @@ import hudson.model.UpdateCenter.UpdateCenterJob;
 import hudson.util.FormValidation;
 import hudson.util.FormValidation.Kind;
 import hudson.util.HttpResponses;
-import hudson.util.MemoryReductionUtil;
+import static hudson.util.MemoryReductionUtil.*;
 import hudson.util.TextFile;
 import static java.util.concurrent.TimeUnit.*;
 import hudson.util.VersionNumber;
@@ -520,7 +520,7 @@ public class UpdateSite {
         public final String connectionCheckUrl;
 
         Data(JSONObject o) {
-            this.sourceId = ((String)o.get("id")).intern();
+            this.sourceId = Util.intern((String)o.get("id"));
             JSONObject c = o.optJSONObject("core");
             if (c!=null) {
                 core = new Entry(sourceId, c, url);
@@ -550,7 +550,7 @@ public class UpdateSite {
                         }
                     }
                 }
-                plugins.put(e.getKey().intern(), p);
+                plugins.put(Util.intern(e.getKey()), p);
             }
 
             connectionCheckUrl = (String)o.get("connectionCheckUrl");
@@ -622,8 +622,8 @@ public class UpdateSite {
 
         Entry(String sourceId, JSONObject o, String baseURL) {
             this.sourceId = sourceId;
-            this.name = o.getString("name").intern();
-            this.version = o.getString("version").intern();
+            this.name = Util.intern(o.getString("name"));
+            this.version = Util.intern(o.getString("version"));
 
             // Trim this to prevent issues when the other end used Base64.encodeBase64String that added newlines
             // to the end in old commons-codec. Not the case on updates.jenkins-ci.org, but let's be safe.
@@ -829,7 +829,7 @@ public class UpdateSite {
                 this.type = Type.UNKNOWN;
             }
             this.id = o.getString("id");
-            this.component = o.getString("name").intern();
+            this.component = Util.intern(o.getString("name"));
             this.message = o.getString("message");
             this.url = o.getString("url");
 
@@ -984,26 +984,26 @@ public class UpdateSite {
             this.wiki = get(o,"wiki");
             this.title = get(o,"title");
             this.excerpt = get(o,"excerpt");
-            this.compatibleSinceVersion = get(o,"compatibleSinceVersion").intern();
-            this.requiredCore = get(o,"requiredCore").intern();
-            this.categories = o.has("labels") ? MemoryReductionUtil.internInPlace((String[])o.getJSONArray("labels").toArray(MemoryReductionUtil.EMPTY_STRING_ARRAY)) : null;
+            this.compatibleSinceVersion = Util.intern(get(o,"compatibleSinceVersion"));
+            this.requiredCore = Util.intern(get(o,"requiredCore"));
+            this.categories = o.has("labels") ? internInPlace((String[])o.getJSONArray("labels").toArray(EMPTY_STRING_ARRAY)) : null;
             JSONArray ja = o.getJSONArray("dependencies");
             int depCount = (int)(ja.stream().filter(IS_DEP_PREDICATE.and(IS_OPTIONAL.negate())).count());
             int optionalDepCount = (int)(ja.stream().filter(IS_DEP_PREDICATE.and(IS_OPTIONAL)).count());
-            dependencies = MemoryReductionUtil.getPresizedMap(depCount);
-            optionalDependencies = MemoryReductionUtil.getPresizedMap(optionalDepCount);
+            dependencies = getPresizedMap(depCount);
+            optionalDependencies = getPresizedMap(optionalDepCount);
 
             for(Object jo : o.getJSONArray("dependencies")) {
                 JSONObject depObj = (JSONObject) jo;
                 // Make sure there's a name attribute and that the optional value isn't true.
-                if (get(depObj,"name")!=null) {
+                String depName = Util.intern(get(depObj,"name"));
+                if (depName!=null) {
                     if (get(depObj, "optional").equals("false")) {
-                        dependencies.put(get(depObj, "name").intern(), get(depObj, "version").intern());
+                        dependencies.put(depName, Util.intern(get(depObj, "version")));
                     } else {
-                        optionalDependencies.put(get(depObj, "name").intern(), get(depObj, "version").intern());
+                        optionalDependencies.put(depName, Util.intern(get(depObj, "version")));
                     }
                 }
-                
             }
 
         }

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -42,6 +42,7 @@ import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 
+import hudson.util.MemoryReductionUtil;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -325,10 +326,8 @@ public class Search implements StaplerProxy {
     static final class TokenList {
         private final String[] tokens;
 
-        private final static String[] EMPTY = new String[0];
-
         public TokenList(String tokenList) {
-            tokens = tokenList!=null ? tokenList.split("(?<=\\s)(?=\\S)") : EMPTY;
+            tokens = tokenList!=null ? tokenList.split("(?<=\\s)(?=\\S)") : MemoryReductionUtil.EMPTY_STRING_ARRAY;
         }
 
         public int length() { return tokens.length; }

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 
-import hudson.util.MemoryReductionUtil;
+import jenkins.util.MemoryReductionUtil;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;

--- a/core/src/main/java/hudson/security/WhoAmI.java
+++ b/core/src/main/java/hudson/security/WhoAmI.java
@@ -8,6 +8,7 @@ import hudson.model.UnprotectedRootAction;
 import java.util.ArrayList;
 import java.util.List;
 
+import hudson.util.MemoryReductionUtil;
 import jenkins.model.Jenkins;
 
 import org.acegisecurity.Authentication;
@@ -62,7 +63,7 @@ public class WhoAmI implements UnprotectedRootAction {
     @Exported
     public String[] getAuthorities() {
         if (auth().getAuthorities() == null) {
-            return new String[0];
+            return MemoryReductionUtil.EMPTY_STRING_ARRAY;
         }
         List <String> authorities = new ArrayList<String>();
         for (GrantedAuthority a : auth().getAuthorities()) {

--- a/core/src/main/java/hudson/security/WhoAmI.java
+++ b/core/src/main/java/hudson/security/WhoAmI.java
@@ -8,7 +8,7 @@ import hudson.model.UnprotectedRootAction;
 import java.util.ArrayList;
 import java.util.List;
 
-import hudson.util.MemoryReductionUtil;
+import jenkins.util.MemoryReductionUtil;
 import jenkins.model.Jenkins;
 
 import org.acegisecurity.Authentication;

--- a/core/src/main/java/hudson/util/MemoryReductionUtil.java
+++ b/core/src/main/java/hudson/util/MemoryReductionUtil.java
@@ -44,8 +44,9 @@ public class MemoryReductionUtil {
         }
     }
 
-    public static Map getPresizedMap(int elementCount) {
-        return (elementCount > 0) ? new HashMap(preallocatedHashmapCapacity(elementCount)) : Collections.EMPTY_MAP;
+    /** Returns a mutable HashMap presized to hold the given number of elements without needing to resize. */
+    public static Map getPresizedMutableMap(int elementCount) {
+        return new HashMap(preallocatedHashmapCapacity(elementCount));
     }
 
     /** Empty string array, exactly what it says on the tin. Avoids repeatedly created empty array when calling "toArray." */

--- a/core/src/main/java/hudson/util/MemoryReductionUtil.java
+++ b/core/src/main/java/hudson/util/MemoryReductionUtil.java
@@ -23,6 +23,7 @@
  */
 package hudson.util;
 
+import hudson.Util;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,7 +59,7 @@ public class MemoryReductionUtil {
             return EMPTY_STRING_ARRAY;
         }
         for (int i=0; i<input.length; i++) {
-            input[i] = input[i].intern();
+            input[i] = Util.intern(input[i]);
         }
         return input;
     }

--- a/core/src/main/java/hudson/util/MemoryReductionUtil.java
+++ b/core/src/main/java/hudson/util/MemoryReductionUtil.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utilities to reduce memory footprint
+ * @author Sam Van Oort
+ */
+public class MemoryReductionUtil {
+    /** Returns the capacity we need to allocate for a HashMap so it will hold all elements without needing to resize. */
+    public static int preallocatedHashmapCapacity(int elementsToHold) {
+        if (elementsToHold <= 0) {
+            return 0;
+        } else if (elementsToHold < 3) {
+            return elementsToHold+1;
+        } else {
+            return elementsToHold+elementsToHold/3; // Default load factor is 0.75, so we want to fill that much.
+        }
+    }
+
+    public static Map getPresizedMap(int elementCount) {
+        return (elementCount > 0) ? new HashMap(preallocatedHashmapCapacity(elementCount)) : Collections.EMPTY_MAP;
+    }
+
+    /** Empty string array, exactly what it says on the tin. Avoids repeatedly created empty array when calling "toArray." */
+    public static final String[] EMPTY_STRING_ARRAY = new String[0];
+
+    /** Returns the input strings, but with all values interned. */
+    public static String[] internInPlace(String[] input) {
+        if (input == null) {
+            return null;
+        } else if (input.length == 0) {
+            return EMPTY_STRING_ARRAY;
+        }
+        for (int i=0; i<input.length; i++) {
+            input[i] = input[i].intern();
+        }
+        return input;
+    }
+
+}

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -40,6 +40,8 @@ import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
+
+import hudson.util.MemoryReductionUtil;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -188,7 +190,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
         String[] kids = dir.list();
         if (kids == null) {
             // the job may have just been created
-            kids = EMPTY_STRING_ARRAY;
+            kids = MemoryReductionUtil.EMPTY_STRING_ARRAY;
         }
         SortedIntList list = new SortedIntList(kids.length / 2);
         for (String s : kids) {
@@ -585,8 +587,6 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
     public enum Direction {
         ASC, DESC, EXACT
     }
-
-    private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
     private static final SortedMap EMPTY_SORTED_MAP = Collections.unmodifiableSortedMap(new TreeMap());
 

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -41,7 +41,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 
-import hudson.util.MemoryReductionUtil;
+import jenkins.util.MemoryReductionUtil;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 

--- a/core/src/main/java/jenkins/org/apache/commons/validator/routines/DomainValidator.java
+++ b/core/src/main/java/jenkins/org/apache/commons/validator/routines/DomainValidator.java
@@ -17,7 +17,7 @@
 /* Copied from commons-validator:commons-validator:1.6, with [PATCH] modifications */
 package jenkins.org.apache.commons.validator.routines;
 
-import hudson.util.MemoryReductionUtil;
+import jenkins.util.MemoryReductionUtil;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 

--- a/core/src/main/java/jenkins/org/apache/commons/validator/routines/DomainValidator.java
+++ b/core/src/main/java/jenkins/org/apache/commons/validator/routines/DomainValidator.java
@@ -17,6 +17,7 @@
 /* Copied from commons-validator:commons-validator:1.6, with [PATCH] modifications */
 package jenkins.org.apache.commons.validator.routines;
 
+import hudson.util.MemoryReductionUtil;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -71,8 +72,6 @@ import java.util.Locale;
 public class DomainValidator implements Serializable {
     
     private static final int MAX_DOMAIN_LENGTH = 253;
-    
-    private static final String[] EMPTY_STRING_ARRAY = new String[0];
     
     private static final long serialVersionUID = -4407125112880174009L;
     
@@ -1853,16 +1852,16 @@ public class DomainValidator implements Serializable {
      * using the getInstance methods which are all (now) synchronised.
      */
     // WARNING: this array MUST be sorted, otherwise it cannot be searched reliably using binary search
-    private static volatile String[] countryCodeTLDsPlus = EMPTY_STRING_ARRAY;
+    private static volatile String[] countryCodeTLDsPlus = MemoryReductionUtil.EMPTY_STRING_ARRAY;
     
     // WARNING: this array MUST be sorted, otherwise it cannot be searched reliably using binary search
-    private static volatile String[] genericTLDsPlus = EMPTY_STRING_ARRAY;
+    private static volatile String[] genericTLDsPlus = MemoryReductionUtil.EMPTY_STRING_ARRAY;
     
     // WARNING: this array MUST be sorted, otherwise it cannot be searched reliably using binary search
-    private static volatile String[] countryCodeTLDsMinus = EMPTY_STRING_ARRAY;
+    private static volatile String[] countryCodeTLDsMinus = MemoryReductionUtil.EMPTY_STRING_ARRAY;
     
     // WARNING: this array MUST be sorted, otherwise it cannot be searched reliably using binary search
-    private static volatile String[] genericTLDsMinus = EMPTY_STRING_ARRAY;
+    private static volatile String[] genericTLDsMinus = MemoryReductionUtil.EMPTY_STRING_ARRAY;
     
     /**
      * enum used by {@link DomainValidator#updateTLDOverride(DomainValidator.ArrayType, String[])}
@@ -1893,10 +1892,10 @@ public class DomainValidator implements Serializable {
     // For use by unit test code only
     static synchronized void clearTLDOverrides() {
         inUse = false;
-        countryCodeTLDsPlus = EMPTY_STRING_ARRAY;
-        countryCodeTLDsMinus = EMPTY_STRING_ARRAY;
-        genericTLDsPlus = EMPTY_STRING_ARRAY;
-        genericTLDsMinus = EMPTY_STRING_ARRAY;
+        countryCodeTLDsPlus = MemoryReductionUtil.EMPTY_STRING_ARRAY;
+        countryCodeTLDsMinus = MemoryReductionUtil.EMPTY_STRING_ARRAY;
+        genericTLDsPlus = MemoryReductionUtil.EMPTY_STRING_ARRAY;
+        genericTLDsMinus = MemoryReductionUtil.EMPTY_STRING_ARRAY;
     }
     /**
      * Update one of the TLD override arrays.

--- a/core/src/main/java/jenkins/util/MemoryReductionUtil.java
+++ b/core/src/main/java/jenkins/util/MemoryReductionUtil.java
@@ -21,10 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package hudson.util;
+package jenkins.util;
 
 import hudson.Util;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -54,6 +54,8 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
+import hudson.util.MemoryReductionUtil;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.ArtifactManager;
 import jenkins.security.MasterToSlaveCallable;
@@ -175,7 +177,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
      */
     @Deprecated
     public @Nonnull String[] list(String glob) throws IOException {
-        return list(glob.replace('\\', '/'), null, true).toArray(new String[0]);
+        return list(glob.replace('\\', '/'), null, true).toArray(MemoryReductionUtil.EMPTY_STRING_ARRAY);
     }
 
     /**

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -55,7 +55,6 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-import hudson.util.MemoryReductionUtil;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.ArtifactManager;
 import jenkins.security.MasterToSlaveCallable;

--- a/core/src/test/java/jenkins/security/ClassFilterImplSanityTest.java
+++ b/core/src/test/java/jenkins/security/ClassFilterImplSanityTest.java
@@ -28,6 +28,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+
+import hudson.util.MemoryReductionUtil;
 import org.apache.commons.io.IOUtils;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -45,7 +47,7 @@ public class ClassFilterImplSanityTest {
     public void whitelistSanity() throws Exception {
         try (InputStream is = ClassFilterImpl.class.getResourceAsStream("whitelisted-classes.txt")) {
             List<String> lines = IOUtils.readLines(is, StandardCharsets.UTF_8).stream().filter(line -> !line.matches("#.*|\\s*")).collect(Collectors.toList());
-            assertThat("whitelist is NOT ordered", new TreeSet<>(lines), contains(lines.toArray(new String[0])));
+            assertThat("whitelist is NOT ordered", new TreeSet<>(lines), contains(lines.toArray(MemoryReductionUtil.EMPTY_STRING_ARRAY)));
             for (String line : lines) {
                 try {
                     Class.forName(line);

--- a/core/src/test/java/jenkins/security/ClassFilterImplSanityTest.java
+++ b/core/src/test/java/jenkins/security/ClassFilterImplSanityTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import hudson.util.MemoryReductionUtil;
+import jenkins.util.MemoryReductionUtil;
 import org.apache.commons.io.IOUtils;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;


### PR DESCRIPTION
Applying part of findings from a small investigation into how to reduce overall Jenkins memory footprint -- too small to really merit a JIRA.

WIP until CI tests pass

* Created utility to reduce memory waste of HashMaps, especially for small maps
* Use map sizing utility to reduce wasted HashMap oversizing for plugin dependency maps
* Intern a whole bunch of duplicated Plugin strings (name, short-name, version, etc)
* Use a canonical empty String array rather than creating empty ones just for casting (and use this where previously we were using static fields throughout core). 
* Should be covered by existing tests

### Proposed changelog entries

* Minor improvements to reduce minimum memory footprint for Jenkins, especially around Update Center & plugin metadata

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)

### Desired reviewers

@oleg-nenashev - may be of a bit of interest as a basic platform enhancement that can be applied in other places to make Jenkins more friendly for lightweight cloud deployment.