### PR TITLE
[JENKINS-56776] Remove 'nonStoredPasswordParam' symbol

### DIFF
--- a/core/src/main/java/hudson/model/PasswordParameterDefinition.java
+++ b/core/src/main/java/hudson/model/PasswordParameterDefinition.java
@@ -96,16 +96,11 @@ public class PasswordParameterDefinition extends SimpleParameterDefinition {
         this.defaultValue = Secret.fromString(defaultValue);
     }
 
-    @Extension @Symbol({"password","nonStoredPasswordParam"})
+    @Extension @Symbol({"password"})
     public final static class ParameterDescriptorImpl extends ParameterDescriptor {
         @Override
         public String getDisplayName() {
             return Messages.PasswordParameterDefinition_DisplayName();
-        }
-        
-        @Override
-        public String getHelpFile() {
-            return "/help/parameter/string.html";
         }
     }
 }

--- a/core/src/main/resources/hudson/model/PasswordParameterDefinition/help.html
+++ b/core/src/main/resources/hudson/model/PasswordParameterDefinition/help.html
@@ -1,0 +1,5 @@
+<div>
+    Pass a password to your build.
+    The password entered here is made available to the build in plain text as an environment variable like a string parameter would be.
+    The value will be stored encrypted on the Jenkins master, similar to passwords in Jenkins configuration.
+</div>


### PR DESCRIPTION
See [JENKINS-56776](https://issues.jenkins-ci.org/browse/JENKINS-56776).

Also add an actual inline help for the password parameter.

### Proposed changelog entries

* Major RFE: Remove `nonStoredPasswordParam` symbol for password parameters since it's actually stored.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
