### PR TITLE
[JENKINS-57484] Improving the scripting capacity for the API Tokens

### DIFF
--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -115,8 +115,9 @@ public class SetupWizard extends PageDecorator {
      * - true
      *      A token is generated using random value at startup and the information is put 
      *      in the file "$JENKINS_HOME/secrets/initialAdminApiToken"
-     * @since TODO
+     * @since TODO (for the existence of the sysprop, not the availability to plugin)
      */
+    @Restricted(NoExternalUse.class)
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
     public static /* not final */ String ADMIN_INITIAL_API_TOKEN =
             SystemProperties.getString(SetupWizard.class.getName() + ".adminInitialApiToken");
@@ -647,6 +648,7 @@ public class SetupWizard extends PageDecorator {
      * Gets the file used to store the initial admin API Token, in case the system property
      * {@link #ADMIN_INITIAL_API_TOKEN} is set to "true" (and only in this case).
      */
+    @Restricted(NoExternalUse.class)
     public FilePath getInitialAdminApiTokenFile() {
         return Jenkins.get().getRootPath().child("secrets/initialAdminApiToken");
     }

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -98,6 +98,8 @@ public class SetupWizard extends PageDecorator {
 
     private static final Logger LOGGER = Logger.getLogger(SetupWizard.class.getName());
 
+    private static final String ADMIN_INITIAL_API_TOKEN_PROPERTY_NAME = SetupWizard.class.getName() + ".adminInitialApiToken";
+
     /**
      * This property determines the behavior during the SetupWizard install phase concerning the API Token creation 
      * for the initial admin account.
@@ -119,8 +121,8 @@ public class SetupWizard extends PageDecorator {
      */
     @Restricted(NoExternalUse.class)
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
-    private static /* not final */ String ADMIN_INITIAL_API_TOKEN =
-            SystemProperties.getString(SetupWizard.class.getName() + ".adminInitialApiToken");
+    private static /* not final */ String ADMIN_INITIAL_API_TOKEN = SystemProperties.getString(ADMIN_INITIAL_API_TOKEN_PROPERTY_NAME);
+    
 
     @NonNull
     @Override
@@ -233,19 +235,19 @@ public class SetupWizard extends PageDecorator {
                 // no need for path traversal check as it's coming from the instance creator only
                 File apiTokenFile = new File(sysProp.substring(1));
                 if (!apiTokenFile.exists()) {
-                    LOGGER.log(Level.WARNING, "The API Token cannot be retrieved from a inexistent file: {0}", apiTokenFile);
+                    LOGGER.log(Level.WARNING, "The API Token cannot be retrieved from a non-existing file: {0}", apiTokenFile);
                     return;
                 }
 
                 try {
                     plainText = FileUtils.readFileToString(apiTokenFile, StandardCharsets.UTF_8);
-                    LOGGER.log(Level.INFO, "The API Token was generated using the file referenced by the given system property");
+                    LOGGER.log(Level.INFO, "API Token generated using contents of file: {0}", apiTokenFile.getAbsolutePath());
                 } catch (IOException e) {
                     LOGGER.log(Level.WARNING, String.format("The API Token cannot be retrieved from the file: %s", apiTokenFile), e);
                     return;
                 }
             } else {
-                LOGGER.log(Level.INFO, "The API Token was generated using directly the given system property");
+                LOGGER.log(Level.INFO, "API Token generated using system property: {0}", ADMIN_INITIAL_API_TOKEN_PROPERTY_NAME);
                 plainText = sysProp;
             }
 

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -122,8 +122,7 @@ public class SetupWizard extends PageDecorator {
      * during your installation script using the other ways at your disposal so that you have a fresh token
      * with less traces for your script.
      *
-     * If you do not provide any value to that system property, the default admin account will not have an API Token,
-     * it's the default behavior.
+     * If you do not provide any value to that system property, the default admin account will not have an API Token.
      *
      * @since TODO (for the existence of the sysprop, not the availability to plugin)
      */

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -104,6 +104,9 @@ public class SetupWizard extends PageDecorator {
      * This property determines the behavior during the SetupWizard install phase concerning the API Token creation 
      * for the initial admin account.
      * The behavior depends on the provided value:
+     * - true
+     *      A token is generated using random value at startup and the information is put 
+     *      in the file "$JENKINS_HOME/secrets/initialAdminApiToken".
      * - [2-char hash version][32-hex-char of secret], where the hash version is currently only 11. 
      *      E.g. 110123456789abcdef0123456789abcdef.
      *      A fixed API Token will be created for the user with that plain value as the token.
@@ -114,15 +117,19 @@ public class SetupWizard extends PageDecorator {
      *      /user/[user-login]/descriptorByName/jenkins.security.ApiTokenProperty/revokeAllExcept 
      * - @[file-location] where the file contains plain text value of the token, all stuff explained above is applicable
      *      The application will not delete the file after read, so the script is responsible to clean up the stuff
-     * - true
-     *      A token is generated using random value at startup and the information is put 
-     *      in the file "$JENKINS_HOME/secrets/initialAdminApiToken"
+     *
+     * When the API Token is generated using this system property, it's strongly recommended that you are revoking it
+     * during your installation script using the other ways at your disposal so that you have a fresh token
+     * with less traces for your script.
+     *
+     * If you do not provide any value to that system property, the default admin account will not have an API Token,
+     * it's the default behavior.
+     *
      * @since TODO (for the existence of the sysprop, not the availability to plugin)
      */
     @Restricted(NoExternalUse.class)
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
     private static /* not final */ String ADMIN_INITIAL_API_TOKEN = SystemProperties.getString(ADMIN_INITIAL_API_TOKEN_PROPERTY_NAME);
-    
 
     @NonNull
     @Override

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -26,7 +26,10 @@ import javax.servlet.http.HttpSession;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.security.csrf.GlobalCrumbIssuerConfiguration;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.model.JenkinsLocationConfiguration;
+import jenkins.security.ApiTokenProperty;
+import jenkins.security.apitoken.TokenUuidAndPlainValue;
 import jenkins.security.seed.UserSeedProperty;
 import jenkins.util.SystemProperties;
 import jenkins.util.UrlHelper;
@@ -95,6 +98,29 @@ public class SetupWizard extends PageDecorator {
 
     private static final Logger LOGGER = Logger.getLogger(SetupWizard.class.getName());
 
+    /**
+     * This property determines the behavior during the SetupWizard install phase concerning the API Token creation 
+     * for the initial admin account.
+     * The behavior depends on the provided value:
+     * - [2-char hash version][32-hex-char of secret], where the hash version is currently only 11. 
+     *      E.g. 110123456789abcdef0123456789abcdef.
+     *      A fixed API Token will be created for the user with that plain value as the token.
+     *      It is strongly recommended to use it to generate a new one (random) and then revoke it.
+     *      See {@link ApiTokenProperty#generateNewToken(String)} and {@link ApiTokenProperty#revokeAllTokensExceptOne(String)}
+     *      for scripting methods or using the web API calls: 
+     *      /user/[user-login]/descriptorByName/jenkins.security.ApiTokenProperty/generateNewToken and 
+     *      /user/[user-login]/descriptorByName/jenkins.security.ApiTokenProperty/revokeAllExcept 
+     * - @[file-location] where the file contains plain text value of the token, all stuff explained above is applicable
+     *      The application will not delete the file after read, so the script is responsible to clean up the stuff
+     * - true
+     *      A token is generated using random value at startup and the information is put 
+     *      in the file "$JENKINS_HOME/secrets/initialAdminApiToken"
+     * @since TODO
+     */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
+    public static /* not final */ String ADMIN_INITIAL_API_TOKEN =
+            SystemProperties.getString(SetupWizard.class.getName() + ".adminInitialApiToken");
+
     @NonNull
     @Override
     public String getDisplayName() {
@@ -121,7 +147,11 @@ public class SetupWizard extends PageDecorator {
                     String randomUUID = UUID.randomUUID().toString().replace("-", "").toLowerCase(Locale.ENGLISH);
     
                     // create an admin user
-                    securityRealm.createAccount(SetupWizard.initialSetupAdminUserName, randomUUID);
+                    User initialAdmin = securityRealm.createAccount(SetupWizard.initialSetupAdminUserName, randomUUID);
+                    
+                    if (ADMIN_INITIAL_API_TOKEN != null) {
+                        createInitialApiToken(initialAdmin);
+                    }
     
                     // JENKINS-33599 - write to a file in the jenkins home directory
                     // most native packages of Jenkins creates a machine user account 'jenkins' to run Jenkins,
@@ -177,6 +207,53 @@ public class SetupWizard extends PageDecorator {
             UpdateCenter.updateDefaultSite();
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, e.getMessage(), e);
+        }
+    }
+
+    private void createInitialApiToken(User user) throws IOException, InterruptedException {
+        ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);
+
+        String sysProp = ADMIN_INITIAL_API_TOKEN;
+        if (sysProp.equals("true")) {
+            TokenUuidAndPlainValue tokenUuidAndPlainValue = apiTokenProperty.generateNewToken("random-generation-during-setup-wizard");
+            FilePath fp = getInitialAdminApiTokenFile();
+            // same comment as in the init method
+
+            // JENKINS-33599 - write to a file in the jenkins home directory
+            // most native packages of Jenkins creates a machine user account 'jenkins' to run Jenkins,
+            // and use group 'jenkins' for admins. So we allow groups to read this file
+            fp.touch(System.currentTimeMillis());
+            fp.chmod(0640);
+            fp.write(tokenUuidAndPlainValue.plainValue, StandardCharsets.UTF_8.name());
+            LOGGER.log(Level.INFO, "The API Token was randomly generated and the information was put in {0}", fp.getRemote());
+        } else {
+            String plainText;
+            if (sysProp.startsWith("@")) {
+                File apiTokenFile = new File(sysProp.substring(1));
+                if (!apiTokenFile.exists()) {
+                    LOGGER.log(Level.WARNING, "The API Token cannot be retrieved from a inexistent file: {0}", apiTokenFile);
+                    return;
+                }
+
+                try {
+                    plainText = FileUtils.readFileToString(apiTokenFile, StandardCharsets.UTF_8);
+                    LOGGER.log(Level.INFO, "The API Token was generated using the file referenced by the given system property");
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, String.format("The API Token cannot be retrieved from the file: %s", apiTokenFile), e);
+                    return;
+                }
+            } else {
+                LOGGER.log(Level.INFO, "The API Token was generated using directly the given system property");
+                plainText = sysProp;
+            }
+
+            try {
+                apiTokenProperty.addFixedNewToken("fix-generation-during-setup-wizard", plainText);
+            }
+            catch (IllegalArgumentException e) {
+                String constraintFailureMessage = e.getMessage();
+                LOGGER.log(Level.WARNING, "The API Token cannot be generated using the provided value due to: {0}", constraintFailureMessage);
+            }
         }
     }
 
@@ -255,7 +332,10 @@ public class SetupWizard extends PageDecorator {
 
         User admin = securityRealm.getUser(SetupWizard.initialSetupAdminUserName);
         try {
+            ApiTokenProperty initialApiTokenProperty = null;
+
             if (admin != null) {
+                initialApiTokenProperty = admin.getProperty(ApiTokenProperty.class);
                 admin.delete(); // assume the new user may well be 'admin'
             }
 
@@ -263,10 +343,22 @@ public class SetupWizard extends PageDecorator {
             if (admin != null) {
                 admin = null;
             }
+            if (initialApiTokenProperty != null) {
+                // actually it will remove the current one and replace it with the one from initial admin
+                newUser.addProperty(initialApiTokenProperty);
+            }
 
             // Success! Delete the temporary password file:
             try {
                 getInitialAdminPasswordFile().delete();
+            } catch (InterruptedException e) {
+                throw new IOException(e);
+            }
+            try {
+                FilePath fp = getInitialAdminApiTokenFile();
+                if (fp.exists()) {
+                    fp.delete();
+                }
             } catch (InterruptedException e) {
                 throw new IOException(e);
             }
@@ -549,6 +641,14 @@ public class SetupWizard extends PageDecorator {
      */
     public FilePath getInitialAdminPasswordFile() {
         return Jenkins.get().getRootPath().child("secrets/initialAdminPassword");
+    }
+    
+    /**
+     * Gets the file used to store the initial admin API Token, in case the system property
+     * {@link #ADMIN_INITIAL_API_TOKEN} is set to "true" (and only in this case).
+     */
+    public FilePath getInitialAdminApiTokenFile() {
+        return Jenkins.get().getRootPath().child("secrets/initialAdminApiToken");
     }
 
     /**

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -119,7 +119,7 @@ public class SetupWizard extends PageDecorator {
      */
     @Restricted(NoExternalUse.class)
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
-    public static /* not final */ String ADMIN_INITIAL_API_TOKEN =
+    private static /* not final */ String ADMIN_INITIAL_API_TOKEN =
             SystemProperties.getString(SetupWizard.class.getName() + ".adminInitialApiToken");
 
     @NonNull
@@ -230,6 +230,7 @@ public class SetupWizard extends PageDecorator {
         } else {
             String plainText;
             if (sysProp.startsWith("@")) {
+                // no need for path traversal check as it's coming from the instance creator only
                 File apiTokenFile = new File(sysProp.substring(1));
                 if (!apiTokenFile.exists()) {
                     LOGGER.log(Level.WARNING, "The API Token cannot be retrieved from a inexistent file: {0}", apiTokenFile);
@@ -357,6 +358,7 @@ public class SetupWizard extends PageDecorator {
             }
             try {
                 FilePath fp = getInitialAdminApiTokenFile();
+                // no care about TOCTOU as it's done during instance creation process only (i.e. not yet user reachable)
                 if (fp.exists()) {
                     fp.delete();
                 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -374,12 +374,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @see #securityRealm
      */
     private Boolean useSecurity;
-    
-    /**
-     * Determine if the default admin user already received a desired fixed API Token. 
-     * If it was already the case, no other will be given, to avoid forgotten system property to make the instance insecure
-     */
-    private Boolean adminAlreadyReceivedFixedApiToken;
 
     /**
      * Controls how the

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -374,6 +374,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @see #securityRealm
      */
     private Boolean useSecurity;
+    
+    /**
+     * Determine if the default admin user already received a desired fixed API Token. 
+     * If it was already the case, no other will be given, to avoid forgotten system property to make the instance insecure
+     */
+    private Boolean adminAlreadyReceivedFixedApiToken;
 
     /**
      * Controls how the

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -29,6 +29,7 @@ import hudson.Util;
 import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
 import jenkins.security.apitoken.ApiTokenStats;
 import jenkins.security.apitoken.ApiTokenStore;
+import jenkins.security.apitoken.TokenUuidAndPlainValue;
 import jenkins.util.SystemProperties;
 import hudson.model.Descriptor.FormException;
 import hudson.model.User;
@@ -110,7 +111,7 @@ public class ApiTokenProperty extends UserProperty {
     
     /**
      * Store the usage information of the different token for this user
-     * The save operation can be toggled by using {@link ApiTokenPropertyConfiguration#usageStatisticsEnabled}
+     * The save operation can be toggled by using {@link ApiTokenPropertyConfiguration#setUsageStatisticsEnabled(boolean)}
      * The information are stored in a separate file to avoid problem with some configuration synchronization tools
      */
     private transient ApiTokenStats tokenStats;
@@ -358,6 +359,34 @@ public class ApiTokenProperty extends UserProperty {
         return tokenStats;
     }
 
+    // essentially meant for scripting
+    public @Nonnull String addFixedNewToken(@Nonnull String name, @Nonnull String tokenPlainValue) throws IOException {
+        String tokenUuid = this.tokenStore.addFixedNewToken(name, tokenPlainValue);
+        user.save();
+        return tokenUuid;
+    }
+    
+    // essentially meant for scripting
+    public @Nonnull TokenUuidAndPlainValue generateNewToken(@Nonnull String name) throws IOException {
+        TokenUuidAndPlainValue tokenUuidAndPlainValue = tokenStore.generateNewToken(name);
+        user.save();
+        return tokenUuidAndPlainValue;
+    }
+    
+    // essentially meant for scripting
+    public void revokeAllTokens() throws IOException {
+        tokenStats.removeAll();
+        tokenStore.revokeAllTokens();
+        user.save();
+    }
+    
+    // essentially meant for scripting
+    public void revokeAllTokensExceptOne(@Nonnull String tokenUuid) throws IOException {
+        tokenStats.removeAllExcept(tokenUuid);
+        tokenStore.revokeAllTokensExcept(tokenUuid);
+        user.save();
+    }
+
     @Extension
     @Symbol("apiToken")
     public static final class DescriptorImpl extends UserPropertyDescriptor {
@@ -473,13 +502,47 @@ public class ApiTokenProperty extends UserProperty {
                 u.addProperty(p);
             }
             
-            ApiTokenStore.TokenUuidAndPlainValue tokenUuidAndPlainValue = p.tokenStore.generateNewToken(tokenName);
-            u.save();
+            TokenUuidAndPlainValue tokenUuidAndPlainValue = p.generateNewToken(tokenName);
             
             return HttpResponses.okJSON(new HashMap<String, String>() {{ 
                 put("tokenUuid", tokenUuidAndPlainValue.tokenUuid); 
                 put("tokenName", tokenName); 
                 put("tokenValue", tokenUuidAndPlainValue.plainValue); 
+            }});
+        }
+    
+        /**
+         * This method is dangerous and should not be used without caution. The token passed here could have been tracked
+         * by different network system during its path.
+         * It is recommended to revoke this token after the generation of a new one.
+         */
+        @RequirePOST
+        public HttpResponse doAddFixedToken(@AncestorInPath User u, 
+                                            @QueryParameter String newTokenName, 
+                                            @QueryParameter String newTokenPlainValue) throws IOException {
+            if (!hasCurrentUserRightToGenerateNewToken(u)) {
+                return HttpResponses.forbidden();
+            }
+            
+            final String tokenName;
+            if (StringUtils.isBlank(newTokenName)) {
+                tokenName = String.format("Token created on %s", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()));
+            } else {
+                tokenName = newTokenName;
+            }
+            
+            ApiTokenProperty p = u.getProperty(ApiTokenProperty.class);
+            if (p == null) {
+                p = forceNewInstance(u, false);
+                u.addProperty(p);
+            }
+            
+            String tokenUuid = p.tokenStore.addFixedNewToken(tokenName, newTokenPlainValue);
+            u.save();
+            
+            return HttpResponses.okJSON(new HashMap<String, String>() {{
+                put("tokenUuid", tokenUuid);
+                put("tokenName", tokenName);
             }});
         }
         
@@ -539,6 +602,42 @@ public class ApiTokenProperty extends UserProperty {
                 p.tokenStats.removeId(revoked.getUuid());
             }
             u.save();
+            
+            return HttpResponses.ok();
+        }
+        
+        @RequirePOST
+        public HttpResponse doRevokeAll(@AncestorInPath User u) throws IOException {
+            // only current user + administrator can revoke token
+            u.checkPermission(Jenkins.ADMINISTER);
+            
+            ApiTokenProperty p = u.getProperty(ApiTokenProperty.class);
+            if (p == null) {
+                return HttpResponses.errorWithoutStack(400, "The user does not have any ApiToken yet, try generating one before.");
+            }
+            
+            p.revokeAllTokens();
+            
+            return HttpResponses.ok();
+        }
+        
+        @RequirePOST
+        public HttpResponse doRevokeAllExcept(@AncestorInPath User u,
+                                              @QueryParameter String tokenUuid) throws IOException {
+            // only current user + administrator can revoke token
+            u.checkPermission(Jenkins.ADMINISTER);
+            
+            if(StringUtils.isBlank(tokenUuid)){
+                // using the web UI this should not occur
+                return HttpResponses.errorWithoutStack(400, "The tokenUuid cannot be empty");
+            }
+            
+            ApiTokenProperty p = u.getProperty(ApiTokenProperty.class);
+            if (p == null) {
+                return HttpResponses.errorWithoutStack(400, "The user does not have any ApiToken yet, try generating one before.");
+            }
+            
+            p.revokeAllTokensExceptOne(tokenUuid);
             
             return HttpResponses.ok();
         }

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -361,7 +361,7 @@ public class ApiTokenProperty extends UserProperty {
 
     // essentially meant for scripting
     @Restricted(NoExternalUse.class)
-    public @Nonnull String addFixedNewToken(@Nonnull String name, @Nonnull String tokenPlainValue) throws IOException {
+    public @NonNull String addFixedNewToken(@NonNull String name, @NonNull String tokenPlainValue) throws IOException {
         String tokenUuid = this.tokenStore.addFixedNewToken(name, tokenPlainValue);
         user.save();
         return tokenUuid;
@@ -369,7 +369,7 @@ public class ApiTokenProperty extends UserProperty {
     
     // essentially meant for scripting
     @Restricted(NoExternalUse.class)
-    public @Nonnull TokenUuidAndPlainValue generateNewToken(@Nonnull String name) throws IOException {
+    public @NonNull TokenUuidAndPlainValue generateNewToken(@NonNull String name) throws IOException {
         TokenUuidAndPlainValue tokenUuidAndPlainValue = tokenStore.generateNewToken(name);
         user.save();
         return tokenUuidAndPlainValue;
@@ -385,7 +385,7 @@ public class ApiTokenProperty extends UserProperty {
     
     // essentially meant for scripting
     @Restricted(NoExternalUse.class)
-    public void revokeAllTokensExceptOne(@Nonnull String tokenUuid) throws IOException {
+    public void revokeAllTokensExceptOne(@NonNull String tokenUuid) throws IOException {
         tokenStats.removeAllExcept(tokenUuid);
         tokenStore.revokeAllTokensExcept(tokenUuid);
         user.save();
@@ -516,8 +516,8 @@ public class ApiTokenProperty extends UserProperty {
         }
     
         /**
-         * This method is dangerous and should not be used without caution. The token passed here could have been tracked
-         * by different network system during its path.
+         * This method is dangerous and should not be used without caution. 
+         * The token passed here could have been tracked by different network system during its trip.
          * It is recommended to revoke this token after the generation of a new one.
          */
         @RequirePOST

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -552,7 +552,6 @@ public class ApiTokenProperty extends UserProperty {
         }
         
         @RequirePOST
-        @Restricted(NoExternalUse.class)
         public HttpResponse doRename(@AncestorInPath User u,
                                      @QueryParameter String tokenUuid, @QueryParameter String newName) throws IOException {
             // only current user + administrator can rename token

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -127,10 +127,10 @@ public class ApiTokenProperty extends UserProperty {
         if (this.tokenStore == null) {
             this.tokenStore = new ApiTokenStore();
         }
-        if (this.tokenStats == null) {
+        if(this.tokenStats == null){
             this.tokenStats = ApiTokenStats.load(user);
         }
-        if (this.apiToken != null) {
+        if(this.apiToken != null){
             this.tokenStore.regenerateTokenFromLegacyIfRequired(this.apiToken);
         }
     }
@@ -140,7 +140,7 @@ public class ApiTokenProperty extends UserProperty {
      * but for the initial value of the token we need to compute the seed by ourselves.
      */
     /*package*/ ApiTokenProperty(@CheckForNull String seed) {
-        if (seed != null) {
+        if(seed != null){
             apiToken = Secret.fromString(seed);
         }
     }
@@ -157,7 +157,7 @@ public class ApiTokenProperty extends UserProperty {
     @NonNull
     public String getApiToken() {
         LOGGER.log(Level.FINE, "Deprecated usage of getApiToken");
-        if (LOGGER.isLoggable(Level.FINER)) {
+        if(LOGGER.isLoggable(Level.FINER)){
             LOGGER.log(Level.FINER, "Deprecated usage of getApiToken (trace)", new Exception());
         }
         return hasPermissionToSeeToken()
@@ -176,7 +176,7 @@ public class ApiTokenProperty extends UserProperty {
     @NonNull
     @Restricted(NoExternalUse.class)
     /*package*/ String getApiTokenInsecure() {
-        if (apiToken == null) {
+        if(apiToken == null){
             return Messages.ApiTokenProperty_NoLegacyToken();
         }
 
@@ -190,12 +190,12 @@ public class ApiTokenProperty extends UserProperty {
     }
     
     public boolean matchesPassword(String token) {
-        if (StringUtils.isBlank(token)) {
+        if(StringUtils.isBlank(token)){
             return false;
         }
     
         ApiTokenStore.HashedToken matchingToken = tokenStore.findMatchingToken(token);
-        if (matchingToken == null) {
+        if(matchingToken == null){
             return false;
         }
         
@@ -328,7 +328,7 @@ public class ApiTokenProperty extends UserProperty {
         _changeApiToken();
         tokenStore.regenerateTokenFromLegacy(apiToken);
     
-        if (existingLegacyToken != null) {
+        if(existingLegacyToken != null){
             tokenStats.removeId(existingLegacyToken.getUuid());
         }
         user.save();
@@ -360,6 +360,7 @@ public class ApiTokenProperty extends UserProperty {
     }
 
     // essentially meant for scripting
+    @Restricted(NoExternalUse.class)
     public @Nonnull String addFixedNewToken(@Nonnull String name, @Nonnull String tokenPlainValue) throws IOException {
         String tokenUuid = this.tokenStore.addFixedNewToken(name, tokenPlainValue);
         user.save();
@@ -367,6 +368,7 @@ public class ApiTokenProperty extends UserProperty {
     }
     
     // essentially meant for scripting
+    @Restricted(NoExternalUse.class)
     public @Nonnull TokenUuidAndPlainValue generateNewToken(@Nonnull String name) throws IOException {
         TokenUuidAndPlainValue tokenUuidAndPlainValue = tokenStore.generateNewToken(name);
         user.save();
@@ -374,6 +376,7 @@ public class ApiTokenProperty extends UserProperty {
     }
     
     // essentially meant for scripting
+    @Restricted(NoExternalUse.class)
     public void revokeAllTokens() throws IOException {
         tokenStats.removeAll();
         tokenStore.revokeAllTokens();
@@ -381,6 +384,7 @@ public class ApiTokenProperty extends UserProperty {
     }
     
     // essentially meant for scripting
+    @Restricted(NoExternalUse.class)
     public void revokeAllTokensExceptOne(@Nonnull String tokenUuid) throws IOException {
         tokenStats.removeAllExcept(tokenUuid);
         tokenStore.revokeAllTokensExcept(tokenUuid);
@@ -422,7 +426,7 @@ public class ApiTokenProperty extends UserProperty {
         }
         
         private ApiTokenProperty forceNewInstance(User user, boolean withLegacyToken) {
-            if (withLegacyToken) {
+            if(withLegacyToken){
                 return new ApiTokenProperty(API_KEY_SEED.mac(user.getId()));
             }else{
                 return new ApiTokenProperty(null);
@@ -439,7 +443,7 @@ public class ApiTokenProperty extends UserProperty {
         @Restricted(NoExternalUse.class)
         public boolean mustDisplayLegacyApiToken(User propertyOwner) {
             ApiTokenProperty property = propertyOwner.getProperty(ApiTokenProperty.class);
-            if (property != null && property.apiToken != null) {
+            if(property != null && property.apiToken != null){
                 return true;
             }
             return ApiTokenPropertyConfiguration.get().isCreationOfLegacyTokenEnabled();
@@ -462,7 +466,7 @@ public class ApiTokenProperty extends UserProperty {
 
             LOGGER.log(Level.FINE, "Deprecated action /changeToken used, consider using /generateNewToken instead");
 
-            if (!mustDisplayLegacyApiToken(u)) {
+            if(!mustDisplayLegacyApiToken(u)){
                 // user does not have legacy token and the capability to create one without an existing one is disabled
                 return HttpResponses.html(Messages.ApiTokenProperty_ChangeToken_CapabilityNotAllowed());
             }
@@ -485,7 +489,7 @@ public class ApiTokenProperty extends UserProperty {
 
         @RequirePOST
         public HttpResponse doGenerateNewToken(@AncestorInPath User u, @QueryParameter String newTokenName) throws IOException {
-            if (!hasCurrentUserRightToGenerateNewToken(u)) {
+            if(!hasCurrentUserRightToGenerateNewToken(u)){
                 return HttpResponses.forbidden();
             }
             
@@ -517,6 +521,7 @@ public class ApiTokenProperty extends UserProperty {
          * It is recommended to revoke this token after the generation of a new one.
          */
         @RequirePOST
+        @Restricted(NoExternalUse.class)
         public HttpResponse doAddFixedToken(@AncestorInPath User u, 
                                             @QueryParameter String newTokenName, 
                                             @QueryParameter String newTokenPlainValue) throws IOException {
@@ -547,6 +552,7 @@ public class ApiTokenProperty extends UserProperty {
         }
         
         @RequirePOST
+        @Restricted(NoExternalUse.class)
         public HttpResponse doRename(@AncestorInPath User u,
                                      @QueryParameter String tokenUuid, @QueryParameter String newName) throws IOException {
             // only current user + administrator can rename token
@@ -555,7 +561,7 @@ public class ApiTokenProperty extends UserProperty {
             if (StringUtils.isBlank(newName)) {
                 return HttpResponses.errorJSON("The name cannot be empty");
             }
-            if (StringUtils.isBlank(tokenUuid)) {
+            if(StringUtils.isBlank(tokenUuid)){
                 // using the web UI this should not occur
                 return HttpResponses.errorWithoutStack(400, "The tokenUuid cannot be empty");
             }
@@ -566,7 +572,7 @@ public class ApiTokenProperty extends UserProperty {
             }
             
             boolean renameOk = p.tokenStore.renameToken(tokenUuid, newName);
-            if (!renameOk) {
+            if(!renameOk){
                 // that could potentially happen if the token is removed from another page
                 // between your page loaded and your action
                 return HttpResponses.errorJSON("No token found, try refreshing the page");
@@ -583,7 +589,7 @@ public class ApiTokenProperty extends UserProperty {
             // only current user + administrator can revoke token
             u.checkPermission(Jenkins.ADMINISTER);
             
-            if (StringUtils.isBlank(tokenUuid)) {
+            if(StringUtils.isBlank(tokenUuid)){
                 // using the web UI this should not occur
                 return HttpResponses.errorWithoutStack(400, "The tokenUuid cannot be empty");
             }
@@ -607,6 +613,7 @@ public class ApiTokenProperty extends UserProperty {
         }
         
         @RequirePOST
+        @Restricted(NoExternalUse.class)
         public HttpResponse doRevokeAll(@AncestorInPath User u) throws IOException {
             // only current user + administrator can revoke token
             u.checkPermission(Jenkins.ADMINISTER);
@@ -622,6 +629,7 @@ public class ApiTokenProperty extends UserProperty {
         }
         
         @RequirePOST
+        @Restricted(NoExternalUse.class)
         public HttpResponse doRevokeAllExcept(@AncestorInPath User u,
                                               @QueryParameter String tokenUuid) throws IOException {
             // only current user + administrator can revoke token

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStats.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStats.java
@@ -141,7 +141,7 @@ public class ApiTokenStats implements Saveable {
         }
     }
     
-    public synchronized void removeAllExcept(@Nonnull String tokenUuid) {
+    public synchronized void removeAllExcept(@NonNull String tokenUuid) {
         int sizeBefore = tokenStats.size();
         tokenStats.removeIf(s -> !s.tokenUuid.equals(tokenUuid));
         int sizeAfter = tokenStats.size();

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStats.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStats.java
@@ -117,7 +117,7 @@ public class ApiTokenStats implements Saveable {
     }
     
     /**
-     * Will trigger the save if there is some modification
+     * Will trigger the save if there is some modifications
      */
     public synchronized void removeId(@NonNull String tokenUuid) {
         if(areStatsDisabled()){
@@ -126,6 +126,26 @@ public class ApiTokenStats implements Saveable {
         
         boolean tokenRemoved = tokenStats.removeIf(s -> s.tokenUuid.equals(tokenUuid));
         if (tokenRemoved) {
+            save();
+        }
+    }
+    
+    /**
+     * Will trigger the save if there is some modifications
+     */
+    public synchronized void removeAll() {
+        int size = tokenStats.size();
+        tokenStats.clear();
+        if (size > 0) {
+            save();
+        }
+    }
+    
+    public synchronized void removeAllExcept(@Nonnull String tokenUuid) {
+        int sizeBefore = tokenStats.size();
+        tokenStats.removeIf(s -> !s.tokenUuid.equals(tokenUuid));
+        int sizeAfter = tokenStats.size();
+        if (sizeBefore != sizeAfter) {
             save();
         }
     }

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
@@ -195,7 +195,7 @@ public class ApiTokenStore {
      * Be careful with this method. Depending on how the tokenPlainValue was stored/sent to this method, 
      * it could be a good idea to generate a new token randomly and revoke this one.
      */
-    public synchronized @Nonnull String addFixedNewToken(@Nonnull String name, @Nonnull String tokenPlainValue) {
+    public synchronized @NonNull String addFixedNewToken(@NonNull String name, @NonNull String tokenPlainValue) {
         if (tokenPlainValue.length() != VERSION_LENGTH + HEX_CHAR_LENGTH) {
             LOGGER.log(Level.INFO, "addFixedNewToken, length received: {0}" + tokenPlainValue.length());
             throw new IllegalArgumentException("The token must consist of 2 characters for the version and 32 hex-characters for the secret");
@@ -217,7 +217,7 @@ public class ApiTokenStore {
         return token.uuid;
     }
     
-    private @Nonnull HashedToken prepareAndStoreToken(@Nonnull String name, @Nonnull String tokenPlainValue) {
+    private @NonNull HashedToken prepareAndStoreToken(@NonNull String name, @NonNull String tokenPlainValue) {
         String secretValueHashed = this.plainSecretToHashInHex(tokenPlainValue);
         
         HashValue hashValue = new HashValue(HASH_VERSION, secretValueHashed);
@@ -322,7 +322,7 @@ public class ApiTokenStore {
         tokenList.clear();
     }
     
-    public synchronized void revokeAllTokensExcept(@Nonnull String tokenUuid) {
+    public synchronized void revokeAllTokensExcept(@NonNull String tokenUuid) {
         tokenList.removeIf(token -> !token.uuid.equals(tokenUuid));
     }
     

--- a/core/src/main/java/jenkins/security/apitoken/TokenUuidAndPlainValue.java
+++ b/core/src/main/java/jenkins/security/apitoken/TokenUuidAndPlainValue.java
@@ -23,6 +23,9 @@
  */
 package jenkins.security.apitoken;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -30,6 +33,7 @@ import javax.annotation.concurrent.Immutable;
  * It should not be stored as is, but just displayed once to the user and then forget about it.
  */
 @Immutable
+@Restricted(NoExternalUse.class)
 public class TokenUuidAndPlainValue {
     /**
      * The token identifier to allow manipulation of the token

--- a/core/src/main/java/jenkins/security/apitoken/TokenUuidAndPlainValue.java
+++ b/core/src/main/java/jenkins/security/apitoken/TokenUuidAndPlainValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2019, CloudBees, Inc.
+ * Copyright (c) 2020, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,13 +26,10 @@ package jenkins.security.apitoken;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import javax.annotation.concurrent.Immutable;
-
 /**
  * Contains information about the token and the secret value.
  * It should not be stored as is, but just displayed once to the user and then forget about it.
  */
-@Immutable
 @Restricted(NoExternalUse.class)
 public class TokenUuidAndPlainValue {
     /**

--- a/core/src/main/java/jenkins/security/apitoken/TokenUuidAndPlainValue.java
+++ b/core/src/main/java/jenkins/security/apitoken/TokenUuidAndPlainValue.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.security.apitoken;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Contains information about the token and the secret value.
+ * It should not be stored as is, but just displayed once to the user and then forget about it.
+ */
+@Immutable
+public class TokenUuidAndPlainValue {
+    /**
+     * The token identifier to allow manipulation of the token
+     */
+    public final String tokenUuid;
+    
+    /**
+     * Confidential information, must not be stored.<p>
+     * It's meant to be send only one to the user and then only store the hash of this value.
+     */
+    public final String plainValue;
+    
+    public TokenUuidAndPlainValue(String tokenUuid, String plainValue) {
+        this.tokenUuid = tokenUuid;
+        this.plainValue = plainValue;
+    }
+}

--- a/test/src/test/java/hudson/security/WhoAmITest.java
+++ b/test/src/test/java/hudson/security/WhoAmITest.java
@@ -30,6 +30,7 @@ import hudson.model.User;
 import jenkins.model.Jenkins;
 import jenkins.security.ApiTokenProperty;
 import jenkins.security.apitoken.ApiTokenStore;
+import jenkins.security.apitoken.TokenUuidAndPlainValue;
 import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.userdetails.UserDetails;
@@ -181,7 +182,7 @@ public class WhoAmITest {
 
         User user = User.getById("user", true);
         ApiTokenProperty prop = user.getProperty(ApiTokenProperty.class);
-        ApiTokenStore.TokenUuidAndPlainValue token = prop.getTokenStore().generateNewToken("test");
+        TokenUuidAndPlainValue token = prop.getTokenStore().generateNewToken("test");
 
         JenkinsRule.WebClient wc = j.createWebClient().withBasicCredentials("user", token.plainValue);
         String base64ApiToken = new String(Base64.getEncoder().encode(("user:" + token.plainValue).getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);

--- a/test/src/test/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitorTest.java
+++ b/test/src/test/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitorTest.java
@@ -78,7 +78,7 @@ public class LegacyApiTokenAdministrativeMonitorTest {
         LegacyApiTokenAdministrativeMonitor monitor = j.jenkins.getExtensionList(AdministrativeMonitor.class).get(LegacyApiTokenAdministrativeMonitor.class);
         assertFalse(monitor.isActivated());
         
-        ApiTokenStore.TokenUuidAndPlainValue tokenInfo = apiTokenProperty.getTokenStore().generateNewToken("Not Legacy");
+        TokenUuidAndPlainValue tokenInfo = apiTokenProperty.getTokenStore().generateNewToken("Not Legacy");
         // "new" token does not trigger the monitor
         assertFalse(monitor.isActivated());
         
@@ -399,7 +399,7 @@ public class LegacyApiTokenAdministrativeMonitorTest {
                 simulateUseOfLegacyToken(user);
                 Thread.sleep(1);
                 
-                ApiTokenStore.TokenUuidAndPlainValue tokenInfo = apiTokenProperty.getTokenStore().generateNewToken("Fresh and recent token");
+                TokenUuidAndPlainValue tokenInfo = apiTokenProperty.getTokenStore().generateNewToken("Fresh and recent token");
                 simulateUseOfToken(user, tokenInfo.plainValue);
             } else {
                 simulateUseOfLegacyToken(user);
@@ -409,7 +409,7 @@ public class LegacyApiTokenAdministrativeMonitorTest {
             }
         } else {
             if (recent) {
-                ApiTokenStore.TokenUuidAndPlainValue tokenInfo = apiTokenProperty.getTokenStore().generateNewToken("Recent token");
+                TokenUuidAndPlainValue tokenInfo = apiTokenProperty.getTokenStore().generateNewToken("Recent token");
                 Thread.sleep(1);
                 
                 simulateUseOfLegacyToken(user);


### PR DESCRIPTION
See [JENKINS-57484](https://issues.jenkins-ci.org/browse/JENKINS-57484), companion of [helm/charts#13868](https://github.com/helm/charts/pull/13868)

New API endpoints added:
- `<jenkinsUrl>/user/<userLogin>/descriptorByName/jenkins.security.ApiTokenProperty/addFixedToken` with formencoded body containing `newTokenName` and `newTokenPlainValue`. The plain value must be in the form of `11` + 32-char in hex, e.g. `110123456789abcdef0123456789abcdef`
- `<jenkinsUrl>/user/<userLogin>/descriptorByName/jenkins.security.ApiTokenProperty/revokeAll`
- `<jenkinsUrl>/user/<userLogin>/descriptorByName/jenkins.security.ApiTokenProperty/revokeAllExcept` with formencoded body containing `tokenUuid`

New system propriety added:
- `jenkins.install.SetupWizard.ADMIN_INITIAL_API_TOKEN` only used before/during the Setup Wizard. No impact once an instance is configured. Possible values: 
  - `"true"`: a random token will be created and stored in the file `secrets/initialAdminApiToken` 💡 This approach is the more interesting (+ secure) when you have read access to the Jenkins home directory. 
  - `11[32-char hex]`: a fixed token will be created with this plain text value, example: `110123456789abcdef0123456789abcdef` _(better to use the file approach to avoid putting the sensitive information in the environment variables)_.
  - `@[file-path]`: with file-path being the path to a file containing a valid fixed token value _(and only that)_.

⚠️ Be careful, it's **strongly** recommended that you generate a new random token, using the token generated by the system property, to ensure better confidentiality.

### Example of usages

#### For instance creation using external scripts
- Generate a random token value in your script (or use a fixed value, at your own risks)
- Create an instance of Jenkins with the system property `jenkins.install.SetupWizard.ADMIN_INITIAL_API_TOKEN` set to the value from previous step (either by directly providing the value or for additional security by putting its value in a file and passing the file path)
- After setup done, send a request to the (existing) "doGenerateNewToken" endpoint by usign the initial API Token. Using the response, you can replace the token of your script and keep the new UUID.
- Send a request to the new `revokeAllExcept` endpoint using the new token as authentication and providing its own UUID to revoke the previously random one that was transmitted with the system property.

#### For instance creation using Groovy scripts
- See [helm/charts#13868](https://github.com/helm/charts/pull/13868) for an example, esp. [init-add-api-token-to-admin.groovy](https://github.com/helm/charts/pull/13868/files#diff-7146a5152507fba3404ff5118aab029cR288]


#### For instance creation using "old" approach with basic authentication
- Create an instance of Jenkins as usual with an admin account with a known password
- Using a webclient able to store cookies (or manually managing it, only important cookie is the JSESSION_ID), retrieve the CSRF token as usual (also called "crumb")
- Generate a random token value in your script (or use a fixed value, at your own risks)
- Then with this basic authentication setup, you can send a request to the new `addFixedToken` endpoint (ensure to *not* pass the plain text value as a parameter but as a body content, otherwise it could be logged by firewalls and others)
- Using the response, you get a UUID and you can generate a random token as explained in the above steps.


<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Improve the scripting capacity related to the API Token system
* Provide a way to configure a fixed/default API Token for admin during installation phase

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

