### PR TITLE
JTH 2.46

### DIFF
--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -54,7 +54,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2.42</version>
+      <version>2.46</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -145,17 +145,6 @@ THE SOFTWARE.
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>1.3</version>
-    </dependency>
-    <dependency><!-- we exclude this transient dependency from htmlunit, which we actually need in the test -->
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <version>2.7.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <!-- for testing JNLP launch. -->


### PR DESCRIPTION
See jenkinsci/jenkins-test-harness#89.

Bump JTH from 2.42 to 2.46, mainly to test Jenkins itself with a space in temp dir path.

### Proposed changelog entries

* Internal: bump jenkins-test-harness from [2.42 to 2.46](https://github.com/jenkinsci/jenkins-test-harness/compare/jenkins-test-harness-2.42...jenkins-test-harness-2.46)

### Submitter checklist

- [ ] JIRA issue is well described ***=> no Jira issue, this is just a followup for jenkinsci/jenkins-test-harness#89***
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [ ] Appropriate autotests or explanation to why this change has no tests ***=> no additionnal test, just checking that existing tests are fine***
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

(several reviewers are already there)