### PR TITLE
Correct DownloadService TimeUnit mix on lastAttempt

### DIFF
--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -46,7 +46,6 @@ import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.DownloadSettings;
@@ -92,7 +91,7 @@ public class DownloadService extends PageDecorator {
         if(Jenkins.getInstance().hasPermission(Jenkins.READ)) {
             long now = System.currentTimeMillis();
             for (Downloadable d : Downloadable.all()) {
-                if(d.getDue()<now && TimeUnit.SECONDS.toMillis(d.lastAttempt+10)<now) {
+                if(d.getDue()<now && d.lastAttempt+10*1000<now) {
                     buf.append("<script>")
                        .append("Behaviour.addLoadEvent(function() {")
                        .append("  downloadService.download(")

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -91,7 +91,7 @@ public class DownloadService extends PageDecorator {
         if(Jenkins.getInstance().hasPermission(Jenkins.READ)) {
             long now = System.currentTimeMillis();
             for (Downloadable d : Downloadable.all()) {
-                if(d.getDue()<now && d.lastAttempt+10*1000<now) {
+                if(d.getDue()<now && d.lastAttempt+TimeUnit.SECONDS.toMillis(10)<now) {
                     buf.append("<script>")
                        .append("Behaviour.addLoadEvent(function() {")
                        .append("  downloadService.download(")

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -46,6 +46,7 @@ import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.DownloadSettings;


### PR DESCRIPTION
Downloadable.lastAttempt is set in milliseconds but the #3913 change
the test to toMillis(millis+seconds)<millis.

Thank you @pzygielo for this catch.

### Proposed changelog entries

I'm not sure a changelog entry is relevent here as the error is not yet part of any release of Jenkins core.

### Desired reviewers

@daniel-beck @oleg-nenashev 