### PR TITLE
[JENKINS-55512] Allow regular tasks to skip quiet down blockage

### DIFF
--- a/core/src/main/java/hudson/model/LoadBalancer.java
+++ b/core/src/main/java/hudson/model/LoadBalancer.java
@@ -50,15 +50,24 @@ import java.util.Map;
  */
 public abstract class LoadBalancer implements ExtensionPoint {
     /**
-     * Chooses the executor(s) to carry out the build for the given task.
+     * @deprecated
+     *      Call {@link #map(Queue.Item, MappingWorksheet)} instead.
+     *      Subclasses should continue to implement this, while implementing the other is optional.
+     */
+    @Deprecated
+    public abstract Mapping map(Task task, MappingWorksheet worksheet);
+
+    /**
+     *
+     * Chooses the executor(s) to carry out the build for the task of the given item.
      *
      * <p>
      * This method is invoked from different threads, but the execution is serialized by the caller.
      * The thread that invokes this method always holds a lock to {@link Queue}, so queue contents
      * can be safely introspected from this method, if that information is necessary to make
      * decisions.
-     * 
-     * @param  task
+     *
+     * @param  item
      *      The task whose execution is being considered. Never null.
      * @param worksheet
      *      The work sheet that represents the matching that needs to be made.
@@ -70,13 +79,8 @@ public abstract class LoadBalancer implements ExtensionPoint {
      *      Return null if you don't want the task to be executed right now,
      *      in which case this method will be called some time later with the same task.
      *
-     * @deprecated
-     *      Call {@link #map(Queue.Item, MappingWorksheet)} instead.
-     *      Subclasses can continue to implement this.
+     * @since TODO
      */
-    @Deprecated
-    public abstract Mapping map(Task task, MappingWorksheet worksheet);
-
     public Mapping map(Queue.Item item, MappingWorksheet worksheet) {
         return map(item.task, worksheet);
     }

--- a/core/src/main/java/hudson/model/queue/BackFiller.java
+++ b/core/src/main/java/hudson/model/queue/BackFiller.java
@@ -105,7 +105,7 @@ public class BackFiller extends LoadPredictor {
             // also ignore all load predictions as we just want to figure out some executable assignment
             // and we are not trying to figure out if this task is executable right now.
             MappingWorksheet worksheet = new MappingWorksheet(bi, slots, Collections.<LoadPredictor>emptyList());
-            Mapping m = Jenkins.getInstance().getQueue().getLoadBalancer().map(bi.task, worksheet);
+            Mapping m = Jenkins.getInstance().getQueue().getLoadBalancer().map(bi, worksheet);
             if (m==null)    return null;
 
             // figure out how many executors we need on each computer?

--- a/core/src/main/java/hudson/model/queue/MappingWorksheet.java
+++ b/core/src/main/java/hudson/model/queue/MappingWorksheet.java
@@ -83,6 +83,7 @@ import static java.lang.Math.*;
  * which is represented as {@link Mapping}.
  *
  * @see LoadBalancer#map(Queue.Task, MappingWorksheet)
+ * @see LoadBalancer#map(Queue.Item, MappingWorksheet) 
  * @author Kohsuke Kawaguchi
  */
 public class MappingWorksheet {


### PR DESCRIPTION
See [JENKINS-55512](https://issues.jenkins-ci.org/browse/JENKINS-55512). Most recent comments have some thoughts how to accomplish the goal of allowing regular tasks to bypass the quiet down blockage.

Possible followup changes: This action could be added by parameterized-trigger plugin when set to wait for the downstream build result (as a build step), else there's a deadlock. Less of a problem for pipeline-build-step, but still possible.

And of course, could be exposed to users via a [QueueDecisionHandler](https://javadoc.jenkins.io/hudson/model/Queue.QueueDecisionHandler.html)s that adds the action based on the presence of e.g. a `JobProperty` on the job.

#### Possible problems

`Task` based APIs are still around but might not reflect the desired reality. The way to implement a `LoadBalancer` now is weird, requiring a deprecated API.

### Proposed changelog entries

    * Developer: Add <code>Queue.NonBlockingAction</code> that will allow a queue item to bypass the quiet down mode block.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jimklimov @jglick @abayer 