### PR TITLE
[JENKINS-55049] Avoid NumberFormatException when a symlink is used as…

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1394,6 +1394,10 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         }
         
         public long getFileSize(){
+            if (length.length() == 0) {
+                // case for symlink
+                return 0;
+            }
             return Long.decode(length);
         }
 

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1394,11 +1394,13 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         }
         
         public long getFileSize(){
-            if (length.length() == 0) {
-                // case for symlink
+            try {
+                return Long.decode(length);
+            }
+            catch (NumberFormatException e) {
+                LOGGER.log(FINE, "The length {0} is a valid long.", length);
                 return 0;
             }
-            return Long.decode(length);
         }
 
         public String getTreeNodeId() {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1398,7 +1398,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                 return Long.decode(length);
             }
             catch (NumberFormatException e) {
-                LOGGER.log(FINE, "The length {0} is a valid long.", length);
+                LOGGER.log(FINE, "Cannot determine file size of the artifact {0}. The length {1} is not a valid long value", new Object[] {this, length});
                 return 0;
             }
         }

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -40,8 +40,10 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
+import hudson.model.Run;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
 import jenkins.MasterToSlaveFileCallable;
@@ -314,6 +316,53 @@ public class ArtifactArchiverTest {
         String expectedPath = build.getWorkspace().child(FILENAME).getRemote();
         j.assertLogContains("ERROR: Step ‘Archive the artifacts’ failed: java.nio.file.AccessDeniedException: " + expectedPath, build);
         assertThat("No stacktrace shown", build.getLog(31), Matchers.iterableWithSize(lessThan(30)));
+    }
+
+    @Test 
+    @Issue("JENKINS-55049")
+    public void lengthOfArtifactIsCorrect_eventForInvalidSymlink() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new TestBuilder() {
+            @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                FilePath ws = build.getWorkspace();
+                if (ws == null) {
+                    return false;
+                }
+                FilePath dir = ws.child("dir");
+                dir.mkdirs();
+                dir.child("existant").write("contents", null);
+                dir.child("_toExistant").symlinkTo("existant", listener);
+                dir.child("_nonexistant").symlinkTo("nonexistant", listener);
+                return true;
+            }
+        });
+        ArtifactArchiver aa = new ArtifactArchiver("dir/**");
+        aa.setAllowEmptyArchive(true);
+        p.getPublishersList().add(aa);
+        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        FilePath ws = b.getWorkspace();
+        assertNotNull(ws);
+        List<FreeStyleBuild.Artifact> artifacts = b.getArtifacts();
+        assertEquals(3, artifacts.size());
+        artifacts.sort(Comparator.comparing(Run.Artifact::getFileName));
+        
+        // invalid symlink => size of 0
+        FreeStyleBuild.Artifact artifact = artifacts.get(0);
+        assertEquals("dir/_nonexistant", artifact.relativePath);
+        assertEquals(0, artifact.getFileSize());
+        assertEquals("", artifact.getLength());
+    
+        // valid symlink => same size of the target, 8
+        artifact = artifacts.get(1);
+        assertEquals("dir/_toExistant", artifact.relativePath);
+        assertEquals(8, artifact.getFileSize());
+        assertEquals("8", artifact.getLength());
+    
+        // existant => size of 8
+        artifact = artifacts.get(2);
+        assertEquals("dir/existant", artifact.relativePath);
+        assertEquals(8, artifact.getFileSize());
+        assertEquals("8", artifact.getLength());
     }
 
     private static class RemoveReadPermission extends MasterToSlaveFileCallable<Object> {


### PR DESCRIPTION
- Avoid NumberFormatException when a symlink is used as artifact
- Display a "0 B" instead of nothing + exception thrown
- The page was displayed "correctly" before, just the console log that was flooded

See [JENKINS-55049](https://issues.jenkins-ci.org/browse/JENKINS-55049).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: Prevent an stacktrace to be displayed in log when a symlink is archived as artifact

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->