### PR TITLE
[JENKINS-42443] Fix spinner interaction with tabbar.less

### DIFF
--- a/war/src/main/js/widgets/config/tabbar.less
+++ b/war/src/main/js/widgets/config/tabbar.less
@@ -228,7 +228,7 @@
           height:@input-line-height;
           line-height:@input-line-height;
         }
-        select{
+        select:not(.select-ajax-pending) {
           border-radius:0;
           background:@brightest;
         }


### PR DESCRIPTION
Bug [JENKINS-42443](https://issues.jenkins-ci.org/browse/JENKINS-42443) added a spinner for `<f:select...>` loads. Unfortunately, the css in tabbar.less was much more specific which means that in most cases it never worked.

I found this while testing jenkinsci/github-branch-source-plugin#208

### Proposed changelog entries

* [JENKINS-42443] Actually show spinner when select tries to load an async request

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@stephenc 