### PR TITLE
[JENKINS-57273] Jenkins/Nodes.addNode could replace an existing node, but always fired onCreated

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2084,6 +2084,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     /**
      * Adds one more {@link Node} to Jenkins.
+     * If a node of the same name already exists then that node will be replaced.
      */
     public void addNode(Node n) throws IOException {
         nodes.addNode(n);

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -46,13 +46,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -131,10 +131,11 @@ public class Nodes implements Saveable {
         if (node != oldNode) {
             // TODO we should not need to lock the queue for adding nodes but until we have a way to update the
             // computer list for just the new node
+            AtomicReference<Node> old = new AtomicReference<>();
             Queue.withLock(new Runnable() {
                 @Override
                 public void run() {
-                    nodes.put(node.getNodeName(), node);
+                    old.set(nodes.put(node.getNodeName(), node));
                     jenkins.updateComputerList();
                     jenkins.trimLabels();
                 }
@@ -155,7 +156,11 @@ public class Nodes implements Saveable {
                 });
                 throw e;
             }
-            NodeListener.fireOnCreated(node);
+            if (old.get() != null) {
+                NodeListener.fireOnUpdated(old.get(), node);
+            } else {
+                NodeListener.fireOnCreated(node);
+            }
         }
     }
 
@@ -210,6 +215,7 @@ public class Nodes implements Saveable {
         if (exists) {
             // TODO there is a theoretical race whereby the node instance is updated/removed after lock release
             persistNode(node);
+            // TODO should this fireOnUpdated?
             return true;
         }
         return false;

--- a/test/src/test/java/jenkins/model/NodesTest.java
+++ b/test/src/test/java/jenkins/model/NodesTest.java
@@ -24,6 +24,7 @@
 
 package jenkins.model;
 
+import hudson.ExtensionList;
 import hudson.model.Descriptor;
 import hudson.model.Node;
 import hudson.model.Slave;
@@ -33,14 +34,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-
+import org.jvnet.hudson.test.TestExtension;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class NodesTest {
 
@@ -88,6 +86,27 @@ public class NodesTest {
         Node newNode = r.createSlave("foo", "", null);
         r.jenkins.addNode(newNode);
         assertThat(r.jenkins.getNode("foo"), sameInstance(newNode));
+        ListenerImpl l = ExtensionList.lookupSingleton(ListenerImpl.class);
+        assertEquals(0, l.deleted);
+        assertEquals(1, l.updated);
+        assertEquals(1, l.created);
+    }
+    @TestExtension("addNodeShouldReplaceExistingNode")
+    public static final class ListenerImpl extends NodeListener {
+        int deleted, updated, created;
+        @Override
+        protected void onDeleted(Node node) {
+            deleted++;
+        }
+        @Override
+        protected void onUpdated(Node oldOne, Node newOne) {
+            assertNotSame(oldOne, newOne);
+            updated++;
+        }
+        @Override
+        protected void onCreated(Node node) {
+            created++;
+        }
     }
 
     @Test


### PR DESCRIPTION
[JENKINS-57273](https://issues.jenkins-ci.org/browse/JENKINS-57273)

Buglet I noticed while working on something else.

### Proposed changelog entries

* `NodeListener.onCreated` was called when `Jenkins.addNode` or `Nodes.addNode` actually replaced an existing node.