### PR TITLE
Java cleanup

### DIFF
--- a/core/src/main/java/hudson/EnvVars.java
+++ b/core/src/main/java/hudson/EnvVars.java
@@ -226,8 +226,8 @@ public class EnvVars extends TreeMap<String,String> {
                 }
                 return refereeSetMap.get(n);
             }
-        };
-        
+        }
+
         private final Comparator<? super String> comparator;
         
         @Nonnull

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -636,7 +636,6 @@ public final class FilePath implements Serializable {
     private void unzip(File dir, File zipFile) throws IOException {
         dir = dir.getAbsoluteFile();    // without absolutization, getParentFile below seems to fail
         ZipFile zip = new ZipFile(zipFile);
-        @SuppressWarnings("unchecked")
         Enumeration<ZipEntry> entries = zip.getEntries();
 
         try {

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2361,12 +2361,7 @@ public final class FilePath implements Serializable {
                 future.get();
                 return future2.get();
             } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause == null) cause = e;
-                throw cause instanceof IOException
-                        ? (IOException) cause
-                        : new IOException(cause)
-                ;
+                throw ioWithCause(e);
             }
         } else {
             // remote -> local copy
@@ -2391,15 +2386,20 @@ public final class FilePath implements Serializable {
             try {
                 return future.get();
             } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause == null) cause = e;
-                throw cause instanceof IOException
-                        ? (IOException) cause
-                        : new IOException(cause)
-                ;
+                throw ioWithCause(e);
             }
         }
     }
+
+    private IOException ioWithCause(ExecutionException e) {
+        Throwable cause = e.getCause();
+        if (cause == null) cause = e;
+        return cause instanceof IOException
+                ? (IOException) cause
+                : new IOException(cause)
+                ;
+    }
+
     private class CopyRecursiveLocal extends SecureFileCallable<Integer> {
         private final FilePath target;
         private final DirScanner scanner;

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1929,8 +1929,7 @@ public final class FilePath implements Serializable {
         } catch (BuildException x) {
             throw new IOException(x.getMessage());
         }
-        String[] files = ds.getIncludedFiles();
-        return files;
+        return ds.getIncludedFiles();
     }
 
     /**

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -385,7 +385,7 @@ public final class FilePath implements Serializable {
             return false;
         // Windows can handle '/' as a path separator but Unix can't,
         // so err on Unix side
-        return remote.indexOf("\\")==-1;
+        return !remote.contains("\\");
     }
 
     /**

--- a/core/src/main/java/hudson/Main.java
+++ b/core/src/main/java/hudson/Main.java
@@ -25,6 +25,7 @@ package hudson;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import jenkins.util.SystemProperties;
@@ -97,7 +98,7 @@ public class Main {
 
         // check for authentication info
         String auth = new URL(home).getUserInfo();
-        if(auth != null) auth = "Basic " + new Base64Encoder().encode(auth.getBytes("UTF-8"));
+        if(auth != null) auth = "Basic " + new Base64Encoder().encode(auth.getBytes(StandardCharsets.UTF_8));
 
         {// check if the home is set correctly
             HttpURLConnection con = open(new URL(home));
@@ -143,7 +144,7 @@ public class Main {
         try {
             int ret;
             try (OutputStream os = Files.newOutputStream(tmpFile.toPath());
-                 Writer w = new OutputStreamWriter(os,"UTF-8")) {
+                 Writer w = new OutputStreamWriter(os, StandardCharsets.UTF_8)) {
                 w.write("<?xml version='1.1' encoding='UTF-8'?>");
                 w.write("<run><log encoding='hexBinary' content-encoding='"+Charset.defaultCharset().name()+"'>");
                 w.flush();

--- a/core/src/main/java/hudson/Platform.java
+++ b/core/src/main/java/hudson/Platform.java
@@ -47,7 +47,7 @@ public enum Platform {
      */
     public final char pathSeparator;
 
