### PR TITLE
TEST-ONLY - DON'T MERGE - Verify jenkins-test-harness improvements

### DIFF
--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -54,7 +54,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2.46</version>
+      <version>2.47-20190221.102815-1</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
As requested by @batmat:
This is only to verify that the improvements in jenkins-test-harness don't break anything in Jenkins core.
See https://github.com/jenkinsci/jenkins-test-harness/pull/118.