### PR TITLE
SlaveComputer.getRetentionStrategy mistake led to launches of unused agent JVMs

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -801,7 +801,7 @@ public class SlaveComputer extends Computer {
 
     public RetentionStrategy getRetentionStrategy() {
         Slave n = getNode();
-        return n==null ? RetentionStrategy.INSTANCE : n.getRetentionStrategy();
+        return n==null ? RetentionStrategy.NOOP : n.getRetentionStrategy();
     }
 
     /**


### PR DESCRIPTION
While playing with a scenario in which `mock-slave` was configured with a `Cloud` producing agents using `CloudRetentionStrategy`, I found a strange problem: after running and then terminating a highly parallel build, the now-idle agents would after a 1min delay be disconnected as expected. Yet the vagaries of `NodeProvisioner` meant that more agents were initially connected than actually needed; and after all agents were apparently disconnected from the master, according to the executor widget etc., there would still be lots of `remoting.jar` processes running. The clue to the problem was that the master log was printing a message from `SlaveComputer.tryReconnect`—which is a method only called by `RetentionStrategy.Always` and never by `CloudRetentionStrategy`! It seems that there were a bunch of stranded `SlaveComputer`s with no associated `Slave`s after the cleanup (these things that get temporarily out of synch), and when `getRetentionStrategy` was being called, `getNode` was null, so it was falling back to `INSTANCE` ~ `Always`, which then tried to reconnect the computer—even though it was supposed to be dying. After the re`launch`, there was nothing to find and terminate the rogue computer connections.

After restarting Jenkins with this fix applied, the problem went away. The number of agent JVMs actually running reliably matched the number of online agents according to the Jenkins web UI.

### Proposed changelog entries

* Under some conditions when using elastic agents (clouds), agent JVMs could be incorrectly relaunched and never terminated.