### PR TITLE
Changed exception presented when AtomicFileWriter fails to write to file

### DIFF
--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -205,18 +205,18 @@ public class AtomicFileWriter extends Writer {
             try {
                 Files.move(tmpPath, destPath, StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException e1) {
-                e1.addSuppressed(e);
+                e.addSuppressed(e1);
                 LOGGER.log(Level.WARNING, "Unable to move {0} to {1}. Attempting to delete {0} and abandoning.",
                            new Path[]{tmpPath, destPath});
                 try {
                     Files.deleteIfExists(tmpPath);
                 } catch (IOException e2) {
-                    e2.addSuppressed(e1);
+                    e1.addSuppressed(e2);
                     LOGGER.log(Level.WARNING, "Unable to delete {0}, good bye then!", tmpPath);
-                    throw e2;
+                    throw e;
                 }
 
-                throw e1;
+                throw e;
             }
         }
     }


### PR DESCRIPTION
Make sure the original failure gets thrown even when there are some exceptions thrown trying to recover.

### Proposed changelog entries

* Minor: Changed exception presented when AtomicFileWriter fails to write to file.

### Submitter checklist

None of that is applicable.

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs
