### PR TITLE
[JENKINS-51577] - Windows Agent Installer: Enable TLS 1.2 on agent downloads when running with .NET 4.6 or above

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -110,7 +110,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>windows-slave-installer</artifactId>
-      <version>1.10.0</version>
+      <version>1.11</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
See [JENKINS-51577](https://issues.jenkins-ci.org/browse/JENKINS-51577). Without this patch new agent installations does not work well on modern systems with Jenkins behind HTTPs

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* rfe, Windows Agent Installer 1.11:  Enable TLS 1.2 on agent downloads when running with .NET 4.6 or above
  * Full changelog: https://github.com/jenkinsci/windows-slave-installer-module/blob/master/CHANGELOG.md#111

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/sig-platform 
