### PR TITLE
JENKINS-53077 - don't process empty responseText

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1515,6 +1515,10 @@ function refreshPart(id,url) {
                             window.clearInterval(intervalID);
                         return;
                     }
+                    if (!rsp.responseText) {
+                        console.log("Failed to retrieve response for ID " + id + ", perhaps Jenkins is unavailable");
+                        return;
+                    }
                     var p = hist.up();
 
                     var div = document.createElement('div');


### PR DESCRIPTION
The goal of this function appears to be to replace one content tree
with another content tree.

If the response is empty, that doesn't result in a content tree,
and thus one can't use replaceChild.

See [JENKINS-53077](https://issues.jenkins-ci.org/browse/JENKINS-53077).

### Proposed changelog entries

* Entry 1: Try to be slightly more graceful when the network link to jenkins is down

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers