### PR TITLE
Add missing space

### DIFF
--- a/core/src/main/resources/hudson/cli/CLIAction/index.properties
+++ b/core/src/main/resources/hudson/cli/CLIAction/index.properties
@@ -1,4 +1,4 @@
 Jenkins\ CLI=Jenkins CLI
 blurb=You can access various features in Jenkins through a command-line tool. See \
-  <a href="https://jenkins.io/redirect/cli">the documentation</a> for more details of this feature.\
+  <a href="https://jenkins.io/redirect/cli">the documentation</a> for more details of this feature. \
   To get started, download <a href="{0}/jnlpJars/jenkins-cli.jar">jenkins-cli.jar</a>, and run it as follows:

--- a/core/src/main/resources/jenkins/model/Jenkins/legend.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/legend.properties
@@ -24,7 +24,7 @@ grey=The project has never been built before, or the project is disabled.
 grey_anime=The first build of the project is in progress.
 blue=The last build was successful.
 blue_anime=The last build was successful. A new build is in progress.
-yellow=The last build was successful but unstable.\
+yellow=The last build was successful but unstable. \
        This is primarily used to represent test failures.
 yellow_anime=The last build was successful but unstable. A new build is in progress.
 red=The last build fatally failed.


### PR DESCRIPTION
Properties parse:
foo=blah\
   this

As: foo=blahthis
-- stripping leading whitespace...

Fixes:
* /legend
* /cli/

### Proposed changelog entries

* Added missing space for help text in /legend and /cli

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

