### PR TITLE
[JENKINS-55448] Util delete regression

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1271,7 +1271,7 @@ public final class FilePath implements Serializable {
         private static final long serialVersionUID = 1L;
         @Override
         public Void invoke(File f, VirtualChannel channel) throws IOException {
-            Util.deleteRecursive(fileToPath(f), path -> deleting(path.toFile()).delete());
+            Util.deleteRecursive(fileToPath(f), path -> deleting(path.toFile()));
             return null;
         }
     }
@@ -1286,7 +1286,7 @@ public final class FilePath implements Serializable {
         private static final long serialVersionUID = 1L;
         @Override
         public Void invoke(File f, VirtualChannel channel) throws IOException {
-            Util.deleteContentsRecursive(fileToPath(f), path -> deleting(path.toFile()).delete());
+            Util.deleteContentsRecursive(fileToPath(f), path -> deleting(path.toFile()));
             return null;
         }
     }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1271,7 +1271,7 @@ public final class FilePath implements Serializable {
         private static final long serialVersionUID = 1L;
         @Override
         public Void invoke(File f, VirtualChannel channel) throws IOException {
-            Util.deleteRecursive(deleting(f));
+            Util.deleteRecursive(fileToPath(f), path -> deleting(path.toFile()).delete());
             return null;
         }
     }
@@ -1286,7 +1286,7 @@ public final class FilePath implements Serializable {
         private static final long serialVersionUID = 1L;
         @Override
         public Void invoke(File f, VirtualChannel channel) throws IOException {
-            Util.deleteContentsRecursive(deleting(f));
+            Util.deleteContentsRecursive(fileToPath(f), path -> deleting(path.toFile()).delete());
             return null;
         }
     }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1271,7 +1271,7 @@ public final class FilePath implements Serializable {
         private static final long serialVersionUID = 1L;
         @Override
         public Void invoke(File f, VirtualChannel channel) throws IOException {
-            deleteRecursive(deleting(f));
+            Util.deleteRecursive(deleting(f));
             return null;
         }
     }
@@ -1286,32 +1286,9 @@ public final class FilePath implements Serializable {
         private static final long serialVersionUID = 1L;
         @Override
         public Void invoke(File f, VirtualChannel channel) throws IOException {
-            deleteContentsRecursive(f);
+            Util.deleteContentsRecursive(deleting(f));
             return null;
         }
-    }
-
-    private void deleteRecursive(File dir) throws IOException {
-        if(!isSymlink(dir))
-            deleteContentsRecursive(dir);
-        try {
-            deleteFile(deleting(dir));
-        } catch (IOException e) {
-            // if some of the child directories are big, it might take long enough to delete that
-            // it allows others to create new files, causing problems like JENKINS-10113
-            // so give it one more attempt before we give up.
-            if(!isSymlink(dir))
-                deleteContentsRecursive(dir);
-            deleteFile(deleting(dir));
-        }
-    }
-
-    private void deleteContentsRecursive(File file) throws IOException {
-        File[] files = file.listFiles();
-        if(files==null)
-            return;     // the directory didn't exist in the first place
-        for (File child : files)
-            deleteRecursive(child);
     }
 
     /**

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -30,7 +30,6 @@ import hudson.util.VariableResolver;
 import jenkins.util.SystemProperties;
 
 import jenkins.util.io.PathRemover;
-import jenkins.util.os.windows.WindowsCommandLineFormatter;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
@@ -1275,28 +1274,6 @@ public class Util {
         } catch (Exception x) {
             throw new IOException(x);
         }
-    }
-
-    /**
-     * Creates an NTFS junction point if supported. Similar to symbolic links, NTFS provides junction points which
-     * provide different features than symbolic links. This method is primarily useful for unit testing on Windows.
-     * @param junction NTFS junction point to create
-     * @param target target directory to junction
-     * @return the newly created junction point
-     * @throws IOException if the call to mklink exits with a non-zero status code
-     * @throws InterruptedException if the call to mklink is interrupted before completing
-     * @throws AssertionError if this method is called on a non-Windows platform
-     */
-    static @Nonnull File createJunction(@Nonnull File junction, @Nonnull File target) throws IOException, InterruptedException {
-        if (!Functions.isWindows()) throw new AssertionError("Cannot create junctions on non-Windows platforms");
-        String command = "cmd.exe /C mklink /J " +
-                WindowsCommandLineFormatter.quoteArgumentForCmd(junction.getAbsolutePath()) +
-                ' ' +
-                WindowsCommandLineFormatter.quoteArgumentForCmd(target.getAbsolutePath());
-        Process process = Runtime.getRuntime().exec(command);
-        int result = process.waitFor();
-        if (result != 0) throw new IOException("Command `" + command + "` failed with status code " + result);
-        return junction;
     }
 
     /**

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -245,18 +245,18 @@ public class Util {
      *      if the operation fails.
      */
     public static void deleteContentsRecursive(@Nonnull File file) throws IOException {
-        deleteContentsRecursive(fileToPath(file), path -> true);
+        deleteContentsRecursive(fileToPath(file), PathRemover.PathChecker.ALLOW_ALL);
     }
 
     /**
-     * Deletes the given directory contents (but not the directory itself) recursively using a filter.
+     * Deletes the given directory contents (but not the directory itself) recursively using a PathChecker.
      * @param path a directory to delete
-     * @param pathFilter a predicate that when evaluated to true will delete that path; when false, will ignore that path
+     * @param pathChecker a security check to validate a path before deleting
      * @throws IOException if the operation fails
      */
     @Restricted(NoExternalUse.class)
