### PR TITLE
[JENKINS-54176] Enable the authenticationCache

### DIFF
--- a/test/src/test/java/hudson/cli/CLIRegistererTest.java
+++ b/test/src/test/java/hudson/cli/CLIRegistererTest.java
@@ -1,37 +1,43 @@
 package hudson.cli;
 
-import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
-import static hudson.cli.CLICommandInvoker.Matcher.succeededSilently;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-
-import jenkins.model.Jenkins;
-import hudson.cli.CLICommandInvoker;
 import hudson.cli.CLICommandInvoker.Result;
-
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
+import static hudson.cli.CLICommandInvoker.Matcher.succeededSilently;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class CLIRegistererTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
+    /**
+     * See also {@link ClientAuthenticationCacheTest#overHttpAlsoForRegisterer()} for the equivalent using remoting / authenticationCache, i.e. login+logout
+     */
     @Test
-    public void testAuthWithSecurityRealmCLIAuthenticator() {
-        j.getInstance().setSecurityRealm(j.createDummySecurityRealm());
+    public void testAuthWithSecurityRealmCLIAuthenticator() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        FreeStyleProject project = j.createFreeStyleProject();
+        FreeStyleBuild build1 = j.buildAndAssertSuccess(project);
+        assertFalse("By default the build log should not be kept", build1.isKeepLog());
 
-        CLICommandInvoker command = new CLICommandInvoker(j, "quiet-down");
+        CLICommandInvoker command = new CLICommandInvoker(j, "keep-build");
 
-        Result invocation = command.invokeWithArgs("--username", "foo", "--password", "invalid");
+        Result invocation = command.invokeWithArgs(project.getName(), build1.getNumber() + "", "--username", "foo", "--password", "invalid");
         assertThat(invocation, failedWith(7));
         assertThat(invocation.stderr(), containsString("ERROR: Bad Credentials. Search the server log for "));
-        assertThat("Unauthorized command was executed", Jenkins.getInstance().isQuietingDown(), is(false));
+        assertFalse("The command should have not been executed", build1.isKeepLog());
 
-        invocation = command.invokeWithArgs("--username", "foo", "--password", "foo");
+        invocation = command.invokeWithArgs(project.getName(), build1.getNumber() + "", "--username", "foo", "--password", "foo");
         assertThat(invocation, succeededSilently());
-        assertThat("Authorized command was not executed", Jenkins.getInstance().isQuietingDown(), is(true));
+        assertTrue("The command should have been executed", build1.isKeepLog());
     }
 }


### PR DESCRIPTION
- for CLI using remoting with command from `@CLIMethod`
- correct the existing test that was no longer "effective" for `CLIRegisterer`

See [JENKINS-54176](https://issues.jenkins-ci.org/browse/JENKINS-54176).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Correct a bug that prevented `@CLIMethod` (like `safe-restart`, or `keep-build`), to load authentication from the cache (populated by `login`)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

