### PR TITLE
[WIP] Problem: [JENKINS-55512] Jenkins stalls in quietDown with complex jobs

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2087,7 +2087,7 @@ public class Queue extends ResourceController implements Saveable {
         }
 
 
-		/**
+        /**
          * Project to be built.
          */
         @Exported


### PR DESCRIPTION
Solution: Allow to run tasks that are spawned by tasks,
and only block other build causes if the Jenkins server
is shutting down or otherwise quiescing. Otherwise, it
waits indefinitely for the parent job to complete while
its subsequent children (which the job blocks waiting
for) never run.

Added a couple of "FIXME" comments for possible future
refinement that is not in direct scope of fixing this
deadlock.

This change does not introduce new automated tests for
the functionality, since there I found none to extend and
my Java-fu is not that good to make it from scratch :)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

See [JENKINS-55512](https://issues.jenkins-ci.org/browse/JENKINS-55512).

### Proposed changelog entries

* Entry 1: JENKINS-55512, Fix Jenkins stalls in quietDown with complex jobs

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@oleg-nenashev  @kohsuke @daniel-beck 
