### PR TITLE
Simpler check for local file modifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ for(j = 0; j < jdks.size(); j++) {
 
                             if(isUnix()) {
                                 sh mvnCmd
-                                sh 'test `git status --short | tee /dev/stderr | wc --bytes` -eq 0'
+                                sh 'git add . && git diff --exit-code HEAD'
                             } else {
                                 bat mvnCmd
                             }


### PR DESCRIPTION
Simplified version of trick employed in https://github.com/jenkinsci/jenkins/pull/2860, having the benefits of

* showing the actual diff in case of failures
* avoiding `/dev/stderr`, which may not work with `sh`