### PR TITLE
Optimize FilePath.readToString

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2031,14 +2031,13 @@ public final class FilePath implements Serializable {
      */
     public String readToString() throws IOException, InterruptedException {
         return act(new ReadToString());
-    }
+    } 
     private final class ReadToString extends SecureFileCallable<String> {
-        private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;       
         @Override
         public String invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
             return new String(Files.readAllBytes(fileToPath(reading(f))));
         }
-
     }
 
     /**

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2045,9 +2045,15 @@ public final class FilePath implements Serializable {
      * Reads this file into a string, by using the current system encoding.
      */
     public String readToString() throws IOException, InterruptedException {
-        try (InputStream in = read()) {
-            return org.apache.commons.io.IOUtils.toString(in);
+        return act(new ReadToString());
+    }
+    private final class ReadToString extends SecureFileCallable<String> {
+        private static final long serialVersionUID = 1L;
+        @Override
+        public String invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+            return new String(Files.readAllBytes(fileToPath(reading(f))));
         }
+
     }
 
     /**

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2028,7 +2028,7 @@ public final class FilePath implements Serializable {
     }
 
     /**
-     * Reads this file into a string, by using the current system encoding.
+     * Reads this file into a string, by using the current system encoding on the remote machine.
      */
     public String readToString() throws IOException, InterruptedException {
         return act(new ReadToString());
@@ -2080,7 +2080,7 @@ public final class FilePath implements Serializable {
      * Overwrites this file by placing the given String as the content.
      *
      * @param encoding
-     *      Null to use the platform default encoding.
+     *      Null to use the platform default encoding on the remote machine.
      * @since 1.105
      */
     public void write(final String content, final String encoding) throws IOException, InterruptedException {

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -81,7 +81,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.LinkOption;
@@ -3306,13 +3305,9 @@ public final class FilePath implements Serializable {
                     // in case this folder / file will be copied somewhere else, 
                     // it becomes the responsibility of that system to check the isDescendant with the existing links
                     // we are not taking the parentRealPath to avoid possible problem
-                    try {
-                        Path child = currentFileAbsolutePath.normalize();
-                        Path parent = parentAbsolutePath.normalize();
-                        return child.startsWith(parent);
-                    } catch (InvalidPathException e2) { // TODO which method would throw this?
-                        throw new IOException(e2);
-                    }
+                    Path child = currentFileAbsolutePath.normalize();
+                    Path parent = parentAbsolutePath.normalize();
+                    return child.startsWith(parent);
                 }
             }
 


### PR DESCRIPTION
While discussing an `OutOfMemoryError` whose investigation led to https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/96, @dwnusbaum pointed out that `FilePath.readToString` winds up allocating a `IOUtils.DEFAULT_BUFFER_SIZE` ~ 4Kib buffer. This is clearly inefficient for the common case of reading a small text file, not to mention the overhead of using `ProxyOutputStream` in the Remoting channel if the file is remote. Better in typical cases to just read the whole file at once remotely and send back one packet with the result. (The current implementation would only make sense for huge text files, and using this method for such cases is likely a sign of poor code anyway.)

Note that I avoided `FileUtils.readFileToString` from Commons IO since it has the same 4Kib buffer size, perversely.

Also note that the rewritten implementation alters the behavior slightly: the default charset being used is now that of the agent, rather than the master. This is generally what you would want, and matches the behavior of `FilePath.write(content, null)`.

### Proposed changelog entries

* Internal optimization in the method to read a remote file as text.