### PR TITLE
Rely on auto unboxing

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1569,7 +1569,7 @@ public class Util {
      * give up, thus improving build reliability.
      */
     @Restricted(value = NoExternalUse.class)
-    static int DELETION_MAX = Math.max(1, SystemProperties.getInteger(Util.class.getName() + ".maxFileDeletionRetries", 3).intValue());
+    static int DELETION_MAX = Math.max(1, SystemProperties.getInteger(Util.class.getName() + ".maxFileDeletionRetries", 3));
 
     /**
      * The time (in milliseconds) that we will wait between attempts to
@@ -1581,7 +1581,7 @@ public class Util {
      * between attempts.
      */
     @Restricted(value = NoExternalUse.class)
-    static int WAIT_BETWEEN_DELETION_RETRIES = SystemProperties.getInteger(Util.class.getName() + ".deletionRetryWait", 100).intValue();
+    static int WAIT_BETWEEN_DELETION_RETRIES = SystemProperties.getInteger(Util.class.getName() + ".deletionRetryWait", 100);
 
     /**
      * If this flag is set to true then we will request a garbage collection

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1214,7 +1214,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         if (cachedBuildHealthReportsBuildNumber != null
                 && cachedBuildHealthReports != null
                 && lastBuild != null
-                && cachedBuildHealthReportsBuildNumber.intValue() == lastBuild
+                && cachedBuildHealthReportsBuildNumber == lastBuild
                         .getNumber()) {
             reports.addAll(cachedBuildHealthReports);
         } else if (lastBuild != null) {

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -321,7 +321,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
         }
 
         Boolean shouldKeepFlag = SystemProperties.optBoolean(KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME);
-        if (shouldKeepFlag != null && shouldKeepFlag.booleanValue()) {
+        if (shouldKeepFlag != null && shouldKeepFlag) {
             return parameters;
         }
 


### PR DESCRIPTION
Sometimes java will automatically unbox and thus there is no need to manually write out the call. There aren't many instances of manually unboxing. I think there's some value in only manually unboxing where it's absolutely necessary.

### Proposed changelog entries

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
