### PR TITLE
[JENKINS-56379] Absorb pipeline-model-definition symbol-hetero-list.jelly into hetero-list.jelly

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -126,7 +126,7 @@ THE SOFTWARE.
         <div name="${attrs.name}" title="${descriptor.displayName}" tooltip="${descriptor.tooltip}" descriptorId="${descriptor.id}">
           <j:set var="capture" value="${attrs.capture?:''}" />
           <local:body deleteCaption="${attrs.deleteCaption}">
-            <l:renderOnDemand tag="tr" clazz="config-page" capture="descriptor,it,instance,${capture}">
+            <l:renderOnDemand tag="tr" clazz="config-page" capture="descriptor,it,instance,h,${capture}">
               <l:ajax>
                 <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true" />
               </l:ajax>

--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -69,6 +69,10 @@ THE SOFTWARE.
       variables seen in the caller aren't visible to them. This attribute allows you
       to nominate additional variables and their values to be captured for descriptors.
     </st:attribute>
+    <st:attribute name="titleClassMethod">
+      If set to an item of the form <tt>className#classMethod</tt>, it will be used
+      to call <tt>className.classMethod(descriptor)</tt> to calculate each item title.
+    </st:attribute>
   </st:documentation>
   <d:taglib uri="local">
     <d:tag name="body">
@@ -123,7 +127,19 @@ THE SOFTWARE.
       <j:set var="instance" value="${null}" />
       <j:set var="descriptors" value="${h.filterDescriptors(it,attrs.descriptors)}" />
       <j:forEach var="descriptor" items="${descriptors}" varStatus="loop">
-        <div name="${attrs.name}" title="${descriptor.displayName}" tooltip="${descriptor.tooltip}" descriptorId="${descriptor.id}">
+        <j:choose>
+          <j:when test="${titleClassMethod!=null}">
+            <j:set var="classAndMethod" value="${titleClassMethod.split(&quot;#&quot;)}"/>
+            <j:invokeStatic var="symbol" className="${classAndMethod[0]}" method="${classAndMethod[1]}">
+              <j:arg value="${descriptor}" type="hudson.model.Descriptor" />
+            </j:invokeStatic>
+            <j:set var="title" value="${symbol}: ${descriptor.displayName}"/>
+          </j:when>
+          <j:otherwise>
+            <j:set var="title" value="${descriptor.displayName}"/>
+          </j:otherwise>
+        </j:choose>
+        <div name="${attrs.name}" title="${title}" tooltip="${descriptor.tooltip}" descriptorId="${descriptor.id}">
           <j:set var="capture" value="${attrs.capture?:''}" />
           <local:body deleteCaption="${attrs.deleteCaption}">
             <l:renderOnDemand tag="tr" clazz="config-page" capture="descriptor,it,instance,h,${capture}">

--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -142,7 +142,7 @@ THE SOFTWARE.
         <div name="${attrs.name}" title="${title}" tooltip="${descriptor.tooltip}" descriptorId="${descriptor.id}">
           <j:set var="capture" value="${attrs.capture?:''}" />
           <local:body deleteCaption="${attrs.deleteCaption}">
-            <l:renderOnDemand tag="tr" clazz="config-page" capture="descriptor,it,instance,h,${capture}">
+            <l:renderOnDemand tag="tr" clazz="config-page" capture="descriptor,it,instance,${capture}">
               <l:ajax>
                 <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true" />
               </l:ajax>


### PR DESCRIPTION
See [JENKINS-56379](https://issues.jenkins-ci.org/browse/JENKINS-56379).

The guts of symbol-hetero-list.jelly becomes:

```
  <f:hetero-list
        name="${name}"
        items="${items}"
        descriptors="${descriptors}"
        addCaption="${addCaption}"
        deleteCaption="${deleteCaption}"
        targetType="${targetType}"
        hasHeader="${hasHeader}"
        oneEach="${oneEach}"
        menuAlign="${menuAlign}"
        honorOrder="${honorOrder}"
        capture="${capture}"
        titleClassMethod="org.jenkinsci.plugins.pipeline.modeldefinition.generator.DirectiveGenerator#getSymbolForDescriptor"
        />
```
### Proposed changelog entries

* Support <f:hetero-list ... titleClassMethod ...> so that symbol-hetero-list.jelly can derive from it

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@abayer 