### PR TITLE
[JENKINS-57244, JENKINS-57229] - Revert "[JENKINS-47896] SerializableOnlyOverRemoting"

### DIFF
--- a/core/src/main/java/hudson/model/TaskListener.java
+++ b/core/src/main/java/hudson/model/TaskListener.java
@@ -33,11 +33,11 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Formatter;
 import javax.annotation.Nonnull;
-import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.accmod.restrictions.ProtectedExternally;
@@ -66,7 +66,7 @@ import org.kohsuke.accmod.restrictions.ProtectedExternally;
  *
  * @author Kohsuke Kawaguchi
  */
-public interface TaskListener extends SerializableOnlyOverRemoting {
+public interface TaskListener extends Serializable {
     /**
      * This writer will receive the output of the build
      */

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -40,7 +40,6 @@ import hudson.util.ProcessTree.OSProcess;
 import hudson.util.ProcessTreeRemoting.IOSProcess;
 import hudson.util.ProcessTreeRemoting.IProcessTree;
 import jenkins.security.SlaveToMasterCallable;
-import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 import jenkins.util.java.JavaUtils;
 import org.jvnet.winp.WinProcess;
 import org.jvnet.winp.WinpException;
@@ -55,7 +54,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.io.Serializable;
-import java.io.ObjectStreamException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -97,7 +95,7 @@ import javax.annotation.Nonnull;
  * @author Kohsuke Kawaguchi
  * @since 1.315
  */
-public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, SerializableOnlyOverRemoting {
+public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, Serializable {
     /**
      * To be filled in the constructor of the derived type.
      */
@@ -1830,7 +1828,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
     /**
      * Represents a process tree over a channel.
      */
-    public static class Remote extends ProcessTree {
+    public static class Remote extends ProcessTree implements Serializable {
         private final IProcessTree proxy;
 
         @Deprecated
@@ -1910,8 +1908,8 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
     /**
      * Use {@link Remote} as the serialized form.
      */
-    /*package*/ Object writeReplace() throws ObjectStreamException {
-        return new Remote(this, getChannelForSerialization());
+    /*package*/ Object writeReplace() {
+        return new Remote(this,Channel.current());
     }
 
 //    public static void main(String[] args) {

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -1909,7 +1909,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
      * Use {@link Remote} as the serialized form.
      */
     /*package*/ Object writeReplace() {
-        return new Remote(this,Channel.current());
+        return new Remote(this, Channel.current());
     }
 
 //    public static void main(String[] args) {


### PR DESCRIPTION
Reverts jenkinsci/jenkins#3980 which caused a number of regressions in 2.175

* https://issues.jenkins-ci.org/browse/JENKINS-47896

Regressions:

* https://issues.jenkins-ci.org/browse/JENKINS-57244
* https://issues.jenkins-ci.org/browse/JENKINS-57229
* https://github.com/gatling/gatling/issues/3722

Until the plan in https://github.com/jenkinsci/jenkins/pull/3980#issuecomment-489070316 is implemented, I propose reverting it as a plan B if we do not have a clean fix by the next weekly.

### Changelog entry

* Major bug - Revert the fix of JENKINS-47896 which exposed serialization defects in plugins when running with Jenkins 2.175. A more clean version of the fix will be delivered later

