### PR TITLE
Disable DisablePluginCommandTest

### DIFF
--- a/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
@@ -29,6 +29,7 @@ import hudson.Functions;
 import hudson.PluginWrapper;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -46,6 +47,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.*;
 
+@Ignore("appears to run in an infinite loop")
 public class DisablePluginCommandTest {
 
     @Rule


### PR DESCRIPTION
Steps to reproduce (for me):

* Check out e3af0f3bb1d2f80a672e85e31d2dd63157033c16
* `mvn -Dfindbugs.skip=true -Dtest=DisablePluginCommandTest clean install`

Result:
https://gist.github.com/daniel-beck/59cddf409b384483c002f162a3b35f65

It continued to run for a while until I aborted it. I have no idea whether it ever finishes, or will just continue to run the test over and over.

I have no idea what's going on here. Perhaps the author @MRamonLeon knows?