### PR TITLE
DRAFT: Improve resilience of nextBuildNumber (stable-2.150 branch)

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -238,6 +238,13 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
         for (JobProperty p : properties)
             p.setOwner(this);
+
+        if (this instanceof LazyBuildMixIn.LazyLoadingJob) {
+            // LazyBuildMixIn.onLoad will call fixNextBuildNumber() at just the right time
+        } else {
+            final SortedMap<Integer, ? extends RunT> builds = _getRuns();
+            fixNextBuildNumber(builds);
+        }
     }
 
     /**

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -303,7 +303,8 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         if (nextBuildNumber == 0) { // #3361
             nextBuildNumber = 1;
         }
-        getNextBuildNumberFile().write(String.valueOf(nextBuildNumber) + '\n');
+        final TextFile nextBuildNumberFile = getNextBuildNumberFile();
+        nextBuildNumberFile.write(String.valueOf(nextBuildNumber) + '\n');
     }
 
     @Exported

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -68,6 +68,7 @@ import java.awt.Paint;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -305,7 +306,13 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         }
         final TextFile nextBuildNumberFile = getNextBuildNumberFile();
         final String text = String.valueOf(nextBuildNumber) + '\n';
-        nextBuildNumberFile.write(text);
+        try {
+            nextBuildNumberFile.write(text);
+        }
+        catch (IOException ignored) {
+            final Path pathToFile = Util.fileToPath(nextBuildNumberFile.file);
+            LOGGER.log(Level.WARNING, "Could not save the next build number to file {0}.", pathToFile);
+        }
     }
 
     @Exported

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -304,7 +304,8 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             nextBuildNumber = 1;
         }
         final TextFile nextBuildNumberFile = getNextBuildNumberFile();
-        nextBuildNumberFile.write(String.valueOf(nextBuildNumber) + '\n');
+        final String text = String.valueOf(nextBuildNumber) + '\n';
+        nextBuildNumberFile.write(text);
     }
 
     @Exported

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -240,6 +240,23 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             p.setOwner(this);
     }
 
+    /**
+     * In case the nextBuildNumber file couldn't be written (because it was locked),
+     * make sure the nextBuildNumber is at least one more than the max of the runs that are there.
+     * @param builds runs sorted by their ID in decreasing order
+     * @throws IOException can be thrown if unable to write the file
+     */
+    public void fixNextBuildNumber(final SortedMap<Integer, ? extends RunT> builds) throws IOException {
+        if (builds != null && !builds.isEmpty()) {
+            int max = builds.firstKey();
+            int next = getNextBuildNumber();
+            if (next <= max) {
+                LOGGER.log(Level.WARNING, "JENKINS-27530: improper nextBuildNumber {0} detected in {1} with highest build number {2}; adjusting", new Object[] {next, this, max});
+                updateNextBuildNumber(max + 1);
+            }
+        }
+    }
+
     @Override
     public void onCopiedFrom(Item src) {
         super.onCopiedFrom(src);

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -102,12 +102,7 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT,RunT> & Queue.Task & 
     @SuppressWarnings("unchecked")
     public void onLoad(ItemGroup<? extends Item> parent, String name) throws IOException {
         RunMap<RunT> _builds = createBuildRunMap();
-        int max = _builds.maxNumberOnDisk();
-        int next = asJob().getNextBuildNumber();
-        if (next <= max) {
-            LOGGER.log(Level.WARNING, "JENKINS-27530: improper nextBuildNumber {0} detected in {1} with highest build number {2}; adjusting", new Object[] {next, asJob(), max});
-            asJob().updateNextBuildNumber(max + 1);
-        }
+        asJob().fixNextBuildNumber(_builds);
         RunMap<RunT> currentBuilds = this.builds;
         if (parent != null) {
             // are we overwriting what currently exist?

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -332,8 +332,18 @@ public class JobTest {
         onLoadAfterOneRun(queueJob);
     }
 
+    @Test public void onLoadAfterOneRun_TestQueueJob() throws Exception {
+        final QueueJob queueJob = createTestQueueJob();
+        onLoadAfterOneRun(queueJob);
+    }
+
     @Test public void onLoadAfterTwoRuns_LazyBuildMixin() throws Exception {
         final QueueJob queueJob = createLazyBuildMixinQueueJob();
+        onLoadAfterTwoRuns(queueJob);
+    }
+
+    @Test public void onLoadAfterTwoRuns_TestQueueJob() throws Exception {
+        final QueueJob queueJob = createTestQueueJob();
         onLoadAfterTwoRuns(queueJob);
     }
 
@@ -342,13 +352,28 @@ public class JobTest {
         onLoadAfterTwoRunsAndCorruption(queueJob);
     }
 
+    @Test public void onLoadAfterTwoRunsAndCorruption_TestQueueJob() throws Exception {
+        final QueueJob queueJob = createTestQueueJob();
+        onLoadAfterTwoRunsAndCorruption(queueJob);
+    }
+
     @Test public void onLoadAfterTwoRunsAndDeletion_LazyBuildMixin() throws Exception {
         final QueueJob queueJob = createLazyBuildMixinQueueJob();
         onLoadAfterTwoRunsAndDeletion(queueJob);
     }
 
+    @Test public void onLoadAfterTwoRunsAndDeletion_TestQueueJob() throws Exception {
+        final QueueJob queueJob = createTestQueueJob();
+        onLoadAfterTwoRunsAndDeletion(queueJob);
+    }
+
     @Test public void onLoadAfterTwoRunsAndOutdatedFile_LazyBuildMixin() throws Exception {
         final QueueJob queueJob = createLazyBuildMixinQueueJob();
+        onLoadAfterTwoRunsAndOutdatedFile(queueJob);
+    }
+
+    @Test public void onLoadAfterTwoRunsAndOutdatedFile_TestQueueJob() throws Exception {
+        final QueueJob queueJob = createTestQueueJob();
         onLoadAfterTwoRunsAndOutdatedFile(queueJob);
     }
 

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -317,6 +317,18 @@ public class JobTest {
 
         assertEquals(1, project.getNextBuildNumber());
     }
+
+    @Test public void onLoadAfterOneRun() throws Exception {
+        final AbstractProject project = j.createFreeStyleProject();
+        project.assignBuildNumber();
+        assertEquals(2, project.getNextBuildNumber());
+        project.nextBuildNumber = 0;
+
+        project.onLoad(j.jenkins, project.name);
+
+        assertEquals(2, project.getNextBuildNumber());
+    }
+
     @Issue("JENKINS-19764")
     @Test public void testRenameWithCustomBuildsDirWithSubdir() throws Exception {
         j.jenkins.setRawBuildsDir("${JENKINS_HOME}/builds/${ITEM_FULL_NAME}/builds");

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -320,7 +320,7 @@ public class JobTest {
 
     @Test public void onLoadAfterOneRun() throws Exception {
         final AbstractProject project = j.createFreeStyleProject();
-        project.assignBuildNumber();
+        project.scheduleBuild2(0).get();
         assertEquals(2, project.getNextBuildNumber());
         project.nextBuildNumber = 0;
 
@@ -331,8 +331,8 @@ public class JobTest {
 
     @Test public void onLoadAfterTwoRuns() throws Exception {
         final AbstractProject project = j.createFreeStyleProject();
-        project.assignBuildNumber();
-        project.assignBuildNumber();
+        project.scheduleBuild2(0).get();
+        project.scheduleBuild2(0).get();
         assertEquals(3, project.getNextBuildNumber());
         project.nextBuildNumber = 0;
 

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -329,6 +329,18 @@ public class JobTest {
         assertEquals(2, project.getNextBuildNumber());
     }
 
+    @Test public void onLoadAfterTwoRuns() throws Exception {
+        final AbstractProject project = j.createFreeStyleProject();
+        project.assignBuildNumber();
+        project.assignBuildNumber();
+        assertEquals(3, project.getNextBuildNumber());
+        project.nextBuildNumber = 0;
+
+        project.onLoad(j.jenkins, project.name);
+
+        assertEquals(3, project.getNextBuildNumber());
+    }
+
     @Issue("JENKINS-19764")
     @Test public void testRenameWithCustomBuildsDirWithSubdir() throws Exception {
         j.jenkins.setRawBuildsDir("${JENKINS_HOME}/builds/${ITEM_FULL_NAME}/builds");

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -310,8 +310,32 @@ public class JobTest {
         }).intValue());
     }
 
-    @Test public void onLoadAfterCreation() throws Exception {
+    @Test public void onLoadAfterCreation_LazyBuildMixin() throws Exception {
         final QueueJob queueJob = createLazyBuildMixinQueueJob();
+        onLoadAfterCreation(queueJob);
+    }
+
+    @Test public void onLoadAfterOneRun_LazyBuildMixin() throws Exception {
+        final QueueJob queueJob = createLazyBuildMixinQueueJob();
+        onLoadAfterOneRun(queueJob);
+    }
+
+    @Test public void onLoadAfterTwoRuns_LazyBuildMixin() throws Exception {
+        final QueueJob queueJob = createLazyBuildMixinQueueJob();
+        onLoadAfterTwoRuns(queueJob);
+    }
+
+    @Test public void onLoadAfterTwoRunsAndCorruption_LazyBuildMixin() throws Exception {
+        final QueueJob queueJob = createLazyBuildMixinQueueJob();
+        onLoadAfterTwoRunsAndCorruption(queueJob);
+    }
+
+    @Test public void onLoadAfterTwoRunsAndDeletion_LazyBuildMixin() throws Exception {
+        final QueueJob queueJob = createLazyBuildMixinQueueJob();
+        onLoadAfterTwoRunsAndDeletion(queueJob);
+    }
+
+    private void onLoadAfterCreation(final JobTest.QueueJob queueJob) throws Exception {
         final Job job = queueJob.getJob();
         job.saveNextBuildNumber();
         assertEquals(1, job.getNextBuildNumber());
@@ -322,8 +346,7 @@ public class JobTest {
         assertEquals(1, job.getNextBuildNumber());
     }
 
-    @Test public void onLoadAfterOneRun() throws Exception {
-        final QueueJob queueJob = createLazyBuildMixinQueueJob();
+    private void onLoadAfterOneRun(final JobTest.QueueJob queueJob) throws Exception {
         scheduleAndWait(queueJob);
         final Job job = queueJob.getJob();
         assertEquals(2, job.getNextBuildNumber());
@@ -334,8 +357,7 @@ public class JobTest {
         assertEquals(2, job.getNextBuildNumber());
     }
 
-    @Test public void onLoadAfterTwoRuns() throws Exception {
-        final QueueJob queueJob = createLazyBuildMixinQueueJob();
+    private void onLoadAfterTwoRuns(final JobTest.QueueJob queueJob) throws Exception {
         scheduleAndWait(queueJob);
         scheduleAndWait(queueJob);
         final Job job = queueJob.getJob();
@@ -347,8 +369,7 @@ public class JobTest {
         assertEquals(3, job.getNextBuildNumber());
     }
 
-    @Test public void onLoadAfterTwoRunsAndCorruption() throws Exception {
-        final QueueJob queueJob = createLazyBuildMixinQueueJob();
+    private void onLoadAfterTwoRunsAndCorruption(final JobTest.QueueJob queueJob) throws Exception {
         scheduleAndWait(queueJob);
         scheduleAndWait(queueJob);
         final Job job = queueJob.getJob();
@@ -361,8 +382,7 @@ public class JobTest {
         assertEquals(3, job.getNextBuildNumber());
     }
 
-    @Test public void onLoadAfterTwoRunsAndDeletion() throws Exception {
-        final QueueJob queueJob = createLazyBuildMixinQueueJob();
+    private void onLoadAfterTwoRunsAndDeletion(final JobTest.QueueJob queueJob) throws Exception {
         scheduleAndWait(queueJob);
         scheduleAndWait(queueJob);
         final Job job = queueJob.getJob();

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -307,6 +307,16 @@ public class JobTest {
         }).intValue());
     }
 
+    @Test public void onLoadAfterCreation() throws Exception {
+        final AbstractProject project = j.createFreeStyleProject();
+        project.saveNextBuildNumber();
+        assertEquals(1, project.getNextBuildNumber());
+        project.nextBuildNumber = 0;
+
+        project.onLoad(j.jenkins, project.name);
+
+        assertEquals(1, project.getNextBuildNumber());
+    }
     @Issue("JENKINS-19764")
     @Test public void testRenameWithCustomBuildsDirWithSubdir() throws Exception {
         j.jenkins.setRawBuildsDir("${JENKINS_HOME}/builds/${ITEM_FULL_NAME}/builds");

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -341,6 +341,32 @@ public class JobTest {
         assertEquals(3, project.getNextBuildNumber());
     }
 
+    @Test public void onLoadAfterTwoRunsAndCorruption() throws Exception {
+        final AbstractProject project = j.createFreeStyleProject();
+        project.scheduleBuild2(0).get();
+        project.scheduleBuild2(0).get();
+        assertEquals(3, project.getNextBuildNumber());
+        project.getNextBuildNumberFile().write("corrupting file on purpose\n");
+        project.nextBuildNumber = 0;
+
+        project.onLoad(j.jenkins, project.name);
+
+        assertEquals(3, project.getNextBuildNumber());
+    }
+
+    @Test public void onLoadAfterTwoRunsAndDeletion() throws Exception {
+        final AbstractProject project = j.createFreeStyleProject();
+        project.scheduleBuild2(0).get();
+        project.scheduleBuild2(0).get();
+        assertEquals(3, project.getNextBuildNumber());
+        project.getNextBuildNumberFile().file.delete();
+        project.nextBuildNumber = 0;
+
+        project.onLoad(j.jenkins, project.name);
+
+        assertEquals(3, project.getNextBuildNumber());
+    }
+
     @Issue("JENKINS-19764")
     @Test public void testRenameWithCustomBuildsDirWithSubdir() throws Exception {
         j.jenkins.setRawBuildsDir("${JENKINS_HOME}/builds/${ITEM_FULL_NAME}/builds");

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -347,6 +347,11 @@ public class JobTest {
         onLoadAfterTwoRunsAndDeletion(queueJob);
     }
 
+    @Test public void onLoadAfterTwoRunsAndOutdatedFile_LazyBuildMixin() throws Exception {
+        final QueueJob queueJob = createLazyBuildMixinQueueJob();
+        onLoadAfterTwoRunsAndOutdatedFile(queueJob);
+    }
+
     private void onLoadAfterCreation(final JobTest.QueueJob queueJob) throws Exception {
         final Job job = queueJob.getJob();
         job.saveNextBuildNumber();
@@ -400,6 +405,19 @@ public class JobTest {
         final Job job = queueJob.getJob();
         assertEquals(3, job.getNextBuildNumber());
         job.getNextBuildNumberFile().file.delete();
+        job.nextBuildNumber = 0;
+
+        job.onLoad(j.jenkins, job.name);
+
+        assertEquals(3, job.getNextBuildNumber());
+    }
+
+    private void onLoadAfterTwoRunsAndOutdatedFile(final JobTest.QueueJob queueJob) throws Exception {
+        scheduleAndWait(queueJob);
+        scheduleAndWait(queueJob);
+        final Job job = queueJob.getJob();
+        assertEquals(3, job.getNextBuildNumber());
+        job.getNextBuildNumberFile().write("2\n");
         job.nextBuildNumber = 0;
 
         job.onLoad(j.jenkins, job.name);


### PR DESCRIPTION
This is a backport of #3731 to the `stable-2.150` branch, since we prefer to run on an LTS version.

I'm posting this as a `DRAFT` until #3731 is reviewed.