### PR TITLE
JENKINS-56554 Add run parameter filter to API response

### DIFF
--- a/core/src/main/java/hudson/model/RunParameterDefinition.java
+++ b/core/src/main/java/hudson/model/RunParameterDefinition.java
@@ -112,6 +112,7 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
      * @return The current filter value, if filter is null, returns ALL
      * @since 1.517
      */
+    @Exported
     public RunParameterFilter getFilter() {
     	// if filter is null, default to RunParameterFilter.ALL
         return (null == filter) ? RunParameterFilter.ALL : filter;


### PR DESCRIPTION
See [JENKINS-56554](https://issues.jenkins-ci.org/browse/JENKINS-56554).

In short, this adds the run parameter build filter value to the response of the job API call:
```json
{
   "_class":"hudson.model.RunParameterDefinition",
   "defaultParameterValue":{
      "_class":"hudson.model.RunParameterValue"
   },
   "description":"",
   "name":"Run_Parameter",
   "type":"RunParameterDefinition",
   "filter":"COMPLETED",
   "projectName":"Project"
}
```

This change currently does not have any tests associated with it. It's a pretty simple change, but if adding tests for this were preferred, I would be very grateful for a pointer to similar test cases that I can use for orientation.

### Proposed changelog entries

* JENKINS-56554, Add the run parameter filter value to the relevant API responses

### Submitter checklist

- [ x] JIRA issue is well described
- [ x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs
