### PR TITLE
Pinning ATH version used in runATH

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,9 @@ builds.ath = {
             metadataPath = pwd() + "/essentials.yml"
         }
         dir("ath") {
-            runATH jenkins: fileUri, athRevision: "d917fee6683bf83cc9b40cac6ad1f5ade5b54cfc", metadataFile: metadataPath
+            runATH jenkins: fileUri,
+                   athRevision: "d917fee6683bf83cc9b40cac6ad1f5ade5b54cfc",
+                   metadataFile: metadataPath
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ builds.ath = {
             metadataPath = pwd() + "/essentials.yml"
         }
         dir("ath") {
-            runATH jenkins: fileUri, metadataFile: metadataPath
+            runATH jenkins: fileUri, athRevision: "d917fee6683bf83cc9b40cac6ad1f5ade5b54cfc", metadataFile: metadataPath
         }
     }
 }


### PR DESCRIPTION
This PR is designed to, hopefully, get the Core build back to green durably. 
Since a few days, we have many if not all PRs and the master branch failing because of ATH tests failures.

So I'm pinning the ATH sha in use for `runATH`. It's going to be much better in terms of stability and control.
We'll want to regularly file PRs to bump ATH SHA to use.

No JIRA. No changelog, purely internal change.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- N/A ~JIRA issue is well described~
- N/A Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- N/A Appropriate autotests or explanation to why this change has no tests
- N/A For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/java11-support @olivergondza 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
