### PR TITLE
[JENKINS-55829] New getter method in AbstractCIBase

### DIFF
--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -92,8 +92,11 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
     * Package-protected, but accessed API
     * ============================================================================================================== */
 
-    /*package*/ final CopyOnWriteArraySet<String> disabledAdministrativeMonitors = new CopyOnWriteArraySet<String>();
-
+    /*package*/
+    @Restricted(NoExternalUse.class)
+    public CopyOnWriteArraySet<String> getDisabledAdministrativeMonitors(){
+    	return new CopyOnWriteArraySet<String>();
+    }
     /* =================================================================================================================
      * Implementation provided
      * ============================================================================================================== */

--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -90,9 +90,11 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
         c.kill();
     }
 
+	final CopyOnWriteArraySet<String> disabledAdministrativeMonitors = new CopyOnWriteArraySet<String>();
+
     @Restricted(NoExternalUse.class)
     public CopyOnWriteArraySet<String> getDisabledAdministrativeMonitors(){
-    	return new CopyOnWriteArraySet<String>();
+    	return disabledAdministrativeMonitors;
     }
     /* =================================================================================================================
      * Implementation provided

--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -88,11 +88,6 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
         c.kill();
     }
 
-    /* =================================================================================================================
-    * Package-protected, but accessed API
-    * ============================================================================================================== */
-
-    /*package*/
     @Restricted(NoExternalUse.class)
     public CopyOnWriteArraySet<String> getDisabledAdministrativeMonitors(){
     	return new CopyOnWriteArraySet<String>();

--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -33,6 +33,8 @@ import hudson.slaves.RetentionStrategy;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerFallback;
 import org.kohsuke.stapler.StaplerProxy;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;

--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -90,12 +90,17 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
         c.kill();
     }
 
-	final CopyOnWriteArraySet<String> disabledAdministrativeMonitors = new CopyOnWriteArraySet<String>();
+    /* =================================================================================================================
+    * Package-protected, but accessed API
+    * ============================================================================================================== */
+
+    /*package*/ final CopyOnWriteArraySet<String> disabledAdministrativeMonitors = new CopyOnWriteArraySet<String>();
 
     @Restricted(NoExternalUse.class)
     public CopyOnWriteArraySet<String> getDisabledAdministrativeMonitors(){
     	return disabledAdministrativeMonitors;
     }
+    
     /* =================================================================================================================
      * Implementation provided
      * ============================================================================================================== */

--- a/core/src/main/java/hudson/model/AdministrativeMonitor.java
+++ b/core/src/main/java/hudson/model/AdministrativeMonitor.java
@@ -131,7 +131,7 @@ public abstract class AdministrativeMonitor extends AbstractModelObject implemen
      * he wants to ignore.
      */
     public boolean isEnabled() {
-        return !((AbstractCIBase)Jenkins.get()).disabledAdministrativeMonitors.contains(id);
+        return !(Jenkins.get()).getDisabledAdministrativeMonitors().contains(id);
     }
 
     /**

--- a/core/src/main/java/hudson/model/AdministrativeMonitor.java
+++ b/core/src/main/java/hudson/model/AdministrativeMonitor.java
@@ -117,7 +117,7 @@ public abstract class AdministrativeMonitor extends AbstractModelObject implemen
      */
     public void disable(boolean value) throws IOException {
         AbstractCIBase jenkins = Jenkins.get();
-        Set<String> set = jenkins.disabledAdministrativeMonitors;
+        Set<String> set = jenkins.getDisabledAdministrativeMonitors();
         if(value)   set.add(id);
         else        set.remove(id);
         jenkins.save();
@@ -131,7 +131,7 @@ public abstract class AdministrativeMonitor extends AbstractModelObject implemen
      * he wants to ignore.
      */
     public boolean isEnabled() {
-        return !(Jenkins.get()).getDisabledAdministrativeMonitors().contains(id);
+        return !Jenkins.get().getDisabledAdministrativeMonitors().contains(id);
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-55829](https://issues.jenkins-ci.org/browse/JENKINS-55829).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* `Internal` : A new getter method is created in AbstractCIBase and has marked it as `@Restricted(NoExternalUse.class)`.
* Also typecast has been removed as now getter method is in AbstractCIBase, so typecast is of no use.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev @daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
