### PR TITLE
Bumping to frontend-m-p:1.6 for consistency

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -604,7 +604,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>1.4</version>
+            <version>1.6</version>
             <executions>
 
               <execution>


### PR DESCRIPTION
This has been bumped for instance in Blue Ocean already quite some time ago. Also done in plugin-pom more recently.

See:
* https://github.com/jenkinsci/plugin-pom/pull/138
* https://github.com/jenkinsci/blueocean-plugin/pull/1464

No JIRA. Existing tests infra should be enough to catch potential issue, which isn't expected given Blue Ocean has already upgraded and makes a much more intensive of UI features.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* `Internal:` Update `frontend-maven-plugin` from 1.4 to 1.6

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- ~JIRA issue is well described~
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
