### PR TITLE
[JENKINS-54950] - use bindJSON(this,json) as default implementation for Descriptor#configure

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -639,8 +639,8 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler</artifactId>
-      <version>1.256-20181012.162708-1</version>
-      <!-- https://github.com/stapler/stapler/pull/147 -->
+      <version>1.256-20181016.115646-4</version>
+      <!-- see https://github.com/stapler/stapler/pull/147 -->
     </dependency>
     
   </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -639,7 +639,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler</artifactId>
-      <version>1.256-20181016.115646-4</version>
+      <version>1.256-20181020.094214-5</version>
       <!-- see https://github.com/stapler/stapler/pull/147 -->
     </dependency>
     

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -45,6 +45,7 @@ THE SOFTWARE.
   </properties>
 
   <dependencies>
+
     <dependency>
       <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
       <artifactId>icon-set</artifactId>
@@ -634,6 +635,14 @@ THE SOFTWARE.
       <artifactId>jzlib</artifactId>
       <version>1.1.3-kohsuke-1</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.kohsuke.stapler</groupId>
+      <artifactId>stapler</artifactId>
+      <version>1.256-20181012.162708-1</version>
+      <!-- https://github.com/stapler/stapler/pull/147 -->
+    </dependency>
+    
   </dependencies>
 
   <build>

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -144,6 +144,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.IconSet;
 import org.jvnet.tiger_types.Types;
 import org.kohsuke.stapler.Ancestor;
+import org.kohsuke.stapler.DefaultValue;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -1883,6 +1884,30 @@ public class Functions {
         }
         return o.toString();
     }
