### PR TITLE
use secure cookies

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -638,6 +638,7 @@ public class Functions {
             // to avoid conflicts with any other web apps that might be on the same machine.
             c.setPath("/");
             c.setMaxAge(60*60*24*30); // persist it roughly for a month
+            c.setSecure(true);
             response.addCookie(c);
         }
         if (refresh) {

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -308,6 +308,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
         cookie.setSecure(req.isSecure());
         cookie.setHttpOnly(true);
         cookie.setPath(req.getContextPath().length()>0 ? req.getContextPath() : "/");
+        cookie.setSecure(true);
         rsp.addCookie(cookie);
 
         rsp.sendRedirect2(getPostLogOutUrl(req,auth));

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4484,6 +4484,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             throw new ServletException();
         Cookie cookie = new Cookie("iconSize", Functions.validateIconSize(qs));
         cookie.setMaxAge(/* ~4 mo. */9999999); // #762
+        cookie.setSecure(true);
         rsp.addCookie(cookie);
         String ref = req.getHeader("Referer");
         if(ref==null)   ref=".";


### PR DESCRIPTION
* Call `setSecure(true)` on cookie before adding to response (3 places)

These fix issues identified by lgtm.com for [this project](https://lgtm.com/projects/g/jenkinsci/jenkins/alerts/?mode=list&severity=error). lgtm.com documents some motivation for these amendment [here](https://lgtm.com/rules/7860076/).