### PR TITLE
[JENKINS-55081] SEC-904 related test failing on java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ for(j = 0; j < jdks.size(); j++) {
                                     "MAVEN_OPTS=-Xmx1536m -Xms512m"], jdk) {
                             // Actually run Maven!
                             // -Dmaven.repo.local=… tells Maven to create a subdir in the temporary directory for the local Maven repository
-                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
+                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install -Dtest=*904* ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
 
                             if(isUnix()) {
                                 sh mvnCmd

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ for(j = 0; j < jdks.size(); j++) {
                                     "MAVEN_OPTS=-Xmx1536m -Xms512m"], jdk) {
                             // Actually run Maven!
                             // -Dmaven.repo.local=… tells Maven to create a subdir in the temporary directory for the local Maven repository
-                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install -Dtest=*904* ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
+                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
 
                             if(isUnix()) {
                                 sh mvnCmd

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -3328,6 +3328,7 @@ public final class FilePath implements Serializable {
                 if (childUsingFullPathAbs.length() == directChildAbs.length()) {
                     remainingPath = "";
                 } else {
+                    // +1 to avoid the last slash
                     remainingPath = childUsingFullPathAbs.substring(directChildAbs.length() + 1);
                 }
 

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -3322,8 +3322,14 @@ public final class FilePath implements Serializable {
             while (!remainingPath.isEmpty()) {
                 Path directChild = this.getDirectChild(currentFilePath, remainingPath);
                 Path childUsingFullPath = currentFilePath.resolve(remainingPath);
-                Path rel = directChild.toAbsolutePath().relativize(childUsingFullPath.toAbsolutePath());
-                remainingPath = rel.toString();
+                String childUsingFullPathAbs = childUsingFullPath.toAbsolutePath().toString();
+                String directChildAbs = directChild.toAbsolutePath().toString();
+
+                if (childUsingFullPathAbs.length() == directChildAbs.length()) {
+                    remainingPath = "";
+                } else {
+                    remainingPath = childUsingFullPathAbs.substring(directChildAbs.length() + 1);
+                }
 
                 File childFileSymbolic = Util.resolveSymlinkToFile(directChild.toFile());
                 if (childFileSymbolic == null) {

--- a/core/src/test/java/hudson/FilePathSEC904Test.java
+++ b/core/src/test/java/hudson/FilePathSEC904Test.java
@@ -84,8 +84,6 @@ public class FilePathSEC904Test {
         // the intermediate path "./.." goes out of workspace and so is refused
         assertFalse(workspaceFolder.isDescendant("./../workspace"));
         assertFalse(workspaceFolder.isDescendant("./../workspace/"));
-        assertFalse(workspaceFolder.isDescendant(".\\..\\workspace"));
-        assertFalse(workspaceFolder.isDescendant(".\\..\\workspace\\"));
         assertFalse(workspaceFolder.isDescendant("./../workspace/regular.txt"));
         assertFalse(workspaceFolder.isDescendant("../workspace/regular.txt"));
         assertFalse(workspaceFolder.isDescendant("./../../root/workspace/regular.txt"));
@@ -143,9 +141,7 @@ public class FilePathSEC904Test {
         assertTrue(workspaceFolder.isDescendant("b/../a/a.txt"));
         assertTrue(workspaceFolder.isDescendant("b"));
         assertTrue(workspaceFolder.isDescendant("./b"));
-        assertTrue(workspaceFolder.isDescendant(".\\b"));
         assertTrue(workspaceFolder.isDescendant("b/_a/a.txt"));
-        assertTrue(workspaceFolder.isDescendant("b/_a\\a.txt"));
         assertTrue(workspaceFolder.isDescendant("b/_a/../a/a.txt"));
         assertTrue(workspaceFolder.isDescendant("b/_atxt"));
         
@@ -201,6 +197,12 @@ public class FilePathSEC904Test {
         
         assertTrue(workspaceFolder.isDescendant("b"));
         assertTrue(workspaceFolder.isDescendant("b/_a/a.txt"));
+        assertTrue(workspaceFolder.isDescendant("b\\_a\\a.txt"));
+        assertTrue(workspaceFolder.isDescendant("b\\_a\\../a/a.txt"));
+        assertTrue(workspaceFolder.isDescendant("b\\_a\\..\\a\\a.txt"));
+        assertTrue(workspaceFolder.isDescendant(".\\b\\_a\\..\\a\\a.txt"));
+        assertTrue(workspaceFolder.isDescendant("b/_a/../a/a.txt"));
+        assertTrue(workspaceFolder.isDescendant("./b/_a/../a/a.txt"));
         
         // nonexistent and not proven illegal, the junction links are not resolved 
         // by Util.resolveSymlinkToFile / neither Path.toRealPath under Windows

--- a/core/src/test/java/hudson/FilePathSEC904Test.java
+++ b/core/src/test/java/hudson/FilePathSEC904Test.java
@@ -84,6 +84,8 @@ public class FilePathSEC904Test {
         // the intermediate path "./.." goes out of workspace and so is refused
         assertFalse(workspaceFolder.isDescendant("./../workspace"));
         assertFalse(workspaceFolder.isDescendant("./../workspace/"));
+        assertFalse(workspaceFolder.isDescendant(".\\..\\workspace"));
+        assertFalse(workspaceFolder.isDescendant(".\\..\\workspace\\"));
         assertFalse(workspaceFolder.isDescendant("./../workspace/regular.txt"));
         assertFalse(workspaceFolder.isDescendant("../workspace/regular.txt"));
         assertFalse(workspaceFolder.isDescendant("./../../root/workspace/regular.txt"));
@@ -137,8 +139,14 @@ public class FilePathSEC904Test {
         assertTrue(workspaceFolder.isDescendant("_nonexistent"));
         assertTrue(workspaceFolder.isDescendant("a"));
         assertTrue(workspaceFolder.isDescendant("a/a.txt"));
+        assertTrue(workspaceFolder.isDescendant("a/../a/a.txt"));
+        assertTrue(workspaceFolder.isDescendant("b/../a/a.txt"));
         assertTrue(workspaceFolder.isDescendant("b"));
+        assertTrue(workspaceFolder.isDescendant("./b"));
+        assertTrue(workspaceFolder.isDescendant(".\\b"));
         assertTrue(workspaceFolder.isDescendant("b/_a/a.txt"));
+        assertTrue(workspaceFolder.isDescendant("b/_a\\a.txt"));
+        assertTrue(workspaceFolder.isDescendant("b/_a/../a/a.txt"));
         assertTrue(workspaceFolder.isDescendant("b/_atxt"));
         
         // nonexistent but illegal


### PR DESCRIPTION
- just running the tests for the moment

See [JENKINS-55081](https://issues.jenkins-ci.org/browse/JENKINS-55081).

### Proposed changelog entries

* Internal: correct test failing with Java 11: `FilePathSEC904Test.isDescendant_regularFiles`

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

