### PR TITLE
Drop fatally

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/legend.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/legend.properties
@@ -27,8 +27,8 @@ blue_anime=The last build was successful. A new build is in progress.
 yellow=The last build was successful but unstable.\
        This is primarily used to represent test failures.
 yellow_anime=The last build was successful but unstable. A new build is in progress.
-red=The last build fatally failed.
-red_anime=The last build fatally failed. A new build is in progress.
+red=The last build failed.
+red_anime=The last build failed. A new build is in progress.
 health-81plus=Project health is over 80%. You can hover the mouse over the project\u2019s icon for a more detailed explanation.
 health-61to80=Project health is over 60% and up to 80%. You can hover the mouse over the project\u2019s icon for a more detailed explanation.
 health-41to60=Project health is over 40% and up to 60%. You can hover the mouse over the project\u2019s icon for a more detailed explanation.


### PR DESCRIPTION
Builds are either successful (in which case they are not red) or they are not (in which case they are red).
There is no case where a build can be fatally successful, or not fatal and still fail.

Note: this code dates to the 0th revision of this repository: https://github.com/jenkinsci/jenkins/blob/8a0dc230f44e84e5a7f7920cf9a31f09a54999ac/core/src/main/resources/hudson/model/Hudson/legend.jelly

### Proposed changelog entries

* Drop `fatally` from /legend

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers
