### PR TITLE
[JENKINS-56403]: Renaming an agent retains old agent configuration

### DIFF
--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -233,7 +233,11 @@ public class Nodes implements Saveable {
                 }
             });
             updateNode(newOne);
+            if (!newOne.getNodeName().equals(oldOne.getNodeName())) {
+                Util.deleteRecursive(new File(getNodesDir(), oldOne.getNodeName()));
+            }
             NodeListener.fireOnUpdated(oldOne, newOne);
+
             return true;
         } else {
             return false;

--- a/test/src/test/java/jenkins/model/NodesTest.java
+++ b/test/src/test/java/jenkins/model/NodesTest.java
@@ -38,6 +38,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 public class NodesTest {
@@ -86,6 +88,28 @@ public class NodesTest {
         Node newNode = r.createSlave("foo", "", null);
         r.jenkins.addNode(newNode);
         assertThat(r.jenkins.getNode("foo"), sameInstance(newNode));
+    }
+
+    @Test
+    @Issue("JENKINS-56403")
+    public void replaceNodeShouldRemoveOldNode() throws Exception {
+        Node oldNode = r.createSlave("foo", "", null);
+        Node newNode = r.createSlave("foo-new", "", null);
+        r.jenkins.addNode(oldNode);
+        r.jenkins.getNodesObject().replaceNode(oldNode, newNode);
+        r.jenkins.getNodesObject().load();
+        assertNull(r.jenkins.getNode(oldNode.getNodeName()));
+    }
+
+    @Test
+    @Issue("JENKINS-56403")
+    public void replaceNodeShouldNotRemoveIdenticalOldNode() throws Exception {
+        Node oldNode = r.createSlave("foo", "", null);
+        Node newNode = r.createSlave("foo", "", null);
+        r.jenkins.addNode(oldNode);
+        r.jenkins.getNodesObject().replaceNode(oldNode, newNode);
+        r.jenkins.getNodesObject().load();
+        assertNotNull(r.jenkins.getNode(oldNode.getNodeName()));
     }
 
     private static class InvalidNode extends Slave {

--- a/test/src/test/java/jenkins/model/NodesTest.java
+++ b/test/src/test/java/jenkins/model/NodesTest.java
@@ -98,7 +98,7 @@ public class NodesTest {
         r.jenkins.addNode(oldNode);
         r.jenkins.getNodesObject().replaceNode(oldNode, newNode);
         r.jenkins.getNodesObject().load();
-        assertNull(r.jenkins.getNode(oldNode.getNodeName()));
+        assertNull(r.jenkins.getNode("foo"));
     }
 
     @Test
@@ -109,7 +109,7 @@ public class NodesTest {
         r.jenkins.addNode(oldNode);
         r.jenkins.getNodesObject().replaceNode(oldNode, newNode);
         r.jenkins.getNodesObject().load();
-        assertNotNull(r.jenkins.getNode(oldNode.getNodeName()));
+        assertNotNull(r.jenkins.getNode("foo"));
     }
 
     private static class InvalidNode extends Slave {


### PR DESCRIPTION
[JENKINS-33780](https://issues.jenkins-ci.org/browse/JENKINS-33780) introduced a regression in persisting the update to disk. In prior code, the update was performed through a full config save after updating the nodes, but the functionality was not carried over.

See [JENKINS-56403](https://issues.jenkins-ci.org/browse/JENKINS-56403).

### Proposed changelog entries

* Renaming an agent retains old agent configuration, causing it to re-appear on restart

### Submitter checklist
* [x]  JIRA issue is well described
* [x]  Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
* [N/A] Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
* [x]  Appropriate autotests or explanation to why this change has no tests
* [N/A]  For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jenkinsci/code-reviewers