### PR TITLE
Rejuvenate log levels

### DIFF
--- a/cli/src/main/java/hudson/cli/FullDuplexHttpStream.java
+++ b/cli/src/main/java/hudson/cli/FullDuplexHttpStream.java
@@ -59,7 +59,7 @@ public class FullDuplexHttpStream {
         UUID uuid = UUID.randomUUID(); // so that the server can correlate those two connections
 
         // server->client
-        LOGGER.fine("establishing download side");
+        LOGGER.finest("establishing download side");
         HttpURLConnection con = (HttpURLConnection) target.openConnection();
         con.setDoOutput(true); // request POST to avoid caching
         con.setRequestMethod("POST");
@@ -74,10 +74,10 @@ public class FullDuplexHttpStream {
         if (con.getHeaderField("Hudson-Duplex") == null) {
             throw new CLI.NotTalkingToJenkinsException("There's no Jenkins running at " + target + ", or is not serving the HTTP Duplex transport");
         }
-        LOGGER.fine("established download side"); // calling getResponseCode or getHeaderFields breaks everything
+        LOGGER.finest("established download side"); // calling getResponseCode or getHeaderFields breaks everything
 
         // client->server uses chunked encoded POST for unlimited capacity.
-        LOGGER.fine("establishing upload side");
+        LOGGER.finest("establishing upload side");
         con = (HttpURLConnection) target.openConnection();
         con.setDoOutput(true); // request POST
         con.setRequestMethod("POST");
@@ -89,7 +89,7 @@ public class FullDuplexHttpStream {
         	con.addRequestProperty ("Authorization", authorization);
         }
         output = con.getOutputStream();
-        LOGGER.fine("established upload side");
+        LOGGER.finest("established upload side");
     }
 
     // As this transport mode is using POST, it is necessary to resolve possible redirections using GET first.

--- a/cli/src/main/java/hudson/cli/SSHCLI.java
+++ b/cli/src/main/java/hudson/cli/SSHCLI.java
@@ -25,6 +25,9 @@
 package hudson.cli;
 
 import hudson.util.QuotedStringTokenizer;
+
+import static java.util.logging.Level.FINEST;
+
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
@@ -36,7 +39,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
-import static java.util.logging.Level.FINE;
 import java.util.logging.Logger;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.channel.ClientChannel;
@@ -74,7 +76,7 @@ class SSHCLI {
             return -1;
         }
 
-        CLI.LOGGER.log(FINE, "Connecting via SSH to: {0}", endpointDescription);
+        CLI.LOGGER.log(FINEST, "Connecting via SSH to: {0}", endpointDescription);
 
         int sshPort = Integer.parseInt(endpointDescription.split(":")[1]);
         String sshHost = endpointDescription.split(":")[0];
@@ -103,7 +105,7 @@ class SSHCLI {
             cf.await();
             try (ClientSession session = cf.getSession()) {
                 for (KeyPair pair : provider.getKeys()) {
-                    CLI.LOGGER.log(FINE, "Offering {0} private key", pair.getPrivate().getAlgorithm());
+                    CLI.LOGGER.log(FINEST, "Offering {0} private key", pair.getPrivate().getAlgorithm());
                     session.addPublicKeyIdentity(pair);
                 }
                 session.auth().verify(10000L);

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -214,7 +214,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
         }
         File disableFile = new File(archive.getPath() + ".disabled");
         if (disableFile.exists()) {
-            LOGGER.info("Plugin " + archive.getName() + " is disabled");
+            LOGGER.finest("Plugin " + archive.getName() + " is disabled");
         }
 
         // compute dependencies
@@ -397,7 +397,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
         DependencyClassLoader classLoader = findAncestorDependencyClassLoader(depender.classLoader);
         if (classLoader != null) {
             classLoader.updateTransientDependencies();
-            LOGGER.log(Level.INFO, "Updated dependency of {0}", depender.getShortName());
+            LOGGER.log(Level.FINEST, "Updated dependency of {0}", depender.getShortName());
         }
     }
 

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -214,7 +214,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
         }
         File disableFile = new File(archive.getPath() + ".disabled");
         if (disableFile.exists()) {
-            LOGGER.finest("Plugin " + archive.getName() + " is disabled");
+            LOGGER.info("Plugin " + archive.getName() + " is disabled");
         }
 
         // compute dependencies
@@ -397,7 +397,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
         DependencyClassLoader classLoader = findAncestorDependencyClassLoader(depender.classLoader);
         if (classLoader != null) {
             classLoader.updateTransientDependencies();
-            LOGGER.log(Level.FINEST, "Updated dependency of {0}", depender.getShortName());
+            LOGGER.log(Level.INFO, "Updated dependency of {0}", depender.getShortName());
         }
     }
 

--- a/core/src/main/java/hudson/DependencyRunner.java
+++ b/core/src/main/java/hudson/DependencyRunner.java
@@ -58,17 +58,17 @@ public class DependencyRunner implements Runnable {
         try {
             Set<AbstractProject> topLevelProjects = new HashSet<AbstractProject>();
             // Get all top-level projects
-            LOGGER.fine("assembling top level projects");
+            LOGGER.finest("assembling top level projects");
             for (AbstractProject p : Jenkins.getInstance().allItems(AbstractProject.class))
                 if (p.getUpstreamProjects().size() == 0) {
-                    LOGGER.fine("adding top level project " + p.getName());
+                    LOGGER.finest("adding top level project " + p.getName());
                     topLevelProjects.add(p);
                 } else {
-                    LOGGER.fine("skipping project since not a top level project: " + p.getName());
+                    LOGGER.finest("skipping project since not a top level project: " + p.getName());
                 }
             populate(topLevelProjects);
             for (AbstractProject p : polledProjects) {
-                    LOGGER.fine("running project in correct dependency order: " + p.getName());
+                    LOGGER.finest("running project in correct dependency order: " + p.getName());
                 runnable.run(p);
             }
         } finally {
@@ -81,11 +81,11 @@ public class DependencyRunner implements Runnable {
             if (polledProjects.contains(p)) {
                 // Project will be readded at the queue, so that we always use
                 // the longest path
-            	LOGGER.fine("removing project " + p.getName() + " for re-add");
+            	LOGGER.finest("removing project " + p.getName() + " for re-add");
                 polledProjects.remove(p);
             }
 
-            LOGGER.fine("adding project " + p.getName());
+            LOGGER.finest("adding project " + p.getName());
             polledProjects.add(p);
 
             // Add all downstream dependencies

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -446,8 +446,8 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                         if (verbose) {
                             LOGGER.log(Level.WARNING, "Failed to instantiate " + key + "; skipping this component", x);
                         } else {
-                            LOGGER.log(Level.INFO, "Failed to instantiate optional component {0}; skipping", key.getTypeLiteral());
-                            LOGGER.log(Level.FINE, key.toString(), x);
+                            LOGGER.log(Level.FINEST, "Failed to instantiate optional component {0}; skipping", key.getTypeLiteral());
+                            LOGGER.log(Level.FINEST, key.toString(), x);
                         }
                     }
                 };
@@ -497,7 +497,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                             resolve(f.getType());
                         }
                     }
-                    LOGGER.log(Level.FINER, "{0} looks OK", c);
+                    LOGGER.log(Level.FINEST, "{0} looks OK", c);
                     while (c != Object.class) {
                         c.getGenericSuperclass();
                         c = c.getSuperclass();

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -446,7 +446,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                         if (verbose) {
                             LOGGER.log(Level.WARNING, "Failed to instantiate " + key + "; skipping this component", x);
                         } else {
-                            LOGGER.log(Level.FINEST, "Failed to instantiate optional component {0}; skipping", key.getTypeLiteral());
+                            LOGGER.log(Level.INFO, "Failed to instantiate optional component {0}; skipping", key.getTypeLiteral());
                             LOGGER.log(Level.FINEST, key.toString(), x);
                         }
                     }

