### PR TITLE
[JEP-216] Bump localizer

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.jvnet.localizer</groupId>
       <artifactId>localizer</artifactId>
-      <version>1.24</version>
+      <version>1.26</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sshd</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -226,7 +226,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jvnet.localizer</groupId>
       <artifactId>localizer</artifactId>
-      <version>1.24</version>
+      <version>1.26</version>
     </dependency>
     <dependency>
       <groupId>antlr</groupId>


### PR DESCRIPTION
See [JEP-216](https://github.com/jenkinsci/jep/tree/master/jep/216).

This is extracted from #3729 and can in principle be delivered independently (although I caution against its use in individual localization plugins like the Chinese one, as multiple such plugins would override each other).

Demonstrating use in https://github.com/daniel-beck/localization-support-plugin/tree/master/src/main/java/io/jenkins/plugins/localization/support/localizer

Localizer library has no changelog, diff is [here](https://github.com/kohsuke/localizer/compare/localizer-parent-1.24...localizer-parent-1.26).

### Proposed changelog entries

* JEP-216: Update localizer library from 1.24 to 1.26 allowing plugins to override the lookup for localized resource files. (all changes: https://github.com/kohsuke/localizer/compare/localizer-parent-1.24...localizer-parent-1.26 )

### Submitter checklist

- [x] JEP is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs
