### PR TITLE
[JENKINS-38719] Console note/annotator script.js URLs must include SESSION_HASH

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1827,7 +1827,7 @@ public class Functions {
      * from {@link ConsoleAnnotatorFactory}s and {@link ConsoleAnnotationDescriptor}s.
      */
     public static String generateConsoleAnnotationScriptAndStylesheet() {
-        String cp = Stapler.getCurrentRequest().getContextPath();
+        String cp = Stapler.getCurrentRequest().getContextPath() + Jenkins.RESOURCE_PATH;
         StringBuilder buf = new StringBuilder();
         for (ConsoleAnnotatorFactory f : ConsoleAnnotatorFactory.all()) {
             String path = cp + "/extensionList/" + ConsoleAnnotatorFactory.class.getName() + "/" + f.getClass().getName();

--- a/test/src/test/java/hudson/console/ConsoleAnnotatorTest.java
+++ b/test/src/test/java/hudson/console/ConsoleAnnotatorTest.java
@@ -3,6 +3,7 @@ package hudson.console;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.html.DomElement;
 import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.FilePath;
@@ -27,6 +28,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
+import jenkins.model.Jenkins;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
 import org.junit.Rule;
@@ -288,6 +290,12 @@ public class ConsoleAnnotatorTest {
         // verify that there's an element inserted by the script
         assertNotNull(html.getElementById("inserted-by-test1"));
         assertNotNull(html.getElementById("inserted-by-test2"));
+        for (DomElement e : html.getElementsByTagName("script")) {
+            String src = e.getAttribute("src");
+            if (!src.isEmpty()) {
+                assertThat(src, containsString(Jenkins.SESSION_HASH));
+            }
+        }
     }
 
     public static final class JustToIncludeScript extends ConsoleNote<Object> {


### PR DESCRIPTION
To properly invalidate scripts across restarts. A user of https://github.com/jenkinsci/workflow-job-plugin/pull/111 reported seeing the old version of a `script.js`, which I suspect was caused by this.

### Proposed changelog entries

* Do not cache CSS/JS resource files for console annotations like Timestamper Plugin across Jenkins restarts.