--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -373,7 +373,7 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
      * Loads all the extensions.
      */
     protected List<ExtensionComponent<T>> load() {
-        LOGGER.fine(() -> String.format("Loading ExtensionList '%s'", extensionType.getName()));
+        LOGGER.finest(() -> String.format("Loading ExtensionList '%s'", extensionType.getName()));
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.log(Level.FINER, String.format("Loading ExtensionList '%s' from", extensionType.getName()), new Throwable("Only present for stacktrace information"));
         }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2430,7 +2430,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                         if (exceptionEncountered) {
                             Files.copy(fileToPath(f), targetPath, StandardCopyOption.REPLACE_EXISTING);
                             if (!logMessageShown) {
-                                LOGGER.log(Level.FINEST, 
+                                LOGGER.log(Level.INFO, 
                                     "JENKINS-52325: Jenkins failed to retain attributes when copying to {0}, so proceeding without attributes.", 
                                     dest.getAbsolutePath());
                                 logMessageShown = true;

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2430,7 +2430,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                         if (exceptionEncountered) {
                             Files.copy(fileToPath(f), targetPath, StandardCopyOption.REPLACE_EXISTING);
                             if (!logMessageShown) {
-                                LOGGER.log(Level.INFO, 
+                                LOGGER.log(Level.FINEST, 
                                     "JENKINS-52325: Jenkins failed to retain attributes when copying to {0}, so proceeding without attributes.", 
                                     dest.getAbsolutePath());
                                 logMessageShown = true;
@@ -3302,7 +3302,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                 try{
                     Path child = currentFileAbsolutePath.toRealPath();
                     if (!child.startsWith(parentRealPath)) {
-                        LOGGER.log(Level.FINE, "Child [{0}] does not start with parent [{1}] => not descendant", new Object[]{ child, parentRealPath });
+                        LOGGER.log(Level.FINEST, "Child [{0}] does not start with parent [{1}] => not descendant", new Object[]{ child, parentRealPath });
                         return false;
                     }
                 } catch (NoSuchFileException e) {

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -464,7 +464,7 @@ public abstract class Launcher {
         public int join() throws IOException, InterruptedException {
             // The logging around procHolderForJoin prevents the preliminary object deallocation we saw in JENKINS-23271
             final Proc procHolderForJoin = start();
-            LOGGER.log(Level.FINER, "Started the process {0}", procHolderForJoin);
+            LOGGER.log(Level.FINEST, "Started the process {0}", procHolderForJoin);
             
             if (procHolderForJoin instanceof ProcWithJenkins23271Patch) {
                 return procHolderForJoin.join();
@@ -472,7 +472,7 @@ public abstract class Launcher {
                 // Fallback to the internal handling logic
                 if (!(procHolderForJoin instanceof LocalProc)) {
                     // We consider that the process may be at risk of JENKINS-23271
-                    LOGGER.log(Level.FINE, "Process {0} of type {1} is neither {2} nor instance of {3}. "
+                    LOGGER.log(Level.FINEST, "Process {0} of type {1} is neither {2} nor instance of {3}. "
                             + "If this process operates with Jenkins agents via remote invocation, you may get into JENKINS-23271",
                             new Object[] {procHolderForJoin, procHolderForJoin.getClass(), LocalProc.class, ProcWithJenkins23271Patch.class});
                 }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -252,7 +252,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     public static @NonNull PluginManager createDefault(@NonNull Jenkins jenkins) {
         String pmClassName = SystemProperties.getString(CUSTOM_PLUGIN_MANAGER);
         if (!StringUtils.isBlank(pmClassName)) {
-            LOGGER.log(FINE, String.format("Use of custom plugin manager [%s] requested.", pmClassName));
+            LOGGER.log(FINEST, String.format("Use of custom plugin manager [%s] requested.", pmClassName));
             try {
                 final Class<? extends PluginManager> klass = Class.forName(pmClassName).asSubclass(PluginManager.class);
                 // Iteration is in declaration order
@@ -446,7 +446,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                                     private boolean isDuplicate(PluginWrapper p) {
                                         String shortName = p.getShortName();
                                         if (inspectedShortNames.containsKey(shortName)) {
-                                            LOGGER.info("Ignoring "+arc+" because "+inspectedShortNames.get(shortName)+" is already loaded");
+                                            LOGGER.finest("Ignoring "+arc+" because "+inspectedShortNames.get(shortName)+" is already loaded");
                                             return true;
                                         }
 
@@ -723,7 +723,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         VersionNumber lastExecVersion = new VersionNumber(InstallUtil.getLastExecVersion());
         if (lastExecVersion.isNewerThan(InstallUtil.NEW_INSTALL_VERSION) && lastExecVersion.isOlderThan(Jenkins.getVersion())) {
 
-            LOGGER.log(INFO, "Upgrading Jenkins. The last running version was {0}. This Jenkins is version {1}.",
+            LOGGER.log(FINEST, "Upgrading Jenkins. The last running version was {0}. This Jenkins is version {1}.",
                     new Object[] {lastExecVersion, Jenkins.VERSION});
 
             final List<DetachedPluginsUtil.DetachedPlugin> detachedPlugins = DetachedPluginsUtil.getDetachedPlugins(lastExecVersion);
@@ -759,7 +759,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 }
             });
 
-            LOGGER.log(INFO, "Upgraded Jenkins from version {0} to version {1}. Loaded detached plugins (and dependencies): {2}",
+            LOGGER.log(FINEST, "Upgraded Jenkins from version {0} to version {1}. Loaded detached plugins (and dependencies): {2}",
                     new Object[] {lastExecVersion, Jenkins.VERSION, loadedDetached});
 
             InstallUtil.saveLastExecVersion();
@@ -789,7 +789,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                         return false;
                     }
                 });
-                LOGGER.log(INFO, "Upgraded detached plugins (and dependencies): {0}",
+                LOGGER.log(FINEST, "Upgraded detached plugins (and dependencies): {0}",
                         new Object[]{loadedDetached});
             }
         }
@@ -858,7 +858,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @Restricted(NoExternalUse.class)
     public void dynamicLoad(File arc, boolean removeExisting) throws IOException, InterruptedException, RestartRequiredException {
         try (ACLContext context = ACL.as(ACL.SYSTEM)) {
-            LOGGER.info("Attempting to dynamic load "+arc);
+            LOGGER.finest("Attempting to dynamic load "+arc);
             PluginWrapper p = null;
             String sn;
             try {
@@ -955,7 +955,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             } catch (ExtensionRefreshException e) {
                 throw new IOException("Failed to refresh extensions after installing " + sn + " plugin", e);
             }
-            LOGGER.info("Plugin " + p.getShortName()+":"+p.getVersion() + " dynamically installed");
+            LOGGER.finest("Plugin " + p.getShortName()+":"+p.getVersion() + " dynamically installed");
         }
     }
 
@@ -1012,7 +1012,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      * with a reasonable up-to-date check. A convenience method to be used by the {@link #loadBundledPlugins()}.
      */
     protected void copyBundledPlugin(URL src, String fileName) throws IOException {
-        LOGGER.log(FINE, "Copying {0}", src);
+        LOGGER.log(FINEST, "Copying {0}", src);
         fileName = fileName.replace(".hpi",".jpi"); // normalize fileNames to have the correct suffix
         String legacyName = fileName.replace(".jpi",".hpi");
         long lastModified = getModificationDate(src);
@@ -1158,7 +1158,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 				Object strategy = klazz.getConstructor(PluginManager.class)
 						.newInstance(this);
 				if (strategy instanceof PluginStrategy) {
-					LOGGER.info("Plugin strategy: " + strategyName);
+					LOGGER.finest("Plugin strategy: " + strategyName);
 					return (PluginStrategy) strategy;
 				} else {
 					LOGGER.warning("Plugin strategy (" + strategyName +
@@ -1171,7 +1171,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 				LOGGER.log(WARNING, "Could not instantiate plugin strategy: "
 						+ strategyName + ". Falling back to ClassicPluginStrategy", e);
 			}
-			LOGGER.info("Falling back to ClassicPluginStrategy");
+			LOGGER.finest("Falling back to ClassicPluginStrategy");
 		}
 
 		// default and fallback

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -585,13 +585,13 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
         Plugin plugin = getPlugin();
         if (plugin != null) {
             try {
-                LOGGER.log(Level.FINE, "Stopping {0}", shortName);
+                LOGGER.log(Level.FINEST, "Stopping {0}", shortName);
                 plugin.stop();
             } catch (Throwable t) {
                 LOGGER.log(WARNING, "Failed to shut down " + shortName, t);
             }
         } else {
-            LOGGER.log(Level.FINE, "Could not find Plugin instance to stop for {0}", shortName);
+            LOGGER.log(Level.FINEST, "Could not find Plugin instance to stop for {0}", shortName);
         }
         // Work around a bug in commons-logging.
         // See http://www.szegedi.org/articles/memleak.html

--- a/core/src/main/java/hudson/Proc.java
+++ b/core/src/main/java/hudson/Proc.java
@@ -238,7 +238,7 @@ public abstract class Proc {
         }
 
         private LocalProc( String name, ProcessBuilder procBuilder, InputStream in, OutputStream out, OutputStream err ) throws IOException {
-            Logger.getLogger(Proc.class.getName()).log(Level.FINE, "Running: {0}", name);
+            Logger.getLogger(Proc.class.getName()).log(Level.FINEST, "Running: {0}", name);
             this.name = name;
             this.out = out;
             this.cookie = EnvVars.createCookie();

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -112,7 +112,7 @@ public final class TcpSlaveAgentListener extends Thread {
             TcpSlaveAgentListenerRescheduler.schedule(t, e);
         });
 
-        LOGGER.log(Level.FINE, "TCP agent listener started on port {0}", getPort());
+        LOGGER.log(Level.FINEST, "TCP agent listener started on port {0}", getPort());
 
         start();
     }
@@ -242,7 +242,7 @@ public final class TcpSlaveAgentListener extends Thread {
         @Override
         public void run() {
             try {
-                LOGGER.log(Level.FINE, "Accepted connection #{0} from {1}", new Object[] {id, s.getRemoteSocketAddress()});
+                LOGGER.log(Level.FINEST, "Accepted connection #{0} from {1}", new Object[] {id, s.getRemoteSocketAddress()});
 
                 DataInputStream in = new DataInputStream(s.getInputStream());
                 PrintWriter out = new PrintWriter(
@@ -395,10 +395,10 @@ public final class TcpSlaveAgentListener extends Thread {
         public void handle(Socket socket) throws IOException, InterruptedException {
             try {
                 try (OutputStream stream = socket.getOutputStream()) {
-                    LOGGER.log(Level.FINE, "Received ping request from {0}", socket.getRemoteSocketAddress());
+                    LOGGER.log(Level.FINEST, "Received ping request from {0}", socket.getRemoteSocketAddress());
                     stream.write(ping);
                     stream.flush();
-                    LOGGER.log(Level.FINE, "Sent ping response to {0}", socket.getRemoteSocketAddress());
+                    LOGGER.log(Level.FINEST, "Sent ping response to {0}", socket.getRemoteSocketAddress());
                 }
             } finally {
                 socket.close();
@@ -407,17 +407,17 @@ public final class TcpSlaveAgentListener extends Thread {
 
         public boolean connect(Socket socket) throws IOException {
             try {
-                LOGGER.log(Level.FINE, "Requesting ping from {0}", socket.getRemoteSocketAddress());
+                LOGGER.log(Level.FINEST, "Requesting ping from {0}", socket.getRemoteSocketAddress());
                 try (DataOutputStream out = new DataOutputStream(socket.getOutputStream())) {
                     out.writeUTF("Protocol:Ping");
                     try (InputStream in = socket.getInputStream()) {
                         byte[] response = new byte[ping.length];
                         int responseLength = in.read(response);
                         if (responseLength == ping.length && Arrays.equals(response, ping)) {
-                            LOGGER.log(Level.FINE, "Received ping response from {0}", socket.getRemoteSocketAddress());
+                            LOGGER.log(Level.FINEST, "Received ping response from {0}", socket.getRemoteSocketAddress());
                             return true;
                         } else {
-                            LOGGER.log(Level.FINE, "Expected ping response from {0} of {1} got {2}", new Object[]{
+                            LOGGER.log(Level.FINEST, "Expected ping response from {0} of {1} got {2}", new Object[]{
                                     socket.getRemoteSocketAddress(),
                                     new String(ping, StandardCharsets.UTF_8),
                                     responseLength > 0 && responseLength <= response.length ?
@@ -487,7 +487,7 @@ public final class TcpSlaveAgentListener extends Thread {
                     int port = Jenkins.getInstance().getSlaveAgentPort();
                     if (port != -1) {
                         new TcpSlaveAgentListener(port).start();
-                        LOGGER.log(Level.INFO, "Restarted TcpSlaveAgentListener");
+                        LOGGER.log(Level.FINEST, "Restarted TcpSlaveAgentListener");
                     } else {
                         LOGGER.log(Level.SEVERE, "Uncaught exception in TcpSlaveAgentListener " + originThread + ". Port is disabled, not rescheduling", cause);
                     }

--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -241,7 +241,7 @@ public class WebAppMain implements ServletContextListener {
                         BootFailure.getBootFailureFile(_home).delete();
 
                         // at this point we are open for business and serving requests normally
-                        LOGGER.info("Jenkins is fully up and running");
+                        LOGGER.finest("Jenkins is fully up and running");
                         success = true;
                     } catch (Error e) {
                         new HudsonFailedToLoad(e).publish(context,_home);
@@ -385,7 +385,7 @@ public class WebAppMain implements ServletContextListener {
             terminated = true;
             Thread t = initThread;
             if (t != null && t.isAlive()) {
-                LOGGER.log(Level.INFO, "Shutting down a Jenkins instance that was still starting up", new Throwable("reason"));
+                LOGGER.log(Level.FINEST, "Shutting down a Jenkins instance that was still starting up", new Throwable("reason"));
                 t.interrupt();
             }
 

--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -246,10 +246,10 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
             p.parseArgument(args.toArray(new String[0]));
             if (!(this instanceof HelpCommand || this instanceof WhoAmICommand))
                 Jenkins.getActiveInstance().checkPermission(Jenkins.READ);
-            LOGGER.log(Level.FINE, "Invoking CLI command {0}, with {1} arguments, as user {2}.",
+            LOGGER.log(Level.FINEST, "Invoking CLI command {0}, with {1} arguments, as user {2}.",
                     new Object[] {getName(), args.size(), auth.getName()});
             int res = run();
-            LOGGER.log(Level.FINE, "Executed CLI command {0}, with {1} arguments, as user {2}, return code {3}",
+            LOGGER.log(Level.FINEST, "Executed CLI command {0}, with {1} arguments, as user {2}, return code {3}",
                     new Object[] {getName(), args.size(), auth.getName(), res});
             return res;
         } catch (CmdLineException e) {

--- a/core/src/main/java/hudson/cli/declarative/CLIRegisterer.java
+++ b/core/src/main/java/hudson/cli/declarative/CLIRegisterer.java
@@ -98,7 +98,7 @@ public class CLIRegisterer extends ExtensionFinder {
     }
 
     private List<ExtensionComponent<CLICommand>> discover(@Nonnull final Jenkins jenkins) {
-        LOGGER.fine("Listing up @CLIMethod");
+        LOGGER.finest("Listing up @CLIMethod");
         List<ExtensionComponent<CLICommand>> r = new ArrayList<>();
 
         try {

--- a/core/src/main/java/hudson/cli/handlers/GenericItemOptionHandler.java
+++ b/core/src/main/java/hudson/cli/handlers/GenericItemOptionHandler.java
@@ -65,7 +65,7 @@ public abstract class GenericItemOptionHandler<T extends Item> extends OptionHan
             try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
                 Item actual = j.getItemByFullName(src);
                 if (actual == null) {
-                    LOGGER.log(Level.FINE, "really no item exists named {0}", src);
+                    LOGGER.log(Level.FINEST, "really no item exists named {0}", src);
                 } else {
                     LOGGER.log(Level.WARNING, "running as {0} could not find {1} of {2}", new Object[] {who.getPrincipal(), actual, type()});
                 }

--- a/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageChecker.java
+++ b/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageChecker.java
@@ -47,12 +47,12 @@ public class HudsonHomeDiskUsageChecker extends PeriodicWork {
             long total = Jenkins.getInstance().getRootDir().getTotalSpace();
             if(free<=0 || total<=0) {
                 // information unavailable. pointless to try.
-                LOGGER.info("JENKINS_HOME disk usage information isn't available. aborting to monitor");
+                LOGGER.finest("JENKINS_HOME disk usage information isn't available. aborting to monitor");
                 cancel();
                 return;
             }
 
-            LOGGER.fine("Monitoring disk usage of JENKINS_HOME. total="+total+" free="+free);
+            LOGGER.finest("Monitoring disk usage of JENKINS_HOME. total="+total+" free="+free);
 
 
             // if it's more than 90% full and less than the minimum, activate

--- a/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
@@ -67,7 +67,7 @@ public class ReverseProxySetupMonitor extends AdministrativeMonitor {
         Jenkins j = Jenkins.getInstance();
         // May need to send an absolute URL, since handling of HttpRedirect with a relative URL does not currently honor X-Forwarded-Proto/Port at all.
         String redirect = j.getRootUrl() + "administrativeMonitor/" + id + "/testForReverseProxySetup/" + (referer != null ? Util.rawEncode(referer) : "NO-REFERER") + "/";
-        LOGGER.log(Level.FINE, "coming from {0} and redirecting to {1}", new Object[] {referer, redirect});
+        LOGGER.log(Level.FINEST, "coming from {0} and redirecting to {1}", new Object[] {referer, redirect});
         return new HttpRedirect(redirect);
     }
 

--- a/core/src/main/java/hudson/init/InitStrategy.java
+++ b/core/src/main/java/hudson/init/InitStrategy.java
@@ -119,7 +119,7 @@ public class InitStrategy {
             return new InitStrategy(); // default
         }
         InitStrategy s = it.next();
-        LOGGER.log(Level.FINE, "Using {0} as InitStrategy", s);
+        LOGGER.log(Level.FINEST, "Using {0} as InitStrategy", s);
         return s;
     }
 

--- a/core/src/main/java/hudson/init/impl/InstallUncaughtExceptionHandler.java
+++ b/core/src/main/java/hudson/init/impl/InstallUncaughtExceptionHandler.java
@@ -38,7 +38,7 @@ public class InstallUncaughtExceptionHandler {
         });
         try {
             Thread.setDefaultUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler());
-            LOGGER.log(Level.FINE, "Successfully installed a global UncaughtExceptionHandler.");
+            LOGGER.log(Level.FINEST, "Successfully installed a global UncaughtExceptionHandler.");
         }
         catch (SecurityException ex) {
             LOGGER.log(Level.SEVERE,

--- a/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
@@ -197,7 +197,7 @@ public class WindowsInstallerLink extends ManagementLink {
                         public void run() {
                             try {
                                 if(!oldRoot.equals(installationDir)) {
-                                    LOGGER.info("Moving data");
+                                    LOGGER.finest("Moving data");
                                     Move mv = new Move();
                                     Project p = new Project();
                                     p.addBuildListener(createLogger());
@@ -210,7 +210,7 @@ public class WindowsInstallerLink extends ManagementLink {
                                     mv.setFailOnError(false); // plugins can also fail to move
                                     mv.execute();
                                 }
-                                LOGGER.info("Starting a Windows service");
+                                LOGGER.finest("Starting a Windows service");
                                 StreamTaskListener task = StreamTaskListener.fromStdout();
                                 int r = runElevated(
                                         new File(installationDir, "jenkins.exe"), "start", task, installationDir);

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -76,7 +76,7 @@ public class WindowsServiceLifecycle extends Lifecycle {
                     File stage = new File(baseDir,name+".new");
                     FileUtils.copyURLToFile(exe,stage);
                     Kernel32.INSTANCE.MoveFileExA(stage.getAbsolutePath(),currentCopy.getAbsolutePath(),MOVEFILE_DELAY_UNTIL_REBOOT|MOVEFILE_REPLACE_EXISTING);
-                    LOGGER.info("Scheduled a replacement of "+name);
+                    LOGGER.finest("Scheduled a replacement of "+name);
                 } catch (IOException e) {
                     LOGGER.log(Level.SEVERE, "Failed to replace "+name,e);
                 } catch (InterruptedException e) {

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -688,7 +688,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 if ((bs instanceof Publisher && ((Publisher)bs).needsToRunAfterFinalized()) ^ phase)
                     try {
                         if (!perform(bs,listener)) {
-                            LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, bs});
+                            LOGGER.log(Level.FINEST, "{0} : {1} failed", new Object[] {AbstractBuild.this, bs});
                             r = false;
                             if (phase) {
                                 setResult(Result.FAILURE);
@@ -712,7 +712,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             }
 
             if (e instanceof AbortException) {
-                LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, buildStep});
+                LOGGER.log(Level.FINEST, "{0} : {1} failed", new Object[] {AbstractBuild.this, buildStep});
                 listener.error("Step ‘" + buildStep + "’ failed: " + e.getMessage());
             } else {
                 String msg = "Step ‘" + buildStep + "’ aborted due to exception: ";
@@ -790,7 +790,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         protected final boolean preBuild(BuildListener listener,Iterable<? extends BuildStep> steps) {
             for (BuildStep bs : steps)
                 if (!bs.prebuild(AbstractBuild.this,listener)) {
-                    LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {AbstractBuild.this, bs});
+                    LOGGER.log(Level.FINEST, "{0} : {1} failed", new Object[] {AbstractBuild.this, bs});
                     return false;
                 }
             return true;

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -529,7 +529,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
         String uri = req == null ? null : req.getRequestURI();
         if (req != null) {
             String seed = Functions.getNearestAncestorUrl(req,this);
-            LOGGER.log(Level.FINER, "seed={0} for {1} from {2}", new Object[] {seed, this, uri});
+            LOGGER.log(Level.FINEST, "seed={0} for {1} from {2}", new Object[] {seed, this, uri});
             if(seed!=null) {
                 // trim off the context path portion and leading '/', but add trailing '/'
                 return seed.substring(req.getContextPath().length()+1)+'/';
@@ -542,23 +542,23 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                     if (view.getOwner().getItemGroup() == getParent() && !view.isDefault()) {
                         // Showing something inside a view, so should use that as the base URL.
                         String base = last.getUrl().substring(req.getContextPath().length() + 1) + '/';
-                        LOGGER.log(Level.FINER, "using {0}{1} for {2} from {3}", new Object[] {base, shortUrl, this, uri});
+                        LOGGER.log(Level.FINEST, "using {0}{1} for {2} from {3}", new Object[] {base, shortUrl, this, uri});
                         return base + shortUrl;
                     } else {
-                        LOGGER.log(Level.FINER, "irrelevant {0} for {1} from {2}", new Object[] {view.getViewName(), this, uri});
+                        LOGGER.log(Level.FINEST, "irrelevant {0} for {1} from {2}", new Object[] {view.getViewName(), this, uri});
                     }
                 } else {
-                    LOGGER.log(Level.FINER, "inapplicable {0} for {1} from {2}", new Object[] {last.getObject(), this, uri});
+                    LOGGER.log(Level.FINEST, "inapplicable {0} for {1} from {2}", new Object[] {last.getObject(), this, uri});
                 }
             } else {
-                LOGGER.log(Level.FINER, "no ancestors for {0} from {1}", new Object[] {this, uri});
+                LOGGER.log(Level.FINEST, "no ancestors for {0} from {1}", new Object[] {this, uri});
             }
         } else {
-            LOGGER.log(Level.FINER, "no current request for {0}", this);
+            LOGGER.log(Level.FINEST, "no current request for {0}", this);
         }
         // otherwise compute the path normally
         String base = getParent().getUrl();
-        LOGGER.log(Level.FINER, "falling back to {0}{1} for {2} from {3}", new Object[] {base, shortUrl, this, uri});
+        LOGGER.log(Level.FINEST, "falling back to {0}{1} for {2} from {3}", new Object[] {base, shortUrl, this, uri});
         return base + shortUrl;
     }
 

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1077,7 +1077,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
                 // The build has been likely deleted after the isLogUpdated() call.
                 // Another cause may be an API implementation glitсh in the implementation for AbstractProject. 
                 // Anyway, we should let the code go then.
-                LOGGER.log(Level.FINE, "The last build has been deleted during the non-concurrent cause creation. The build is not blocked anymore");
+                LOGGER.log(Level.FINEST, "The last build has been deleted during the non-concurrent cause creation. The build is not blocked anymore");
             }
         }
         if (blockBuildWhenDownstreamBuilding()) {
@@ -1384,7 +1384,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
 
         } else {
             // polling without workspace
-            LOGGER.fine("Polling SCM changes of " + getName());
+            LOGGER.finest("Polling SCM changes of " + getName());
             if (pollingBaseline==null) // see NOTE-NO-BASELINE above
                 calcPollingBaseline(getLastBuild(),null,listener);
             PollingResult r = scm.poll(this, null, null, listener, pollingBaseline);
@@ -1406,7 +1406,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         try {
             String nodeName = node != null ? node.getSelfLabel().getName() : "[node_unavailable]";
             listener.getLogger().println("Polling SCM changes on " + nodeName);
-            LOGGER.fine("Polling SCM changes of " + getName());
+            LOGGER.finest("Polling SCM changes of " + getName());
             if (pollingBaseline==null) // see NOTE-NO-BASELINE above
                 calcPollingBaseline(lb,launcher,listener);
             PollingResult r = scm.poll(this, launcher, ws, listener, pollingBaseline);

--- a/core/src/main/java/hudson/model/AllView.java
+++ b/core/src/main/java/hudson/model/AllView.java
@@ -161,7 +161,7 @@ public class AllView extends View {
                 for (Locale l : Locale.getAvailableLocales()) {
                     if (primaryView.equals(Messages._Hudson_ViewName().toString(l))) {
                         // bingo JENKINS-38606 detected
-                        LOGGER.log(Level.INFO,
+                        LOGGER.log(Level.FINEST,
                                 "JENKINS-38606 detected for AllView in {0}; renaming view from {1} to {2}",
                                 new Object[] {allView.owner, primaryView, DEFAULT_VIEW_NAME});
                         allView.name = DEFAULT_VIEW_NAME;

--- a/core/src/main/java/hudson/model/Build.java
+++ b/core/src/main/java/hudson/model/Build.java
@@ -204,7 +204,7 @@ public abstract class Build <P extends Project<P,B>,B extends Build<P,B>>
         private boolean build(@Nonnull BuildListener listener, @Nonnull Collection<Builder> steps) throws IOException, InterruptedException {
             for( BuildStep bs : steps ) {
                 if(!perform(bs,listener)) {
-                    LOGGER.log(Level.FINE, "{0} : {1} failed", new Object[] {Build.this, bs});
+                    LOGGER.log(Level.FINEST, "{0} : {1} failed", new Object[] {Build.this, bs});
                     return false;
                 }
                 

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1272,11 +1272,11 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             try {
                 InetAddress ia = InetAddress.getByName(address);
                 if(!(ia instanceof Inet4Address)) {
-                    LOGGER.log(Level.FINE, "{0} is not an IPv4 address", address);
+                    LOGGER.log(Level.FINEST, "{0} is not an IPv4 address", address);
                     continue;
                 }
                 if(!ComputerPinger.checkIsReachable(ia, 3)) {
-                    LOGGER.log(Level.FINE, "{0} didn't respond to ping", address);
+                    LOGGER.log(Level.FINEST, "{0} didn't respond to ping", address);
                     continue;
                 }
                 cachedHostName = ia.getCanonicalHostName();
@@ -1328,21 +1328,21 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             Enumeration<NetworkInterface> nis = NetworkInterface.getNetworkInterfaces();
             while (nis.hasMoreElements()) {
                 NetworkInterface ni =  nis.nextElement();
-                LOGGER.log(Level.FINE, "Listing up IP addresses for {0}", ni.getDisplayName());
+                LOGGER.log(Level.FINEST, "Listing up IP addresses for {0}", ni.getDisplayName());
                 Enumeration<InetAddress> e = ni.getInetAddresses();
                 while (e.hasMoreElements()) {
                     InetAddress ia =  e.nextElement();
                     if(ia.isLoopbackAddress()) {
-                        LOGGER.log(Level.FINE, "{0} is a loopback address", ia);
+                        LOGGER.log(Level.FINEST, "{0} is a loopback address", ia);
                         continue;
                     }
 
                     if(!(ia instanceof Inet4Address)) {
-                        LOGGER.log(Level.FINE, "{0} is not an IPv4 address", ia);
+                        LOGGER.log(Level.FINEST, "{0} is not an IPv4 address", ia);
                         continue;
                     }
 
-                    LOGGER.log(Level.FINE, "{0} is a viable candidate", ia);
+                    LOGGER.log(Level.FINEST, "{0} is a viable candidate", ia);
                     names.add(ia.getHostAddress());
                 }
             }
@@ -1645,7 +1645,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
                 newLocation.getParentFile().mkdirs();
                 boolean relocationSuccessful=f.renameTo(newLocation);
                 if (relocationSuccessful) { // The operation will fail if mkdir fails
-                    LOGGER.log(Level.INFO, "Relocated log file {0} to {1}",new Object[] {f.getPath(),newLocation.getPath()});
+                    LOGGER.log(Level.FINEST, "Relocated log file {0} to {1}",new Object[] {f.getPath(),newLocation.getPath()});
                 } else {
                     LOGGER.log(Level.WARNING, "Cannot relocate log file {0} to {1}",new Object[] {f.getPath(),newLocation.getPath()});
                 }

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -619,21 +619,21 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
         private final Map<JSONObject,Boolean> processed = new IdentityHashMap<>();
 
         NewInstanceBindInterceptor(BindInterceptor oldInterceptor) {
-            LOGGER.log(Level.FINER, "new interceptor delegating to {0}", oldInterceptor);
+            LOGGER.log(Level.FINEST, "new interceptor delegating to {0}", oldInterceptor);
             this.oldInterceptor = oldInterceptor;
         }
 
         private boolean isApplicable(Class type, JSONObject json) {
             if (Modifier.isAbstract(type.getModifiers())) {
-                LOGGER.log(Level.FINER, "ignoring abstract {0} {1}", new Object[] {type.getName(), json});
+                LOGGER.log(Level.FINEST, "ignoring abstract {0} {1}", new Object[] {type.getName(), json});
                 return false;
             }
             if (!Describable.class.isAssignableFrom(type)) {
-                LOGGER.log(Level.FINER, "ignoring non-Describable {0} {1}", new Object[] {type.getName(), json});
+                LOGGER.log(Level.FINEST, "ignoring non-Describable {0} {1}", new Object[] {type.getName(), json});
                 return false;
             }
             if (Boolean.TRUE.equals(processed.put(json, true))) {
-                LOGGER.log(Level.FINER, "already processed {0} {1}", new Object[] {type.getName(), json});
+                LOGGER.log(Level.FINEST, "already processed {0} {1}", new Object[] {type.getName(), json});
                 return false;
             }
             return true;
@@ -642,7 +642,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
         @Override
         public Object instantiate(Class actualType, JSONObject json) {
             if (isApplicable(actualType, json)) {
-                LOGGER.log(Level.FINE, "switching to newInstance {0} {1}", new Object[] {actualType.getName(), json});
+                LOGGER.log(Level.FINEST, "switching to newInstance {0} {1}", new Object[] {actualType.getName(), json});
                 try {
                     final Descriptor descriptor = Jenkins.getActiveInstance().getDescriptor(actualType);
                     if (descriptor != null) {
@@ -668,7 +668,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
             if (jsonSource instanceof JSONObject) {
                 JSONObject json = (JSONObject) jsonSource;
                 if (isApplicable(targetTypeErasure, json)) {
-                    LOGGER.log(Level.FINE, "switching to newInstance {0} {1}", new Object[] {targetTypeErasure.getName(), json});
+                    LOGGER.log(Level.FINEST, "switching to newInstance {0} {1}", new Object[] {targetTypeErasure.getName(), json});
                     try {
                         return Jenkins.getActiveInstance().getDescriptor(targetTypeErasure).newInstance(Stapler.getCurrentRequest(), json);
                     } catch (Exception x) {
@@ -676,7 +676,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
                     }
                 }
             } else {
-                LOGGER.log(Level.FINER, "ignoring non-object {0}", jsonSource);
+                LOGGER.log(Level.FINEST, "ignoring non-object {0}", jsonSource);
             }
             return oldInterceptor.onConvert(targetType, targetTypeErasure, jsonSource);
         }

--- a/core/src/main/java/hudson/model/DisplayNameListener.java
+++ b/core/src/main/java/hudson/model/DisplayNameListener.java
@@ -79,7 +79,7 @@ public class DisplayNameListener extends ItemListener {
                 // This means that the displayname was never set, so we want to set it
                 // to null as it was before
                 try {
-                    LOGGER.info(String.format("onRenamed():Setting displayname to null for item.name=%s", item.getName()));
+                    LOGGER.finest(String.format("onRenamed():Setting displayname to null for item.name=%s", item.getName()));
                     abstractItem.setDisplayName(null);
                 }
                 catch(IOException ioe) {

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -226,14 +226,14 @@ public class DownloadService extends PageDecorator {
             for (Downloadable d : Downloadable.all()) {
                 TextFile f = d.getDataFile();
                 if (f == null || !f.exists()) {
-                    LOGGER.log(Level.FINE, "Updating metadata for " + d.getId());
+                    LOGGER.log(Level.FINEST, "Updating metadata for " + d.getId());
                     try {
                         d.updateNow();
                     } catch (IOException e) {
                         LOGGER.log(Level.WARNING, "Failed to update metadata for " + d.getId(), e);
                     }
                 } else {
-                    LOGGER.log(Level.FINER, "Skipping update of metadata for " + d.getId());
+                    LOGGER.log(Level.FINEST, "Skipping update of metadata for " + d.getId());
                 }
             }
         }
@@ -390,7 +390,7 @@ public class DownloadService extends PageDecorator {
             TextFile df = getDataFile();
             df.write(json);
             df.file.setLastModified(dataTimestamp);
-            LOGGER.info("Obtained the updated data file for "+id);
+            LOGGER.finest("Obtained the updated data file for "+id);
             return FormValidation.ok();
         }
 

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -415,7 +415,7 @@ public class Executor extends Thread implements ModelObject {
 
                 setName(getName() + " : executing " + executable.toString());
                 Authentication auth = workUnit.context.item.authenticate();
-                LOGGER.log(FINE, "{0} is now executing {1} as {2}", new Object[] {getName(), executable, auth});
+                LOGGER.log(FINEST, "{0} is now executing {1} as {2}", new Object[] {getName(), executable, auth});
                 if (LOGGER.isLoggable(FINE) && auth.equals(ACL.SYSTEM)) { // i.e., unspecified
                     if (QueueItemAuthenticatorDescriptor.all().isEmpty()) {
                         LOGGER.fine("no QueueItemAuthenticator implementations installed");
@@ -472,7 +472,7 @@ public class Executor extends Thread implements ModelObject {
             workUnit.context.abort(problems);
         }
        long time = System.currentTimeMillis() - startTime;
-        LOGGER.log(FINE, "{0} completed {1} in {2}ms", new Object[]{getName(), executable, time});
+        LOGGER.log(FINEST, "{0} completed {1} in {2}ms", new Object[]{getName(), executable, time});
         try {
             workUnit.context.synchronizeEnd(this, executable, problems, time);
         } catch (InterruptedException e) {
@@ -484,7 +484,7 @@ public class Executor extends Thread implements ModelObject {
 
     private void finish2() {
         for (RuntimeException e1 : owner.getTerminatedBy()) {
-            LOGGER.log(Level.FINE, String.format("%s termination trace", getName()), e1);
+            LOGGER.log(Level.FINEST, String.format("%s termination trace", getName()), e1);
         }
         owner.removeExecutor(this);
         if (this instanceof OneOffExecutor) {

--- a/core/src/main/java/hudson/model/FullDuplexHttpChannel.java
+++ b/core/src/main/java/hudson/model/FullDuplexHttpChannel.java
@@ -59,7 +59,7 @@ abstract public class FullDuplexHttpChannel extends FullDuplexHttpService {
         PingThread ping = new PingThread(channel) {
             @Override
             protected void onDead(Throwable diagnosis) {
-                LOGGER.log(Level.INFO, "Duplex-HTTP session " + uuid + " is terminated", diagnosis);
+                LOGGER.log(Level.FINEST, "Duplex-HTTP session " + uuid + " is terminated", diagnosis);
                 // this will cause the channel to abort and subsequently clean up
                 try {
                     upload.close();

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -629,7 +629,7 @@ public class Queue extends ResourceController implements Saveable {
                 }
             }
             if (duplicatesInQueue.isEmpty()) {
-                LOGGER.log(Level.FINE, "{0} added to queue", p);
+                LOGGER.log(Level.FINEST, "{0} added to queue", p);
 
                 // put the item in the queue
                 WaitingItem added = new WaitingItem(due, p, actions);
@@ -638,7 +638,7 @@ public class Queue extends ResourceController implements Saveable {
                 return ScheduleResult.created(added);
             }
 
-            LOGGER.log(Level.FINE, "{0} is already in the queue", p);
+            LOGGER.log(Level.FINEST, "{0} is already in the queue", p);
 
             // but let the actions affect the existing stuff.
             for (Item item : duplicatesInQueue) {
@@ -721,7 +721,7 @@ public class Queue extends ResourceController implements Saveable {
     public boolean cancel(Task p) {
         lock.lock();
         try { try {
-            LOGGER.log(Level.FINE, "Cancelling {0}", p);
+            LOGGER.log(Level.FINEST, "Cancelling {0}", p);
             for (WaitingItem item : waitingList) {
                 if (item.task.equals(p)) {
                     return item.cancel(this);
@@ -743,7 +743,7 @@ public class Queue extends ResourceController implements Saveable {
     }
 
     public boolean cancel(Item item) {
-        LOGGER.log(Level.FINE, "Cancelling {0} item#{1}", new Object[] {item.task, item.id});
+        LOGGER.log(Level.FINEST, "Cancelling {0} item#{1}", new Object[] {item.task, item.id});
         lock.lock();
         try { try {
             return item.cancel(this);
@@ -1461,7 +1461,7 @@ public class Queue extends ResourceController implements Saveable {
         lock.lock();
         try { try {
 
-            LOGGER.log(Level.FINE, "Queue maintenance started on {0} with {1}", new Object[] {this, snapshot});
+            LOGGER.log(Level.FINEST, "Queue maintenance started on {0} with {1}", new Object[] {this, snapshot});
 
             // The executors that are currently waiting for a job to run.
             Map<Executor, JobOffer> parked = new HashMap<>();
@@ -1589,7 +1589,7 @@ public class Queue extends ResourceController implements Saveable {
                 if (causeOfBlockage != null) {
                     p.leave(this);
                     new BlockedItem(p, causeOfBlockage).enter(this);
-                    LOGGER.log(Level.FINE, "Catching that {0} is blocked in the last minute", p);
+                    LOGGER.log(Level.FINEST, "Catching that {0} is blocked in the last minute", p);
                     // JENKINS-28926 we have moved an unblocked task into the blocked state, update snapshot
                     // so that other buildables which might have been blocked by this can see the state change
                     updateSnapshot();
@@ -1629,7 +1629,7 @@ public class Queue extends ResourceController implements Saveable {
                         // if we couldn't find the executor that fits,
                         // just leave it in the buildables list and
                         // check if we can execute other projects
-                        LOGGER.log(Level.FINER, "Failed to map {0} to executors. candidates={1} parked={2}",
+                        LOGGER.log(Level.FINEST, "Failed to map {0} to executors. candidates={1} parked={2}",
                                 new Object[]{p, candidates, parked.values()});
                         p.transientCausesOfBlockage = reasons.isEmpty() ? null : reasons;
                         continue;
@@ -2583,7 +2583,7 @@ public class Queue extends ResourceController implements Saveable {
         }
 
         /*package*/ void enter(Queue q) {
-            LOGGER.log(Level.FINE, "{0} is blocked", this);
+            LOGGER.log(Level.FINEST, "{0} is blocked", this);
             blockedProjects.add(this);
             for (QueueListener ql : QueueListener.all()) {
                 try {
@@ -2598,7 +2598,7 @@ public class Queue extends ResourceController implements Saveable {
         /*package*/ boolean leave(Queue q) {
             boolean r = blockedProjects.remove(this);
             if (r) {
-                LOGGER.log(Level.FINE, "{0} no longer blocked", this);
+                LOGGER.log(Level.FINEST, "{0} no longer blocked", this);
                 for (QueueListener ql : QueueListener.all()) {
                     try {
                         ql.onLeaveBlocked(this);
@@ -2706,7 +2706,7 @@ public class Queue extends ResourceController implements Saveable {
         /*package*/ boolean leave(Queue q) {
             boolean r = q.buildables.remove(this);
             if (r) {
-                LOGGER.log(Level.FINE, "{0} no longer blocked", this);
+                LOGGER.log(Level.FINEST, "{0} no longer blocked", this);
                 for (QueueListener ql : QueueListener.all()) {
                     try {
                         ql.onLeaveBuildable(this);

--- a/core/src/main/java/hudson/model/ResourceList.java
+++ b/core/src/main/java/hudson/model/ResourceList.java
@@ -133,7 +133,7 @@ public final class ResourceList {
                 else // Otherwise set it to a very large value, since it's read/write conflict
                     v = MAX_INT;
                 if(r.getKey().isCollidingWith(l,unbox(v))) {
-                    LOGGER.info("Collision with " + r + " and " + l);
+                    LOGGER.finest("Collision with " + r + " and " + l);
                     return r.getKey();
                 }
             }

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -298,7 +298,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     protected Run(@Nonnull JobT job) throws IOException {
         this(job, System.currentTimeMillis());
         this.number = project.assignBuildNumber();
-        LOGGER.log(FINER, "new {0} @{1}", new Object[] {this, hashCode()});
+        LOGGER.log(FINEST, "new {0} @{1}", new Object[] {this, hashCode()});
     }
 
     /**
@@ -342,7 +342,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         getDataFile().unmarshal(this); // load the rest of the data
 
         if (state == State.COMPLETED) {
-            LOGGER.log(FINER, "reload {0} @{1}", new Object[] {this, hashCode()});
+            LOGGER.log(FINEST, "reload {0} @{1}", new Object[] {this, hashCode()});
         } else {
             LOGGER.log(WARNING, "reload {0} @{1} with anomalous state {2}", new Object[] {this, hashCode(), state});
         }
@@ -480,7 +480,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         // result can only get worse
         if (result==null || r.isWorseThan(result)) {
             result = r;
-            LOGGER.log(FINE, this + " in " + getRootDir() + ": result is set to " + r, LOGGER.isLoggable(Level.FINER) ? new Exception() : null);
+            LOGGER.log(FINEST, this + " in " + getRootDir() + ": result is set to " + r, LOGGER.isLoggable(Level.FINER) ? new Exception() : null);
         }
     }
 
@@ -1592,7 +1592,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
         if(!renamingSucceeded)
             throw new IOException(rootDir+" is in use");
-        LOGGER.log(FINE, "{0}: {1} successfully deleted", new Object[] {this, rootDir});
+        LOGGER.log(FINEST, "{0}: {1} successfully deleted", new Object[] {this, rootDir});
 
         removeRunFromParent();
         }
@@ -1817,7 +1817,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
 
                     setResult(job.run(listener));
 
-                    LOGGER.log(INFO, "{0} main build action completed: {1}", new Object[] {this, result});
+                    LOGGER.log(FINEST, "{0} main build action completed: {1}", new Object[] {this, result});
                     CheckPoint.MAIN_COMPLETED.report();
                 } catch (ThreadDeath t) {
                     throw t;
@@ -1856,7 +1856,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                 // will now see this build as completed.
                 // things like triggering other builds requires this as pre-condition.
                 // see issue #980.
-                LOGGER.log(FINER, "moving into POST_PRODUCTION on {0}", this);
+                LOGGER.log(FINEST, "moving into POST_PRODUCTION on {0}", this);
                 state = State.POST_PRODUCTION;
 
                 if (listener != null) {
@@ -1962,7 +1962,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */
     private void handleFatalBuildProblem(@Nonnull BuildListener listener, @Nonnull Throwable e) {
         if(listener!=null) {
-            LOGGER.log(FINE, getDisplayName()+" failed to build",e);
+            LOGGER.log(FINEST, getDisplayName()+" failed to build",e);
 
             if(e instanceof IOException)
                 Util.displayIOException((IOException)e,listener);
@@ -1977,7 +1977,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * Called when a job started building.
      */
     protected void onStartBuilding() {
-        LOGGER.log(FINER, "moving to BUILDING on {0}", this);
+        LOGGER.log(FINEST, "moving to BUILDING on {0}", this);
         state = State.BUILDING;
         startTime = System.currentTimeMillis();
         if (runner!=null)
@@ -1991,7 +1991,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     protected void onEndBuilding() {
         // signal that we've finished building.
         state = State.COMPLETED;
-        LOGGER.log(FINER, "moving to COMPLETED on {0}", this);
+        LOGGER.log(FINEST, "moving to COMPLETED on {0}", this);
         if (runner!=null) {
             // MavenBuilds may be created without their corresponding runners.
             runner.checkpoints.allDone();

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -130,7 +130,7 @@ public abstract class Slave extends Node implements Serializable {
      * Job allocation strategy.
      */
     private Mode mode = Mode.NORMAL;
-
+    
     /**
      * Agent availability strategy.
      */
@@ -429,7 +429,7 @@ public abstract class Slave extends Node implements Serializable {
             if(res==null) {
                 throw new FileNotFoundException(name); // giving up
             } else {
-                LOGGER.log(Level.FINE, "found {0}", res);
+                LOGGER.log(Level.FINEST, "found {0}", res);
             }
             return res;
         }
@@ -444,7 +444,7 @@ public abstract class Slave extends Node implements Serializable {
                             try (JarFile jf = new JarFile(actualJar, false)) {
                                 Manifest mf = jf.getManifest();
                                 if (mf != null && mainClass.getName().equals(mf.getMainAttributes().getValue("Main-Class"))) {
-                                    LOGGER.log(Level.FINE, "found {0}", actualJar);
+                                    LOGGER.log(Level.FINEST, "found {0}", actualJar);
                                     return actualJar.toURI().toURL();
                                 }
                             }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -42,7 +42,7 @@ import jenkins.util.SystemProperties;
 import hudson.Util;
 import hudson.XmlFile;
 import static hudson.init.InitMilestone.PLUGINS_STARTED;
-import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.WARNING;
 
 import hudson.init.Initializer;
@@ -276,11 +276,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         String requiredClassName = SystemProperties.getString(UpdateCenter.class.getName()+".className", null);
         if (requiredClassName == null) {
             // Use the default Update Center
-            LOGGER.log(Level.FINE, "Using the default Update Center implementation");
+            LOGGER.log(Level.FINEST, "Using the default Update Center implementation");
             return createDefaultUpdateCenter(config);
         }
         
-        LOGGER.log(Level.FINE, "Using the custom update center: {0}", requiredClassName);
+        LOGGER.log(Level.FINEST, "Using the custom update center: {0}", requiredClassName);
         try {
             final Class<?> clazz = Class.forName(requiredClassName).asSubclass(UpdateCenter.class);
             if (!UpdateCenter.class.isAssignableFrom(clazz)) {
@@ -291,7 +291,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             final Class<? extends UpdateCenter> ucClazz = clazz.asSubclass(UpdateCenter.class);
             final Constructor<? extends UpdateCenter> defaultConstructor = ucClazz.getConstructor();
             final Constructor<? extends UpdateCenter> configConstructor = ucClazz.getConstructor(UpdateCenterConfiguration.class);
-            LOGGER.log(Level.FINE, "Using the constructor {0} Update Center configuration for {1}",
+            LOGGER.log(Level.FINEST, "Using the constructor {0} Update Center configuration for {1}",
                     new Object[] {config != null ? "with" : "without", requiredClassName});
             return config != null ? configConstructor.newInstance(config) : defaultConstructor.newInstance();
         } catch(ClassCastException e) {
@@ -661,7 +661,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             return;
         }
 
-        LOGGER.info("Scheduling the core upgrade");
+        LOGGER.finest("Scheduling the core upgrade");
         addJob(job);
         rsp.sendRedirect2(".");
     }
@@ -689,7 +689,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         synchronized (jobs) {
             if (!isRestartScheduled()) {
                 addJob(new RestartJenkinsJob(getCoreSource()));
-                LOGGER.info("Scheduling Jenkins reboot");
+                LOGGER.finest("Scheduling Jenkins reboot");
             }
         }
         response.sendRedirect2(".");
@@ -704,7 +704,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             for (UpdateCenterJob job : jobs) {
                 if (job instanceof RestartJenkinsJob) {
                     if (((RestartJenkinsJob) job).cancel()) {
-                        LOGGER.info("Scheduled Jenkins reboot unscheduled");
+                        LOGGER.finest("Scheduled Jenkins reboot unscheduled");
                     }
                 }
             }
@@ -764,7 +764,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         }
 
         HudsonDowngradeJob job = new HudsonDowngradeJob(getCoreSource(), Jenkins.getAuthentication());
-        LOGGER.info("Scheduling the core downgrade");
+        LOGGER.finest("Scheduling the core downgrade");
         addJob(job);
         rsp.sendRedirect2(".");
     }
@@ -775,7 +775,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     @RequirePOST
     public void doRestart(StaplerResponse rsp) throws IOException, ServletException {
         HudsonDowngradeJob job = new HudsonDowngradeJob(getCoreSource(), Jenkins.getAuthentication());
-        LOGGER.info("Scheduling the core downgrade");
+        LOGGER.finest("Scheduling the core downgrade");
 
         addJob(job);
         rsp.sendRedirect2(".");
@@ -1162,7 +1162,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 File dst = job.getDestination();
                 File tmp = new File(dst.getPath()+".tmp");
 
-                LOGGER.info("Downloading "+job.getName());
+                LOGGER.finest("Downloading "+job.getName());
                 Thread t = Thread.currentThread();
                 String oldName = t.getName();
                 t.setName(oldName + ": " + src);
@@ -1383,7 +1383,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
          *      {@link Future} to keeps track of the status of the execution.
          */
         public Future<UpdateCenterJob> submit() {
-            LOGGER.fine("Scheduling "+this+" to installerService");
+            LOGGER.finest("Scheduling "+this+" to installerService");
             // TODO: seems like this access to jobs should be synchronized, no?
             // It might get synch'd accidentally via the addJob method, but that wouldn't be good.
             jobs.add(this);
@@ -1495,7 +1495,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             if (ID_UPLOAD.equals(site.getId())) {
                 return;
             }
-            LOGGER.fine("Doing a connectivity check");
+            LOGGER.finest("Doing a connectivity check");
             Future<?> internetCheck = null;
             try {
                 final String connectionCheckUrl = site.getConnectionCheckUrl();
@@ -1721,11 +1721,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
 
         public void run() {
             try {
-                LOGGER.info("Starting the installation of "+getName()+" on behalf of "+getUser().getName());
+                LOGGER.finest("Starting the installation of "+getName()+" on behalf of "+getUser().getName());
 
                 _run();
 
-                LOGGER.info("Installation successful: "+getName());
+                LOGGER.finest("Installation successful: "+getName());
                 status = new Success();
                 onSuccess();
             } catch (InstallationStatus e) {
@@ -1938,7 +1938,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         }
 
         if (result512 == VerificationResult.NOT_PROVIDED && result256 == VerificationResult.NOT_PROVIDED) {
-            LOGGER.log(INFO, "Attempt to verify a downloaded file (" + file.getName() + ") using SHA-512 or SHA-256 failed since your configured update site does not provide either of those checksums. Falling back to SHA-1.");
+            LOGGER.log(FINEST, "Attempt to verify a downloaded file (" + file.getName() + ") using SHA-512 or SHA-256 failed since your configured update site does not provide either of those checksums. Falling back to SHA-1.");
         }
 
         VerificationResult result1 = verifyChecksums(entry.getSha1(), job.getComputedSHA1(), true);
@@ -2008,7 +2008,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             if (wasInstalled()) {
                 // Do this first so we can avoid duplicate downloads, too
                 // check to see if the plugin is already installed at the same version and skip it
-                LOGGER.info("Skipping duplicate install of: " + plugin.getDisplayName() + "@" + plugin.version);
+                LOGGER.finest("Skipping duplicate install of: " + plugin.getDisplayName() + "@" + plugin.version);
                 return;
             }
             try {
@@ -2039,7 +2039,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             } finally {
                 synchronized(this) {
                     // There may be other threads waiting on completion
-                    LOGGER.fine("Install complete for: " + plugin.getDisplayName() + "@" + plugin.version);
+                    LOGGER.finest("Install complete for: " + plugin.getDisplayName() + "@" + plugin.version);
                     // some status other than Installing or Downloading needs to be set here
                     // {@link #isAlreadyInstalling()}, it will be overwritten by {@link DownloadJob#run()}
                     status = new Skipped();
@@ -2067,7 +2067,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                             synchronized(ij) {
                                 if(ij.status instanceof Installing || ij.status instanceof Pending) {
                                     try {
-                                        LOGGER.fine("Waiting for other plugin install of: " + plugin.getDisplayName() + "@" + plugin.version);
+                                        LOGGER.finest("Waiting for other plugin install of: " + plugin.getDisplayName() + "@" + plugin.version);
                                         ij.wait();
                                     } catch (InterruptedException e) {
                                         throw new RuntimeException(e);
@@ -2166,11 +2166,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         @Override
         public void run() {
             try {
-                LOGGER.info("Starting the downgrade of "+getName()+" on behalf of "+getUser().getName());
+                LOGGER.finest("Starting the downgrade of "+getName()+" on behalf of "+getUser().getName());
 
                 _run();
 
-                LOGGER.info("Downgrade successful: "+getName());
+                LOGGER.finest("Downgrade successful: "+getName());
                 status = new Success();
                 onSuccess();
             } catch (Throwable e) {
@@ -2263,11 +2263,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         @Override
         public void run() {
             try {
-                LOGGER.info("Starting the downgrade of "+getName()+" on behalf of "+getUser().getName());
+                LOGGER.finest("Starting the downgrade of "+getName()+" on behalf of "+getUser().getName());
 
                 _run();
 
-                LOGGER.info("Downgrading successful: "+getName());
+                LOGGER.finest("Downgrading successful: "+getName());
                 status = new Success();
                 onSuccess();
             } catch (Throwable e) {

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -221,7 +221,7 @@ public class UpdateSite {
             }
         }
 
-        LOGGER.info("Obtained the latest update center data file for UpdateSource " + id);
+        LOGGER.finest("Obtained the latest update center data file for UpdateSource " + id);
         retryWindow = 0;
         getDataFile().write(json);
         data = new Data(o);
@@ -1341,10 +1341,10 @@ public class UpdateSite {
             for (Plugin dep : getNeededDependencies()) {
                 UpdateCenter.InstallationJob job = uc.getJob(dep);
                 if (job == null || job.status instanceof UpdateCenter.DownloadJob.Failure) {
-                    LOGGER.log(Level.INFO, "Adding dependent install of " + dep.name + " for plugin " + name);
+                    LOGGER.log(Level.FINEST, "Adding dependent install of " + dep.name + " for plugin " + name);
                     dep.deploy(dynamicLoad);
                 } else {
-                    LOGGER.log(Level.INFO, "Dependent install of " + dep.name + " for plugin " + name + " already added, skipping");
+                    LOGGER.log(Level.FINEST, "Dependent install of " + dep.name + " for plugin " + name + " already added, skipping");
                 }
             }
             PluginWrapper pw = getInstalled();

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -392,7 +392,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
 
         try {
             UserDetails userDetails = userDetailsService.loadUserByUsername(id);
-            LOGGER.log(Level.FINE, "Impersonation of the user {0} was a success", id);
+            LOGGER.log(Level.FINEST, "Impersonation of the user {0} was a success", id);
             return userDetails;
         } catch (UserMayOrMayNotExistException e) {
             LOGGER.log(Level.FINE, "The user {0} may or may not exist in the SecurityRealm, so we provide minimum access", id);
@@ -1179,7 +1179,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
             for (CanonicalIdResolver resolver : CanonicalIdResolver.all()) {
                 String id = resolver.resolveCanonicalId(idOrFullName, context);
                 if (id != null) {
-                    LOGGER.log(Level.FINE, "{0} mapped {1} to {2}", new Object[]{resolver, idOrFullName, id});
+                    LOGGER.log(Level.FINEST, "{0} mapped {1} to {2}", new Object[]{resolver, idOrFullName, id});
                     return id;
                 }
             }

--- a/core/src/main/java/hudson/model/UserIdMigrator.java
+++ b/core/src/main/java/hudson/model/UserIdMigrator.java
@@ -89,15 +89,15 @@ class UserIdMigrator {
     }
 
     void migrateUsers(UserIdMapper mapper) throws IOException {
-        LOGGER.fine("Beginning migration of users to userId mapping.");
+        LOGGER.finest("Beginning migration of users to userId mapping.");
         Map<String, File> existingUsers = scanExistingUsers();
         for (Map.Entry<String, File> existingUser : existingUsers.entrySet()) {
             File newDirectory = mapper.putIfAbsent(existingUser.getKey(), false);
-            LOGGER.log(Level.INFO, "Migrating user '" + existingUser.getKey() + "' from 'users/" + existingUser.getValue().getName() + "/' to 'users/" + newDirectory.getName() + "/'");
+            LOGGER.log(Level.FINEST, "Migrating user '" + existingUser.getKey() + "' from 'users/" + existingUser.getValue().getName() + "/' to 'users/" + newDirectory.getName() + "/'");
             Files.move(existingUser.getValue().toPath(), newDirectory.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
         mapper.save();
-        LOGGER.fine("Completed migration of users to userId mapping.");
+        LOGGER.finest("Completed migration of users to userId mapping.");
     }
 
 }

--- a/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
+++ b/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
@@ -62,7 +62,7 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
 
     @Override protected void execute(TaskListener listener) throws InterruptedException, IOException {
         if (disabled) {
-            LOGGER.fine("Disabled. Skipping execution");
+            LOGGER.finest("Disabled. Skipping execution");
             return;
         }
         List<Node> nodes = new ArrayList<>();
@@ -104,7 +104,7 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
         // One remoting can execute "exists", "lastModified", and "delete" all at once.
         // (Could even invert master loop so that one FileCallable takes care of all known items.)
         if(!dir.exists()) {
-            LOGGER.log(Level.FINE, "Directory {0} does not exist", dir);
+            LOGGER.log(Level.FINEST, "Directory {0} does not exist", dir);
             return false;
         }
 
@@ -121,15 +121,15 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
         if (item instanceof AbstractProject<?,?>) {
             AbstractProject<?,?> p = (AbstractProject<?,?>) item;
             Node lb = p.getLastBuiltOn();
-            LOGGER.log(Level.FINER, "Directory {0} is last built on {1}", new Object[] {dir, lb});
+            LOGGER.log(Level.FINEST, "Directory {0} is last built on {1}", new Object[] {dir, lb});
             if(lb!=null && lb.equals(n)) {
                 // this is the active workspace. keep it.
-                LOGGER.log(Level.FINE, "Directory {0} is the last workspace for {1}", new Object[] {dir, p});
+                LOGGER.log(Level.FINEST, "Directory {0} is the last workspace for {1}", new Object[] {dir, p});
                 return false;
             }
             
             if(!p.getScm().processWorkspaceBeforeDeletion((Job<?, ?>) p,dir,n)) {
-                LOGGER.log(Level.FINE, "Directory deletion of {0} is vetoed by SCM", dir);
+                LOGGER.log(Level.FINEST, "Directory deletion of {0} is vetoed by SCM", dir);
                 return false;
             }
         }
@@ -138,12 +138,12 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
         if (item instanceof Job<?,?>) {
             Job<?,?> j = (Job<?,?>) item;
             if (j.isBuilding()) {
-                LOGGER.log(Level.FINE, "Job {0} is building, so not deleting", item.getFullDisplayName());
+                LOGGER.log(Level.FINEST, "Job {0} is building, so not deleting", item.getFullDisplayName());
                 return false;
             }
         }
 
-        LOGGER.log(Level.FINER, "Going to delete directory {0}", dir);
+        LOGGER.log(Level.FINEST, "Going to delete directory {0}", dir);
         return true;
     }
 

--- a/core/src/main/java/hudson/node_monitors/AbstractDiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractDiskSpaceMonitor.java
@@ -47,7 +47,7 @@ public abstract class AbstractDiskSpaceMonitor extends NodeMonitor {
         if(size!=null && size.size > getThresholdBytes() && c.isOffline() && c.getOfflineCause() instanceof DiskSpace)
             if(this.getClass().equals(((DiskSpace)c.getOfflineCause()).getTrigger()))
                 if(getDescriptor().markOnline(c)) {
-                    LOGGER.info(Messages.DiskSpaceMonitor_MarkedOnline(c.getDisplayName()));
+                    LOGGER.finest(Messages.DiskSpaceMonitor_MarkedOnline(c.getDisplayName()));
                 }
         return size;
     }

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -306,7 +306,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
                 timestamp = System.currentTimeMillis();
                 record = this;
 
-                LOGGER.log(Level.FINE, "Node monitoring {0} completed in {1}ms", new Object[] {getDisplayName(), System.currentTimeMillis()-startTime});
+                LOGGER.log(Level.FINEST, "Node monitoring {0} completed in {1}ms", new Object[] {getDisplayName(), System.currentTimeMillis()-startTime});
             } catch (InterruptedException x) {
                 // interrupted by new one, fine
             } catch (Throwable t) {

--- a/core/src/main/java/hudson/os/PosixAPI.java
+++ b/core/src/main/java/hudson/os/PosixAPI.java
@@ -78,7 +78,7 @@ public class PosixAPI {
         }
 
         public void warn(WARNING_ID warning_id, String s, Object... objects) {
-            LOGGER.fine(s);
+            LOGGER.finest(s);
         }
 
         public boolean isVerbose() {

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -376,7 +376,7 @@ public class Search implements StaplerProxy {
 
         List<SearchItem> items = new ArrayList<SearchItem>(); // items found in 1 step
 
-        LOGGER.log(Level.FINE, "tokens={0}", tokens);
+        LOGGER.log(Level.FINEST, "tokens={0}", tokens);
         
         // first token
         int w=1;    // width of token
@@ -385,7 +385,7 @@ public class Search implements StaplerProxy {
             m.find(index,token,items);
             for (SearchItem si : items) {
                 paths[w].add(SuggestedItem.build(searchContext ,si));
-                LOGGER.log(Level.FINE, "found search item: {0}", si.getSearchName());
+                LOGGER.log(Level.FINEST, "found search item: {0}", si.getSearchName());
             }
             w++;
         }

--- a/core/src/main/java/hudson/security/AuthenticationProcessingFilter2.java
+++ b/core/src/main/java/hudson/security/AuthenticationProcessingFilter2.java
@@ -115,7 +115,7 @@ public class AuthenticationProcessingFilter2 extends AuthenticationProcessingFil
     @Override
     protected void onUnsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
         super.onUnsuccessfulAuthentication(request, response, failed);
-        LOGGER.log(Level.FINE, "Login attempt failed", failed);
+        LOGGER.log(Level.FINEST, "Login attempt failed", failed);
         Authentication auth = failed.getAuthentication();
         if (auth != null) {
             SecurityListener.fireFailedToLogIn(auth.getName());

--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -98,7 +98,7 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
         BulkChange bc = new BulkChange(Jenkins.getInstance());
         try{
             boolean result = configure(req, req.getSubmittedForm());
-            LOGGER.log(Level.FINE, "security saved: "+result);
+            LOGGER.log(Level.FINEST, "security saved: "+result);
             Jenkins.getInstance().save();
             FormApply.success(req.getContextPath()+"/manage").generateResponse(req, rsp, null);
         } finally {

--- a/core/src/main/java/hudson/security/HudsonFilter.java
+++ b/core/src/main/java/hudson/security/HudsonFilter.java
@@ -107,11 +107,11 @@ public class HudsonFilter implements Filter {
             Jenkins hudson = Jenkins.getInstanceOrNull();
             if (hudson != null) {
                 // looks like we are initialized after Hudson came into being. initialize it now. See #3069
-                LOGGER.fine("Security wasn't initialized; Initializing it...");
+                LOGGER.finest("Security wasn't initialized; Initializing it...");
                 SecurityRealm securityRealm = hudson.getSecurityRealm();
                 reset(securityRealm);
-                LOGGER.fine("securityRealm is " + securityRealm);
-                LOGGER.fine("Security initialized");
+                LOGGER.finest("securityRealm is " + securityRealm);
+                LOGGER.finest("Security initialized");
             }
         } catch (ExceptionInInitializerError e) {
             // see HUDSON-4592. In some containers this happens before

--- a/core/src/main/java/hudson/slaves/ChannelPinger.java
+++ b/core/src/main/java/hudson/slaves/ChannelPinger.java
@@ -113,7 +113,7 @@ public class ChannelPinger extends ComputerListener {
         // both sides can notice it and take compensation actions.
         try {
             channel.call(new SetUpRemotePing(pingTimeoutSeconds, pingIntervalSeconds));
-            LOGGER.fine("Set up a remote ping for " + channel.getName());
+            LOGGER.finest("Set up a remote ping for " + channel.getName());
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to set up a ping for " + channel.getName(), e);
         }
@@ -183,7 +183,7 @@ public class ChannelPinger extends ComputerListener {
     @VisibleForTesting
     @Restricted(NoExternalUse.class)
     public static void setUpPingForChannel(final Channel channel, final SlaveComputer computer, int timeoutSeconds, int intervalSeconds, final boolean analysis) {
-        LOGGER.log(Level.FINE, "setting up ping on {0} with a {1} seconds interval and {2} seconds timeout", new Object[] {channel.getName(), intervalSeconds, timeoutSeconds});
+        LOGGER.log(Level.FINEST, "setting up ping on {0} with a {1} seconds interval and {2} seconds timeout", new Object[] {channel.getName(), intervalSeconds, timeoutSeconds});
         final AtomicBoolean isInClosed = new AtomicBoolean(false);
         final PingThread t = new PingThread(channel, TimeUnit.SECONDS.toMillis(timeoutSeconds), TimeUnit.SECONDS.toMillis(intervalSeconds)) {
             @Override
@@ -198,9 +198,9 @@ public class ChannelPinger extends ComputerListener {
                         computer.disconnect(new OfflineCause.ChannelTermination(exception));
                     }
                     if (inClosed) {
-                        LOGGER.log(Level.FINE,"Ping failed after the channel "+channel.getName()+" is already partially closed.",cause);
+                        LOGGER.log(Level.FINEST,"Ping failed after the channel "+channel.getName()+" is already partially closed.",cause);
                     } else {
-                        LOGGER.log(Level.INFO,"Ping failed. Terminating the channel "+channel.getName()+".",cause);
+                        LOGGER.log(Level.FINEST,"Ping failed. Terminating the channel "+channel.getName()+".",cause);
                     }
             }
             /** Keep in a separate method so we do not even try to do class loading on {@link PingFailureAnalyzer} from an agent JVM. */
@@ -223,14 +223,14 @@ public class ChannelPinger extends ComputerListener {
         channel.addListener(new Channel.Listener() {
             @Override
             public void onClosed(Channel channel, IOException cause) {
-                LOGGER.fine("Terminating ping thread for " + channel.getName());
+                LOGGER.finest("Terminating ping thread for " + channel.getName());
                 isInClosed.set(true);
                 t.interrupt();  // make sure the ping thread is terminated
             }
         });
 
         t.start();
-        LOGGER.log(Level.FINE, "Ping thread started for {0} with a {1} seconds interval and a {2} seconds timeout",
+        LOGGER.log(Level.FINEST, "Ping thread started for {0} with a {1} seconds interval and a {2} seconds timeout",
                    new Object[] { channel, intervalSeconds, timeoutSeconds });
     }
 }

--- a/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
@@ -54,7 +54,7 @@ public class CloudRetentionStrategy extends RetentionStrategy<AbstractCloudCompu
         if (c.isIdle() && !disabled && computerNode != null) {
             final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
             if (idleMilliseconds > MINUTES.toMillis(idleMinutes)) {
-                LOGGER.log(Level.INFO, "Disconnecting {0}", c.getName());
+                LOGGER.log(Level.FINEST, "Disconnecting {0}", c.getName());
                 try {
                     computerNode.terminate();
                 } catch (InterruptedException | IOException e) {

--- a/core/src/main/java/hudson/slaves/ConnectionActivityMonitor.java
+++ b/core/src/main/java/hudson/slaves/ConnectionActivityMonitor.java
@@ -67,7 +67,7 @@ public class ConnectionActivityMonitor extends AsyncPeriodicWork {
                     Long lastPing = (Long)channel.getProperty(ConnectionActivityMonitor.class);
 
                     if (lastPing!=null && now-lastPing > TIMEOUT) {
-                        LOGGER.info("Repeated ping attempts failed on "+c.getName()+". Disconnecting");
+                        LOGGER.finest("Repeated ping attempts failed on "+c.getName()+". Disconnecting");
                         c.disconnect(OfflineCause.create(Messages._ConnectionActivityMonitor_OfflineCause()));
                     } else {
                         // send a ping. if we receive a reply, it will be reflected in the next getLastHeard() call.

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -239,7 +239,7 @@ public class NodeProvisioner {
 
                                     try {
                                         jenkins.addNode(node);
-                                        LOGGER.log(Level.INFO,
+                                        LOGGER.log(Level.FINEST,
                                                 "{0} provisioning successfully completed. "
                                                         + "We have now {1,number,integer} computer(s)",
                                                 new Object[]{f.displayName, jenkins.getComputers().length});
@@ -300,7 +300,7 @@ public class NodeProvisioner {
                     int queueLengthSnapshot = snapshot.getQueueLength();
 
                     if (queueLengthSnapshot <= availableSnapshot) {
-                        LOGGER.log(Level.FINER,
+                        LOGGER.log(Level.FINEST,
                                 "Queue length {0} is less than the available capacity {1}. No provisioning strategy required",
                                 new Object[]{queueLengthSnapshot, availableSnapshot});
                         provisioningState = null;
@@ -315,10 +315,10 @@ public class NodeProvisioner {
                 for (Strategy strategy : strategies.isEmpty()
                         ? Collections.<Strategy>singletonList(new StandardStrategyImpl())
                         : strategies) {
-                    LOGGER.log(Level.FINER, "Consulting {0} provisioning strategy with state {1}",
+                    LOGGER.log(Level.FINEST, "Consulting {0} provisioning strategy with state {1}",
                             new Object[]{strategy, provisioningState});
                     if (StrategyDecision.PROVISIONING_COMPLETED == strategy.apply(provisioningState)) {
-                        LOGGER.log(Level.FINER, "Provisioning strategy {0} declared provisioning complete",
+                        LOGGER.log(Level.FINEST, "Provisioning strategy {0} declared provisioning complete",
                                 strategy);
                         break;
                     }
@@ -677,7 +677,7 @@ public class NodeProvisioner {
                 }
                 float m = calcThresholdMargin(state.getTotalSnapshot());
                 if (excessWorkload > 1 - m) {// and there's more work to do...
-                    LOGGER.log(Level.FINE, "Excess workload {0,number,#.###} detected. "
+                    LOGGER.log(Level.FINEST, "Excess workload {0,number,#.###} detected. "
                                     + "(planned capacity={1,number,#.###},connecting capacity={7,number,#.###},"
                                     + "Qlen={2,number,#.###},available={3,number,#.###}&{4,number,integer},"
                                     + "online={5,number,integer},m={6,number,#.###})",
@@ -718,7 +718,7 @@ public class NodeProvisioner {
 
                             for (PlannedNode ac : additionalCapacities) {
                                 excessWorkload -= ac.numExecutors;
-                                LOGGER.log(Level.INFO, "Started provisioning {0} from {1} with {2,number,integer} "
+                                LOGGER.log(Level.FINEST, "Started provisioning {0} from {1} with {2,number,integer} "
                                                 + "executors. Remaining excess workload: {3,number,#.###}",
                                         new Object[]{ac.displayName, c.name, ac.numExecutors, excessWorkload});
                             }

--- a/core/src/main/java/hudson/slaves/RetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/RetentionStrategy.java
@@ -256,7 +256,7 @@ public abstract class RetentionStrategy<T extends Computer> extends AbstractDesc
 
                 if (needComputer) {
                     // we've been in demand for long enough
-                    logger.log(Level.INFO, "Launching computer {0} as it has been in demand for {1}",
+                    logger.log(Level.FINEST, "Launching computer {0} as it has been in demand for {1}",
                             new Object[]{c.getName(), Util.getTimeSpanString(demandMilliseconds)});
                     c.connect(false);
                 }
@@ -264,7 +264,7 @@ public abstract class RetentionStrategy<T extends Computer> extends AbstractDesc
                 final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
                 if (idleMilliseconds > TimeUnit.MINUTES.toMillis(idleDelay)) {
                     // we've been idle for long enough
-                    logger.log(Level.INFO, "Disconnecting computer {0} as it has been idle for {1}",
+                    logger.log(Level.FINEST, "Disconnecting computer {0} as it has been idle for {1}",
                             new Object[]{c.getName(), Util.getTimeSpanString(idleMilliseconds)});
                     c.disconnect(new OfflineCause.IdleOfflineCause());
                 } else {

--- a/core/src/main/java/hudson/slaves/SimpleScheduledRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/SimpleScheduledRetentionStrategy.java
@@ -36,6 +36,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.concurrent.GuardedBy;
+
+import static java.util.logging.Level.FINEST;
+
 import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.util.Calendar;
@@ -43,7 +46,6 @@ import java.util.GregorianCalendar;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import static java.util.logging.Level.INFO;
 
 /**
  * {@link RetentionStrategy} that controls the agent based on a schedule.
@@ -168,10 +170,10 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
     @GuardedBy("hudson.model.Queue.lock")
     public synchronized long check(final SlaveComputer c) {
         boolean shouldBeOnline = isOnlineScheduled();
-        LOGGER.log(Level.FINE, "Checking computer {0} against schedule. online = {1}, shouldBeOnline = {2}",
+        LOGGER.log(Level.FINEST, "Checking computer {0} against schedule. online = {1}, shouldBeOnline = {2}",
                 new Object[]{c.getName(), c.isOnline(), shouldBeOnline});
         if (shouldBeOnline && c.isOffline()) {
-            LOGGER.log(INFO, "Trying to launch computer {0} as schedule says it should be on-line at "
+            LOGGER.log(FINEST, "Trying to launch computer {0} as schedule says it should be on-line at "
                     + "this point in time", new Object[]{c.getName()});
             if (c.isLaunchSupported()) {
                 Computer.threadPoolForRemoting.submit(new Runnable() {
@@ -179,10 +181,10 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
                         try {
                             c.connect(true).get();
                             if (c.isOnline()) {
-                                LOGGER.log(INFO, "Launched computer {0} per schedule", new Object[]{c.getName()});
+                                LOGGER.log(FINEST, "Launched computer {0} per schedule", new Object[]{c.getName()});
                             }
                             if (keepUpWhenActive && c.isOnline() && !c.isAcceptingTasks()) {
-                                LOGGER.log(INFO,
+                                LOGGER.log(FINEST,
                                         "Enabling new jobs for computer {0} as it has started its scheduled uptime",
                                         new Object[]{c.getName()});
                                 c.setAcceptingTasks(true);
@@ -196,7 +198,7 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
             if (keepUpWhenActive) {
                 if (!c.isIdle() && c.isAcceptingTasks()) {
                     c.setAcceptingTasks(false);
-                    LOGGER.log(INFO,
+                    LOGGER.log(FINEST,
                             "Disabling new jobs for computer {0} as it has finished its scheduled uptime",
                             new Object[]{c.getName()});
                     return 1;
@@ -205,7 +207,7 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
                         @Override
                         public void run() {
                             if (c.isIdle()) {
-                                LOGGER.log(INFO, "Disconnecting computer {0} as it has finished its scheduled uptime",
+                                LOGGER.log(FINEST, "Disconnecting computer {0} as it has finished its scheduled uptime",
                                         new Object[]{c.getName()});
                                 c.disconnect(OfflineCause
                                         .create(Messages._SimpleScheduledRetentionStrategy_FinishedUpTime()));
@@ -219,7 +221,7 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
                         @Override
                         public void run() {
                             if (c.isIdle()) {
-                                LOGGER.log(INFO, "Disconnecting computer {0} as it has finished all jobs running when "
+                                LOGGER.log(FINEST, "Disconnecting computer {0} as it has finished all jobs running when "
                                         + "it completed its scheduled uptime", new Object[]{c.getName()});
                                 c.disconnect(OfflineCause
                                         .create(Messages._SimpleScheduledRetentionStrategy_FinishedUpTime()));
@@ -229,7 +231,7 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
                 }
             } else {
                 // no need to get the queue lock as the user has selected the break builds option!
-                LOGGER.log(INFO, "Disconnecting computer {0} as it has finished its scheduled uptime",
+                LOGGER.log(FINEST, "Disconnecting computer {0} as it has finished its scheduled uptime",
                         new Object[]{c.getName()});
                 c.disconnect(OfflineCause.create(Messages._SimpleScheduledRetentionStrategy_FinishedUpTime()));
             }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -275,7 +275,7 @@ public class SlaveComputer extends Computer {
         if(!forceReconnect && isConnecting())
             return lastConnectActivity;
         if(forceReconnect && isConnecting())
-            logger.fine("Forcing a reconnect on "+getName());
+            logger.finest("Forcing a reconnect on "+getName());
 
         closeChannel();
         return lastConnectActivity = Computer.threadPoolForRemoting.submit(new java.util.concurrent.Callable<Object>() {
@@ -771,7 +771,7 @@ public class SlaveComputer extends Computer {
         numRetryAttempt++;
         if(numRetryAttempt<6 || (numRetryAttempt%12)==0) {
             // initially retry several times quickly, and after that, do it infrequently.
-            logger.info("Attempting to reconnect "+nodeName);
+            logger.finest("Attempting to reconnect "+nodeName);
             connect(true);
         }
     }

--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -110,7 +110,7 @@ public class LogRotator extends BuildDiscarder {
 
     @SuppressWarnings("rawtypes")
     public void perform(Job<?,?> job) throws IOException, InterruptedException {
-        LOGGER.log(FINE, "Running the log rotation for {0} with numToKeep={1} daysToKeep={2} artifactNumToKeep={3} artifactDaysToKeep={4}", new Object[] {job, numToKeep, daysToKeep, artifactNumToKeep, artifactDaysToKeep});
+        LOGGER.log(FINEST, "Running the log rotation for {0} with numToKeep={1} daysToKeep={2} artifactNumToKeep={3} artifactDaysToKeep={4}", new Object[] {job, numToKeep, daysToKeep, artifactNumToKeep, artifactDaysToKeep});
         
         // always keep the last successful and the last stable builds
         Run lsb = job.getLastSuccessfulBuild();
@@ -127,7 +127,7 @@ public class LogRotator extends BuildDiscarder {
                 if (shouldKeepRun(r, lsb, lstb)) {
                     continue;
                 }
-                LOGGER.log(FINE, "{0} is to be removed", r);
+                LOGGER.log(FINEST, "{0} is to be removed", r);
                 r.delete();
             }
         }
@@ -141,7 +141,7 @@ public class LogRotator extends BuildDiscarder {
                     break;
                 }
                 if (!shouldKeepRun(r, lsb, lstb)) {
-                    LOGGER.log(FINE, "{0} is to be removed", r);
+                    LOGGER.log(FINEST, "{0} is to be removed", r);
                     r.delete();
                 }
                 r = r.getNextBuild();
@@ -154,7 +154,7 @@ public class LogRotator extends BuildDiscarder {
                 if (shouldKeepRun(r, lsb, lstb)) {
                     continue;
                 }
-                LOGGER.log(FINE, "{0} is to be purged of artifacts", r);
+                LOGGER.log(FINEST, "{0} is to be purged of artifacts", r);
                 r.deleteArtifacts();
             }
         }
@@ -168,7 +168,7 @@ public class LogRotator extends BuildDiscarder {
                     break;
                 }
                 if (!shouldKeepRun(r, lsb, lstb)) {
-                    LOGGER.log(FINE, "{0} is to be purged of artifacts", r);
+                    LOGGER.log(FINEST, "{0} is to be purged of artifacts", r);
                     r.deleteArtifacts();
                 }
                 r = r.getNextBuild();
@@ -178,19 +178,19 @@ public class LogRotator extends BuildDiscarder {
 
     private boolean shouldKeepRun(Run r, Run lsb, Run lstb) {
         if (r.isKeepLog()) {
-            LOGGER.log(FINER, "{0} is not to be removed or purged of artifacts because it’s marked as a keeper", r);
+            LOGGER.log(FINEST, "{0} is not to be removed or purged of artifacts because it’s marked as a keeper", r);
             return true;
         }
         if (r == lsb) {
-            LOGGER.log(FINER, "{0} is not to be removed or purged of artifacts because it’s the last successful build", r);
+            LOGGER.log(FINEST, "{0} is not to be removed or purged of artifacts because it’s the last successful build", r);
             return true;
         }
         if (r == lstb) {
-            LOGGER.log(FINER, "{0} is not to be removed or purged of artifacts because it’s the last stable build", r);
+            LOGGER.log(FINEST, "{0} is not to be removed or purged of artifacts because it’s the last stable build", r);
             return true;
         }
         if (r.isBuilding()) {
-            LOGGER.log(FINER, "{0} is not to be removed or purged of artifacts because it’s still building", r);
+            LOGGER.log(FINEST, "{0} is not to be removed or purged of artifacts because it’s still building", r);
             return true;
         }
         return false;
@@ -198,7 +198,7 @@ public class LogRotator extends BuildDiscarder {
 
     private boolean tooNew(Run r, Calendar cal) {
         if (!r.getTimestamp().before(cal)) {
-            LOGGER.log(FINER, "{0} is not to be removed or purged of artifacts because it’s still new", r);
+            LOGGER.log(FINEST, "{0} is not to be removed or purged of artifacts because it’s still new", r);
             return true;
         } else {
             return false;

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -177,16 +177,16 @@ public class SCMTrigger extends Trigger<Item> {
 
         DescriptorImpl d = getDescriptor();
 
-        LOGGER.fine("Scheduling a polling for "+job);
+        LOGGER.finest("Scheduling a polling for "+job);
         if (d.synchronousPolling) {
-        	LOGGER.fine("Running the trigger directly without threading, " +
+        	LOGGER.finest("Running the trigger directly without threading, " +
         			"as it's already taken care of by Trigger.Cron");
             new Runner(additionalActions).run();
         } else {
             // schedule the polling.
             // even if we end up submitting this too many times, that's OK.
             // the real exclusion control happens inside Runner.
-        	LOGGER.fine("scheduling the trigger to (asynchronously) run");
+        	LOGGER.finest("scheduling the trigger to (asynchronously) run");
             d.queue.execute(new Runner(additionalActions));
             d.clogCheck();
         }
@@ -636,7 +636,7 @@ public class SCMTrigger extends Trigger<Item> {
                     LOGGER.log(Level.SEVERE, "Failed to record SCM polling for " + job, e);
                 }
 
-                LOGGER.log(Level.FINE, "Skipping polling for {0} due to veto from {1}",
+                LOGGER.log(Level.FINEST, "Skipping polling for {0} due to veto from {1}",
                         new Object[]{job.getFullDisplayName(), veto}
                 );
                 return;
@@ -660,9 +660,9 @@ public class SCMTrigger extends Trigger<Item> {
                     queueActions[0] = new CauseAction(cause);
                     System.arraycopy(additionalActions, 0, queueActions, 1, additionalActions.length);
                     if (p.scheduleBuild2(p.getQuietPeriod(), queueActions) != null) {
-                        LOGGER.info("SCM changes detected in "+ job.getFullDisplayName()+". Triggering "+name);
+                        LOGGER.finest("SCM changes detected in "+ job.getFullDisplayName()+". Triggering "+name);
                     } else {
-                        LOGGER.info("SCM changes detected in "+ job.getFullDisplayName()+". Job is already in the queue");
+                        LOGGER.finest("SCM changes detected in "+ job.getFullDisplayName()+". Job is already in the queue");
                     }
                 }
             } finally {

--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -221,7 +221,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
 
         public void doRun() {
             while(new Date().getTime() >= cal.getTimeInMillis()) {
-                LOGGER.log(Level.FINE, "cron checking {0}", cal.getTime());
+                LOGGER.log(Level.FINEST, "cron checking {0}", cal.getTime());
                 try {
                     checkTriggers(cal);
                 } catch (Throwable e) {
@@ -242,7 +242,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
         // Are we using synchronous polling?
         SCMTrigger.DescriptorImpl scmd = inst.getDescriptorByType(SCMTrigger.DescriptorImpl.class);
         if (scmd.synchronousPolling) {
-            LOGGER.fine("using synchronous polling");
+            LOGGER.finest("using synchronous polling");
 
             // Check that previous synchronous polling job is done to prevent piling up too many jobs
             if (previousSynchronousPolling == null || previousSynchronousPolling.isDone()) {
@@ -254,14 +254,14 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
                     public void run(AbstractProject p) {
                         for (Trigger t : (Collection<Trigger>) p.getTriggers().values()) {
                             if (t instanceof SCMTrigger) {
-                                LOGGER.fine("synchronously triggering SCMTrigger for project " + t.job.getName());
+                                LOGGER.finest("synchronously triggering SCMTrigger for project " + t.job.getName());
                                 t.run();
                             }
                         }
                     }
                 }));
             } else {
-                LOGGER.fine("synchronous polling has detected unfinished jobs, will not trigger additional jobs.");
+                LOGGER.finest("synchronous polling has detected unfinished jobs, will not trigger additional jobs.");
             }
         }
 
@@ -270,7 +270,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
             for (Trigger t : p.getTriggers().values()) {
                 if (!(t instanceof SCMTrigger && scmd.synchronousPolling)) {
                     if (t !=null && t.spec != null && t.tabs != null) {
-                        LOGGER.log(Level.FINE, "cron checking {0} with spec ‘{1}’", new Object[]{p, t.spec.trim()});
+                        LOGGER.log(Level.FINEST, "cron checking {0} with spec ‘{1}’", new Object[]{p, t.spec.trim()});
 
                         if (t.tabs.check(cal)) {
                             LOGGER.log(Level.CONFIG, "cron triggered {0}", p);
@@ -282,7 +282,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
                                 LOGGER.log(Level.WARNING, t.getClass().getName() + ".run() failed for " + p, e);
                             }
                         } else {
-                            LOGGER.log(Level.FINER, "did not trigger {0}", p);
+                            LOGGER.log(Level.FINEST, "did not trigger {0}", p);
                         }
                     } else {
                         LOGGER.log(Level.WARNING, "The job {0} has a syntactically incorrect config and is missing the cron spec for a trigger", p.getFullName());

--- a/core/src/main/java/hudson/util/CharacterEncodingFilter.java
+++ b/core/src/main/java/hudson/util/CharacterEncodingFilter.java
@@ -58,13 +58,13 @@ public class CharacterEncodingFilter implements Filter {
             = SystemProperties.getBoolean(CharacterEncodingFilter.class.getName() + ".forceEncoding");
 
     public void init(FilterConfig filterConfig) throws ServletException {
-        LOGGER.log(Level.FINE,
+        LOGGER.log(Level.FINEST,
                 "CharacterEncodingFilter initialized. DISABLE_FILTER: {0} FORCE_ENCODING: {1}",
                 new Object[]{DISABLE_FILTER, FORCE_ENCODING});
     }
 
     public void destroy() {
-        LOGGER.fine("CharacterEncodingFilter destroyed.");
+        LOGGER.finest("CharacterEncodingFilter destroyed.");
     }
 
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -167,7 +167,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
      * Either of the parameter can be null.
      */
     public void killAll(Process proc, Map<String, String> modelEnvVars) throws InterruptedException {
-        LOGGER.fine("killAll: process="+proc+" and envs="+modelEnvVars);
+        LOGGER.finest("killAll: process="+proc+" and envs="+modelEnvVars);
         OSProcess p = get(proc);
         if(p!=null) p.killRecursively();
         if(modelEnvVars!=null)
@@ -518,7 +518,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             if (getVeto() != null) 
                 return;
 
-            LOGGER.log(FINER, "Killing recursively {0}", getPid());
+            LOGGER.log(FINEST, "Killing recursively {0}", getPid());
             // Firstly try to kill the root process gracefully, then do a forcekill if it does not help (algorithm is described in JENKINS-17116)
             killSoftly();
             p.killRecursively();
@@ -531,7 +531,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 return;
             }
             
-            LOGGER.log(FINER, "Killing {0}", getPid());
+            LOGGER.log(FINEST, "Killing {0}", getPid());
             // Firstly try to kill it gracefully, then do a forcekill if it does not help (algorithm is described in JENKINS-17116)
             killSoftly();
             p.kill();
@@ -722,7 +722,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 }
             });
             if(processes==null) {
-                LOGGER.info("No /proc");
+                LOGGER.finest("No /proc");
                 return;
             }
 
@@ -771,7 +771,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 return;
             try {
                 int pid = getPid();
-                LOGGER.fine("Killing pid="+pid);
+                LOGGER.finest("Killing pid="+pid);
                 UnixReflection.destroy(pid);
                 // after sending SIGTERM, wait for the process to cease to exist
                 int sleepTime = 10; // initially we sleep briefly, then sleep up to 1sec
@@ -807,7 +807,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
 
         private void killRecursively(long deadline) throws InterruptedException {
             // We kill individual processes of a tree, so handling vetoes inside #kill() is enough for UnixProcess es
-            LOGGER.fine("Recursively killing pid="+getPid());
+            LOGGER.finest("Recursively killing pid="+getPid());
             for (OSProcess p : getChildren()) {
                 if (p instanceof UnixProcess) {
                     ((UnixProcess)p).killRecursively(deadline);
@@ -1631,7 +1631,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 }
 
                 int count = size.getValue()/sizeOf_kinfo_proc;
-                LOGGER.fine("Found "+count+" processes");
+                LOGGER.finest("Found "+count+" processes");
 
                 for( int base=0; base<size.getValue(); base+=sizeOf_kinfo_proc) {
                     int pid = m.getInt(base+ kinfo_proc_pid_offset);

--- a/core/src/main/java/hudson/util/Retrier.java
+++ b/core/src/main/java/hudson/util/Retrier.java
@@ -81,7 +81,7 @@ public class Retrier <V>{
             if (!success) {
                 if (currentAttempt < attempts) {
                     LOGGER.log(Level.WARNING, Messages.Retrier_AttemptFailed(currentAttempt, action));
-                    LOGGER.log(Level.FINE, Messages.Retrier_Sleeping(delay, action));
+                    LOGGER.log(Level.FINEST, Messages.Retrier_Sleeping(delay, action));
                     try {
                         Thread.sleep(delay);
                     } catch (InterruptedException ie) {
@@ -91,10 +91,10 @@ public class Retrier <V>{
                     }
                 } else {
                     // Failed to perform the action
-                    LOGGER.log(Level.INFO, Messages.Retrier_NoSuccess(action, attempts));
+                    LOGGER.log(Level.FINEST, Messages.Retrier_NoSuccess(action, attempts));
                 }
             } else {
-                LOGGER.log(Level.INFO, Messages.Retrier_Success(action, currentAttempt));
+                LOGGER.log(Level.FINEST, Messages.Retrier_Success(action, currentAttempt));
             }
         }
 

--- a/core/src/main/java/hudson/util/RobustReflectionConverter.java
+++ b/core/src/main/java/hudson/util/RobustReflectionConverter.java
@@ -41,6 +41,9 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.mapper.Mapper;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.Saveable;
+
+import static java.util.logging.Level.FINEST;
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -52,7 +55,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import static java.util.logging.Level.FINE;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
@@ -373,7 +375,7 @@ public class RobustReflectionConverter implements Converter {
     }
 
     public static void addErrorInContext(UnmarshallingContext context, Throwable e) {
-        LOGGER.log(FINE, "Failed to load", e);
+        LOGGER.log(FINEST, "Failed to load", e);
         ArrayList<Throwable> list = (ArrayList<Throwable>)context.get("ReadError");
         if (list == null)
             context.put("ReadError", list = new ArrayList<>());

--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -198,7 +198,7 @@ public class XStream2 extends XStream {
                         }
                         v = null;
                     }
-                    LOGGER.log(Level.FINE, "JENKINS-21017: nulling out {0} in {1}", new Object[] {f, o});
+                    LOGGER.log(Level.FINEST, "JENKINS-21017: nulling out {0} in {1}", new Object[] {f, o});
                     Fields.write(f, o, v);
                 });
             }

--- a/core/src/main/java/jenkins/diagnosis/HsErrPidList.java
+++ b/core/src/main/java/jenkins/diagnosis/HsErrPidList.java
@@ -100,7 +100,7 @@ public class HsErrPidList extends AdministrativeMonitor {
 
 
     private void scan(String pattern) {
-        LOGGER.fine("Scanning "+pattern+" for hs_err_pid files");
+        LOGGER.finest("Scanning "+pattern+" for hs_err_pid files");
 
         pattern = pattern.replace("%p","*").replace("%%","%");
         File f = new File(pattern).getAbsoluteFile();
@@ -125,7 +125,7 @@ public class HsErrPidList extends AdministrativeMonitor {
     }
 
     private void scanFile(File log) {
-        LOGGER.fine("Scanning "+log);
+        LOGGER.finest("Scanning "+log);
 
         try (Reader rawReader = new FileReader(log);
              BufferedReader r = new BufferedReader(rawReader)) {

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -315,7 +315,7 @@ public class InstallUtil {
 		installingPluginsFile.delete();
 		return;
 	}
-	LOGGER.fine("Writing install state to: " + installingPluginsFile.getAbsolutePath());
+	LOGGER.finest("Writing install state to: " + installingPluginsFile.getAbsolutePath());
 	Map<String,String> statuses = new HashMap<>();
 	for(UpdateCenterJob j : installingPlugins) {
 		if(j instanceof InstallationJob && j.getCorrelationId() != null) { // only include install jobs with a correlation id (directly selected)

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -145,7 +145,7 @@ public class SetupWizard extends PageDecorator {
             if(iapf.exists()) {
                 String setupKey = iapf.readToString().trim();
                 String ls = System.lineSeparator();
-                LOGGER.info(ls + ls + "*************************************************************" + ls
+                LOGGER.finest(ls + ls + "*************************************************************" + ls
                         + "*************************************************************" + ls
                         + "*************************************************************" + ls
                         + ls
@@ -343,7 +343,7 @@ public class SetupWizard extends PageDecorator {
     }
     
     private void useRootUrl(Map<String, String> errors, @CheckForNull String rootUrl){
-        LOGGER.log(Level.FINE, "Root URL set during SetupWizard to {0}", new Object[]{ rootUrl });
+        LOGGER.log(Level.FINEST, "Root URL set during SetupWizard to {0}", new Object[]{ rootUrl });
         JenkinsLocationConfiguration.getOrDie().setUrl(rootUrl);
     }
 

--- a/core/src/main/java/jenkins/install/UpgradeWizard.java
+++ b/core/src/main/java/jenkins/install/UpgradeWizard.java
@@ -1,6 +1,6 @@
 package jenkins.install;
 
-import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
 
 import java.io.File;
 import java.io.IOException;
@@ -162,7 +162,7 @@ public class UpgradeWizard extends InstallState {
         File f = SetupWizard.getUpdateStateFile();
         FileUtils.touch(f);
         f.setLastModified(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));
-        LOGGER.log(FINE, "Snoozed the upgrade wizard notice");
+        LOGGER.log(FINEST, "Snoozed the upgrade wizard notice");
         return HttpResponses.redirectToContextRoot();
     }
     

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1002,12 +1002,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     LOGGER.log(Level.WARNING, null, x);
                 }
                 if (LOG_STARTUP_PERFORMANCE)
-                    LOGGER.info(String.format("Took %dms for item listener %s startup",
+                    LOGGER.finest(String.format("Took %dms for item listener %s startup",
                             System.currentTimeMillis()-itemListenerStart,l.getClass().getName()));
             }
 
             if (LOG_STARTUP_PERFORMANCE)
-                LOGGER.info(String.format("Took %dms for complete Jenkins startup",
+                LOGGER.finest(String.format("Took %dms for complete Jenkins startup",
                         System.currentTimeMillis()-start));
 
             STARTUP_MARKER_FILE.on();
@@ -1095,7 +1095,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     long start = System.currentTimeMillis();
                     super.runTask(task);
                     if(LOG_STARTUP_PERFORMANCE)
-                        LOGGER.info(String.format("Took %dms for %s by %s",
+                        LOGGER.finest(String.format("Took %dms for %s by %s",
                                 System.currentTimeMillis()-start, taskName, name));
                 } catch (Exception | Error x) {
                     if (containsLinkageError(x)) {
@@ -2525,11 +2525,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             if (filter == null) {
                 // Fix for #3069: This filter is not necessarily initialized before the servlets.
                 // when HudsonFilter does come back, it'll initialize itself.
-                LOGGER.fine("HudsonFilter has not yet been initialized: Can't perform security setup for now");
+                LOGGER.finest("HudsonFilter has not yet been initialized: Can't perform security setup for now");
             } else {
-                LOGGER.fine("HudsonFilter has been previously initialized: Setting security up");
+                LOGGER.finest("HudsonFilter has been previously initialized: Setting security up");
                 filter.reset(securityRealm);
-                LOGGER.fine("Security is now fully set up");
+                LOGGER.finest("Security is now fully set up");
             }
             if (!oldUserIdStrategy.equals(this.securityRealm.getUserIdStrategy())) {
                 User.rekey();
@@ -3065,7 +3065,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             buildsDir = newBuildsDir;
             mustSave = true;
         } else if (!isDefaultBuildDir()) {
-            LOGGER.log(Level.INFO, "Using non default builds directories: {0}.", buildsDir);
+            LOGGER.log(Level.FINEST, "Using non default builds directories: {0}.", buildsDir);
         }
 
         String newWorkspacesDir = SystemProperties.getString(WORKSPACES_DIR_PROP);
@@ -3076,7 +3076,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             workspaceDir = newWorkspacesDir;
             mustSave = true;
         } else if (!isDefaultWorkspaceDir()) {
-            LOGGER.log(Level.INFO, "Using non default workspaces directories: {0}.", workspaceDir);
+            LOGGER.log(Level.FINEST, "Using non default workspaces directories: {0}.", workspaceDir);
         }
 
         if (mustSave) {
@@ -3253,10 +3253,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         if(BulkChange.contains(this))   return;
 
         if (initLevel == InitMilestone.COMPLETED) {
-            LOGGER.log(FINE, "setting version {0} to {1}", new Object[] {version, VERSION});
+            LOGGER.log(FINEST, "setting version {0} to {1}", new Object[] {version, VERSION});
             version = VERSION;
         } else {
-            LOGGER.log(FINE, "refusing to set version {0} to {1} during {2}", new Object[] {version, VERSION, initLevel});
+            LOGGER.log(FINEST, "refusing to set version {0} to {1} during {2}", new Object[] {version, VERSION, initLevel});
         }
 
         getConfigFile().write(this);
@@ -3288,7 +3288,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             cleanUpStarted = true;
         }
         try {
-            LOGGER.log(Level.INFO, "Stopping Jenkins");
+            LOGGER.log(Level.FINEST, "Stopping Jenkins");
 
             final List<Throwable> errors = new ArrayList<>();
 
@@ -3324,7 +3324,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
             _cleanUpReleaseAllLoggers(errors);
 
-            LOGGER.log(Level.INFO, "Jenkins stopped");
+            LOGGER.log(Level.FINEST, "Jenkins stopped");
 
             if (!errors.isEmpty()) {
                 StringBuilder message = new StringBuilder("Unexpected issues encountered during cleanUp: ");
@@ -3351,7 +3351,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     private void fireBeforeShutdown(List<Throwable> errors) {
-        LOGGER.log(Level.FINE, "Notifying termination");
+        LOGGER.log(Level.FINEST, "Notifying termination");
         for (ItemListener l : ItemListener.all()) {
             try {
                 l.onBeforeShutdown();
@@ -3447,7 +3447,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     private void _cleanUpShutdownUDPBroadcast(List<Throwable> errors) {
         if(udpBroadcastThread!=null) {
-            LOGGER.log(Level.FINE, "Shutting down {0}", udpBroadcastThread.getName());
+            LOGGER.log(Level.FINEST, "Shutting down {0}", udpBroadcastThread.getName());
             try {
                 udpBroadcastThread.shutdown();
             } catch (OutOfMemoryError e) {
@@ -3466,7 +3466,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     private void _cleanUpCloseDNSMulticast(List<Throwable> errors) {
         if(dnsMultiCast!=null) {
-            LOGGER.log(Level.FINE, "Closing DNS Multicast service");
+            LOGGER.log(Level.FINEST, "Closing DNS Multicast service");
             try {
                 dnsMultiCast.close();
             } catch (OutOfMemoryError e) {
@@ -3484,7 +3484,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     private void _cleanUpInterruptReloadThread(List<Throwable> errors) {
-        LOGGER.log(Level.FINE, "Interrupting reload thread");
+        LOGGER.log(Level.FINEST, "Interrupting reload thread");
         try {
             interruptReloadThread();
         } catch (SecurityException e) {
@@ -3504,7 +3504,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     private void _cleanUpShutdownTriggers(List<Throwable> errors) {
-        LOGGER.log(Level.FINE, "Shutting down triggers");
+        LOGGER.log(Level.FINEST, "Shutting down triggers");
         try {
             final java.util.Timer timer = Trigger.timer;
             if (timer != null) {
@@ -3517,10 +3517,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     }
                 }, 0);
                 if (latch.await(10, TimeUnit.SECONDS)) {
-                    LOGGER.log(Level.FINE, "Triggers shut down successfully");
+                    LOGGER.log(Level.FINEST, "Triggers shut down successfully");
                 } else {
                     timer.cancel();
-                    LOGGER.log(Level.INFO, "Gave up waiting for triggers to finish running");
+                    LOGGER.log(Level.FINEST, "Gave up waiting for triggers to finish running");
                 }
             }
             Trigger.timer = null;
@@ -3538,7 +3538,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     private void _cleanUpShutdownTimer(List<Throwable> errors) {
-        LOGGER.log(Level.FINE, "Shutting down timer");
+        LOGGER.log(Level.FINEST, "Shutting down timer");
         try {
             Timer.shutdown();
         } catch (SecurityException e) {
@@ -3559,7 +3559,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     private void _cleanUpShutdownTcpSlaveAgent(List<Throwable> errors) {
         if(tcpSlaveAgentListener!=null) {
-            LOGGER.log(FINE, "Shutting down TCP/IP agent listener");
+            LOGGER.log(FINEST, "Shutting down TCP/IP agent listener");
             try {
                 tcpSlaveAgentListener.shutdown();
             } catch (OutOfMemoryError e) {
@@ -3617,7 +3617,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     private void _cleanUpShutdownThreadPoolForLoad(List<Throwable> errors) {
-        LOGGER.log(FINE, "Shuting down Jenkins load thread pool");
+        LOGGER.log(FINEST, "Shuting down Jenkins load thread pool");
         try {
             threadPoolForLoad.shutdown();
         } catch (SecurityException e) {
@@ -3663,7 +3663,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     private void _cleanUpPluginServletFilters(List<Throwable> errors) {
-        LOGGER.log(Level.FINE, "Stopping filters");
+        LOGGER.log(Level.FINEST, "Stopping filters");
         try {
             PluginServletFilter.cleanUp();
         } catch (OutOfMemoryError e) {
@@ -3680,7 +3680,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     private void _cleanUpReleaseAllLoggers(List<Throwable> errors) {
-        LOGGER.log(Level.FINE, "Releasing all loggers");
+        LOGGER.log(Level.FINEST, "Releasing all loggers");
         try {
             LogFactory.releaseAll();
         } catch (OutOfMemoryError e) {
@@ -4244,7 +4244,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
                     // give some time for the browser to load the "reloading" page
                     Thread.sleep(TimeUnit.SECONDS.toMillis(5));
-                    LOGGER.info(String.format("Restarting VM as requested by %s",exitUser));
+                    LOGGER.finest(String.format("Restarting VM as requested by %s",exitUser));
                     for (RestartListener listener : RestartListener.all())
                         listener.onRestart();
                     lifecycle.restart();
@@ -4278,14 +4278,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     if (isQuietingDown) {
                         servletContext.setAttribute("app",new HudsonIsRestarting());
                         // give some time for the browser to load the "reloading" page
-                        LOGGER.info("Restart in 10 seconds");
+                        LOGGER.finest("Restart in 10 seconds");
                         Thread.sleep(TimeUnit.SECONDS.toMillis(10));
-                        LOGGER.info(String.format("Restarting VM as requested by %s",exitUser));
+                        LOGGER.finest(String.format("Restarting VM as requested by %s",exitUser));
                         for (RestartListener listener : RestartListener.all())
                             listener.onRestart();
                         lifecycle.restart();
                     } else {
-                        LOGGER.info("Safe-restart mode cancelled");
+                        LOGGER.finest("Safe-restart mode cancelled");
                     }
                 } catch (Throwable e) {
                     LOGGER.log(Level.WARNING, "Failed to restart Jenkins",e);
@@ -4340,7 +4340,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             public void run() {
                 try {
                     ACL.impersonate(ACL.SYSTEM);
-                    LOGGER.info(String.format("Shutting down VM as requested by %s from %s",
+                    LOGGER.finest(String.format("Shutting down VM as requested by %s from %s",
                             getAuthentication().getName(), req != null ? req.getRemoteAddr() : "???"));
 
                     cleanUp();
@@ -4368,7 +4368,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             public void run() {
                 try {
                     ACL.impersonate(ACL.SYSTEM);
-                    LOGGER.info(String.format("Shutting down VM as requested by %s from %s",
+                    LOGGER.finest(String.format("Shutting down VM as requested by %s from %s",
                                                 exitUser, exitAddr));
                     // Wait 'til we have no active executors.
                     doQuietDown(true, 0);
@@ -5011,13 +5011,13 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     File pom = new File(dir, "pom.xml");
                     if (pom.exists() && "pom".equals(XMLUtils.getValue("/project/artifactId", pom))) {
                         pom =  pom.getCanonicalFile();
-                        LOGGER.info("Reading version from: " + pom.getAbsolutePath());
+                        LOGGER.finest("Reading version from: " + pom.getAbsolutePath());
                         ver = XMLUtils.getValue("/project/version", pom);
                         break;
                     }
                     dir = dir.getParentFile();
                 }
-                LOGGER.info("Jenkins is in dev mode, using version: " + ver);
+                LOGGER.finest("Jenkins is in dev mode, using version: " + ver);
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to read Jenkins version: " + e.getMessage(), e);
             }

--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -164,7 +164,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
         synchronized (symlinks) {
             String target = symlinks.get(cache);
             if (target != null) {
-                LOGGER.log(Level.FINE, "readSymlink cached {0} → {1}", new Object[] {cache, target});
+                LOGGER.log(Level.FINEST, "readSymlink cached {0} → {1}", new Object[] {cache, target});
                 return target;
             }
         }
@@ -173,7 +173,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
             // if this file isn't a symlink, it must be a regular file
             target = FileUtils.readFileToString(cache,"UTF-8").trim();
         }
-        LOGGER.log(Level.FINE, "readSymlink {0} → {1}", new Object[] {cache, target});
+        LOGGER.log(Level.FINEST, "readSymlink {0} → {1}", new Object[] {cache, target});
         synchronized (symlinks) {
             symlinks.put(cache, target);
         }
@@ -181,7 +181,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
     }
 
     static void writeSymlink(File cache, String target) throws IOException, InterruptedException {
-        LOGGER.log(Level.FINE, "writeSymlink {0} → {1}", new Object[] {cache, target});
+        LOGGER.log(Level.FINEST, "writeSymlink {0} → {1}", new Object[] {cache, target});
         synchronized (symlinks) {
             symlinks.put(cache, target);
         }

--- a/core/src/main/java/jenkins/model/RunIdMigrator.java
+++ b/core/src/main/java/jenkins/model/RunIdMigrator.java
@@ -153,14 +153,14 @@ public final class RunIdMigrator {
      */
     public synchronized boolean migrate(File dir, @CheckForNull File jenkinsHome) {
         if (load(dir)) {
-            LOGGER.log(FINER, "migration already performed for {0}", dir);
+            LOGGER.log(FINEST, "migration already performed for {0}", dir);
             return false;
         }
         if (!dir.isDirectory()) {
-            LOGGER.log(/* normal during Job.movedTo */FINE, "{0} was unexpectedly missing", dir);
+            LOGGER.log(FINEST, "{0} was unexpectedly missing", dir);
             return false;
         }
-        LOGGER.log(INFO, "Migrating build records in {0}", dir);
+        LOGGER.log(FINEST, "Migrating build records in {0}", dir);
         doMigrate(dir);
         save(dir);
         if (jenkinsHome != null && offeredToUnmigrate.add(jenkinsHome))
@@ -206,9 +206,9 @@ public final class RunIdMigrator {
             }
             try {
                 if (Util.isSymlink(kid)) {
-                    LOGGER.log(FINE, "deleting build number symlink {0} → {1}", new Object[] {name, Util.resolveSymlink(kid)});
+                    LOGGER.log(FINEST, "deleting build number symlink {0} → {1}", new Object[] {name, Util.resolveSymlink(kid)});
                 } else if (kid.isDirectory()) {
-                    LOGGER.log(FINE, "ignoring build directory {0}", name);
+                    LOGGER.log(FINEST, "ignoring build directory {0}", name);
                     continue;
                 } else {
                     LOGGER.log(WARNING, "need to delete anomalous file entry {0}", name);
@@ -226,13 +226,13 @@ public final class RunIdMigrator {
                 String name = kid.getName();
                 try {
                     Integer.parseInt(name);
-                    LOGGER.log(FINE, "skipping new build dir {0}", name);
+                    LOGGER.log(FINEST, "skipping new build dir {0}", name);
                     continue;
                 } catch (NumberFormatException x) {
                     // OK, next…
                 }
                 if (!kid.isDirectory()) {
-                    LOGGER.log(FINE, "skipping non-directory {0}", name);
+                    LOGGER.log(FINEST, "skipping non-directory {0}", name);
                     continue;
                 }
                 long timestamp;
@@ -261,7 +261,7 @@ public final class RunIdMigrator {
                 File newKid = new File(dir, Integer.toString(number));
                 move(kid, newKid);
                 FileUtils.writeStringToFile(new File(newKid, "build.xml"), xml, Charsets.UTF_8);
-                LOGGER.log(FINE, "fully processed {0} → {1}", new Object[] {name, number});
+                LOGGER.log(FINEST, "fully processed {0} → {1}", new Object[] {name, number});
                 idToNumber.put(name, number);
             } catch (Exception x) {
                 LOGGER.log(WARNING, "failed to process " + kid, x);

--- a/core/src/main/java/jenkins/model/StandardArtifactManager.java
+++ b/core/src/main/java/jenkins/model/StandardArtifactManager.java
@@ -64,10 +64,10 @@ public class StandardArtifactManager extends ArtifactManager {
     @Override public final boolean delete() throws IOException, InterruptedException {
         File ad = getArtifactsDir();
         if (!ad.exists()) {
-            LOG.log(Level.FINE, "no such directory {0} to delete for {1}", new Object[] {ad, build});
+            LOG.log(Level.FINEST, "no such directory {0} to delete for {1}", new Object[] {ad, build});
             return false;
         }
-        LOG.log(Level.FINE, "deleting {0} for {1}", new Object[] {ad, build});
+        LOG.log(Level.FINEST, "deleting {0} for {1}", new Object[] {ad, build});
         Util.deleteRecursive(ad);
         return true;
     }

--- a/core/src/main/java/jenkins/model/lazy/BuildReference.java
+++ b/core/src/main/java/jenkins/model/lazy/BuildReference.java
@@ -120,7 +120,7 @@ public final class BuildReference<R> {
         for (HolderFactory f : ExtensionList.lookup(HolderFactory.class)) {
             Holder<R> h = f.make(referent);
             if (h != null) {
-                LOGGER.log(Level.FINE, "created build reference for {0} using {1}", new Object[] {referent, f});
+                LOGGER.log(Level.FINEST, "created build reference for {0} using {1}", new Object[] {referent, f});
                 return h;
             }
         }

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -36,6 +36,9 @@ import hudson.model.listeners.ItemListener;
 import hudson.model.queue.SubTask;
 import hudson.widgets.BuildHistoryWidget;
 import hudson.widgets.HistoryWidget;
+
+import static java.util.logging.Level.FINEST;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -46,7 +49,6 @@ import javax.annotation.Nonnull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
-import static java.util.logging.Level.FINER;
 import jenkins.model.RunIdMigrator;
 
 /**
@@ -129,7 +131,7 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT,RunT> & Queue.Task & 
                 if (r.isBuilding()) {
                     // Do not use RunMap.put(Run):
                     _builds.put(r.getNumber(), r);
-                    LOGGER.log(Level.FINE, "keeping reloaded {0}", r);
+                    LOGGER.log(Level.FINEST, "keeping reloaded {0}", r);
                 }
             }
         }
@@ -369,7 +371,7 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT,RunT> & Queue.Task & 
                     if (pb != null) {
                         pb.getRunMixIn().nextBuildR = createReference();   // establish bi-di link
                         this.previousBuildR = pb.getRunMixIn().createReference();
-                        LOGGER.log(FINER, "Linked {0}<->{1} in getPreviousBuild()", new Object[]{this, pb});
+                        LOGGER.log(FINEST, "Linked {0}<->{1} in getPreviousBuild()", new Object[]{this, pb});
                         return pb;
                     } else {
                         this.previousBuildR = none();
@@ -403,7 +405,7 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT,RunT> & Queue.Task & 
                     if (nb != null) {
                         nb.getRunMixIn().previousBuildR = createReference();   // establish bi-di link
                         this.nextBuildR = nb.getRunMixIn().createReference();
-                        LOGGER.log(FINER, "Linked {0}<->{1} in getNextBuild()", new Object[]{this, nb});
+                        LOGGER.log(FINEST, "Linked {0}<->{1} in getNextBuild()", new Object[]{this, nb});
                         return nb;
                     } else {
                         this.nextBuildR = none();

--- a/core/src/main/java/jenkins/plugins/DetachedPluginsUtil.java
+++ b/core/src/main/java/jenkins/plugins/DetachedPluginsUtil.java
@@ -88,13 +88,13 @@ public class DetachedPluginsUtil {
                 continue;
             }
             if (BREAK_CYCLES.contains(pluginName + ' ' + detached.shortName)) {
-                LOGGER.log(Level.FINE, "skipping implicit dependency {0} → {1}", new Object[]{pluginName, detached.shortName});
+                LOGGER.log(Level.FINEST, "skipping implicit dependency {0} → {1}", new Object[]{pluginName, detached.shortName});
                 continue;
             }
             // some earlier versions of maven-hpi-plugin apparently puts "null" as a literal in Hudson-Version. watch out for them.
             if (jenkinsVersion == null || jenkinsVersion.equals("null") || new VersionNumber(jenkinsVersion).compareTo(detached.splitWhen) <= 0) {
                 out.add(new PluginWrapper.Dependency(detached.shortName + ':' + detached.requiredVersion));
-                LOGGER.log(Level.FINE, "adding implicit dependency {0} → {1} because of {2}",
+                LOGGER.log(Level.FINEST, "adding implicit dependency {0} → {1} because of {2}",
                            new Object[]{pluginName, detached.shortName, jenkinsVersion});
             }
         }

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -156,7 +156,7 @@ public class ApiTokenProperty extends UserProperty {
     @Nonnull
     @SuppressFBWarnings("NP_NONNULL_RETURN_VIOLATION")
     public String getApiToken() {
-        LOGGER.log(Level.FINE, "Deprecated usage of getApiToken");
+        LOGGER.log(Level.FINEST, "Deprecated usage of getApiToken");
         if(LOGGER.isLoggable(Level.FINER)){
             LOGGER.log(Level.FINER, "Deprecated usage of getApiToken (trace)", new Exception());
         }
@@ -318,7 +318,7 @@ public class ApiTokenProperty extends UserProperty {
         // just to keep the same level of security
         user.checkPermission(Jenkins.ADMINISTER);
 
-        LOGGER.log(Level.FINE, "Deprecated usage of changeApiToken");
+        LOGGER.log(Level.FINEST, "Deprecated usage of changeApiToken");
 
         ApiTokenStore.HashedToken existingLegacyToken = tokenStore.getLegacyToken();
         _changeApiToken();
@@ -443,7 +443,7 @@ public class ApiTokenProperty extends UserProperty {
             // you are the user or you have ADMINISTER permission
             u.checkPermission(Jenkins.ADMINISTER);
 
-            LOGGER.log(Level.FINE, "Deprecated action /changeToken used, consider using /generateNewToken instead");
+            LOGGER.log(Level.FINEST, "Deprecated action /changeToken used, consider using /generateNewToken instead");
 
             if(!mustDisplayLegacyApiToken(u)){
                 // user does not have legacy token and the capability to create one without an existing one is disabled

--- a/core/src/main/java/jenkins/security/BasicHeaderProcessor.java
+++ b/core/src/main/java/jenkins/security/BasicHeaderProcessor.java
@@ -75,10 +75,10 @@ public class BasicHeaderProcessor implements Filter {
                 }
 
                 for (BasicHeaderAuthenticator a : all()) {
-                    LOGGER.log(FINER, "Attempting to authenticate with {0}", a);
+                    LOGGER.log(FINEST, "Attempting to authenticate with {0}", a);
                     Authentication auth = a.authenticate(req, rsp, username, password);
                     if (auth!=null) {
-                        LOGGER.log(FINE, "Request authenticated as {0} by {1}", new Object[]{auth,a});
+                        LOGGER.log(FINEST, "Request authenticated as {0} by {1}", new Object[]{auth,a});
                         success(req, rsp, chain, auth);
                         return;
                     }
@@ -144,7 +144,7 @@ public class BasicHeaderProcessor implements Filter {
     }
 
     protected void fail(HttpServletRequest req, HttpServletResponse rsp, BadCredentialsException failure) throws IOException, ServletException {
-        LOGGER.log(FINE, "Authentication of BASIC header failed");
+        LOGGER.log(FINEST, "Authentication of BASIC header failed");
 
         rememberMeServices.loginFail(req, rsp);
 

--- a/core/src/main/java/jenkins/security/BasicHeaderRealPasswordAuthenticator.java
+++ b/core/src/main/java/jenkins/security/BasicHeaderRealPasswordAuthenticator.java
@@ -55,7 +55,7 @@ public class BasicHeaderRealPasswordAuthenticator extends BasicHeaderAuthenticat
         try {
             Authentication a = Jenkins.getInstance().getSecurityRealm().getSecurityComponents().manager.authenticate(authRequest);
             // Authentication success
-            LOGGER.log(FINER, "Authentication success: {0}", a);
+            LOGGER.log(FINEST, "Authentication success: {0}", a);
             return a;
         } catch (AuthenticationException failed) {
             // Authentication failed

--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -130,7 +130,7 @@ public class ClassFilterImpl extends ClassFilter {
             Boolean r = f.permits(_c);
             if (r != null) {
                 if (r) {
-                    LOGGER.log(Level.FINER, "{0} specifies a policy for {1}: {2}", new Object[] {f, _c.getName(), true});
+                    LOGGER.log(Level.FINEST, "{0} specifies a policy for {1}: {2}", new Object[] {f, _c.getName(), true});
                 } else {
                     notifyRejected(_c, _c.getName(), String.format("%s specifies a policy for %s: %s ", f, _c.getName(), r));
                 }
@@ -148,32 +148,32 @@ public class ClassFilterImpl extends ClassFilter {
                 return true;
             }
             if (c.isArray()) {
-                LOGGER.log(Level.FINE, "permitting {0} since it is an array", name);
+                LOGGER.log(Level.FINEST, "permitting {0} since it is an array", name);
                 return false;
             }
             if (Throwable.class.isAssignableFrom(c)) {
-                LOGGER.log(Level.FINE, "permitting {0} since it is a throwable", name);
+                LOGGER.log(Level.FINEST, "permitting {0} since it is a throwable", name);
                 return false;
             }
             if (Enum.class.isAssignableFrom(c)) { // Class.isEnum seems to be false for, e.g., java.util.concurrent.TimeUnit$6
-                LOGGER.log(Level.FINE, "permitting {0} since it is an enum", name);
+                LOGGER.log(Level.FINEST, "permitting {0} since it is an enum", name);
                 return false;
             }
             String location = codeSource(c);
             if (location != null) {
                 if (isLocationWhitelisted(location)) {
-                    LOGGER.log(Level.FINE, "permitting {0} due to its location in {1}", new Object[] {name, location});
+                    LOGGER.log(Level.FINEST, "permitting {0} due to its location in {1}", new Object[] {name, location});
                     return false;
                 }
             } else {
                 ClassLoader loader = c.getClassLoader();
                 if (loader != null && loader.getClass().getName().equals("hudson.remoting.RemoteClassLoader")) {
-                    LOGGER.log(Level.FINE, "permitting {0} since it was loaded by a remote class loader", name);
+                    LOGGER.log(Level.FINEST, "permitting {0} since it was loaded by a remote class loader", name);
                     return false;
                 }
             }
             if (WHITELISTED_CLASSES.contains(name)) {
-                LOGGER.log(Level.FINE, "tolerating {0} by whitelist", name);
+                LOGGER.log(Level.FINEST, "tolerating {0} by whitelist", name);
                 return false;
             }
             if (SUPPRESS_WHITELIST || SUPPRESS_ALL) {
@@ -192,11 +192,11 @@ public class ClassFilterImpl extends ClassFilter {
     private boolean isLocationWhitelisted(String _loc) {
         return codeSourceCache.computeIfAbsent(_loc, loc -> {
             if (loc.equals(JENKINS_LOC)) {
-                LOGGER.log(Level.FINE, "{0} seems to be the location of Jenkins core, OK", loc);
+                LOGGER.log(Level.FINEST, "{0} seems to be the location of Jenkins core, OK", loc);
                 return true;
             }
             if (loc.equals(REMOTING_LOC)) {
-                LOGGER.log(Level.FINE, "{0} seems to be the location of Remoting, OK", loc);
+                LOGGER.log(Level.FINEST, "{0} seems to be the location of Remoting, OK", loc);
                 return true;
             }
             if (loc.matches("file:/.+[.]jar")) {
@@ -204,13 +204,13 @@ public class ClassFilterImpl extends ClassFilter {
                     Manifest mf = jf.getManifest();
                     if (mf != null) {
                         if (isPluginManifest(mf)) {
-                            LOGGER.log(Level.FINE, "{0} seems to be a Jenkins plugin, OK", loc);
+                            LOGGER.log(Level.FINEST, "{0} seems to be a Jenkins plugin, OK", loc);
                             return true;
                         } else {
-                            LOGGER.log(Level.FINE, "{0} does not look like a Jenkins plugin", loc);
+                            LOGGER.log(Level.FINEST, "{0} does not look like a Jenkins plugin", loc);
                         }
                     } else {
-                        LOGGER.log(Level.FINE, "ignoring {0} with no manifest", loc);
+                        LOGGER.log(Level.FINEST, "ignoring {0} with no manifest", loc);
                     }
                 } catch (Exception x) {
                     LOGGER.log(Level.WARNING, "problem checking " + loc, x);
@@ -224,34 +224,34 @@ public class ClassFilterImpl extends ClassFilter {
                     if (manifestFile.isFile()) {
                         try (InputStream is = new FileInputStream(manifestFile)) {
                             if (isPluginManifest(new Manifest(is))) {
-                                LOGGER.log(Level.FINE, "{0} looks like a Jenkins plugin based on {1}, OK", new Object[] {loc, manifestFile});
+                                LOGGER.log(Level.FINEST, "{0} looks like a Jenkins plugin based on {1}, OK", new Object[] {loc, manifestFile});
                                 return true;
                             } else {
-                                LOGGER.log(Level.FINE, "{0} does not look like a Jenkins plugin", manifestFile);
+                                LOGGER.log(Level.FINEST, "{0} does not look like a Jenkins plugin", manifestFile);
                             }
                         }
                     } else {
-                        LOGGER.log(Level.FINE, "{0} has no matching {1}", new Object[] {loc, manifestFile});
+                        LOGGER.log(Level.FINEST, "{0} has no matching {1}", new Object[] {loc, manifestFile});
                     }
                 } catch (Exception x) {
                     LOGGER.log(Level.WARNING, "problem checking " + loc, x);
                 }
             }
             if (loc.endsWith("/target/classes/") || loc.matches(".+/build/classes/[^/]+/main/")) {
-                LOGGER.log(Level.FINE, "{0} seems to be current plugin classes, OK", loc);
+                LOGGER.log(Level.FINEST, "{0} seems to be current plugin classes, OK", loc);
                 return true;
             }
             if (Main.isUnitTest) {
                 if (loc.endsWith("/target/test-classes/") || loc.endsWith("-tests.jar") || loc.matches(".+/build/classes/[^/]+/test/")) {
-                    LOGGER.log(Level.FINE, "{0} seems to be test classes, OK", loc);
+                    LOGGER.log(Level.FINEST, "{0} seems to be test classes, OK", loc);
                     return true;
                 }
                 if (loc.matches(".+/jenkins-test-harness-.+[.]jar")) {
-                    LOGGER.log(Level.FINE, "{0} seems to be jenkins-test-harness, OK", loc);
+                    LOGGER.log(Level.FINEST, "{0} seems to be jenkins-test-harness, OK", loc);
                     return true;
                 }
             }
-            LOGGER.log(Level.FINE, "{0} is not recognized; rejecting", loc);
+            LOGGER.log(Level.FINEST, "{0} is not recognized; rejecting", loc);
             return false;
         });
     }
@@ -304,7 +304,7 @@ public class ClassFilterImpl extends ClassFilter {
             Boolean r = f.permits(name);
             if (r != null) {
                 if (r) {
-                    LOGGER.log(Level.FINER, "{0} specifies a policy for {1}: {2}", new Object[] {f, name, true});
+                    LOGGER.log(Level.FINEST, "{0} specifies a policy for {1}: {2}", new Object[] {f, name, true});
                 } else {
                     notifyRejected(null, name,
                             String.format("%s specifies a policy for %s: %s", f, name, r));

--- a/core/src/main/java/jenkins/security/CustomClassFilter.java
+++ b/core/src/main/java/jenkins/security/CustomClassFilter.java
@@ -103,7 +103,7 @@ public interface CustomClassFilter extends ExtensionPoint {
                         overrides.put(entry, true);
                     }
                 }
-                Logger.getLogger(Static.class.getName()).log(Level.FINE, "user-defined entries: {0}", overrides);
+                Logger.getLogger(Static.class.getName()).log(Level.FINEST, "user-defined entries: {0}", overrides);
             }
         }
 
@@ -168,7 +168,7 @@ public interface CustomClassFilter extends ExtensionPoint {
                     }
                 }
             }
-            Logger.getLogger(Contributed.class.getName()).log(Level.FINE, "plugin-defined entries: {0}", overrides);
+            Logger.getLogger(Contributed.class.getName()).log(Level.FINEST, "plugin-defined entries: {0}", overrides);
         }
 
     }

--- a/core/src/main/java/jenkins/security/ExceptionTranslationFilter.java
+++ b/core/src/main/java/jenkins/security/ExceptionTranslationFilter.java
@@ -116,7 +116,7 @@ public class ExceptionTranslationFilter implements Filter, InitializingBean {
 		try {
 			chain.doFilter(request, response);
 
-			LOGGER.finer("Chain processed normally");
+			LOGGER.finest("Chain processed normally");
 		}
 		catch (AuthenticationException | AccessDeniedException ex) {
 			handleException(request, response, chain, ex);
@@ -149,20 +149,20 @@ public class ExceptionTranslationFilter implements Filter, InitializingBean {
 	private void handleException(ServletRequest request, ServletResponse response, FilterChain chain,
 			AcegiSecurityException exception) throws IOException, ServletException {
 		if (exception instanceof AuthenticationException) {
-			LOGGER.log(Level.FINER, "Authentication exception occurred; redirecting to authentication entry point", exception);
+			LOGGER.log(Level.FINEST, "Authentication exception occurred; redirecting to authentication entry point", exception);
 
 			sendStartAuthentication(request, response, chain, (AuthenticationException) exception);
 		}
 		else if (exception instanceof AccessDeniedException) {
 			if (authenticationTrustResolver.isAnonymous(SecurityContextHolder.getContext().getAuthentication())) {
-					LOGGER.log(Level.FINER, "Access is denied (user is anonymous); redirecting to authentication entry point",
+					LOGGER.log(Level.FINEST, "Access is denied (user is anonymous); redirecting to authentication entry point",
 						exception);
 
 				sendStartAuthentication(request, response, chain, new InsufficientAuthenticationException(
 						"Full authentication is required to access this resource",exception));
 			}
 			else {
-				LOGGER.log(Level.FINER, "Access is denied (user is not anonymous); delegating to AccessDeniedHandler",
+				LOGGER.log(Level.FINEST, "Access is denied (user is not anonymous); delegating to AccessDeniedHandler",
 						exception);
 
 				accessDeniedHandler.handle(request, response, (AccessDeniedException) exception);
@@ -193,7 +193,7 @@ public class ExceptionTranslationFilter implements Filter, InitializingBean {
 
 		SavedRequest savedRequest = new SavedRequest(httpRequest, portResolver);
 
-		LOGGER.finer("Authentication entry point being called; SavedRequest added to Session: " + savedRequest);
+		LOGGER.finest("Authentication entry point being called; SavedRequest added to Session: " + savedRequest);
 
 		if (createSessionAllowed) {
 			// Store the HTTP request itself. Used by AbstractProcessingFilter

--- a/core/src/main/java/jenkins/security/QueueItemAuthenticatorMonitor.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticatorMonitor.java
@@ -122,7 +122,7 @@ public class QueueItemAuthenticatorMonitor extends AdministrativeMonitor {
 
             if (!(li.task instanceof Job<?, ?>)) {
                 // Only care about jobs for now -- Do not react to folder scans and similar
-                LOGGER.log(Level.FINE, displayName + " is not a job");
+                LOGGER.log(Level.FINEST, displayName + " is not a job");
                 return;
             }
 
@@ -130,11 +130,11 @@ public class QueueItemAuthenticatorMonitor extends AdministrativeMonitor {
             Authentication buildAuthentication = li.authenticate();
             boolean buildRunsAsSystem = buildAuthentication == ACL.SYSTEM;
             if (!buildRunsAsSystem) {
-                LOGGER.log(Level.FINE, displayName + " does not run as SYSTEM");
+                LOGGER.log(Level.FINEST, displayName + " does not run as SYSTEM");
                 return;
             }
 
-            LOGGER.log(Level.FINE, displayName + " is running as SYSTEM");
+            LOGGER.log(Level.FINEST, displayName + " is running as SYSTEM");
             if (isQueueItemAuthenticatorConfigured()) {
                 anyBuildLaunchedAsSystemWithAuthenticatorPresent = true;
             }

--- a/core/src/main/java/jenkins/security/RekeySecretAdminMonitor.java
+++ b/core/src/main/java/jenkins/security/RekeySecretAdminMonitor.java
@@ -134,7 +134,7 @@ public class RekeySecretAdminMonitor extends AsynchronousAdministrativeMonitor {
 
     @Override
     protected void fix(TaskListener listener) throws Exception {
-        LOGGER.info("Initiating a re-keying of secrets. See "+getLogFile());
+        LOGGER.finest("Initiating a re-keying of secrets. See "+getLogFile());
 
         SecretRewriter rewriter = new SecretRewriter();
 
@@ -144,7 +144,7 @@ public class RekeySecretAdminMonitor extends AsynchronousAdministrativeMonitor {
             int count = rewriter.rewriteRecursive(Jenkins.getInstance().getRootDir(), listener);
             log.printf("Completed re-keying %d files on %s\n",count,new Date());
             new RekeySecretAdminMonitor().done.on();
-            LOGGER.info("Secret re-keying completed");
+            LOGGER.finest("Secret re-keying completed");
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Fatal failure in re-keying secrets",e);
             Functions.printStackTrace(e, listener.error("Fatal failure in rewriting secrets"));

--- a/core/src/main/java/jenkins/security/SecurityListener.java
+++ b/core/src/main/java/jenkins/security/SecurityListener.java
@@ -108,7 +108,7 @@ public abstract class SecurityListener implements ExtensionPoint {
 
     /** @since TODO */
     public static void fireUserCreated(@Nonnull String username) {
-        LOGGER.log(Level.FINE, "new user created: {0}", username);
+        LOGGER.log(Level.FINEST, "new user created: {0}", username);
         for (SecurityListener l : all()) {
             l.userCreated(username);
         }
@@ -116,7 +116,7 @@ public abstract class SecurityListener implements ExtensionPoint {
 
     /** @since 1.569 */
     public static void fireFailedToAuthenticate(@Nonnull String username) {
-        LOGGER.log(Level.FINE, "failed to authenticate: {0}", username);
+        LOGGER.log(Level.FINEST, "failed to authenticate: {0}", username);
         for (SecurityListener l : all()) {
             l.failedToAuthenticate(username);
         }
@@ -124,7 +124,7 @@ public abstract class SecurityListener implements ExtensionPoint {
 
     /** @since 1.569 */
     public static void fireLoggedIn(@Nonnull String username) {
-        LOGGER.log(Level.FINE, "logged in: {0}", username);
+        LOGGER.log(Level.FINEST, "logged in: {0}", username);
         for (SecurityListener l : all()) {
             l.loggedIn(username);
         }
@@ -132,7 +132,7 @@ public abstract class SecurityListener implements ExtensionPoint {
 
     /** @since 1.569 */
     public static void fireFailedToLogIn(@Nonnull String username) {
-        LOGGER.log(Level.FINE, "failed to log in: {0}", username);
+        LOGGER.log(Level.FINEST, "failed to log in: {0}", username);
         for (SecurityListener l : all()) {
             l.failedToLogIn(username);
         }
@@ -140,7 +140,7 @@ public abstract class SecurityListener implements ExtensionPoint {
 
     /** @since 1.569 */
     public static void fireLoggedOut(@Nonnull String username) {
-        LOGGER.log(Level.FINE, "logged out: {0}", username);
+        LOGGER.log(Level.FINEST, "logged out: {0}", username);
         for (SecurityListener l : all()) {
             l.loggedOut(username);
         }

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStats.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStats.java
@@ -203,7 +203,7 @@ public class ApiTokenStats implements Saveable {
         if (userFolder == null && this.user != null) {
             userFolder = user.getUserFolder();
             if (userFolder == null) {
-                LOGGER.log(Level.INFO, "No user folder yet for user {0}", user.getId());
+                LOGGER.log(Level.FINEST, "No user folder yet for user {0}", user.getId());
                 return null;
             }
             this.parent = userFolder;

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
@@ -105,13 +105,13 @@ public class ApiTokenStore {
         tokenList.forEach(hashedToken -> {
             JSONObject receivedTokenData = tokenStoreDataMap.get(hashedToken.uuid);
             if (receivedTokenData == null) {
-                LOGGER.log(Level.INFO, "No token received for {0}", hashedToken.uuid);
+                LOGGER.log(Level.FINEST, "No token received for {0}", hashedToken.uuid);
                 return;
             }
             
             String name = receivedTokenData.getString("tokenName");
             if (StringUtils.isBlank(name)) {
-                LOGGER.log(Level.INFO, "Empty name received for {0}, we do not care about it", hashedToken.uuid);
+                LOGGER.log(Level.FINEST, "Empty name received for {0}, we do not care about it", hashedToken.uuid);
                 return;
             }
             
@@ -294,7 +294,7 @@ public class ApiTokenStore {
             }
         }
         
-        LOGGER.log(Level.FINER, "The target token for rename does not exist, for uuid = {0}, with desired name = {1}", new Object[]{tokenUuid, newName});
+        LOGGER.log(Level.FINEST, "The target token for rename does not exist, for uuid = {0}, with desired name = {1}", new Object[]{tokenUuid, newName});
         return false;
     }
     

--- a/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
+++ b/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
@@ -164,19 +164,19 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
             }
             User user = User.getById(value.userId, false);
             if (user == null) {
-                LOGGER.log(Level.INFO, "User not found id={0}", value.userId);
+                LOGGER.log(Level.FINEST, "User not found id={0}", value.userId);
             } else {
                 ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);
                 if (apiTokenProperty == null) {
-                    LOGGER.log(Level.INFO, "User without apiTokenProperty found id={0}", value.userId);
+                    LOGGER.log(Level.FINEST, "User without apiTokenProperty found id={0}", value.userId);
                 } else {
                     ApiTokenStore.HashedToken revokedToken = apiTokenProperty.getTokenStore().revokeToken(value.uuid);
                     if (revokedToken == null) {
-                        LOGGER.log(Level.INFO, "User without selected token id={0}, tokenUuid={1}", new Object[]{value.userId, value.uuid});
+                        LOGGER.log(Level.FINEST, "User without selected token id={0}, tokenUuid={1}", new Object[]{value.userId, value.uuid});
                     } else {
                         apiTokenProperty.deleteApiToken();
                         user.save();
-                        LOGGER.log(Level.INFO, "Revocation success for user id={0}, tokenUuid={1}", new Object[]{value.userId, value.uuid});
+                        LOGGER.log(Level.FINEST, "Revocation success for user id={0}, tokenUuid={1}", new Object[]{value.userId, value.uuid});
                     }
                 }
             }

--- a/core/src/main/java/jenkins/security/s2m/CallableDirectionChecker.java
+++ b/core/src/main/java/jenkins/security/s2m/CallableDirectionChecker.java
@@ -50,13 +50,13 @@ public class CallableDirectionChecker extends RoleChecker {
         final String name = subject.getClass().getName();
 
         if (expected.contains(Roles.MASTER)) {
-            LOGGER.log(Level.FINE, "Executing {0} is allowed since it is targeted for the master role", name);
+            LOGGER.log(Level.FINEST, "Executing {0} is allowed since it is targeted for the master role", name);
             return;    // known to be safe
         }
 
         if (isWhitelisted(subject,expected)) {
             // this subject is dubious, but we are letting it through as per whitelisting
-            LOGGER.log(Level.FINE, "Explicitly allowing {0} to be sent from agent to master", name);
+            LOGGER.log(Level.FINEST, "Explicitly allowing {0} to be sent from agent to master", name);
             return;
         }
 

--- a/core/src/main/java/jenkins/security/s2m/DefaultFilePathFilter.java
+++ b/core/src/main/java/jenkins/security/s2m/DefaultFilePathFilter.java
@@ -54,7 +54,7 @@ import java.util.logging.Logger;
         new ReflectiveFilePathFilter() {
             protected boolean op(String op, File f) throws SecurityException {
                 if (BYPASS) {
-                    LOGGER.log(Level.FINE, "agent allowed to {0} {1}", new Object[] {op, f});
+                    LOGGER.log(Level.FINEST, "agent allowed to {0} {1}", new Object[] {op, f});
                     return true;
                 } else {
                     return false;

--- a/core/src/main/java/jenkins/security/stapler/StaticRoutingDecisionProvider.java
+++ b/core/src/main/java/jenkins/security/stapler/StaticRoutingDecisionProvider.java
@@ -137,49 +137,49 @@ public class StaticRoutingDecisionProvider extends RoutingDecisionProvider imple
             throw new ExceptionInInitializerError(e);
         }
         
-        LOGGER.log(Level.FINE, "Found {0} getter in the standard whitelist", whitelistSignaturesFromFixedList.size());
+        LOGGER.log(Level.FINEST, "Found {0} getter in the standard whitelist", whitelistSignaturesFromFixedList.size());
     }
     
     public synchronized StaticRoutingDecisionProvider add(@Nonnull String signature) {
         if (this.whitelistSignaturesFromUserControlledList.add(signature)) {
-            LOGGER.log(Level.INFO, "Signature [{0}] added to the whitelist", signature);
+            LOGGER.log(Level.FINEST, "Signature [{0}] added to the whitelist", signature);
             save();
             resetMetaClassCache();
         } else {
-            LOGGER.log(Level.INFO, "Signature [{0}] was already present in the whitelist", signature);
+            LOGGER.log(Level.FINEST, "Signature [{0}] was already present in the whitelist", signature);
         }
         return this;
     }
     
     public synchronized StaticRoutingDecisionProvider addBlacklistSignature(@Nonnull String signature) {
         if (this.blacklistSignaturesFromUserControlledList.add(signature)) {
-            LOGGER.log(Level.INFO, "Signature [{0}] added to the blacklist", signature);
+            LOGGER.log(Level.FINEST, "Signature [{0}] added to the blacklist", signature);
             save();
             resetMetaClassCache();
         } else {
-            LOGGER.log(Level.INFO, "Signature [{0}] was already present in the blacklist", signature);
+            LOGGER.log(Level.FINEST, "Signature [{0}] was already present in the blacklist", signature);
         }
         return this;
     }
     
     public synchronized StaticRoutingDecisionProvider remove(@Nonnull String signature) {
         if (this.whitelistSignaturesFromUserControlledList.remove(signature)) {
-            LOGGER.log(Level.INFO, "Signature [{0}] removed from the whitelist", signature);
+            LOGGER.log(Level.FINEST, "Signature [{0}] removed from the whitelist", signature);
             save();
             resetMetaClassCache();
         } else {
-            LOGGER.log(Level.INFO, "Signature [{0}] was not present in the whitelist", signature);
+            LOGGER.log(Level.FINEST, "Signature [{0}] was not present in the whitelist", signature);
         }
         return this;
     }
     
     public synchronized StaticRoutingDecisionProvider removeBlacklistSignature(@Nonnull String signature) {
         if (this.blacklistSignaturesFromUserControlledList.remove(signature)) {
-            LOGGER.log(Level.INFO, "Signature [{0}] removed from the blacklist", signature);
+            LOGGER.log(Level.FINEST, "Signature [{0}] removed from the blacklist", signature);
             save();
             resetMetaClassCache();
         } else {
-            LOGGER.log(Level.INFO, "Signature [{0}] was not present in the blacklist", signature);
+            LOGGER.log(Level.FINEST, "Signature [{0}] was not present in the blacklist", signature);
         }
         return this;
     }
@@ -218,14 +218,14 @@ public class StaticRoutingDecisionProvider extends RoutingDecisionProvider imple
         if (!file.exists()) {
             if ((whitelistSignaturesFromUserControlledList != null && whitelistSignaturesFromUserControlledList.isEmpty()) ||
                     (blacklistSignaturesFromUserControlledList != null && blacklistSignaturesFromUserControlledList.isEmpty())) {
-                LOGGER.log(Level.INFO, "No whitelist source file found at " + file + " so resetting user-controlled whitelist");
+                LOGGER.log(Level.FINEST, "No whitelist source file found at " + file + " so resetting user-controlled whitelist");
             }
             whitelistSignaturesFromUserControlledList = new HashSet<>();
             blacklistSignaturesFromUserControlledList = new HashSet<>();
             return;
         }
 
-        LOGGER.log(Level.INFO, "Whitelist source file found at " + file);
+        LOGGER.log(Level.FINEST, "Whitelist source file found at " + file);
 
         try {
             whitelistSignaturesFromUserControlledList = new HashSet<>();

--- a/core/src/main/java/jenkins/security/stapler/TypedFilter.java
+++ b/core/src/main/java/jenkins/security/stapler/TypedFilter.java
@@ -33,13 +33,13 @@ public class TypedFilter implements FieldRef.Filter, FunctionList.Filter {
             Class<?> elementClazz = clazz.getComponentType();
             // does not seem possible to fall in an infinite loop since array cannot be recursively defined
             if (isClassAcceptable(elementClazz)) {
-                LOGGER.log(Level.FINE,
+                LOGGER.log(Level.FINEST,
                         "Class {0} is acceptable because it is an Array of acceptable elements {1}",
                         new Object[]{clazz.getName(), elementClazz.getName()}
                 );
                 return true;
             } else {
-                LOGGER.log(Level.FINE,
+                LOGGER.log(Level.FINEST,
                         "Class {0} is not acceptable because it is an Array of non-acceptable elements {1}",
                         new Object[]{clazz.getName(), elementClazz.getName()}
                 );
@@ -183,7 +183,7 @@ public class TypedFilter implements FieldRef.Filter, FunctionList.Filter {
         Class<?> returnType = fieldRef.getReturnType();
 
         boolean isOk = isClassAcceptable(returnType);
-        LOGGER.log(Level.FINE, "Field analyzed: {0} => {1}", new Object[]{fieldRef.getName(), isOk});
+        LOGGER.log(Level.FINEST, "Field analyzed: {0} => {1}", new Object[]{fieldRef.getName(), isOk});
         return isOk;
     }
 
@@ -264,7 +264,7 @@ public class TypedFilter implements FieldRef.Filter, FunctionList.Filter {
         Class<?> returnType = function.getReturnType();
 
         boolean isOk = isClassAcceptable(returnType);
-        LOGGER.log(Level.FINE, "Function analyzed: {0} => {1}", new Object[]{signature, isOk});
+        LOGGER.log(Level.FINEST, "Function analyzed: {0} => {1}", new Object[]{signature, isOk});
         return isOk;
     }
 

--- a/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
+++ b/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
@@ -96,7 +96,7 @@ public class DefaultJnlpSlaveReceiver extends JnlpAgentReceiver {
             } else if (launcher instanceof ComputerLauncherFilter) {
                 launcher = ((ComputerLauncherFilter) launcher).getCore();
             } else if (null != (l = getDelegate(launcher))) {  // TODO remove when all plugins are fixed
-                LOGGER.log(Level.INFO, "Connecting {0} as an inbound agent where the launcher {1} does not mark "
+                LOGGER.log(Level.FINE, "Connecting {0} as an inbound agent where the launcher {1} does not mark "
                                 + "itself correctly as being an inbound agent",
                         new Object[]{clientName, computer.getLauncher().getClass()});
                 launcher = l;
@@ -125,7 +125,7 @@ public class DefaultJnlpSlaveReceiver extends JnlpAgentReceiver {
             if (cookie != null && cookie.equals(ch.getProperty(COOKIE_NAME))) {
                 // we think we are currently connected, but this request proves that it's from the party
                 // we are supposed to be communicating to. so let the current one get disconnected
-                LOGGER.log(Level.INFO, "Disconnecting {0} as we are reconnected from the current peer", clientName);
+                LOGGER.log(Level.FINE, "Disconnecting {0} as we are reconnected from the current peer", clientName);
                 try {
                     computer.disconnect(new ConnectionFromCurrentPeer()).get(15, TimeUnit.SECONDS);
                 } catch (ExecutionException | TimeoutException | InterruptedException e) {

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
@@ -191,7 +191,7 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
             X509Certificate certificate = (X509Certificate) keyStore.getCertificate("jenkins");
             if (certificate == null
                     || certificate.getNotAfter().getTime() < System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1)) {
-                LOGGER.log(Level.INFO, "Updating {0} TLS certificate to retain validity", getName());
+                LOGGER.log(Level.FINEST, "Updating {0} TLS certificate to retain validity", getName());
                 X509Certificate identityCertificate = InstanceIdentityProvider.RSA.getCertificate();
                 RSAPrivateKey privateKey = InstanceIdentityProvider.RSA.getPrivateKey();
                 char[] password = "password".toCharArray();

--- a/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
+++ b/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
@@ -60,7 +60,7 @@ public class JnlpSlaveRestarterInstaller extends ComputerListener implements Ser
 
             List<SlaveRestarter> effective = ch.call(new FindEffectiveRestarters(restarters));
 
-            LOGGER.log(FINE, "Effective SlaveRestarter on {0}: {1}", new Object[] {c.getName(), effective});
+            LOGGER.log(FINEST, "Effective SlaveRestarter on {0}: {1}", new Object[] {c.getName(), effective});
         } catch (Throwable e) {
             Functions.printStackTrace(e, listener.error("Failed to install restarter"));
         }
@@ -90,7 +90,7 @@ public class JnlpSlaveRestarterInstaller extends ComputerListener implements Ser
                     try {
                         for (SlaveRestarter r : restarters) {
                             try {
-                                LOGGER.info("Restarting agent via "+r);
+                                LOGGER.finest("Restarting agent via "+r);
                                 r.restart();
                             } catch (Exception x) {
                                 LOGGER.log(SEVERE, "Failed to restart agent with "+r, x);

--- a/core/src/main/java/jenkins/slaves/restarter/WinswSlaveRestarter.java
+++ b/core/src/main/java/jenkins/slaves/restarter/WinswSlaveRestarter.java
@@ -39,7 +39,7 @@ public class WinswSlaveRestarter extends SlaveRestarter {
         copy(p.getInputStream(), baos);
         int r = p.waitFor();
         if (r!=0)
-            LOGGER.info(exe+" cmd: output:\n"+baos);
+            LOGGER.finest(exe+" cmd: output:\n"+baos);
         return r;
     }
 

--- a/core/src/main/java/jenkins/telemetry/Telemetry.java
+++ b/core/src/main/java/jenkins/telemetry/Telemetry.java
@@ -156,7 +156,7 @@ public abstract class Telemetry implements ExtensionPoint {
         @Override
         protected void execute(TaskListener listener) throws IOException, InterruptedException {
             if (isDisabled()) {
-                LOGGER.info("Collection of anonymous usage statistics is disabled, skipping telemetry collection and submission");
+                LOGGER.finest("Collection of anonymous usage statistics is disabled, skipping telemetry collection and submission");
                 return;
             }
             Telemetry.all().forEach(telemetry -> {

--- a/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
+++ b/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
@@ -77,7 +77,7 @@ public class GlobalToolConfiguration extends ManagementLink {
     @RequirePOST
     public synchronized void doConfigure(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, Descriptor.FormException {
         boolean result = configure(req, req.getSubmittedForm());
-        LOGGER.log(Level.FINE, "tools saved: "+result);
+        LOGGER.log(Level.FINEST, "tools saved: "+result);
         FormApply.success(req.getContextPath() + "/manage").generateResponse(req, rsp, null);
     }
 

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -261,7 +261,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
                     }
                     List<Job> upstreams =
                             Items.fromNameList(downstream.getParent(), trigger.getUpstreamProjects(), Job.class);
-                    LOGGER.log(Level.FINE, "from {0} see upstreams {1}", new Object[]{downstream, upstreams});
+                    LOGGER.log(Level.FINEST, "from {0} see upstreams {1}", new Object[]{downstream, upstreams});
                     for (Job upstream : upstreams) {
                         if (upstream instanceof AbstractProject && downstream instanceof AbstractProject) {
                             continue; // handled specially

--- a/core/src/main/java/jenkins/util/FullDuplexHttpService.java
+++ b/core/src/main/java/jenkins/util/FullDuplexHttpService.java
@@ -100,7 +100,7 @@ public abstract class FullDuplexHttpService {
         {// wait until we have the other channel
             long end = System.currentTimeMillis() + CONNECTION_TIMEOUT;
             while (upload == null && System.currentTimeMillis() < end) {
-                LOGGER.log(Level.FINE, "Waiting for upload stream for {0}: {1}", new Object[] {uuid, this});
+                LOGGER.log(Level.FINEST, "Waiting for upload stream for {0}: {1}", new Object[] {uuid, this});
                 wait(1000);
             }
 
@@ -108,7 +108,7 @@ public abstract class FullDuplexHttpService {
                 throw new IOException("HTTP full-duplex channel timeout: " + uuid);
             }
 
-            LOGGER.log(Level.FINE, "Received upload stream {0} for {1}: {2}", new Object[] {upload, uuid, this});
+            LOGGER.log(Level.FINEST, "Received upload stream {0} for {1}: {2}", new Object[] {upload, uuid, this});
         }
 
         try {
@@ -134,7 +134,7 @@ public abstract class FullDuplexHttpService {
 
         // publish the upload channel
         upload = in;
-        LOGGER.log(Level.FINE, "Recording upload stream {0} for {1}: {2}", new Object[] {upload, uuid, this});
+        LOGGER.log(Level.FINEST, "Recording upload stream {0} for {1}: {2}", new Object[] {upload, uuid, this});
         notify();
 
         // wait until we are done
@@ -169,12 +169,12 @@ public abstract class FullDuplexHttpService {
 
                 if (req.getHeader("Side").equals("download")) {
                     FullDuplexHttpService service = createService(req, uuid);
-                    LOGGER.log(Level.FINE, "Processing download side for {0}: {1}", new Object[] {uuid, service});
+                    LOGGER.log(Level.FINEST, "Processing download side for {0}: {1}", new Object[] {uuid, service});
                     services.put(uuid, service);
                     try {
                         service.download(req, rsp);
                     } finally {
-                        LOGGER.log(Level.FINE, "Finished download side for {0}: {1}", new Object[] {uuid, service});
+                        LOGGER.log(Level.FINEST, "Finished download side for {0}: {1}", new Object[] {uuid, service});
                         services.remove(uuid);
                     }
                 } else {
@@ -182,11 +182,11 @@ public abstract class FullDuplexHttpService {
                     if (service == null) {
                         throw new IOException("No download side found for " + uuid);
                     }
-                    LOGGER.log(Level.FINE, "Processing upload side for {0}: {1}", new Object[] {uuid, service});
+                    LOGGER.log(Level.FINEST, "Processing upload side for {0}: {1}", new Object[] {uuid, service});
                     try {
                         service.upload(req, rsp);
                     } finally {
-                        LOGGER.log(Level.FINE, "Finished upload side for {0}: {1}", new Object[] {uuid, service});
+                        LOGGER.log(Level.FINEST, "Finished upload side for {0}: {1}", new Object[] {uuid, service});
                     }
                 }
             } catch (InterruptedException e) {

--- a/core/src/main/java/jenkins/util/JSONSignatureValidator.java
+++ b/core/src/main/java/jenkins/util/JSONSignatureValidator.java
@@ -78,7 +78,7 @@ public class JSONSignatureValidator {
                         } catch (CertificateNotYetValidException e) {
                             warning = FormValidation.warning(e, String.format("Certificate %s is not yet valid in %s", cert.toString(), name));
                         }
-                        LOGGER.log(Level.FINE, "Add certificate found in json doc: \r\n\tsubjectDN: {0}\r\n\tissuer: {1}", new Object[]{c.getSubjectDN(), c.getIssuerDN()});
+                        LOGGER.log(Level.FINEST, "Add certificate found in json doc: \r\n\tsubjectDN: {0}\r\n\tissuer: {1}", new Object[]{c.getSubjectDN(), c.getIssuerDN()});
                         certs.add(c);
                     } catch (IllegalArgumentException ex) {
                         throw new IOException("Could not decode certificate", ex);
@@ -103,7 +103,7 @@ public class JSONSignatureValidator {
                     case ERROR:
                         return resultSha512;
                     case WARNING:
-                        LOGGER.log(Level.INFO, "JSON data source '" + name + "' does not provide a SHA-512 content checksum or signature. Looking for SHA-1.");
+                        LOGGER.log(Level.FINEST, "JSON data source '" + name + "' does not provide a SHA-512 content checksum or signature. Looking for SHA-1.");
                         break;
                     case OK:
                         // fall through
@@ -263,7 +263,7 @@ public class JSONSignatureValidator {
             }
             try {
                 TrustAnchor certificateAuthority = new TrustAnchor((X509Certificate) certificate, null);
-                LOGGER.log(Level.FINE, "Add Certificate Authority {0}: {1}",
+                LOGGER.log(Level.FINEST, "Add Certificate Authority {0}: {1}",
                         new Object[]{cert, (certificateAuthority.getTrustedCert() == null ? null : certificateAuthority.getTrustedCert().getSubjectDN())});
                 anchors.add(certificateAuthority);
             } catch (IllegalArgumentException e) {
@@ -294,7 +294,7 @@ public class JSONSignatureValidator {
                 }
                 try {
                     TrustAnchor certificateAuthority = new TrustAnchor((X509Certificate) certificate, null);
-                    LOGGER.log(Level.FINE, "Add Certificate Authority {0}: {1}",
+                    LOGGER.log(Level.FINEST, "Add Certificate Authority {0}: {1}",
                             new Object[]{cert, (certificateAuthority.getTrustedCert() == null ? null : certificateAuthority.getTrustedCert().getSubjectDN())});
                     anchors.add(certificateAuthority);
                 } catch (IllegalArgumentException e) {

--- a/core/src/main/java/jenkins/util/ProgressiveRendering.java
+++ b/core/src/main/java/jenkins/util/ProgressiveRendering.java
@@ -109,7 +109,7 @@ public abstract class ProgressiveRendering {
         }
         boundObjectTable = ((BoundObjectTable) ancestor.getObject()).getTable();
         boundId = ancestor.getNextToken(0);
-        LOG.log(Level.FINE, "starting rendering {0} at {1}", new Object[] {uri, boundId});
+        LOG.log(Level.FINEST, "starting rendering {0} at {1}", new Object[] {uri, boundId});
         final ExecutorService executorService = executorService();
         executorService.submit(new Runnable() {
             @Override public void run() {
@@ -128,12 +128,12 @@ public abstract class ProgressiveRendering {
                 } finally {
                     SecurityContextHolder.setContext(orig);
                     setCurrentRequest(null);
-                    LOG.log(Level.FINE, "{0} finished in {1}msec with status {2}", new Object[] {uri, System.currentTimeMillis() - start, status});
+                    LOG.log(Level.FINEST, "{0} finished in {1}msec with status {2}", new Object[] {uri, System.currentTimeMillis() - start, status});
                 }
                 if (executorService instanceof ScheduledExecutorService) {
                     ((ScheduledExecutorService) executorService).schedule(new Runnable() {
                         @Override public void run() {
-                            LOG.log(Level.FINE, "some time has elapsed since {0} finished, so releasing", boundId);
+                            LOG.log(Level.FINEST, "some time has elapsed since {0} finished, so releasing", boundId);
                             release();
                         }
                     }, timeout() /* add some grace period for browser/network overhead */ * 2, TimeUnit.MILLISECONDS);
@@ -177,7 +177,7 @@ public abstract class ProgressiveRendering {
             }
         }
         List/*<AncestorImpl>*/ ancestors = currentRequest.ancestors;
-        LOG.log(Level.FINER, "mocking ancestors {0} using {1}", new Object[] {ancestors, getters});
+        LOG.log(Level.FINEST, "mocking ancestors {0} using {1}", new Object[] {ancestors, getters});
         TokenList tokens = currentRequest.tokens;
         return new RequestImpl(Stapler.getCurrent(), (HttpServletRequest) Proxy.newProxyInstance(ProgressiveRendering.class.getClassLoader(), new Class<?>[] {HttpServletRequest.class}, new InvocationHandler() {
             @Override public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
@@ -258,7 +258,7 @@ public abstract class ProgressiveRendering {
         long elapsed = now - lastNewsTime;
         if (elapsed > timeout()) {
             status = CANCELED;
-            LOG.log(Level.FINE, "{0} canceled due to {1}msec inactivity after {2}msec", new Object[] {uri, elapsed, now - start});
+            LOG.log(Level.FINEST, "{0} canceled due to {1}msec inactivity after {2}msec", new Object[] {uri, elapsed, now - start});
             return true;
         } else {
             return false;
@@ -280,11 +280,11 @@ public abstract class ProgressiveRendering {
         Object statusJSON = status == 1 ? "done" : status == CANCELED ? "canceled" : status == ERROR ? "error" : status;
         r.put("status", statusJSON);
         if (statusJSON instanceof String) { // somehow completed
-            LOG.log(Level.FINE, "finished in news so releasing {0}", boundId);
+            LOG.log(Level.FINEST, "finished in news so releasing {0}", boundId);
             release();
         }
         lastNewsTime = System.currentTimeMillis();
-        LOG.log(Level.FINER, "news from {0}", uri);
+        LOG.log(Level.FINEST, "news from {0}", uri);
         return r;
     }
 

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -141,7 +141,7 @@ public class SystemProperties {
                 for (String key : ALLOW_ON_AGENT) {
                     snapshot.put(key, getString(key));
                 }
-                LOGGER.log(Level.FINE, "taking snapshot of {0}", snapshot);
+                LOGGER.log(Level.FINEST, "taking snapshot of {0}", snapshot);
             }
             @Override
             public Void call() throws RuntimeException {

--- a/core/src/main/java/jenkins/util/groovy/GroovyHookScript.java
+++ b/core/src/main/java/jenkins/util/groovy/GroovyHookScript.java
@@ -115,14 +115,14 @@ public class GroovyHookScript {
 
     protected void execute(URL bundled) throws IOException {
         if (bundled!=null) {
-            LOGGER.info("Executing bundled script: "+bundled);
+            LOGGER.finest("Executing bundled script: "+bundled);
             execute(new GroovyCodeSource(bundled));
         }
     }
 
     protected void execute(File f) {
         if (f.exists()) {
-            LOGGER.info("Executing "+f);
+            LOGGER.finest("Executing "+f);
             try {
                 execute(new GroovyCodeSource(f));
             } catch (IOException e) {

--- a/core/src/test/java/hudson/util/RetrierTest.java
+++ b/core/src/test/java/hudson/util/RetrierTest.java
@@ -29,7 +29,7 @@ public class RetrierTest {
                 (
                         // action to perform
                         () -> {
-                            LOG.info("action performed");
+                            LOG.finest("action performed");
                             return true;
                         },
                         // check the result and return true if success
@@ -71,7 +71,7 @@ public class RetrierTest {
                 (
                         // action to perform
                         () -> {
-                            LOG.info("action performed");
+                            LOG.finest("action performed");
                             return true;
                         },
                         // check the result and return true if success
@@ -123,7 +123,7 @@ public class RetrierTest {
                 (
                         // action to perform
                         () -> {
-                            LOG.info("action performed");
+                            LOG.finest("action performed");
                             return false;
                         },
                         // check the result and return true if success

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -389,10 +389,10 @@ public class ProjectTest {
 
     private QueueTaskFuture<FreeStyleBuild> waitForStart(FreeStyleProject p) throws InterruptedException, ExecutionException {
         long start = System.nanoTime();
-        LOGGER.info("Scheduling "+p);
+        LOGGER.finest("Scheduling "+p);
         QueueTaskFuture<FreeStyleBuild> f = p.scheduleBuild2(0);
         f.waitForStart();
-        LOGGER.info("Wait:"+ TimeUnit.NANOSECONDS.toMillis(System.nanoTime()-start));
+        LOGGER.finest("Wait:"+ TimeUnit.NANOSECONDS.toMillis(System.nanoTime()-start));
         return f;
     }
 

--- a/test/src/test/java/hudson/slaves/NodeParallelTest.java
+++ b/test/src/test/java/hudson/slaves/NodeParallelTest.java
@@ -36,7 +36,7 @@ public class NodeParallelTest {
         List<Callable<Void>> tasks = Collections.nCopies(n, () -> {
             try {
                 int i = count.incrementAndGet();
-                LOGGER.log(Level.INFO, "Creating slave " + i);
+                LOGGER.log(Level.FINEST, "Creating slave " + i);
                 // JenkinsRule sync on Jenkins singleton, so this doesn't work
                 // r.createSlave();
                 DumbSlave agent = new DumbSlave("agent-"+i, "/tmp", new JNLPLauncher(true));

--- a/test/src/test/java/hudson/tasks/LogRotatorTest.java
+++ b/test/src/test/java/hudson/tasks/LogRotatorTest.java
@@ -239,14 +239,14 @@ public class LogRotatorTest {
         public @Override boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener)
                 throws IOException, InterruptedException {
             archiver.perform(build, launcher, listener);
-            Logger.getAnonymousLogger().log(Level.INFO, "Building #{0}", build.getNumber());
+            Logger.getAnonymousLogger().log(Level.FINEST, "Building #{0}", build.getNumber());
             synchronized (waitLock) {
                 if (waitBuildNumber < build.getNumber()) {
                     waitBuildNumber = build.getNumber();
                     waitLock.notifyAll();
                 }
             }
-            Logger.getAnonymousLogger().log(Level.INFO, "Waiting #{0}", build.getNumber());
+            Logger.getAnonymousLogger().log(Level.FINEST, "Waiting #{0}", build.getNumber());
             synchronized (syncLock) {
                 while (build.getNumber() > syncBuildNumber) {
                     try {
@@ -257,14 +257,14 @@ public class LogRotatorTest {
                     }
                 }
             }
-            Logger.getAnonymousLogger().log(Level.INFO, "Done #{0}", build.getNumber());
+            Logger.getAnonymousLogger().log(Level.FINEST, "Done #{0}", build.getNumber());
             return true;
         }
         
         public void release(int upToBuildNumber) {
             synchronized (syncLock) {
                 if (syncBuildNumber < upToBuildNumber) {
-                    Logger.getAnonymousLogger().log(Level.INFO, "Signal #{0}", upToBuildNumber);
+                    Logger.getAnonymousLogger().log(Level.FINEST, "Signal #{0}", upToBuildNumber);
                     syncBuildNumber = upToBuildNumber;
                     syncLock.notifyAll();
                 }

--- a/test/src/test/java/jenkins/util/FullDuplexHttpServiceTest.java
+++ b/test/src/test/java/jenkins/util/FullDuplexHttpServiceTest.java
@@ -64,7 +64,7 @@ public class FullDuplexHttpServiceTest {
         OutputStream os = con.getOutputStream();
         os.write(33);
         os.flush();
-        Logger.getLogger(FullDuplexHttpServiceTest.class.getName()).info("uploaded initial content");
+        Logger.getLogger(FullDuplexHttpServiceTest.class.getName()).finest("uploaded initial content");
         assertEquals(0, is.read()); // see FullDuplexHttpStream.getInputStream
         assertEquals(66, is.read());
     }


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. We hypothesize that portions of a system that are worked on more and more recently should have higher log levels (e.g., INFO as compared to FINEST) and vice-versa. This places event logs related to tasks that are currently more important to the forefront while pushing event logs pertaining to tasks worked on in the past to the background. The goal is to reduce information overload, bring more relevant events to developers' attention, and alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and program elements, such as edits. In this project, we calculate the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Settings

We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

1. Treat CONFIG, WARNING, and SEVERE levels as a category and not a traditional level, i.e., our tool ignores these log levels.
1. Never lower the logging level of logging statements within catch blocks.
1. Never lower the logging level of logging statements within if statements.
1. Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
1. The greatest number of commits evaluated: 1000.

The head at time of analysis was: 44c4d3989232082c254d27ae360aa810669f44b7