### PR TITLE
Making ConfidentialKey instances safe to keep in static fields even across JenkinsRule starts

### DIFF
--- a/core/src/main/java/hudson/util/Secret.java
+++ b/core/src/main/java/hudson/util/Secret.java
@@ -298,14 +298,6 @@ public final class Secret implements Serializable {
      */
     private static final CryptoConfidentialKey KEY = new CryptoConfidentialKey(Secret.class.getName());
 
-    /**
-     * Reset the internal secret key for testing.
-     */
-    @Restricted(NoExternalUse.class)
-    /*package*/ static void resetKeyForTest() {
-        KEY.resetForTest();
-    }
-
     private static final long serialVersionUID = 1L;
 
     static {

--- a/core/src/main/java/jenkins/security/CryptoConfidentialKey.java
+++ b/core/src/main/java/jenkins/security/CryptoConfidentialKey.java
@@ -1,6 +1,5 @@
 package jenkins.security;
 
-import hudson.Main;
 import hudson.util.Secret;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -22,7 +21,9 @@ public class CryptoConfidentialKey extends ConfidentialKey {
     @Restricted(NoExternalUse.class) // TODO pending API
     public static final int DEFAULT_IV_LENGTH = 16;
 
-    private volatile SecretKey secret;
+    private ConfidentialStore lastCS;
+    private SecretKey secret;
+
     public CryptoConfidentialKey(String id) {
         super(id);
     }
@@ -31,25 +32,23 @@ public class CryptoConfidentialKey extends ConfidentialKey {
         this(owner.getName()+'.'+shortName);
     }
 
-    private SecretKey getKey() {
-        try {
-            if (secret==null) {
-                synchronized (this) {
-                    if (secret==null) {
-                        byte[] payload = load();
-                        if (payload==null) {
-                            payload = ConfidentialStore.get().randomBytes(256);
-                            store(payload);
-                        }
-                        // Due to the stupid US export restriction JDK only ships 128bit version.
-                        secret = new SecretKeySpec(payload,0,128/8, KEY_ALGORITHM);
-                    }
+    private synchronized SecretKey getKey() {
+        ConfidentialStore cs = ConfidentialStore.get();
+        if (secret == null || cs != lastCS) {
+            lastCS = cs;
+            try {
+                byte[] payload = load();
+                if (payload == null) {
+                    payload = cs.randomBytes(256);
+                    store(payload);
                 }
+                // Due to the stupid US export restriction JDK only ships 128bit version.
+                secret = new SecretKeySpec(payload, 0, 128 / 8, KEY_ALGORITHM);
+            } catch (IOException e) {
+                throw new Error("Failed to load the key: " + getId(), e);
             }
-            return secret;
-        } catch (IOException e) {
-            throw new Error("Failed to load the key: "+getId(),e);
         }
+        return secret;
     }
 
     /**
@@ -140,15 +139,4 @@ public class CryptoConfidentialKey extends ConfidentialKey {
     private static final String KEY_ALGORITHM = "AES";
     private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
 
-    /**
-     * Reset the internal secret key for testing.
-     */
-    @Restricted(NoExternalUse.class)
-    public void resetForTest() {
-        if (Main.isUnitTest) {
-            this.secret = null;
-        } else {
-            throw new IllegalStateException("Only for testing");
-        }
-    }
 }

--- a/core/src/main/java/jenkins/security/RSAConfidentialKey.java
+++ b/core/src/main/java/jenkins/security/RSAConfidentialKey.java
@@ -48,6 +48,8 @@ import java.security.spec.RSAPublicKeySpec;
  * @author Kohsuke Kawaguchi
  */
 public abstract class RSAConfidentialKey extends ConfidentialKey {
+
+    private ConfidentialStore lastCS;
     private RSAPrivateKey priv;
     private RSAPublicKey pub;
 
@@ -71,7 +73,9 @@ public abstract class RSAConfidentialKey extends ConfidentialKey {
      */
     protected synchronized RSAPrivateKey getPrivateKey() {
         try {
-            if (priv == null) {
+            ConfidentialStore cs = ConfidentialStore.get();
+            if (priv == null || cs != lastCS) {
+                lastCS = cs;
                 byte[] payload = load();
                 if (payload == null) {
                     KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");

--- a/test/src/test/java/hudson/util/SecretCompatTest.java
+++ b/test/src/test/java/hudson/util/SecretCompatTest.java
@@ -28,19 +28,14 @@ import hudson.model.FreeStyleProject;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.PasswordParameterDefinition;
-import org.hamcrest.core.Is;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-import java.io.IOException;
 import java.util.regex.Pattern;
 
-import static org.hamcrest.core.Is.isA;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.*;
@@ -51,19 +46,7 @@ import static org.junit.Assert.*;
 public class SecretCompatTest {
 
     @Rule
-    public JenkinsRule j = new JenkinsRule() {
-        @Override
-        public void before() throws Throwable {
-            Secret.resetKeyForTest();  //As early as possible
-            super.before();
-        }
-    };
-
-    @After
-    public void after() {
-        Secret.resetKeyForTest();
-    }
-
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
     @Issue("SECURITY-304")


### PR DESCRIPTION
See https://github.com/jenkinsci/instance-identity-module/pull/16/commits/45c78626f3269b60812c4f6d837a60dd5638ac44 for background.

### Proposed changelog entries

None should be required; should only affect test code.