### PR TITLE
[JENKINS-57122] - add restricted no external use for ToolDescriptor#getDefaultProperties

### DIFF
--- a/core/src/main/java/hudson/tools/ToolDescriptor.java
+++ b/core/src/main/java/hudson/tools/ToolDescriptor.java
@@ -41,6 +41,8 @@ import jenkins.model.Jenkins;
 import jenkins.tools.ToolConfigurationCategory;
 import net.sf.json.JSONObject;
 import org.jvnet.tiger_types.Types;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -87,8 +89,8 @@ public abstract class ToolDescriptor<T extends ToolInstallation> extends Descrip
             return emptyArray_unsafeCast();
         }
     }
-    
-    //TODO: Get rid of it? 
+
+    //TODO: Get rid of it?
     //It's unsafe according to http://stackoverflow.com/questions/2927391/whats-the-reason-i-cant-create-generic-array-types-in-java
     @SuppressWarnings("unchecked")
     @SuppressFBWarnings(value = "BC_IMPOSSIBLE_DOWNCAST",
@@ -134,6 +136,7 @@ public abstract class ToolDescriptor<T extends ToolInstallation> extends Descrip
      * Default value for {@link ToolInstallation#getProperties()} used in the form binding.
      * @since 1.305
      */
+    @Restricted(NoExternalUse.class)
     public DescribableList<ToolProperty<?>,ToolPropertyDescriptor> getDefaultProperties() throws IOException {
         DescribableList<ToolProperty<?>,ToolPropertyDescriptor> r
                 = new DescribableList<>(NOOP);

--- a/core/src/main/java/hudson/tools/ToolDescriptor.java
+++ b/core/src/main/java/hudson/tools/ToolDescriptor.java
@@ -25,6 +25,7 @@
 package hudson.tools;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.RestrictedSince;
 import hudson.model.Descriptor;
 import hudson.util.DescribableList;
 import hudson.util.FormValidation;
@@ -137,6 +138,7 @@ public abstract class ToolDescriptor<T extends ToolInstallation> extends Descrip
      * @since 1.305
      */
     @Restricted(NoExternalUse.class)
+    @RestrictedSince("2.179")
     public DescribableList<ToolProperty<?>,ToolPropertyDescriptor> getDefaultProperties() throws IOException {
         DescribableList<ToolProperty<?>,ToolPropertyDescriptor> r
                 = new DescribableList<>(NOOP);


### PR DESCRIPTION
See [JENKINS-57122](https://issues.jenkins-ci.org/browse/JENKINS-57122).

Without this change JCasC would export the following:

```yml
tool:
  customTool:
    defaultProperties:
    - installSource:
        installers:
        - "zip"
  git:
    installations:
    - home: "git"
      name: "Default"
  jdk:
    defaultProperties:
    - installSource:
        installers:
        - jdkInstaller:
            acceptLicense: false
  maven:
    defaultProperties:
    - installSource:
        installers:
        - "maven"
```

With this change.

```yml
tool:
  git:
    installations:
    - home: "git"
      name: "Default"
```

JCasC will exclude un-configured plugins if I went ahead and configured maven.

```yml
tool:
  git:
    installations:
    - home: "git"
      name: "Default"
  maven:
    installations:
    - name: "my custom maven"
      properties:
      - installSource:
          installers:
          - maven:
              id: "3.6.1"
```

Ignore git tool as it cannot be excluded before `PersistentDescriptor` is adopted. See #3570

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: restrict ToolDescriptor#getDefaultProperties to no external use, used for form bindings.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
