### PR TITLE
Let some tests skip themselves which are sensitive to the live contents of the update center

### DIFF
--- a/test/src/test/java/hudson/model/UpdateCenter2Test.java
+++ b/test/src/test/java/hudson/model/UpdateCenter2Test.java
@@ -27,6 +27,7 @@ import hudson.model.UpdateCenter.DownloadJob;
 import hudson.model.UpdateCenter.DownloadJob.Success;
 import hudson.model.UpdateCenter.DownloadJob.Failure;
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeNotNull;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -48,7 +49,9 @@ public class UpdateCenter2Test {
     @Test public void install() throws Exception {
         UpdateSite.neverUpdate = false;
         j.jenkins.pluginManager.doCheckUpdatesServer(); // load the metadata
-        DownloadJob job = (DownloadJob) j.jenkins.getUpdateCenter().getPlugin("changelog-history").deploy().get(); // this seems like one of the smallest plugin
+        UpdateSite.Plugin plugin = j.jenkins.getUpdateCenter().getPlugin("changelog-history");
+        assumeNotNull(plugin);
+        DownloadJob job = (DownloadJob) plugin.deploy().get(); // this seems like one of the smallest plugin
         System.out.println(job.status);
         assertTrue(job.status instanceof Success);
     }
@@ -66,8 +69,10 @@ public class UpdateCenter2Test {
         String wrongChecksum = "ABCDEFG1234567890";
 
         // usually the problem is the file having a wrong checksum, but changing the expected one works just the same
-        j.jenkins.getUpdateCenter().getSite("default").getPlugin("changelog-history").sha512 = wrongChecksum;
-        DownloadJob job = (DownloadJob) j.jenkins.getUpdateCenter().getPlugin("changelog-history").deploy().get();
+        UpdateSite.Plugin plugin = j.jenkins.getUpdateCenter().getSite("default").getPlugin("changelog-history");
+        assumeNotNull(plugin);
+        plugin.sha512 = wrongChecksum;
+        DownloadJob job = (DownloadJob) plugin.deploy().get();
         assertTrue(job.status instanceof Failure);
         assertTrue("error message references checksum", ((Failure) job.status).problem.getMessage().contains(wrongChecksum));
     }

--- a/test/src/test/java/hudson/model/UpdateCenterPluginInstallTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterPluginInstallTest.java
@@ -26,7 +26,7 @@ package hudson.model;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.junit.Assert;
-import org.junit.Assume;
+import static org.junit.Assume.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -44,10 +44,14 @@ public class UpdateCenterPluginInstallTest {
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
 
-    public void setup() throws IOException {
-        jenkinsRule.jenkins.getUpdateCenter().getSite(UpdateCenter.ID_DEFAULT).updateDirectlyNow(false);
+    private void setup() {
+        try {
+            jenkinsRule.jenkins.getUpdateCenter().getSite(UpdateCenter.ID_DEFAULT).updateDirectlyNow(false);
+        } catch (Exception x) {
+            assumeNoException(x);
+        }
         InetSocketAddress address = new InetSocketAddress("updates.jenkins-ci.org", 80);
-        Assume.assumeFalse("Unable to resolve updates.jenkins-ci.org. Skip test.", address.isUnresolved());
+        assumeFalse("Unable to resolve updates.jenkins-ci.org. Skip test.", address.isUnresolved());
     }
 
     @Test


### PR DESCRIPTION
On a Javadoc-only PR (#3958) I got four test failures which were apparently due to some transient problem in the update center (or at least I cannot reproduce the failures locally). Two representative examples:

```
java.lang.NullPointerException
	at hudson.model.UpdateCenter2Test.install(UpdateCenter2Test.java:51)
```

```
net.sf.json.JSONException: Expected a ',' or '}' at character 99537 of {"connectionCheckUrl":"http://www.google.com/",…,"name":"audit-trail",…,"wiki":"https://plugins.jenkins.io/audit-trail"}
	at net.sf.json.util.JSONTokener.syntaxError(JSONTokener.java:499)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:1043)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:156)
	at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:348)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:955)
	at net.sf.json.JSONObject._fromString(JSONObject.java:1145)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:162)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:132)
	at hudson.model.UpdateSite.updateData(UpdateSite.java:205)
	at hudson.model.UpdateSite.updateDirectlyNow(UpdateSite.java:188)
	at hudson.model.UpdateCenterPluginInstallTest.setup(UpdateCenterPluginInstallTest.java:48)
	at hudson.model.UpdateCenterPluginInstallTest.test_installUnknownPlugin(UpdateCenterPluginInstallTest.java:55)
```