### PR TITLE
 JENKINS-55834 Typo in hudsonHomeIsFull, because of escaping apostrophes

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.properties
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.properties
@@ -23,7 +23,7 @@
 blurb=<tt>JENKINS_HOME</tt> is almost full
 description.1=\
   Your <tt>JENKINS_HOME</tt> ({0}) is almost full. \
-  When this directory completely fills up, it will wreak havoc because Jenkins can''t store any more data.
+  When this directory completely fills up, it will wreak havoc because Jenkins can not store any more data.
 description.2=To prevent that problem, you should act now.
 solution.1=Clean up some files from this partition to make more room.
 solution.2=\

--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.properties
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.properties
@@ -23,7 +23,7 @@
 blurb=<tt>JENKINS_HOME</tt> is almost full
 description.1=\
   Your <tt>JENKINS_HOME</tt> ({0}) is almost full. \
-  When this directory completely fills up, it will wreak havoc because Jenkins can not store any more data.
+  When this directory completely fills up, it will wreak havoc because Jenkins cannot store any more data.
 description.2=To prevent that problem, you should act now.
 solution.1=Clean up some files from this partition to make more room.
 solution.2=\

--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.properties
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.properties
@@ -23,7 +23,7 @@
 blurb=<tt>JENKINS_HOME</tt> is almost full
 description.1=\
   Your <tt>JENKINS_HOME</tt> ({0}) is almost full. \
-  When this directory completely fills up, it\'ll wreak havoc because Jenkins can\'t store any more data.
+  When this directory completely fills up, it will wreak havoc because Jenkins can\'t store any more data.
 description.2=To prevent that problem, you should act now.
 solution.1=Clean up some files from this partition to make more room.
 solution.2=\

--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.properties
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.properties
@@ -23,7 +23,7 @@
 blurb=<tt>JENKINS_HOME</tt> is almost full
 description.1=\
   Your <tt>JENKINS_HOME</tt> ({0}) is almost full. \
-  When this directory completely fills up, it will wreak havoc because Jenkins can\'t store any more data.
+  When this directory completely fills up, it will wreak havoc because Jenkins can''t store any more data.
 description.2=To prevent that problem, you should act now.
 solution.1=Clean up some files from this partition to make more room.
 solution.2=\


### PR DESCRIPTION
See (https://issues.jenkins-ci.org/browse/JENKINS-55834).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries
Update typo from "It'll to It will"

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
