### PR TITLE
Add Dockerfile for CD of Docker images in the Master branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# This is a Dockerfile definition for Experimental Docker builds.
+# DockerHub: https://hub.docker.com/r/jenkins/jenkins-experimental/
+# If you are looking for official images, see https://github.com/jenkinsci/docker
+FROM maven:3.5.4-jdk-8 as builder
+
+COPY .mvn/ /jenkins/src/.mvn/
+COPY cli/ /jenkins/src/cli/
+COPY core/ /jenkins/src/core/
+COPY src/ /jenkins/src/src/
+COPY test/ /jenkins/src/test/
+COPY war/ /jenkins/src/war/
+COPY *.xml /jenkins/src/
+COPY LICENSE.txt /jenkins/src/LICENSE.txt
+COPY licenseCompleter.groovy /jenkins/src/licenseCompleter.groovy
+COPY show-pom-version.rb /jenkins/src/show-pom-version.rb
+
+WORKDIR /jenkins/src/
+RUN mvn clean install --batch-mode -Plight-test
+
+# The image is based on the previous weekly, new changes in jenkinci/docker are not applied
+FROM jenkins/jenkins:latest
+
+LABEL Description="This is an experimental image for the master branch of the Jenkins core" Vendor="Jenkins Project"
+
+COPY --from=builder /jenkins/src/war/target/jenkins.war /usr/share/jenkins/jenkins.war
+ENTRYPOINT ["tini", "--", "/usr/local/bin/jenkins.sh"]


### PR DESCRIPTION
Follow-up to https://groups.google.com/forum/#!topic/jenkinsci-dev/jfxiuABqO7I.
No JIRA ticket, because I cannot access it from the hotel network.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE: Make experimental Docker images available for the master branch in a CD Manner

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
