### PR TITLE
JENKINS-55062 - set resURL and rootURL for restarting template to load from the right places

### DIFF
--- a/core/src/main/resources/hudson/util/HudsonIsLoading/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonIsLoading/index.jelly
@@ -25,12 +25,14 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml" xmlns:f="/lib/form">
-
+    <j:new var="h" className="hudson.Functions"/><!-- instead of JSP functions -->
     <st:statusCode value="503"/><!-- SERVICE NOT AVAILABLE -->
     <st:setHeader name="Expires" value="0"/>
     <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate"/>
     <!-- response contentType header -->
     <st:contentType value="text/html;charset=UTF-8"/>
+    <!-- get default/commong page variable -->
+    ${h.initPageVariables(context)}
     <x:doctype name="html"/>
     <html lang="${request.getLocale().toLanguageTag()}">
         <head data-rooturl="${rootURL}" data-resurl="${resURL}" resURL="${resURL}">

--- a/core/src/main/resources/hudson/util/HudsonIsLoading/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonIsLoading/index.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml" xmlns:f="/lib/form">
-    <j:new var="h" className="hudson.Functions"/><!-- instead of JSP functions -->
+    <j:new var="h" className="hudson.Functions" />
     <st:statusCode value="503"/><!-- SERVICE NOT AVAILABLE -->
     <st:setHeader name="Expires" value="0"/>
     <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate"/>

--- a/core/src/main/resources/hudson/util/HudsonIsRestarting/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonIsRestarting/index.jelly
@@ -25,12 +25,14 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml" xmlns:f="/lib/form">
-
+    <j:new var="h" className="hudson.Functions"/><!-- instead of JSP functions -->
     <st:statusCode value="503"/><!-- SERVICE NOT AVAILABLE -->
     <st:setHeader name="Expires" value="0"/>
     <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate"/>
     <!-- response contentType header -->
     <st:contentType value="text/html;charset=UTF-8"/>
+    <!-- get default/commong page variable -->
+    ${h.initPageVariables(context)}
     <x:doctype name="html"/>
     <html lang="${request.getLocale().toLanguageTag()}">
         <head data-rooturl="${rootURL}" data-resurl="${resURL}" resURL="${resURL}">

--- a/core/src/main/resources/hudson/util/HudsonIsRestarting/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonIsRestarting/index.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml" xmlns:f="/lib/form">
-    <j:new var="h" className="hudson.Functions"/><!-- instead of JSP functions -->
+    <j:new var="h" className="hudson.Functions" />
     <st:statusCode value="503"/><!-- SERVICE NOT AVAILABLE -->
     <st:setHeader name="Expires" value="0"/>
     <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate"/>

--- a/test/src/test/java/hudson/util/HudsonIsLoading.java
+++ b/test/src/test/java/hudson/util/HudsonIsLoading.java
@@ -1,0 +1,32 @@
+package hudson.util;
+
+import com.gargoylesoftware.htmlunit.Page;
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class HudsonIsLoading {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-55062")
+    public void withPrefix() throws Exception {
+        j.jenkins.servletContext.setAttribute("app", new HudsonIsLoading());
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.getOptions().setThrowExceptionOnFailingStatusCode(false); // this is a failure page already
+        wc.getOptions().setJavaScriptEnabled(false);
+
+        Page p = wc.goTo("", "text/html");
+        assertTrue( p.isHtmlPage() );
+        String body = p.getWebResponse().getContentAsString();
+        assertThat(body, CoreMatchers.containsString("data-resurl=\""));
+        assertThat(body, CoreMatchers.containsString("data-rooturl=\""));
+        assertThat(body, CoreMatchers.containsString("resURL=\""));
+    }
+}

--- a/test/src/test/java/hudson/util/HudsonIsRestarting.java
+++ b/test/src/test/java/hudson/util/HudsonIsRestarting.java
@@ -1,0 +1,32 @@
+package hudson.util;
+
+import com.gargoylesoftware.htmlunit.Page;
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.*;
+
+public class HudsonIsRestarting {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-55062")
+    public void withPrefix() throws Exception {
+        j.jenkins.servletContext.setAttribute("app", new HudsonIsRestarting());
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.getOptions().setThrowExceptionOnFailingStatusCode(false); // this is a failure page already
+        wc.getOptions().setJavaScriptEnabled(false);
+
+        Page p = wc.goTo("", "text/html");
+        assertTrue( p.isHtmlPage() );
+        String body = p.getWebResponse().getContentAsString();
+        assertThat(body, CoreMatchers.containsString("data-resurl=\""));
+        assertThat(body, CoreMatchers.containsString("data-rooturl=\""));
+        assertThat(body, CoreMatchers.containsString("resURL=\""));
+    }
+}


### PR DESCRIPTION
See [JENKINS-55062](https://issues.jenkins-ci.org/browse/JENKINS-55062).

### Proposed changelog entries

* Fix Restarting and Loading views so they pull css from the right urls

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [X] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

