### PR TITLE
Upgrade to latest version of Remoting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3.26</remoting.version>
+    <remoting.version>3.27</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.4</remoting.minimum.supported.version>
 


### PR DESCRIPTION
Primarily this eliminates a potential deadlock in managing the ProtocolStack. The potential for this deadlock exists but it has been rarely reported.

See [JENKINS-53569](https://issues.jenkins-ci.org/browse/JENKINS-53569).

See also [REMOTING:PR-289](https://github.com/jenkinsci/remoting/pull/289) for further information on the issue and the fix. See also the Remoting [Changelog](https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#327), which includes a couple of other minor changes including in this release: 

### Proposed changelog entries

* Update Remoting from 3.26 to 3.27 to eliminate a potential deadlock. (issue 53569)
** https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#327

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@reviewbybees @jvz 

