### PR TITLE
Add telemetry for 'auto refresh' feature

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -179,6 +179,7 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
 @SuppressWarnings("rawtypes")
 public class Functions {
     private static final AtomicLong iota = new AtomicLong();
+    private static Logger LOGGER = Logger.getLogger(Functions.class.getName());
 
     public Functions() {
     }
@@ -651,7 +652,7 @@ public class Functions {
         try {
             ExtensionList.lookupSingleton(AutoRefresh.class).recordRequest(request, refresh);
         } catch (Exception e) {
-            // ignore telemetry problems
+            LOGGER.log(Level.FINE, "Failed to record auto refresh status in telemetry", e);
         }
     }
 

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -27,6 +27,7 @@ package hudson;
 
 import hudson.model.Slave;
 import hudson.security.*;
+import jenkins.telemetry.impl.AutoRefresh;
 import jenkins.util.SystemProperties;
 import hudson.cli.CLICommand;
 import hudson.console.ConsoleAnnotationDescriptor;
@@ -645,6 +646,12 @@ public class Functions {
         }
         if (refresh) {
             response.addHeader("Refresh", SystemProperties.getString("hudson.Functions.autoRefreshSeconds", "10"));
+        }
+
+        try {
+            ExtensionList.lookupSingleton(AutoRefresh.class).recordRequest(request, refresh);
+        } catch (Exception e) {
+            // ignore telemetry problems
         }
     }
 

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -652,7 +652,7 @@ public class Functions {
         try {
             ExtensionList.lookupSingleton(AutoRefresh.class).recordRequest(request, refresh);
         } catch (Exception e) {
-            LOGGER.log(Level.FINE, "Failed to record auto refresh status in telemetry", e);
+            LOGGER.log(Level.WARNING, "Failed to record auto refresh status in telemetry", e);
         }
     }
 

--- a/core/src/main/java/jenkins/telemetry/Telemetry.java
+++ b/core/src/main/java/jenkins/telemetry/Telemetry.java
@@ -141,6 +141,22 @@ public abstract class Telemetry implements ExtensionPoint {
         return jenkins == null || !jenkins.isUsageStatisticsCollected();
     }
 
