### PR TITLE
Bump ATH version to one that support Selenium 3

### DIFF
--- a/essentials.yml
+++ b/essentials.yml
@@ -1,7 +1,7 @@
 ---
 ath:
   useLocalSnapshots: false
-  athRevision: "06caf67d37d945ec5228a80d73714fac692c28d3"
-  athImage: "jenkins/ath:acceptance-test-harness-1.62"
+  athRevision: "809fb7629c311ebddc6cada91fc865a950155bb0"
+  athImage: "jenkins/ath:acceptance-test-harness-1.63"
   categories:
     - org.jenkinsci.test.acceptance.junit.SmokeTest


### PR DESCRIPTION
Just keeping version in sync to minimize the change once ATH will be ready to run on Java 11

### Proposed changelog entries

Not noteworthy

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@raul-arabaolaza 

