### PR TITLE
[JEKINS-53998] Skip notifying SaveableListener during startup

### DIFF
--- a/core/src/main/java/hudson/model/listeners/SaveableListener.java
+++ b/core/src/main/java/hudson/model/listeners/SaveableListener.java
@@ -27,8 +27,13 @@ package hudson.model.listeners;
 import hudson.ExtensionPoint;
 import hudson.Extension;
 import hudson.ExtensionList;
+import hudson.Functions;
 import hudson.XmlFile;
 import hudson.model.Saveable;
+import jenkins.util.SystemProperties;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -76,6 +81,10 @@ public abstract class SaveableListener implements ExtensionPoint {
      * Fires the {@link #onChange} event.
      */
     public static void fireOnChange(Saveable o, XmlFile file) {
+        if (!Functions.isExtensionsAvailable() && !NOTIFY_DURING_STARTUP) {
+            LOGGER.info("Skipping notification for " + o + " in " + file + " as Jenkins is starting up or shutting down");
+            return;
+        }
         for (SaveableListener l : all()) {
             try {
                 l.onChange(o,file);
@@ -93,4 +102,9 @@ public abstract class SaveableListener implements ExtensionPoint {
     public static ExtensionList<SaveableListener> all() {
         return ExtensionList.lookup(SaveableListener.class);
     }
+
+    private static Logger LOGGER = Logger.getLogger(SaveableListener.class.getName());
+
+    @Restricted(NoExternalUse.class)
+    public /* for script console */ static boolean NOTIFY_DURING_STARTUP = SystemProperties.getBoolean(SaveableListener.class.getName() + ".notifyDuringStartup");
 }


### PR DESCRIPTION
See [JENKINS-53998](https://issues.jenkins-ci.org/browse/JENKINS-53998), [JENKINS-54888](https://issues.jenkins-ci.org/browse/JENKINS-54888).

Unsure what the default should be here, and whether it's a good idea at all, or whether this is an indicator of something else being broken. Feedback welcome. Still untested.

Unsure how to auto-test this, since tests have a different plugin manager.

### Proposed changelog entries

* Improve robustness by skipping some error-prone listener notifications during startup.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
