### PR TITLE
[JENKINS-55361] DescriptorExtensionList not locking correctly, leading to deadlocks

### DIFF
--- a/core/src/main/java/hudson/DescriptorExtensionList.java
+++ b/core/src/main/java/hudson/DescriptorExtensionList.java
@@ -212,7 +212,7 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
     }
 
     private ExtensionList<Descriptor> getDescriptorExtensionList() {
-        return jenkins.getExtensionList(Descriptor.class);
+        return ExtensionList.lookup(Descriptor.class);
     }
 
     /**

--- a/core/src/main/java/hudson/DescriptorExtensionList.java
+++ b/core/src/main/java/hudson/DescriptorExtensionList.java
@@ -176,6 +176,7 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
      */
     @Override
     protected Object getLoadLock() {
+        // Get a lock for the singleton extension list to prevent deadlocks (JENKINS-55361)
         return getDescriptorExtensionList().getLoadLock();
     }
 

--- a/core/src/main/java/hudson/DescriptorExtensionList.java
+++ b/core/src/main/java/hudson/DescriptorExtensionList.java
@@ -176,7 +176,7 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
      */
     @Override
     protected Object getLoadLock() {
-        return this;
+        return getDescriptorExtensionList().getLoadLock();
     }
 
     /**

--- a/core/src/main/java/hudson/DescriptorExtensionList.java
+++ b/core/src/main/java/hudson/DescriptorExtensionList.java
@@ -161,13 +161,13 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
     @Override
     public boolean add(D d) {
         boolean r = super.add(d);
-        hudson.getExtensionList(Descriptor.class).add(d);
+        getDescriptorExtensionList().add(d);
         return r;
     }
 
     @Override
     public boolean remove(Object o) {
-        hudson.getExtensionList(Descriptor.class).remove(o);
+        getDescriptorExtensionList().remove(o);
         return super.remove(o);
     }
 
@@ -189,7 +189,7 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
             LOGGER.log(Level.WARNING, "Cannot load extension components, because Jenkins instance has not been assigned yet");
             return Collections.emptyList();
         }
-        return _load(jenkins.getExtensionList(Descriptor.class).getComponents());
+        return _load(getDescriptorExtensionList().getComponents());
     }
 
     @Override
@@ -209,6 +209,10 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
             }
         }
         return r;
+    }
+
+    private ExtensionList<Descriptor> getDescriptorExtensionList() {
+        return jenkins.getExtensionList(Descriptor.class);
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-55361](https://issues.jenkins-ci.org/browse/JENKINS-55361).

This PR aims to remove an intermittent deadlock at startup.

Not exactly sure of how to test this appropriately, so did not include any related test.

(Unsure, but might be linked in some way to the underlying problem #3777 is aiming to solve)

### Proposed changelog entries

* Removed a potential startup deadlock situation in extension loading

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests
- ~~For dependency updates: links to external changelogs and, if possible, full diffs~~

### Desired reviewers

@daniel-beck, @oleg-nenashev 
