### PR TITLE
Correct the Logger name for Legacy API Token monitor

### DIFF
--- a/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
+++ b/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
@@ -26,7 +26,6 @@ package jenkins.security.apitoken;
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.User;
-import hudson.node_monitors.AbstractAsyncNodeMonitorDescriptor;
 import hudson.util.HttpResponses;
 import jenkins.security.ApiTokenProperty;
 import org.jenkinsci.Symbol;
@@ -53,7 +52,7 @@ import java.util.stream.Collectors;
 @Symbol("legacyApiTokenUsage")
 @Restricted(NoExternalUse.class)
 public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
-    private static final Logger LOGGER = Logger.getLogger(AbstractAsyncNodeMonitorDescriptor.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(LegacyApiTokenAdministrativeMonitor.class.getName());
     
     public LegacyApiTokenAdministrativeMonitor() {
         super("legacyApiToken");


### PR DESCRIPTION
No ticket, that was missed during implementation / review of the new API Token system.

### Proposed changelog entries

* (internal) correct the name of the Logger for the Legacy API Token monitor

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

