### PR TITLE
[JENKINS-20155] Don't select plugins with compat warning in update view

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -1,3 +1,12 @@
+function checkPluginsWithoutWarnings() {
+    var inputs = document.getElementsByTagName('input');
+    for(var i = 0; i < inputs.length; i++) {
+        var candidate = inputs[i];
+        if(candidate.type === "checkbox" && candidate.dataset.compatWarning === 'false') {
+            candidate.checked = true;
+        }
+    }
+}
 function showhideCategories(hdr,on) {
   var table = hdr.parentNode.parentNode.parentNode,
       newDisplay = on ? '' : 'none',

--- a/core/src/main/resources/hudson/PluginManager/index.jelly
+++ b/core/src/main/resources/hudson/PluginManager/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <local:table page="updates" list="${app.updateCenter.updates}" xmlns:local="/hudson/PluginManager">
     <div style="margin-top:1em">
-      ${%Select}: <a href="javascript:toggleCheckboxes(true);">${%All}</a>, <a href="javascript:toggleCheckboxes(false);">${%None}</a><br/>
+      ${%Select}: <a href="javascript:checkPluginsWithoutWarnings();">${%All}</a>, <a href="javascript:toggleCheckboxes(false);">${%None}</a><br/>
       ${%UpdatePageDescription}
       <j:if test="${!empty(app.updateCenter.jobs)}">
         <br/> ${%UpdatePageLegend(rootURL+'/updateCenter/')}

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -91,7 +91,8 @@ THE SOFTWARE.
                     <td class="pane" align="center" data="${thisCat}_">
                       <input type="checkbox" name="plugin.${p.name}.${p.sourceId}"
                              checked="${installedOk ? 'checked' : null}"
-                             disabled="${installedOk ? 'disabled' : null}" onClick="flip(this);"/>
+                             disabled="${installedOk ? 'disabled' : null}" onClick="flip(this);"
+                             data-compat-warning="${!p.isCompatibleWithInstalledVersion()}" />
                     </td>
                     <td class="pane" data="${h.xmlEscape(p.displayName)}">
                       <div>


### PR DESCRIPTION
See [JENKINS-20155](https://issues.jenkins-ci.org/browse/JENKINS-20155).

When updating plugins, there's a small link to select all plugins. Currently, this link also selects plugins which have compatibility warnings. This PR changes that so that users wanting to quickly update all plugins don't accidentally break their installation.

This minor change doesn't have tests because that would require setting up the whole page in a fake environment, which is significant overhead for such a small piece of code. I don't think there's e2e tests for the remaining JavaScript either. I have however manually verified that this does in fact work, by using a debugger to make `UpdateSite.Plugin#isCompatibleWithInstalledVersion()` return `false`.

### Proposed changelog entries
 * Plugin Manager: "Select All" link no longer pre-selects possibly incompatible plugins in update table

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
- [X] Appropriate autotests or explanation to why this change has no tests
- [X] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers
@jenkinsci/hacktoberfest
