### PR TITLE
[JENKINS-57466] If two users trigger updateDirectly -> isDue, make one wait

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -283,12 +283,12 @@ public class UpdateSite {
     /**
      * Returns true if it's time for us to check for new version.
      */
-    public boolean isDue() {
+    synchronized public boolean isDue() {
         if(neverUpdate)     return false;
         if(dataTimestamp == 0)
             dataTimestamp = getDataFile().file.lastModified();
         long now = System.currentTimeMillis();
-        
+
         retryWindow = Math.max(retryWindow,SECONDS.toMillis(15));
         
         boolean due = now - dataTimestamp > DAY && now - lastAttempt > retryWindow;

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -283,7 +283,7 @@ public class UpdateSite {
     /**
      * Returns true if it's time for us to check for new version.
      */
-    synchronized public boolean isDue() {
+    public synchronized boolean isDue() {
         if(neverUpdate)     return false;
         if(dataTimestamp == 0)
             dataTimestamp = getDataFile().file.lastModified();


### PR DESCRIPTION
See [JENKINS-57466](https://issues.jenkins-ci.org/browse/JENKINS-57466).

This is for discussion

### Proposed changelog entries

* Internal: Mark `hudson.model.UpdateSite.isDue` as synchronized

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@Wadeck 