+
+    /**
+     * Retrieve default value to be used when setting field on type.
+     * Used by {@code <f:textbox>} to retrieve default value defined by component meta-data.
+     */
+    public String getDefaultValue(Class type, String field) {
+
+        // TODO to be replaced by DataModel API once implemented
+        try {
+            final DefaultValue defaultValue = type.getField(field).getAnnotation(DefaultValue.class);
+            if (defaultValue != null) return defaultValue.value();
+            return null;
+        } catch (NoSuchFieldException e) {
+            String setter = "set" + StringUtils.capitalize(field);
+            return Arrays.stream(type.getMethods())
+                    .filter(method -> method.getParameterCount() == 1)
+                    .filter(method -> method.getName().equals(setter))
+                    .findFirst()
+                    .map(method -> method.getParameters()[0].getAnnotation(DefaultValue.class))
+                    .map(DefaultValue::value)
+                    .orElse("");
+        }
+    }
+
 
     public List filterDescriptors(Object context, Iterable descriptors) {
         return DescriptorVisibilityFilter.apply(context,descriptors);

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -81,6 +81,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -1206,6 +1207,17 @@ public class Util {
     @Nonnull
     public static <T> T fixNull(@CheckForNull T s, @Nonnull T defaultValue) {
         return s != null ? s : defaultValue;
+    }
+
+    /**
+     * Convert {@code null} to a default value lazily provided by a {@link Supplier}.
+     * @param s
+     * @param supplier
+     * @since TODO
+     */
+    public static <T> T fixNull(@CheckForNull T s, @Nonnull Supplier<T> supplier) {
+        if (s == null) return supplier.get();
+        return s;
     }
 
     /**

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -828,6 +828,8 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
     /**
      * Configure descriptor instance form structured form submission where this specific descriptor is nested in
      * a larger payload, which typically happens when Descriptor doesn't have a dedicated configuration view.
+     * also collapse the structure to remain backward compatible with the JSON structure used before 1.238, as
+     * introduced by 10b20952addbdd025cb95817f5c3ad1fc6c7bcea.
      */
     public boolean configureNested( StaplerRequest req, JSONObject json) throws FormException, IOException {
         String name = getJsonSafeClassName();

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -807,8 +807,14 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      *      to keep the client in the same config page.
      */
     public boolean configure( StaplerRequest req, JSONObject json ) throws FormException {
-        // compatibility
-        return configure(req);
+        if (Util.isOverridden(Descriptor.class, getClass(), "configure", StaplerRequest.class)) {
+            // compatibility
+            return configure(req);
+        }
+
+        req.bindJSON(this, json);
+        save();
+        return true;
     }
 
     public String getConfigPage() {

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -34,6 +34,8 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.DefaultValue;
 import org.kohsuke.stapler.StaplerRequest;
 
 import javax.crypto.Cipher;
@@ -191,17 +193,15 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
         }
     }
 
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        try {
-            // for backward compatibility reasons, this configuration is stored in Jenkins
-            Jenkins.getInstance().setNoUsageStatistics(json.has("usageStatisticsCollected") ? null : true);
-            return true;
-        } catch (IOException e) {
-            throw new FormException(e,"usageStatisticsCollected");
-        }
+    public boolean isUsageStatisticsCollected() {
+        return Jenkins.get().isUsageStatisticsCollected();
     }
 
+    @DataBoundSetter
+    public void setUsageStatisticsCollected(@DefaultValue("true") boolean usageStatisticsCollected) throws IOException {
+        Jenkins.get().setNoUsageStatistics(!usageStatisticsCollected);
+    }
+    
     /**
      * Asymmetric cipher is slow and in case of Sun RSA implementation it can only encrypt the first block.
      *

--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -107,7 +107,7 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
         }
     }
 
-    public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException {
+    public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException, IOException {
         // for compatibility reasons, the actual value is stored in Jenkins
         Jenkins j = Jenkins.getInstance();
         j.checkPermission(Jenkins.ADMINISTER);
@@ -150,19 +150,11 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
         // persist all the additional security configs
         boolean result = true;
         for(Descriptor<?> d : Functions.getSortedDescriptorsForGlobalConfig(FILTER)){
-            result &= configureDescriptor(req,json,d);
+            result &= d.configureNested(req, json);
         }
         
         return result;
     }
-    
-    private boolean configureDescriptor(StaplerRequest req, JSONObject json, Descriptor<?> d) throws FormException {
-        // collapse the structure to remain backward compatible with the JSON structure before 1.
-        String name = d.getJsonSafeClassName();
-        JSONObject js = json.has(name) ? json.getJSONObject(name) : new JSONObject(); // if it doesn't have the property, the method returns invalid null object.
-        json.putAll(js);
-        return d.configure(req, js);
-    }    
 
     @Override
     public String getDisplayName() {

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -210,12 +210,6 @@ public class Shell extends CommandInterpreter {
             return FormValidation.ok();
         }
 
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject data) throws FormException {
-            req.bindJSON(this, data);
-            return super.configure(req, data);
-        }
-
         /**
          * Check the existence of sh in the given location.
          */

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -317,7 +317,7 @@ public class SCMTrigger extends Trigger<Item> {
             }
 
             maximumThreads = n;
-
+            save();
             resizeThreadPool();
         }
 
@@ -349,21 +349,6 @@ public class SCMTrigger extends Trigger<Item> {
         @PostConstruct
         /*package*/ synchronized void resizeThreadPool() {
             queue.setExecutors(Executors.newFixedThreadPool(maximumThreads, threadFactory()));
-        }
-
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-            String t = json.optString("pollingThreadCount",null);
-            if (doCheckPollingThreadCount(t).kind != FormValidation.Kind.OK) {
-                setPollingThreadCount(THREADS_DEFAULT);
-            } else {
-                setPollingThreadCount(Integer.parseInt(t));
-            }
-
-            // Save configuration
-            save();
-
-            return true;
         }
 
         public FormValidation doCheckPollingThreadCount(@QueryParameter String value) {

--- a/core/src/main/java/hudson/util/PersistedList.java
+++ b/core/src/main/java/hudson/util/PersistedList.java
@@ -33,6 +33,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.mapper.Mapper;
 import hudson.model.Describable;
 import hudson.model.Saveable;
+import org.kohsuke.stapler.Replaceable;
 
 import java.io.IOException;
 import java.util.AbstractList;
@@ -47,7 +48,7 @@ import java.util.List;
  * @author Kohsuke Kawaguchi
  * @since 1.333
  */
-public class PersistedList<T> extends AbstractList<T> {
+public class PersistedList<T> extends AbstractList<T> implements Replaceable<Collection<? extends T>> {
     protected final CopyOnWriteList<T> data = new CopyOnWriteList<T>();
     protected Saveable owner = Saveable.NOOP;
 
@@ -80,6 +81,7 @@ public class PersistedList<T> extends AbstractList<T> {
         return true;
     }
 
+    @Override
     public void replaceBy(Collection<? extends T> col) throws IOException {
         data.replaceBy(col);
         onModified();

--- a/core/src/main/java/hudson/views/GlobalDefaultViewConfiguration.java
+++ b/core/src/main/java/hudson/views/GlobalDefaultViewConfiguration.java
@@ -29,6 +29,7 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
@@ -38,23 +39,18 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 @Extension(ordinal=300) @Symbol("defaultView")
 public class GlobalDefaultViewConfiguration extends GlobalConfiguration {
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        // for compatibility reasons, the actual value is stored in Jenkins
-        Jenkins j = Jenkins.get();
-        if (json.has("primaryView")) {
-            final String viewName = json.getString("primaryView");
-            final View newPrimaryView = j.getView(viewName);
-            if (newPrimaryView == null) {
-                throw new FormException(Messages.GlobalDefaultViewConfiguration_ViewDoesNotExist(viewName), "primaryView");
-            }
-            j.setPrimaryView(newPrimaryView);
-        } else {
-            // Fallback if the view is not specified
-            j.setPrimaryView(j.getViews().iterator().next());
+
+    public String getPrimaryViewName() {
+        return Jenkins.get().getPrimaryView().getViewName();
+    }
+
+    @DataBoundSetter
+    public void setPrimaryViewName(String viewName) throws FormException {
+        final Jenkins j = Jenkins.get();
+        if (viewName != null &&j.getView(viewName) == null) {
+            throw new FormException(Messages.GlobalDefaultViewConfiguration_ViewDoesNotExist(viewName), "primaryView");
         }
-        
-        return true;
+        j.setPrimaryView(viewName);
     }
 }
 

--- a/core/src/main/java/hudson/views/MyViewsTabBar.java
+++ b/core/src/main/java/hudson/views/MyViewsTabBar.java
@@ -103,18 +103,8 @@ public abstract class MyViewsTabBar extends AbstractDescribableImpl<MyViewsTabBa
             return Jenkins.get().getMyViewsTabBar();
         }
 
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-            // for compatibility reasons, the actual value is stored in Jenkins
-            Jenkins j = Jenkins.get();
-
-            if (json.has("myViewsTabBar")) {
-                j.setMyViewsTabBar(req.bindJSON(MyViewsTabBar.class,json.getJSONObject("myViewsTabBar")));
-            } else {
-                j.setMyViewsTabBar(new DefaultMyViewsTabBar());
-            }
-
-            return true;
+        public void setMyViewsTabBar(MyViewsTabBar myViewsTabBar) {
+            Jenkins.get().setMyViewsTabBar(myViewsTabBar);
         }
     }
 }

--- a/core/src/main/java/hudson/views/ViewsTabBar.java
+++ b/core/src/main/java/hudson/views/ViewsTabBar.java
@@ -42,6 +42,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
@@ -105,18 +106,9 @@ public abstract class ViewsTabBar extends AbstractDescribableImpl<ViewsTabBar> i
             return Jenkins.get().getViewsTabBar();
         }
 
-        @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-            // for compatibility reasons, the actual value is stored in Jenkins
-            Jenkins j = Jenkins.get();
-
-            if (json.has("viewsTabBar")) {
-                j.setViewsTabBar(req.bindJSON(ViewsTabBar.class,json.getJSONObject("viewsTabBar")));
-            } else {
-                j.setViewsTabBar(new DefaultViewsTabBar());
-            }
-
-            return true;
+        @DataBoundSetter
+        public void setViewsTabBar(ViewsTabBar viewsTabBar) {
+            Jenkins.get().setViewsTabBar(viewsTabBar);
         }
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalCloudConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalCloudConfiguration.java
@@ -18,13 +18,8 @@ import java.io.IOException;
  */
 @Extension(ordinal=-100) @Symbol("cloud") // historically this was placed at the very end of the configuration page
 public class GlobalCloudConfiguration  extends GlobalConfiguration {
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        try {
-            Jenkins.get().clouds.rebuildHetero(req,json, Cloud.all(), "cloud");
-            return true;
-        } catch (IOException e) {
-            throw new FormException(e,"clouds");
-        }
+
+    public Jenkins.CloudList getClouds() {
+        return Jenkins.get().clouds;
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalConfiguration.java
@@ -58,17 +58,6 @@ public abstract class GlobalConfiguration extends Descriptor<GlobalConfiguration
     }
 
     /**
-     * By default, calls {@link StaplerRequest#bindJSON(Object, JSONObject)},
-     * appropriate when your implementation has getters and setters for all fields.
-     * <p>{@inheritDoc}
-     */
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        req.bindJSON(this, json);
-        return true;
-    }
-
-    /**
      * Returns all the registered {@link GlobalConfiguration} descriptors.
      */
     public static @Nonnull ExtensionList<GlobalConfiguration> all() {

--- a/core/src/main/java/jenkins/model/GlobalNodePropertiesConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalNodePropertiesConfiguration.java
@@ -3,6 +3,7 @@ package jenkins.model;
 import hudson.Extension;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
+import hudson.util.DescribableList;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
@@ -16,17 +17,8 @@ import java.io.IOException;
  */
 @Extension(ordinal=110) @Symbol("nodeProperties") // historically this was placed above GlobalPluginConfiguration
 public class GlobalNodePropertiesConfiguration extends GlobalConfiguration {
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        try {
-            Jenkins j = Jenkins.get();
-            JSONObject np = json.getJSONObject("globalNodeProperties");
-            if (!np.isNullObject()) {
-                j.getGlobalNodeProperties().rebuild(req, np, NodeProperty.for_(j));
-            }
-            return true;
-        } catch (IOException e) {
-            throw new FormException(e,"globalNodeProperties");
-        }
+
+    public DescribableList<NodeProperty<?>, NodePropertyDescriptor> getGlobalNodeProperties() {
+        return Jenkins.get().getGlobalNodeProperties();
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalProjectNamingStrategyConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalProjectNamingStrategyConfiguration.java
@@ -24,11 +24,8 @@
 package jenkins.model;
 
 import hudson.Extension;
-import jenkins.model.ProjectNamingStrategy.DefaultProjectNamingStrategy;
-import net.sf.json.JSONObject;
-
 import org.jenkinsci.Symbol;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Configures the project naming strategy.
@@ -38,25 +35,12 @@ import org.kohsuke.stapler.StaplerRequest;
 @Extension(ordinal = 250) @Symbol("projectNamingStrategy")
 public class GlobalProjectNamingStrategyConfiguration extends GlobalConfiguration {
 
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException {
-        // for compatibility reasons, the actual value is stored in Jenkins
-        Jenkins j = Jenkins.get();
-        final JSONObject optJSONObject = json.optJSONObject("useProjectNamingStrategy");
-        if (optJSONObject != null) {
-            final JSONObject strategyObject = optJSONObject.getJSONObject("namingStrategy");
-            final String className = strategyObject.getString("$class");
-            try {
-                Class clazz = Class.forName(className, true, j.getPluginManager().uberClassLoader);
-                final ProjectNamingStrategy strategy = (ProjectNamingStrategy) req.bindJSON(clazz, strategyObject);
-                j.setProjectNamingStrategy(strategy);
-            } catch (ClassNotFoundException e) {
-                throw new FormException(e, "namingStrategy");
-            }
-        }
-        if (j.getProjectNamingStrategy() == null) {
-            j.setProjectNamingStrategy(DefaultProjectNamingStrategy.DEFAULT_NAMING_STRATEGY);
-        }
-        return true;
+    public ProjectNamingStrategy getProjectNamingStrategy() {
+        return Jenkins.get().getProjectNamingStrategy();
+    }
+
+    @DataBoundSetter
+    public void setProjectNamingStrategy(ProjectNamingStrategy ns) {
+        Jenkins.get().setProjectNamingStrategy(ns);
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalQuietPeriodConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalQuietPeriodConfiguration.java
@@ -26,6 +26,8 @@ package jenkins.model;
 import hudson.Extension;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.DefaultValue;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
@@ -41,20 +43,8 @@ public class GlobalQuietPeriodConfiguration extends GlobalConfiguration {
         return Jenkins.get().getQuietPeriod();
     }
 
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        int i=0;
-        try {
-            i = Integer.parseInt(json.getString("quietPeriod"));
-        } catch (NumberFormatException e) {
-            // fall through
-        }
-        try {
-            // for compatibility reasons, this value is stored in Jenkins
-            Jenkins.get().setQuietPeriod(i);
-            return true;
-        } catch (IOException e) {
-            throw new FormException(e,"quietPeriod");
-        }
+    @DataBoundSetter
+    public void setQuietPeriod(@DefaultValue("0") int quietPeriod) throws IOException {
+        Jenkins.get().setQuietPeriod(quietPeriod);
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalSCMRetryCountConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalSCMRetryCountConfiguration.java
@@ -27,6 +27,7 @@ import hudson.Extension;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
@@ -42,16 +43,8 @@ public class GlobalSCMRetryCountConfiguration extends GlobalConfiguration {
         return Jenkins.get().getScmCheckoutRetryCount();
     }
 
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        try {
-            // for compatibility reasons, this value is stored in Jenkins
-            Jenkins.get().setScmCheckoutRetryCount(json.getInt("scmCheckoutRetryCount"));
-            return true;
-        } catch (IOException e) {
-            throw new FormException(e,"quietPeriod");
-        } catch (JSONException e) {
-            throw new FormException(e.getMessage(), "quietPeriod");
-        }
+    @DataBoundSetter
+    public void setScmCheckoutRetryCount(int scmCheckoutRetryCount) throws IOException {
+        Jenkins.get().setScmCheckoutRetryCount(scmCheckoutRetryCount);
     }
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3696,7 +3696,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
             boolean result = true;
             for (Descriptor<?> d : Functions.getSortedDescriptorsForGlobalConfigUnclassified())
-                result &= configureDescriptor(req,json,d);
+                result &= d.configureNested(req,json);
             
             save();
             updateComputerList();
@@ -3725,14 +3725,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     public synchronized void doTestPost( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
         rsp.sendRedirect("foo");
-    }
-
-    private boolean configureDescriptor(StaplerRequest req, JSONObject json, Descriptor<?> d) throws FormException {
-        // collapse the structure to remain backward compatible with the JSON structure before 1.
-        String name = d.getJsonSafeClassName();
-        JSONObject js = json.has(name) ? json.getJSONObject(name) : new JSONObject(); // if it doesn't have the property, the method returns invalid null object.
-        json.putAll(js);
-        return d.configure(req, js);
     }
 
     /**

--- a/core/src/main/java/jenkins/model/ManagedBy.java
+++ b/core/src/main/java/jenkins/model/ManagedBy.java
@@ -1,0 +1,23 @@
+package jenkins.model;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Document a property is actually managed by another component, and the annotated field/setter shouldn't be used
+ * directly.
+ * Typical usage is for {@link Jenkins} fields being managed by some {@link GlobalConfiguration}.
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Retention(RUNTIME)
+@Target({FIELD, METHOD})
+@Documented
+public @interface ManagedBy {
+
+    Class value();
+}

--- a/core/src/main/java/jenkins/model/MasterBuildConfiguration.java
+++ b/core/src/main/java/jenkins/model/MasterBuildConfiguration.java
@@ -27,8 +27,10 @@ import hudson.Extension;
 import hudson.model.Node.Mode;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.Nonnegative;
 import java.io.IOException;
 
 /**
@@ -38,6 +40,11 @@ import java.io.IOException;
  */
 @Extension(ordinal=500) @Symbol("masterBuild")
 public class MasterBuildConfiguration extends GlobalConfiguration {
+
+    public Mode getMode() {
+        return Jenkins.get().getMode();
+    }
+
     public int getNumExecutors() {
         return Jenkins.get().getNumExecutors();
     }
@@ -46,28 +53,19 @@ public class MasterBuildConfiguration extends GlobalConfiguration {
         return Jenkins.get().getLabelString();
     }
 
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-        Jenkins j = Jenkins.get();
-        try {
-            // for compatibility reasons, this value is stored in Jenkins
-            String num = json.getString("numExecutors");
-            if (!num.matches("\\d+")) {
-                throw new FormException(Messages.Hudson_Computer_IncorrectNumberOfExecutors(),"numExecutors");
-            }
-            
-            j.setNumExecutors(json.getInt("numExecutors"));
-            if (req.hasParameter("master.mode"))
-                j.setMode(Mode.valueOf(req.getParameter("master.mode")));
-            else
-                j.setMode(Mode.NORMAL);
+    @DataBoundSetter
+    public void setMode(Mode m) throws IOException {
+        Jenkins.get().setMode(m);
+    }
 
-            j.setLabelString(json.optString("labelString", ""));
+    @DataBoundSetter
+    public void setNumExecutors(@Nonnegative int n) throws IOException, IllegalArgumentException {
+        Jenkins.get().setNumExecutors(n);
+    }
 
-            return true;
-        } catch (IOException e) {
-            throw new FormException(e,"numExecutors");
-        }
+    @DataBoundSetter
+    public void setLabelString(String label) throws IOException {
+        Jenkins.get().setLabelString(label);
     }
 }
 

--- a/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
+++ b/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
@@ -87,18 +87,11 @@ public class GlobalToolConfiguration extends ManagementLink {
 
         boolean result = true;
         for(Descriptor<?> d : Functions.getSortedDescriptorsForGlobalConfig(FILTER)){
-            result &= configureDescriptor(req, json, d);
+            result &= d.configureNested(req, json);
         }
         j.save();
 
         return result;
-    }
-
-    private boolean configureDescriptor(StaplerRequest req, JSONObject json, Descriptor<?> d) throws Descriptor.FormException {
-        String name = d.getJsonSafeClassName();
-        JSONObject js = json.has(name) ? json.getJSONObject(name) : new JSONObject(); // if it doesn't have the property, the method returns invalid null object.
-        json.putAll(js);
-        return d.configure(req, js);
     }
 
     public static Predicate<GlobalConfigurationCategory> FILTER = new Predicate<GlobalConfigurationCategory>() {

--- a/core/src/main/resources/hudson/model/UsageStatistics/global.groovy
+++ b/core/src/main/resources/hudson/model/UsageStatistics/global.groovy
@@ -3,5 +3,7 @@ package hudson.model.UsageStatistics;
 def f=namespace(lib.FormTagLib)
 
 f.section(title: _("Usage Statistics")) {
-    f.optionalBlock(field: "usageStatisticsCollected", checked: app.usageStatisticsCollected, title: _("statsBlurb"))
+    f.entry(field: "usageStatisticsCollected") {
+        f.checkbox(title: _("statsBlurb"))
+    }
 }

--- a/core/src/main/resources/hudson/views/GlobalDefaultViewConfiguration/config.groovy
+++ b/core/src/main/resources/hudson/views/GlobalDefaultViewConfiguration/config.groovy
@@ -3,8 +3,8 @@ package hudson.views.GlobalDefaultViewConfiguration
 def f=namespace(lib.FormTagLib)
 
 if (app.views.size()>1) {
-    f.entry(title:_("Default view"), field:"defaultView") {
-        select("class":"setting-input", name:"primaryView") {
+    f.entry(title:_("Default view"), field:"primaryViewName") {
+        select("class":"setting-input", name:"primaryViewName") {
             app.views.each { v ->
                 f.option(value:v.viewName, selected:app.primaryView==v) {
                     text(v.viewName)

--- a/core/src/main/resources/jenkins/model/GlobalCloudConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/GlobalCloudConfiguration/config.groovy
@@ -8,8 +8,8 @@ def clouds = Cloud.all()
 
 if (!clouds.isEmpty()) {
     f.section(title:_("Cloud")) {
-        f.block {
-            f.hetero_list(name:"cloud", hasHeader:true, descriptors:Cloud.all(), items:app.clouds,
+        f.entry(field: "clouds") {
+            f.hetero_list(hasHeader:true, descriptors:Cloud.all(),
                 addCaption:_("Add a new cloud"), deleteCaption:_("Delete cloud"))
         }
     }

--- a/core/src/main/resources/jenkins/model/GlobalNodePropertiesConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/GlobalNodePropertiesConfiguration/config.groovy
@@ -4,5 +4,6 @@ import hudson.Functions
 
 def f=namespace(lib.FormTagLib)
 
-f.descriptorList(title:_("Global properties"),  name:"globalNodeProperties",
-        instances: app.globalNodeProperties, descriptors: Functions.getGlobalNodePropertyDescriptors());
+f.entry(title:_("Global properties"), field: "globalNodeProperties") {
+    f.descriptorList(descriptors: Functions.getGlobalNodePropertyDescriptors())
+}

--- a/core/src/main/resources/jenkins/model/GlobalProjectNamingStrategyConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/model/GlobalProjectNamingStrategyConfiguration/config.groovy
@@ -4,12 +4,9 @@ import jenkins.model.ProjectNamingStrategy
 
 def f=namespace(lib.FormTagLib)
 
-f.optionalBlock( field:"useProjectNamingStrategy", title:_("useNamingStrategy"), checked:app.useProjectNamingStrategy) {
-
-    f.entry(title:_("namingStrategyTitle")) {
-        table(style:"width:100%") {
-            f.descriptorRadioList(title:_("strategy"), varName:"namingStrategy", instance:app.projectNamingStrategy, descriptors:ProjectNamingStrategy.all())
-        }
+f.entry(title:_("namingStrategyTitle"), field:"projectNamingStrategy") {
+    table(style:"width:100%") {
+        f.descriptorRadioList(title:_("strategy"), varName:"namingStrategy",
+                instance:instance.projectNamingStrategy, descriptors:ProjectNamingStrategy.all())
     }
-
 }

--- a/core/src/main/resources/lib/form/number.jelly
+++ b/core/src/main/resources/lib/form/number.jelly
@@ -74,7 +74,7 @@ THE SOFTWARE.
     On the other hand, HTML5 <input> permits floating-point numbers.
   -->
   <j:set var="name" value="${attrs.name ?: '_.'+attrs.field}"/>
-  <j:set var="default" value="${attrs.default ?: ''}"/>
+  <j:set var="default" value="${attrs.default ?: h.getDefaultValue(instance, field)}"/>
   <j:set var="value" value="${attrs.value ?: instance[attrs.field] ?: default}"/>
   <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
          class="setting-input ${attrs.checkUrl!=null?'validated':''} ${attrs.clazz}"

--- a/core/src/main/resources/lib/form/textarea.jelly
+++ b/core/src/main/resources/lib/form/textarea.jelly
@@ -75,7 +75,7 @@ THE SOFTWARE.
   </st:documentation>
 
   <f:prepareDatabinding />
-  <j:set var="default" value="${attrs.default ?: ''}"/>
+  <j:set var="default" value="${attrs.default ?: h.getDefaultValue(instance, field)}"/>
   <j:set var="value" value="${attrs.value ?: instance[attrs.field] ?: default}" />
   <j:if test="${attrs['previewEndpoint']!=null || attrs['codemirror-mode']!=null}">
     <st:adjunct includes="lib.form.textarea.textarea"/>

--- a/core/src/main/resources/lib/form/textbox.jelly
+++ b/core/src/main/resources/lib/form/textbox.jelly
@@ -80,7 +80,7 @@ THE SOFTWARE.
 
   <!-- mostly pass-through all the attributes -->
   <j:set var="name" value="${attrs.name ?: '_.'+attrs.field}"/>
-  <j:set var="default" value="${attrs.default ?: ''}"/>
+  <j:set var="default" value="${attrs.default ?: h.getDefaultValue(instance, field)}"/>
   <j:set var="value" value="${attrs.value ?: instance[attrs.field] ?: default}"/>
   <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
          class="setting-input ${attrs.checkUrl!=null?'validated':''} ${attrs.autoCompleteUrl!=null?'auto-complete':null} ${attrs.clazz}"

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -30,17 +30,9 @@ import hudson.model.Descriptor.PropertyType;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.tasks.Shell;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.Callable;
-
+import hudson.triggers.SCMTrigger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.*;
-
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,6 +42,14 @@ import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.*;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class DescriptorTest {
@@ -220,5 +220,13 @@ public class DescriptorTest {
             assertThat(response, containsString(cause.getClass().getCanonicalName()));
             assertThat(response, containsString(getClass().getCanonicalName()));
         }
+    }
+
+    @Test
+    public void descriptor_config_roudtrip() throws Exception {
+        final SCMTrigger.DescriptorImpl d = rule.get(SCMTrigger.DescriptorImpl.class);
+        d.setPollingThreadCount(20);
+        rule.configRoundtrip();
+        assertEquals(20, d.getPollingThreadCount());
     }
 }

--- a/test/src/test/java/hudson/views/GlobalDefaultViewConfigurationTest.java
+++ b/test/src/test/java/hudson/views/GlobalDefaultViewConfigurationTest.java
@@ -27,6 +27,8 @@ import hudson.model.Descriptor;
 import net.sf.json.JSONObject;
 import static org.hamcrest.Matchers.*;
 import org.junit.Assert;
+
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,21 +48,19 @@ public class GlobalDefaultViewConfigurationTest {
     
     @Test
     @Issue("JENKINS-42717")
-    public void shouldNotFailIfTheDefaultViewIsMissing() {
+    public void shouldNotFailIfTheDefaultViewIsMissing() throws Descriptor.FormException {
         String viewName = "NonExistentView";
         GlobalDefaultViewConfiguration c = new GlobalDefaultViewConfiguration();
         
         StaplerRequest create = new MockStaplerRequestBuilder(j, "/configure").build();
         JSONObject params = new JSONObject();
         params.accumulate("primaryView", viewName);
-        try {
-            c.configure(create, params);
-        } catch(Descriptor.FormException ex) {
-            assertThat("Wrong exception message for the form failure", 
-                    ex.getMessage(), containsString(Messages.GlobalDefaultViewConfiguration_ViewDoesNotExist(viewName)));
-            return;
-        }
-        Assert.fail("Expected FormException");
+
+        // JENKINS-42717: Should *not* throw an exception
+        c.configure(create, params);
+
+        // Should have a reasonable default set
+        assertNotNull(j.jenkins.getPrimaryView());
     }
     
 }

--- a/test/src/test/java/jenkins/model/GlobalSCMRetryCountConfigurationTest.java
+++ b/test/src/test/java/jenkins/model/GlobalSCMRetryCountConfigurationTest.java
@@ -32,7 +32,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.stapler.MockStaplerRequestBuilder;
 import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Tests of {@link GlobalSCMRetryCountConfiguration}.
@@ -50,18 +52,20 @@ public class GlobalSCMRetryCountConfigurationTest {
             GlobalSCMRetryCountConfiguration gc = (GlobalSCMRetryCountConfiguration)
                     GlobalConfiguration.all().getDynamic("jenkins.model.GlobalSCMRetryCountConfiguration");
 
+            final StaplerRequest req = new MockStaplerRequestBuilder(j, "/configure").build();
+
             json.element("scmCheckoutRetryCount", 5);
-            gc.configure(Stapler.getCurrentRequest(), json);
+            gc.configure(req, json);
             assertThat("Wrong value, it should be equal to 5",
                     j.getInstance().getScmCheckoutRetryCount(), equalTo(5));
 
             json.element("scmCheckoutRetryCount", 3);
-            gc.configure(Stapler.getCurrentRequest(), json);
+            gc.configure(req, json);
             assertThat("Wrong value, it should be equal to 3",
                     j.getInstance().getScmCheckoutRetryCount(), equalTo(3));
 
             JSONObject emptyJson = new JSONObject();
-            gc.configure(Stapler.getCurrentRequest(), emptyJson);
+            gc.configure(req, emptyJson);
         } catch (Descriptor.FormException e) {
             assertThat("Scm Retry count value changed! This shouldn't happen.",
                     j.getInstance().getScmCheckoutRetryCount(), equalTo(3));

--- a/test/src/test/java/org/kohsuke/stapler/MockStaplerRequestBuilder.java
+++ b/test/src/test/java/org/kohsuke/stapler/MockStaplerRequestBuilder.java
@@ -23,22 +23,16 @@
  */
 package org.kohsuke.stapler;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import javax.annotation.Nonnull;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import jenkins.model.Jenkins;
-import org.eclipse.jetty.server.Request;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.mockito.Mockito;
-import org.springframework.web.multipart.support.DefaultMultipartHttpServletRequest;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Mocked version of {@link StaplerRequest}.
@@ -74,8 +68,14 @@ public class MockStaplerRequestBuilder{
     }
        
     public StaplerRequest build() throws AssertionError {        
-        HttpServletRequest rawRequest = Mockito.mock(HttpServletRequest.class);
-        return new RequestImpl(stapler != null ? stapler : new Stapler(), rawRequest, ancestors, tokens);
+        HttpServletRequest rawRequest = mock(HttpServletRequest.class);
+        return new RequestImpl(stapler != null ? stapler : getStapler(), rawRequest, ancestors, tokens);
     }
-       
+
+    private Stapler getStapler() {
+        final Stapler stapler = new Stapler();
+        stapler.setWebApp(new WebApp(null));
+        return stapler;
+    }
+
 }


### PR DESCRIPTION
This change is intended to promote use of databinding relying on DataBoundSetters in Descriptors, as required by JCasC. 

See [JENKINS-54950](https://issues.jenkins-ci.org/browse/JENKINS-54950).

### Proposed changelog entries

* Internal: use bindJSON() as default implementation for Descriptor#configure

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). 
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

