### PR TITLE
[JENKINS-56575][2] Support REST client for restart

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4187,6 +4187,13 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return;
         }
 
+        //Request from rest client
+        if (req.getReferer() == null || req.getMethod().equals("POST")) {
+            rsp.setStatus(200);
+            restart();
+            return;
+        }
+
         if (req == null || req.getMethod().equals("POST")) {
             restart();
         }
@@ -4208,6 +4215,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         checkPermission(ADMINISTER);
         if (req != null && req.getMethod().equals("GET"))
             return HttpResponses.forwardToView(this,"_safeRestart.jelly");
+
+        //Request from rest client
+        if (req.getReferer() == null || req.getMethod().equals("POST")){
+            safeRestart();
+            return HttpResponses.text("safeRestart");
+        }
 
         if (req == null || req.getMethod().equals("POST")) {
             safeRestart();

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4217,7 +4217,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return HttpResponses.forwardToView(this, "_safeRestart.jelly");
         }
 
-        if (isRestClientAndPost(req)){
+        if (isRestClientAndPost(req)) {
             safeRestart();
             return HttpResponses.status(HttpURLConnection.HTTP_ACCEPTED);
         }
@@ -4244,11 +4244,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return false;
         }
 
-        if (acceptValue.equals("application/json")) {
-            return true;
-        }
-
-        return false;
+        return acceptValue.equals("application/json");
     }
 
     private static Lifecycle restartableLifecycle() throws RestartNotSupportedException {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4188,7 +4188,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
 
         //Request from rest client
-        if (req.getReferer() == null || req.getMethod().equals("POST")) {
+        if (req != null && req.getReferer() == null && req.getMethod().equals("POST")) {
             rsp.setStatus(200);
             restart();
             return;
@@ -4217,7 +4217,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return HttpResponses.forwardToView(this,"_safeRestart.jelly");
 
         //Request from rest client
-        if (req.getReferer() == null || req.getMethod().equals("POST")){
+        if (req != null && req.getReferer() == null && req.getMethod().equals("POST")){
             safeRestart();
             return HttpResponses.text("safeRestart");
         }

--- a/test/src/test/java/jenkins/model/Jenkins56575Test.java
+++ b/test/src/test/java/jenkins/model/Jenkins56575Test.java
@@ -1,0 +1,227 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model;
+
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import hudson.Launcher;
+import hudson.Main;
+import hudson.lifecycle.Lifecycle;
+import hudson.lifecycle.RestartNotSupportedException;
+import hudson.util.StreamTaskListener;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+
+public class Jenkins56575Test {
+    
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+    
+    private File jar;
+    
+    private AtomicReference<Boolean> restartCalled = new AtomicReference<>(false);
+    private AtomicReference<Boolean> verifyRestartableCalled = new AtomicReference<>(false);
+    private Semaphore restartSemaphore = new Semaphore(0);
+    
+    private Lifecycle previousLifecycle;
+    private Field instanceField;
+    
+    @Before
+    public void setupMockLifecycle() throws Exception {
+        Main.isUnitTest = false;
+        j.jenkins.setCrumbIssuer(null);
+        
+        previousLifecycle = Lifecycle.get();
+        
+        instanceField = Lifecycle.class.getDeclaredField("INSTANCE");
+        instanceField.setAccessible(true);
+        instanceField.set(null, new Lifecycle() {
+            @Override
+            public void verifyRestartable() throws RestartNotSupportedException {
+                verifyRestartableCalled.set(true);
+            }
+            
+            @Override
+            public void restart() throws IOException, InterruptedException {
+                restartCalled.set(true);
+                restartSemaphore.release();
+            }
+        });
+    }
+    
+    @Before
+    public void grabCliJar() throws IOException {
+        jar = tmp.newFile("jenkins-cli.jar");
+        FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
+    }
+    
+    @After
+    public void resetSettings() throws Exception {
+        Main.isUnitTest = true;
+        
+        instanceField.set(null, previousLifecycle);
+    }
+    
+    @Test
+    public void testRestart_regularClient() throws Exception {
+        WebClient wc = j.createWebClient()
+                .withRedirectEnabled(false)
+                .withThrowExceptionOnFailingStatusCode(false);
+        WebRequest request = new WebRequest(new URL(j.getURL() + "restart"), HttpMethod.POST);
+        
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+        
+        Page page = wc.getPage(request);
+        assertThat(page.getWebResponse().getStatusCode(), is(HttpURLConnection.HTTP_MOVED_TEMP));
+        
+        restartSemaphore.acquire(1);
+        
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+    
+    @Test
+    @Issue("JENKINS-56575")
+    public void testRestart_restClient() throws Exception {
+        WebClient wc = j.createWebClient()
+                .withRedirectEnabled(false)
+                .withThrowExceptionOnFailingStatusCode(false);
+        WebRequest request = new WebRequest(new URL(j.getURL() + "restart"), HttpMethod.POST);
+        request.setAdditionalHeader("Accept", "application/json");
+        
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+        
+        Page page = wc.getPage(request);
+        assertThat(page.getWebResponse().getStatusCode(), is(HttpURLConnection.HTTP_OK));
+        
+        restartSemaphore.acquire(1);
+        
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+    
+    @Test
+    public void testRestart_cliClient() throws Exception {
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+        
+        assertEquals(0, launchCLI("java",
+                "-jar", jar.getAbsolutePath(),
+                "-s", j.getURL().toString(),
+                "restart"));
+        
+        restartSemaphore.acquire(1);
+        
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+    
+    @Test
+    public void testSafeRestart_regularClient() throws Exception {
+        WebClient wc = j.createWebClient()
+                .withRedirectEnabled(false)
+                .withThrowExceptionOnFailingStatusCode(false);
+        WebRequest request = new WebRequest(new URL(j.getURL() + "safeRestart"), HttpMethod.POST);
+        
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+        
+        Page page = wc.getPage(request);
+        assertThat(page.getWebResponse().getStatusCode(), is(HttpURLConnection.HTTP_MOVED_TEMP));
+        
+        restartSemaphore.acquire(1);
+        
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+    
+    @Test
+    @Issue("JENKINS-56575")
+    public void testSafeRestart_restClient() throws Exception {
+        WebClient wc = j.createWebClient()
+                .withRedirectEnabled(false)
+                .withThrowExceptionOnFailingStatusCode(false);
+        WebRequest request = new WebRequest(new URL(j.getURL() + "safeRestart"), HttpMethod.POST);
+        request.setAdditionalHeader("Accept", "application/json");
+        
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+        
+        Page page = wc.getPage(request);
+        assertThat(page.getWebResponse().getStatusCode(), is(HttpURLConnection.HTTP_ACCEPTED));
+        
+        restartSemaphore.acquire(1);
+        
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+    
+    @Test
+    public void testSafeRestart_cliClient() throws Exception {
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+        
+        assertEquals(0, launchCLI("java",
+                "-jar", jar.getAbsolutePath(),
+                "-s", j.getURL().toString(),
+                "safe-restart"));
+        
+        restartSemaphore.acquire(1);
+        
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+    
+    private int launchCLI(String... cmdArgs) throws Exception {
+        return new Launcher.LocalLauncher(StreamTaskListener.fromStderr())
+                .launch()
+                .cmds(cmdArgs)
+                .join();
+    }
+}


### PR DESCRIPTION
❗️ Closed in favor of #4030

----

⚠️ Superseed of [#3972](https://github.com/jenkinsci/jenkins/pull/3972) coming from my fork this time.

Alternative proposed in #3937 using `Accept` instead of `Referer`.
- The REST clients must use `Accept: application/json` as a distinction factor.
- In addition, multiple tests are provided to cover the existing code and the new one

See [JENKINS-56575](https://issues.jenkins-ci.org/browse/JENKINS-56575).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Improve support for REST clients in the `restart` and `safeRestart` web methods

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@P01son6415 @batmat 