### PR TITLE
[JENKINS-47324] Use NIO in FilePath#isDirectory

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -88,6 +88,7 @@ import java.nio.file.Path;
 import java.nio.file.LinkOption;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
@@ -1650,7 +1651,7 @@ public final class FilePath implements Serializable {
         private static final long serialVersionUID = 1L;
         @Override
         public Boolean invoke(File f, VirtualChannel channel) throws IOException {
-            return stating(f).isDirectory();
+            return Files.readAttributes(fileToPath(stating(f)), BasicFileAttributes.class).isDirectory();
         }
     }
     

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -582,7 +582,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
             }
             @Override public boolean isDirectory() throws IOException {
                 try {
-                    return f.isDirectory();
+                    return exists() && f.isDirectory();
                 } catch (InterruptedException x) {
                     throw new IOException(x);
                 }


### PR DESCRIPTION
See [JENKINS-47324](https://issues.jenkins-ci.org/browse/JENKINS-47324). 

This came up as a possible improvement to help diagnose [JENKINS-55356](https://issues.jenkins-ci.org/browse/JENKINS-55356). Needs a test case at the least, and some investigation to understand the cases that previously would have returned false that would now throw exceptions to understand the risk of the change.

From the [`File#isDirectory` Javadoc](https://docs.oracle.com/javase/7/docs/api/java/io/File.html#isDirectory()):

> Where it is required to distinguish an I/O exception from the case that the file is not a directory, or where several attributes of the same file are required at the same time, then the Files.readAttributes method may be used.

Known cases where the behavior changes between the old and new implementations:

* If the file does not exist, the new code throws `NoSuchFileException` instead of returning `false`
  * This change seems likely to affect existing callers, maybe we handle it specially?

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: Allow callers of `FilePath#isDirectory` to differentiate between failures and non-directories by throwing exceptions in the case of failure.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
