### PR TITLE
[JENKINS-54135] Fix concurrency bug in languages telemetry

### DIFF
--- a/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
+++ b/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
@@ -41,9 +41,9 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
 @Restricted(NoExternalUse.class)
 public class UserLanguages extends Telemetry {
 
-    private static volatile Map<String, AtomicLong> requestsByLanguage = new HashMap<>();
+    private static final Map<String, AtomicLong> requestsByLanguage = new ConcurrentSkipListMap<>();
     private static Logger LOGGER = Logger.getLogger(UserLanguages.class.getName());
 
     @Nonnull
@@ -82,11 +82,11 @@ public class UserLanguages extends Telemetry {
     @Nonnull
     @Override
     public JSONObject createContent() {
+        Map<String, AtomicLong> currentRequests = new TreeMap<>(requestsByLanguage);
+        requestsByLanguage.clear();
+
         JSONObject payload = new JSONObject();
-        Map<String, AtomicLong> currentRequests = requestsByLanguage;
-        requestsByLanguage = new HashMap<>();
-        Map<String, AtomicLong> sortedRequests = new TreeMap<>(currentRequests);
-        for (Map.Entry<String, AtomicLong> entry : sortedRequests.entrySet()) {
+        for (Map.Entry<String, AtomicLong> entry : currentRequests.entrySet()) {
             payload.put(entry.getKey(), entry.getValue().longValue());
         }
         return payload;

--- a/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
+++ b/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
@@ -41,6 +41,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -51,7 +52,7 @@ import java.util.logging.Logger;
 @Restricted(NoExternalUse.class)
 public class UserLanguages extends Telemetry {
 
-    private static volatile Map<String, AtomicLong> requestsByLanguage = new TreeMap<>();
+    private static volatile Map<String, AtomicLong> requestsByLanguage = new HashMap<>();
     private static Logger LOGGER = Logger.getLogger(UserLanguages.class.getName());
 
     @Nonnull
@@ -83,8 +84,9 @@ public class UserLanguages extends Telemetry {
     public JSONObject createContent() {
         JSONObject payload = new JSONObject();
         Map<String, AtomicLong> currentRequests = requestsByLanguage;
-        requestsByLanguage = new TreeMap<>();
-        for (Map.Entry<String, AtomicLong> entry : currentRequests.entrySet()) {
+        requestsByLanguage = new HashMap<>();
+        Map<String, AtomicLong> sortedRequests = new TreeMap<>(currentRequests);
+        for (Map.Entry<String, AtomicLong> entry : sortedRequests.entrySet()) {
             payload.put(entry.getKey(), entry.getValue().longValue());
         }
         return payload;


### PR DESCRIPTION
See [JENKINS-54135](https://issues.jenkins-ci.org/browse/JENKINS-54135).

Looks like just I used the slowest imaginable Map implementation for this…? Use a HashMap for collection, and only order when collecting the data for submission.

Unsure how to test. Ideas?

### Proposed changelog entries

* JENKINS-54135: Improve performance for user languages telemetry.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
