### PR TITLE
Pin ATH revision to latest to have JDK11

### DIFF
--- a/essentials.yml
+++ b/essentials.yml
@@ -1,7 +1,7 @@
 ---
 ath:
   useLocalSnapshots: false
-  athRevision: "809fb7629c311ebddc6cada91fc865a950155bb0"
-  athImage: "jenkins/ath:acceptance-test-harness-1.63"
+  athRevision: "4e295015ce6b4d5c7a4617bb99dc2968e2436634"
+  athImage: "jenkins/ath@sha256:284c2fdfaf1a51e95783126367c0a88c07af83ff9234063d12ba3001959628e8"
   categories:
     - org.jenkinsci.test.acceptance.junit.SmokeTest


### PR DESCRIPTION
Fix the failures on PRs and master due to disalignment between pipeline-library and acceptance-test-harness. By default, the builds are using latest version of pipeline-library, which needs the last version of acceptance-test-harness. But there is no new tag of ATH by now. So I pin to the commit.

@jenkinsci/java11-support @raul-arabaolaza @olivergondza @batmat 