+    /**
+     * Returns true iff we're in the time period during which this is supposed to collect data.
+     * @return true iff we're in the time period during which this is supposed to collect data
+     *
+     * @since TODO
+     */
+    public boolean isActivePeriod() {
+        if (getStart().isAfter(LocalDate.now())) {
+            return false;
+        }
+        if (getEnd().isBefore(LocalDate.now())) {
+            return false;
+        }
+        return true;
+    }
+
     @Extension
     public static class TelemetryReporter extends AsyncPeriodicWork {
 

--- a/core/src/main/java/jenkins/telemetry/Telemetry.java
+++ b/core/src/main/java/jenkins/telemetry/Telemetry.java
@@ -149,13 +149,7 @@ public abstract class Telemetry implements ExtensionPoint {
      */
     public boolean isActivePeriod() {
         LocalDate now = LocalDate.now();
-        if (getStart().isAfter(now)) {
-            return false;
-        }
-        if (getEnd().isBefore(now)) {
-            return false;
-        }
-        return true;
+        return now.isAfter(getStart()) && now.isBefore(getEnd());
     }
 
     @Extension

--- a/core/src/main/java/jenkins/telemetry/Telemetry.java
+++ b/core/src/main/java/jenkins/telemetry/Telemetry.java
@@ -148,10 +148,11 @@ public abstract class Telemetry implements ExtensionPoint {
      * @since TODO
      */
     public boolean isActivePeriod() {
-        if (getStart().isAfter(LocalDate.now())) {
+        LocalDate now = LocalDate.now();
+        if (getStart().isAfter(now)) {
             return false;
         }
-        if (getEnd().isBefore(LocalDate.now())) {
+        if (getEnd().isBefore(now)) {
             return false;
         }
         return true;

--- a/core/src/main/java/jenkins/telemetry/impl/AutoRefresh.java
+++ b/core/src/main/java/jenkins/telemetry/impl/AutoRefresh.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.telemetry.impl;
+
+import hudson.Extension;
+import jenkins.telemetry.Telemetry;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class AutoRefresh extends Telemetry {
+
+    private static final Map<Boolean, Set<String>> sessionsBySetting = new ConcurrentSkipListMap<>();
+
+    @Nonnull
+    @Override
+    public String getId() {
+        return AutoRefresh.class.getName();
+    }
+
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+        return "Use of auto refresh feature";
+    }
+
+    @Nonnull
+    @Override
+    public LocalDate getStart() {
+        return LocalDate.of(2019, 2, 10);
+    }
+
+    @Nonnull
+    @Override
+    public LocalDate getEnd() {
+        return LocalDate.of(2019, 4, 10);
+    }
+
+    @Override
+    public JSONObject createContent() {
+        if (sessionsBySetting.size() == 0) {
+            return null;
+        }
+        Map<Boolean, Set<String>> currentSessions = new TreeMap<>(sessionsBySetting);
+        sessionsBySetting.clear();
+
+        JSONObject payload = new JSONObject();
+        for (Map.Entry<Boolean, Set<String>> entry : currentSessions.entrySet()) {
+            payload.put(entry.getKey().toString(), entry.getValue().size());
+        }
+        return payload;
+    }
+
+    public void recordRequest(HttpServletRequest request, boolean enabled) {
+        if (Telemetry.isDisabled()) {
+            return;
+        }
+        if (!isActivePeriod()) {
+            return;
+        }
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            String sessionId = session.getId();
+            sessionsBySetting.putIfAbsent(enabled, new HashSet<>());
+            sessionsBySetting.get(enabled).add(sessionId);
+        }
+    }
+}

--- a/core/src/main/java/jenkins/telemetry/impl/AutoRefresh.java
+++ b/core/src/main/java/jenkins/telemetry/impl/AutoRefresh.java
@@ -54,7 +54,7 @@ public class AutoRefresh extends Telemetry {
     @Nonnull
     @Override
     public String getDisplayName() {
-        return "Use of auto refresh feature";
+        return Messages.AutoRefresh_DisplayName();
     }
 
     @Nonnull
@@ -66,7 +66,7 @@ public class AutoRefresh extends Telemetry {
     @Nonnull
     @Override
     public LocalDate getEnd() {
-        return LocalDate.of(2019, 4, 10);
+        return LocalDate.of(2019, 5, 31);
     }
 
     @Override
@@ -74,8 +74,11 @@ public class AutoRefresh extends Telemetry {
         if (sessionsBySetting.size() == 0) {
             return null;
         }
-        Map<Boolean, Set<String>> currentSessions = new TreeMap<>(sessionsBySetting);
-        sessionsBySetting.clear();
+        Map<Boolean, Set<String>> currentSessions;
+        synchronized (sessionsBySetting) {
+            currentSessions = new TreeMap<>(sessionsBySetting);
+            sessionsBySetting.clear();
+        }
 
         JSONObject payload = new JSONObject();
         for (Map.Entry<Boolean, Set<String>> entry : currentSessions.entrySet()) {
@@ -94,8 +97,10 @@ public class AutoRefresh extends Telemetry {
         HttpSession session = request.getSession(false);
         if (session != null) {
             String sessionId = session.getId();
-            sessionsBySetting.putIfAbsent(enabled, new HashSet<>());
-            sessionsBySetting.get(enabled).add(sessionId);
+            synchronized (sessionsBySetting) {
+                sessionsBySetting.putIfAbsent(enabled, new HashSet<>());
+                sessionsBySetting.get(enabled).add(sessionId);
+            }
         }
     }
 }

--- a/core/src/main/java/jenkins/telemetry/impl/AutoRefresh.java
+++ b/core/src/main/java/jenkins/telemetry/impl/AutoRefresh.java
@@ -35,7 +35,6 @@ import javax.servlet.http.HttpSession;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.Collections;
 
 @Extension
 @Restricted(NoExternalUse.class)

--- a/core/src/main/java/jenkins/telemetry/impl/AutoRefresh.java
+++ b/core/src/main/java/jenkins/telemetry/impl/AutoRefresh.java
@@ -45,12 +45,6 @@ public class AutoRefresh extends Telemetry {
 
     @Nonnull
     @Override
-    public String getId() {
-        return AutoRefresh.class.getName();
-    }
-
-    @Nonnull
-    @Override
     public String getDisplayName() {
         return Messages.AutoRefresh_DisplayName();
     }

--- a/core/src/main/resources/jenkins/telemetry/impl/AutoRefresh/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/AutoRefresh/description.jelly
@@ -1,0 +1,5 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    This trial collects information about the "Auto Refresh" feature to determine whether use of the feature is used enough to not remove it in a future release of Jenkins.
+    We collect the number of HTTP sessions that have the feature (typically controlled via a cookie) enabled or disabled.
+</j:jelly>

--- a/core/src/main/resources/jenkins/telemetry/impl/AutoRefresh/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/AutoRefresh/description.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-    This trial collects information about the "Auto Refresh" feature to determine whether use of the feature is used enough to not remove it in a future release of Jenkins.
+    This trial collects information about the "Auto Refresh" feature to determine whether the feature is used enough to not remove it in a future release of Jenkins.
     We collect the number of HTTP sessions that have the feature (typically controlled via a cookie) enabled or disabled.
 </j:jelly>

--- a/core/src/main/resources/jenkins/telemetry/impl/Messages.properties
+++ b/core/src/main/resources/jenkins/telemetry/impl/Messages.properties
@@ -1,0 +1,1 @@
+AutoRefresh.DisplayName = Use of auto refresh feature


### PR DESCRIPTION
Helps understand whether #2979 is a good idea or not. We don't need to implement changes with unknown impact blindly anymore, we can gather data now.

Using sessions as a proxy for users. It might be better to use actual users unless anonymous, but OTOH this counts frequent users, as well as users on multiple devices, more. Unsure which is better, or whether it makes much of a difference since we clear the collection on a daily basis.

### Samples

Instance with two users not using "Auto Refresh":

    Submitting JSON: {"type":"jenkins.telemetry.impl.AutoRefresh","payload":{"false":2},"correlator":"…"}

Instance with one user not using "Auto Refresh", and another switching between states:

    Submitting JSON: {"type":"jenkins.telemetry.impl.AutoRefresh","payload":{"false":2,"true":1},"correlator":"…"}

### Help text on UI

> ![screen shot](https://user-images.githubusercontent.com/1831569/52646726-909a5c80-2ee3-11e9-87b7-ba76c10ea3d1.png)


### Proposed changelog entries

* Add telemetry on the use of the 'auto refresh' feature.

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
