### PR TITLE
[JENKINS-48220] list-jobs command shows all the items recursively of a given item

### DIFF
--- a/core/src/main/java/hudson/cli/ListJobsCommand.java
+++ b/core/src/main/java/hudson/cli/ListJobsCommand.java
@@ -66,7 +66,8 @@ public class ListJobsCommand extends CLICommand {
 
                 // If item group was found use it's jobs.
                 if (item instanceof ModifiableTopLevelItemGroup) {
-                    jobs = ((ModifiableTopLevelItemGroup) item).getAllItems(TopLevelItem.class);
+                    jobs = ((ModifiableTopLevelItemGroup) item).getItems();
+
                 }
                 // No view and no item group with the given name found.
                 else {

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -76,24 +76,6 @@ public class ListJobsCommandTest {
         assertThat(stdout, is(empty()));
     }
 
-    /*
-    @Test
-    @Issue("JENKINS-18393")
-    public void failForMatrixProject() throws Exception {
-
-        final MatrixProject matrix = mock(MatrixProject.class);
-        final MatrixConfiguration config = mock(MatrixConfiguration.class);
-        when(matrix.getItems()).thenReturn(Arrays.asList(config));
-
-        when(jenkins.getView("MatrixJob")).thenReturn(null);
-        when(jenkins.getItemByFullName("MatrixJob")).thenReturn(matrix);
-
-        assertThat(runWith("MatrixJob"), equalTo(-1));
-        assertThat(stdout, is(empty()));
-        assertThat(stderr.toString(), containsString("No view or item group with the given name found"));
-    }
-    */
-
     @Test
     public void getAllJobsForEmptyName() throws Exception {
 

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -94,69 +94,6 @@ public class ListJobsCommandTest {
     }
     */
 
-    @Ignore("TODO enable when you figure out why ListJobsCommandTest$1Folder$$EnhancerByMockitoWithCGLIB$$f124784a calls ReturnsEmptyValues, or just use MockFolder and move to the test module with JenkinsRule")
-    @Test
-    public void getAllJobsFromFolders() throws Exception {
-
-        abstract class Folder implements ModifiableTopLevelItemGroup, TopLevelItem {
-        }
-
-        final Folder folder = mock(Folder.class);
-        final Folder nestedFolder = mock(Folder.class);
-        when(folder.getDisplayName()).thenReturn("Folder");
-        when(nestedFolder.getDisplayName()).thenReturn("NestedFolder");
-
-        final TopLevelItem job = job("job");
-        final TopLevelItem nestedJob = job("nestedJob");
-        when(job.hasPermission(Item.READ)).thenReturn(true);
-        when(nestedJob.hasPermission(Item.READ)).thenReturn(true);
-        when(job.getRelativeNameFrom((ItemGroup<TopLevelItem>) folder)).thenReturn("job");
-        when(nestedJob.getRelativeNameFrom((ItemGroup<TopLevelItem>) folder)).thenReturn("nestedJob");
-
-        when(folder.getItems()).thenReturn(Arrays.asList(nestedFolder, job));
-        when(nestedFolder.getItems()).thenReturn(Arrays.asList(nestedJob));
-
-        when(jenkins.getView("OuterFolder")).thenReturn(null);
-        when(jenkins.getItemByFullName("OuterFolder")).thenReturn(folder);
-
-        assertThat(runWith("OuterFolder"), equalTo(0));
-        assertThat(stdout, listsJobs("job", "nestedJob"));
-        assertThat(stderr, is(empty()));
-    }
-
-    @Issue("JENKINS-48220")
-    @Test
-    public void getAllJobsForSubFolder() throws Exception {
-
-        abstract class Folder implements ModifiableTopLevelItemGroup, TopLevelItem {
-        }
-
-        final Folder folder = mock(Folder.class);
-        final Folder nestedFolder = mock(Folder.class);
-        final Folder subNestedFolder = mock(Folder.class);
-        when(folder.getDisplayName()).thenReturn("Folder");
-        when(nestedFolder.getDisplayName()).thenReturn("NestedFolder");
-        when(subNestedFolder.getDisplayName()).thenReturn("NestedFolder_1");
-
-        final TopLevelItem job = job("job");
-        final TopLevelItem nestedJob = job("nestedJob");
-        final TopLevelItem subNestedJob = job("subNestedJob");
-        when(job.hasPermission(Item.READ)).thenReturn(true);
-        when(nestedJob.hasPermission(Item.READ)).thenReturn(true);
-        when(subNestedJob.hasPermission(Item.READ)).thenReturn(true);
-        when(job.getRelativeNameFrom((ItemGroup<TopLevelItem>) folder)).thenReturn("job");
-        when(nestedJob.getRelativeNameFrom((ItemGroup<TopLevelItem>) nestedFolder)).thenReturn("nestedJob");
-        when(subNestedJob.getRelativeNameFrom((ItemGroup<TopLevelItem>) subNestedFolder)).thenReturn("subNestedJob");
-
-        when(folder.getItems()).thenReturn(Arrays.asList(nestedFolder, job));
-        when(nestedFolder.getItems()).thenReturn(Arrays.asList(nestedJob, subNestedFolder));
-        when(subNestedFolder.getItems()).thenReturn(Arrays.asList(subNestedJob));
-
-        assertThat(runWith("NestedFolder"), equalTo(0));
-        assertThat(stdout, listsJobs("nestedJob", "NestedFolder_1"));
-        assertThat(stderr, is(empty()));
-    }
-
     @Test
     public void getAllJobsForEmptyName() throws Exception {
 

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.Issue;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -120,6 +121,39 @@ public class ListJobsCommandTest {
 
         assertThat(runWith("OuterFolder"), equalTo(0));
         assertThat(stdout, listsJobs("job", "nestedJob"));
+        assertThat(stderr, is(empty()));
+    }
+
+    @Issue("JENKINS-48220")
+    @Test
+    public void getAllJobsForSubFolder() throws Exception {
+
+        abstract class Folder implements ModifiableTopLevelItemGroup, TopLevelItem {
+        }
+
+        final Folder folder = mock(Folder.class);
+        final Folder nestedFolder = mock(Folder.class);
+        final Folder subNestedFolder = mock(Folder.class);
+        when(folder.getDisplayName()).thenReturn("Folder");
+        when(nestedFolder.getDisplayName()).thenReturn("NestedFolder");
+        when(subNestedFolder.getDisplayName()).thenReturn("NestedFolder_1");
+
+        final TopLevelItem job = job("job");
+        final TopLevelItem nestedJob = job("nestedJob");
+        final TopLevelItem subNestedJob = job("subNestedJob");
+        when(job.hasPermission(Item.READ)).thenReturn(true);
+        when(nestedJob.hasPermission(Item.READ)).thenReturn(true);
+        when(subNestedJob.hasPermission(Item.READ)).thenReturn(true);
+        when(job.getRelativeNameFrom((ItemGroup<TopLevelItem>) folder)).thenReturn("job");
+        when(nestedJob.getRelativeNameFrom((ItemGroup<TopLevelItem>) nestedFolder)).thenReturn("nestedJob");
+        when(subNestedJob.getRelativeNameFrom((ItemGroup<TopLevelItem>) subNestedFolder)).thenReturn("subNestedJob");
+
+        when(folder.getItems()).thenReturn(Arrays.asList(nestedFolder, job));
+        when(nestedFolder.getItems()).thenReturn(Arrays.asList(nestedJob, subNestedFolder));
+        when(subNestedFolder.getItems()).thenReturn(Arrays.asList(subNestedJob));
+
+        assertThat(runWith("NestedFolder"), equalTo(0));
+        assertThat(stdout, listsJobs("nestedJob", "NestedFolder_1"));
         assertThat(stderr, is(empty()));
     }
 

--- a/test/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/test/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -42,6 +42,7 @@ import org.jvnet.hudson.test.MockFolder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 
 public class ListJobsCommandTest {
@@ -126,5 +127,15 @@ public class ListJobsCommandTest {
         assertThat(result.stdout(), containsString("job1"));
         assertThat(result.stdout(), containsString("job2"));
         assertThat(result.stdout(), containsString("mvn"));
+    }
+
+    @Issue("JENKINS-18393")
+    @Test public void failForMatrixProject() throws Exception {
+        MatrixProject matrixProject = j.createProject(MatrixProject.class, "mp");
+
+        CLICommandInvoker.Result result = command.invokeWithArgs("MatrixJob");
+        assertThat(result, CLICommandInvoker.Matcher.failedWith(3));
+        assertThat(result.stdout(), isEmptyString());
+        assertThat(result.stderr(), containsString("No view or item group with the given name 'MatrixJob' found."));
     }
 }

--- a/test/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/test/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -1,0 +1,130 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Victor Martinez.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.cli;
+
+import hudson.matrix.Axis;
+import hudson.matrix.AxisList;
+import hudson.matrix.MatrixProject;
+import hudson.maven.MavenModuleSet;
+import hudson.model.DirectlyModifiableView;
+import hudson.model.FreeStyleProject;
+import hudson.model.Label;
+import hudson.model.ListView;
+import hudson.model.labels.LabelExpression;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockFolder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+public class ListJobsCommandTest {
+
+    @Rule public JenkinsRule j = new JenkinsRule();
+    private CLICommand listJobsCommand;
+    private CLICommandInvoker command;
+
+    @Before public void setUp() {
+        listJobsCommand = new ListJobsCommand();
+        command = new CLICommandInvoker(j, listJobsCommand);
+    }
+
+    @Test public void getAllJobsFromView() throws Exception {
+        MockFolder folder = j.createFolder("Folder");
+        MockFolder nestedFolder = folder.createProject(MockFolder.class, "NestedFolder");
+        FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
+        FreeStyleProject nestedJob = nestedFolder.createProject(FreeStyleProject.class, "nestedJob");
+
+        ListView view = new ListView("OuterFolder");
+        view.setRecurse(true);
+        j.jenkins.addView(view);
+
+        ((DirectlyModifiableView) j.jenkins.getView("OuterFolder")).add(folder);
+        ((DirectlyModifiableView) j.jenkins.getView("OuterFolder")).add(job);
+
+        CLICommandInvoker.Result result = command.invokeWithArgs("OuterFolder");
+        assertThat(result, CLICommandInvoker.Matcher.succeeded());
+        assertThat(result.stdout(), containsString("Folder"));
+        assertThat(result.stdout(), containsString("job"));
+        assertThat(result.stdout(), not(containsString("nestedJob")));
+    }
+
+    @Issue("JENKINS-48220")
+    @Test public void getAllJobsFromFolder() throws Exception {
+        MockFolder folder = j.createFolder("Folder");
+        MockFolder nestedFolder = folder.createProject(MockFolder.class, "NestedFolder");
+
+        FreeStyleProject job = folder.createProject(FreeStyleProject.class, "job");
+        FreeStyleProject nestedJob = nestedFolder.createProject(FreeStyleProject.class, "nestedJob");
+
+        CLICommandInvoker.Result result = command.invokeWithArgs("Folder");
+        assertThat(result, CLICommandInvoker.Matcher.succeeded());
+        assertThat(result.stdout(), containsString("job"));
+        assertThat(result.stdout(), containsString("NestedFolder"));
+        assertThat(result.stdout(), not(containsString("nestedJob")));
+    }
+
+    @Issue("JENKINS-18393")
+    @Test public void getAllJobsFromFolderWithMatrixProject() throws Exception {
+        MockFolder folder = j.createFolder("Folder");
+
+        FreeStyleProject job1 = folder.createProject(FreeStyleProject.class, "job1");
+        FreeStyleProject job2 = folder.createProject(FreeStyleProject.class, "job2");
+        MatrixProject matrixProject = folder.createProject(MatrixProject.class, "mp");
+
+        matrixProject.setDisplayName("downstream");
+        matrixProject.setAxes(new AxisList(
+                new Axis("axis", "a", "b")
+        ));
+
+        Label label = LabelExpression.get("aws-linux-dummy");
+        matrixProject.setAssignedLabel(label);
+
+        CLICommandInvoker.Result result = command.invokeWithArgs("Folder");
+        assertThat(result, CLICommandInvoker.Matcher.succeeded());
+        assertThat(result.stdout(), containsString("job1"));
+        assertThat(result.stdout(), containsString("job2"));
+        assertThat(result.stdout(), containsString("mp"));
+    }
+
+    @Issue("JENKINS-18393")
+    @Test public void getAllJobsFromFolderWithMavenModuleSet() throws Exception {
+        MockFolder folder = j.createFolder("Folder");
+
+        FreeStyleProject job1 = folder.createProject(FreeStyleProject.class, "job1");
+        FreeStyleProject job2 = folder.createProject(FreeStyleProject.class, "job2");
+        MavenModuleSet mavenProject = folder.createProject(MavenModuleSet.class, "mvn");
+
+        CLICommandInvoker.Result result = command.invokeWithArgs("Folder");
+        assertThat(result, CLICommandInvoker.Matcher.succeeded());
+        assertThat(result.stdout(), containsString("job1"));
+        assertThat(result.stdout(), containsString("job2"));
+        assertThat(result.stdout(), containsString("mvn"));
+    }
+}


### PR DESCRIPTION
See [JENKINS-48220](https://issues.jenkins-ci.org/browse/JENKINS-48220).

### Proposed changelog entries

* Entry 1: JENKINS-48220, `Do not list items recursively when listing a folder.`
```
type: bug
      message: >
        The <code>list-jobs</code> CLI command doesn't list items recursively when listing a folder.
      issue: 48220
      pull: 3711
```

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@oleg-nenashev , @jglick 
