### PR TITLE
Add new compressor methods to Run.getLogStream()

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1,11 +1,9 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2019 Intel Corporation 
- *
  * Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi,
  * Daniel Dyer, Red Hat, Inc., Tom Huybrechts, Romain Seguy, Yahoo! Inc.,
- * Darek Ostolski, CloudBees, Inc.
+ * Darek Ostolski, CloudBees, Inc., Martin Schroeder, Intel Corporation
  *
  * Copyright (c) 2012, Martin Schroeder, Intel Mobile Communications GmbH
  * 

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1506,10 +1506,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             }
         }
         String message = String.format(
-                "No log files found or readable: %s%s%s",
+                "No log files found or readable: %s%slog[.gz|.xz|.lz|.sz]",
                 logRoot.getPath(),
-                File.separator,
-                logNames
+                File.separator
         );
         return new ByteArrayInputStream(
                 charset != null ? message.getBytes(charset) : message.getBytes()

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -118,8 +118,8 @@ import jenkins.util.io.OnMaster;
 import net.sf.json.JSONObject;
 import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.Authentication;
-import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.lzma.LZMACompressorInputStream;
+import org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorInputStream;
 import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 import org.apache.commons.io.IOUtils;
@@ -1470,11 +1470,13 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                     return new GZIPInputStream(fis);
                 } else if (lName.endsWith(".xz")) {
                     return new XZCompressorInputStream(fis);
-                } else if (lName.endsWith(".bzip2") || lName.endsWith(".bz2")) {
-                    return new BZip2CompressorInputStream(fis);
                 } else if (lName.endsWith(".lzma") || lName.endsWith(".lz")) {
                     return new LZMACompressorInputStream(fis);
-                } else if (lName.endsWith(".snappy") || lName.endsWith(".sz")) {
+                } else if (lName.endsWith(".sz")) {
+                    //Assume framed snappy format
+                    return new FramedSnappyCompressorInputStream(fis);
+                } else if (lName.endsWith(".snappy")) {
+                    //Assume raw, unframed snappy format
                     return new SnappyCompressorInputStream(fis);
                 } else {
                     //Uncompressed file, hopefully


### PR DESCRIPTION
Currently, Run.getLogStream() only supports uncompressed and GZIP compressed
log files.

This change adds support for more compression methods from Apache Commons:
 - XZ
 - LZMA
 - Bzip2
 - Snappy

This allows the Jenkins users to choose from a wider range of compression
algorithms for their logfiles -- tuning Jenkins either for better CPU usage or
for smaller log files.

Signed-off-by: Martin Schroeder <martin.h.schroeder@intel.com>