### PR TITLE
[SECURITY-901] Follow up: Remove restriction

### DIFF
--- a/core/src/main/java/jenkins/security/seed/UserSeedProperty.java
+++ b/core/src/main/java/jenkins/security/seed/UserSeedProperty.java
@@ -58,8 +58,6 @@ import java.util.Objects;
  * @see hudson.security.AuthenticationProcessingFilter2 for the addition of seed inside the session
  * @see hudson.security.HttpSessionContextIntegrationFilter2 for the seed check from the session before using it
  */
-//TODO remove restriction on the weekly after the security fix
-@Restricted(NoExternalUse.class)
 public class UserSeedProperty extends UserProperty {
     /**
      * Escape hatch for User seed based revocation feature. 


### PR DESCRIPTION
This is a follow up on SECURITY-901 changes to remove the `@Restricted`
annotation after the security release is done.

See [SECURITY-901](https://issues.jenkins-ci.org/browse/SECURITY-901).

### Proposed changelog entries

* SECURITY-901 follow up: `UserSeedProperty` is not restricted now

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jenkinsci/code-reviewers

