### PR TITLE
Correct small JS bug

### DIFF
--- a/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/resources.js
+++ b/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/resources.js
@@ -144,7 +144,7 @@ function onCheckChanged(checkBox){
         var allCheckBoxes = document.querySelectorAll('.token-to-revoke');
         for(var i = 0; i < allCheckBoxes.length; i++){
             var checkBox = allCheckBoxes[i];
-            checkBox.onchange = function(){ onCheckChanged(checkBox); };
+            checkBox.onchange = function(){ onCheckChanged(this); };
         }
     });
 })()


### PR DESCRIPTION
#### Context
The "Manage Legacy API Token usage" page, used for migrating the legacy API Token.

#### Problem
If you click on a line, the checkbox is checked and the line is highlighted. But if you click on the checkbox, the behavior should be the same. This is not the case for all the lines, except the last one.

#### Root cause
In the code, I used a `var` inside a loop. Due to the JS behavior, the `var` are not scoped to their "block", but to their "function block". That results in the `onCheckChanged(checkBox)`, the checkBox change it's value, due to the closure, that keep the reference to a variable that is changed.

#### Solution
Either using `let` instead of `var` or using the `this` that corresponds to the checkbox in this case.

#### Impact
The highlighting of the line is not triggered. The "functional" feature is working as expected.

<details>
<summary>Behavior Gif</summary>

#### Before patch

![legacy_api_token_not_working](https://user-images.githubusercontent.com/2662497/54070947-dccc8880-4266-11e9-8a49-362239dce120.gif)

#### After patch
![legacy_api_token_working](https://user-images.githubusercontent.com/2662497/54070950-de964c00-4266-11e9-8f22-ccac7211c91f.gif)

</details>

Tested with Chrome and Firefox.

No ticket.
 
### Proposed changelog entries

* UI Bugfix: in the Legacy API Token usage page, the checkbox was not triggering the "line highlight" effect.

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
