### PR TITLE
[JENKINS-56398] Mobile friendly login / load / restart screens

### DIFF
--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
@@ -50,6 +50,8 @@ THE SOFTWARE.
             <title>${%Create an account! [Jenkins]}</title>
             <!-- we do not want bots on this page -->
             <meta name="ROBOTS" content="NOFOLLOW"/>
+            <!-- mobile friendly layout -->
+            <meta name="viewport" content="width=device-width, initial-scale=1"/>
             <!-- css styling, will fallback to default implementation -->
             <st:include it="${simpleDecorator}" page="simple-head.jelly" optional="true"/>
             <link rel="stylesheet" href="${resURL}/css/signup.css" type="text/css"/>

--- a/core/src/main/resources/hudson/util/HudsonIsLoading/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonIsLoading/index.jelly
@@ -39,6 +39,8 @@ THE SOFTWARE.
             <title>${%Starting Jenkins}</title>
             <!-- we do not want bots on this page -->
             <meta name="ROBOTS" content="NOFOLLOW"/>
+            <!-- mobile friendly layout -->
+            <meta name="viewport" content="width=device-width, initial-scale=1"/>
             <link rel="stylesheet" href="${resURL}/css/simple-page.css" type="text/css" />
             <link rel="stylesheet" href="${resURL}/css/simple-page.theme.css" type="text/css" />
             <link rel="stylesheet" href="${resURL}/css/loading.css" type="text/css" />

--- a/core/src/main/resources/hudson/util/HudsonIsRestarting/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonIsRestarting/index.jelly
@@ -39,6 +39,8 @@ THE SOFTWARE.
             <title>${%Restarting Jenkins}</title>
             <!-- we do not want bots on this page -->
             <meta name="ROBOTS" content="NOFOLLOW"/>
+            <!-- mobile friendly layout -->
+            <meta name="viewport" content="width=device-width, initial-scale=1"/>
             <link rel="stylesheet" href="${resURL}/css/simple-page.css" type="text/css" />
             <link rel="stylesheet" href="${resURL}/css/simple-page.theme.css" type="text/css" />
             <link rel="stylesheet" href="${resURL}/css/loading.css" type="text/css" />

--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -57,6 +57,8 @@ THE SOFTWARE.
       <title>${%signIn} [Jenkins]</title>
       <!-- we do not want bots on this page -->
       <meta name="ROBOTS" content="NOFOLLOW" />
+      <!-- mobile friendly layout -->
+      <meta name="viewport" content="width=device-width, initial-scale=1"/>
       <!-- css styling, will fallback to default implementation -->
       <st:include it="${simpleDecorator}" page="simple-head.jelly" optional="true"/>
     </head>

--- a/war/src/main/webapp/css/signup.css
+++ b/war/src/main/webapp/css/signup.css
@@ -22,17 +22,15 @@
  * THE SOFTWARE.
  */
 .signup{
-  min-width: 480px;
   max-width: 480px;
-  width: 480px;
+  width: 100%;
 }
 .signupIntroDefault {
   text-align: center;
 }
 form.signup{
-  min-width: 480px;
   max-width: 480px;
-  width: 480px;
+  width: 100%;
   text-align: left;
 }
 .inputHeader {

--- a/war/src/main/webapp/css/simple-page.css
+++ b/war/src/main/webapp/css/simple-page.css
@@ -30,6 +30,7 @@ html {
 
 .simple-page h1 {
   font-size: 24px;
+  line-height: normal;
 }
 
 .simple-page {
@@ -50,7 +51,7 @@ html {
   -webkit-justify-content: center;
   justify-content: center;
   min-height: 90vh;
-  padding: 0px 16px;
+  padding: 0 16px;
 }
 
 .simple-page form {

--- a/war/src/main/webapp/css/simple-page.css
+++ b/war/src/main/webapp/css/simple-page.css
@@ -51,7 +51,6 @@ html {
   -webkit-justify-content: center;
   justify-content: center;
   min-height: 90vh;
-  padding: 0 16px;
 }
 
 .simple-page form {

--- a/war/src/main/webapp/css/simple-page.css
+++ b/war/src/main/webapp/css/simple-page.css
@@ -50,6 +50,7 @@ html {
   -webkit-justify-content: center;
   justify-content: center;
   min-height: 90vh;
+  padding: 0px 16px;
 }
 
 .simple-page form {


### PR DESCRIPTION
See [JENKINS-56398](https://issues.jenkins-ci.org/browse/JENKINS-56398).

### Proposed changelog entries

* Mobile friendly layout of the login, loading and restart screens

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

Note: the padding change makes no difference for login, but looks slightly better for restart. 

## Login before
![login-current](https://user-images.githubusercontent.com/1105305/53830777-7ce29300-3f83-11e9-9aa9-0e55a5f1ff70.png)
## Login after
![login-mobile-friendly](https://user-images.githubusercontent.com/1105305/53830794-83710a80-3f83-11e9-9d8c-fd915be03fed.png)
## Restart before
![restart-current](https://user-images.githubusercontent.com/1105305/53830813-8d930900-3f83-11e9-98a3-e1308b77e5e8.png)
## Restart after
![restart-mobile-friendly](https://user-images.githubusercontent.com/1105305/53830819-92f05380-3f83-11e9-85ec-e44a64eed1c6.png)