### PR TITLE
[JENKINS-54539] /userToken/generate HTTP API

### DIFF
--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -370,17 +370,7 @@ public class ApiTokenProperty extends UserProperty {
      * </code>
      */
     @Extension
-    public static class TokenGenerateAndGetREST extends CrumbExclusion implements RootAction {
-
-        @Override
-        public boolean process(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
-            String pathInfo = request.getPathInfo();
-            if (pathInfo != null && pathInfo.startsWith(getUrlName())) {
-                chain.doFilter(request, response);
-                return true;
-            }
-            return false;
-        }
+    public static class TokenGenerateAndGetREST implements RootAction {
 
         @RequirePOST
         public HttpResponse doGenerate(@QueryParameter String newTokenName) throws IOException {


### PR DESCRIPTION
See [JENKINS-54539](https://issues.jenkins-ci.org/browse/JENKINS-54539).

### Proposed changelog entries

* JENKINS-54539: HTTP endpoint to generate API Tokens (`/userToken/generate`)

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@Wadeck (as the original author of the API Token generation refactor)
