### PR TITLE
Make ${port} be honored by `mvn -f war hudson-dev:run`

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -459,11 +459,9 @@ THE SOFTWARE.
             Reload webapp when you hit ENTER. (See JETTY-282 for more)
           -->
           <reload>manual</reload>
-          <connectors>
-            <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                <port>${port}</port>
-            </connector>
-          </connectors>
+          <httpConnector>
+              <port>${port}</port>
+          </httpConnector>
           <additionalClassesDirectories>
             <!-- load resources straight from source -->
             <additionalClassesDirectory>../core/src/main/resources</additionalClassesDirectory>


### PR DESCRIPTION
To work around https://github.com/ubuntu/microk8s/issues/43 (my 8080 port is often unavailable), I have a local profile

```xml
<profile>
    <id>microk8s-hpi-run</id>
    <activation>
        <activeByDefault>true</activeByDefault>
    </activation>
    <properties>
        <port>8090</port>
    </properties>
</profile>
```

which works fine for `mvn hpi:run` but did not work in Jenkins core, despite `war/pom.xml` advertising

```xml
<port>8080</port><!-- HTTP listener port -->
```

Digging into `maven-hudson-dev-plugin`’s `JettyRunMojo`, I could not find anything that would bind to `connectors`. In its superclass I did however find

```java
@Parameter
protected MavenServerConnector httpConnector;
```

and this in turn has a property

```java
private int port;
```

Indeed when I made the change in this patch, Jetty started listening on port 8090 as expected, rather than 8080 as before (apparently from `MavenServerConnector.DEFAULT_PORT` via `AbstractJettyMojo.startJetty`).

Perhaps this bit of configuration was left over from some older version of the plugin? I would have expected Maven to complain about unrecognized configuration though.

### Changelog entry

* RFE, Internal: Respect the `port` property in the `mvn -f war hudson-dev:run` command