### PR TITLE
[JENKINS-53462] Jenkins websites use non-trusted 'submit' event to start form submission when current browser is Firefox

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -517,7 +517,16 @@ function registerRegexpValidator(e,regexp,message) {
  *      YUI Button widget.
  */
 function makeButton(e,onclick) {
-    var h = e.onclick;
+    var type = e.type;
+    var h = e.onclick || function (event) {
+        if (type && type.toLowerCase() === 'submit') {
+            var target = event.target;
+            var form = findAncestor(target, "FORM");
+            form.submit();
+        } else {
+            //FIXME: get some usecases for else
+        }
+    };
     var clsName = e.className;
     var n = e.name;
     var btn = new YAHOO.widget.Button(e,{});


### PR DESCRIPTION
Use a workaround to submit the form with a trusted event. No comments on the underlying insanity of hudson-behavior.

See [JENKINS-53462](https://issues.jenkins-ci.org/browse/JENKINS-53462).

This is just a hack to be able to see whether it fixed the current situation. It would be nice if it could be validated with the real ff in place. 

Meanwhile I am looking into the code that is doing agent specific stuff to figure out why we hit the bug when simulating ff with chrome.

### Proposed changelog entries

* Entry 1: JENKINS-53462, Jenkins websites use non-trusted 'submit' event to start form submission when current browser is Firefox

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs


### Desired reviewers

@jenkinsci/code-reviewers
