### PR TITLE
Improve alignment of settings widgets

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -300,6 +300,11 @@ pre.console {
   padding-top: 0;
 }
 
+.setting-name, .setting-main > input, .setting-main > textarea {
+  vertical-align: middle;
+  margin-top: 0;
+}
+
 /* tabBar */
 
 .tabBar {


### PR DESCRIPTION
At some point, the default layout for various widgets input/textarea/label may have changed a bit. But at least in modern time, the behavior of input-type=checkbox w/ label as rendered w/ the jenkins styles is pretty bad, and the use of td{vertical-align:top} makes for a pretty ugly outcome when a setting interacts with an input.

## Before
![image](https://user-images.githubusercontent.com/2119212/51520839-c7a0b500-1df2-11e9-9375-7f4103a0232f.png)
## After
![image](https://user-images.githubusercontent.com/2119212/51520845-ca9ba580-1df2-11e9-8039-e6704c4d137a.png)

### Proposed changelog entries

* Entry 1: Improve alignment of form widgets with labels

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)

### Desired reviewers