### PR TITLE
[JENKINS-54136] Use per-trial correlation IDs

### DIFF
--- a/core/src/main/java/jenkins/telemetry/Correlator.java
+++ b/core/src/main/java/jenkins/telemetry/Correlator.java
@@ -23,6 +23,7 @@
  */
 package jenkins.telemetry;
 
+import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -54,6 +55,12 @@ public class Correlator extends Descriptor<Correlator> implements Describable<Co
 
     public String getCorrelationId() {
         return correlationId;
+    }
+
+    @Restricted(NoExternalUse.class)
+    @VisibleForTesting
+    void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
     }
 
     @Override

--- a/core/src/main/java/jenkins/telemetry/Telemetry.java
+++ b/core/src/main/java/jenkins/telemetry/Telemetry.java
@@ -34,6 +34,7 @@ import hudson.model.UsageStatistics;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
 import net.sf.json.JSONObject;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -172,7 +173,8 @@ public abstract class Telemetry implements ExtensionPoint {
                 JSONObject wrappedData = new JSONObject();
                 wrappedData.put("type", telemetry.getId());
                 wrappedData.put("payload", data);
-                wrappedData.put("correlator", ExtensionList.lookupSingleton(Correlator.class).getCorrelationId());
+                String correlationId = ExtensionList.lookupSingleton(Correlator.class).getCorrelationId();
+                wrappedData.put("correlator", DigestUtils.sha256Hex(correlationId + telemetry.getId()));
 
                 try {
                     URL url = new URL(ENDPOINT);

--- a/test/src/test/java/jenkins/telemetry/TelemetryTest.java
+++ b/test/src/test/java/jenkins/telemetry/TelemetryTest.java
@@ -50,6 +50,7 @@ public class TelemetryTest {
     public void prepare() throws Exception {
         correlators.clear();
         types.clear();
+        counter = 0;
         j.jenkins.setNoUsageStatistics(false); // tests usually don't submit this, but we need this
         Telemetry.ENDPOINT = j.getURL().toString() + "uplink/events";
     }

--- a/test/src/test/java/jenkins/telemetry/TelemetryTest.java
+++ b/test/src/test/java/jenkins/telemetry/TelemetryTest.java
@@ -29,7 +29,10 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 public class TelemetryTest {
     @Rule
@@ -55,7 +58,8 @@ public class TelemetryTest {
         assertThat(types, hasItem("test-data"));
         assertThat(types, not(hasItem("future")));
         assertThat(types, not(hasItem("past")));
-        assertThat(correlators.size(), is(1));
+        assertThat(correlators.size(), is(counter));
+        assertTrue(Pattern.compile("[0-9a-f]+").matcher(correlators.first()).matches());
         assertTrue("at least one request received", counter > 0); // TestTelemetry plus whatever real impls exist
     }
 
@@ -174,7 +178,7 @@ public class TelemetryTest {
         }
     }
 
-    private static Set<String> correlators = new HashSet<>();
+    private static SortedSet<String> correlators = new TreeSet<>();
     private static Set<String> types = new HashSet<>();
 
     @TestExtension


### PR DESCRIPTION
See [JENKINS-54136](https://issues.jenkins-ci.org/browse/JENKINS-54136).

### Proposed changelog entries

* JENKINS-54136: Use per-trial correlation IDs

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
