### PR TITLE
[JENKINS-55980] - Switch Java Specification Version comparison in the core to a robust implementation.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,7 +63,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.5</version>
+      <version>1.6</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -33,6 +33,7 @@ import hudson.model.ModelObject;
 import hudson.model.UpdateCenter;
 import hudson.model.UpdateSite;
 import hudson.util.VersionNumber;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import jenkins.util.java.JavaUtils;
@@ -763,8 +764,8 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
             String minimumJavaVersion = getMinimumJavaVersion();
             if (minimumJavaVersion != null) {
-                VersionNumber actualVersion = JavaUtils.getCurrentJavaRuntimeVersionNumber();
-                if (actualVersion.isOlderThan(new VersionNumber(minimumJavaVersion))) {
+                JavaSpecificationVersion actualVersion = JavaUtils.getCurrentJavaRuntimeVersionNumber();
+                if (actualVersion.isOlderThan(new JavaSpecificationVersion(minimumJavaVersion))) {
                     versionDependencyError(Messages.PluginWrapper_obsoleteJava(actualVersion.toString(), minimumJavaVersion), actualVersion.toString(), minimumJavaVersion);
                 }
             }

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -64,6 +64,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import jenkins.model.Jenkins;
 import jenkins.model.DownloadSettings;
 import jenkins.plugins.DetachedPluginsUtil;
@@ -1133,8 +1134,8 @@ public class UpdateSite {
          */
         public boolean isForNewerJava() {
             try {
-                final VersionNumber currentRuntimeJavaVersion = JavaUtils.getCurrentJavaRuntimeVersionNumber();
-                return minimumJavaVersion != null && new VersionNumber(minimumJavaVersion).isNewerThan(
+                final JavaSpecificationVersion currentRuntimeJavaVersion = JavaUtils.getCurrentJavaRuntimeVersionNumber();
+                return minimumJavaVersion != null && new JavaSpecificationVersion(minimumJavaVersion).isNewerThan(
                         currentRuntimeJavaVersion);
             } catch (NumberFormatException nfe) {
                 logBadMinJavaVersion();

--- a/core/src/main/java/jenkins/plugins/DetachedPluginsUtil.java
+++ b/core/src/main/java/jenkins/plugins/DetachedPluginsUtil.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import hudson.ClassicPluginStrategy;
 import hudson.PluginWrapper;
 import hudson.util.VersionNumber;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import jenkins.util.java.JavaUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -174,13 +175,13 @@ public class DetachedPluginsUtil {
          */
         private final VersionNumber splitWhen;
         private final String requiredVersion;
-        private final VersionNumber minJavaVersion;
+        private final JavaSpecificationVersion minJavaVersion;
 
         private DetachedPlugin(String shortName, String splitWhen, String requiredVersion, String minJavaVersion) {
             this.shortName = shortName;
             this.splitWhen = new VersionNumber(splitWhen);
             this.requiredVersion = requiredVersion;
-            this.minJavaVersion = new VersionNumber(minJavaVersion);
+            this.minJavaVersion = new JavaSpecificationVersion(minJavaVersion);
         }
 
         /**
@@ -217,7 +218,7 @@ public class DetachedPluginsUtil {
         }
 
         @Nonnull
-        public VersionNumber getMinimumJavaVersion() {
+        public JavaSpecificationVersion getMinimumJavaVersion() {
             return minJavaVersion;
         }
     }

--- a/core/src/main/java/jenkins/util/java/JavaUtils.java
+++ b/core/src/main/java/jenkins/util/java/JavaUtils.java
@@ -24,6 +24,7 @@
 package jenkins.util.java;
 
 import hudson.util.VersionNumber;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -59,8 +60,8 @@ public class JavaUtils {
     /**
      * Returns the JVM's current version as a {@link VersionNumber} instance.
      */
-    public static VersionNumber getCurrentJavaRuntimeVersionNumber() {
-        return new VersionNumber(getCurrentRuntimeJavaVersion());
+    public static JavaSpecificationVersion getCurrentJavaRuntimeVersionNumber() {
+        return JavaSpecificationVersion.forCurrentJVM();
     }
 
     /**


### PR DESCRIPTION
After the change all Java Specification Version comparison operations are robust against comparison of old and new Java spec version formats. It should prevent issues like [JENKINS-55562](https://issues.jenkins-ci.org/browse/JENKINS-55562)

See [JENKINS-55980](https://issues.jenkins-ci.org/browse/JENKINS-55980). Also see https://openjdk.java.net/jeps/223 for the new format


<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE: Make the plugin manager robust against Java version specification format mismatches while comparing versions (esp. after Java [JEP 223](https://openjdk.java.net/jeps/223)).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/java11-support and esp. @batmat 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
