### PR TITLE
[JENKINS-57071] Fixing problems affecting Linux agent installer modules

### DIFF
--- a/core/src/main/java/hudson/os/SU.java
+++ b/core/src/main/java/hudson/os/SU.java
@@ -155,7 +155,7 @@ public abstract class SU {
             else // in production code this never happens, but during debugging this is convenient    
                 args.add("-cp").add(slaveJar).add(hudson.remoting.Launcher.class.getName());
 
-            if(rootPassword==null) {
+            if (Util.fixEmptyAndTrim(rootPassword) == null) {
                 // try sudo, in the hope that the user has the permission to do so without password
                 return new LocalLauncher(listener).launchChannel(
                         args.prepend(sudoExe()).toCommandArray(),

--- a/core/src/main/java/jenkins/security/ChannelConfigurator.java
+++ b/core/src/main/java/jenkins/security/ChannelConfigurator.java
@@ -5,7 +5,6 @@ import hudson.ExtensionPoint;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelBuilder;
 import hudson.slaves.SlaveComputer;
-import jenkins.model.Jenkins;
 
 import javax.annotation.Nullable;
 
@@ -39,6 +38,6 @@ public abstract class ChannelConfigurator implements ExtensionPoint {
      * All the registered {@link ChannelConfigurator}s.
      */
     public static ExtensionList<ChannelConfigurator> all() {
-        return Jenkins.getInstance().getExtensionList(ChannelConfigurator.class);
+        return ExtensionList.lookup(ChannelConfigurator.class);
     }
 }


### PR DESCRIPTION
[JENKINS-57071](https://issues.jenkins-ci.org/browse/JENKINS-57071)

The `systemd-slave-installer` module was not working for me, and `upstart-slave-installer` probably had the same issues.

* `ChannelConfigurator.all` was failing when run from an agent JVM (as it would be via `Channels.forProcess` via `SU`).
* Even if you left the root password blank, `SwingPrompter` would return an empty string rather than null, improperly trying to run `sudo -S`. You might be able to work around this using the **Cancel** button rather than **OK** in the password prompt, but at any rate the dialog explicitly tells you to leave it blank so that is what I tried.

Discovered while examining the baseline behavior for [JENKINS-55582](https://issues.jenkins-ci.org/browse/JENKINS-55582). Who knows how long this has broken—definitely in 2.164.2. Maybe no one actually uses these features?

The Mac OS X variant (`launchd-slave-installer`) uses different APIs and should be affected by neither of these issues.

### Proposed changelog entries

* Fixing some errors seen in the Linux agent installers.