### PR TITLE
[Jenkins-16750] Update build status icon

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
         </div>
       </div>
 
-      <t:buildCaption>
+      <t:buildCaption autorefresh="true">
         ${%Build} ${it.displayName}
         (<i:formatDate value="${it.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)
       </t:buildCaption>

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -56,7 +56,8 @@ THE SOFTWARE.
             <div id="spinner">
               <img src="${imagesURL}/spinner.gif" alt="" /> 
             </div>
-          <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner" startOffset="${offset}" />
+          <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner"
+               startOffset="${offset}" callback="window.updateBuildCaptionIcon"/>
         </j:when>
         <!-- output is completed now. -->
         <j:otherwise>

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
               <img src="${imagesURL}/spinner.gif" alt="" /> 
             </div>
           <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner"
-               startOffset="${offset}" callback="window.updateBuildCaptionIcon"/>
+               startOffset="${offset}" onFinishEvent="jenkins:consoleFinished"/>
         </j:when>
         <!-- output is completed now. -->
         <j:otherwise>

--- a/core/src/main/resources/hudson/model/Run/statusIcon.jelly
+++ b/core/src/main/resources/hudson/model/Run/statusIcon.jelly
@@ -3,6 +3,8 @@ The MIT License
 
 Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
 
+Copyright (c) 2012, Martin Schroeder, Intel Mobile Communications GmbH
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
@@ -26,22 +28,9 @@ THE SOFTWARE.
   Displays the console output
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${it.fullDisplayName} ${%Changes}">
-    <st:include page="sidepanel.jelly" />
-    <l:main-panel>
-      <t:buildCaption autorefresh="true">${%Changes}</t:buildCaption>
-      <j:choose>
-        <j:when test="${it.hasChangeSetComputed()}">
-          <st:include page="index.jelly" it="${it.changeSet}" />
-        </j:when>
-        <j:when test="${it.building}">
-          ${%Not yet determined}
-        </j:when>
-        <j:otherwise>
-          ${%Failed to determine} (<a href="console">${%log}</a>)
-        </j:otherwise>
-      </j:choose>
-    </l:main-panel>
-  </l:layout>
-</j:jelly>
+<st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<st:setHeader name="X-Building" value="${it.building}" />
+<l:ajax>
+  <l:icon alt="${it.iconColor.description}" class="${it.buildStatusIconClassName} icon-xlg" tooltip="${it.iconColor.description}"/>
+</l:ajax>
+</st:compress>

--- a/core/src/main/resources/lib/hudson/buildCaption.jelly
+++ b/core/src/main/resources/lib/hudson/buildCaption.jelly
@@ -46,13 +46,13 @@ THE SOFTWARE.
 	  </j:if>
 	  
 	  <l:icon alt="${it.iconColor.description}" class="${it.buildStatusIconClassName} icon-xlg" tooltip="${it.iconColor.description}"/>
-	  <script>
-          function updateBuildCaptionIcon(){
+        <script>
+          (function(autorefresh){
+            function updateBuildCaptionIcon(){
               new Ajax.Request("statusIcon",{
                 method: "get",
                 onComplete: function(rsp,_) {
                   var isBuilding = rsp.getResponseHeader("X-Building");
-                  console.log("Building:"+isBuilding);
                   if (isBuilding == "true") {
                     setTimeout(updateBuildCaptionIcon, 5000)
                   } else {
@@ -63,12 +63,18 @@ THE SOFTWARE.
                   }
                   document.querySelector(".build-caption .icon-xlg").outerHTML = rsp.responseText;
                 }
+              });
+            }
+
+            window.addEventListener("load", function(){
+              if (autorefresh) {
+                updateBuildCaptionIcon()
+              }
+              Event.observe(window, "jenkins:consoleFinished", updateBuildCaptionIcon);
             });
-          }
-          <j:if test="${autorefresh!=null}">
-                window.addEventListener("load", updateBuildCaptionIcon);
-          </j:if>
-          </script>
+
+          })(${autorefresh});
+        </script>
 	  <d:invokeBody />
 	</h1>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/buildCaption.jelly
+++ b/core/src/main/resources/lib/hudson/buildCaption.jelly
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 <!--
     displays a caption for build/externalRun.
+    <%@attribute name="autorefresh" required="false" description="Whether to reload this component automatically using AJAX" %>
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
@@ -45,6 +46,29 @@ THE SOFTWARE.
 	  </j:if>
 	  
 	  <l:icon alt="${it.iconColor.description}" class="${it.buildStatusIconClassName} icon-xlg" tooltip="${it.iconColor.description}"/>
+	  <script>
+          function updateBuildCaptionIcon(){
+              new Ajax.Request("statusIcon",{
+                method: "get",
+                onComplete: function(rsp,_) {
+                  var isBuilding = rsp.getResponseHeader("X-Building");
+                  console.log("Building:"+isBuilding);
+                  if (isBuilding == "true") {
+                    setTimeout(updateBuildCaptionIcon, 5000)
+                  } else {
+                    var progressBar = document.querySelector(".build-caption-progress-container");
+                    if (progressBar) {
+                      progressBar.style.display = "none";
+                    }
+                  }
+                  document.querySelector(".build-caption .icon-xlg").outerHTML = rsp.responseText;
+                }
+            });
+          }
+          <j:if test="${autorefresh!=null}">
+                window.addEventListener("load", updateBuildCaptionIcon);
+          </j:if>
+          </script>
 	  <d:invokeBody />
 	</h1>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/progressiveText.jelly
+++ b/core/src/main/resources/lib/hudson/progressiveText.jelly
@@ -31,6 +31,7 @@ THE SOFTWARE.
 	<%@attribute name="idref" required="true" description="ID of the HTML element in which the result is displayed" %>
 	<%@attribute name="spinner" required="false" description="ID of the HTML element in which the spinner is displayed" %>
 	<%@attribute name="startOffset" required="false" description="Skip this many bytes rather than showing from start of data" %>
+	<%@attribute name="callback" required="false" description="JS function with one argument, receives true when complete and false for intermediate steps" %>
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
@@ -49,16 +50,16 @@ THE SOFTWARE.
 	      @param href
 	          Where to retrieve additional text from
 	    -->
-	    function fetchNext(e,href) {
+	    function fetchNext(e,href,callback) {
         var headers = {};
         if (e.consoleAnnotator!=undefined)
           headers["X-ConsoleAnnotator"] = e.consoleAnnotator;
 
-	      new Ajax.Request(href,{
-	          method: "post",
-	          parameters: {"start":e.fetchedBytes},
-            requestHeaders: headers,
-	          onComplete: function(rsp,_) {
+          new Ajax.Request(href,{
+              method: "post",
+              parameters: {"start":e.fetchedBytes},
+              requestHeaders: headers,
+              onComplete: function(rsp,_) {
               <!-- append text and do autoscroll if applicable-->
               var stickToBottom = scroller.isSticking();
               var text = rsp.responseText;
@@ -79,17 +80,21 @@ THE SOFTWARE.
 
               e.fetchedBytes     = rsp.getResponseHeader("X-Text-Size");
               e.consoleAnnotator = rsp.getResponseHeader("X-ConsoleAnnotator");
-	            if(rsp.getResponseHeader("X-More-Data")=="true")
-	              setTimeout(function(){fetchNext(e,href);},1000);
-	          <j:if test="${spinner!=null}">
-	            else
-	              $$("${spinner}").style.display = "none";
-	          </j:if>
-	          }
-	      });
-	    }
-	  </j:if>
-	  $$("${idref}").fetchedBytes = ${empty(startOffset)?0:startOffset};
-	  fetchNext($$("${idref}"),"${href}");
-	</script>
+              if(rsp.getResponseHeader("X-More-Data")=="true") {
+                setTimeout(function(){fetchNext(e,href,callback);},1000);
+              } else {
+              <j:if test="${spinner!=null}">
+                $$("${spinner}").style.display = "none";
+              </j:if>
+                if (callback) {
+                  callback();
+                }
+              }
+            }
+          });
+        }
+      </j:if>
+      $$("${idref}").fetchedBytes = ${empty(startOffset)?0:startOffset};
+      fetchNext($$("${idref}"),"${href}",${empty(callback)?"null":callback});
+    </script>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/progressiveText.jelly
+++ b/core/src/main/resources/lib/hudson/progressiveText.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
 	<%@attribute name="idref" required="true" description="ID of the HTML element in which the result is displayed" %>
 	<%@attribute name="spinner" required="false" description="ID of the HTML element in which the spinner is displayed" %>
 	<%@attribute name="startOffset" required="false" description="Skip this many bytes rather than showing from start of data" %>
-	<%@attribute name="callback" required="false" description="JS function with one argument, receives true when complete and false for intermediate steps" %>
+	<%@attribute name="onFinishEvent" required="false" description="JS custom event to be fired when progress is finished" %>
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
@@ -50,7 +50,7 @@ THE SOFTWARE.
 	      @param href
 	          Where to retrieve additional text from
 	    -->
-	    function fetchNext(e,href,callback) {
+	    function fetchNext(e,href,onFinishEvent) {
         var headers = {};
         if (e.consoleAnnotator!=undefined)
           headers["X-ConsoleAnnotator"] = e.consoleAnnotator;
@@ -81,13 +81,13 @@ THE SOFTWARE.
               e.fetchedBytes     = rsp.getResponseHeader("X-Text-Size");
               e.consoleAnnotator = rsp.getResponseHeader("X-ConsoleAnnotator");
               if(rsp.getResponseHeader("X-More-Data")=="true") {
-                setTimeout(function(){fetchNext(e,href,callback);},1000);
+                setTimeout(function(){fetchNext(e,href,onFinishEvent);},1000);
               } else {
               <j:if test="${spinner!=null}">
                 $$("${spinner}").style.display = "none";
               </j:if>
-                if (callback) {
-                  callback();
+                if (onFinishEvent) {
+                  Event.fire(window, onFinishEvent);
                 }
               }
             }
@@ -95,6 +95,6 @@ THE SOFTWARE.
         }
       </j:if>
       $$("${idref}").fetchedBytes = ${empty(startOffset)?0:startOffset};
-      fetchNext($$("${idref}"),"${href}",${empty(callback)?"null":callback});
+      fetchNext($$("${idref}"),"${href}","${empty(onFinishEvent)?"":onFinishEvent}");
     </script>
 </j:jelly>


### PR DESCRIPTION
See [JENKINS-16750](https://issues.jenkins-ci.org/browse/JENKINS-16750).

### Proposed changelog entries

* Update status icon of a build when the build is finished

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x ] JIRA issue is well described
- [x ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a ] Appropriate autotests or explanation to why this change has no tests
- [n/a ] For dependency updates: links to external changelogs and, if possible, full diffs
