### PR TITLE
Fix executors widget summary

### DIFF
--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -121,9 +121,15 @@ THE SOFTWARE.
   </d:taglib>
   <j:set var="computers" value="${attrs.computers?:app.computers}" />
   <j:set var="computersSize" value="${computers.size()}"/>
+    <j:set var="busyExecutors" value="0"/>
+    <j:set var="totalExecutors" value="0"/>
+    <j:forEach var="computer" items="${computers}">
+      <j:set var="busyExecutors" value="${busyExecutors + computer.countBusy()}"/>
+      <j:set var="totalExecutors" value="${totalExecutors + computer.countExecutors()}"/>
+    </j:forEach>
     <l:pane width="3" id="executors"
         title="&lt;a href='${rootURL}/computer/'>${%Build Executor Status}&lt;/a>"
-        collapsedText="${%Computers(computersSize - 1, app.unlabeledLoad.computeTotalExecutors() - app.unlabeledLoad.computeIdleExecutors(), app.unlabeledLoad.computeTotalExecutors())}">
+        collapsedText="${%Computers(computersSize - 1, busyExecutors, totalExecutors)}">
       <colgroup><col width="30"/><col width="200*"/><col width="24"/></colgroup>
 
       <j:forEach var="c" items="${computers}">

--- a/core/src/main/resources/lib/layout/pane.jelly
+++ b/core/src/main/resources/lib/layout/pane.jelly
@@ -38,7 +38,7 @@ THE SOFTWARE.
       Specify the number of columns in the table
       (so that the title can stretch to the entire table width.
     </st:attribute>
-    <st:attribute name="id">
+    <st:attribute name="id" use="required">
       @id of the table, if specified.
     </st:attribute>
     <st:attribute name="class">
@@ -46,6 +46,9 @@ THE SOFTWARE.
     </st:attribute>
     <st:attribute name="footer">
       Footer of the box. Can include HTML.
+    </st:attribute>
+    <st:attribute name="collapsedText">
+      Text shown when the pane is collapsed
     </st:attribute>
   </st:documentation>
   <j:set var="paneIsCollapsed" value="${h.isCollapsed(attrs.id)}" />


### PR DESCRIPTION
This looks like a bug:

> ![Screen Shot](https://user-images.githubusercontent.com/1831569/56456888-f804da80-6372-11e9-81cc-a63de2ff3b57.png)

The problem here is that different executors are eligible to be idle than to be counted in the total in the load statistics.

Idle: https://github.com/jenkinsci/jenkins/blob/2767b00146ce2ff2738b7fd7c6db95a26b8f9f39/core/src/main/java/jenkins/model/UnlabeledLoadStatistics.java#L60

Total: https://github.com/jenkinsci/jenkins/blob/2767b00146ce2ff2738b7fd7c6db95a26b8f9f39/core/src/main/java/jenkins/model/UnlabeledLoadStatistics.java#L72


As load statistics are used to determine provisioning need, I'm not going anywhere near that mess.

It's unclear to me why https://github.com/jenkinsci/jenkins/pull/1014 chose `app.unlabeledLoad`. Not just the labeled/unlabeled issue, but given that the set of computers is different depending on view and associated filters, accessing a global number makes no sense at all.

Also clean up problems with `pane.jelly` I mentioned there after it was merged.

**Untested.**

### Proposed changelog entries

* Fix summary in collapsed executors widget

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
