### PR TITLE
[JENKINS-24513] Add access control for builds admin monitor

### DIFF
--- a/core/src/main/java/jenkins/security/QueueItemAuthenticatorMonitor.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticatorMonitor.java
@@ -1,0 +1,140 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.security;
+
+import hudson.Extension;
+import hudson.model.AdministrativeMonitor;
+import hudson.model.Queue;
+import hudson.model.queue.QueueListener;
+import hudson.security.ACL;
+import hudson.security.AuthorizationStrategy;
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
+import hudson.security.LegacyAuthorizationStrategy;
+import hudson.util.HttpResponses;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Display an administrative monitor if we expect {@link QueueItemAuthenticator} to be a useful security measure,
+ * but either it's not present, or potentially badly configured.
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class QueueItemAuthenticatorMonitor extends AdministrativeMonitor {
+    @Override
+    public boolean isActivated() {
+        AuthorizationStrategy authorizationStrategy = Jenkins.get().getAuthorizationStrategy();
+        if (authorizationStrategy instanceof AuthorizationStrategy.Unsecured) {
+            return false;
+        }
+        if (authorizationStrategy instanceof LegacyAuthorizationStrategy) {
+            return false;
+        }
+        if (authorizationStrategy instanceof FullControlOnceLoggedInAuthorizationStrategy) {
+            return false;
+        }
+        return !isQueueItemAuthenticatorPresent() || !isQueueItemAuthenticatorConfigured() || isAnyBuildLaunchedAsSystemWithAuthenticatorPresent();
+    }
+
+    @RequirePOST
+    public HttpResponse doAct(@QueryParameter String redirect, @QueryParameter String dismiss, @QueryParameter String reset) throws IOException {
+        if (redirect != null) {
+            return HttpResponses.redirectTo("https://jenkins.io/redirect/queue-item-security");
+        }
+        if (dismiss != null) {
+            this.disable(true);
+        }
+        if (reset != null) {
+            anyBuildLaunchedAsSystemWithAuthenticatorPresent = false;
+        }
+        return HttpResponses.forwardToPreviousPage();
+    }
+
+    public static boolean isQueueItemAuthenticatorPresent() {
+        // there is no QueueItemAuthenticatorDescriptor; perhaps you need to install authorize-project?
+        return !QueueItemAuthenticatorDescriptor.all().isEmpty();
+    }
+
+    public static boolean isQueueItemAuthenticatorConfigured() {
+        // there is no configured QueueItemAuthenticator; perhaps you need to configure it?
+        return !QueueItemAuthenticatorConfiguration.get().getAuthenticators().isEmpty();
+    }
+
+    public boolean isAnyBuildLaunchedAsSystemWithAuthenticatorPresent() {
+        // you configured a QueueItemAuthenticator, but builds are still running as SYSTEM
+        return anyBuildLaunchedAsSystemWithAuthenticatorPresent;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Messages.QueueItemAuthenticatorMonitor_DisplayName();
+    }
+
+    @Restricted(NoExternalUse.class)
+    @Extension
+    public static class QueueListenerImpl extends QueueListener {
+        @Override
+        public void onLeft(Queue.LeftItem li) {
+            if (li.isCancelled()) {
+                return;
+            }
+
+            // XXX This can probably be done better, unsure what the expected priority order is
+            String displayName = li.getDisplayName();
+            if (displayName == null && li.task != null) {
+                displayName = li.task.getFullDisplayName();
+            }
+            Queue.Executable executable = li.getExecutable();
+            if (displayName == null && executable != null) {
+                displayName = executable.toString();
+            }
+
+            // TODO this is probably not intended to be used as a getter -- seems potentially unstable
+            Authentication buildAuthentication = li.authenticate();
+            boolean buildRunsAsSystem = buildAuthentication == ACL.SYSTEM;
+            if (!buildRunsAsSystem) {
+                LOGGER.log(Level.FINE, li.getDisplayName() + " does not run as SYSTEM");
+                return;
+            }
+
+            LOGGER.log(Level.FINE, displayName + " is running as SYSTEM");
+            if (isQueueItemAuthenticatorConfigured()) {
+                anyBuildLaunchedAsSystemWithAuthenticatorPresent = true;
+            }
+        }
+    }
+
+    private static boolean anyBuildLaunchedAsSystemWithAuthenticatorPresent = false;
+
+    private static final Logger LOGGER = Logger.getLogger(QueueItemAuthenticatorMonitor.class.getName());
+}

--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -88,7 +88,8 @@
             { "name": "pam-auth", "suggested": true },
             { "name": "ldap", "suggested": true },
             { "name": "role-strategy" },
