### PR TITLE
[JENKINS-55076/JENKINS-55080] - Generalize the Java version discovery logic + Java 11 experimental UC

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -63,6 +63,7 @@ import jenkins.RestartRequiredException;
 import jenkins.install.InstallUtil;
 import jenkins.model.Jenkins;
 import jenkins.util.io.OnMaster;
+import jenkins.util.java.JavaUtils;
 import net.sf.json.JSONObject;
 
 import org.acegisecurity.Authentication;
@@ -153,7 +154,8 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 @ExportedBean
 public class UpdateCenter extends AbstractModelObject implements Saveable, OnMaster, StaplerProxy {
 
-    private static final String UPDATE_CENTER_URL = SystemProperties.getString(UpdateCenter.class.getName()+".updateCenterUrl","https://updates.jenkins.io/");
+    private static final Logger LOGGER;
+    private static final String UPDATE_CENTER_URL;
 
     /**
      * Read timeout when downloading plugins, defaults to 1 minute
@@ -206,6 +208,25 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     private UpdateCenterConfiguration config;
 
     private boolean requiresRestart;
+
+    static {
+        Logger logger = Logger.getLogger(UpdateCenter.class.getName());
+        LOGGER = logger;
+        String ucOverride = SystemProperties.getString(UpdateCenter.class.getName()+".updateCenterUrl");
+        if (ucOverride != null) {
+            logger.log(Level.INFO, "Using a custom update center defined by the system property: {0}", ucOverride);
+            UPDATE_CENTER_URL = ucOverride;
+        } else if (JavaUtils.isRunningWithJava8OrBelow()) {
+            UPDATE_CENTER_URL = "https://updates.jenkins.io/";
+        } else {
+            //TODO: Rollback the default for Java 11 when it goes to GA
+            String experimentalJava11UC = "https://updates.jenkins.io/temporary-experimental-java11";
+            logger.log(Level.WARNING, "Running Jenkins with Java {0} which is available in the preview mode only. " +
+                    "A custom experimental update center will be used: {1}",
+                    new Object[] {System.getProperty("java.specification.version"), experimentalJava11UC});
+            UPDATE_CENTER_URL = experimentalJava11UC;
+        }
+    }
 
     /**
      * Simple connection status enum.
@@ -2374,8 +2395,6 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      * Sequence number generator.
      */
     private static final AtomicInteger iota = new AtomicInteger();
-
-    private static final Logger LOGGER = Logger.getLogger(UpdateCenter.class.getName());
 
     /**
      * @deprecated as of 1.333

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -220,7 +220,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             UPDATE_CENTER_URL = "https://updates.jenkins.io/";
         } else {
             //TODO: Rollback the default for Java 11 when it goes to GA
-            String experimentalJava11UC = "https://updates.jenkins.io/temporary-experimental-java11";
+            String experimentalJava11UC = "https://updates.jenkins.io/temporary-experimental-java11/";
             logger.log(Level.WARNING, "Running Jenkins with Java {0} which is available in the preview mode only. " +
                     "A custom experimental update center will be used: {1}",
                     new Object[] {System.getProperty("java.specification.version"), experimentalJava11UC});

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -235,6 +235,6 @@ public class JNLPLauncher extends ComputerLauncher {
      */
     @Restricted(NoExternalUse.class) // Jelly use
     public boolean isJavaWebStartSupported() {
-        return !JavaUtils.isRunningWithPostJava8();
+        return JavaUtils.isRunningWithJava8OrBelow();
     }
 }

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -34,6 +34,7 @@ import javax.annotation.Nonnull;
 
 import jenkins.model.Jenkins;
 import jenkins.slaves.RemotingWorkDirSettings;
+import jenkins.util.java.JavaUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -234,6 +235,6 @@ public class JNLPLauncher extends ComputerLauncher {
      */
     @Restricted(NoExternalUse.class) // Jelly use
     public boolean isJavaWebStartSupported() {
-        return System.getProperty("java.version", "1.8").startsWith("1.8");
+        return !JavaUtils.isRunningWithPostJava8();
     }
 }

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -40,6 +40,7 @@ import hudson.util.ProcessTree.OSProcess;
 import hudson.util.ProcessTreeRemoting.IOSProcess;
 import hudson.util.ProcessTreeRemoting.IProcessTree;
 import jenkins.security.SlaveToMasterCallable;
