### PR TITLE
[JENKINS-55257] If ConsoleNote.encodeToBytes is called at all from an agent, it should not use AnonymousClassWarnings

### DIFF
--- a/core/src/main/java/hudson/console/ConsoleNote.java
+++ b/core/src/main/java/hudson/console/ConsoleNote.java
@@ -56,6 +56,8 @@ import jenkins.security.HMACConfidentialKey;
 import jenkins.util.JenkinsJVM;
 import jenkins.util.SystemProperties;
 import org.jenkinsci.remoting.util.AnonymousClassWarnings;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Data that hangs off from a console output.
@@ -131,7 +133,8 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
      * Disables checking of {@link #MAC} so do not set this flag unless you completely trust all users capable of affecting build output,
      * which in practice means that all SCM committers as well as all Jenkins users with any non-read-only access are consider administrators.
      */
-    static /* nonfinal for tests & script console */ boolean INSECURE = SystemProperties.getBoolean(ConsoleNote.class.getName() + ".INSECURE");
+    @Restricted(NoExternalUse.class)
+    public static /* nonfinal for tests & script console */ boolean INSECURE = SystemProperties.getBoolean(ConsoleNote.class.getName() + ".INSECURE");
 
     /**
      * When the line of a console output that this annotation is attached is read by someone,

--- a/core/src/main/java/hudson/console/ConsoleNote.java
+++ b/core/src/main/java/hudson/console/ConsoleNote.java
@@ -183,7 +183,7 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
     private ByteArrayOutputStream encodeToBytes() throws IOException {
         ByteArrayOutputStream buf = new ByteArrayOutputStream();
         try (OutputStream gzos = new GZIPOutputStream(buf);
-             ObjectOutputStream oos = new ObjectOutputStream(JenkinsJVM.isJenkinsJVM() ? AnonymousClassWarnings.checkingObjectOutputStream(gzos) : gzos)) {
+             ObjectOutputStream oos = JenkinsJVM.isJenkinsJVM() ? AnonymousClassWarnings.checkingObjectOutputStream(gzos) : new ObjectOutputStream(gzos)) {
             oos.writeObject(this);
         }
 


### PR DESCRIPTION
Fix for [JENKINS-55257](https://issues.jenkins-ci.org/browse/JENKINS-55257), though https://github.com/jenkinsci/timestamper-plugin/pull/25 addresses the root issue. Possibly triggered by changes done in JEP-210 (remoting `ConsoleLogFilter`s), though the real problem was introduced in https://github.com/jenkinsci/jenkins/pull/3333.

Proposed changelog entry:
* When using certain console annotators such as the Timestamper plugin in conjunction with certain Pipeline steps such as `git` and an agent using an old `slave.jar`, builds could break with an `IllegalAccessError`.