### PR TITLE
Include generated message files in Eclipse classpath

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -139,6 +139,24 @@
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+              <goals>
+                 <goal>add-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>${project.build.directory}/generated-sources/localizer</source>
+                </sources>
+              </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
       </plugin>
     </plugins>


### PR DESCRIPTION
No Jira issue. 

When you open Jenkins in Eclipse, for the core Jenkins module the generated message files are added to the classpath correctly, but not for the CLI module, leading to compilation errors (compilation outside of Eclipse runs fine). This PR reuses the classpath setting from Core also in CLI.

### Proposed changelog entries

* Developer: include generated source files of CLI module in the classpath

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [n/a ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
-