### PR TITLE
Adapt to stapler/stapler#149

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.255-null-1-SNAPSHOT</stapler.version>
+    <stapler.version>1.255</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.12</groovy.version>
   </properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.254.2</stapler.version>
+    <stapler.version>1.255-null-1-SNAPSHOT</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.12</groovy.version>
   </properties>

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -942,12 +942,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     public Object getTarget() {
         if (!SKIP_PERMISSION_CHECK) {
             if (!getACL().hasPermission(Item.DISCOVER)) {
-                // work around Stapler bug when returning null from getTarget()
-                try {
-                    Stapler.getCurrentResponse().sendError(SC_NOT_FOUND); // send same response body Stapler would send
-                } catch (IOException ex) {
-                    throw HttpResponses.notFound();
-                }
+                return null;
             }
             getACL().checkPermission(Item.READ);
         }

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2580,12 +2580,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         if (!SKIP_PERMISSION_CHECK) {
             // This is a bit weird, but while the Run's PermissionScope does not have READ, delegate to the parent
             if (!getParent().hasPermission(Item.DISCOVER)) {
-                // work around Stapler bug when returning null from getTarget()
-                try {
-                    Stapler.getCurrentResponse().sendError(SC_NOT_FOUND); // send same response body Stapler would send
-                } catch (IOException ex) {
-                    throw HttpResponses.notFound();
-                }
+                return null;
             }
             getParent().checkPermission(Item.READ);
         }

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -1123,13 +1123,8 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     @Restricted(NoExternalUse.class)
     public Object getTarget() {
         if (!SKIP_PERMISSION_CHECK) {
-            if (!Jenkins.getInstance().hasPermission(Jenkins.READ)) {
-                // work around Stapler bug when returning null from getTarget()
-                try {
-                    Stapler.getCurrentResponse().sendError(SC_NOT_FOUND); // send same response body Stapler would send
-                } catch (IOException ex) {
-                    throw HttpResponses.notFound();
-                }
+            if (!Jenkins.get().hasPermission(Jenkins.READ)) {
+                return null;
             }
         }
         return this;


### PR DESCRIPTION
Downstream adaptation to stapler/stapler#149

Still basically tested by `AbstractItemSecurity1114Test`, even better than before (now we don't send the response manually, but have Stapler do it).

### Proposed changelog entries

* (Will be folded into Stapler upgrade message)

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs
