### PR TITLE
[JENKINS-52869] Show error messages on user creation

### DIFF
--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -391,7 +391,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
      * @param validateCaptcha  whether to attempt to validate a captcha in the request
      *
      * @return a {@link SignupInfo#SignupInfo(StaplerRequest) SignupInfo from given request}, with {@link
-     * SignupInfo#errors} set to a non-null value if any of the supported fields are invalid
+     * SignupInfo#errors} containing errors (keyed by field name), if any of the supported fields are invalid
      */
     private SignupInfo validateAccountCreationForm(StaplerRequest req, boolean validateCaptcha) {
         // form field validation
@@ -553,10 +553,16 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         public String username,password1,password2,fullname,email,captcha;
 
         /**
-         * To display an error message, set it here.
+         * To display a general error message, set it here.
+         *
          */
         public String errorMessage;
 
+        /**
+         * Add field-specific error messages here.
+         * Keys are field names (e.g. {@code password2}), values are the messages.
+         */
+        // TODO i18n?
         public HashMap<String, String> errors = new HashMap<String, String>();
 
         public SignupInfo() {

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
@@ -27,11 +27,11 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <h1>${title}</h1>
   <div style="margin: 2em;">
-    <j:if test="${data.errorMessage!=null}">
+    <j:forEach var="error" items="${data.errors}">
       <div class="error" style="margin-bottom:1em">
-        ${data.errorMessage}
+        ${error.value}
       </div>
-    </j:if>
+    </j:forEach>
       <table>
         <tr>
           <td>${%Username}:</td>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
@@ -27,6 +27,11 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <h1>${title}</h1>
   <div style="margin: 2em;">
+    <j:if test="${data.errorMessage!=null}">
+      <div class="error" style="margin-bottom:1em">
+        ${data.errorMessage}
+      </div>
+    </j:if>
     <j:forEach var="error" items="${data.errors}">
       <div class="error" style="margin-bottom:1em">
         ${error.value}


### PR DESCRIPTION
See [JENKINS-52869](https://issues.jenkins-ci.org/browse/JENKINS-52869).

> ![screen shot](https://user-images.githubusercontent.com/1831569/48211300-88c59c00-e379-11e8-8da5-b6501cfd0e51.png)

Someone else can make this as fancy as the redesigned regular signup, for now we need the error messages back.

### Proposed changelog entries

* Bug: User account creation by administrators did not show error messages when it failed. (Regression in 2.129).

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
