### PR TITLE
Insist that PR Template checkboxes must be checked

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,8 @@ The changelogs will be integrated by the core maintainers after the merge.  See 
       * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
 - [ ] Appropriate autotests or explanation to why this change has no tests
 - [ ] For dependency updates: links to external changelogs and, if possible, full diffs
+- [ ] After PR automated build has run, i.e. a few hours, check the result.
+      If failing, the **submitter** is responsible for checking why and provide either additional fixes, or clear explanations as to why the failure looks unrelated.
 
 <!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,10 @@
 See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).
 
-<!-- Comment: 
+<!-- Comment:
+
+IMPORTANT: ALL checkboxes below are a MUST.
+They are required for a PR to be analyzed, you must check each checkbox, and if not applicable simply ~~cross~~ the full line to show you've taken it in account, ideally add a short explanation as to why it's irrelevant if not obvious.
+
 If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
 
  * We do not require JIRA issues for minor improvements.
@@ -13,7 +17,7 @@ If the issue is not fully described in the ticket, add more information here (ju
 * Entry 1: Issue, Human-readable Text
 * ...
 
-<!-- Comment: 
+<!-- Comment:
 The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->
 
 ### Submitter checklist


### PR DESCRIPTION
Special meta-PR, wiping out the PR template (yes, I see the irony, but I'm not touching the code :-)).

I have seen many cases where submitters are waiting, AFAICT, for the reviewers to check the PR build result and analyze potential test/build failures. Though we did have a bit of flakiness recently, I still think the submitter is the one responsible for providing this analysis.