### PR TITLE
Collect information on Accept-Language header values

### DIFF
--- a/core/src/main/java/jenkins/telemetry/Telemetry.java
+++ b/core/src/main/java/jenkins/telemetry/Telemetry.java
@@ -76,7 +76,7 @@ public abstract class Telemetry implements ExtensionPoint {
      * Good IDs are globally unique and human readable (i.e. no UUIDs).
      *
      * For a periodically updated list of all public implementations, see https://jenkins.io/doc/developer/extensions/jenkins-core/#telemetry
-     * 
+     *
      * @return ID of the collector, never null or empty
      */
     @Nonnull
@@ -126,6 +126,14 @@ public abstract class Telemetry implements ExtensionPoint {
         return ExtensionList.lookup(Telemetry.class);
     }
 
+    /**
+     * @since TODO
+     * @return whether to collect telemetry
+     */
+    public static boolean isDisabled() {
+        return UsageStatistics.DISABLED || !Jenkins.get().isUsageStatisticsCollected();
+    }
+
     @Extension
     public static class TelemetryReporter extends AsyncPeriodicWork {
 
@@ -140,7 +148,7 @@ public abstract class Telemetry implements ExtensionPoint {
 
         @Override
         protected void execute(TaskListener listener) throws IOException, InterruptedException {
-            if (UsageStatistics.DISABLED || !Jenkins.getInstance().isUsageStatisticsCollected()) {
+            if (isDisabled()) {
                 LOGGER.info("Collection of anonymous usage statistics is disabled, skipping telemetry collection and submission");
                 return;
             }

--- a/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
+++ b/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
@@ -112,10 +112,12 @@ public class UserLanguages extends Telemetry {
             if (request instanceof HttpServletRequest) {
                 HttpServletRequest httpServletRequest = (HttpServletRequest) request;
                 String language = httpServletRequest.getHeader("Accept-Language");
-                if (!requestsByLanguage.containsKey(language)) {
-                    requestsByLanguage.put(language, new MutableLong(0));
+                if (language != null) {
+                    if (!requestsByLanguage.containsKey(language)) {
+                        requestsByLanguage.put(language, new MutableLong(0));
+                    }
+                    requestsByLanguage.get(language).increment();
                 }
-                requestsByLanguage.get(language).increment();
             }
             chain.doFilter(request, response);
         }

--- a/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
+++ b/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.telemetry.impl;
+
+import hudson.Extension;
+import hudson.init.Initializer;
+import hudson.util.PluginServletFilter;
+import jenkins.telemetry.Telemetry;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.mutable.MutableLong;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.Nonnull;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class UserLanguages extends Telemetry {
+
+    private static Map<String, MutableLong> requestsByLanguage = new TreeMap<>();
+    private static Logger LOGGER = Logger.getLogger(UserLanguages.class.getName());
+
+    @Nonnull
+    @Override
+    public String getId() {
+        return UserLanguages.class.getName();
+    }
+
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+        return "Browser languages";
+    }
+
+    @Nonnull
+    @Override
+    public LocalDate getStart() {
+        return LocalDate.of(2018, 10, 1);
+    }
+
+    @Nonnull
+    @Override
+    public LocalDate getEnd() {
+        return LocalDate.of(2019, 1, 1);
+    }
+
+    @Nonnull
+    @Override
+    public JSONObject createContent() {
+        JSONObject payload = new JSONObject();
+        for (Map.Entry<String, MutableLong> entry : requestsByLanguage.entrySet()) {
+            payload.put(entry.getKey(), entry.getValue().longValue());
+        }
+        return payload;
+    }
+
+    @Initializer
+    public static void setUpFilter() {
+        Filter filter = new AcceptLanguageFilter();
+        if (!PluginServletFilter.hasFilter(filter)) {
+            try {
+                PluginServletFilter.addFilter(filter);
+            } catch (ServletException ex) {
+                LOGGER.log(Level.WARNING, "Failed to set up languages servlet filter", ex);
+            }
+        }
+    }
+
+    public static final class AcceptLanguageFilter implements Filter {
+
+        @Override
+        public void init(FilterConfig filterConfig) {
+
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+            if (request instanceof HttpServletRequest) {
+                HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+                String language = httpServletRequest.getHeader("Accept-Language");
+                if (!requestsByLanguage.containsKey(language)) {
+                    requestsByLanguage.put(language, new MutableLong(0));
+                }
+                requestsByLanguage.get(language).increment();
+            }
+            chain.doFilter(request, response);
+        }
+
+        @Override
+        public void destroy() {
+
+        }
+
+        @Override
+        public boolean equals(Object obj) { // support PluginServletFilter#hasFilter
+            return obj != null && obj.getClass() == AcceptLanguageFilter.class;
+        }
+    }
+}

--- a/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
+++ b/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
@@ -133,5 +133,11 @@ public class UserLanguages extends Telemetry {
         public boolean equals(Object obj) { // support PluginServletFilter#hasFilter
             return obj != null && obj.getClass() == AcceptLanguageFilter.class;
         }
+
+        // findbugs
+        @Override
+        public int hashCode() {
+            return 42;
+        }
     }
 }

--- a/core/src/main/resources/jenkins/telemetry/impl/UserLanguages/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/UserLanguages/description.jelly
@@ -1,0 +1,5 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    This trial collects information about the prevalence of <code>Accept-Language</code> header values among Jenkins users' browsers to help guide localization efforts.
+    We collect the values of the Accept-Language headers and the number of requests sent to Jenkins with each of the headers.
+</j:jelly>


### PR DESCRIPTION
RFC: Would this be useful?

I imagine it might help understand the need for certain translations. At the very least, it would show how many users use Jenkins with a non-English language.

Data submitted looks like this:

    {"en-US,en;q=0.5":9,"en-US,en;q=0.7,de;q=0.3":89}

### Proposed changelog entries

* Add telemetry trial about user languages

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
