### PR TITLE
Add i18n support for "icon size" control hyperlinks

### DIFF
--- a/core/src/main/resources/lib/hudson/iconSize.jelly
+++ b/core/src/main/resources/lib/hudson/iconSize.jelly
@@ -41,9 +41,9 @@ THE SOFTWARE.
       </d:taglib>
 
       <td xmlns:local="local">${%Icon}:
-        <local:iconSizeLink title="S" sz="16x16" />
-        <local:iconSizeLink title="M" sz="24x24" />
-        <local:iconSizeLink title="L" sz="32x32" />
+        <local:iconSizeLink title="${%S}" sz="16x16" />
+        <local:iconSizeLink title="${%M}" sz="24x24" />
+        <local:iconSizeLink title="${%L}" sz="32x32" />
       </td><td>
         <d:invokeBody />
       </td>

--- a/core/src/main/resources/lib/hudson/iconSize.properties
+++ b/core/src/main/resources/lib/hudson/iconSize.properties
@@ -1,0 +1,26 @@
+# The MIT License
+#
+# Copyright (c) 2018, linuxsuren
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Icon=Icon
+S=S
+M=M
+L=L


### PR DESCRIPTION
### Changelog entry:

* Add internationalization support for "icon size" control hyperlinks