### PR TITLE
Java 11 test failure: no need to log at WARNING

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -221,7 +221,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         } else {
             //TODO: Rollback the default for Java 11 when it goes to GA
             String experimentalJava11UC = "https://updates.jenkins.io/temporary-experimental-java11/";
-            logger.log(Level.WARNING, "Running Jenkins with Java {0} which is available in the preview mode only. " +
+            logger.log(Level.INFO, "Running Jenkins with Java {0} which is available in preview mode only. " +
                     "A custom experimental update center will be used: {1}",
                     new Object[] {System.getProperty("java.specification.version"), experimentalJava11UC});
             UPDATE_CENTER_URL = experimentalJava11UC;


### PR DESCRIPTION
```
java.lang.AssertionError: expected:<[]> but was:<[Running Jenkins with Java 11 which is available in the preview mode only. A custom experimental update center will be used: https://updates.jenkins.io/temporary-experimental-java11/]>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at jenkins.model.StartupTest.noWarnings(StartupTest.java:45)
```

Note that this was marked as a flake because Surefire reruns the test (apparently in the same JVM despite `reuse.forks=false`) and the message is printed in a `static` initializer, which gets run just once.

I was actually looking around at other flakes I saw in #3804, one of which I fixed there (https://github.com/jenkinsci/jenkins/pull/3804/commits/08d273f3c6006896490593cb6e018a21d8c89a26) because it happened enough to mark the build unstable. The others I saw were

```
java.lang.AssertionError: expected:<5> but was:<6>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at hudson.slaves.NodeProvisionerTest.loadSpike(NodeProvisionerTest.java:116)
java.lang.AssertionError: expected:<3> but was:<4>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at hudson.slaves.NodeProvisionerTest.baselineSlaveUsage(NodeProvisionerTest.java:134)
```

which are long-known flakes; in #2188 I let them be since `rerunFailingTestsCount` seems to take care of them, but perhaps these tests should just be disabled (if there is no obvious way to fix them).