### PR TITLE
Add message to the build log when a build is running as SYSTEM

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1798,7 +1798,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                     listener.started(getCauses());
 
                     Authentication auth = Jenkins.getAuthentication();
-                    if (!auth.equals(ACL.SYSTEM)) {
+                    if (auth.equals(ACL.SYSTEM)) {
+                        listener.getLogger().println(Messages.Run_running_as_SYSTEM());
+                    } else {
                         String id = auth.getName();
                         if (!auth.equals(Jenkins.ANONYMOUS)) {
                             final User usr = User.getById(id, false);

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -221,7 +221,7 @@ Run.BuildAborted=Build was aborted
 Run.MarkedExplicitly=This record is explicitly marked to be kept.
 Run.Permissions.Title=Run
 Run.running_as_=Running as {0}
-Run.running_as_SYSTEM=This build is running using the Jenkins-internal SYSTEM authentication with no permission restrictions.
+Run.running_as_SYSTEM=Running as SYSTEM
 Run.UnableToDelete=Unable to delete {0}: {1}
 Run.DeletePermission.Description=\
   This permission allows users to manually delete specific builds from the build history.

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -221,6 +221,7 @@ Run.BuildAborted=Build was aborted
 Run.MarkedExplicitly=This record is explicitly marked to be kept.
 Run.Permissions.Title=Run
 Run.running_as_=Running as {0}
+Run.running_as_SYSTEM=This build is running using the Jenkins-internal SYSTEM authentication with no permission restrictions.
 Run.UnableToDelete=Unable to delete {0}: {1}
 Run.DeletePermission.Description=\
   This permission allows users to manually delete specific builds from the build history.


### PR DESCRIPTION
See [JENKINS-22949](https://issues.jenkins-ci.org/browse/JENKINS-22949).

Until the linked issue was addressed in https://jenkins.io/changelog/#v2.62, the concept of build item authenticators was a lot more discoverable. So let's restore that part.

Unsure how best to phrase this. Tempted to add a link to a jenkins.io page with build authentication docs, but that may be a bit much for every build. Thoughts?

### Proposed changelog entries

* Add a log message to build logs when builds run with the virtual SYSTEM authentication.

### Submitter checklist

- [sort of] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
