### PR TITLE
populate allPlugins map

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1337,6 +1337,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 pluginInfo.put("dependencies", Collections.emptyMap());
             }
             response.add(pluginInfo);
+            allPlugins.put(plugin.getShortName(), pluginInfo);
         }
         for (UpdateSite site : Jenkins.getActiveInstance().getUpdateCenter().getSiteList()) {
             for (UpdateSite.Plugin plugin: site.getAvailables()) {


### PR DESCRIPTION
* Populate `allPlugins` map in `PluginManager.doPlugins`

I was browsing this project on [lgtm.com](https://lgtm.com/projects/g/jenkinsci/jenkins/alerts/?mode=list&severity=error) and noticed an alert there indicating that `allPlugins` is read but never written. It looks like the intention was to populate it with currently installed plugins.