### PR TITLE
[simple] Remove debug timeout that was forgotten

### DIFF
--- a/test/src/test/java/jenkins/security/seed/UserSeedChangeListenerTest.java
+++ b/test/src/test/java/jenkins/security/seed/UserSeedChangeListenerTest.java
@@ -26,8 +26,6 @@ package jenkins.security.seed;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import hudson.model.User;
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -36,7 +34,6 @@ import org.jvnet.hudson.test.TestExtension;
 import javax.annotation.Nonnull;
 
 import java.net.URL;
-import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNull;
@@ -46,7 +43,6 @@ public class UserSeedChangeListenerTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
-    {j.timeout = 0;}
 
     @Test
     public void onProgrammaticUserSeedChange_listenerTriggered() throws Exception {


### PR DESCRIPTION
Remove a debug instruction in a test that was forgotten during initial PR + clean import statements as well.

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