-    private Platform(char pathSeparator) {
+    Platform(char pathSeparator) {
         this.pathSeparator = pathSeparator;
     }
 

--- a/core/src/main/java/hudson/PluginFirstClassLoader.java
+++ b/core/src/main/java/hudson/PluginFirstClassLoader.java
@@ -80,29 +80,25 @@ public class PluginFirstClassLoader
     protected Enumeration findResources( String arg0, boolean arg1 )
         throws IOException
     {
-        Enumeration enu = super.findResources( arg0, arg1 );
-        return enu;
+        return super.findResources( arg0, arg1 );
     }
 
     @Override
     protected Enumeration findResources( String name )
         throws IOException
     {
-        Enumeration enu = super.findResources( name );
-        return enu;
+        return super.findResources( name );
     }
 
     @Override
     public URL getResource( String arg0 )
     {
-        URL url = super.getResource( arg0 );
-        return url;
+        return super.getResource( arg0 );
     }
 
     @Override
     public InputStream getResourceAsStream( String name )
     {
-        InputStream is = super.getResourceAsStream( name );
-        return is;
+        return super.getResourceAsStream( name );
     }
 }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1045,8 +1045,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 URL res = cl.findResource(PluginWrapper.MANIFEST_FILENAME);
                 if (res!=null) {
                     in = getBundledJpiManifestStream(res);
-                    Manifest manifest = new Manifest(in);
-                    return manifest;
+                    return new Manifest(in);
                 }
             } finally {
                 Util.closeAndLogFailures(in, LOGGER, PluginWrapper.MANIFEST_FILENAME, bundledJpi.toString());

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.SequenceInputStream;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPublicKey;
 import javax.annotation.Nullable;
 
@@ -236,7 +237,7 @@ public final class TcpSlaveAgentListener extends Thread {
 
                 DataInputStream in = new DataInputStream(s.getInputStream());
                 PrintWriter out = new PrintWriter(
-                        new BufferedWriter(new OutputStreamWriter(s.getOutputStream(),"UTF-8")),
+                        new BufferedWriter(new OutputStreamWriter(s.getOutputStream(), StandardCharsets.UTF_8)),
                         true); // DEPRECATED: newer protocol shouldn't use PrintWriter but should use DataOutputStream
 
                 // peek the first few bytes to determine what to do with this client
@@ -291,7 +292,7 @@ public final class TcpSlaveAgentListener extends Thread {
          */
         private void respondHello(String header, Socket s) throws IOException {
             try {
-                Writer o = new OutputStreamWriter(s.getOutputStream(), "UTF-8");
+                Writer o = new OutputStreamWriter(s.getOutputStream(), StandardCharsets.UTF_8);
 
                 //TODO: expose version about minimum supported Remoting version (JENKINS-48766)
                 if (header.startsWith("GET / ")) {
@@ -358,11 +359,7 @@ public final class TcpSlaveAgentListener extends Thread {
         private final byte[] ping;
 
         public PingAgentProtocol() {
-            try {
-                ping = "Ping\n".getBytes("UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new IllegalStateException("JLS mandates support for UTF-8 charset", e);
-            }
+            ping = "Ping\n".getBytes(StandardCharsets.UTF_8);
         }
 
         /**
@@ -414,9 +411,9 @@ public final class TcpSlaveAgentListener extends Thread {
                         } else {
                             LOGGER.log(Level.FINE, "Expected ping response from {0} of {1} got {2}", new Object[]{
                                     socket.getRemoteSocketAddress(),
-                                    new String(ping, "UTF-8"),
+                                    new String(ping, StandardCharsets.UTF_8),
                                     responseLength > 0 && responseLength <= response.length ?
-                                        new String(response, 0, responseLength, "UTF-8") :
+                                        new String(response, 0, responseLength, StandardCharsets.UTF_8) :
                                         "bad response length " + responseLength
                             });
                             return false;

--- a/core/src/main/java/hudson/UDPBroadcastThread.java
+++ b/core/src/main/java/hudson/UDPBroadcastThread.java
@@ -79,6 +79,7 @@ public class UDPBroadcastThread extends Thread {
             mcs.joinGroup(MULTICAST);
             ready.signal();
 
+            //noinspection InfiniteLoopStatement
             while(true) {
                 byte[] buf = new byte[2048];
                 DatagramPacket p = new DatagramPacket(buf,buf.length);

--- a/core/src/main/java/hudson/UDPBroadcastThread.java
+++ b/core/src/main/java/hudson/UDPBroadcastThread.java
@@ -37,6 +37,7 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.channels.ClosedByInterruptException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -99,7 +100,7 @@ public class UDPBroadcastThread extends Thread {
 
                 rsp.append("</hudson>");
 
-                byte[] response = rsp.toString().getBytes("UTF-8");
+                byte[] response = rsp.toString().getBytes(StandardCharsets.UTF_8);
                 mcs.send(new DatagramPacket(response,response.length,sender));
             }
         } catch (ClosedByInterruptException e) {

--- a/core/src/main/java/hudson/cli/CliCrumbExclusion.java
+++ b/core/src/main/java/hudson/cli/CliCrumbExclusion.java
@@ -43,7 +43,7 @@ public class CliCrumbExclusion extends CrumbExclusion {
     @Override
     public boolean process(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         String pathInfo = request.getPathInfo();
-        if (pathInfo != null && "/cli".equals(pathInfo)) {
+        if ("/cli".equals(pathInfo)) {
             chain.doFilter(request, response);
             return true;
         }

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -145,7 +145,7 @@ public class WindowsServiceLifecycle extends Lifecycle {
             throw new IOException(baos.toString());
     }
     
-    private static final File getBaseDir() {
+    private static File getBaseDir() {
         File baseDir;
         
         String baseEnv = System.getenv("BASE");

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1450,11 +1450,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
                     }
                 }
                 //We can roam, check that the master is set to be used as much as possible, and not tied jobs only.
-                if(Jenkins.getInstance().getMode() == Mode.EXCLUSIVE) {
-                    return true;
-                } else {
-                    return false;
-                }
+                return Jenkins.getInstance().getMode() == Mode.EXCLUSIVE;
             }
         }
         return true;

--- a/core/src/main/java/hudson/model/Api.java
+++ b/core/src/main/java/hudson/model/Api.java
@@ -50,6 +50,7 @@ import java.io.OutputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -188,7 +189,7 @@ public class Api extends AbstractModelObject {
                 // simple output allowed
                 rsp.setContentType("text/plain;charset=UTF-8");
                 String text = result instanceof CharacterData ? ((CharacterData) result).getText() : result.toString();
-                o.write(text.getBytes("UTF-8"));
+                o.write(text.getBytes(StandardCharsets.UTF_8));
                 return;
             }
 

--- a/core/src/main/java/hudson/model/BooleanParameterValue.java
+++ b/core/src/main/java/hudson/model/BooleanParameterValue.java
@@ -79,9 +79,7 @@ public class BooleanParameterValue extends ParameterValue {
 
         BooleanParameterValue that = (BooleanParameterValue) o;
 
-        if (value != that.value) return false;
-
-        return true;
+        return value == that.value;
     }
 
     @Override

--- a/core/src/main/java/hudson/model/BuildAuthorizationToken.java
+++ b/core/src/main/java/hudson/model/BuildAuthorizationToken.java
@@ -64,8 +64,7 @@ public final class BuildAuthorizationToken {
     }
 
     @Deprecated public static void checkPermission(AbstractProject<?,?> project, BuildAuthorizationToken token, StaplerRequest req, StaplerResponse rsp) throws IOException {
-        Job<?,?> j = project;
-        checkPermission(j, token, req, rsp);
+        checkPermission((Job<?,?>) project, token, req, rsp);
     }
 
     public static void checkPermission(Job<?,?> project, BuildAuthorizationToken token, StaplerRequest req, StaplerResponse rsp) throws IOException {

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -244,7 +245,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                 rsp.setContentType("text/plain;charset=UTF-8");
                 try (OutputStream os = rsp.getOutputStream()) {
                     for (VirtualFile kid : baseFile.list()) {
-                        os.write(kid.getName().getBytes("UTF-8"));
+                        os.write(kid.getName().getBytes(StandardCharsets.UTF_8));
                         if (kid.isDirectory()) {
                             os.write('/');
                         }

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -558,7 +558,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
      * Evaluates whether the current label name is equal to the name parameter.
      *
      */
-    private final boolean matches(String name) {
+    private boolean matches(String name) {
         return this.name.equals(name);
     }
 

--- a/core/src/main/java/hudson/model/ModifiableViewGroup.java
+++ b/core/src/main/java/hudson/model/ModifiableViewGroup.java
@@ -38,5 +38,5 @@ public interface ModifiableViewGroup extends ViewGroup {
     /**
      * Add new {@link View} to this {@link ViewGroup}.
      */
-    public void addView(@Nonnull View view) throws IOException;
+    void addView(@Nonnull View view) throws IOException;
 }

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -268,8 +268,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
     @Nonnull
     public ParametersAction merge(@CheckForNull ParametersAction overrides) {
         if (overrides == null) {
-            ParametersAction parametersAction = new ParametersAction(parameters, this.safeParameters);
-            return parametersAction;
+            return new ParametersAction(parameters, this.safeParameters);
         }
         ParametersAction parametersAction = createUpdated(overrides.parameters);
         Set<String> safe = new TreeSet<>();

--- a/core/src/main/java/hudson/model/ResultTrend.java
+++ b/core/src/main/java/hudson/model/ResultTrend.java
@@ -75,7 +75,7 @@ public enum ResultTrend {
     
     private final Localizable description;
 
-    private ResultTrend(Localizable description) {
+    ResultTrend(Localizable description) {
         this.description = description;
     }
     

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -236,7 +236,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */
     private volatile transient State state;
 
-    private static enum State {
+    private enum State {
         /**
          * Build is created/queued but we haven't started building it.
          */

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -225,7 +225,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      * Simple connection status enum.
      */
     @Restricted(NoExternalUse.class)
-    static enum ConnectionStatus {
+    enum ConnectionStatus {
         /**
          * Connection status has not started yet.
          */
@@ -1888,7 +1888,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         return VerificationResult.FAIL;
     }
 
-    private static enum VerificationResult {
+    private enum VerificationResult {
         PASS,
         NOT_PROVIDED,
         NOT_COMPUTED,

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -159,7 +159,7 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
         // capture the descriptors as these should be small compared with the number of items
         // so we will walk all items only once and we can short-cut the search of descriptors
         TopLevelItemDescriptor[] descriptors = Items.all().toArray(new TopLevelItemDescriptor[0]);
-        int counts[] = new int[descriptors.length];
+        int[] counts = new int[descriptors.length];
         for (TopLevelItem item: j.allItems(TopLevelItem.class)) {
             TopLevelItemDescriptor d = item.getDescriptor();
             for (int i = 0; i < descriptors.length; i++) {

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -49,6 +49,7 @@ import java.io.OutputStream;
 import java.io.FilterInputStream;
 import java.io.InputStream;
 import java.io.DataInputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyFactory;
@@ -181,7 +182,7 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
             // json -> UTF-8 encode -> gzip -> encrypt -> base64 -> string
             try (OutputStream cipheros = new CombinedCipherOutputStream(baos,getKey(),"AES");
                  OutputStream zipos = new GZIPOutputStream(cipheros);
-                 OutputStreamWriter w = new OutputStreamWriter(zipos, "UTF-8")) {
+                 OutputStreamWriter w = new OutputStreamWriter(zipos, StandardCharsets.UTF_8)) {
                 o.write(w);
             }
 

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -728,7 +728,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
         AllUsers.clear();
     }
 
-    private static final File getConfigFileFor(String id) {
+    private static File getConfigFileFor(String id) {
         return new File(getUserFolderFor(id), "config.xml");
     }
     

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -99,6 +99,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -1206,7 +1207,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
         }
 
         // try to reflect the changes by reloading
-        try (InputStream in = new BufferedInputStream(new ByteArrayInputStream(out.toString().getBytes("UTF-8")))){
+        try (InputStream in = new BufferedInputStream(new ByteArrayInputStream(out.toString().getBytes(StandardCharsets.UTF_8)))){
             // Do not allow overwriting view name as it might collide with another
             // view in same ViewGroup and might not satisfy Jenkins.checkGoodName.
             String oldname = name;

--- a/core/src/main/java/hudson/model/labels/LabelExpression.java
+++ b/core/src/main/java/hudson/model/labels/LabelExpression.java
@@ -176,7 +176,7 @@ public abstract class LabelExpression extends Label {
 
         @Override
         protected boolean op(boolean a, boolean b) {
-            return !(a ^ b);
+            return a == b;
         }
 
         @Override

--- a/core/src/main/java/hudson/node_monitors/ClockMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ClockMonitor.java
@@ -77,5 +77,5 @@ public class ClockMonitor extends NodeMonitor {
         public NodeMonitor newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             return new ClockMonitor();
         }
-    };
+    }
 }

--- a/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
@@ -106,7 +106,7 @@ public class SwapSpaceMonitor extends NodeMonitor {
         public NodeMonitor newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             return new SwapSpaceMonitor();
         }
-    };
+    }
 
     /**
      * Obtains the string that represents the architecture.

--- a/core/src/main/java/hudson/org/apache/tools/tar/TarOutputStream.java
+++ b/core/src/main/java/hudson/org/apache/tools/tar/TarOutputStream.java
@@ -30,6 +30,7 @@ import org.apache.tools.tar.TarEntry;
 import java.io.FilterOutputStream;
 import java.io.OutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * The TarOutputStream writes a UNIX tar archive as an OutputStream.
@@ -186,7 +187,7 @@ public class TarOutputStream extends FilterOutputStream {
                 TarEntry longLinkEntry = new TarEntry(TarConstants.GNU_LONGLINK,
                                                       TarConstants.LF_GNUTYPE_LONGNAME);
 
-                byte[] name = entry.getName().getBytes("UTF-8");
+                byte[] name = entry.getName().getBytes(StandardCharsets.UTF_8);
                 longLinkEntry.setSize(name.length + 1);
                 putNextEntry(longLinkEntry);
                 write(name);

--- a/core/src/main/java/hudson/scheduler/Hash.java
+++ b/core/src/main/java/hudson/scheduler/Hash.java
@@ -24,6 +24,7 @@
 package hudson.scheduler;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Random;
@@ -55,7 +56,7 @@ public abstract class Hash {
     public static Hash from(String seed) {
         try {
             MessageDigest md5 = MessageDigest.getInstance("MD5");
-            md5.update(seed.getBytes("UTF-8"));
+            md5.update(seed.getBytes(StandardCharsets.UTF_8));
             byte[] digest = md5.digest();
 
             for (int i=8; i<digest.length; i++)
@@ -74,8 +75,6 @@ public abstract class Hash {
             };
         } catch (NoSuchAlgorithmException e) {
             throw new AssertionError(e);    // MD5 is a part of JRE
-        } catch (UnsupportedEncodingException e) {
-            throw new AssertionError(e);    // UTF-8 is mandatory
         }
     }
 

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -902,8 +902,8 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
             return password.startsWith(JBCRYPT_HEADER) && JBCRYPT_ENCODER.isHashValid(password.substring(JBCRYPT_HEADER.length()));
         }
 
-    };
-    
+    }
+
     public static final MultiPasswordEncoder PASSWORD_ENCODER = new MultiPasswordEncoder();
 
     @Extension @Symbol("local")

--- a/core/src/main/java/hudson/security/LegacySecurityRealm.java
+++ b/core/src/main/java/hudson/security/LegacySecurityRealm.java
@@ -110,5 +110,5 @@ public final class LegacySecurityRealm extends SecurityRealm implements Authenti
         public String getDisplayName() {
             return Messages.LegacySecurityRealm_Displayname();
         }
-    };
+    }
 }

--- a/core/src/main/java/hudson/security/csrf/CrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbIssuer.java
@@ -24,6 +24,7 @@ import hudson.model.Descriptor;
 import hudson.util.MultipartFormDataParser;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import javax.servlet.ServletException;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -216,7 +217,7 @@ public abstract class CrumbIssuer implements Describable<CrumbIssuer>, Extension
             if (text != null) {
                 try (OutputStream o = rsp.getCompressedOutputStream(req)) {
                     rsp.setContentType("text/plain;charset=UTF-8");
-                    o.write(text.getBytes("UTF-8"));
+                    o.write(text.getBytes(StandardCharsets.UTF_8));
                 }
             } else {
                 super.doXml(req, rsp, xpath, wrapper, tree, depth);

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -334,7 +334,7 @@ public class NodeProvisioner {
      * Represents the decision taken by an individual {@link hudson.slaves.NodeProvisioner.Strategy}.
      * @since 1.588
      */
-    public static enum StrategyDecision {
+    public enum StrategyDecision {
         /**
          * This decision is the default decision and indicates that the {@link hudson.slaves.NodeProvisioner.Strategy}
          * either could not provision sufficient resources or did not take any action. Any remaining strategies

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -327,7 +327,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
                 return FormValidation.ok();
             }
             // defensive approach to remain case sensitive in doubtful situations
-            boolean bCaseSensitive = caseSensitive == null || !"false".equals(caseSensitive);
+            boolean bCaseSensitive = !"false".equals(caseSensitive);
             return FilePath.validateFileMask(project.getSomeWorkspace(), value, bCaseSensitive);
         }
 

--- a/core/src/main/java/hudson/tools/AbstractCommandInstaller.java
+++ b/core/src/main/java/hudson/tools/AbstractCommandInstaller.java
@@ -73,7 +73,7 @@ public abstract class AbstractCommandInstaller extends ToolInstaller {
         // TODO support Unix scripts with interpreter line (see Shell.buildCommandLine)
         FilePath script = dir.createTextTempFile("hudson", getCommandFileExtension(), command);
         try {
-            String cmd[] = getCommandCall(script);
+            String[] cmd = getCommandCall(script);
             int r = node.createLauncher(log).launch().cmds(cmd).stdout(log).pwd(dir).join();
             if (r != 0) {
                 throw new IOException("Command returned status " + r);

--- a/core/src/main/java/hudson/tools/BatchCommandInstaller.java
+++ b/core/src/main/java/hudson/tools/BatchCommandInstaller.java
@@ -50,8 +50,7 @@ public class BatchCommandInstaller extends AbstractCommandInstaller {
 
     @Override
     public String[] getCommandCall(FilePath script) {
-        String[] cmd = {"cmd", "/c", "call", script.getRemote()};
-        return cmd;
+        return new String[]{"cmd", "/c", "call", script.getRemote()};
     }
 
     private Object readResolve() throws ObjectStreamException {

--- a/core/src/main/java/hudson/tools/CommandInstaller.java
+++ b/core/src/main/java/hudson/tools/CommandInstaller.java
@@ -49,8 +49,7 @@ public class CommandInstaller extends AbstractCommandInstaller {
 
     @Override
     public String[] getCommandCall(FilePath script) {
-        String[] cmd = {"sh", "-e", script.getRemote()};
-        return cmd;
+        return new String[]{"sh", "-e", script.getRemote()};
     }
 
     private Object readResolve() throws ObjectStreamException {

--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -192,9 +192,8 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
             ToolInstallerList toolInstallerList = new ToolInstallerList();
             toolInstallerList.list = new ToolInstallerEntry[reducedToolEntries.size()];
             reducedToolEntries.toArray(toolInstallerList.list);
-            JSONObject reducedToolEntriesJsonList = JSONObject.fromObject(toolInstallerList);
             //return the list with no duplicates
-            return reducedToolEntriesJsonList;
+            return JSONObject.fromObject(toolInstallerList);
         }
 
         /**

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -188,7 +188,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      */
     public ArgumentListBuilder addKeyValuePairs(String prefix, Map<String,String> props, Set<String> propsToMask) {
         for (Entry<String,String> e : props.entrySet()) {
-            addKeyValuePair(prefix, e.getKey(), e.getValue(), (propsToMask == null) ? false : propsToMask.contains(e.getKey()));
+            addKeyValuePair(prefix, e.getKey(), e.getValue(), (propsToMask != null) && propsToMask.contains(e.getKey()));
         }
         return this;
     }
@@ -230,7 +230,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
         properties = Util.replaceMacro(properties, propertiesGeneratingResolver(vr));
 
         for (Entry<Object,Object> entry : Util.loadProperties(properties).entrySet()) {
-            addKeyValuePair(prefix, (String)entry.getKey(), entry.getValue().toString(), (propsToMask == null) ? false : propsToMask.contains(entry.getKey()));
+            addKeyValuePair(prefix, (String)entry.getKey(), entry.getValue().toString(), (propsToMask != null) && propsToMask.contains(entry.getKey()));
         }
         return this;
     }

--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -162,7 +162,7 @@ public class AtomicFileWriter extends Writer {
         core.write(str,off,len);
     }
 
-    public void write(char cbuf[], int off, int len) throws IOException {
+    public void write(char[] cbuf, int off, int len) throws IOException {
         core.write(cbuf,off,len);
     }
 

--- a/core/src/main/java/hudson/util/ByteBuffer.java
+++ b/core/src/main/java/hudson/util/ByteBuffer.java
@@ -46,7 +46,7 @@ public class ByteBuffer extends OutputStream {
     private int size = 0;
 
 
-    public synchronized void write(byte b[], int off, int len) throws IOException {
+    public synchronized void write(byte[] b, int off, int len) throws IOException {
         ensureCapacity(len);
         System.arraycopy(b,off,buf,size,len);
         size+=len;
@@ -94,7 +94,7 @@ public class ByteBuffer extends OutputStream {
                 }
             }
 
-            public int read(byte b[], int off, int len) throws IOException {
+            public int read(byte[] b, int off, int len) throws IOException {
                 synchronized(ByteBuffer.this) {
                     if(size==pos)
                         return -1;

--- a/core/src/main/java/hudson/util/CharSpool.java
+++ b/core/src/main/java/hudson/util/CharSpool.java
@@ -41,7 +41,7 @@ public final class CharSpool extends Writer {
     private char[] last = new char[1024];
     private int pos;
 
-    public void write(char cbuf[], int off, int len) {
+    public void write(char[] cbuf, int off, int len) {
         while(len>0) {
             int sz = Math.min(last.length-pos,len);
             System.arraycopy(cbuf,off,last,pos,sz);

--- a/core/src/main/java/hudson/util/ChunkedInputStream.java
+++ b/core/src/main/java/hudson/util/ChunkedInputStream.java
@@ -342,7 +342,7 @@ public class ChunkedInputStream extends InputStream {
      */
     static void exhaustInputStream(InputStream inStream) throws IOException {
         // read and discard the remainder of the message
-        byte buffer[] = new byte[1024];
+        byte[] buffer = new byte[1024];
         while (inStream.read(buffer) >= 0) {
             ;
         }

--- a/core/src/main/java/hudson/util/ChunkedInputStream.java
+++ b/core/src/main/java/hudson/util/ChunkedInputStream.java
@@ -345,7 +345,6 @@ public class ChunkedInputStream extends InputStream {
         // read and discard the remainder of the message
         byte[] buffer = new byte[1024];
         while (inStream.read(buffer) >= 0) {
-            ;
         }
     }
 }

--- a/core/src/main/java/hudson/util/ChunkedInputStream.java
+++ b/core/src/main/java/hudson/util/ChunkedInputStream.java
@@ -33,6 +33,7 @@ package hudson.util;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 
 
@@ -266,7 +267,7 @@ public class ChunkedInputStream extends InputStream {
         }
 
         //parse data
-        String dataString = new String(baos.toByteArray(),"US-ASCII");
+        String dataString = new String(baos.toByteArray(), StandardCharsets.US_ASCII);
         int separator = dataString.indexOf(';');
         dataString = (separator > 0)
             ? dataString.substring(0, separator).trim()

--- a/core/src/main/java/hudson/util/ChunkedOutputStream.java
+++ b/core/src/main/java/hudson/util/ChunkedOutputStream.java
@@ -42,13 +42,17 @@ import java.io.OutputStream;
 public class ChunkedOutputStream extends OutputStream {
 
     // ------------------------------------------------------- Static Variables
-    private static final byte CRLF[] = new byte[] {(byte) 13, (byte) 10};
+    private static final byte[] CRLF = new byte[]{(byte) 13, (byte) 10};
 
-    /** End chunk */
-    private static final byte ENDCHUNK[] = CRLF;
+    /**
+     * End chunk
+     */
+    private static final byte[] ENDCHUNK = CRLF;
 
-    /** 0 */
-    private static final byte ZERO[] = new byte[] {(byte) '0'};
+    /**
+     * 0
+     */
+    private static final byte[] ZERO = new byte[]{(byte) '0'};
 
     // ----------------------------------------------------- Instance Variables
     private OutputStream stream = null;
@@ -92,7 +96,7 @@ public class ChunkedOutputStream extends OutputStream {
      */
     protected void flushCache() throws IOException {
         if (cachePosition > 0) {
-            byte chunkHeader[] = (Integer.toHexString(cachePosition) + "\r\n").getBytes("US-ASCII");
+            byte[] chunkHeader = (Integer.toHexString(cachePosition) + "\r\n").getBytes("US-ASCII");
             stream.write(chunkHeader, 0, chunkHeader.length);
             stream.write(cache, 0, cachePosition);
             stream.write(ENDCHUNK, 0, ENDCHUNK.length);
@@ -110,8 +114,8 @@ public class ChunkedOutputStream extends OutputStream {
      *
      * @since 3.0
      */
-    protected void flushCacheWithAppend(byte bufferToAppend[], int off, int len) throws IOException {
-        byte chunkHeader[] = (Integer.toHexString(cachePosition + len) + "\r\n").getBytes("US-ASCII");
+    protected void flushCacheWithAppend(byte[] bufferToAppend, int off, int len) throws IOException {
+        byte[] chunkHeader = (Integer.toHexString(cachePosition + len) + "\r\n").getBytes("US-ASCII");
         stream.write(chunkHeader, 0, chunkHeader.length);
         stream.write(cache, 0, cachePosition);
         stream.write(bufferToAppend, off, len);
@@ -167,12 +171,12 @@ public class ChunkedOutputStream extends OutputStream {
      * @since 3.0
      */
     @Override
-    public void write(byte b[]) throws IOException {
+    public void write(byte[] b) throws IOException {
         this.write(b, 0, b.length);
     }
 
     @Override
-    public void write(byte src[], int off, int len) throws IOException {
+    public void write(byte[] src, int off, int len) throws IOException {
         if (len >= cache.length - cachePosition) {
             flushCacheWithAppend(src, off, len);
         } else {

--- a/core/src/main/java/hudson/util/ChunkedOutputStream.java
+++ b/core/src/main/java/hudson/util/ChunkedOutputStream.java
@@ -32,6 +32,7 @@ package hudson.util;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Implements HTTP chunking support. Writes are buffered to an internal buffer (2048 default size).
@@ -96,7 +97,7 @@ public class ChunkedOutputStream extends OutputStream {
      */
     protected void flushCache() throws IOException {
         if (cachePosition > 0) {
-            byte[] chunkHeader = (Integer.toHexString(cachePosition) + "\r\n").getBytes("US-ASCII");
+            byte[] chunkHeader = (Integer.toHexString(cachePosition) + "\r\n").getBytes(StandardCharsets.US_ASCII);
             stream.write(chunkHeader, 0, chunkHeader.length);
             stream.write(cache, 0, cachePosition);
             stream.write(ENDCHUNK, 0, ENDCHUNK.length);
@@ -115,7 +116,7 @@ public class ChunkedOutputStream extends OutputStream {
      * @since 3.0
      */
     protected void flushCacheWithAppend(byte[] bufferToAppend, int off, int len) throws IOException {
-        byte[] chunkHeader = (Integer.toHexString(cachePosition + len) + "\r\n").getBytes("US-ASCII");
+        byte[] chunkHeader = (Integer.toHexString(cachePosition + len) + "\r\n").getBytes(StandardCharsets.US_ASCII);
         stream.write(chunkHeader, 0, chunkHeader.length);
         stream.write(cache, 0, cachePosition);
         stream.write(bufferToAppend, off, len);

--- a/core/src/main/java/hudson/util/FileChannelWriter.java
+++ b/core/src/main/java/hudson/util/FileChannelWriter.java
@@ -66,7 +66,7 @@ public class FileChannelWriter extends Writer {
     }
 
     @Override
-    public void write(char cbuf[], int off, int len) throws IOException {
+    public void write(char[] cbuf, int off, int len) throws IOException {
         final CharBuffer charBuffer = CharBuffer.wrap(cbuf, off, len);
         ByteBuffer byteBuffer = charset.encode(charBuffer);
         channel.write(byteBuffer);

--- a/core/src/main/java/hudson/util/HeadBufferingStream.java
+++ b/core/src/main/java/hudson/util/HeadBufferingStream.java
@@ -57,7 +57,7 @@ public class HeadBufferingStream extends FilterInputStream {
     }
 
     @Override
-    public int read(byte b[], int off, int len) throws IOException {
+    public int read(byte[] b, int off, int len) throws IOException {
         int r = in.read(b, off, len);
         if(r>0) {
             int sp = space();

--- a/core/src/main/java/hudson/util/LineEndNormalizingWriter.java
+++ b/core/src/main/java/hudson/util/LineEndNormalizingWriter.java
@@ -48,7 +48,7 @@ public class LineEndNormalizingWriter extends FilterWriter {
         super(out);
     }
 
-    public void write(char cbuf[]) throws IOException {
+    public void write(char[] cbuf) throws IOException {
         write(cbuf, 0, cbuf.length);
     }
 
@@ -64,7 +64,7 @@ public class LineEndNormalizingWriter extends FilterWriter {
         seenCR = (c==CR);
     }
 
-    public void write(char cbuf[], int off, int len) throws IOException {
+    public void write(char[] cbuf, int off, int len) throws IOException {
         int end = off+len;
         int writeBegin = off;
 

--- a/core/src/main/java/hudson/util/NullStream.java
+++ b/core/src/main/java/hudson/util/NullStream.java
@@ -32,11 +32,11 @@ public final class NullStream extends OutputStream {
     public NullStream() {}
 
     @Override
-    public void write(byte b[]) {
+    public void write(byte[] b) {
     }
 
     @Override
-    public void write(byte b[], int off, int len) {
+    public void write(byte[] b, int off, int len) {
     }
 
     public void write(int b) {

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -873,8 +873,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     JAVA_9_PROCESSHANDLE_DESTROY = null;
                 }
             } catch (ClassNotFoundException | NoSuchFieldException | NoSuchMethodException e) {
-                LinkageError x = new LinkageError("Cannot initialize reflection for Unix Processes", e);
-                throw x;
+                throw new LinkageError("Cannot initialize reflection for Unix Processes", e);
             }
         }
 

--- a/core/src/main/java/hudson/util/SecretRewriter.java
+++ b/core/src/main/java/hudson/util/SecretRewriter.java
@@ -88,7 +88,7 @@ public class SecretRewriter {
             boolean modified = false; // did we actually change anything?
             try (PrintWriter out = new PrintWriter(new BufferedWriter(w))) {
                 try (InputStream fin = Files.newInputStream(f.toPath())) {
-                    BufferedReader r = new BufferedReader(new InputStreamReader(fin, "UTF-8"));
+                    BufferedReader r = new BufferedReader(new InputStreamReader(fin, StandardCharsets.UTF_8));
                     String line;
                     StringBuilder buf = new StringBuilder();
 

--- a/core/src/main/java/hudson/util/Service.java
+++ b/core/src/main/java/hudson/util/Service.java
@@ -27,6 +27,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
@@ -50,7 +51,7 @@ public class Service {
         final Enumeration<URL> e = classLoader.getResources("META-INF/services/"+type.getName());
         while (e.hasMoreElements()) {
             URL url = e.nextElement();
-            try (BufferedReader configFile = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"))) {
+            try (BufferedReader configFile = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = configFile.readLine()) != null) {
                     line = line.trim();
@@ -84,7 +85,7 @@ public class Service {
             Enumeration<URL> e = cl.getResources("META-INF/services/" + spi.getName());
             while(e.hasMoreElements()) {
                 final URL url = e.nextElement();
-                try (BufferedReader r = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"))) {
+                try (BufferedReader r = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
                     String line;
                     while ((line = r.readLine()) != null) {
                         if (line.startsWith("#"))

--- a/core/src/main/java/hudson/util/WriterOutputStream.java
+++ b/core/src/main/java/hudson/util/WriterOutputStream.java
@@ -62,7 +62,7 @@ public class WriterOutputStream extends OutputStream {
         buf.put((byte)b);
     }
 
-    public void write(byte b[], int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws IOException {
         while(len>0) {
             if(buf.remaining()==0)
                 decode(false);

--- a/core/src/main/java/hudson/util/jna/RegistryKey.java
+++ b/core/src/main/java/hudson/util/jna/RegistryKey.java
@@ -18,6 +18,7 @@ package hudson.util.jna;
 import com.sun.jna.ptr.IntByReference;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -65,11 +66,7 @@ public class RegistryKey {
      * @return String
      */
     private static String convertBufferToString(byte[] buf) {
-        try {
-            return new String(buf, 0, buf.length - 2, "UTF-16LE");
-        } catch (UnsupportedEncodingException e) {
-            throw new AssertionError(e);    // impossible
-        }
+        return new String(buf, 0, buf.length - 2, StandardCharsets.UTF_16LE);
     }
 
     /**
@@ -128,15 +125,11 @@ public class RegistryKey {
      * Writes a String value.
      */
     public void setValue(String name, String value) {
-        try {
-            byte[] bytes = value.getBytes("UTF-16LE");
-            int newLength = bytes.length+2; // for 0 padding
-            byte[] with0 = new byte[newLength];
-            System.arraycopy(bytes, 0, with0, 0, newLength);
-            check(Advapi32.INSTANCE.RegSetValueEx(handle, name, 0, WINNT.REG_SZ, with0, with0.length));
-        } catch (UnsupportedEncodingException e) {
-            throw new AssertionError(e);
-        }
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_16LE);
+        int newLength = bytes.length+2; // for 0 padding
+        byte[] with0 = new byte[newLength];
+        System.arraycopy(bytes, 0, with0, 0, newLength);
+        check(Advapi32.INSTANCE.RegSetValueEx(handle, name, 0, WINNT.REG_SZ, with0, with0.length));
     }
 
     /**

--- a/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
+++ b/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
@@ -104,9 +104,10 @@ public class SHELLEXECUTEINFO extends Structure {
 
         public static class ByReference extends DUMMYUNIONNAME_union implements Structure.ByReference {
             
-        };
+        }
+
         public static class ByValue extends DUMMYUNIONNAME_union implements Structure.ByValue {
             
-        };
-    };
+        }
+    }
 }

--- a/core/src/main/java/hudson/widgets/HistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/HistoryWidget.java
@@ -95,7 +95,7 @@ public class HistoryWidget<O extends ModelObject,T> extends Widget {
         this.owner = owner;
         this.newerThan = getPagingParam(currentRequest, "newer-than");
         this.olderThan = getPagingParam(currentRequest, "older-than");
-        this.searchString = currentRequest.getParameter("search");;
+        this.searchString = currentRequest.getParameter("search");
     }
 
     /**

--- a/core/src/main/java/jenkins/PluginSubtypeMarker.java
+++ b/core/src/main/java/jenkins/PluginSubtypeMarker.java
@@ -46,6 +46,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 /**
@@ -110,7 +111,7 @@ public class PluginSubtypeMarker extends AbstractProcessor {
     private void write(TypeElement c) throws IOException {
         FileObject f = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT,
                 "", "META-INF/services/hudson.Plugin");
-        try (Writer w = new OutputStreamWriter(f.openOutputStream(), "UTF-8")) {
+        try (Writer w = new OutputStreamWriter(f.openOutputStream(), StandardCharsets.UTF_8)) {
             w.write(c.getQualifiedName().toString());
         }
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4168,6 +4168,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
         System.out.println("Creating artificial OutOfMemoryError situation");
         List<Object> args = new ArrayList<Object>();
+        //noinspection InfiniteLoopStatement
         while (true)
             args.add(new byte[1024*1024]);
     }

--- a/core/src/main/java/jenkins/model/ModelObjectWithChildren.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithChildren.java
@@ -20,5 +20,5 @@ public interface ModelObjectWithChildren extends ModelObject {
     /**
      * Generates the context menu to list up all the children.
      */
-    public ContextMenu doChildrenContextMenu(StaplerRequest request, StaplerResponse response) throws Exception;
+    ContextMenu doChildrenContextMenu(StaplerRequest request, StaplerResponse response) throws Exception;
 }

--- a/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
@@ -53,7 +53,7 @@ public interface ModelObjectWithContextMenu extends ModelObject {
      * which implements the default behaviour. See {@link ContextMenu#from(ModelObjectWithContextMenu, StaplerRequest, StaplerResponse)}
      * for more details of what it does. This should suit most implementations.
      */
-    public ContextMenu doContextMenu(StaplerRequest request, StaplerResponse response) throws Exception;
+    ContextMenu doContextMenu(StaplerRequest request, StaplerResponse response) throws Exception;
 
     /**
      * Data object that represents the context menu.
@@ -61,7 +61,7 @@ public interface ModelObjectWithContextMenu extends ModelObject {
      * Via {@link HttpResponse}, this class is capable of converting itself to JSON that {@code <l:breadcrumb/>} understands.
      */
     @ExportedBean
-    public class ContextMenu implements HttpResponse {
+    class ContextMenu implements HttpResponse {
         /**
          * The actual contents of the menu.
          */
@@ -225,7 +225,7 @@ public interface ModelObjectWithContextMenu extends ModelObject {
      * Menu item in {@link ContextMenu}
      */
     @ExportedBean
-    public class MenuItem {
+    class MenuItem {
         /**
          * Target of the link.
          *

--- a/core/src/main/java/jenkins/model/NewViewLink.java
+++ b/core/src/main/java/jenkins/model/NewViewLink.java
@@ -44,8 +44,7 @@ public class NewViewLink extends TransientViewActionFactory {
 
             @Override
             public String getUrlName() {
-                String urlName = Jenkins.getInstance().getRootUrl() + URL_NAME;
-                return urlName;
+                return Jenkins.getInstance().getRootUrl() + URL_NAME;
             }
 
             private boolean hasPermission(View view) {

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -266,7 +266,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
      * Computes the build cause, using RemoteCause or UserCause as appropriate.
      */
     @Restricted(NoExternalUse.class)
-    public static final CauseAction getBuildCause(ParameterizedJob job, StaplerRequest req) {
+    public static CauseAction getBuildCause(ParameterizedJob job, StaplerRequest req) {
         Cause cause;
         @SuppressWarnings("deprecation")
         hudson.model.BuildAuthorizationToken authToken = job.getAuthToken();

--- a/core/src/main/java/jenkins/model/lazy/Boundary.java
+++ b/core/src/main/java/jenkins/model/lazy/Boundary.java
@@ -45,7 +45,7 @@ enum Boundary {
 
     private final int offsetOfExactMatch, offsetOfInsertionPoint;
 
-    private Boundary(int offsetOfExactMatch, int offsetOfInsertionPoint) {
+    Boundary(int offsetOfExactMatch, int offsetOfInsertionPoint) {
         this.offsetOfExactMatch = offsetOfExactMatch;
         this.offsetOfInsertionPoint = offsetOfInsertionPoint;
     }

--- a/core/src/main/java/jenkins/model/lazy/Boundary.java
+++ b/core/src/main/java/jenkins/model/lazy/Boundary.java
@@ -54,10 +54,9 @@ enum Boundary {
      * Computes the boundary value.
      */
     public int apply(int binarySearchOutput) {
-        int r = binarySearchOutput;
-        if (r>=0)    return r+offsetOfExactMatch;   // if we had some x_i==p
+        if (binarySearchOutput >=0)    return binarySearchOutput +offsetOfExactMatch;   // if we had some x_i==p
 
-        int ip = -(r+1);
+        int ip = -(binarySearchOutput +1);
         return ip+offsetOfInsertionPoint;
     }
 }

--- a/core/src/main/java/jenkins/mvn/GlobalSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/GlobalSettingsProvider.java
@@ -48,7 +48,7 @@ public abstract class GlobalSettingsProvider extends AbstractDescribableImpl<Glo
      *            the listener of the current build
      * @return the path to the global settings.xml
      */
-    public static final FilePath getSettingsFilePath(GlobalSettingsProvider settings, AbstractBuild<?, ?> build, TaskListener listener) {
+    public static FilePath getSettingsFilePath(GlobalSettingsProvider settings, AbstractBuild<?, ?> build, TaskListener listener) {
         FilePath settingsPath = null;
         if (settings != null) {
             settingsPath = settings.supplySettings(build, listener);
@@ -67,7 +67,7 @@ public abstract class GlobalSettingsProvider extends AbstractDescribableImpl<Glo
      *            the listener of the current build
      * @return the path to the global settings.xml
      */
-    public static final String getSettingsRemotePath(GlobalSettingsProvider provider, AbstractBuild<?, ?> build, TaskListener listener) {
+    public static String getSettingsRemotePath(GlobalSettingsProvider provider, AbstractBuild<?, ?> build, TaskListener listener) {
         FilePath fp = getSettingsFilePath(provider, build, listener);
         return fp == null ? null : fp.getRemote();
     }

--- a/core/src/main/java/jenkins/mvn/SettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/SettingsProvider.java
@@ -47,7 +47,7 @@ public abstract class SettingsProvider extends AbstractDescribableImpl<SettingsP
      *            the listener of the current build
      * @return the path to the settings.xml
      */
-    public static final FilePath getSettingsFilePath(SettingsProvider settings, AbstractBuild<?, ?> build, TaskListener listener) {
+    public static FilePath getSettingsFilePath(SettingsProvider settings, AbstractBuild<?, ?> build, TaskListener listener) {
         FilePath settingsPath = null;
         if (settings != null) {
             settingsPath = settings.supplySettings(build, listener);
@@ -66,7 +66,7 @@ public abstract class SettingsProvider extends AbstractDescribableImpl<SettingsP
      *            the listener of the current build
      * @return the path to the settings.xml
      */
-    public static final String getSettingsRemotePath(SettingsProvider settings, AbstractBuild<?, ?> build, TaskListener listener) {
+    public static String getSettingsRemotePath(SettingsProvider settings, AbstractBuild<?, ?> build, TaskListener listener) {
         FilePath fp = getSettingsFilePath(settings, build, listener);
         return fp == null ? null : fp.getRemote();
     }

--- a/core/src/main/java/jenkins/org/apache/commons/validator/routines/DomainValidator.java
+++ b/core/src/main/java/jenkins/org/apache/commons/validator/routines/DomainValidator.java
@@ -1886,9 +1886,8 @@ public class DomainValidator implements Serializable {
         INFRASTRUCTURE_RO,
         /** Get a copy of the local table */
         LOCAL_RO
-        ;
-    };
-    
+    }
+
     // For use by unit test code only
     static synchronized void clearTLDOverrides() {
         inUse = false;

--- a/core/src/main/java/jenkins/org/apache/commons/validator/routines/DomainValidator.java
+++ b/core/src/main/java/jenkins/org/apache/commons/validator/routines/DomainValidator.java
@@ -1961,7 +1961,7 @@ public class DomainValidator implements Serializable {
      * @since 1.5.1
      */
     public static String [] getTLDEntries(DomainValidator.ArrayType table) {
-        final String array[];
+        final String[] array;
         switch(table) {
             case COUNTRY_CODE_MINUS:
                 array = countryCodeTLDsMinus;

--- a/core/src/main/java/jenkins/security/CustomClassFilter.java
+++ b/core/src/main/java/jenkins/security/CustomClassFilter.java
@@ -84,7 +84,7 @@ public interface CustomClassFilter extends ExtensionPoint {
      */
     @Restricted(NoExternalUse.class)
     @Extension
-    public class Static implements CustomClassFilter {
+    class Static implements CustomClassFilter {
 
         /**
          * Map from {@link Class#getName} to true to permit, false to reject.
@@ -132,7 +132,7 @@ public interface CustomClassFilter extends ExtensionPoint {
      */
     @Restricted(NoExternalUse.class)
     @Extension
-    public class Contributed implements CustomClassFilter {
+    class Contributed implements CustomClassFilter {
 
         /**
          * Map from {@link Class#getName} to true to permit, false to reject.

--- a/core/src/main/java/jenkins/security/HMACConfidentialKey.java
+++ b/core/src/main/java/jenkins/security/HMACConfidentialKey.java
@@ -8,6 +8,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -84,11 +85,7 @@ public class HMACConfidentialKey extends ConfidentialKey {
      * While redundant, often convenient.
      */
     public String mac(String message) {
-        try {
-            return Util.toHexString(mac(message.getBytes("UTF-8")));
-        } catch (UnsupportedEncodingException e) {
-            throw new AssertionError(e);
-        }
+        return Util.toHexString(mac(message.getBytes(StandardCharsets.UTF_8)));
     }
 
     /**

--- a/core/src/main/java/jenkins/security/RSADigitalSignatureConfidentialKey.java
+++ b/core/src/main/java/jenkins/security/RSADigitalSignatureConfidentialKey.java
@@ -24,6 +24,7 @@
 package jenkins.security;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.Signature;
 import java.security.interfaces.RSAPrivateKey;
@@ -50,12 +51,10 @@ public class RSADigitalSignatureConfidentialKey extends RSAConfidentialKey {
             RSAPrivateKey key = getPrivateKey();
             Signature sig = Signature.getInstance(SIGNING_ALGORITHM + "with" + key.getAlgorithm());
             sig.initSign(key);
-            sig.update(msg.getBytes("UTF-8"));
+            sig.update(msg.getBytes(StandardCharsets.UTF_8));
             return hudson.remoting.Base64.encode(sig.sign());
         } catch (GeneralSecurityException e) {
             throw new SecurityException(e);
-        } catch (UnsupportedEncodingException e) {
-            throw new AssertionError(e);    // UTF-8 is mandatory
         }
     }
 

--- a/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
+++ b/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
@@ -92,8 +92,7 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
     @Restricted(NoExternalUse.class)
     public @Nullable ApiTokenStore.HashedToken getLegacyTokenOf(@Nonnull User user) {
         ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);
-        ApiTokenStore.HashedToken legacyToken = apiTokenProperty.getTokenStore().getLegacyToken();
-        return legacyToken;
+        return apiTokenProperty.getTokenStore().getLegacyToken();
     }
     
     // used by Jelly view
@@ -102,8 +101,7 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
         ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);
         if (legacyToken != null) {
             ApiTokenStats.SingleTokenStats legacyStats = apiTokenProperty.getTokenStats().findTokenStatsById(legacyToken.getUuid());
-            ApiTokenProperty.TokenInfoAndStats tokenInfoAndStats = new ApiTokenProperty.TokenInfoAndStats(legacyToken, legacyStats);
-            return tokenInfoAndStats;
+            return new ApiTokenProperty.TokenInfoAndStats(legacyToken, legacyStats);
         }
         
         // in case the legacy token was revoked during the request

--- a/core/src/main/java/jenkins/slaves/EncryptedSlaveAgentJnlpFile.java
+++ b/core/src/main/java/jenkins/slaves/EncryptedSlaveAgentJnlpFile.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.logging.Level;
@@ -91,7 +92,7 @@ public class EncryptedSlaveAgentJnlpFile implements HttpResponse {
             if(it instanceof SlaveComputer) {
                 jnlpMac = Util.fromHexString(((SlaveComputer)it).getJnlpMac());
             } else {
-                jnlpMac = JnlpSlaveAgentProtocol.SLAVE_SECRET.mac(slaveName.getBytes("UTF-8"));
+                jnlpMac = JnlpSlaveAgentProtocol.SLAVE_SECRET.mac(slaveName.getBytes(StandardCharsets.UTF_8));
             }
             SecretKey key = new SecretKeySpec(jnlpMac, 0, /* export restrictions */ 128 / 8, "AES");
             byte[] encrypted;

--- a/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
+++ b/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
@@ -105,7 +105,7 @@ public interface SimpleBuildStep extends BuildStep {
     @SuppressWarnings("rawtypes")
     @Restricted(NoExternalUse.class)
     @Extension
-    public static final class LastBuildActionFactory extends TransientActionFactory<Job> {
+    final class LastBuildActionFactory extends TransientActionFactory<Job> {
 
         @Override
         public Class<Job> type() {

--- a/core/src/main/java/jenkins/util/MarkFindingOutputStream.java
+++ b/core/src/main/java/jenkins/util/MarkFindingOutputStream.java
@@ -3,6 +3,7 @@ package jenkins.util;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Filtering {@link OutputStream} that looks for {@link #MARK} in the output stream and notifies the callback.
@@ -109,10 +110,6 @@ public abstract class MarkFindingOutputStream extends OutputStream {
     private static final byte[] MBYTES = toUTF8(MARK);
     
     private static byte[] toUTF8(String s) {
-        try {
-            return s.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new AssertionError(e);
-        }
+        return s.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/core/src/main/java/jenkins/util/MarkFindingOutputStream.java
+++ b/core/src/main/java/jenkins/util/MarkFindingOutputStream.java
@@ -46,7 +46,7 @@ public abstract class MarkFindingOutputStream extends OutputStream {
         }
     }
 
-    public void write(byte b[], int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws IOException {
         final int start = off; 
         final int end = off + len;
         for (int i=off; i<end; ) {

--- a/core/src/main/java/jenkins/util/Timer.java
+++ b/core/src/main/java/jenkins/util/Timer.java
@@ -62,6 +62,6 @@ public class Timer {
     /**
      * Do not create this.
      */
-    private Timer() {};
+    private Timer() {}
 
 }


### PR DESCRIPTION
This is for discussion.

Notes:
* Most commits were created by IntelliJ (the descriptions are mine because I lost the details)
* a number of members aren't tagged as `final` but appear to be designed to be mutated by a script or debugger -- I've tried to leave those alone. Once these `final`s are added, I can go back and add comments warning people that the others are intentional (some already have a hint, but not all)
* Individual commits are mostly self contained (except for whitespace cleanup which precedes some other change)
* In general, most commits should not change program behavior at all
* 2842b43 is a manual attempt to address non-atomic access to a volatile variable (not sure if it works)
* 78f5fe7 is a behavior change for what appears to be a bug, as is, the function is an expensive NOP

* Calculating the right `serialVersionUID` is painful, I mostly used this:
```
CLASSPATH=$(echo ~/.jenkins-2.161/war/WEB-INF/lib/*.jar|tr ' ' ':')
for a in `cat`; do serialver -classpath $CLASSPATH $a 2>/dev/null; done|grep 'serialVersionUID'|egrep [a-z]
````
But it didn't always give an answer. I've tried to flag all those instances.

### Proposed changelog entries

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
