### PR TITLE
[JENKINS-31448] Protect against NPE in update center on restart

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -485,7 +485,15 @@ public class UpdateSite {
      * Is this the legacy default update center site?
      */
     public boolean isLegacyDefault() {
-        return id.equals(UpdateCenter.PREDEFINED_UPDATE_SITE_ID) && url.startsWith("http://hudson-ci.org/") || url.startsWith("http://updates.hudson-labs.org/");
+        return updateSiteIsHudsonCI() || updateSiteIsHudsonLabs();
+    }
+
+    private boolean updateSiteIsHudsonCI() {
+        return url != null && UpdateCenter.PREDEFINED_UPDATE_SITE_ID.equals(id) && url.startsWith("http://hudson-ci.org/");
+    }
+
+    private boolean updateSiteIsHudsonLabs() {
+        return url != null && url.startsWith("http://updates.hudson-labs.org/");
     }
 
     /**

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -485,14 +485,14 @@ public class UpdateSite {
      * Is this the legacy default update center site?
      */
     public boolean isLegacyDefault() {
-        return updateSiteIsHudsonCI() || updateSiteIsHudsonLabs();
+        return isHudsonCI() || isUpdatesFromHudsonLabs();
     }
 
-    private boolean updateSiteIsHudsonCI() {
+    private boolean isHudsonCI() {
         return url != null && UpdateCenter.PREDEFINED_UPDATE_SITE_ID.equals(id) && url.startsWith("http://hudson-ci.org/");
     }
 
-    private boolean updateSiteIsHudsonLabs() {
+    private boolean isUpdatesFromHudsonLabs() {
         return url != null && url.startsWith("http://updates.hudson-labs.org/");
     }
 

--- a/test/src/test/java/hudson/model/UpdateSiteTest.java
+++ b/test/src/test/java/hudson/model/UpdateSiteTest.java
@@ -54,6 +54,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
@@ -150,5 +151,14 @@ public class UpdateSiteTest {
         assertEquals(FormValidation.ok(), site.updateDirectly(false).get());
         assertEquals("number of warnings", 7, site.getData().getWarnings().size());
         assertNotEquals("plugin data is present", Collections.emptyMap(), site.getData().plugins);
+    }
+
+    @Issue("JENKINS-31448")
+    @Test public void isLegacyDefault() throws Exception {
+        assertFalse("isLegacyDefault should be false with null id",new UpdateSite(null,"url").isLegacyDefault());
+        assertFalse("isLegacyDefault should be false when id is not default and url is http://hudson-ci.org/",new UpdateSite("dummy","http://hudson-ci.org/").isLegacyDefault());
+        assertTrue("isLegacyDefault should be true when id is default and url is http://hudson-ci.org/",new UpdateSite(UpdateCenter.PREDEFINED_UPDATE_SITE_ID,"http://hudson-ci.org/").isLegacyDefault());
+        assertTrue("isLegacyDefault should be true when url is http://updates.hudson-labs.org/",new UpdateSite("dummy","http://updates.hudson-labs.org/").isLegacyDefault());
+        assertFalse("isLegacyDefault should be false with null url",new UpdateSite(null,null).isLegacyDefault());
     }
 }


### PR DESCRIPTION
See [JENKINS-31448](https://issues.jenkins-ci.org/browse/JENKINS-31448).

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

