### PR TITLE
Deprecating Run.getLogFile

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1429,7 +1429,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     /**
      * Returns the log file.
      * @return The file may reference both uncompressed or compressed logs
-     */  
+     * @deprecated Assumes file-based storage of the log. Use other methods giving various kinds of streams.
+     */
+    @Deprecated
     public @Nonnull File getLogFile() {
         File rawF = new File(getRootDir(), "log");
         if (rawF.isFile()) {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1429,7 +1429,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     /**
      * Returns the log file.
      * @return The file may reference both uncompressed or compressed logs
-     * @deprecated Assumes file-based storage of the log. Use other methods giving various kinds of streams.
+     * @deprecated Assumes file-based storage of the log, which is not necessarily the case for Pipelines after JEP-210. Use other methods giving various kinds of streams such as {@link Run#getLogReader()},  {@link Run#getLogInputStream()}, or {@link Run#getLogText()}.
      */
     @Deprecated
     public @Nonnull File getLogFile() {


### PR DESCRIPTION
See [JENKINS-38381](https://issues.jenkins-ci.org/browse/JENKINS-38381).

### Proposed changelog entries

* Noting that `Run.getLogFile()` should not be used, as it is not compatible with [JEP-210](https://jenkins.io/jep/210). Other log-related methods are implemented properly in `workflow-job`.