### PR TITLE
[LTS backport] [JENKINS-56995] Implement MavenConsoleAnnotator.flush

### DIFF
--- a/core/src/main/java/hudson/tasks/_maven/MavenConsoleAnnotator.java
+++ b/core/src/main/java/hudson/tasks/_maven/MavenConsoleAnnotator.java
@@ -76,6 +76,11 @@ public class MavenConsoleAnnotator extends LineTransformationOutputStream {
     }
 
     @Override
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    @Override
     public void close() throws IOException {
         super.close();
         out.close();


### PR DESCRIPTION
Backport of one piece of a larger change, if accepted for LTS. [JENKINS-56995](https://issues.jenkins-ci.org/browse/JENKINS-56995) https://github.com/jenkinsci/jenkins/pull/3959#issuecomment-482700672