### PR TITLE
[FIX JENKINS-43218] Fix Fingerprint.toString()

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1412,7 +1412,7 @@ public class Fingerprint implements ModelObject, Saveable {
     }
 
     @Override public String toString() {
-        return "Fingerprint[original=" + original + ",hash=" + getHashString() + ",fileName=" + fileName + ",timestamp=" + DATE_CONVERTER.toString(timestamp) + ",usages=" + ((usages==null) ? "null" : new TreeMap<String,RangeSet>(getUsages())) + ",facets=" + facets + "]";
+        return "Fingerprint[original=" + original + ",hash=" + getHashString() + ",fileName=" + fileName + ",timestamp=" + DATE_CONVERTER.toString(timestamp) + ",usages=" + ((usages == null) ? "null" : new TreeMap<String,RangeSet>(getUsages())) + ",facets=" + facets + "]";
     }
     
     /**

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -73,7 +73,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.Authentication;
 import org.xmlpull.v1.XmlPullParserException;
@@ -974,7 +973,7 @@ public class Fingerprint implements ModelObject, Saveable {
         return r;
     }
 
-    public @Nullable Hashtable<String,RangeSet> getUsages() {
+    public @CheckForNull Hashtable<String,RangeSet> getUsages() {
         return usages;
     }
 

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -73,6 +73,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.Authentication;
 import org.xmlpull.v1.XmlPullParserException;
@@ -973,7 +974,7 @@ public class Fingerprint implements ModelObject, Saveable {
         return r;
     }
 
-    public @Nonnull Hashtable<String,RangeSet> getUsages() {
+    public @Nullable Hashtable<String,RangeSet> getUsages() {
         return usages;
     }
 
@@ -1412,7 +1413,7 @@ public class Fingerprint implements ModelObject, Saveable {
     }
 
     @Override public String toString() {
-        return "Fingerprint[original=" + original + ",hash=" + getHashString() + ",fileName=" + fileName + ",timestamp=" + DATE_CONVERTER.toString(timestamp) + ",usages=" + new TreeMap<String,RangeSet>(usages) + ",facets=" + facets + "]";
+        return "Fingerprint[original=" + original + ",hash=" + getHashString() + ",fileName=" + fileName + ",timestamp=" + DATE_CONVERTER.toString(timestamp) + ",usages=" + ((usages==null) ? "null" : new TreeMap<String,RangeSet>(getUsages())) + ",facets=" + facets + "]";
     }
     
     /**


### PR DESCRIPTION
1. Use getUsage() method instead of usages
   variable in Fingerprint.toString() method
   to fix when usages = null .

Signed-off-by: Mit Naria <mit4dev@gmail.com>

### Changelog entry

* Prevent NullPointerException when discarding unreadable fingerprint data

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs
