### PR TITLE
[JENKINS-29150] - Fix the CronTabTest.testTimezone test

### DIFF
--- a/core/src/test/java/hudson/scheduler/CronTabTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import static org.junit.Assert.*;
 import org.junit.Test;
@@ -199,7 +200,7 @@ public class CronTabTest {
     }
 
     /**
-     * Humans can't easily see difference in two {@link Calendar}s, do help the diagnosis by using {@link DateFormat}. 
+     * Humans can't easily see difference in two {@link Calendar}s, do help the diagnosis by using {@link DateFormat}.
      */
     private void compare(Calendar expected, Calendar actual) {
         DateFormat f = DateFormat.getDateTimeInstance();
@@ -307,7 +308,9 @@ public class CronTabTest {
         CronTabList tabs = CronTabList.create("TZ=Australia/Sydney\nH * * * *\nH * * * *", Hash.from("seed"));
         List<Integer> times = new ArrayList<Integer>();
         for (int i = 0; i < 60; i++) {
-            if (tabs.check(new GregorianCalendar(2013, 3, 3, 11, i, 0))) {
+            GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("Australia/Sydney"));
+            calendar.set(2013, Calendar.APRIL, 3, 11, i, 0);
+            if (tabs.check(calendar)) {
                 times.add(i);
             }
         }

--- a/core/src/test/java/hudson/scheduler/CronTabTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabTest.java
@@ -308,7 +308,7 @@ public class CronTabTest {
         CronTabList tabs = CronTabList.create("TZ=Australia/Sydney\nH * * * *\nH * * * *", Hash.from("seed"));
         List<Integer> times = new ArrayList<Integer>();
         for (int i = 0; i < 60; i++) {
-            GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("Australia/Sydney"));
+            GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
             calendar.set(2013, Calendar.APRIL, 3, 11, i, 0);
             if (tabs.check(calendar)) {
                 times.add(i);


### PR DESCRIPTION
<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->


I cloned the Jenkins repository and tried to run `mvn compile`. The build failed with the following error:
```
[ERROR] Failures: 
[ERROR] CronTabTest.testTimezone:314 expected:<[[35, 5]6]> but was:<[[5, 2]6]>
```
I saw the code for the failing test and changed the time zone to match the time zone being tested against.
<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed changelog entries

* `Internal:` Fix `CronTabTest.testTimezone` JUnit test;

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention
@jenkinsci/code-reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention
-->
