### PR TITLE
[JENKINS-33843] Permit disabling optional dependencies

### DIFF
--- a/core/src/main/java/hudson/LocalPluginManager.java
+++ b/core/src/main/java/hudson/LocalPluginManager.java
@@ -66,12 +66,6 @@ public class LocalPluginManager extends PluginManager {
         this(null, rootDir);
     }
 
-    /**
-     * If the war file has any "/WEB-INF/plugins/*.jpi", extract them into the plugin directory.
-     *
-     * @return
-     *      File names of the bundled plugins. Like {"ssh-slaves.jpi","subversion.jpi"}
-     */
     @Override
     protected Collection<String> loadBundledPlugins() {
         // this is used in tests, when we want to override the default bundled plugins with .jpl (or .hpl) versions

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1001,15 +1001,18 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      * If the war file has any "/WEB-INF/plugins/[*.jpi | *.hpi]", extract them into the plugin directory.
      *
      * @return
-     *      File names of the bundled plugins. Like {"ssh-slaves.hpi","subversion.jpi"}
+     *      File names of the bundled plugins. Normally empty (not to be confused with {@link #loadDetachedPlugins}) but OEM WARs may have some.
      * @throws Exception
      *      Any exception will be reported and halt the startup.
      */
     protected abstract Collection<String> loadBundledPlugins() throws Exception;
 
     /**
-     * Copies the bundled plugin from the given URL to the destination of the given file name (like 'abc.jpi'),
-     * with a reasonable up-to-date check. A convenience method to be used by the {@link #loadBundledPlugins()}.
+     * Copies the plugin from the given URL to the given destination.
+     * Despite the name, this is used also from {@link #loadDetachedPlugins}.
+     * Includes a reasonable up-to-date check.
+     * A convenience method to be used by {@link #loadBundledPlugins()}.
+     * @param fileName like {@code abc.jpi}
      */
     protected void copyBundledPlugin(URL src, String fileName) throws IOException {
         LOGGER.log(FINE, "Copying {0}", src);

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -275,6 +275,16 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     }
 
     /**
+     * Like {@link #getDependents} but excluding optional dependencies.
+     * @since TODO
+     */
+    public @Nonnull Set<String> getMandatoryDependents() {
+        Set<String> s = new HashSet<>(dependents);
+        s.removeAll(optionalDependents);
+        return s;
+    }
+
+    /**
      * @return The list of components that depend optionally on this plugin.
      */
     public @Nonnull Set<String> getOptionalDependents() {
@@ -297,6 +307,17 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      */
     public boolean hasDependents() {
         return (isBundled || !dependents.isEmpty());
+    }
+
+    /**
+     * Like {@link #hasDependents} but excluding optional dependencies.
+     * @since TODO
+     */
+    public boolean hasMandatoryDependents() {
+        if (isBundled) {
+            return true;
+        }
+        return dependents.stream().anyMatch(d -> !optionalDependents.contains(d));
     }
 
     /**
@@ -326,10 +347,19 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * Does this plugin depend on any other plugins.
+     * Note that this include optional dependencies.
      * @return {@code true} if this plugin depends on other plugins, otherwise {@code false}.
      */
     public boolean hasDependencies() {
-        return (dependencies != null && !dependencies.isEmpty());
+        return !dependencies.isEmpty();
+    }
+
+    /**
+     * Like {@link #hasDependencies} but omitting optional dependencies.
+     * @since TODO
+     */
+    public boolean hasMandatoryDependencies() {
+        return dependencies.stream().anyMatch(d -> !d.optional);
     }
 
     @ExportedBean
@@ -451,6 +481,14 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     @Exported
     public List<Dependency> getDependencies() {
         return dependencies;
+    }
+
+    /**
+     * Like {@link #getDependencies} but omits optional dependencies.
+     * @since TODO
+     */
+    public List<Dependency> getMandatoryDependencies() {
+        return dependencies.stream().filter(d -> !d.optional).collect(Collectors.toList());
     }
 
     public List<Dependency> getOptionalDependencies() {

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -394,6 +394,9 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 		this.active = !disableFile.exists();
 		this.dependencies = dependencies;
 		this.optionalDependencies = optionalDependencies;
+        for (Dependency d : optionalDependencies) {
+            assert d.optional : d + " included among optionalDependencies of " + shortName + " but was not marked optional";
+        }
         this.archive = archive;
     }
 

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -255,6 +255,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * Get the list of components that depend on this plugin.
+     * Note that the list will include elements of {@link #getOptionalDependents}.
      * @return The list of components that depend on this plugin.
      */
     public @Nonnull Set<String> getDependents() {
@@ -290,6 +291,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * Does this plugin have anything that depends on it.
+     * Note that optional dependents are included.
      * @return {@code true} if something (Jenkins core, or another plugin) depends on this
      * plugin, otherwise {@code false}.
      */
@@ -441,6 +443,11 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
         return getBaseName(fileName);
     }
 
+    /**
+     * Gets all dependencies of this plugin on other plugins.
+     * Note that the list will <em>usually</em> include the members of {@link #getOptionalDependencies}
+     * (missing optional dependencies will however be omitted).
+     */
     @Exported
     public List<Dependency> getDependencies() {
         return dependencies;
@@ -756,7 +763,12 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     public void setHasCycleDependency(boolean hasCycle){
         hasCycleDependency = hasCycle;
     }
-    
+
+    /**
+     * Is this plugin bundled in the WAR?
+     * Normally false as noted in {@link PluginManager#loadBundledPlugins}:
+     * this does <em>not</em> apply to “detached” plugins.
+     */
     @Exported
     public boolean isBundled() {
         return isBundled;

--- a/core/src/main/java/jenkins/plugins/DetachedPluginsUtil.java
+++ b/core/src/main/java/jenkins/plugins/DetachedPluginsUtil.java
@@ -93,7 +93,7 @@ public class DetachedPluginsUtil {
             }
             // some earlier versions of maven-hpi-plugin apparently puts "null" as a literal in Hudson-Version. watch out for them.
             if (jenkinsVersion == null || jenkinsVersion.equals("null") || new VersionNumber(jenkinsVersion).compareTo(detached.splitWhen) <= 0) {
-                out.add(new PluginWrapper.Dependency(detached.shortName + ':' + detached.requiredVersion));
+                out.add(new PluginWrapper.Dependency(detached.shortName + ':' + detached.requiredVersion + ";resolution:=optional"));
                 LOGGER.log(Level.FINE, "adding implicit dependency {0} → {1} because of {2}",
                            new Object[]{pluginName, detached.shortName, jenkinsVersion});
             }

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -67,7 +67,7 @@ THE SOFTWARE.
                 <th width="1">${%Uninstall}</th>
               </tr>
               <j:forEach var="p" items="${app.pluginManager.plugins}">
-                <tr class="plugin ${p.hasDependents()?'has-dependents':''} ${(p.hasDependents() &amp;&amp; !p.enabled)?'has-dependents-but-disabled':''} ${p.isDeleted()?'deleted':''}" data-plugin-id="${p.shortName}" data-plugin-name="${p.displayName}">
+                <tr class="plugin ${p.hasMandatoryDependents()?'has-dependents':''} ${(p.hasMandatoryDependents() &amp;&amp; !p.enabled)?'has-dependents-but-disabled':''} ${p.isDeleted()?'deleted':''}" data-plugin-id="${p.shortName}" data-plugin-name="${p.displayName}">
                   <j:set var="state" value="${p.enabled?'true':null}"/>
                   <td class="center pane enable" data="${state}">
                     <input type="checkbox" checked="${state}" onclick="flip(event)"
@@ -118,16 +118,16 @@ THE SOFTWARE.
                         <p>${%Uninstallation pending}</p>
                       </j:when>
                       <j:otherwise>
-                          <j:if test="${p.hasDependents()}">
+                          <j:if test="${p.hasMandatoryDependents()}">
                             <div class="dependent-list">
-                              <j:forEach var="dependent" items="${p.dependents}">
+                              <j:forEach var="dependent" items="${p.mandatoryDependents}">
                                 <span data-plugin-id="${dependent}"></span>
                               </j:forEach>
                             </div>
                           </j:if>
-                          <j:if test="${p.hasDependencies()}">
+                          <j:if test="${p.hasMandatoryDependencies()}">
                             <div class="dependency-list">
-                              <j:forEach var="dependency" items="${p.dependencies}">
+                              <j:forEach var="dependency" items="${p.mandatoryDependencies}">
                                 <span data-plugin-id="${dependency.shortName}"></span>  
                               </j:forEach>
                             </div>


### PR DESCRIPTION
See [JENKINS-33843](https://issues.jenkins-ci.org/browse/JENKINS-33843).

- [X] fixed data model bug involving implicit optional dependencies on detached plugins
- [X] introduced and used alternate methods considering only mandatory dependencies
- [x] added a bit of test coverage

It would be possible to improve the GUI to note unsatisfied optional dependencies somehow, given data such as this:

```groovy
Jenkins.instance.pluginManager.plugins.sort(false, {it.shortName}).each {p ->
  p.optionalDependencies*.shortName.each {d ->
    def dp = Jenkins.instance.pluginManager.getPlugin(d);
    if (dp == null) {
      println("missing dep $p.shortName → $d");
    } else if (!dp.enabled) {
      println("disabled dep $p.shortName → $d");
    }
  };
}; null
```

Ideally this would also be reactive, meaning `_table.js` would update it as you click **Enabled** checkboxes. Perhaps missing deps would be displayed under the depender, whereas disabled deps would be displayed under the dependee. I decided not to spend time touching the GUI in this PR, mainly because I am not very good at it; would be a good enhancement for someone else to pick up.

### Proposed changelog entries

* The plugin manager’s **Installed** tab incorrectly prevented administrators from disabling a plugin if any other plugin had even an optional dependency on it.

### Desired reviewers

@jenkinsci/code-reviewers