### PR TITLE
Fixed AdministrativeMonitor JavaDoc: replaced div class "warning" with "alert alert-warning"

### DIFF
--- a/core/src/main/java/hudson/model/AdministrativeMonitor.java
+++ b/core/src/main/java/hudson/model/AdministrativeMonitor.java
@@ -68,7 +68,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  * If {@link #isActivated()} returns true, Jenkins will use the {@code message.jelly}
  * view of this object to render the warning text. This happens in the
  * {@code http://SERVER/jenkins/manage} page. This view should typically render
- * a DIV box with class='error' or class='warning' with a human-readable text
+ * a DIV box with class='alert alert-error' or class='alert alert-warning' with a human-readable text
  * inside it. It often also contains a link to a page that provides more details
  * about the problem.
  * </dd>


### PR DESCRIPTION
Replaced in JavaDoc of AdministrativeMonitor the old classes "warning" and "error" with the new bootstrap versions "alert alert-warning" and "alert alert-error".

No tests and Jira required.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: Fixed JavaDoc of AdministratorMonitor (use correct div class for messages). 

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->