### PR TITLE
Switch a few URLs to HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
   <licenses>
     <license>
       <name>The MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <url>https://www.opensource.org/licenses/mit</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -123,7 +123,7 @@ THE SOFTWARE.
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
       <!-- allow snapshots -->
     </repository>
   </repositories>
@@ -131,7 +131,7 @@ THE SOFTWARE.
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
We should get dependencies via HTTPS by default, even if it's unlikely to make much of a difference in practice due to `settings.xml` customization (mirrors etc.).

Additionally, use a nicer license URL.

### Proposed changelog entries

_(too minor)_