### PR TITLE
Installation wizard: replaced analysis plugins with Warnings Next Generation Plugin

### DIFF
--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -35,11 +35,10 @@
     {
         "category":"Build Analysis and Reporting",
         "plugins": [
-            { "name": "checkstyle" },
             { "name": "cobertura" },
             { "name": "htmlpublisher" },
             { "name": "junit" },
-            { "name": "warnings" },
+            { "name": "warnings-ng" },
             { "name": "xunit" }
         ]
     },
@@ -84,7 +83,7 @@
     },
     {
         "category":"User Management and Security",
-        "plugins": [            
+        "plugins": [
             { "name": "matrix-auth", "suggested": true },
             { "name": "pam-auth", "suggested": true },
             { "name": "ldap", "suggested": true },


### PR DESCRIPTION
Since a couple of weeks the [Warnings Next Generations Plugin](https://github.com/jenkinsci/warnings-ng-plugin) is available. It replaces the whole static analysis suite, in particular the plugins Checkstyle and Warnings which are currently part of the default installation selection list. Therefore I removed these two end-of-life plugins and replaced them with the new [warnings-ng](https://github.com/jenkinsci/warnings-ng-plugin) plugin.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Enhancement, Replaced Warnings and Checkstyle plugins with Warnings Next Generation Plugin in installation wizard.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->