### PR TITLE
When a node is back to normal, log as INFO instead of WARN

### DIFF
--- a/core/src/main/java/hudson/node_monitors/AbstractDiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractDiskSpaceMonitor.java
@@ -47,7 +47,7 @@ public abstract class AbstractDiskSpaceMonitor extends NodeMonitor {
         if(size!=null && size.size > getThresholdBytes() && c.isOffline() && c.getOfflineCause() instanceof DiskSpace)
             if(this.getClass().equals(((DiskSpace)c.getOfflineCause()).getTrigger()))
                 if(getDescriptor().markOnline(c)) {
-                    LOGGER.warning(Messages.DiskSpaceMonitor_MarkedOnline(c.getName()));
+                    LOGGER.info(Messages.DiskSpaceMonitor_MarkedOnline(c.getName()));
                 }
         return size;
     }


### PR DESCRIPTION
I think when a node becomes available again automatically after a disk space issue is resolved, INFO is enough (even more given Jenkins has INFO as displayed by default)

No JIRA nor additional automated tests deemed needed.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Lower log level from `WARN` to `INFO` when a node is automatically put back online after a disk space issue is resolved

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- ~JIRA issue is well described~
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- ~For dependency updates: links to external changelogs and, if possible, full diffs~

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@rtyler FYI

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

(For reference, this surfaced in Evergreen backend as `EVERGREEN-F7`).