### PR TITLE
Minor version annotation update

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -156,7 +156,7 @@ public final class TcpSlaveAgentListener extends Thread {
 
     /**
      * Gets Remoting minimum supported version to prevent unsupported agents from connecting
-     * @since 2.169
+     * @since TODO
      */
     public VersionNumber getRemotingMinimumVersion() {
         return RemotingVersionInfo.getMinimumSupportedVersion();

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -156,7 +156,7 @@ public final class TcpSlaveAgentListener extends Thread {
 
     /**
      * Gets Remoting minimum supported version to prevent unsupported agents from connecting
-     * @since TODO
+     * @since 2.171
      */
     public VersionNumber getRemotingMinimumVersion() {
         return RemotingVersionInfo.getMinimumSupportedVersion();


### PR DESCRIPTION
Minor version annotation update in TcpSlaveAgentListener.java

This is a patch for PR https://github.com/jenkinsci/jenkins/pull/3938

@batmat  I've changed `@since` annotation from a fixed version to `@since TODO` as you suggested. Thank you for pointing out that problem! 