### PR TITLE
[JENKINS-56114] Correct behavior for Windows Server 2016 with Docker

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -3264,7 +3264,7 @@ public final class FilePath implements Serializable {
             Path parentRealPath;
             try {
                 if (Functions.isWindows()) {
-                    parentRealPath = this.relaxedToRealPath(parentAbsolutePath);
+                    parentRealPath = this.windowsToRealPath(parentAbsolutePath);
                 } else {
                     parentRealPath = parentAbsolutePath.toRealPath();
                 }
@@ -3330,7 +3330,7 @@ public final class FilePath implements Serializable {
             return current;
         }
         
-        private @Nonnull Path relaxedToRealPath(@Nonnull Path path) throws IOException {
+        private @Nonnull Path windowsToRealPath(@Nonnull Path path) throws IOException {
             try {
                 return path.toRealPath();
             }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -132,6 +132,7 @@ import org.jenkinsci.remoting.RoleChecker;
 import org.jenkinsci.remoting.RoleSensitive;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.Function;
 import org.kohsuke.stapler.Stapler;
 
 import static hudson.FilePath.TarCompression.GZIP;
@@ -3262,7 +3263,11 @@ public final class FilePath implements Serializable {
             Path parentAbsolutePath = Util.fileToPath(parentFile.getAbsoluteFile());
             Path parentRealPath;
             try {
-                parentRealPath = relaxedToRealPath(parentAbsolutePath);
+                if (Functions.isWindows()) {
+                    parentRealPath = this.relaxedToRealPath(parentAbsolutePath);
+                } else {
+                    parentRealPath = parentAbsolutePath.toRealPath();
+                }
             }
             catch (NoSuchFileException e) {
                 LOGGER.log(Level.FINE, String.format("Cannot find the real path to the parentFile: %s", parentAbsolutePath), e);
@@ -3325,7 +3330,7 @@ public final class FilePath implements Serializable {
             return current;
         }
         
-        private Path relaxedToRealPath(Path path) throws IOException {
+        private @Nonnull Path relaxedToRealPath(@Nonnull Path path) throws IOException {
             try {
                 return path.toRealPath();
             }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -3330,7 +3330,9 @@ public final class FilePath implements Serializable {
                 return path.toRealPath();
             }
             catch (IOException e) {
-                LOGGER.log(Level.FINE, String.format("relaxedToRealPath cannot use the regular toRealPath on %s, trying with toRealPath(LinkOption.NOFOLLOW_LINKS)", path), e);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, String.format("relaxedToRealPath cannot use the regular toRealPath on %s, trying with toRealPath(LinkOption.NOFOLLOW_LINKS)", path), e);
+                }
             }
 
             // that's required for specific environment like Windows Server 2016, running MSFT docker

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -3329,7 +3329,7 @@ public final class FilePath implements Serializable {
             try {
                 return path.toRealPath();
             }
-            catch(IOException e) {
+            catch (IOException e) {
                 LOGGER.log(Level.FINE, String.format("relaxedToRealPath cannot use the regular toRealPath on %s, trying with toRealPath(LinkOption.NOFOLLOW_LINKS)", path), e);
             }
 

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -546,7 +546,11 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
         private boolean isIllegalSymlink() {
             try {
-                return !this.isDescendant("");
+                String myPath = f.toPath().toRealPath().toString();
+                String rootPath = root.toPath().toRealPath().toString();
+                if (!myPath.equals(rootPath) && !myPath.startsWith(rootPath + File.separatorChar)) {
+                    return true;
+                }
             } catch (IOException x) {
                 Logger.getLogger(VirtualFile.class.getName()).log(Level.FINE, "could not determine symlink status of " + f, x);
             } catch (InvalidPathException x2) {


### PR DESCRIPTION
- also correct the isIllegalSymlink that was using the full isDescendant, that is not required there

See [JENKINS-56114](https://issues.jenkins-ci.org/browse/JENKINS-56114).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Correct an issue occuring on Windows Server 2016 with MSFT Docker that prevent the workspace and the artifact to be browse as expected
 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