-    public static void deleteContentsRecursive(@Nonnull Path path, @Nonnull Predicate<Path> pathFilter) throws IOException {
-        newPathRemover(pathFilter).forceRemoveDirectoryContents(path);
+    public static void deleteContentsRecursive(@Nonnull Path path, @Nonnull PathRemover.PathChecker pathChecker) throws IOException {
+        newPathRemover(pathChecker).forceRemoveDirectoryContents(path);
     }
 
     /**
@@ -267,7 +267,7 @@ public class Util {
      * @throws IOException if it exists but could not be successfully deleted
      */
     public static void deleteFile(@Nonnull File f) throws IOException {
-        newPathRemover(path -> true).forceRemoveFile(fileToPath(f));
+        newPathRemover(PathRemover.PathChecker.ALLOW_ALL).forceRemoveFile(fileToPath(f));
     }
 
     /**
@@ -279,18 +279,18 @@ public class Util {
      * if the operation fails.
      */
     public static void deleteRecursive(@Nonnull File dir) throws IOException {
-        deleteRecursive(fileToPath(dir), path -> true);
+        deleteRecursive(fileToPath(dir), PathRemover.PathChecker.ALLOW_ALL);
     }
 
     /**
      * Deletes the given directory and contents recursively using a filter.
      * @param dir a directory to delete
-     * @param pathFilter a predicate that when evaluated to true will delete that path; when false, will ignore that path
+     * @param pathChecker a security check to validate a path before deleting
      * @throws IOException if the operation fails
      */
     @Restricted(NoExternalUse.class)
-    public static void deleteRecursive(@Nonnull Path dir, @Nonnull Predicate<Path> pathFilter) throws IOException {
-        newPathRemover(pathFilter).forceRemoveRecursive(dir);
+    public static void deleteRecursive(@Nonnull Path dir, @Nonnull PathRemover.PathChecker pathChecker) throws IOException {
+        newPathRemover(pathChecker).forceRemoveRecursive(dir);
     }
 
     /*
@@ -1593,8 +1593,8 @@ public class Util {
     @Restricted(value = NoExternalUse.class)
     static boolean GC_AFTER_FAILED_DELETE = SystemProperties.getBoolean(Util.class.getName() + ".performGCOnFailedDelete");
 
-    private static PathRemover newPathRemover(@Nonnull Predicate<Path> pathFilter) {
-        return PathRemover.newFilteredRobustRemover(pathFilter, DELETION_MAX - 1, GC_AFTER_FAILED_DELETE, WAIT_BETWEEN_DELETION_RETRIES);
+    private static PathRemover newPathRemover(@Nonnull PathRemover.PathChecker pathChecker) {
+        return PathRemover.newFilteredRobustRemover(pathChecker, DELETION_MAX - 1, GC_AFTER_FAILED_DELETE, WAIT_BETWEEN_DELETION_RETRIES);
     }
 
     /**

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1303,7 +1303,7 @@ public class Util {
      * Escapes a Windows cmd argument. Cmd supports escaping characters with carats which simplifies nested escapes.
      * @param arg argument to escape
      * @return the quoted argument for use in cmd.exe
-     * @see <a href="https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/>Everyone quotes command line arguments the wrong way</a>
+     * @see <a href="https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way">Everyone quotes command line arguments the wrong way</a>
      */
     @VisibleForTesting
     static String escapeCmdArgument(String arg) {

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -75,6 +75,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -241,7 +242,18 @@ public class Util {
      *      if the operation fails.
      */
     public static void deleteContentsRecursive(@Nonnull File file) throws IOException {
-        newPathRemover().forceRemoveDirectoryContents(fileToPath(file));
+        deleteContentsRecursive(fileToPath(file), path -> true);
+    }
+
+    /**
+     * Deletes the given directory contents (but not the directory itself) recursively using a filter.
+     * @param path a directory to delete
+     * @param pathFilter a predicate that when evaluated to true will delete that path; when false, will ignore that path
+     * @throws IOException if the operation fails
+     */
+    @Restricted(NoExternalUse.class)
+    public static void deleteContentsRecursive(@Nonnull Path path, @Nonnull Predicate<Path> pathFilter) throws IOException {
+        newPathRemover(pathFilter).forceRemoveDirectoryContents(path);
     }
 
     /**
@@ -252,7 +264,7 @@ public class Util {
      * @throws IOException if it exists but could not be successfully deleted
      */
     public static void deleteFile(@Nonnull File f) throws IOException {
-        newPathRemover().forceRemoveFile(fileToPath(f));
+        newPathRemover(path -> true).forceRemoveFile(fileToPath(f));
     }
 
     /**
@@ -264,7 +276,18 @@ public class Util {
      * if the operation fails.
      */
     public static void deleteRecursive(@Nonnull File dir) throws IOException {
-        newPathRemover().forceRemoveRecursive(fileToPath(dir));
+        deleteRecursive(fileToPath(dir), path -> true);
+    }
+
+    /**
+     * Deletes the given directory and contents recursively using a filter.
+     * @param dir a directory to delete
+     * @param pathFilter a predicate that when evaluated to true will delete that path; when false, will ignore that path
+     * @throws IOException if the operation fails
+     */
+    @Restricted(NoExternalUse.class)
+    public static void deleteRecursive(@Nonnull Path dir, @Nonnull Predicate<Path> pathFilter) throws IOException {
+        newPathRemover(pathFilter).forceRemoveRecursive(dir);
     }
 
     /*
@@ -1560,8 +1583,8 @@ public class Util {
     @Restricted(value = NoExternalUse.class)
     static boolean GC_AFTER_FAILED_DELETE = SystemProperties.getBoolean(Util.class.getName() + ".performGCOnFailedDelete");
 
-    private static PathRemover newPathRemover() {
-        return PathRemover.newRobustRemover(DELETION_MAX - 1, GC_AFTER_FAILED_DELETE, WAIT_BETWEEN_DELETION_RETRIES);
+    private static PathRemover newPathRemover(@Nonnull Predicate<Path> pathFilter) {
+        return PathRemover.newFilteredRobustRemover(pathFilter, DELETION_MAX - 1, GC_AFTER_FAILED_DELETE, WAIT_BETWEEN_DELETION_RETRIES);
     }
 
     /**

--- a/core/src/main/java/jenkins/util/os/windows/WindowsCommandLineFormatter.java
+++ b/core/src/main/java/jenkins/util/os/windows/WindowsCommandLineFormatter.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.util.os.windows;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.Nonnull;
+import java.util.regex.Pattern;
+
+/**
+ * Provides formatting utilities for Windows command line processes.
+ *
+ * @see <a href="https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way">Everyone quotes command line arguments the wrong way</a>
+ */
+@Restricted(NoExternalUse.class)
+public final class WindowsCommandLineFormatter {
+    private WindowsCommandLineFormatter() {
+    }
+
+    /**
+     * Quotes an argument while escaping special characters interpreted by CreateProcess.
+     */
+    public static @Nonnull String quoteArgument(@Nonnull String argument) {
+        StringBuilder sb = new StringBuilder();
+        sb.append('"');
+        int end = argument.length();
+        for (int i = 0; i < end; i++) {
+            int nrBackslashes = 0;
+            while (i < end && argument.charAt(i) == '\\') {
+                i++;
+                nrBackslashes++;
+            }
+
+            if (i == end) {
+                // backslashes at the end of the argument must be escaped so the terminate quote isn't
+                nrBackslashes = nrBackslashes * 2;
+            } else if (argument.charAt(i) == '"') {
+                // backslashes preceding a quote all need to be escaped along with the quote
+                nrBackslashes = nrBackslashes * 2 + 1;
+            }
+            // else backslashes have no special meaning and don't need to be escaped here
+
+            for (int j = 0; j < nrBackslashes; j++) {
+                sb.append('\\');
+            }
+
+            if (i < end) {
+                sb.append(argument.charAt(i));
+            }
+        }
+        return sb.append('"').toString();
+    }
+
+    private static final Pattern CMD_METACHARS = Pattern.compile("[()%!^\"<>&|]");
+
+    /**
+     * Quotes an argument while escaping special characters suitable for use as an argument to {@code cmd.exe}.
+     */
+    public static @Nonnull String quoteArgumentForCmd(@Nonnull String argument) {
+        return CMD_METACHARS.matcher(quoteArgument(argument)).replaceAll("^$0");
+    }
+
+}

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -26,6 +26,7 @@ package hudson;
 import hudson.FilePath.TarCompression;
 import hudson.model.TaskListener;
 import hudson.os.PosixAPI;
+import hudson.os.WindowsUtil;
 import hudson.remoting.VirtualChannel;
 import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
@@ -836,7 +837,7 @@ public class FilePathTest {
         Path targetDir = temp.newFolder("targetDir").toPath();
         Path targetContents = Files.createFile(targetDir.resolve("contents.txt"));
         Path toDelete = temp.newFolder("toDelete").toPath();
-        File junction = Util.createJunction(toDelete.resolve("junction").toFile(), targetDir.toFile());
+        File junction = WindowsUtil.createJunction(toDelete.resolve("junction").toFile(), targetDir.toFile());
         Files.createFile(toDelete.resolve("foo"));
         Files.createFile(toDelete.resolve("bar"));
         FilePath f = new FilePath(toDelete.toFile());

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -836,17 +836,14 @@ public class FilePathTest {
         Path targetDir = temp.newFolder("targetDir").toPath();
         Path targetContents = Files.createFile(targetDir.resolve("contents.txt"));
         Path toDelete = temp.newFolder("toDelete").toPath();
-        Process p = new ProcessBuilder()
-                .directory(toDelete.toFile())
-                .command("cmd.exe", "/C", "mklink /J junction ..\\targetDir")
-                .start();
-        assumeThat("unable to create junction", p.waitFor(), is(0));
+        File junction = Util.createJunction(toDelete.resolve("junction").toFile(), targetDir.toFile());
         Files.createFile(toDelete.resolve("foo"));
         Files.createFile(toDelete.resolve("bar"));
         FilePath f = new FilePath(toDelete.toFile());
         f.deleteRecursive();
         assertTrue("junction target should not be deleted", Files.exists(targetDir));
         assertTrue("junction target contents should not be deleted", Files.exists(targetContents));
+        assertFalse("could not delete junction", junction.exists());
         assertFalse("could not delete target", Files.exists(toDelete));
     }
 

--- a/core/src/test/java/hudson/RemoveWindowsDirectoryJunctionTest.java
+++ b/core/src/test/java/hudson/RemoveWindowsDirectoryJunctionTest.java
@@ -3,7 +3,6 @@
  */
 package hudson;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
@@ -33,19 +32,10 @@ public class RemoveWindowsDirectoryJunctionTest {
         File subdir1 = tmp.newFolder("notJunction");
         File f1 = new File(subdir1, "testfile1.txt");
         assertTrue("Unable to create temporary file in notJunction directory", f1.createNewFile());
-        File j1 = makeJunction(tmp.getRoot(), subdir1);
+        File j1 = Util.createJunction(tmp.getRoot(), subdir1);
         Util.deleteRecursive(j1);
         assertFalse("Windows Junction should have been removed", j1.exists());
         assertTrue("Contents of Windows Junction should not be removed", f1.exists());
     }
 
-    private File makeJunction(File baseDir, File pointToDir) throws Exception {
-       File junc = new File(baseDir, "test Junction");
-       String cmd = "mklink /J \"" + junc.getPath() + "\" \"" + pointToDir.getPath() + "\"";
-       ProcessBuilder pb = new ProcessBuilder("cmd.exe", "/C", cmd);
-       pb.inheritIO();
-       Process p = pb.start();
-       assertEquals("Running mklink failed (cmd=" + cmd + ")", 0, p.waitFor());
-       return junc;
-    }
 }

--- a/core/src/test/java/hudson/RemoveWindowsDirectoryJunctionTest.java
+++ b/core/src/test/java/hudson/RemoveWindowsDirectoryJunctionTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
+
+import hudson.os.WindowsUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,7 +34,7 @@ public class RemoveWindowsDirectoryJunctionTest {
         File subdir1 = tmp.newFolder("notJunction");
         File f1 = new File(subdir1, "testfile1.txt");
         assertTrue("Unable to create temporary file in notJunction directory", f1.createNewFile());
-        File j1 = Util.createJunction(tmp.getRoot(), subdir1);
+        File j1 = WindowsUtil.createJunction(tmp.getRoot(), subdir1);
         Util.deleteRecursive(j1);
         assertFalse("Windows Junction should have been removed", j1.exists());
         assertTrue("Contents of Windows Junction should not be removed", f1.exists());

--- a/core/src/test/java/hudson/RemoveWindowsDirectoryJunctionTest.java
+++ b/core/src/test/java/hudson/RemoveWindowsDirectoryJunctionTest.java
@@ -34,7 +34,7 @@ public class RemoveWindowsDirectoryJunctionTest {
         File subdir1 = tmp.newFolder("notJunction");
         File f1 = new File(subdir1, "testfile1.txt");
         assertTrue("Unable to create temporary file in notJunction directory", f1.createNewFile());
-        File j1 = WindowsUtil.createJunction(tmp.getRoot(), subdir1);
+        File j1 = WindowsUtil.createJunction(new File(tmp.getRoot(), "test junction"), subdir1);
         Util.deleteRecursive(j1);
         assertFalse("Windows Junction should have been removed", j1.exists());
         assertTrue("Contents of Windows Junction should not be removed", f1.exists());

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.*;
 
+import hudson.os.WindowsUtil;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Assume;
@@ -262,7 +263,7 @@ public class UtilTest {
         Assume.assumeTrue("Uses Windows-specific features", Functions.isWindows());
         File targetDir = tmp.newFolder("targetDir");
         File d = tmp.newFolder("dir");
-        File junction = Util.createJunction(new File(d, "junction"), targetDir);
+        File junction = WindowsUtil.createJunction(new File(d, "junction"), targetDir);
         assertTrue(Util.isSymlink(junction));
     }
 
@@ -274,7 +275,7 @@ public class UtilTest {
         File file = new File(targetDir, "test-file");
         new FilePath(file).touch(System.currentTimeMillis());
         File dir = tmp.newFolder();
-        File junction = Util.createJunction(new File(dir, "junction"), targetDir);
+        File junction = WindowsUtil.createJunction(new File(dir, "junction"), targetDir);
 
         assertTrue(Util.isSymlink(junction));
         assertFalse(Util.isSymlink(file));

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -258,14 +258,6 @@ public class UtilTest {
     }
 
     @Test
-    public void testEscapeCmdArgument() {
-        String raw = "hello \"\\world&";
-        String expected = "^\"hello ^\"\\world^&^\"";
-        String actual = Util.escapeCmdArgument(raw);
-        assertEquals(expected, actual);
-    }
-
-    @Test
     public void testIsSymlink_onWindows_junction() throws Exception {
         Assume.assumeTrue("Uses Windows-specific features", Functions.isWindows());
         File targetDir = tmp.newFolder("targetDir");

--- a/core/src/test/java/hudson/os/WindowsUtil.java
+++ b/core/src/test/java/hudson/os/WindowsUtil.java
@@ -39,10 +39,13 @@ import static org.junit.Assert.assertTrue;
 // adapted from:
 // https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
 public class WindowsUtil {
+    private static final Pattern NEEDS_QUOTING = Pattern.compile("[\\s\"]");
+
     /**
      * Quotes an argument while escaping special characters interpreted by CreateProcess.
      */
     public static @Nonnull String quoteArgument(@Nonnull String argument) {
+        if (!NEEDS_QUOTING.matcher(argument).find()) return argument;
         StringBuilder sb = new StringBuilder();
         sb.append('"');
         int end = argument.length();

--- a/core/src/test/java/hudson/os/WindowsUtil.java
+++ b/core/src/test/java/hudson/os/WindowsUtil.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertTrue;
 
+// adapted from:
+// https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
 public class WindowsUtil {
     /**
      * Quotes an argument while escaping special characters interpreted by CreateProcess.

--- a/core/src/test/java/hudson/os/WindowsUtilTest.java
+++ b/core/src/test/java/hudson/os/WindowsUtilTest.java
@@ -22,19 +22,21 @@
  * THE SOFTWARE.
  */
 
-package jenkins.util.os.windows;
+package hudson.os;
 
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class WindowsCommandLineFormatterTest {
-
+/**
+ * Test the test utility code, too!
+ */
+public class WindowsUtilTest {
     @Test
     public void testQuoteArgument() {
         String input = "C:\\Programs and \"Settings\"\\System32\\\\";
         String expected = "\"C:\\Programs and \\\"Settings\\\"\\System32\\\\\\\\\"";
-        String actual = WindowsCommandLineFormatter.quoteArgument(input);
+        String actual = WindowsUtil.quoteArgument(input);
         assertEquals(expected, actual);
     }
 
@@ -42,7 +44,7 @@ public class WindowsCommandLineFormatterTest {
     public void testQuoteArgumentForCmd() {
         String input = "hello \"\\world&";
         String expected = "^\"hello \\^\"\\world^&^\"";
-        String actual = WindowsCommandLineFormatter.quoteArgumentForCmd(input);
+        String actual = WindowsUtil.quoteArgumentForCmd(input);
         assertEquals(expected, actual);
     }
 }

--- a/core/src/test/java/hudson/os/WindowsUtilTest.java
+++ b/core/src/test/java/hudson/os/WindowsUtilTest.java
@@ -26,6 +26,8 @@ package hudson.os;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 
 /**
@@ -41,10 +43,24 @@ public class WindowsUtilTest {
     }
 
     @Test
+    public void testQuoteArgument_OnlyQuotesWhenNecessary() {
+        for (String arg : Arrays.asList("", "foo", "foo-bar", "C:\\test\\path", "http://www.example.com/")) {
+            assertEquals(arg, WindowsUtil.quoteArgument(arg));
+        }
+    }
+
+    @Test
     public void testQuoteArgumentForCmd() {
         String input = "hello \"\\world&";
         String expected = "^\"hello \\^\"\\world^&^\"";
         String actual = WindowsUtil.quoteArgumentForCmd(input);
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testQuoteArgumentForCmd_OnlyQuotesWhenNecessary() {
+        for (String arg : Arrays.asList("", "foo", "foo-bar", "C:\\test\\path", "http://www.example.com/")) {
+            assertEquals(arg, WindowsUtil.quoteArgumentForCmd(arg));
+        }
     }
 }

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -36,6 +36,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.spi.FileSystemProvider;
@@ -138,6 +140,19 @@ public class PathRemoverTest {
         remover.forceRemoveFile(file.toPath());
 
         assertFalse("Unable to delete file: " + file, file.exists());
+    }
+
+    @Test
+    public void testForceRemoveFile_SymbolicLink() throws IOException {
+        File file = tmp.newFile();
+        touchWithFileName(file);
+        Path link = Files.createSymbolicLink(tmp.getRoot().toPath().resolve("test-link"), file.toPath());
+
+        PathRemover remover = PathRemover.newSimpleRemover();
+        remover.forceRemoveFile(link);
+
+        assertTrue("Unable to delete symbolic link: " + link, Files.notExists(link, LinkOption.NOFOLLOW_LINKS));
+        assertTrue("Should not have deleted target file: " + file, file.exists());
     }
 
     @Test

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -366,6 +366,25 @@ public class PathRemoverTest {
         assertTrue("Unable to delete directory: " + folder, Files.notExists(path));
     }
 
+    @Test
+    @Issue("JENKINS-55448")
+    public void testForceRemoveRecursive_ParentIsSymbolicLink() throws IOException {
+        File folder = tmp.newFolder();
+        File d1 = new File(folder, "d1");
+        File d1f1 = new File(d1, "d1f1");
+        File f2 = new File(folder, "f2");
+        mkdirs(d1);
+        touchWithFileName(d1f1, f2);
+        Path symlink = Files.createSymbolicLink(tmp.getRoot().toPath().resolve("linked"), folder.toPath());
+        Path d1p = symlink.resolve("d1");
+
+        PathRemover remover = PathRemover.newSimpleRemover();
+        remover.forceRemoveRecursive(d1p);
+
+        assertTrue("Unable to delete directory: " + d1p, Files.notExists(d1p));
+        assertFalse(d1.exists());
+    }
+
     private static void mkdirs(File... dirs) {
         for (File dir : dirs) {
             assertTrue("Could not mkdir " + dir, dir.mkdir());

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -39,6 +40,7 @@ import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
@@ -344,6 +346,23 @@ public class PathRemoverTest {
         for (File file : Arrays.asList(d1, d1f1, f2)) {
             assertTrue("Should not have deleted target: " + file, file.exists());
         }
+    }
+
+    @Test
+    @Issue("JENKINS-55448")
+    public void testForceRemoveRecursive_ContainsDotPath() throws IOException {
+        File folder = tmp.newFolder();
+        File d1 = new File(folder, "d1");
+        File d1f1 = new File(d1, "d1f1");
+        File f2 = new File(folder, "f2");
+        mkdirs(d1);
+        touchWithFileName(d1f1, f2);
+        Path path = Paths.get(d1.getPath(), "..", "d1");
+
+        PathRemover remover = PathRemover.newSimpleRemover();
+        remover.forceRemoveRecursive(path);
+
+        assertTrue("Unable to delete directory: " + folder, Files.notExists(path));
     }
 
     private static void mkdirs(File... dirs) {

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -91,6 +91,7 @@ public class PathRemoverTest {
         given(path.toString()).willReturn(filename);
         given(path.toFile()).willReturn(file);
         given(path.getFileSystem()).willReturn(fs);
+        given(path.normalize()).willReturn(path);
         given(fs.provider()).willReturn(fsProvider);
         given(fsProvider.deleteIfExists(path)).willThrow(new FileSystemException(filename));
         given(fsProvider.readAttributes(path, BasicFileAttributes.class)).willReturn(attributes);

--- a/core/src/test/java/jenkins/util/os/windows/WindowsCommandLineFormatterTest.java
+++ b/core/src/test/java/jenkins/util/os/windows/WindowsCommandLineFormatterTest.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.util.os.windows;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class WindowsCommandLineFormatterTest {
+
+    @Test
+    public void testQuoteArgument() {
+        String input = "C:\\Programs and \"Settings\"\\System32\\\\";
+        String expected = "\"C:\\Programs and \\\"Settings\\\"\\System32\\\\\\\\\"";
+        String actual = WindowsCommandLineFormatter.quoteArgument(input);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testQuoteArgumentForCmd() {
+        String input = "hello \"\\world&";
+        String expected = "^\"hello \\^\"\\world^&^\"";
+        String actual = WindowsCommandLineFormatter.quoteArgumentForCmd(input);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
See [JENKINS-55448](https://issues.jenkins-ci.org/browse/JENKINS-55448). This is a followup to https://github.com/jenkinsci/jenkins/pull/3812

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fix `jenkins.util.io.CompositeIOException` thrown where workspaces and other directories/files could not be deleted when any of its ancestor files are a symbolic link or junction point or contain path entries of `.` or `..`. ([issue 55448](https://issues.jenkins-ci.org/browse/JENKINS-55448), [issue 55450](https://issues.jenkins-ci.org/browse/JENKINS-55450))
* Internal: Add path checking support to `jenkins.util.io.PathRemover` to help simplify `hudson.FilePath` deletion methods.
* Internal: Revert behavior of `hudson.Util.isSymlink()` to previous algorithm.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
~~- [ ] For dependency updates: links to external changelogs and, if possible, full diffs~~

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jeffret-b @daniel-beck @kevinearls @MRamonLeon @fcojfernandez 
@jenkinsci/code-reviewers
