### PR TITLE
[JENKINS-38719] Serve ConsoleAnnotatorFactory resources through resou…

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1830,7 +1830,7 @@ public class Functions {
         String cp = Stapler.getCurrentRequest().getContextPath();
         StringBuilder buf = new StringBuilder();
         for (ConsoleAnnotatorFactory f : ConsoleAnnotatorFactory.all()) {
-            String path = cp + "/extensionList/" + ConsoleAnnotatorFactory.class.getName() + "/" + f.getClass().getName();
+            String path = cp + getResourcePath() + "/extensionList/" + ConsoleAnnotatorFactory.class.getName() + "/" + f.getClass().getName();
             if (f.hasScript())
                 buf.append("<script src='").append(path).append("/script.js'></script>");
             if (f.hasStylesheet())


### PR DESCRIPTION
…rce path

See [JENKINS-38719](https://issues.jenkins-ci.org/browse/JENKINS-38719).

Because having to do https://github.com/jenkinsci/timestamper-plugin/commit/49c7adef65a3a738ec68bc096d9c51a843e8aa04 is stupid.

**Untested.**

### Proposed changelog entries

* Do not cache CSS/JS resource files for console annotations like Timestamper Plugin across Jenkins restarts.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StevenGBrown  
