### PR TITLE
Do not retain as many artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@
 def runTests = true
 def failFast = false
 
-properties([buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '20')), durabilityHint('PERFORMANCE_OPTIMIZED')])
+properties([buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '3')), durabilityHint('PERFORMANCE_OPTIMIZED')])
 
 // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc for information on what node types are available
 def buildTypes = ['Linux', 'Windows']


### PR DESCRIPTION
When @kohsuke [mentioned in a recent discussion](https://groups.google.com/d/msg/jenkinsci-dev/aYjBTtJWii8/fljHgLFRFQAJ) that there's persistent disk space issues on ci.j.io, I looked at the Jenkinsfile and it archives quite a bit more builds than seem necessary. Even if this isn't the cause of the problems, with incrementals we don't need this many archived artifacts.

I'm leaving build records alone for now. They're ridiculously large thanks to Timestamper, but version 1.9 with [changes](https://github.com/jenkinsci/timestamper-plugin/pull/25) from @jglick should allow us to address that.

### Proposed changelog entries

* n/a

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
