### PR TITLE
[FIX JENKINS-54325] Add support for multiple SimplePageDecorators in …

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1779,6 +1779,14 @@ public class Functions {
         return SimplePageDecorator.first();
     }
 
+    /**
+     * Gets all {@link SimplePageDecorator}s for the login page.
+     * @since TODO
+     */
+    public static List<SimplePageDecorator> getSimplePageDecorators() {
+        return SimplePageDecorator.all();
+    }
+
     public static List<Descriptor<Cloud>> getCloudDescriptors() {
         return Cloud.all();
     }

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1774,7 +1774,9 @@ public class Functions {
     /**
      * Gets only one {@link SimplePageDecorator}.
      * @since 2.128
+     * @deprecated use {@link #getSimplePageDecorators()} instead
      */
+    @Deprecated
     public static SimplePageDecorator getSimplePageDecorator() {
         return SimplePageDecorator.first();
     }

--- a/core/src/main/java/jenkins/model/SimplePageDecorator.java
+++ b/core/src/main/java/jenkins/model/SimplePageDecorator.java
@@ -27,6 +27,9 @@ import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+
+import java.util.List;
+
 /**
  * Participates in the rendering of the login page
  *
@@ -67,6 +70,14 @@ public class SimplePageDecorator extends Descriptor<SimplePageDecorator> impleme
         } else {
             return null;
         }
+    }
+
+    /**
+     * Returns all login page decorators.
+     * @since TODO
+     */
+    public static List<SimplePageDecorator> all() {
+        return Jenkins.get().getDescriptorList(SimplePageDecorator.class);
     }
 
 }

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
@@ -43,14 +43,15 @@ THE SOFTWARE.
     <x:doctype name="html"/>
     <!-- in case of error we want to surround the form elements with an error hint -->
     <j:set var="inputClass" value="${data.errorMessage!=null ? 'danger' : 'normal'}"/>
-    <j:set var="simpleDecorator" value="${h.simplePageDecorator}"/>
+    <j:set var="simpleDecorators" value="${h.simplePageDecorators}"/>
     <html lang="${request.getLocale().toLanguageTag()}">
         <head data-rooturl="${rootURL}" data-resurl="${resURL}" resURL="${resURL}">
             <title>${%Create an account! [Jenkins]}</title>
             <!-- we do not want bots on this page -->
             <meta name="ROBOTS" content="NOFOLLOW"/>
-            <!-- css styling, will fallback to default implementation -->
-            <st:include it="${simpleDecorator}" page="simple-head.jelly" optional="true"/>
+            <j:forEach var="simpleDecorator" items="${simpleDecorators}">
+                <st:include it="${simpleDecorator}" page="simple-head.jelly" optional="true"/>
+            </j:forEach>
             <link rel="stylesheet" href="${resURL}/css/signup.css" type="text/css"/>
         </head>
         <body>
@@ -292,6 +293,11 @@ THE SOFTWARE.
                                 }
                             </script>
                         </j:if>
+                        <div class="footer">
+                            <j:forEach var="simpleDecorator" items="${simpleDecorators}">
+                                <st:include it="${simpleDecorator}" page="simple-footer.jelly" optional="true"/>
+                            </j:forEach>
+                        </div>
                     </form>
                 </div>
             </div>

--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -100,6 +100,7 @@ THE SOFTWARE.
                     class="${inputClass}"
                     type="password"
                     name="j_password"
+                    id="j_password"
                     placeholder="${%Password}"
                   />
                 </div>

--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -49,7 +49,7 @@ THE SOFTWARE.
   <j:set var="from" value="${error ? request.session.getAttribute('from') : request.getParameter('from')}"/>
   <!-- in case of error we want to surround the form elements with an error hint -->
   <j:set var="inputClass" value="${error ? 'danger' : 'normal'}"/>
-  <j:set var="simpleDecorator" value="${h.simplePageDecorator}"/>
+  <j:set var="simpleDecorators" value="${h.simplePageDecorators}"/>
   <!-- real deal starting here -->
   <html lang="${request.getLocale().toLanguageTag()}">
     <head data-rooturl="${rootURL}" data-resurl="${resURL}" resURL="${resURL}">
@@ -57,7 +57,9 @@ THE SOFTWARE.
       <!-- we do not want bots on this page -->
       <meta name="ROBOTS" content="NOFOLLOW" />
       <!-- css styling, will fallback to default implementation -->
-      <st:include it="${simpleDecorator}" page="simple-head.jelly" optional="true"/>
+      <j:forEach var="simpleDecorator" items="${simpleDecorators}">
+        <st:include it="${simpleDecorator}" page="simple-head.jelly" optional="true"/>
+      </j:forEach>
     </head>
     <body>
       <j:choose>
@@ -67,7 +69,9 @@ THE SOFTWARE.
         <j:otherwise>
           <div class="simple-page" role="main">
             <div class="modal login">
-              <st:include it="${simpleDecorator}" page="simple-header.jelly" optional="true"/>
+              <j:forEach var="simpleDecorator" items="${simpleDecorators}">
+                <st:include it="${simpleDecorator}" page="simple-header.jelly" optional="true"/>
+              </j:forEach>
               <!-- login form -->
               <form name="login" action="${it.securityRealm.authenticationGatewayUrl}" method="post">
                 <j:if test="${it.securityRealm.allowsSignup()}">
@@ -145,8 +149,9 @@ THE SOFTWARE.
               </j:forEach>
 
               <div class="footer">
-
-                <st:include it="${simpleDecorator}" page="simple-footer.jelly" optional="true"/>
+                <j:forEach var="simpleDecorator" items="${simpleDecorators}">
+                  <st:include it="${simpleDecorator}" page="simple-footer.jelly" optional="true"/>
+                </j:forEach>
               </div>
 
             </div>


### PR DESCRIPTION
…login.jelly

Signed-off-by: Matt Sicker <boards@gmail.com>

See [JENKINS-54325](https://issues.jenkins-ci.org/browse/JENKINS-54325).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* `Internal:` `login.jelly` and `signup.jelly` now support displaying all registered `SimplePageDecorator` extensions rather than just the top priority one.
* `Internal:` the password field in the login page now has a matching `id` as its `name` (`j_password`) for easier access from the DOM.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @scherler @Wadeck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
