### PR TITLE
Suppressing some tests which fail in CI

### DIFF
--- a/core/src/test/java/hudson/FilePathSEC904Test.java
+++ b/core/src/test/java/hudson/FilePathSEC904Test.java
@@ -36,13 +36,15 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import org.junit.Ignore;
 
 //TODO to be merged back in FilePathTest after security release
 public class FilePathSEC904Test {
     
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
-    
+
+    @Ignore("./../workspace fails on CI")
     @Test
     @Issue("SECURITY-904")
     public void isDescendant_regularFiles() throws IOException, InterruptedException {

--- a/core/src/test/java/hudson/FilePathSEC904Test.java
+++ b/core/src/test/java/hudson/FilePathSEC904Test.java
@@ -42,7 +42,7 @@ public class FilePathSEC904Test {
     
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
-
+    
     @Test
     @Issue("SECURITY-904")
     public void isDescendant_regularFiles() throws IOException, InterruptedException {

--- a/core/src/test/java/hudson/FilePathSEC904Test.java
+++ b/core/src/test/java/hudson/FilePathSEC904Test.java
@@ -36,7 +36,6 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
-import org.junit.Ignore;
 
 //TODO to be merged back in FilePathTest after security release
 public class FilePathSEC904Test {
@@ -44,7 +43,6 @@ public class FilePathSEC904Test {
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
 
-    @Ignore("./../workspace fails on CI")
     @Test
     @Issue("SECURITY-904")
     public void isDescendant_regularFiles() throws IOException, InterruptedException {

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -352,6 +352,7 @@ public class UtilTest {
         assertFalse("f1 exists", f1.exists());
     }
 
+    @Ignore("TODO often fails in CI")
     @Test
     public void testDeleteContentsRecursive_onWindows() throws Exception {
         Assume.assumeTrue(Functions.isWindows());

--- a/test/src/test/java/hudson/PluginSEC925Test.java
+++ b/test/src/test/java/hudson/PluginSEC925Test.java
@@ -19,7 +19,7 @@ public class PluginSEC925Test {
     @Rule
     public JenkinsRule r = new JenkinsRule();
     
-    @Ignore("TODO observed to fail in CI with 404")
+    @Ignore("TODO observed to fail in CI with 404 due to external UC issues")
     @Test
     @Issue("SECURITY-925")
     public void preventTimestamp2_toBeServed() throws Exception {

--- a/test/src/test/java/hudson/PluginSEC925Test.java
+++ b/test/src/test/java/hudson/PluginSEC925Test.java
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Future;
+import org.junit.Ignore;
 
 //TODO merge it within PluginTest after the security release
 public class PluginSEC925Test {
@@ -18,6 +19,7 @@ public class PluginSEC925Test {
     @Rule
     public JenkinsRule r = new JenkinsRule();
     
+    @Ignore("TODO observed to fail in CI with 404")
     @Test
     @Issue("SECURITY-925")
     public void preventTimestamp2_toBeServed() throws Exception {

--- a/test/src/test/java/hudson/cli/CLITest.java
+++ b/test/src/test/java/hudson/cli/CLITest.java
@@ -73,6 +73,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.junit.Ignore;
 
 public class CLITest {
 
@@ -256,6 +257,7 @@ public class CLITest {
         }
     }
 
+    @Ignore("TODO sometimes fails, in CI & locally")
     @Test
     @Issue("JENKINS-54310")
     public void readInputAtOnce() throws Exception {

--- a/test/src/test/java/hudson/util/AtomicFileWriterPerfTest.java
+++ b/test/src/test/java/hudson/util/AtomicFileWriterPerfTest.java
@@ -1,6 +1,7 @@
 package hudson.util;
 
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -23,6 +24,7 @@ public class AtomicFileWriterPerfTest {
      * So using slightly more than the worse value obtained above should avoid making this flaky and still catch
      * <strong>really</strong> bad performance regressions.
      */
+    @Ignore("TODO often fails in CI")
     @Issue("JENKINS-34855")
     @Test(timeout = 50 * 1000L)
     public void poorManPerformanceTestBed() throws Exception {


### PR DESCRIPTION
Various tests which have [prevented us from having a stable `master` build since Nov 27](https://ci.jenkins.io/job/Core/job/jenkins/job/master/), which is intolerable. Exempting [this `DisablePluginCommandTest` test](https://ci.jenkins.io/job/Core/job/jenkins/job/master/1164/testReport/hudson.cli/DisablePluginCommandTest/Linux_jdk11___Linux_Publishing___canDisableDependentPluginsRightOrderStrategyNone/) where it just looks like all hell broke loose, not the fault of the test.