### PR TITLE
IntelliJ/HTML(fr): Start tag has wrong closing tag

### DIFF
--- a/war/src/main/webapp/help/system-config/patternJobNamingStrategy_fr.html
+++ b/war/src/main/webapp/help/system-config/patternJobNamingStrategy_fr.html
@@ -2,7 +2,7 @@
   Définit un pattern (expression régulière) pour vérifier si un nom de job est valide ou pas.
   <p>
   Forcer la vérification sur les jobs existants, permet de forcer une convention de nommage sur les jobs existants - e.g. même si l'utilisateur ne change pas le nom,
-  il sera validé avec le pattern donné lors de toutes les soumissions et aucune mise à jour ne sera possible jusqu'à la confirmation du nom.</br>
+  il sera validé avec le pattern donné lors de toutes les soumissions et aucune mise à jour ne sera possible jusqu'à la confirmation du nom.<br>
   <i>Cette option n'affecte pas l'exécution des jobs dont le nom ne respecte pas le pattern.
   Elle ne fait que contrôler le processus de validation lors de la sauvegarde des configurations de job.</i>
 </div>


### PR DESCRIPTION
### Proposed changelog entries

* minor fix to patternJobNamingStrategy_fr.html

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
