### PR TITLE
warn user when deprecated Secret#toString() is being used

### DIFF
--- a/core/src/main/java/hudson/util/Secret.java
+++ b/core/src/main/java/hudson/util/Secret.java
@@ -42,6 +42,7 @@ import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -64,6 +65,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @author Kohsuke Kawaguchi
  */
 public final class Secret implements Serializable {
+    private static final Logger LOGGER = Logger.getLogger(Secret.class.getName());
+
     private static final byte PAYLOAD_V1 = 1;
     /**
      * Unencrypted secret text.
@@ -92,6 +95,8 @@ public final class Secret implements Serializable {
     @Override
     @Deprecated
     public String toString() {
+        final String from = new Throwable().getStackTrace()[1].toString();
+        LOGGER.warning("Use of toString() on hudson.util.Secret from "+from+". Prefer getPlainText() or getEncryptedValue() depending your needs.");
         return value;
     }
 

--- a/core/src/main/java/hudson/util/Secret.java
+++ b/core/src/main/java/hudson/util/Secret.java
@@ -96,7 +96,7 @@ public final class Secret implements Serializable {
     @Deprecated
     public String toString() {
         final String from = new Throwable().getStackTrace()[1].toString();
-        LOGGER.warning("Use of toString() on hudson.util.Secret from "+from+". Prefer getPlainText() or getEncryptedValue() depending your needs.");
+        LOGGER.warning("Use of toString() on hudson.util.Secret from "+from+". Prefer getPlainText() or getEncryptedValue() depending your needs. see https://jenkins.io/redirect/hudson.util.Secret/");
         return value;
     }
 

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -67,6 +67,6 @@ THE SOFTWARE.
          value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"
          type="password"
          checkMethod="post"
-         ATTRIBUTES="${attrs}" EXCEPT="field clazz" />
+         ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
   <!-- TODO consider customizedFields -->
 </j:jelly>


### PR DESCRIPTION
Secret.toString is deprecated since 1.356 but probably still used in various places. 
This PR adds a warning to let user know about this misuse, the same way remoting's AnonymousClassWarnings warn about bad class design. I expect this to help us prepare the next step, which is to remove Secret.toString override and ensure secret never will leak by misuse of Object.toString (logs, dump, etc)

### Proposed changelog entries

* Warn user when deprecated Secret#toString() is being used

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@daniel-beck 