+import jenkins.util.java.JavaUtils;
 import org.jvnet.winp.WinProcess;
 import org.jvnet.winp.WinpException;
 
@@ -852,7 +853,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
 
         static {
             try {
-                if (isPostJava8()) { // Java 9+
+                if (JavaUtils.isRunningWithPostJava8()) {
                     Class<?> clazz = Process.class;
                     JAVA9_PID_METHOD = clazz.getMethod("pid");
                     JAVA8_PID_FIELD = null;
@@ -906,12 +907,6 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 x.initCause(e);
                 throw x;
             }
-        }
-
-        // Java 9 uses new version format
-        private static boolean isPostJava8() {
-            String javaVersion = System.getProperty("java.version");
-            return !javaVersion.startsWith("1.");
         }
     }
 

--- a/core/src/main/java/jenkins/util/java/JavaUtils.java
+++ b/core/src/main/java/jenkins/util/java/JavaUtils.java
@@ -38,7 +38,16 @@ public class JavaUtils {
     }
 
     /**
-     * Check whether the current JVM is running with Java 11 or above.
+     * Check whether the current JVM is running with Java 8 or below
+     * @return {@code true} if it is Java 8 or older version
+     */
+    public static boolean isRunningWithJava8OrBelow() {
+        String javaVersion = System.getProperty("java.specification.version");
+        return javaVersion.startsWith("1.");
+    }
+
+    /**
+     * Check whether the current JVM is running with Java 9 or above.
      * @return {@code true} if it is Java 9 or above
      */
     public static boolean isRunningWithPostJava8() {

--- a/core/src/main/java/jenkins/util/java/JavaUtils.java
+++ b/core/src/main/java/jenkins/util/java/JavaUtils.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.util.java;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Utility class for Java environment management and checks.
+ * @author Oleg Nenashev
+ */
+@Restricted(NoExternalUse.class)
+public class JavaUtils {
+
+    private JavaUtils() {
+        // Cannnot construct
+    }
+
+    /**
+     * Check whether the current JVM is running with Java 11 or above.
+     * @return {@code true} if it is Java 9 or above
+     */
+    public static boolean isRunningWithPostJava8() {
+        String javaVersion = System.getProperty("java.specification.version");
+        return !javaVersion.startsWith("1.");
+    }
+
+}

--- a/core/src/test/java/jenkins/util/java/JavaUtilsTest.java
+++ b/core/src/test/java/jenkins/util/java/JavaUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.util.java;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+import org.junit.Test;
+import org.jvnet.hudson.test.For;
+
+@For(JavaUtils.class)
+public class JavaUtilsTest {
+
+    @Test
+    public void verifyJava8() {
+        assumeTrue("Test is for Java 8 only", System.getProperty("java.version").startsWith("1."));
+        assertFalse("isRunningWithPostJava8() should return false on Java 8 and below", JavaUtils.isRunningWithPostJava8());
+    }
+
+    @Test
+    public void verifyPostJava8() {
+        assumeFalse("Test is for Java 9+ only", System.getProperty("java.version").startsWith("1."));
+        assertTrue("isRunningWithPostJava8() should return true on Java 9 and above", JavaUtils.isRunningWithPostJava8());
+    }
+}


### PR DESCRIPTION
`java.specification.version` is a requirement for all platforms according to https://openjdk.java.net/jeps/223. `java.version` values may be potentially different on non-OpenJDK platforms + it may include various suffixes like `-ea`. 

See [JENKINS-55076](https://issues.jenkins-ci.org/browse/JENKINS-55076).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

Log entry warning:

<img width="1097" alt="screenshot 2018-12-07 at 21 47 51" src="https://user-images.githubusercontent.com/3000480/49671967-e416a700-fa69-11e8-9ad5-2d59696d1c4c.png">


### Proposed changelog entries

* rfe, JENKINS-55080 - Jenkins is now using a temporary experimental update center by default when running with Java 11
  * More info: https://github.com/jenkinsci/jep/tree/master/jep/211#experimental-update-center-for-java-11
* rfe, JENKINS-55076 (or bug) - Unix process manager and Agent Java Web Start UI now check the actual java version based on `java.specification.version`
* rfe, JENKINS-55076: - Internal: Introduce a `jenkins.util.java.JavaUtils` class with Java discovery methods
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/java11-support 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
