### PR TITLE
[FIXED JENKINS-54903] Ensure the authenticator is created on load path also

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -134,7 +134,11 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
         this.secretPassword = Secret.fromString(password);
         this.noProxyHost = Util.fixEmptyAndTrim(noProxyHost);
         this.testUrl = Util.fixEmptyAndTrim(testUrl);
-        authenticator = new Authenticator() {
+        authenticator = newAuthenticator();
+    }
+
+    private Authenticator newAuthenticator() {
+        return new Authenticator() {
             @Override
             public PasswordAuthentication getPasswordAuthentication() {
                 String userName = getUserName();
@@ -223,6 +227,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
             // backward compatibility : get scrambled password and store it encrypted
             secretPassword = Secret.fromString(Scrambler.descramble(password));
         password = null;
+        authenticator = newAuthenticator();
         return this;
     }
 

--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -134,7 +134,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
         this.secretPassword = Secret.fromString(password);
         this.noProxyHost = Util.fixEmptyAndTrim(noProxyHost);
         this.testUrl = Util.fixEmptyAndTrim(testUrl);
-        authenticator = newAuthenticator();
+        this.authenticator = newAuthenticator();
     }
 
     private Authenticator newAuthenticator() {


### PR DESCRIPTION
See [JENKINS-54903](https://issues.jenkins-ci.org/browse/JENKINS-54903).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Bug: Jenkins did not use the configured proxy credentials for authentication unless they were saved since Jenkins was started. (regression in 2.152)
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