-            { "name": "active-directory" }
+            { "name": "active-directory" },
+            { "name": "authorize-project" }
         ]
     },
     {

--- a/core/src/main/resources/jenkins/security/Messages.properties
+++ b/core/src/main/resources/jenkins/security/Messages.properties
@@ -29,3 +29,4 @@ ApiTokenProperty.LegacyTokenName=Legacy Token
 ApiTokenProperty.NoLegacyToken=This user currently does not have a legacy token
 RekeySecretAdminMonitor.DisplayName=Re-keying
 UpdateSiteWarningsMonitor.DisplayName=Update Site Warnings
+QueueItemAuthenticatorMonitor.DisplayName=Access Control for Builds

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.groovy
@@ -29,7 +29,7 @@ def f = namespace(lib.FormTagLib)
 div(class: "alert alert-warning", role: "alert") {
 
     form(method: "post", action: "${rootURL}/${my.url}/act") {
-        f.submit(name: 'redirect', value: _("Learn more…"))
+        f.submit(name: 'redirect', value: _("Learn more..."))
         f.submit(name: 'dismiss', value: _("Dismiss"))
     }
 

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.groovy
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security.QueueItemAuthenticatorMonitor
+
+def f = namespace(lib.FormTagLib)
+
+div(class: "alert alert-warning", role: "alert") {
+
+    form(method: "post", action: "${rootURL}/${my.url}/act") {
+        f.submit(name: 'redirect', value: _("Learn more…"))
+        f.submit(name: 'dismiss', value: _("Dismiss"))
+    }
+
+    text(_("blurb"))
+
+    ul(style: "list-style-type: none;") {
+        if (my.queueItemAuthenticatorPresent) {
+            li(raw(_("queueItemAuthenticatorPresent")))
+
+
+            if (my.queueItemAuthenticatorConfigured) {
+                li(raw(_("queueItemAuthenticatorConfigured")))
+
+
+                if (my.anyBuildLaunchedAsSystemWithAuthenticatorPresent) {
+                    li(raw(_("anyBuildLaunchedAsSystem", rootURL)))
+                    form(method: "post", action: "${rootURL}/${my.url}/act") {
+                        f.submit(name: 'reset', value: _("Reset"))
+                    }
+                }
+                // else: This monitor will not be displayed
+
+
+            } else {
+                li(raw(_("noQueueItemAuthenticatorConfigured", rootURL)))
+            }
+
+        } else {
+            li(raw(_("noQueueItemAuthenticatorPresent")))
+        }
+
+    }
+}

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.properties
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.properties
@@ -1,0 +1,16 @@
+blurb = Builds in Jenkins run as the virtual SYSTEM user with full permissions by default. \
+  This can be a problem if some users have restricted or no access to some jobs, but can configure others. \
+  If that is the case, it is recommended to install a plugin implementing build authentication, and to override this default.
+
+queueItemAuthenticatorPresent = \u2705 An implementation of access control for builds is present.
+noQueueItemAuthenticatorPresent = \u274c No implementation of access control for builds is present. \
+  It is recommended that you install <a href="https://plugins.jenkins.io/authorize-project" target="_blank">Authorize Project Plugin</a> or another plugin \
+  implementing the <a href="https://jenkins.io/doc/developer/extensions/jenkins-core/#queueitemauthenticator" target="_blank">QueueItemAuthenticator</a> \
+  extension point.
+
+queueItemAuthenticatorConfigured = \u2705 Access control for builds is configured.
+noQueueItemAuthenticatorConfigured = \u274c Access control for builds is possible, but not configured. Configure it in the <a href="{0}/configureSecurity">global security configuration</a>.
+
+anyBuildLaunchedAsSystem = \u274c Builds have been observed as launching as the internal SYSTEM user despite access control for builds being set up. \
+  It is recommended that you <a href="{0}/configureSecurity">review the access control for builds configuration</a> to ensure builds are not generally running as the SYSTEM user.
+notAnyBuildLaunchedAsSystem = \u2705 No builds have been launched as the internal SYSTEM user, indicating a complete configuration.


### PR DESCRIPTION
See [JENKINS-24513](https://issues.jenkins-ci.org/browse/JENKINS-24513) (sort of). Submission in part triggered by https://github.com/jenkinsci/jenkins/pull/3908#issuecomment-465681122

Builds in Jenkins run as SYSTEM by default. This can result in undesirable permission constellations allowing users to do more than they should be able to, e.g. using [Pipeline Build Step Plugin](https://issues.jenkins-ci.org/browse/JENKINS-24513).

> ![stage 1](https://user-images.githubusercontent.com/1831569/53601162-b2663580-3bab-11e9-9da8-93043aaf369c.png)
![stage 2](https://user-images.githubusercontent.com/1831569/53601172-b6925300-3bab-11e9-8ffa-5dc3fb2ac133.png)
![stage 3](https://user-images.githubusercontent.com/1831569/53601178-bbef9d80-3bab-11e9-9de5-676d051c961b.png)

- [x] Admin monitor does not show in permission setups known to be too simple to matter here.
- [x] Progressively show whether a plugin is present implementing the necessary extension, whether it has been configured, and whether builds are still running as SYSTEM.
- [x] Allow resetting the "SYSTEM detector" after a configuration change.
- [x] Link to external docs
- [x] Actually write external docs (https://github.com/jenkins-infra/jenkins.io/pull/2137)

**Work in progress**

- [ ] Look for false positives. Notably, I have not tested this with background processes such as GitHub org or branch indexing and similar processes. The last item could potentially be very noisy.
- [ ] (Optional) Keep track of which projects are running with SYSTEM permission rather than just a boolean.

### Proposed changelog entries

* RFE: Inform administrators about potentially unsafe permissions setup involving builds running as the virtual SYSTEM user.

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
