### PR TITLE
[JENKINS-55976] Upgrade to 3.29 version of Remoting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3.28</remoting.version>
+    <remoting.version>3.29</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.4</remoting.minimum.supported.version>
 


### PR DESCRIPTION
See [JENKINS-55976](https://issues.jenkins-ci.org/browse/JENKINS-55976).

Upgrade to the 3.29 version of Remoting, which contains a minor fix to add a missing log call.

See the [Remoting Changelog](https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#329).

### Proposed changelog entries
* Update Remoting from 3.28 to 3.29 to add a missing log call for severe protocol failures. ([Full changelog](https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#329), [issue 55976](https://issues.jenkins-ci.org/browse/JENKINS-55976))

### Submitter checklist

- [x] JIRA issue is well described
        * Issue is sufficiently well described for the minor fix.
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
          * No tests necessary or useful for adding this logging call that was already intended.
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jvz @oleg-nenashev 