### PR TITLE
[JENKINS-50095] Add X-Remoting-Minimum-Version header in /tcpSlaveAgentListener

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -33,6 +33,7 @@ import java.security.interfaces.RSAPublicKey;
 import javax.annotation.Nullable;
 
 import hudson.model.AperiodicWork;
+import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import jenkins.model.identity.InstanceIdentityProvider;
 import jenkins.security.stapler.StaplerAccessibleType;
@@ -151,6 +152,13 @@ public final class TcpSlaveAgentListener extends Thread {
      */
     public String getAgentProtocolNames() {
         return StringUtils.join(Jenkins.getInstance().getAgentProtocols(), ", ");
+    }
+
+    /**
+     * Gets Remoting minimum supported version to prevent unsupported agents from connecting
+     */
+    public VersionNumber getRemotingMinimumVersion() {
+        return RemotingVersionInfo.getMinimumSupportedVersion();
     }
 
     @Override
@@ -304,7 +312,7 @@ public final class TcpSlaveAgentListener extends Thread {
                     o.write("Jenkins-Session: " + Jenkins.SESSION_HASH + "\r\n");
                     o.write("Client: " + s.getInetAddress().getHostAddress() + "\r\n");
                     o.write("Server: " + s.getLocalAddress().getHostAddress() + "\r\n");
-                    o.write("Remoting-Minimum-Version: " + RemotingVersionInfo.getMinimumSupportedVersion() + "\r\n");
+                    o.write("Remoting-Minimum-Version: " + getRemotingMinimumVersion() + "\r\n");
                     o.flush();
                     s.shutdownOutput();
                 } else {

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -156,6 +156,7 @@ public final class TcpSlaveAgentListener extends Thread {
 
     /**
      * Gets Remoting minimum supported version to prevent unsupported agents from connecting
+     * @since 2.169
      */
     public VersionNumber getRemotingMinimumVersion() {
         return RemotingVersionInfo.getMinimumSupportedVersion();

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -302,8 +302,7 @@ public final class TcpSlaveAgentListener extends Thread {
         private void respondHello(String header, Socket s) throws IOException {
             try {
                 Writer o = new OutputStreamWriter(s.getOutputStream(), StandardCharsets.UTF_8);
-
-                //TODO: expose version about minimum supported Remoting version (JENKINS-48766)
+                
                 if (header.startsWith("GET / ")) {
                     o.write("HTTP/1.0 200 OK\r\n");
                     o.write("Content-Type: text/plain;charset=UTF-8\r\n");

--- a/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
+++ b/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
@@ -39,6 +39,8 @@ THE SOFTWARE.
   <st:header name="X-Instance-Identity" value="${app.tcpSlaveAgentListener.identityPublicKey}" />
   <!-- reduce the number of client connection attempts during protocol negotiation -->
   <st:header name="X-Jenkins-Agent-Protocols" value="${app.tcpSlaveAgentListener.agentProtocolNames}"/>
+  <!-- publish minimum supported version of remoting agent -->
+  <st:header name="X-Remoting-Minimum-Version" value="${app.tcpSlaveAgentListener.remotingMinimumVersion}"/>
 
   Jenkins
 </j:jelly>


### PR DESCRIPTION
See [JENKINS-50095](https://issues.jenkins-ci.org/browse/JENKINS-50095).

Remoting agent will request to `jenkinsHost/tcpSlaveAgentListener` to check for JNLP listener's metadata instead of to `jnlpHost/` so this helps agent check for supporting version without writing a new separate resolver for `jnlpHost/`

This is a minor change to static page so there's no test.

This PR is related to another PR on Remoting's side: https://github.com/jenkinsci/remoting/pull/318

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* [JENKINS-50095](https://issues.jenkins-ci.org/browse/JENKINS-50095): Agent will refuse connection if agent's version is older than minimum supported version

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
