### PR TITLE
Bump to latest 1.50 parent pom release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
As 1.51 is upcoming (esp. to include the bump to extra-enforcer-rules to support JDK 11), the main goal here is to get an intermediate release with 1.50.
This way in case something goes wrong, it will be hopefully easier and quicker to figure where this comes from.

No JIRA, small enough.
Diff is https://github.com/jenkinsci/pom/compare/jenkins-1.49...jenkins-1.50 (contains only the SUREFIRE-1588 workaround)

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* `Internal:` update to 1.50 parent pom to get the SUREFIRE-1588 workaround.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

~~- [ ] JIRA issue is well described~~
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jglick given changes in 1.50 all come from him.

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
