### PR TITLE
Include Build Timestamp in console output page

### DIFF
--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -34,6 +34,7 @@ THE SOFTWARE.
     <l:main-panel>
       <t:buildCaption>
         ${%Console Output}
+        (<i:formatDate value="${it.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)
       </t:buildCaption>
       <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />
       <!-- Show at most last 150KB (can override with system property) unless consoleFull is set -->


### PR DESCRIPTION
### Proposed changelog entries
* Include Build Timestamp in console output page

### Justification/Description of the change
When analyzing the console output, one often needs the start time of the build.
Since that start time is shown in the same location from hudson/model/AbstractBuild/index.jelly, I have copied the respective jelly code from there.

Anyway, this spot of the page is basically unused, so it won't hurt to include this information at this location.

### Trying to comply with the applicable parts of submitter checklist
* No Jenkins issue was created since this a very minor change.
* No tests where added due to the same reason, and since this change is in jelly

