### PR TITLE
[JENKINS-25369] DNS multicast error messages

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -527,9 +527,9 @@ THE SOFTWARE.
       <version>3.2.9</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci</groupId>
+      <groupId>org.jmdns</groupId>
       <artifactId>jmdns</artifactId>
-      <version>3.4.0-jenkins-3</version>
+      <version>3.5.5</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>

--- a/core/src/main/java/hudson/DNSMultiCast.java
+++ b/core/src/main/java/hudson/DNSMultiCast.java
@@ -95,7 +95,7 @@ public class DNSMultiCast implements Closeable {
 
     private static final Logger LOGGER = Logger.getLogger(DNSMultiCast.class.getName());
 
-    public static boolean disabled = SystemProperties.getBoolean(DNSMultiCast.class.getName()+".disabled", true);
+    public static boolean disabled = SystemProperties.getBoolean(DNSMultiCast.class.getName()+".disabled");
 
     private static class JenkinsJmDNS extends JmDNSImpl {
         private static Logger logger = Logger.getLogger(JmDNSImpl.class.getName());
@@ -134,7 +134,15 @@ public class DNSMultiCast implements Closeable {
                 this.cancelTimer();
 
                 // Cancel all services
+                // KK: this is a blocking call that doesn't fit 'abort'
+                // this.unregisterAllServices();
                 executePrivateParentMethod("disposeServiceCollectors");
+
+// KK: another blocking call
+//                if (logger.isLoggable(Level.FINER)) {
+//                    logger.finer("Wait for JmDNS cancel: " + this);
+//                }
+//                this.waitForCanceled(DNSConstants.CLOSE_TIMEOUT);
 
                 // Stop the canceler timer
                 logger.finer("Canceling the state timer");
@@ -165,7 +173,7 @@ public class DNSMultiCast implements Closeable {
                 ExecutorService _executor = (ExecutorService) executor.get(this);
                 _executor.shutdown();
             } catch (NoSuchFieldException | IllegalAccessException e) {
-                logger.severe("Error trying to abort JmDNS: " + e.getMessage());
+                logger.log(Level.SEVERE, "Error trying to abort JmDNS", e);
                 throw new IOException(e);
             }
         }
@@ -176,7 +184,7 @@ public class DNSMultiCast implements Closeable {
                 m.setAccessible(true);
                 m.invoke(this);
             } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-                logger.severe("Error trying to abort JmDNS: " + e.getMessage());
+                logger.log(Level.SEVERE, "Error trying to abort JmDNS", e);
                 throw new IOException(e);
             }
         }

--- a/core/src/main/java/hudson/DNSMultiCast.java
+++ b/core/src/main/java/hudson/DNSMultiCast.java
@@ -4,14 +4,21 @@ import jenkins.util.SystemProperties;
 import jenkins.model.Jenkins;
 import jenkins.model.Jenkins.MasterComputer;
 
-import javax.jmdns.JmDNS;
+import javax.jmdns.ServiceEvent;
 import javax.jmdns.ServiceInfo;
+import javax.jmdns.ServiceListener;
+import javax.jmdns.impl.JmDNSImpl;
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -21,7 +28,7 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 public class DNSMultiCast implements Closeable {
-    private JmDNS jmdns;
+    private JenkinsJmDNS jmdns;
 
     public DNSMultiCast(final Jenkins jenkins) {
         if (disabled)   return; // escape hatch
@@ -30,7 +37,7 @@ public class DNSMultiCast implements Closeable {
         MasterComputer.threadPoolForRemoting.submit(new Callable<Object>() {
             public Object call() {
                 try {
-                    jmdns = JmDNS.create();
+                    jmdns = new JenkinsJmDNS(null, null);
 
                     Map<String,String> props = new HashMap<>();
                     String rootURL = jenkins.getRootUrl();
@@ -77,16 +84,102 @@ public class DNSMultiCast implements Closeable {
 
     public void close() {
         if (jmdns!=null) {
-//            try {
+            try {
                 jmdns.abort();
                 jmdns = null;
-//            } catch (final IOException e) {
-//                LOGGER.log(Level.WARNING,"Failed to close down JmDNS instance!",e);
-//            }
+            } catch (final IOException e) {
+                LOGGER.log(Level.WARNING,"Failed to close down JmDNS instance!",e);
+            }
         }
     }
 
     private static final Logger LOGGER = Logger.getLogger(DNSMultiCast.class.getName());
 
-    public static boolean disabled = SystemProperties.getBoolean(DNSMultiCast.class.getName()+".disabled");
+    public static boolean disabled = SystemProperties.getBoolean(DNSMultiCast.class.getName()+".disabled", true);
+
+    private static class JenkinsJmDNS extends JmDNSImpl {
+        private static Logger logger = Logger.getLogger(JmDNSImpl.class.getName());
+        private final Class parent;
+
+        /**
+         * Create an instance of JmDNS and bind it to a specific network interface given its IP-address.
+         *
+         * @param address IP address to bind to.
+         * @param name    name of the newly created JmDNS
+         * @throws IOException
+         */
+        public JenkinsJmDNS(InetAddress address, String name) throws IOException {
+            super(address, name);
+            this.parent = this.getClass().getSuperclass();
+        }
+
+        /**
+         * Works like {@link #close()} but terminate uncleanly, but rapidly and without blocking.
+         */
+        public void abort() throws IOException {
+            if (this.isClosing()) {
+                return;
+            }
+
+           if (logger.isLoggable(Level.FINER)) {
+                logger.finer("Aborting JmDNS: " + this);
+            }
+            // Stop JmDNS
+            // This protects against recursive calls
+            if (this.closeState()) {
+                // We got the tie break now clean up
+
+                // Stop the timer
+                logger.finer("Canceling the timer");
+                this.cancelTimer();
+
+                // Cancel all services
+                executePrivateParentMethod("disposeServiceCollectors");
+
+                // Stop the canceler timer
+                logger.finer("Canceling the state timer");
+                this.cancelStateTimer();
+
+                // Stop the executor
+                shutdown();
+
+                // close socket
+                executePrivateParentMethod("closeMulticastSocket");
+
+                // remove the shutdown hook
+                if (_shutdown != null) {
+                    Runtime.getRuntime().removeShutdownHook(_shutdown);
+                }
+
+                if (logger.isLoggable(Level.FINER)) {
+                    logger.finer("JmDNS closed.");
+                }
+            }
+            advanceState(null);
+        }
+
+        private void shutdown() throws IOException {
+            try {
+                Field executor = this.parent.getDeclaredField("_executor");
+                executor.setAccessible(true);
+                ExecutorService _executor = (ExecutorService) executor.get(this);
+                _executor.shutdown();
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                logger.severe("Error trying to abort JmDNS: " + e.getMessage());
+                throw new IOException(e);
+            }
+        }
+
+        private void executePrivateParentMethod(String method) throws IOException {
+            try {
+                Method m = this.parent.getDeclaredMethod(method);
+                m.setAccessible(true);
+                m.invoke(this);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                logger.severe("Error trying to abort JmDNS: " + e.getMessage());
+                throw new IOException(e);
+            }
+        }
+
+    }
 }


### PR DESCRIPTION
See [JENKINS-25369](https://issues.jenkins-ci.org/browse/JENKINS-25369).

Diff between versions of jmdns: https://github.com/jmdns/jmdns/compare/jmdns-3.4.0...jmdns-3.5.5

### Proposed changelog entries

* Internal: Update the jmDns library version preventing DNS Multicast error messages. Start using the library instead of the forked one, moving the method added to jenkins-core.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@oleg-nenashev @daniel-beck @batmat 