### PR TITLE
WIP [JENKINS-54333] Try to prevent bubbling

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -518,7 +518,11 @@ function registerRegexpValidator(e,regexp,message) {
  */
 function makeButton(e,onclick) {
     var type = e.type;
-    var h = e.onclick || function (event) {
+    var h = onclick || function (event) {
+        // make sure we prevent further bubbling
+        console.log('before', event);
+        preventDefault(event);
+        console.log('after', event);
         if (type && type.toLowerCase() === 'submit') {
             var target = event.target;
             var form = findAncestor(target, "FORM");
@@ -531,16 +535,33 @@ function makeButton(e,onclick) {
     var n = e.name;
     var btn = new YAHOO.widget.Button(e,{});
     if(onclick!=null)
-        btn.addListener("click",onclick);
+        btn.addListener("click", onclick, true);
     if(h!=null)
-        btn.addListener("click",h);
+        btn.addListener("click", h, true);
     var be = btn.get("element");
     Element.addClassName(be,clsName);
     if(n) // copy the name
         be.setAttribute("name",n);
     return btn;
 }
-
+/**
+ * Trigger different styles to prevent the event from bubble up
+ * @param event you want to intercept
+ */
+function preventDefault(event) {
+    if (event && event.cancelBubble) {
+        event.cancelBubble = true;
+    }
+    if (event && event.bubbles) {
+        event.bubbles = false;
+    }
+    if (event && event.preventDefault instanceof Function) {
+        event.preventDefault();
+    }
+    if (event && event.stopPropagation instanceof Function) {
+        event.stopPropagation();
+    }
+}
 /*
     If we are inside 'to-be-removed' class, some HTML altering behaviors interact badly, because
     the behavior re-executes when the removed master copy gets reinserted later.

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -519,11 +519,12 @@ function registerRegexpValidator(e,regexp,message) {
 function makeButton(e,onclick) {
     var type = e.type;
     var h = onclick || function (event) {
+        var isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
         // make sure we prevent further bubbling
-        console.log('before', event);
+        console.log('before', event, isIE11);
         preventDefault(event);
         console.log('after', event);
-        if (type && type.toLowerCase() === 'submit') {
+        if (type && type.toLowerCase() === 'submit' && !isIE11) {
             var target = event.target;
             var form = findAncestor(target, "FORM");
             form.submit();


### PR DESCRIPTION
See [JENKINS-54333](https://issues.jenkins-ci.org/browse/JENKINS-54333) and maybe [JENKINS-54261](https://issues.jenkins-ci.org/browse/JENKINS-54261)

Prevent event bubbling and in case of IE11 explicitly do not submit the form and rely on the second "phantom" event to trigger the submit. 

...The problem is YUI lib and what I am doing is hacks-over-hacks because the real solution would be to drop YUI lib.
