### PR TITLE
Add telemetry for Stapler dispatches

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.254.1</stapler.version>
+    <stapler.version>1.255-SNAPSHOT</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.12</groovy.version>
   </properties>
@@ -124,7 +124,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler-groovy</artifactId>
-      <version>${stapler.version}</version>
+      <version>1.255-20181009.223300-3</version>
       <exclusions>
         <exclusion>
           <groupId>commons-jelly</groupId>
@@ -148,7 +148,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler-jrebel</artifactId>
-      <version>${stapler.version}</version>
+      <version>1.255-20181009.223304-3</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.255-telemetry-1-SNAPSHOT</stapler.version>
+    <stapler.version>1.255</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.12</groovy.version>
   </properties>

--- a/core/src/main/java/jenkins/telemetry/impl/StaplerDispatches.java
+++ b/core/src/main/java/jenkins/telemetry/impl/StaplerDispatches.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.telemetry.impl;
+
+import hudson.Extension;
+import hudson.PluginWrapper;
+import hudson.model.UsageStatistics;
+import hudson.util.VersionNumber;
+import jenkins.model.Jenkins;
+import jenkins.telemetry.Telemetry;
+import jenkins.util.SystemProperties;
+import net.sf.json.JSONObject;
+import org.kohsuke.MetaInfServices;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.EvaluationTrace;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nonnull;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Telemetry implementation gathering information about Stapler dispatch routes.
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class StaplerDispatches extends Telemetry {
+    @Nonnull
+    @Override
+    public LocalDate getStart() {
+        return LocalDate.of(2018, 10, 10);
+    }
+
+    @Nonnull
+    @Override
+    public LocalDate getEnd() {
+        return LocalDate.of(2019, 2, 1);
+    }
+
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+        return "Stapler request handling";
+    }
+
+    @Nonnull
+    @Override
+    public JSONObject createContent() {
+        Map<String, Object> info = new TreeMap<>();
+        info.put("components", buildComponentInformation());
+        info.put("dispatches", buildDispatches());
+
+        return JSONObject.fromObject(info);
+    }
+
+    private Object buildDispatches() {
+        Set<String> currentTraces = traces;
+        traces = new TreeSet<>();
+        return currentTraces;
+    }
+
+    private Object buildComponentInformation() {
+        Map<String, String> components = new TreeMap<>();
+        VersionNumber core = Jenkins.getVersion();
+        components.put("jenkins-core", core == null ? "" : core.toString());
+
+        for (PluginWrapper plugin : Jenkins.get().pluginManager.getPlugins()) {
+            if (plugin.isActive()) {
+                components.put(plugin.getShortName(), plugin.getVersion());
+            }
+        }
+        return components;
+    }
+
+    @MetaInfServices
+    public static class StaplerTrace extends EvaluationTrace.ApplicationTracer {
+
+        @Override
+        protected void record(StaplerRequest staplerRequest, String s) {
+            if (UsageStatistics.DISABLED || !Jenkins.get().isUsageStatisticsCollected()) {
+                // do not collect traces while usage statistics are disabled
+                return;
+            }
+            traces.add(s);
+        }
+    }
+
+    private static volatile Set<String> traces = new TreeSet<>();
+}

