### PR TITLE
Bump to executable-war:1.44

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -49,7 +49,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>executable-war</artifactId>
-      <version>1.41</version>
+      <version>1.44</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
No JIRA. Trivial change.

* Changelog https://github.com/jenkinsci/extras-executable-war/blob/master/CHANGELOG.md#144 (1.42 and 1.43 were burnt)
    * Only change picked up is https://github.com/jenkinsci/extras-executable-war/pull/20 
* Full diff https://github.com/jenkinsci/extras-executable-war/compare/executable-war-1.41...executable-war-1.44

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Update dependency `executable-war` to `1.44`, allowing to use `JENKINS_ENABLE_FUTURE_JAVA` environment variable as an alternative to the `--enable-future-java` CLI switch.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- ~JIRA issue is well described~
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/java11-support 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
