### PR TITLE
[JENKINS-52818] Add the missing @since

### DIFF
--- a/core/src/main/java/hudson/model/PersistentDescriptor.java
+++ b/core/src/main/java/hudson/model/PersistentDescriptor.java
@@ -8,6 +8,7 @@ import javax.annotation.PostConstruct;
  * {@link Descriptor#load()} method is annotated as {@link PostConstruct} so it get automatically invoked after
  * constructor and field injection.
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @since 2.140
  */
 public interface PersistentDescriptor extends Saveable {
 


### PR DESCRIPTION
- avoid git-archeology to find when the interface was added, information found on [c3988a](https://github.com/jenkinsci/jenkins/commit/c3988aae8ad66fde529830e799fe3d49cd241ebb).
- no changelog due to the comment-only change

Related to the work done in [JENKINS-52818](https://issues.jenkins-ci.org/browse/JENKINS-52818).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

