### PR TITLE
Deprecating ParserConfigurator

### DIFF
--- a/core/src/main/java/hudson/util/io/ParserConfigurator.java
+++ b/core/src/main/java/hudson/util/io/ParserConfigurator.java
@@ -52,7 +52,9 @@ import java.util.Collections;
  *
  * @author Kohsuke Kawaguchi
  * @since 1.416
+ * @deprecated No longer used.
  */
+@Deprecated
 public abstract class ParserConfigurator implements ExtensionPoint, Serializable {
     private static final long serialVersionUID = -2523542286453177108L;
 


### PR DESCRIPTION
As I suggested in https://github.com/jenkinsci/jenkins/pull/2806#pullrequestreview-27413774. This is unused as of https://github.com/jenkinsci/junit-plugin/pull/65 and its follow-up https://github.com/jenkinsci/junit-plugin/commit/14e7403be774bee43b3f226a4dbdfdc449469a76. (Except for [this copy-pasta](https://github.com/jenkinsci/flaky-test-handler-plugin/blob/1f677a545ee8bd6ab160e81417fb36ad6ef16e5e/src/main/java/com/google/jenkins/flakyTestHandler/junit/FlakySuiteResult.java#L88-L109) in a plugin with <1000 installations which I think needs a lot of work anyway.) CC @jerrinot