### PR TITLE
[JENKINS-55085] - Use the main update center by default when running with Java 11

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -216,15 +216,8 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         if (ucOverride != null) {
             logger.log(Level.INFO, "Using a custom update center defined by the system property: {0}", ucOverride);
             UPDATE_CENTER_URL = ucOverride;
-        } else if (JavaUtils.isRunningWithJava8OrBelow()) {
-            UPDATE_CENTER_URL = "https://updates.jenkins.io/";
         } else {
-            //TODO: Rollback the default for Java 11 when it goes to GA
-            String experimentalJava11UC = "https://updates.jenkins.io/temporary-experimental-java11/";
-            logger.log(Level.WARNING, "Running Jenkins with Java {0} which is available in the preview mode only. " +
-                    "A custom experimental update center will be used: {1}",
-                    new Object[] {System.getProperty("java.specification.version"), experimentalJava11UC});
-            UPDATE_CENTER_URL = experimentalJava11UC;
+            UPDATE_CENTER_URL = "https://updates.jenkins.io/";
         }
     }
 


### PR DESCRIPTION
Reverts a custom experimental update center for Java 11 which was enabled to workaround the Java 11 compatibility issue in the Pipeline: Support plugin. See https://github.com/jenkinsci/jenkins/pull/3794 . Now Pipeline: Support plugin 3.0+ is available in the main update center, and a custom UC is no longer required.

See [JENKINS-55085](https://issues.jenkins-ci.org/browse/JENKINS-55085).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Jenkins now uses the standard update center by default when running with Java 11

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/java11-support . Also CC @jglick who was concerned about a flaky test caused by this custom patch

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
