### PR TITLE
JENKINS-56856 - URL Encode data before submitting it to the endpoint just incase there's bad data in it

### DIFF
--- a/war/src/main/js/util/jenkins.js
+++ b/war/src/main/js/util/jenkins.js
@@ -284,8 +284,11 @@ exports.buildFormPost = function($form) {
 	var wnd = exports.getWindow($form);
 	var form = $form[0];
 	if(wnd.buildFormTree(form)) {
-		return $form.serialize() +
-			'&core:apply=&Submit=Save&json=' + $form.find('input[name=json]').val();
+		return $form.serialize() + jquery.param({
+			'core:apply': '',
+			'Submit': 'Save',
+			'json': $form.find('input[name=json]').val()
+		});
 	}
 	return '';
 };

--- a/war/src/main/js/util/jenkins.js
+++ b/war/src/main/js/util/jenkins.js
@@ -284,7 +284,7 @@ exports.buildFormPost = function($form) {
 	var wnd = exports.getWindow($form);
 	var form = $form[0];
 	if(wnd.buildFormTree(form)) {
-		return $form.serialize() + jquery.param({
+		return $form.serialize() + "&" + jquery.param({
 			'core:apply': '',
 			'Submit': 'Save',
 			'json': $form.find('input[name=json]').val()


### PR DESCRIPTION
See [JENKINS-56856](https://issues.jenkins-ci.org/browse/JENKINS-56856).

When submitting a password or other field with %m in it, jetty assumes its url encoded and tries to decode it. 

This fix tells jquery to properly escape the data before sending it to the backend

### Proposed changelog entries

* Entry 1: JENKINS-56856, Property escape data being sent to backend during setup wizard

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
