### PR TITLE
[JENKINS-48516] Uniquify radio button names before setting initial visibility

### DIFF
--- a/core/src/main/resources/lib/form/repeatable/repeatable.js
+++ b/core/src/main/resources/lib/form/repeatable/repeatable.js
@@ -186,7 +186,8 @@ Behaviour.specify("INPUT.repeatable-delete", 'repeatable', 0, function(e) {
     });
 
     // radio buttons in repeatable content
-Behaviour.specify("DIV.repeated-chunk", 'repeatable', 0, function(d) {
+// Needs to run before the radioBlock behavior so that names are already unique.
+Behaviour.specify("DIV.repeated-chunk", 'repeatable', -200, function(d) {
         var inputs = d.getElementsByTagName('INPUT');
         for (var i = 0; i < inputs.length; i++) {
             if (inputs[i].type == 'radio') {


### PR DESCRIPTION
See [JENKINS-48516](https://issues.jenkins-ci.org/browse/JENKINS-48516).

This fixes an issue in workflow-cps-global-lib (see jenkinsci/workflow-cps-global-lib-plugin#55 for an independent fix) where the visibility of nested groups of radio buttons on initial page load would not correspond correctly to the databound values. This PR fixes the problem by making sure radio buttons are uniquified before the initial visibility is decided, so that groups can be determined correctly.

I don't think there is a good way to test this behavior in an automated test here, and I was not able to create an HtmlUnit test in the downstream PR either (see https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/55#issuecomment-427174857).

Screenshots of how global libraries appear on page load before and after the change:

**Before**: (Legacy SCM is selected but the SCM section is missing):
<img width="1052" alt="screen shot 2018-10-04 at 15 20 55" src="https://user-images.githubusercontent.com/1068968/46497645-26f99b80-c7e9-11e8-96b4-0abce8f86396.png">

**After**: (Legacy SCM is selected and the SCM section is shown):
<img width="1039" alt="screen shot 2018-10-04 at 15 19 59" src="https://user-images.githubusercontent.com/1068968/46497640-22cd7e00-c7e9-11e8-920b-ef5b4bff00ed.png">


### Proposed changelog entries

* Bug: The initial visibility of nested groups of radio buttons did not accurately reflect the current databound values.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees 
