### PR TITLE
[JENKINS-54599] - Upgrade the Maven Jenkins Dev plugin from 9.4.5.v20170502 to 9.4.12.v20180830

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@ THE SOFTWARE.
           <!-- this is really just a patched version of maven-jetty-plugin to workaround issue #932 -->
           <groupId>org.jenkins-ci.tools</groupId>
           <artifactId>maven-jenkins-dev-plugin</artifactId>
-          <version>9.4.5.v20170502-jenkins-1</version>
+          <version>9.4.12.v20180830-jenkins-1-20181113.163150-1</version>
         </plugin>
         <plugin>
           <groupId>org.jvnet.updatecenter2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@ THE SOFTWARE.
           <!-- this is really just a patched version of maven-jetty-plugin to workaround issue #932 -->
           <groupId>org.jenkins-ci.tools</groupId>
           <artifactId>maven-jenkins-dev-plugin</artifactId>
-          <version>9.4.12.v20180830-jenkins-1-20181113.163150-1</version>
+          <version>9.4.12.v20180830-jenkins-2</version>
         </plugin>
         <plugin>
           <groupId>org.jvnet.updatecenter2</groupId>


### PR DESCRIPTION
See [JENKINS-54599](https://issues.jenkins-ci.org/browse/JENKINS-54599). This is a downstream of https://github.com/jenkinsci/maven-hudson-dev-plugin/pull/9 

### Proposed changelog entries

* RFE: Internal: Upgrade the Maven Jenkins Dev plugin from 9.4.5.v20170502 to 9.4.12.v20180830 to align it with the Jetty version 

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/java11-support 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
