### PR TITLE
[JENKINS-49987] Clean up warnings in tests about anonymous callable.

### DIFF
--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -26,11 +26,11 @@ package hudson;
 
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
-import hudson.remoting.Callable;
 import hudson.util.ProcessTree;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
 import static org.junit.Assert.*;
@@ -63,7 +63,7 @@ public class LauncherTest {
             long end = System.currentTimeMillis();
             long terminationTime = end - start;
             assertTrue("Join did not finish promptly. The completion time (" + terminationTime + "ms) is longer than expected 15s", terminationTime < 15000);
-            channels.french.call(NOOP); // this only returns after the other side of the channel has finished executing cancellation
+            channels.french.call(new NoopCallable()); // this only returns after the other side of the channel has finished executing cancellation
             Thread.sleep(2000); // more delay to make sure it's gone
             assertNull("process should be gone",ProcessTree.get().get(Integer.parseInt(FileUtils.readFileToString(tmp).trim())));
 
@@ -76,11 +76,11 @@ public class LauncherTest {
             // hangs and on slave machine pgrep sleep => one process; after manual kill, script returns.
     }
 
-    private static final Callable<Object,RuntimeException> NOOP = new MasterToSlaveCallable<Object,RuntimeException>() {
+    private static class NoopCallable extends MasterToSlaveCallable<Object,RuntimeException> {
         public Object call() throws RuntimeException {
             return null;
         }
-    };
+    }
 
     @Issue("JENKINS-15733")
     @Test public void decorateByEnv() throws Exception {

--- a/core/src/test/java/hudson/os/SUTester.java
+++ b/core/src/test/java/hudson/os/SUTester.java
@@ -5,19 +5,19 @@ import java.io.File;
 import java.nio.file.Files;
 import jenkins.security.MasterToSlaveCallable;
 
-import java.io.FileOutputStream;
-
 /**
  * @author Kohsuke Kawaguchi
  */
 public class SUTester {
     public static void main(String[] args) throws Throwable {
-        SU.execute(StreamTaskListener.fromStdout(),"kohsuke","bogus",new MasterToSlaveCallable<Object, Throwable>() {
-            public Object call() throws Throwable {
-                System.out.println("Touching /tmp/x");
-                Files.newOutputStream(new File("/tmp/x").toPath()).close();
-                return null;
-            }
-        });
+        SU.execute(StreamTaskListener.fromStdout(),"kohsuke","bogus", new TouchingCallable());
+    }
+
+    private static class TouchingCallable extends MasterToSlaveCallable<Object, Throwable> {
+        public Object call() throws Throwable {
+            System.out.println("Touching /tmp/x");
+            Files.newOutputStream(new File("/tmp/x").toPath()).close();
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Convert them to static, named classes.

See [JENKINS-49987](https://issues.jenkins-ci.org/browse/JENKINS-49987).

Clean up a couple of tests that would generate unhelpful warning messages. Because of past changes in Remoting, it is preferable to convert anonymous classes to named ones. 

This change only affects tests and only affects messages generated by them, not actual behavior.

### Proposed changelog entries

* (Minor change to tests only. No changelog entry recommended.)

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
### Desired reviewers

@reviewbybees 
