### PR TITLE
Remove incorrect annotation that overrides return type of AbstractItem#getParent

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -1,19 +1,19 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2011, Sun Microsystems, Inc., Kohsuke Kawaguchi,
  * Daniel Dyer, Tom Huybrechts, Yahoo!, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,7 +24,6 @@
  */
 package hudson.model;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import hudson.AbortException;
 import hudson.XmlFile;
 import hudson.Util;
@@ -127,7 +126,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     protected volatile String description;
 
     private transient ItemGroup parent;
-    
+
     protected String displayName;
 
     protected AbstractItem(ItemGroup parent, String name) {
@@ -169,7 +168,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         // if the displayName is not set, then return the name as we use to do
         return getName();
     }
-    
+
     @Exported
     /**
      * This is intended to be used by the Job configuration pages where
@@ -180,9 +179,9 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     public String getDisplayNameOrNull() {
         return displayName;
     }
-    
+
     /**
-     * This method exists so that the Job configuration pages can use 
+     * This method exists so that the Job configuration pages can use
      * getDisplayNameOrNull so that nothing is shown in the display name text
      * box if the display name is not set.
      * @param displayName
@@ -191,20 +190,16 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     public void setDisplayNameOrNull(String displayName) throws IOException {
         setDisplayName(displayName);
     }
-    
+
     public void setDisplayName(String displayName) throws IOException {
         this.displayName = Util.fixEmptyAndTrim(displayName);
         save();
     }
-             
+
     public File getRootDir() {
         return getParent().getRootDirFor(this);
     }
 
-    /**
-     * This bridge method is to maintain binary compatibility with {@link TopLevelItem#getParent()}.
-     */
-    @WithBridgeMethods(value=Jenkins.class,castRequired=true)
     @Override public @Nonnull ItemGroup getParent() {
         if (parent == null) {
             throw new IllegalStateException("no parent set on " + getClass().getName() + "[" + name + "]");
@@ -476,7 +471,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         if(n.length()==0)   return getDisplayName();
         else                return n+" » "+getDisplayName();
     }
-    
+
     /**
      * Gets the display name of the current item relative to the given group.
      *
@@ -488,7 +483,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     public String getRelativeDisplayNameFrom(ItemGroup p) {
         return Functions.getRelativeDisplayNameFrom(this, p);
     }
-    
+
     /**
      * This method only exists to disambiguate {@link #getRelativeNameFrom(ItemGroup)} and {@link #getRelativeNameFrom(Item)}
      * @since 1.512
@@ -514,7 +509,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      * to perform any implementation-specific work.
      *
      * <p>
-     * 
+     *
      *
      * @param src
      *      Item from which it's copied from. The same type as {@code this}. Never null.
@@ -718,8 +713,8 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                         final WorkUnit workUnit = e.getCurrentWorkUnit();
                         final Executable executable = workUnit != null ? workUnit.getExecutable() : null;
                         final SubTask subtask = executable != null ? getParentOf(executable) : null;
-                                
-                        if (subtask != null) {        
+
+                        if (subtask != null) {
                             Item item = Tasks.getItemOf(subtask);
                             if (item != null) {
                                 while (item != null) {


### PR DESCRIPTION
This annotation overrode the return type of AbstractItem#getParent
to return Jenkins instead of ItemGroup. This would not compile, when a
normal ItemGroup was returned, as that does not extend Jenkins.

We ran into this issue when using Mockito with the new ByteBuddy mockmaker
that would throw a WrongTypeOfReturnValue as it expected a Jenkins
value, but saw an ItemGroup instead.

### Proposed changelog entries

* bug: Remove incorrect annotation that overrides return type of AbstractItem#getParentGroup

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described: N/A, minor improvement.
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests: N/A, internal code change
- [X] For dependency updates: links to external changelogs and, if possible, full diffs: N/A, no dependency update
