### PR TITLE
[JENKINS-55449] Add tool to update "@since TODO" entries

### DIFF
--- a/core/src/main/java/hudson/EnvVars.java
+++ b/core/src/main/java/hudson/EnvVars.java
@@ -88,7 +88,7 @@ public class EnvVars extends TreeMap<String,String> {
     
     /**
      * Gets the platform for which these env vars targeted.
-     * @since TODO
+     * @since 2.144
      * @return The platform.
      */
     public @CheckForNull Platform getPlatform() {
@@ -97,7 +97,7 @@ public class EnvVars extends TreeMap<String,String> {
 
     /**
      * Sets the platform for which these env vars target.
-     * @since TODO
+     * @since 2.144
      * @param platform the platform to set.
      */
     public void setPlatform(@Nonnull Platform platform) {

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -964,7 +964,7 @@ public class Util {
     /**
      * Convert {@code null} to a default value.
      * @param defaultValue Default value. It may be immutable or not, depending on the implementation.
-     * @since TODO
+     * @since 2.144
      */
     @Nonnull
     public static <T> T fixNull(@CheckForNull T s, @Nonnull T defaultValue) {

--- a/core/src/main/java/hudson/cli/DisablePluginCommand.java
+++ b/core/src/main/java/hudson/cli/DisablePluginCommand.java
@@ -36,7 +36,7 @@ import java.util.List;
 
 /**
  * Disable one or more installed plugins.
- * @since TODO
+ * @since 2.151
  */
 @Extension
 public class DisablePluginCommand extends CLICommand {

--- a/core/src/main/java/jenkins/model/SimplePageDecorator.java
+++ b/core/src/main/java/jenkins/model/SimplePageDecorator.java
@@ -60,7 +60,7 @@ public class SimplePageDecorator extends Descriptor<SimplePageDecorator> impleme
 
     /**
      * Returns all login page decorators.
-     * @since TODO
+     * @since 2.156
      */
     public static List<SimplePageDecorator> all() {
         return Jenkins.get().getDescriptorList(SimplePageDecorator.class);

--- a/core/src/main/java/jenkins/util/xstream/SafeURLConverter.java
+++ b/core/src/main/java/jenkins/util/xstream/SafeURLConverter.java
@@ -38,7 +38,7 @@ import java.net.URLStreamHandler;
  * for {@link URLStreamHandler#equals(URL, URL)} or {@link URLStreamHandler#hashCode(URL)}. 
  * Required to protect against SECURITY-637
  * 
- * @since TODO
+ * @since 2.121.3
  */
 @Restricted(NoExternalUse.class)
 public class SafeURLConverter extends URLConverter {

--- a/update-since-todo.sh
+++ b/update-since-todo.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This script is a developer tool, to be used by maintainers
+# to update '@since TODO' entries with actual Jenkins release versions.
+
+set -euo pipefail
+
+me=`basename "$0"`
+
+IFS=$'\n'
+for todo in $( git grep --line-number '@since TODO' | grep -v "$me" )
+do
+    #echo "TODO: $todo"
+    file=$( echo $todo | cut -d : -f 1 )
+    line=$( echo $todo | cut -d : -f 2 )
+
+    echo "Analyzing $file:$line"
+
+    lineSha=$( git blame --porcelain -L $line,$line $file | head -1 | cut -d ' ' -f 1 )
+    echo -e "\tfirst sha: $lineSha"
+
+    firstTag=$( git tag --sort=creatordate --contains $lineSha | head -1 )
+
+    if [[ ! -z $firstTag ]]; then
+        echo -e "\tfirst tag was $firstTag"
+        echo -e "\tUpdating file in place"
+        sedExpr="${line}s/@since TODO/@since ${firstTag//jenkins-/}/"
+        sed -i $sedExpr $file
+    else
+        echo -e "\tNot updating file, no tag found. Normal if the associated PR/commit is not merged and released yet"
+    fi
+done


### PR DESCRIPTION
[JENKINS-55449](https://issues.jenkins-ci.org/browse/JENKINS-55449)
No JIRA. No changelog because fully internal/dev tool.

The second commit is a run of the tool, the output was:

```
$ ./update-since-todo.sh
Analyzing core/src/main/java/hudson/EnvVars.java:91
        first sha: 45c837daa920e85f84f288a7337016a853054add
        first tag was jenkins-2.144
        Updating file in place
Analyzing core/src/main/java/hudson/EnvVars.java:100
        first sha: 45c837daa920e85f84f288a7337016a853054add
        first tag was jenkins-2.144
        Updating file in place
Analyzing core/src/main/java/hudson/Util.java:967
        first sha: beadc5946f4415b28cb6d7a3a9cfb8a2782ab316
        first tag was jenkins-2.144
        Updating file in place
Analyzing core/src/main/java/hudson/cli/DisablePluginCommand.java:39
        first sha: 1062f9abd86271bfec678d4f1f103639d11873ca
        first tag was jenkins-2.151
        Updating file in place
Analyzing core/src/main/java/jenkins/model/SimplePageDecorator.java:63
        first sha: 94076ad93c13b4098cc6450676baa1bd425c3d32
        first tag was jenkins-2.156
        Updating file in place
Analyzing core/src/main/java/jenkins/util/xstream/SafeURLConverter.java:41
        first sha: 727d58f690abf64f543407e1de3545eca76ad30e
        first tag was jenkins-2.121.3
        Updating file in place
```
<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- ~JIRA issue is well described~
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- ~Appropriate autotests or explanation to why this change has no tests~
- ~For dependency updates: links to external changelogs and, if possible, full diffs~

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
