### PR TITLE
Add section for agent to master configuration

### DIFF
--- a/core/src/main/resources/jenkins/security/s2m/MasterKillSwitchConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/security/s2m/MasterKillSwitchConfiguration/config.groovy
@@ -3,9 +3,11 @@ package jenkins.security.s2m.MasterKillSwitchConfiguration
 def f=namespace(lib.FormTagLib)
 
 if (instance.isRelevant()) {
-    f.optionalBlock(field:"masterToSlaveAccessControl", title:_("Enable Agent \u2192 Master Access Control")) {
-        f.nested() {
-            raw _("Rules can be tweaked <a href='${rootURL}/administrativeMonitor/slaveToMasterAccessControl/'>here</a>")
+    f.section(title: _('Agent \u2192 Master Security')) {
+        f.optionalBlock(field: "masterToSlaveAccessControl", title: _("Enable Agent \u2192 Master Access Control")) {
+            f.nested() {
+                raw _("Rules can be tweaked <a href='${rootURL}/administrativeMonitor/slaveToMasterAccessControl/'>here</a>")
+            }
         }
     }
 }


### PR DESCRIPTION
Basically each `GlobalConfiguration` needs its own `f:section`(s) or it will result in really confusing UI.

Similar to https://github.com/jenkinsci/jenkins/pull/2744.

**Real diff**: https://github.com/jenkinsci/jenkins/pull/3995/files?w=1

### Before

> ![Screen Shot](https://user-images.githubusercontent.com/1831569/56447077-93ac3180-6306-11e9-970e-2b974ce4531b.png)

### After

> ![Screen Shot](https://user-images.githubusercontent.com/1831569/56447082-9c046c80-6306-11e9-8604-05638ad25a99.png)

### Proposed changelog entries

(too minor)

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
