### PR TITLE
[JENKINS-45318] - Add dependancy on net.i2p.crypto to Jenkins CLI

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -66,6 +66,12 @@
       <version>1.7.0</version>
       <optional>true</optional> <!-- do not expose to core -->
     </dependency>
+	<dependency>
+		<groupId>org.apache.sshd</groupId>
+		<artifactId>sshd-core</artifactId>
+		<version>1.7.0</version>
+		<optional>true</optional> <!-- do not expose to core -->
+	</dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -66,6 +66,7 @@
       <version>1.7.0</version>
       <optional>true</optional> <!-- do not expose to core -->
     </dependency>
+	<!-- ed25519 algorithm, see JENKINS-45318 -->
 	<dependency>
   	  <groupId>net.i2p.crypto</groupId>
 	  <artifactId>eddsa</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -67,10 +67,9 @@
       <optional>true</optional> <!-- do not expose to core -->
     </dependency>
 	<dependency>
-		<groupId>org.apache.sshd</groupId>
-		<artifactId>sshd-core</artifactId>
-		<version>1.7.0</version>
-		<optional>true</optional> <!-- do not expose to core -->
+  	  <groupId>net.i2p.crypto</groupId>
+	  <artifactId>eddsa</artifactId>
+	  <version>0.3.0</version>
 	</dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
See [JENKINS-45318](https://issues.jenkins-ci.org/browse/JENKINS-45318).

### Changelog entries

* RFE JENKINS-45318, Jenkins CLI: Add support of the ed25519 key algorithm in Jenkins CLI

@oleg-nenashev 