### PR TITLE
[JENKINS-52282] Add isJavaWebStartSupported to JNLPLauncher

### DIFF
--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -221,4 +221,19 @@ public class JNLPLauncher extends ComputerLauncher {
         }
     }
 
+    /**
+     * Returns true if Java Web Start button should be displayed.
+     * Java Web Start is only supported when the Jenkins server is
+     * running with Java 8.  Earlier Java versions are not supported by Jenkins.
+     * Later Java versions do not support Java Web Start.
+     *
+     * This flag is checked in {@code config.jelly} before displaying the
+     * Java Web Start button.
+     * @return {@code true} if Java Web Start button should be displayed.
+     * @since FIXME
+     */
+    @Restricted(NoExternalUse.class) // Jelly use
+    public boolean isJavaWebStartSupported() {
+        return System.getProperty("java.version", "1.8").startsWith("1.8");
+    }
 }

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -37,14 +37,16 @@ THE SOFTWARE.
           ${%Connect agent to Jenkins one of these ways:}
         </p>
         <ul>
-          <li>
-            <p>
-              <a href="slave-agent.jnlp" id="jnlp-link">
-                <img src="${imagesURL}/webstart.gif" alt="${%launch agent}" />
-              </a>
-              ${%Launch agent from browser}
-            </p>
-          </li>
+          <j:if test="${it.launcher.javaWebStartSupported}">
+            <li>
+              <p>
+                <a href="slave-agent.jnlp" id="jnlp-link">
+                  <img src="${imagesURL}/webstart.gif" alt="${%launch agent}" />
+                </a>
+                ${%Launch agent from browser}
+              </p>
+            </li>
+          </j:if>
           <j:choose>
             <j:when test="${it.ACL.hasPermission(app.ANONYMOUS, it.CONNECT)}">
               <li>

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -37,16 +37,27 @@ THE SOFTWARE.
           ${%Connect agent to Jenkins one of these ways:}
         </p>
         <ul>
-          <j:if test="${it.launcher.javaWebStartSupported}">
-            <li>
-              <p>
-                <a href="slave-agent.jnlp" id="jnlp-link">
-                  <img src="${imagesURL}/webstart.gif" alt="${%launch agent}" />
-                </a>
-                ${%Launch agent from browser}
-              </p>
-            </li>
-          </j:if>
+          <j:choose>
+            <j:when test="${it.launcher.javaWebStartSupported}">
+              <li>
+                <p>
+                  <a href="slave-agent.jnlp" id="jnlp-link">
+                    <img src="${imagesURL}/webstart.gif" alt="${%launch agent}" />
+                  </a>
+                  ${%Launch agent from browser}
+                </p>
+              </li>
+            </j:when>
+            <j:otherwise>
+              <li>
+                <p>
+                  <a href="https://jenkins.io/redirect/java11-java-web-start">
+                    ${%Java Web Start is not available for the JVM version running Jenkins}
+                  </a>
+                </p>
+              </li>
+            </j:otherwise>
+          </j:choose>
           <j:choose>
             <j:when test="${it.ACL.hasPermission(app.ANONYMOUS, it.CONNECT)}">
               <li>


### PR DESCRIPTION
See [JENKINS-52282](https://issues.jenkins-ci.org/browse/JENKINS-52282), Java 9 and later do not support Java Web Start.

No automated test because I don't have time to write a test for the existence of a button in the user interface.

### Proposed changelog entries

* Entry 1: Don't show the "Java Web Start" button if master is running on Java 11
* ...

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jenkinsci/java11-support
