### PR TITLE
Adding @Deprecated to Slave/DumbSlave constructors

### DIFF
--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -180,9 +180,10 @@ public abstract class Slave extends Node implements Serializable {
     }
 
     /**
-     * @deprecated as of 1.XXX
+     * @deprecated as of 2.2
      *      Use {@link #Slave(String, String, ComputerLauncher)} and set the rest through setters.
      */
+    @Deprecated
     public Slave(@Nonnull String name, String nodeDescription, String remoteFS, int numExecutors,
                  Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties) throws FormException, IOException {
         this.name = name;

--- a/core/src/main/java/hudson/slaves/DumbSlave.java
+++ b/core/src/main/java/hudson/slaves/DumbSlave.java
@@ -53,9 +53,10 @@ public final class DumbSlave extends Slave {
     }
     
     /**
-     * @deprecated as of 1.XXX.
+     * @deprecated as of 2.2.
      *      Use {@link #DumbSlave(String, String, ComputerLauncher)} and configure the rest through setters.
      */
+    @Deprecated
     public DumbSlave(String name, String nodeDescription, String remoteFS, String numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties) throws IOException, FormException {
     	super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
     }


### PR DESCRIPTION
These constructors were deprecated a long time ago, but the annotation was not added...

### Proposed changelog entries

* Adding Deprecated annotation to heavy `Slave(...)` and `DumbSlave(...)` constructors -- use the simpler forms and set additional properties using setters

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@daniel-beck 