### PR TITLE
[JENKINS-55050] Reduce log impact on performance

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -447,7 +447,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
 
                 String targetFile = dir.toString().substring(root.toString().length()) + n;
                 if (!ALLOW_SYMLINK_ESCAPE && root.supportIsDescendant() && !root.isDescendant(targetFile)) {
-                    LOGGER.log(Level.FINE, "Trying to access a file outside of the directory: " + root + ", illicit target: " + targetFile);
+                    LOGGER.log(Level.FINE, "Trying to access a file outside of the directory: {0}, forbidden target: {1}", new Object[] {root, targetFile});
                 } else {
                     // In ZIP archives "All slashes MUST be forward slashes" (http://pkware.com/documents/casestudies/APPNOTE.TXT)
                     // TODO On Linux file names can contain backslashes which should not treated as file separators.

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -447,7 +447,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
 
                 String targetFile = dir.toString().substring(root.toString().length()) + n;
                 if (!ALLOW_SYMLINK_ESCAPE && root.supportIsDescendant() && !root.isDescendant(targetFile)) {
-                    LOGGER.log(Level.INFO, "Trying to access a file outside of the directory: " + root + ", illicit target: " + targetFile);
+                    LOGGER.log(Level.FINE, "Trying to access a file outside of the directory: " + root + ", illicit target: " + targetFile);
                 } else {
                     // In ZIP archives "All slashes MUST be forward slashes" (http://pkware.com/documents/casestudies/APPNOTE.TXT)
                     // TODO On Linux file names can contain backslashes which should not treated as file separators.

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -75,7 +75,7 @@ import org.kohsuke.stapler.StaplerResponse;
 public final class DirectoryBrowserSupport implements HttpResponse {
     // escape hatch for SECURITY-904 to keep legacy behavior
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
-    public static boolean ALLOW_SYMLINK_ESCAPE = Boolean.getBoolean(DirectoryBrowserSupport.class.getName() + ".allowSymlinkEscape");
+    public static boolean ALLOW_SYMLINK_ESCAPE = SystemProperties.getBoolean(DirectoryBrowserSupport.class.getName() + ".allowSymlinkEscape");
 
     public final ModelObject owner;
     


### PR DESCRIPTION
- especially in case of large / deep folder that is fully illegal
- could reduce time by a factor of around 2.

See [JENKINS-55050](https://issues.jenkins-ci.org/browse/JENKINS-55050).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Improve the performance while ziping a large / deep folder outside of the workspace

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

