### PR TITLE
Remove SECURITY-218 class import from TcpSlaveAgentListener test.

### DIFF
--- a/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
+++ b/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
@@ -20,7 +20,6 @@ import javax.annotation.Nullable;
 
 import jenkins.model.Jenkins;
 import jenkins.model.identity.InstanceIdentityProvider;
-import jenkins.security.security218.ysoserial.ExecBlockingSecurityManager.ExecException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;


### PR DESCRIPTION
YAGNI, and it also causes failures when I run Java11 tests in IDE (have to ignore Java classes there).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