--- a/core/src/main/java/jenkins/telemetry/impl/StaplerDispatches.java
+++ b/core/src/main/java/jenkins/telemetry/impl/StaplerDispatches.java
@@ -108,6 +108,7 @@ public class StaplerDispatches extends Telemetry {
         @Override
         protected void record(StaplerRequest staplerRequest, String s) {
             if (UsageStatistics.DISABLED || !Jenkins.get().isUsageStatisticsCollected()) {
+                // TODO use new API after jenkinsci/jenkins#3687 is merged
                 // do not collect traces while usage statistics are disabled
                 return;
             }

--- a/core/src/main/resources/jenkins/telemetry/impl/StaplerDispatches/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/StaplerDispatches/description.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    Stapler is the web framework used by Jenkins.
+    To help develop an upcoming major revision of the framework, this trial collects information about how Stapler processes HTTP requests.
+    In addition to references to classes, methods, and Stapler-related resource files involved in Stapler request processing, this trial collects the names of installed plugins, their versions, and the version of Jenkins core.
+    It does <strong>not</strong> collect URLs or any user data.
+</j:jelly>


### PR DESCRIPTION
I'm looking into modernizing Stapler. This is related to [Stephen's work from last year](https://groups.google.com/d/msg/jenkinsci-dev/UrVVT8wbHIE/_1O35oU4AgAJ) that aimed to make Stapler more declarative. First however I'd like to gather some information about how Stapler is used "in the wild" to determine the impact in terms of changes required to fully adapt to any potential changes I'm looking into. For that reason, this trial collect anonymized dispatch information similar to `X-Stapler-Trace`, but without the actual string values etc. (i.e. this does not collect user data)

Downstream of https://github.com/stapler/stapler/pull/148

Sample payload submitted (formatted for readability):

````
{
  "components": {
    "ace-editor": "1.1",
    "analysis-core": "1.95",
    "antisamy-markup-formatter": "1.5",
    "apache-httpcomponents-client-4-api": "4.5.5-3.0",
    "authentication-tokens": "1.3",
    "authorize-project": "1.3.0",
    "blueocean": "1.8.4",
    "blueocean-autofavorite": "1.2.2",
    "blueocean-bitbucket-pipeline": "1.8.4",
    "blueocean-commons": "1.8.4",
    "blueocean-config": "1.8.4",
    "blueocean-core-js": "1.8.4",
    "blueocean-dashboard": "1.8.4",
    "blueocean-display-url": "2.2.0",
    "blueocean-events": "1.8.4",
    "blueocean-git-pipeline": "1.8.4",
    "blueocean-github-pipeline": "1.8.4",
    "blueocean-i18n": "1.8.4",
    "blueocean-jira": "1.8.4",
    "blueocean-jwt": "1.8.4",
    "blueocean-personalization": "1.8.4",
    "blueocean-pipeline-api-impl": "1.8.4",
    "blueocean-pipeline-editor": "1.8.4",
    "blueocean-pipeline-scm-api": "1.8.4",
    "blueocean-rest": "1.8.4",
    "blueocean-rest-impl": "1.8.4",
    "blueocean-web": "1.8.4",
    "bouncycastle-api": "2.17",
    "branch-api": "2.0.20",
    "checkstyle": "3.50",
    "cloudbees-bitbucket-branch-source": "2.2.12",
    "cloudbees-folder": "6.6",
    "cobertura": "1.13",
    "code-coverage-api": "1.0.5",
    "command-launcher": "1.2",
    "credentials": "2.1.18",
    "credentials-binding": "1.16",
    "display-url-api": "2.2.0",
    "docker-commons": "1.13",
    "docker-workflow": "1.17",
    "durable-task": "1.26",
    "favorite": "2.3.2",
    "git": "3.9.1",
    "git-client": "2.7.3",
    "git-server": "1.7",
    "github": "1.29.2",
    "github-api": "1.92",
    "github-branch-source": "2.4.0",
    "handlebars": "1.1.1",
    "handy-uri-templates-2-api": "2.1.6-1.0",
    "htmlpublisher": "1.17",
    "jackson2-api": "2.8.11.3",
    "javadoc": "1.4",
    "jdk-tool": "1.1",
    "jenkins-core": "2.146-SNAPSHOT",
    "jenkins-design-language": "1.8.4",
    "jira": "3.0.2",
    "jquery": "1.12.4-0",
    "jquery-detached": "1.2.1",
    "jsch": "0.1.54.2",
    "junit": "1.26.1",
    "lockable-resources": "2.3",
    "mailer": "1.21",
    "matrix-auth": "2.3",
    "matrix-project": "1.13",
    "maven-plugin": "3.1.2",
    "mercurial": "2.4",
    "metrics": "4.0.2.2",
    "momentjs": "1.1.1",
    "nodelabelparameter": "1.7.2",
    "pipeline-build-step": "2.7",
    "pipeline-graph-analysis": "1.7",
    "pipeline-input-step": "2.8",
    "pipeline-milestone-step": "1.3.1",
    "pipeline-model-api": "1.3.2",
    "pipeline-model-declarative-agent": "1.1.1",
    "pipeline-model-definition": "1.3.2",
    "pipeline-model-extensions": "1.3.2",
    "pipeline-rest-api": "2.10",
    "pipeline-stage-step": "2.3",
    "pipeline-stage-tags-metadata": "1.3.2",
    "pipeline-stage-view": "2.10",
    "plain-credentials": "1.4",
    "pubsub-light": "1.12",
    "resource-disposer": "0.12",
    "scm-api": "2.2.8",
    "script-security": "1.46",
    "sse-gateway": "1.16",
    "ssh-agent": "1.17",
    "ssh-credentials": "1.14",
    "ssh-slaves": "1.26",
    "structs": "1.17",
    "throttle-concurrents": "2.0.1",
    "timestamper": "1.8.10",
    "token-macro": "2.5",
    "variant": "1.1",
    "workflow-aggregator": "2.6",
    "workflow-api": "2.29",
    "workflow-basic-steps": "2.11",
    "workflow-cps": "2.57",
    "workflow-cps-global-lib": "2.12",
    "workflow-durable-task-step": "2.22",
    "workflow-job": "2.25",
    "workflow-multibranch": "2.20",
    "workflow-scm-step": "2.7",
    "workflow-step-api": "2.16",
    "workflow-support": "2.20",
    "ws-cleanup": "0.34",
    "xunit": "2.3.0"
  },
  "dispatches": [
    "com.cloudbees.hudson.plugins.folder.Folder#doContextMenu",
    "com.cloudbees.hudson.plugins.folder.Folder: Dispatch",
    "com.cloudbees.hudson.plugins.folder.Folder: StaplerProxy.getTarget()",
    "com.cloudbees.jenkins.GitHubWebHook: Dispatch",
    "com.cloudbees.jenkins.GitHubWebHook: Index: doIndex",
    "com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint$DescriptorImpl#doFillCredentialsIdItems",
    "com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint$DescriptorImpl: Dispatch",
    "com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper$CredentialHolder$DescriptorImpl#doFillIdItems",
    "com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper$CredentialHolder$DescriptorImpl: Dispatch",
    "com.cloudbees.plugins.credentials.CredentialsProviderTypeRestriction$Includes$DescriptorImpl#doFillProviderItems",
    "com.cloudbees.plugins.credentials.CredentialsProviderTypeRestriction$Includes$DescriptorImpl#doFillTypeItems",
    "com.cloudbees.plugins.credentials.CredentialsProviderTypeRestriction$Includes$DescriptorImpl: Dispatch",
    "com.cloudbees.plugins.credentials.GlobalCredentialsConfiguration#doConfigure",
    "com.cloudbees.plugins.credentials.GlobalCredentialsConfiguration: Dispatch",
    "com.cloudbees.plugins.credentials.GlobalCredentialsConfiguration: Jelly index: com/cloudbees/plugins/credentials/GlobalCredentialsConfiguration/index.jelly",
    "com.cloudbees.plugins.credentials.PluginImpl#doDynamic(...)",
    "com.cloudbees.plugins.credentials.PluginImpl: Dispatch",
    "hudson.Plugin$DummyImpl#doDynamic(...)",
    "hudson.Plugin$DummyImpl: Dispatch",
    "hudson.logging.LogRecorder: Dispatch",
    "hudson.logging.LogRecorder: Jelly index: hudson/logging/LogRecorder/index.jelly",
    "hudson.logging.LogRecorderManager#getDynamic(...)",
    "hudson.logging.LogRecorderManager: Dispatch",
    "hudson.logging.LogRecorderManager: StaplerProxy.getTarget()",
    "hudson.model.AllView: Dispatch",
    "hudson.model.AllView: Jelly facet: hudson/model/View/ajaxBuildQueue.jelly",
    "hudson.model.AllView: Jelly facet: hudson/model/View/ajaxExecutors.jelly",
    "hudson.model.FreeStyleBuild: Dispatch",
    "hudson.model.FreeStyleBuild: Jelly index: hudson/model/AbstractBuild/index.jelly",
    "hudson.model.FreeStyleProject#doCheckNewName",
    "hudson.model.FreeStyleProject#doContextMenu",
    "hudson.model.FreeStyleProject#getDescriptorByName(String)",
    "hudson.model.FreeStyleProject#getDynamic(...)",
    "hudson.model.FreeStyleProject$DescriptorImpl#doCheckCustomWorkspace",
    "hudson.model.FreeStyleProject$DescriptorImpl: Dispatch",
    "hudson.model.FreeStyleProject: Dispatch",
    "hudson.model.FreeStyleProject: Jelly facet: hudson/model/AbstractItem/confirm-rename.jelly",
    "hudson.model.FreeStyleProject: Jelly facet: hudson/model/Job/configure.jelly",
    "hudson.model.FreeStyleProject: Jelly index: hudson/model/Job/index.jelly",
    "hudson.model.FreeStyleProject: StaplerProxy.getTarget()",
    "hudson.model.Hudson#doCheckDisplayName",
    "hudson.model.Hudson#doConfigSubmit",
    "hudson.model.Hudson#doResources",
    "hudson.model.Hudson#doScript",
    "hudson.model.Hudson#getAdjuncts(String)",
    "hudson.model.Hudson#getDescriptorByName(String)",
    "hudson.model.Hudson#getDynamic(...)",
    "hudson.model.Hudson#getJob(String)",
    "hudson.model.Hudson#getLog()",
    "hudson.model.Hudson#getPlugin(String)",
    "hudson.model.Hudson: Dispatch",
    "hudson.model.Hudson: Jelly facet: jenkins/model/Jenkins/configure.jelly",
    "hudson.model.Hudson: StaplerFallback.getStaplerFallback()",
    "hudson.model.Hudson: StaplerProxy.getTarget()",
    "hudson.plugins.git.GitSCM$DescriptorImpl#doFillGitToolItems",
    "hudson.plugins.git.GitSCM$DescriptorImpl: Dispatch",
    "hudson.plugins.git.GitTool$DescriptorImpl#doCheckName",
    "hudson.plugins.git.GitTool$DescriptorImpl: Dispatch",
    "hudson.plugins.git.UserRemoteConfig$DescriptorImpl#doCheckUrl",
    "hudson.plugins.git.UserRemoteConfig$DescriptorImpl#doFillCredentialsIdItems",
    "hudson.plugins.git.UserRemoteConfig$DescriptorImpl: Dispatch",
    "hudson.plugins.mercurial.MercurialSCM$DescriptorImpl#doFillCredentialsIdItems",
    "hudson.plugins.mercurial.MercurialSCM$DescriptorImpl: Dispatch",
    "hudson.plugins.throttleconcurrents.ThrottleJobProperty$DescriptorImpl#doCheckMaxConcurrentPerNode",
    "hudson.plugins.throttleconcurrents.ThrottleJobProperty$DescriptorImpl#doCheckMaxConcurrentTotal",
    "hudson.plugins.throttleconcurrents.ThrottleJobProperty$DescriptorImpl: Dispatch",
    "hudson.security.GlobalSecurityConfiguration#doConfigure",
    "hudson.security.GlobalSecurityConfiguration: Dispatch",
    "hudson.security.ProjectMatrixAuthorizationStrategy$2#doCheckName",
    "hudson.security.ProjectMatrixAuthorizationStrategy$2: Dispatch",
    "hudson.triggers.SCMTrigger$DescriptorImpl#doCheckScmpoll_spec",
    "hudson.triggers.SCMTrigger$DescriptorImpl: Dispatch",
    "hudson.triggers.TimerTrigger$DescriptorImpl#doCheckSpec",
    "hudson.triggers.TimerTrigger$DescriptorImpl: Dispatch",
    "hudson.widgets.BuildHistoryWidget#doAjax",
    "hudson.widgets.BuildHistoryWidget: Dispatch",
    "hudson.widgets.RenderOnDemandClosure#render",
    "hudson.widgets.RenderOnDemandClosure: Dispatch",
    "io.jenkins.blueocean.BlueOceanUI#getDynamic(...)",
    "io.jenkins.blueocean.BlueOceanUI: Dispatch",
    "io.jenkins.blueocean.BlueOceanUI: Jelly index: io/jenkins/blueocean/BlueOceanUI/index.jelly",
    "io.jenkins.blueocean.i18n.BlueI18n#doDynamic(...)",
    "io.jenkins.blueocean.i18n.BlueI18n: Dispatch",
    "io.jenkins.blueocean.rest.ApiHead#getDynamic(...)",
    "io.jenkins.blueocean.rest.ApiHead: Dispatch",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineImpl#getRuns()",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineImpl: Dispatch",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineNodeContainerImpl: Dispatch",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineNodeContainerImpl: Index: list",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineRunImpl#getArtifacts()",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineRunImpl#getBlueTestSummary()",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineRunImpl#getLog()",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineRunImpl#getNodes()",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineRunImpl#getSteps()",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineRunImpl#replay",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineRunImpl: Dispatch",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineStepContainerImpl: Dispatch",
    "io.jenkins.blueocean.rest.impl.pipeline.PipelineStepContainerImpl: Index: list",
    "io.jenkins.blueocean.rest.model.BlueTestSummary: Dispatch",
    "io.jenkins.blueocean.rest.model.BlueTestSummary: Index: getState",
    "io.jenkins.blueocean.service.embedded.BlueOceanRootAction: Dispatch",
    "io.jenkins.blueocean.service.embedded.BlueOceanRootAction: StaplerProxy.getTarget()",
    "io.jenkins.blueocean.service.embedded.rest.ArtifactContainerImpl: Dispatch",
    "io.jenkins.blueocean.service.embedded.rest.ArtifactContainerImpl: Index: list",
    "io.jenkins.blueocean.service.embedded.rest.ExtensionClassContainerImpl#getDynamic(...)",
    "io.jenkins.blueocean.service.embedded.rest.ExtensionClassContainerImpl: Dispatch",
    "io.jenkins.blueocean.service.embedded.rest.ExtensionClassContainerImpl: Index: getMap",
    "io.jenkins.blueocean.service.embedded.rest.ExtensionClassImpl: Dispatch",
    "io.jenkins.blueocean.service.embedded.rest.ExtensionClassImpl: Index: getState",
    "io.jenkins.blueocean.service.embedded.rest.FavoriteContainerImpl: Dispatch",
    "io.jenkins.blueocean.service.embedded.rest.FavoriteContainerImpl: Index: list",
    "io.jenkins.blueocean.service.embedded.rest.LogResource: Dispatch",
    "io.jenkins.blueocean.service.embedded.rest.LogResource: Index: doIndex",
    "io.jenkins.blueocean.service.embedded.rest.OrganizationContainerImpl#getDynamic(...)",
    "io.jenkins.blueocean.service.embedded.rest.OrganizationContainerImpl: Dispatch",
    "io.jenkins.blueocean.service.embedded.rest.OrganizationImpl#getPipelines()",
    "io.jenkins.blueocean.service.embedded.rest.OrganizationImpl#getUsers()",
    "io.jenkins.blueocean.service.embedded.rest.OrganizationImpl: Dispatch",
    "io.jenkins.blueocean.service.embedded.rest.PipelineContainerImpl#getDynamic(...)",
    "io.jenkins.blueocean.service.embedded.rest.PipelineContainerImpl: Dispatch",
    "io.jenkins.blueocean.service.embedded.rest.RunContainerImpl#getDynamic(...)",
    "io.jenkins.blueocean.service.embedded.rest.RunContainerImpl: Dispatch",
    "io.jenkins.blueocean.service.embedded.rest.RunContainerImpl: Index: list",
    "io.jenkins.blueocean.service.embedded.rest.UserContainerImpl#getDynamic(...)",
    "io.jenkins.blueocean.service.embedded.rest.UserContainerImpl: Dispatch",
    "io.jenkins.blueocean.service.embedded.rest.UserImpl#getFavorites()",
    "io.jenkins.blueocean.service.embedded.rest.UserImpl: Dispatch",
    "jenkins.branch.RateLimitBranchProperty$JobPropertyImpl$DescriptorImpl#doCheckCount",
    "jenkins.branch.RateLimitBranchProperty$JobPropertyImpl$DescriptorImpl#doFillDurationNameItems",
    "jenkins.branch.RateLimitBranchProperty$JobPropertyImpl$DescriptorImpl: Dispatch",
    "jenkins.model.AssetManager#doDynamic(...)",
    "jenkins.model.AssetManager: Dispatch",
    "jenkins.model.JenkinsLocationConfiguration#doCheckUrl",
    "jenkins.model.JenkinsLocationConfiguration: Dispatch",
    "jenkins.model.ProjectNamingStrategy$PatternProjectNamingStrategy$DescriptorImpl#doCheckNamePattern",
    "jenkins.model.ProjectNamingStrategy$PatternProjectNamingStrategy$DescriptorImpl: Dispatch",
    "jenkins.tools.GlobalToolConfiguration: Dispatch",
    "jenkins.triggers.ReverseBuildTrigger$DescriptorImpl#doCheckUpstreamProjects",
    "jenkins.triggers.ReverseBuildTrigger$DescriptorImpl: Dispatch",
    "org.jenkins.plugins.lockableresources.LockableResources#doDynamic(...)",
    "org.jenkins.plugins.lockableresources.LockableResources: Dispatch",
    "org.jenkins.plugins.lockableresources.RequiredResourcesProperty$DescriptorImpl#doCheckLabelName",
    "org.jenkins.plugins.lockableresources.RequiredResourcesProperty$DescriptorImpl#doCheckResourceNames",
    "org.jenkins.plugins.lockableresources.RequiredResourcesProperty$DescriptorImpl#doCheckResourceNumber",
    "org.jenkins.plugins.lockableresources.RequiredResourcesProperty$DescriptorImpl: Dispatch",
    "org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint$DescriptorImpl#doFillCredentialsIdItems",
    "org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint$DescriptorImpl: Dispatch",
    "org.jenkinsci.plugins.github.GitHubPlugin#doDynamic(...)",
    "org.jenkinsci.plugins.github.GitHubPlugin: Dispatch",
    "org.jenkinsci.plugins.github.config.GitHubPluginConfig#doCheckHookUrl",
    "org.jenkinsci.plugins.github.config.GitHubPluginConfig: Dispatch",
    "org.jenkinsci.plugins.github.config.HookSecretConfig$DescriptorImpl#doFillCredentialsIdItems",
    "org.jenkinsci.plugins.github.config.HookSecretConfig$DescriptorImpl: Dispatch",
    "org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript$DescriptorImpl#doCheckScript",
    "org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript$DescriptorImpl: Dispatch",
    "org.jenkinsci.plugins.ssegateway.Endpoint#doConfigure",
    "org.jenkinsci.plugins.ssegateway.Endpoint#doConnect",
    "org.jenkinsci.plugins.ssegateway.Endpoint: Dispatch",
    "org.kohsuke.stapler.bind.BoundObjectTable$Table#getDynamic(...)",
    "org.kohsuke.stapler.bind.BoundObjectTable$Table: Dispatch",
    "org.kohsuke.stapler.bind.BoundObjectTable: Dispatch",
    "org.kohsuke.stapler.bind.BoundObjectTable: StaplerFallback.getStaplerFallback()",
    "org.kohsuke.stapler.framework.adjunct.AdjunctManager#doDynamic(...)",
    "org.kohsuke.stapler.framework.adjunct.AdjunctManager: Dispatch"
  ]
}
````
### Proposed changelog entries

* Add telemetry trial for Stapler web request dispatches

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
