### PR TITLE
[FIX JENKINS-51495] descriptorRadioList does not honor DescriptorVisibilityFilter

### DIFF
--- a/core/src/main/java/hudson/DescriptorExtensionList.java
+++ b/core/src/main/java/hudson/DescriptorExtensionList.java
@@ -138,8 +138,9 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
     public T newInstanceFromRadioList(JSONObject config) throws FormException {
         if(config.isNullObject())
             return null;    // none was selected
-        int idx = config.getInt("value");
-        return get(idx).newInstance(Stapler.getCurrentRequest(),config);
+        String descriptorId = config.getString("value");
+        Descriptor<T> d = findByName(descriptorId);
+        return d != null ? d.newInstance(Stapler.getCurrentRequest(),config) : null;
     }
 
     public T newInstanceFromRadioList(JSONObject parent, String name) throws FormException {

--- a/core/src/main/java/hudson/util/DescriptorList.java
+++ b/core/src/main/java/hudson/util/DescriptorList.java
@@ -161,8 +161,9 @@ public final class DescriptorList<T extends Describable<T>> extends AbstractList
     public T newInstanceFromRadioList(JSONObject config) throws FormException {
         if(config.isNullObject())
             return null;    // none was selected
-        int idx = config.getInt("value");
-        return get(idx).newInstance(Stapler.getCurrentRequest(),config);
+        String descriptorId = config.getString("value");
+        Descriptor<T> d = findByName(descriptorId);
+        return d != null ? d.newInstance(Stapler.getCurrentRequest(),config) : null;
     }
 
     /**

--- a/core/src/main/resources/lib/form/descriptorRadioList.jelly
+++ b/core/src/main/resources/lib/form/descriptorRadioList.jelly
@@ -48,8 +48,8 @@ THE SOFTWARE.
   <j:set var="targetType" value="${attrs.targetType?:it.class}"/>
   <f:section title="${attrs.title}">
     <d:invokeBody />
-	  <j:forEach var="d" items="${descriptors}" varStatus="loop">
-      <f:radioBlock name="${varName}" help="${d.helpFile}" value="${loop.index}"
+	  <j:forEach var="d" items="${descriptors}">
+      <f:radioBlock name="${varName}" help="${d.helpFile}" value="${d.id}"
         title="${d.displayName}" checked="${instance.descriptor==d}">
         <j:set var="descriptor" value="${d}" />
 	      <j:set var="instance" value="${instance.descriptor==d?instance:null}" />

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -177,27 +177,26 @@ public class ExtensionListTest {
         assertEquals(0,LIST.size());
     }
 
-	@Test
-	public void newInstanceFromRadioList() throws Exception {
-		// test for DescriptorList
-		Map<String, String> CONFIGMAP = new HashMap<>();
-		CONFIGMAP.put("value", Tai.class.getName());
-		JSONObject CONFIG = JSONObject.fromObject(CONFIGMAP);
+    @Test
+    public void newInstanceFromRadioList() throws Exception {
+        // test for DescriptorList
+        Map<String, String> CONFIGMAP = new HashMap<>();
+        CONFIGMAP.put("value", Tai.class.getName());
+        JSONObject CONFIG = JSONObject.fromObject(CONFIGMAP);
 
-		DescriptorList<Fish> LIST = new DescriptorList<Fish>(Fish.class);
-		Fish FISH = LIST.newInstanceFromRadioList(CONFIG);
-		assertTrue(FISH instanceof Tai);
+        DescriptorList<Fish> LIST = new DescriptorList<Fish>(Fish.class);
+        Fish FISH = LIST.newInstanceFromRadioList(CONFIG);
+        assertTrue(FISH instanceof Tai);
 
-		// test for DescriptorExtensionList
-		Map<String, String> configMap = new HashMap<>();
-		configMap.put("value", Saba.class.getName());
-		JSONObject config = JSONObject.fromObject(configMap);
+        // test for DescriptorExtensionList
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("value", Saba.class.getName());
+        JSONObject config = JSONObject.fromObject(configMap);
 
-		DescriptorExtensionList<Fish, Descriptor<Fish>> list = j.jenkins
-				.<Fish, Descriptor<Fish>>getDescriptorList(Fish.class);
-		Fish fish = list.newInstanceFromRadioList(config);
-		assertTrue(fish instanceof Saba);
-	}
+        DescriptorExtensionList<Fish, Descriptor<Fish>> list = j.jenkins.<Fish, Descriptor<Fish>>getDescriptorList(Fish.class);
+        Fish fish = list.newInstanceFromRadioList(config);
+        assertTrue(fish instanceof Saba);
+    }
 
     public static class Car implements ExtensionPoint {
         final String name;

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -179,17 +179,17 @@ public class ExtensionListTest {
 
 	@Test
 	public void newInstanceFromRadioList() throws Exception {
-		Map<String, String> configMap = new HashMap<>();
-
 		// test for DescriptorList
-		configMap.put("value", Tai.class.getName());
-		JSONObject CONFIG = JSONObject.fromObject(configMap);
+		Map<String, String> CONFIGMAP = new HashMap<>();
+		CONFIGMAP.put("value", Tai.class.getName());
+		JSONObject CONFIG = JSONObject.fromObject(CONFIGMAP);
 
 		DescriptorList<Fish> LIST = new DescriptorList<Fish>(Fish.class);
 		Fish FISH = LIST.newInstanceFromRadioList(CONFIG);
 		assertTrue(FISH instanceof Tai);
 
 		// test for DescriptorExtensionList
+		Map<String, String> configMap = new HashMap<>();
 		configMap.put("value", Sishamo.class.getName());
 		JSONObject config = JSONObject.fromObject(configMap);
 

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -190,13 +190,13 @@ public class ExtensionListTest {
 
 		// test for DescriptorExtensionList
 		Map<String, String> configMap = new HashMap<>();
-		configMap.put("value", Sishamo.class.getName());
+		configMap.put("value", Saba.class.getName());
 		JSONObject config = JSONObject.fromObject(configMap);
 
 		DescriptorExtensionList<Fish, Descriptor<Fish>> list = j.jenkins
 				.<Fish, Descriptor<Fish>>getDescriptorList(Fish.class);
 		Fish fish = list.newInstanceFromRadioList(config);
-		assertTrue(fish instanceof Sishamo);
+		assertTrue(fish instanceof Saba);
 	}
 
     public static class Car implements ExtensionPoint {

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -6,20 +6,23 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import jenkins.model.Jenkins;
-import hudson.model.Descriptor;
-import hudson.model.Describable;
-import hudson.util.DescriptorList;
 import java.util.ArrayList;
-
-import java.util.List;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
+
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.util.DescriptorList;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -173,6 +176,28 @@ public class ExtensionListTest {
         LIST = new DescriptorList<Fish>();
         assertEquals(0,LIST.size());
     }
+
+	@Test
+	public void newInstanceFromRadioList() throws Exception {
+		Map<String, String> configMap = new HashMap<>();
+
+		// test for DescriptorList
+		configMap.put("value", Tai.class.getName());
+		JSONObject CONFIG = JSONObject.fromObject(configMap);
+
+		DescriptorList<Fish> LIST = new DescriptorList<Fish>(Fish.class);
+		Fish FISH = LIST.newInstanceFromRadioList(CONFIG);
+		assertTrue(FISH instanceof Tai);
+
+		// test for DescriptorExtensionList
+		configMap.put("value", Sishamo.class.getName());
+		JSONObject config = JSONObject.fromObject(configMap);
+
+		DescriptorExtensionList<Fish, Descriptor<Fish>> list = j.jenkins
+				.<Fish, Descriptor<Fish>>getDescriptorList(Fish.class);
+		Fish fish = list.newInstanceFromRadioList(config);
+		assertTrue(fish instanceof Sishamo);
+	}
 
     public static class Car implements ExtensionPoint {
         final String name;


### PR DESCRIPTION
See [JENKINS-51495](https://issues.jenkins-ci.org/browse/JENKINS-51495).

### Proposed changelog entries

Oleg's version:
* Update descriptorRadioList form elements to honor DescriptorVisibilityFilter extension points

Original version
*  Quit using index to associate descriptor selected on the front-end with the implementation on the back-end, and begin using descriptor id instead.

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs
