### PR TITLE
[JENKINS-52024] - Update Metainf services from 1.4 to 1.8 in the master branch

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -36,7 +36,6 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -34,6 +34,11 @@
         <artifactId>access-modifier-annotation</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>annotation-indexer</artifactId>
+      <version>1.12</version>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -570,8 +570,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>
       <artifactId>metainf-services</artifactId>
-      <version>1.4</version>
-      <scope>provided</scope>
+      <version>1.8</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -207,7 +207,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,12 @@ THE SOFTWARE.
         <artifactId>commons-codec</artifactId>
         <version>1.9</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.jenkins-ci</groupId>
+        <artifactId>annotation-indexer</artifactId>
+        <version>1.12</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
See [JENKINS-52024](https://issues.jenkins-ci.org/browse/JENKINS-52024) submitted to Java 10+ support. Originally it was submitted by @svanoort in https://github.com/jenkinsci/jenkins/pull/3516 to fix Jenkins core compilation.

### Proposed changelog entries

* RFE, Internal: Update Metainf services from 1.4 to 1.8 to fix compilation on JDK 10+
  * Component link: https://github.com/kohsuke/metainf-services

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@svanoort @jglick @dwnusbaum 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
