### PR TITLE
[JENKINS-24513] Add details on observed SYSTEM builds

### DIFF
--- a/core/src/main/java/jenkins/security/QueueItemAuthenticatorMonitor.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticatorMonitor.java
@@ -25,8 +25,13 @@ package jenkins.security;
 
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Queue;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.ItemListener;
+import hudson.model.listeners.RunListener;
 import hudson.model.queue.QueueListener;
 import hudson.security.ACL;
 import hudson.security.AuthorizationStrategy;
@@ -42,6 +47,11 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -76,7 +86,9 @@ public class QueueItemAuthenticatorMonitor extends AdministrativeMonitor {
             this.disable(true);
         }
         if (reset != null) {
-            anyBuildLaunchedAsSystemWithAuthenticatorPresent = false;
+            synchronized (buildsLaunchedAsSystemWithAuthenticatorPresentByJob) {
+                buildsLaunchedAsSystemWithAuthenticatorPresentByJob.clear();
+            }
         }
         return HttpResponses.forwardToPreviousPage();
     }
@@ -93,7 +105,7 @@ public class QueueItemAuthenticatorMonitor extends AdministrativeMonitor {
 
     public boolean isAnyBuildLaunchedAsSystemWithAuthenticatorPresent() {
         // you configured a QueueItemAuthenticator, but builds are still running as SYSTEM
-        return anyBuildLaunchedAsSystemWithAuthenticatorPresent;
+        return !buildsLaunchedAsSystemWithAuthenticatorPresentByJob.isEmpty();
     }
 
     @Override
@@ -110,15 +122,17 @@ public class QueueItemAuthenticatorMonitor extends AdministrativeMonitor {
                 return;
             }
 
-            // XXX This can probably be done better, unsure what the expected priority order is
+            if (!isQueueItemAuthenticatorPresent() || !isQueueItemAuthenticatorConfigured()) {
+                // ignore while this is not configured
+                return;
+            }
+
+            // XXX This can probably be done better, unsure what the expected priority order should be
             String displayName = li.getDisplayName();
             if (displayName == null && li.task != null) {
                 displayName = li.task.getFullDisplayName();
             }
-            Queue.Executable executable = li.getExecutable();
-            if (displayName == null && executable != null) {
-                displayName = executable.toString();
-            }
+            // Do not need to check Executable as alternative while Queue#onStartExecuting(Executor) is called before Task#createExecutable() from Executable.
 
             if (!(li.task instanceof Job<?, ?>)) {
                 // Only care about jobs for now -- Do not react to folder scans and similar
@@ -136,12 +150,100 @@ public class QueueItemAuthenticatorMonitor extends AdministrativeMonitor {
 
             LOGGER.log(Level.FINE, displayName + " is running as SYSTEM");
             if (isQueueItemAuthenticatorConfigured()) {
-                anyBuildLaunchedAsSystemWithAuthenticatorPresent = true;
+                QueueIdAndBuildNumber reference = new QueueIdAndBuildNumber(li.getId());
+                synchronized (buildsLaunchedAsSystemWithAuthenticatorPresentByJob) {
+                    buildsLaunchedAsSystemWithAuthenticatorPresentByJob.putIfAbsent(((Job) li.task).getFullName(), new TreeSet<>());
+                    buildsLaunchedAsSystemWithAuthenticatorPresentByJob.get(((Job) li.task).getFullName()).add(reference);
+                }
             }
         }
     }
 
-    private static boolean anyBuildLaunchedAsSystemWithAuthenticatorPresent = false;
+    @Extension
+    public static class BuildListenerImpl extends RunListener<Run< ?, ?>> {
+        @Override
+        public void onStarted(Run<?, ?> run, TaskListener listener) {
+            Job<?, ?> job = run.getParent();
+            long queueId = run.getQueueId();
+            int buildNumber = run.getNumber();
+            QueueIdAndBuildNumber wrappedQueueId = new QueueIdAndBuildNumber(queueId, buildNumber);
+
+            synchronized (buildsLaunchedAsSystemWithAuthenticatorPresentByJob) {
+                if (buildsLaunchedAsSystemWithAuthenticatorPresentByJob.containsKey(job.getFullName())) {
+                    SortedSet<QueueIdAndBuildNumber> recordedQueueItems = buildsLaunchedAsSystemWithAuthenticatorPresentByJob.get(job.getFullName());
+                    if (recordedQueueItems.contains(wrappedQueueId)) {
+                        // we recorded this queue item leaving the queue, so update the record with the build number
+                        recordedQueueItems.remove(wrappedQueueId); // equals/hashCode only look at queueId, so this works
+                        recordedQueueItems.add(wrappedQueueId);
+                        while (recordedQueueItems.size() > 10) {
+                            // limit to 10 items
+                            recordedQueueItems.remove(recordedQueueItems.first());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static final class QueueIdAndBuildNumber implements Comparable<QueueIdAndBuildNumber> {
+        long queueId;
+        Long buildNumber;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            QueueIdAndBuildNumber that = (QueueIdAndBuildNumber) o;
+            return queueId == that.queueId;
+        }
+
+        public QueueIdAndBuildNumber(long queueId) {
+            this.queueId = queueId;
+        }
+
+        public QueueIdAndBuildNumber(long queueId, long buildNumber) {
+            this.queueId = queueId;
+            this.buildNumber = buildNumber;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(queueId);
+        }
+
+        @Override
+        public int compareTo(QueueIdAndBuildNumber o) {
+            return Long.compare(queueId, o.queueId);
+        }
+    }
+
+    @Extension
+    public static class ItemListenerImpl extends ItemListener {
+        @Override
+        public void onDeleted(Item item) {
+            synchronized (buildsLaunchedAsSystemWithAuthenticatorPresentByJob) {
+                buildsLaunchedAsSystemWithAuthenticatorPresentByJob.remove(item.getFullName());
+            }
+        }
+
+        @Override
+        public void onLocationChanged(Item item, String oldFullName, String newFullName) {
+            synchronized (buildsLaunchedAsSystemWithAuthenticatorPresentByJob) {
+                if (buildsLaunchedAsSystemWithAuthenticatorPresentByJob.containsKey(oldFullName)) {
+                    SortedSet<QueueIdAndBuildNumber> references = buildsLaunchedAsSystemWithAuthenticatorPresentByJob.get(oldFullName);
+                    buildsLaunchedAsSystemWithAuthenticatorPresentByJob.remove(oldFullName);
+                    buildsLaunchedAsSystemWithAuthenticatorPresentByJob.put(newFullName, references);
+                }
+            }
+        }
+    }
+
+    /**
+     * Records queue IDs and later build numbers of builds started as SYSTEM if there is an authenticator present.
+     * This is a relatively memory efficient way to get this information.
+     */
+    @Restricted(NoExternalUse.class)
+    public static final Map<String, SortedSet<QueueIdAndBuildNumber>> buildsLaunchedAsSystemWithAuthenticatorPresentByJob = new ConcurrentHashMap<>();
 
     private static final Logger LOGGER = Logger.getLogger(QueueItemAuthenticatorMonitor.class.getName());
 }

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorConfiguration/config.groovy
@@ -30,6 +30,7 @@ f=namespace(lib.FormTagLib)
 if (!QueueItemAuthenticatorDescriptor.all().isEmpty()) {
     f.section(title:_("Access Control for Builds")) {
         f.block() {
+            p(_("blurb"))
             f.repeatableHeteroProperty(field:"authenticators",hasHeader:true)
         }
     }

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorConfiguration/config.groovy
@@ -30,7 +30,7 @@ f=namespace(lib.FormTagLib)
 if (!QueueItemAuthenticatorDescriptor.all().isEmpty()) {
     f.section(title:_("Access Control for Builds")) {
         f.block() {
-            p(_("blurb"))
+            p(raw(_("blurb")))
             f.repeatableHeteroProperty(field:"authenticators",hasHeader:true)
         }
     }

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorConfiguration/config.properties
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorConfiguration/config.properties
@@ -1,3 +1,3 @@
 blurb = Jenkins will attempt to apply each of these authenticators in the order they are specified here, starting at the top. \
-  If none of these apply, a build will run with the default authentication, typically SYSTEM. \
-  It is therefore recommended you put an always applicable, low-privilege authenticator, like making a build run as 'anonymous', last.
+  If none of these apply, a build will run with the default authentication, typically <span style="font-family: monospace;">SYSTEM</span>. \
+  It is therefore recommended you put an always applicable, low-privilege authenticator, like making a build run as <span style="font-family: monospace;">anonymous</span>, last.

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorConfiguration/config.properties
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorConfiguration/config.properties
@@ -1,0 +1,3 @@
+blurb = Jenkins will attempt to apply each of these authenticators in the order they are specified here, starting at the top. \
+  If none of these apply, a build will run with the default authentication, typically SYSTEM. \
+  It is therefore recommended you put an always applicable, low-privilege authenticator, like making a build run as 'anonymous', last.

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/index.groovy
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/index.groovy
@@ -1,0 +1,99 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security.QueueItemAuthenticatorMonitor
+
+import jenkins.model.Jenkins
+import jenkins.security.QueueItemAuthenticatorMonitor
+
+def f=namespace(lib.FormTagLib)
+def l=namespace(lib.LayoutTagLib)
+def st=namespace("jelly:stapler")
+
+l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
+    l.main_panel {
+        h1 {
+            l.icon(class: 'icon-secure icon-xlg')
+            text(my.displayName)
+        }
+
+        p(_('blurb'))
+
+        table(class: 'pane bigtable') {
+            tr {
+                th(_('Project'))
+                th(_('Build'))
+                th(_('Started'))
+            }
+            QueueItemAuthenticatorMonitor.buildsLaunchedAsSystemWithAuthenticatorPresentByJob.toSorted { Jenkins.get().getItemByFullName(it.key)?.fullDisplayName?:it.key }.each { jobName, buildReferences ->
+                def item = Jenkins.get().getItemByFullName(jobName)
+
+                buildReferences.descendingSet().each { reference ->
+                    tr {
+                        td {
+                            if (item == null) {
+                                // deleted?
+                                text(jobName)
+                            } else {
+                                a(class: 'model-link inside', href: "${rootURL}/${item.url}", item?.fullDisplayName)
+                            }
+                        }
+                        td {
+                            if (reference.buildNumber == null) {
+                                _('Not yet known')
+                            } else {
+                                def build = item?.getBuildByNumber((int) reference.buildNumber)
+                                if (build == null) {
+                                    text("#${reference.buildNumber}")
+                                } else {
+                                    a(class: 'model-link inside', href: "${rootURL}/${build.url}", build.displayName)
+                                }
+                            }
+                        }
+                        td {
+                            if (reference.buildNumber == null) {
+                                _('Not yet known')
+                            } else {
+                                def build = item?.getBuildByNumber((int) reference.buildNumber)
+                                if (build == null) {
+                                    _("N/A")
+                                } else {
+//                                hudson.Util.getPastTimeString(System)
+                                    _('ago', build.timestampString)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        f.form(method:'post', name:'config', action:'act') {
+            f.bottomButtonBar {
+                f.submit(name:'reset', value:_("Clear"))
+            }
+        }
+    }
+}
+

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/index.groovy
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/index.groovy
@@ -38,49 +38,34 @@ l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
             text(my.displayName)
         }
 
-        p(_('blurb'))
+        p(raw(_('blurb')))
 
         table(class: 'pane bigtable') {
             tr {
                 th(_('Project'))
-                th(_('Build'))
-                th(_('Started'))
+                th(_('Most Recent Builds Run as SYSTEM'))
             }
             QueueItemAuthenticatorMonitor.buildsLaunchedAsSystemWithAuthenticatorPresentByJob.toSorted { Jenkins.get().getItemByFullName(it.key)?.fullDisplayName?:it.key }.each { jobName, buildReferences ->
                 def item = Jenkins.get().getItemByFullName(jobName)
 
-                buildReferences.descendingSet().each { reference ->
-                    tr {
-                        td {
-                            if (item == null) {
-                                // deleted?
-                                text(jobName)
-                            } else {
-                                a(class: 'model-link inside', href: "${rootURL}/${item.url}", item?.fullDisplayName)
-                            }
+
+                tr {
+                    td {
+                        if (item == null) {
+                            // deleted?
+                            text(jobName)
+                        } else {
+                            a(class: 'model-link inside', href: "${rootURL}/${item.url}", item?.fullDisplayName)
                         }
-                        td {
-                            if (reference.buildNumber == null) {
-                                _('Not yet known')
-                            } else {
+                    }
+                    td {
+                        buildReferences.descendingSet().each { reference ->
+                            if (reference.buildNumber != null) {
                                 def build = item?.getBuildByNumber((int) reference.buildNumber)
                                 if (build == null) {
                                     text("#${reference.buildNumber}")
                                 } else {
                                     a(class: 'model-link inside', href: "${rootURL}/${build.url}", build.displayName)
-                                }
-                            }
-                        }
-                        td {
-                            if (reference.buildNumber == null) {
-                                _('Not yet known')
-                            } else {
-                                def build = item?.getBuildByNumber((int) reference.buildNumber)
-                                if (build == null) {
-                                    _("N/A")
-                                } else {
-//                                hudson.Util.getPastTimeString(System)
-                                    _('ago', build.timestampString)
                                 }
                             }
                         }

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/index.properties
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/index.properties
@@ -1,0 +1,2 @@
+blurb = This page lists the most recent builds run as the SYSTEM user, since Jenkins was started or access control for builds was enabled, in of the projects listed below.
+ago = Started {0} ago

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/index.properties
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/index.properties
@@ -1,2 +1,1 @@
-blurb = This page lists the most recent builds run as the SYSTEM user, since Jenkins was started or access control for builds was enabled, in of the projects listed below.
-ago = Started {0} ago
+blurb = This page lists projects and their most recent builds run as the <span style="font-family: monospace;">SYSTEM</span> user, since Jenkins was started or access control for builds was enabled.

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.groovy
@@ -33,7 +33,7 @@ div(class: "alert alert-warning", role: "alert") {
         f.submit(name: 'dismiss', value: _("Dismiss"))
     }
 
-    text(_("blurb"))
+    text(raw(_("blurb")))
 
     ul(style: "list-style-type: none;") {
         if (my.queueItemAuthenticatorPresent) {

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.groovy
@@ -45,10 +45,7 @@ div(class: "alert alert-warning", role: "alert") {
 
 
                 if (my.anyBuildLaunchedAsSystemWithAuthenticatorPresent) {
-                    li(raw(_("anyBuildLaunchedAsSystem", rootURL)))
-                    form(method: "post", action: "${rootURL}/${my.url}/act") {
-                        f.submit(name: 'reset', value: _("Reset"))
-                    }
+                    li(raw(_("anyBuildLaunchedAsSystem", rootURL, "${rootURL}/${my.url}")))
                 }
                 // else: This monitor will not be displayed
 

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.properties
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.properties
@@ -12,5 +12,6 @@ queueItemAuthenticatorConfigured = \u2705 Access control for builds is configure
 noQueueItemAuthenticatorConfigured = \u274c Access control for builds is possible, but not configured. Configure it in the <a href="{0}/configureSecurity">global security configuration</a>.
 
 anyBuildLaunchedAsSystem = \u274c Builds have been observed as launching as the internal SYSTEM user despite access control for builds being set up. \
+  See <a href="{1}">the list of launched builds</a> for details. \
   It is recommended that you <a href="{0}/configureSecurity">review the access control for builds configuration</a> to ensure builds are not generally running as the SYSTEM user.
 notAnyBuildLaunchedAsSystem = \u2705 No builds have been launched as the internal SYSTEM user, indicating a complete configuration.

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.properties
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.properties
@@ -1,4 +1,4 @@
-blurb = Builds in Jenkins run as the virtual Jenkins SYSTEM user with full Jenkins permissions by default. \
+blurb = Builds in Jenkins run as the internal <span style="font-family: monospace;">SYSTEM</span> user with full permissions by default. \
   This can be a problem if some users have restricted or no access to some jobs, but can configure others. \
   If that is the case, it is recommended to install a plugin implementing build authentication, and to override this default.
 
@@ -11,7 +11,6 @@ noQueueItemAuthenticatorPresent = \u274c No implementation of access control for
 queueItemAuthenticatorConfigured = \u2705 Access control for builds is configured.
 noQueueItemAuthenticatorConfigured = \u274c Access control for builds is possible, but not configured. Configure it in the <a href="{0}/configureSecurity">global security configuration</a>.
 
-anyBuildLaunchedAsSystem = \u274c Builds have been observed as launching as the internal SYSTEM user despite access control for builds being set up. \
+anyBuildLaunchedAsSystem = \u274c Builds have been observed as launching as the internal <span style="font-family: monospace;">SYSTEM</span> user despite access control for builds being set up. \
   See <a href="{1}">the list of launched builds</a> for details. \
-  It is recommended that you <a href="{0}/configureSecurity">review the access control for builds configuration</a> to ensure builds are not generally running as the SYSTEM user.
-notAnyBuildLaunchedAsSystem = \u2705 No builds have been launched as the internal SYSTEM user, indicating a complete configuration.
+  It is recommended that you <a href="{0}/configureSecurity">review the access control for builds configuration</a> to ensure builds are not generally running as the <span style="font-family: monospace;">SYSTEM</span> user.


### PR DESCRIPTION
See [JENKINS-24513](https://issues.jenkins-ci.org/browse/JENKINS-24513). Improves on #3919.

Minor UI enhancement only, so skipped on tests, but can add some inspecting the collection created, if requested.

> ![Screen Shot](https://user-images.githubusercontent.com/1831569/54059066-1a45fd00-41f8-11e9-81ac-daddecc7b0a8.png)

> ![Screen Shot](https://user-images.githubusercontent.com/1831569/54059072-1f0ab100-41f8-11e9-823b-a5ff77784783.png) 

(Since this screen shot the icon changed -- it's now the yellow padlock also used in Global Security Configuration.)

### Proposed changelog entries

* Record which builds were started as SYSTEM when access control for builds is enabled.

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs
