### PR TITLE
JENKINS-54662: make UsageStatistics compatible with CasC plugin.

### DIFF
--- a/core/src/main/resources/hudson/model/UsageStatistics/global.groovy
+++ b/core/src/main/resources/hudson/model/UsageStatistics/global.groovy
@@ -1,7 +1,9 @@
-package hudson.model.UsageStatistics;
+package hudson.model.UsageStatistics
 
-def f=namespace(lib.FormTagLib)
+def f = namespace(lib.FormTagLib)
 
 f.section(title: _("Usage Statistics")) {
-    f.optionalBlock(field: "usageStatisticsCollected", checked: app.usageStatisticsCollected, title: _("statsBlurb"))
+    f.block() {
+        f.checkbox(field: "shouldCollect", checked: instance.shouldCollect, title: _("statsBlurb"))
+    }
 }


### PR DESCRIPTION
See [JENKINS-54662](https://issues.jenkins-ci.org/browse/JENKINS-54662).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: JENKINS-54662, Make `hudson.model.UsageStatistics` compatible with CasC plugin by introducing `shouldCollect` field.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests
- [X] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
