### PR TITLE
Update WinSW from 2.1.2 to 2.2.0 for agents and masters

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -778,7 +778,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>com.sun.winsw</groupId>
                   <artifactId>winsw</artifactId>
-                  <version>2.1.2</version>
+                  <version>2.2.0</version>
                   <classifier>bin</classifier>
                   <type>exe</type>
                   <outputDirectory>${project.build.outputDirectory}/windows-service</outputDirectory>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -110,7 +110,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>windows-slave-installer</artifactId>
-      <version>1.9.3</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
Updates WinSW in Windows Agent Installer and Jenkins Core in order to pick up new logging options and Runaway Process Killer logging improvements. https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md#220

### Proposed changelog entries

* RFE: Update Windows Service Wrapper from 2.1.2 to 2.2.0 to support disabling, renaming and archiving service logs
  * WinSW changelog and documentation: https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md#220
  * Windows Agent Installer 1.10 changelog: https://github.com/jenkinsci/windows-slave-installer-module/blob/master/CHANGELOG.md#1100

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/core 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
