### PR TITLE
Fix Executor Javadoc for getDisplayName()

### DIFF
--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -578,7 +578,7 @@ public class Executor extends Thread implements ModelObject {
     }
 
     /**
-     * Same as {@link #getName()}.
+     * Human readable name of the Jenkins executor. For the Java thread name use {@link #getName()}.
      */
     public String getDisplayName() {
         return "Executor #"+getNumber();


### PR DESCRIPTION
Internal: fix outdated Javadoc comment for Executor.getDisplayName(). Insignificant change, but it cost me about an hour because I trusted it ;-)