### PR TITLE
[JENKINS-54261][JENKINS-54333][JENKINS-54570]

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -517,16 +517,7 @@ function registerRegexpValidator(e,regexp,message) {
  *      YUI Button widget.
  */
 function makeButton(e,onclick) {
-    var type = e.type;
-    var h = e.onclick || function (event) {
-        if (type && type.toLowerCase() === 'submit') {
-            var target = event.target;
-            var form = findAncestor(target, "FORM");
-            form.submit();
-        } else {
-            //FIXME: get some usecases for else
-        }
-    };
+    var h = e.onclick;
     var clsName = e.className;
     var n = e.name;
     var btn = new YAHOO.widget.Button(e,{});


### PR DESCRIPTION
Revert "[JENKINS-53462] Use a workaround to submit the form with a trusted event. No comments on the underlying insanity of hudson-behavior."

This reverts commit fa154b77d14a5d75ec45f2a9f28810b671a34a1a.

----

See [JENKINS-54261](https://issues.jenkins-ci.org/browse/JENKINS-54261),  [JENKINS-54333](https://issues.jenkins-ci.org/browse/JENKINS-54333),  [JENKINS-54570](https://issues.jenkins-ci.org/browse/JENKINS-54570).

Not really happy to have to do this, but the number and severity of regressions outweigh the benefits of the fix at the moment. Revert the change while we look for a better fix.

If https://github.com/jenkinsci/jenkins/pull/3761 is determine to not be broken, it might be a viable alternative to just reverting, but we probably want to split this up -- revert ASAP, and then test #3761 extensively.

### Proposed changelog entries

* Revert compatibility fix for future releases of Firefox due to regressions it caused

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
