### PR TITLE
[JENKINS-16360] @DataBoundConstructor/@DataBoundSetter for FreeStyleProject

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -57,6 +57,7 @@ import jenkins.util.xml.XMLUtils;
 
 import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.types.FileSet;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.WebMethod;
@@ -192,6 +193,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         setDisplayName(displayName);
     }
     
+    @DataBoundSetter
     public void setDisplayName(String displayName) throws IOException {
         this.displayName = Util.fixEmptyAndTrim(displayName);
         save();
@@ -223,6 +225,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     /**
      * Sets the project description HTML.
      */
+    @DataBoundSetter
     public void setDescription(String description) throws IOException {
         this.description = description;
         save();

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -117,6 +117,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.ForwardToView;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
@@ -371,6 +372,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         return concurrentBuild;
     }
 
+    @DataBoundSetter
     public void setConcurrentBuild(boolean b) throws IOException {
         concurrentBuild = b;
         save();
@@ -609,6 +611,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         return scmCheckoutStrategy == null ? new DefaultSCMCheckoutStrategyImpl() : scmCheckoutStrategy;
     }
 
+    @DataBoundSetter
     public void setScmCheckoutStrategy(SCMCheckoutStrategy scmCheckoutStrategy) throws IOException {
         this.scmCheckoutStrategy = scmCheckoutStrategy;
         save();
@@ -627,6 +630,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     /**
      * Sets the custom quiet period of this project, or revert to the global default if null is given.
      */
+    @DataBoundSetter
     public void setQuietPeriod(Integer seconds) throws IOException {
         this.quietPeriod = seconds;
         save();
@@ -649,19 +653,37 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         return true;
     }
 
+    /**
+     * @deprecated use {@link #isBlockBuildWhenDownstreamBuilding()} instead
+     */
+    @Deprecated
     public boolean blockBuildWhenDownstreamBuilding() {
         return blockBuildWhenDownstreamBuilding;
     }
 
+    public boolean isBlockBuildWhenDownstreamBuilding() {
+        return blockBuildWhenDownstreamBuilding;
+    }
+
+    @DataBoundSetter
     public void setBlockBuildWhenDownstreamBuilding(boolean b) throws IOException {
         blockBuildWhenDownstreamBuilding = b;
         save();
     }
 
+    /**
+     * @deprecated use {@link #isBlockBuildWhenUpstreamBuilding()} instead
+     */
+    @Deprecated
     public boolean blockBuildWhenUpstreamBuilding() {
         return blockBuildWhenUpstreamBuilding;
     }
 
+    public boolean isBlockBuildWhenUpstreamBuilding() {
+        return blockBuildWhenUpstreamBuilding;
+    }
+
+    @DataBoundSetter
     public void setBlockBuildWhenUpstreamBuilding(boolean b) throws IOException {
         blockBuildWhenUpstreamBuilding = b;
         save();
@@ -673,6 +695,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     }
 
     @Restricted(DoNotUse.class)
+    @DataBoundSetter
     @Override
     public void setDisabled(boolean disabled) {
         this.disabled = disabled;
@@ -888,6 +911,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     /**
      * Overwrites the JDK setting.
      */
+    @DataBoundSetter
     public void setJDK(JDK jdk) throws IOException {
         this.jdk = jdk.getName();
         save();
@@ -1080,12 +1104,12 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
                 LOGGER.log(Level.FINE, "The last build has been deleted during the non-concurrent cause creation. The build is not blocked anymore");
             }
         }
-        if (blockBuildWhenDownstreamBuilding()) {
+        if (isBlockBuildWhenDownstreamBuilding()) {
             AbstractProject<?,?> bup = getBuildingDownstream();
             if (bup!=null)
                 return new BecauseOfDownstreamBuildInProgress(bup);
         }
-        if (blockBuildWhenUpstreamBuilding()) {
+        if (isBlockBuildWhenUpstreamBuilding()) {
             AbstractProject<?,?> bup = getBuildingUpstream();
             if (bup!=null)
                 return new BecauseOfUpstreamBuildInProgress(bup);
@@ -1498,6 +1522,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         return scm;
     }
 
+    @DataBoundSetter
     public void setScm(SCM scm) throws IOException {
         this.scm = scm;
         save();
@@ -1541,6 +1566,16 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     @SuppressWarnings("unchecked")
     @Override public Map<TriggerDescriptor,Trigger<?>> getTriggers() {
         return triggers().toMap();
+    }
+
+    public DescribableList<Trigger<?>,TriggerDescriptor> getTriggersList() {
+        return triggers();
+    }
+
+    @DataBoundSetter
+    @Restricted(DoNotUse.class)
+    public void setTriggersList(DescribableList<Trigger<?>,TriggerDescriptor> triggers) {
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -2121,6 +2156,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      *
      * @since 1.410
      */
+    @DataBoundSetter
     public void setCustomWorkspace(String customWorkspace) throws IOException {
         this.customWorkspace= Util.fixEmptyAndTrim(customWorkspace);
         save();

--- a/core/src/main/java/hudson/model/FreeStyleProject.java
+++ b/core/src/main/java/hudson/model/FreeStyleProject.java
@@ -31,6 +31,7 @@ import org.jenkinsci.Symbol;
 import jenkins.model.item_category.StandaloneProjectsCategory;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Free-style software project.
@@ -47,6 +48,7 @@ public class FreeStyleProject extends Project<FreeStyleProject,FreeStyleBuild> i
         super(parent, name);
     }
 
+    @DataBoundConstructor
     public FreeStyleProject(ItemGroup parent, String name) {
         super(parent, name);
     }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -107,9 +107,11 @@ import org.jfree.data.category.CategoryDataset;
 import org.jfree.ui.RectangleInsets;
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerOverridable;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -329,6 +331,12 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     @Exported
     public boolean isKeepDependencies() {
         return keepDependencies;
+    }
+
+    @DataBoundSetter
+    @Restricted(DoNotUse.class)
+    public void setKeepDependencies(boolean keepDependencies) {
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -557,6 +565,12 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     @Exported(name="property",inline=true)
     public List<JobProperty<? super JobT>> getAllProperties() {
         return properties.getView();
+    }
+
+    @DataBoundSetter
+    @Restricted(DoNotUse.class)
+    public void setAllProperties(List<JobProperty<? extends JobT>> properties) {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/core/src/main/java/hudson/model/Project.java
+++ b/core/src/main/java/hudson/model/Project.java
@@ -40,6 +40,9 @@ import hudson.triggers.SCMTrigger;
 import hudson.triggers.Trigger;
 import hudson.util.DescribableList;
 import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -136,12 +139,24 @@ public abstract class Project<P extends Project<P,B>,B extends Build<P,B>>
         }
         return builders;
     }
-    
+
+    @DataBoundSetter
+    @Restricted(DoNotUse.class)
+    public void setBuildersList(DescribableList<Builder, Descriptor<Builder>> builders) {
+        throw new UnsupportedOperationException();
+    }
+
     public DescribableList<Publisher,Descriptor<Publisher>> getPublishersList() {
         if (publishers == null) {
             publishersSetter.compareAndSet(this,null,new DescribableList<Publisher,Descriptor<Publisher>>(this));
         }
         return publishers;
+    }
+
+    @DataBoundSetter
+    @Restricted(DoNotUse.class)
+    public void setPublishersList(DescribableList<Publisher, Descriptor<Publisher>> publishers) {
+        throw new UnsupportedOperationException();
     }
 
     public Map<Descriptor<BuildWrapper>,BuildWrapper> getBuildWrappers() {
@@ -153,6 +168,12 @@ public abstract class Project<P extends Project<P,B>,B extends Build<P,B>>
             buildWrappersSetter.compareAndSet(this,null,new DescribableList<BuildWrapper,Descriptor<BuildWrapper>>(this));
         }
         return buildWrappers;
+    }
+
+    @DataBoundSetter
+    @Restricted(DoNotUse.class)
+    public void setBuildWrappersList(DescribableList<BuildWrapper, Descriptor<BuildWrapper>> buildWrappers) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -191,6 +191,26 @@ public class Maven extends Builder {
         return targets;
     }
 
+    @Restricted(NoExternalUse.class)
+    public String getName() {
+        return mavenName;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public String getPom() {
+        return pom;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public String getProperties() {
+        return properties;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public String getJvmOptions() {
+        return jvmOptions;
+    }
+
     /**
      * @since 1.491
      */
@@ -217,7 +237,15 @@ public class Maven extends Builder {
         this.usePrivateRepository = usePrivateRepository;
     }
 
+    /**
+     * @deprecated use {@link #isUsePrivateRepository()} instead
+     */
+    @Deprecated
     public boolean usesPrivateRepository() {
+        return usePrivateRepository;
+    }
+
+    public boolean isUsePrivateRepository() {
         return usePrivateRepository;
     }
 
@@ -352,7 +380,7 @@ public class Maven extends Builder {
             final VariableResolver<String> resolver = new Union<>(new ByMap<>(env), vr);
             args.addKeyValuePairsFromPropertyString("-D", this.properties, resolver, sensitiveVars);
 
-            if (usesPrivateRepository())
+            if (isUsePrivateRepository())
                 args.add("-Dmaven.repo.local=" + build.getWorkspace().child(".repository"));
             args.addTokenized(normalizedTarget);
             wrapUpArguments(args,normalizedTarget,build,launcher,listener);

--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -127,7 +127,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.2</version>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/src/test/java/hudson/model/AbstractProjectTest.java
+++ b/test/src/test/java/hudson/model/AbstractProjectTest.java
@@ -185,7 +185,7 @@ public class AbstractProjectTest {
 
         input.setChecked(true);
         j.submit(form);
-        assertTrue("blockBuildWhenUpstreamBuilding was not updated from configuration form", p.blockBuildWhenUpstreamBuilding());
+        assertTrue("blockBuildWhenUpstreamBuilding was not updated from configuration form", p.isBlockBuildWhenUpstreamBuilding());
 
         form = j.createWebClient().getPage(p, "configure").getFormByName("config");
         input = form.getInputByName("blockBuildWhenUpstreamBuilding");

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -341,8 +341,8 @@ public class ProjectTest {
         assertNotNull("Project did not save scm.", p.getScm());
         assertTrue("Project did not save scm checkout strategy.", p.getScmCheckoutStrategy() instanceof SCMCheckoutStrategyImpl);
         assertEquals("Project did not save quiet period.", 15, p.getQuietPeriod());
-        assertTrue("Project did not save block if downstream is building.", p.blockBuildWhenDownstreamBuilding());
-        assertTrue("Project did not save block if upstream is building.", p.blockBuildWhenUpstreamBuilding());
+        assertTrue("Project did not save block if downstream is building.", p.isBlockBuildWhenDownstreamBuilding());
+        assertTrue("Project did not save block if upstream is building.", p.isBlockBuildWhenUpstreamBuilding());
         assertNotNull("Project did not save jdk", p.getJDK());
         assertEquals("Project did not save custom workspace.", "/some/path", p.getCustomWorkspace());
     }

--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -94,7 +94,7 @@ public class MavenTest {
         assertEquals("b.pom", m.pom);
         assertEquals("c=d", m.properties);
         assertEquals("-e", m.jvmOptions);
-	assertTrue(m.usesPrivateRepository());
+	assertTrue(m.isUsePrivateRepository());
     }
 
     @Test public void withNodeProperty() throws Exception {


### PR DESCRIPTION
See [JENKINS-16360](https://issues.jenkins-ci.org/browse/JENKINS-16360).

The ticket is about generating Job DSL scripts from existing job definitions. It is one of the most requested features for Job DSL.

The approach is (similar to Pipeline) to use structs-plugin to uninstantiate ([UninstantiatedDescribable.java](https://github.com/jenkinsci/structs-plugin/blob/structs-parent-1.17/plugin/src/main/java/org/jenkinsci/plugins/structs/describable/UninstantiatedDescribable.java#L171)) a job and use the information to generate a Job DSL script.

To be able to uninstantiate a job, it must provide valid `@DataBoundConstructor` and `@DataBoundSetter`s with matching getters. As a start this PR adds the relevant annotations and methods to `FreeStyleProject` and it's super classes. Missing getters are also added to the Maven builder to be able to uninstantiate all builders provided by core.

The first milestone for this feature is to be able to generate scripts for all parts (FreeStyleProject, Maven builder, Fingerprint publisher, etc) provided by core.

See https://github.com/jenkinsci/job-dsl-plugin/pull/1171 for the Job DSL part of JENKINS-16360.

### Proposed changelog entries

* Internal: JENKINS-16360, add `@DataBoundConstructor` and `@DataBoundSetter` for `FreeStyleProject`

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jglick
