### PR TITLE
Reuse Telemetry.disabled(), make it work without singleton

### DIFF
--- a/core/src/main/java/jenkins/telemetry/Telemetry.java
+++ b/core/src/main/java/jenkins/telemetry/Telemetry.java
@@ -129,11 +129,16 @@ public abstract class Telemetry implements ExtensionPoint {
     }
 
     /**
-     * @since TODO
+     * @since 2.147
      * @return whether to collect telemetry
      */
     public static boolean isDisabled() {
-        return UsageStatistics.DISABLED || !Jenkins.get().isUsageStatisticsCollected();
+        if (UsageStatistics.DISABLED) {
+            return true;
+        }
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+
+        return jenkins == null || !jenkins.isUsageStatisticsCollected();
     }
 
     @Extension

--- a/core/src/main/java/jenkins/telemetry/impl/StaplerDispatches.java
+++ b/core/src/main/java/jenkins/telemetry/impl/StaplerDispatches.java
@@ -104,8 +104,7 @@ public class StaplerDispatches extends Telemetry {
 
         @Override
         protected void record(StaplerRequest staplerRequest, String s) {
-            if (UsageStatistics.DISABLED || !Jenkins.get().isUsageStatisticsCollected()) {
-                // TODO use new API after jenkinsci/jenkins#3687 is merged
+            if (Telemetry.isDisabled()) {
                 // do not collect traces while usage statistics are disabled
                 return;
             }


### PR DESCRIPTION
Resolve old TODO comment from when Stapler and languages telemetry were in development at the same time.

Also take this opportunity to not require the Jenkins singleton to be present (just assume we don't collect telemetry when it's not). I've seen `github-api` plugin tests fail with 2.138.3 as the `MockGitHub` serves requests using Stapler while there is no Jenkins singleton, but core is on the classpath – `Jenkins.get()` will fail.

Not sure this is deserving of a changelog entry.

(☁️🐝 reference: CORE-1142)