### PR TITLE
[JENKINS-56575][3] Support REST client for restart

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -177,7 +177,6 @@ import hudson.views.MyViewsTabBar;
 import hudson.views.ViewsTabBar;
 import hudson.widgets.Widget;
 
-import java.util.Enumeration;
 import java.util.Objects;
 import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4187,6 +4187,13 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return;
         }
 
+        //Request from rest client
+        if (req.getReferer() == null || req.getMethod().equals("POST")) {
+            rsp.setStatus(200);
+            restart();
+            return;
+        }
+
         if (req == null || req.getMethod().equals("POST")) {
             restart();
         }
@@ -4208,6 +4215,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         checkPermission(ADMINISTER);
         if (req != null && req.getMethod().equals("GET"))
             return HttpResponses.forwardToView(this,"_safeRestart.jelly");
+
+        //Request from rest client
+        if (req.getReferer() == null || req.getMethod().equals("POST")){
+            safeRestart();
+            return HttpResponses.text("safeRestart");
+        }
 
         if (req == null || req.getMethod().equals("POST")) {
             safeRestart();

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4205,6 +4205,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since TODO
      */
     @RequirePOST
+    @Restricted(NoExternalUse.class)
     public void doRestartSimple(StaplerRequest req, StaplerResponse rsp) throws RestartNotSupportedException {
         checkPermission(ADMINISTER);
 
@@ -4242,6 +4243,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since TODO
      */
     @RequirePOST
+    @Restricted(NoExternalUse.class)
     public void doSafeRestartSimple(StaplerRequest req, StaplerResponse rsp) throws RestartNotSupportedException {
         checkPermission(ADMINISTER);
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4252,24 +4252,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         rsp.setStatus(HttpURLConnection.HTTP_ACCEPTED);
     }
 
-    private boolean isRestClientAndPost(@CheckForNull StaplerRequest req) {
-        if (req == null) {
-            return false;
-        }
-
-        if (!req.getMethod().equals("POST")) {
-            return false;
-        }
-
-        // no support for multiple accept types / q-factor weighted ones
-        String acceptValue = req.getHeader("Accept");
-        if (acceptValue == null) {
-            return false;
-        }
-
-        return acceptValue.equals("application/json");
-    }
-
     private static Lifecycle restartableLifecycle() throws RestartNotSupportedException {
         if (Main.isUnitTest) {
             throw new RestartNotSupportedException("Restarting the master JVM is not supported in JenkinsRule-based tests");

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4188,7 +4188,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
 
         //Request from rest client
-        if (req.getReferer() == null || req.getMethod().equals("POST")) {
+        if (req != null && req.getReferer() == null && req.getMethod().equals("POST")) {
             rsp.setStatus(200);
             restart();
             return;
@@ -4217,7 +4217,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return HttpResponses.forwardToView(this,"_safeRestart.jelly");
 
         //Request from rest client
-        if (req.getReferer() == null || req.getMethod().equals("POST")){
+        if (req != null && req.getReferer() == null && req.getMethod().equals("POST")){
             safeRestart();
             return HttpResponses.text("safeRestart");
         }

--- a/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
@@ -46,4 +46,9 @@ THE SOFTWARE.
     <a href="../safeRestart">this URL</a> to restart once no jobs are running.
     All these URLs need the admin privilege to the system.
   </p>
+  <p>
+    If you want to have a REST version of those pages, you can use <a href="../restartSimple">this URL</a> to request 
+    a direct restart and <a href="../safeRestartSimple">this URL</a> for the safe version. 
+    Compared to the regular calls, they will just reply with a 204 and 202 respectively without any page content or redirection.
+  </p>
 </j:jelly>

--- a/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
@@ -42,13 +42,8 @@ THE SOFTWARE.
     Jenkins will enter into the "quiet down" mode by sending a request to <a href="../quietDown">this URL</a>.
     You can cancel this mode by sending a request to <a href="../cancelQuietDown">this URL</a>. On environments
     where Jenkins can restart itself (such as when Jenkins is installed as a Windows service), POSTing to
-    <a href="../restart">this URL</a> will start the restart sequence, or
-    <a href="../safeRestart">this URL</a> to restart once no jobs are running.
+    <a href="../restartSimple">this URL</a> will start the restart sequence, or
+    <a href="../safeRestartSimple">this URL</a> to restart once no jobs are running.
     All these URLs need the admin privilege to the system.
-  </p>
-  <p>
-    If you want to have a REST version of those pages, you can use <a href="../restartSimple">this URL</a> to request 
-    a direct restart and <a href="../safeRestartSimple">this URL</a> for the safe version. 
-    Compared to the regular calls, they will just reply with a 204 and 202 respectively without any page content or redirection.
   </p>
 </j:jelly>

--- a/test/src/test/java/jenkins/model/Jenkins56575Test.java
+++ b/test/src/test/java/jenkins/model/Jenkins56575Test.java
@@ -72,7 +72,10 @@ public class Jenkins56575Test {
 
     @Before
     public void setupMockLifecycle() throws Exception {
+        // to avoid Jenkins.restartableLifecycle to throw RestartNotSupportedException
+        // there is no problem here since we are overriding the Lifecycle and will not really do a restart
         Main.isUnitTest = false;
+
         j.jenkins.setCrumbIssuer(null);
 
         previousLifecycle = Lifecycle.get();
@@ -108,10 +111,8 @@ public class Jenkins56575Test {
 
     @Test
     public void testRestart_regularClient() throws Exception {
-        WebClient wc = j.createWebClient()
-                .withRedirectEnabled(false)
-                .withThrowExceptionOnFailingStatusCode(false);
-        WebRequest request = new WebRequest(new URL(j.getURL() + "restart"), HttpMethod.POST);
+        WebClient wc = j.createWebClient().withRedirectEnabled(false);
+        WebRequest request = preparePostRequest("restart");
 
         assertThat(verifyRestartableCalled.get(), is(false));
         assertThat(restartCalled.get(), is(false));
@@ -128,10 +129,8 @@ public class Jenkins56575Test {
     @Test
     @Issue("JENKINS-56575")
     public void testRestartSimple_restClient() throws Exception {
-        WebClient wc = j.createWebClient()
-                .withRedirectEnabled(false)
-                .withThrowExceptionOnFailingStatusCode(false);
-        WebRequest request = new WebRequest(new URL(j.getURL() + "restartSimple"), HttpMethod.POST);
+        WebClient wc = j.createWebClient().withRedirectEnabled(false);
+        WebRequest request = preparePostRequest("restartSimple");
 
         assertThat(verifyRestartableCalled.get(), is(false));
         assertThat(restartCalled.get(), is(false));
@@ -165,10 +164,8 @@ public class Jenkins56575Test {
 
     @Test
     public void testSafeRestart_regularClient() throws Exception {
-        WebClient wc = j.createWebClient()
-                .withRedirectEnabled(false)
-                .withThrowExceptionOnFailingStatusCode(false);
-        WebRequest request = new WebRequest(new URL(j.getURL() + "safeRestart"), HttpMethod.POST);
+        WebClient wc = j.createWebClient().withRedirectEnabled(false);
+        WebRequest request = preparePostRequest("safeRestart");
 
         assertThat(verifyRestartableCalled.get(), is(false));
         assertThat(restartCalled.get(), is(false));
@@ -185,10 +182,8 @@ public class Jenkins56575Test {
     @Test
     @Issue("JENKINS-56575")
     public void testSafeRestartSimple_restClient() throws Exception {
-        WebClient wc = j.createWebClient()
-                .withRedirectEnabled(false)
-                .withThrowExceptionOnFailingStatusCode(false);
-        WebRequest request = new WebRequest(new URL(j.getURL() + "safeRestartSimple"), HttpMethod.POST);
+        WebClient wc = j.createWebClient().withRedirectEnabled(false);
+        WebRequest request = preparePostRequest("safeRestartSimple");
 
         assertThat(verifyRestartableCalled.get(), is(false));
         assertThat(restartCalled.get(), is(false));
@@ -216,6 +211,10 @@ public class Jenkins56575Test {
 
         assertThat(verifyRestartableCalled.get(), is(true));
         assertThat(restartCalled.get(), is(true));
+    }
+
+    private WebRequest preparePostRequest(String relativeUrl) throws IOException {
+        return new WebRequest(new URL(j.getURL() + relativeUrl), HttpMethod.POST);
     }
 
     private int launchCLI(String... cmdArgs) throws Exception {

--- a/test/src/test/java/jenkins/model/Jenkins56575Test.java
+++ b/test/src/test/java/jenkins/model/Jenkins56575Test.java
@@ -98,8 +98,9 @@ public class Jenkins56575Test {
 
     @Before
     public void grabCliJar() throws IOException {
-        jar = tmp.newFile("jenkins-cli.jar");
-        FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
+        String jenkinsCLI = "jenkins-cli.jar";
+        jar = tmp.newFile(jenkinsCLI);
+        FileUtils.copyURLToFile(j.jenkins.getJnlpJars(jenkinsCLI).getURL(), jar);
     }
 
     @After

--- a/test/src/test/java/jenkins/model/Jenkins56575Test.java
+++ b/test/src/test/java/jenkins/model/Jenkins56575Test.java
@@ -72,7 +72,7 @@ public class Jenkins56575Test {
 
     @Before
     public void setupMockLifecycle() throws Exception {
-        // to avoid Jenkins.restartableLifecycle to throw RestartNotSupportedException
+        // to avoid Jenkins.restartableLifecycle throwing RestartNotSupportedException
         // there is no problem here since we are overriding the Lifecycle and will not really do a restart
         Main.isUnitTest = false;
 

--- a/test/src/test/java/jenkins/model/Jenkins56575Test.java
+++ b/test/src/test/java/jenkins/model/Jenkins56575Test.java
@@ -112,7 +112,7 @@ public class Jenkins56575Test {
 
     @Test
     public void testRestart_regularClient() throws Exception {
-        WebClient wc = j.createWebClient().withRedirectEnabled(false).withThrowExceptionOnFailingStatusCode(true);
+        WebClient wc = j.createWebClient().withRedirectEnabled(false).withThrowExceptionOnFailingStatusCode(false);
         WebRequest request = preparePostRequest("restart");
 
         assertThat(verifyRestartableCalled.get(), is(false));
@@ -165,7 +165,7 @@ public class Jenkins56575Test {
 
     @Test
     public void testSafeRestart_regularClient() throws Exception {
-        WebClient wc = j.createWebClient().withRedirectEnabled(false).withThrowExceptionOnFailingStatusCode(true);
+        WebClient wc = j.createWebClient().withRedirectEnabled(false).withThrowExceptionOnFailingStatusCode(false);
         WebRequest request = preparePostRequest("safeRestart");
 
         assertThat(verifyRestartableCalled.get(), is(false));

--- a/test/src/test/java/jenkins/model/Jenkins56575Test.java
+++ b/test/src/test/java/jenkins/model/Jenkins56575Test.java
@@ -1,0 +1,227 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.model;
+
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.WebResponse;
+import hudson.Launcher;
+import hudson.Main;
+import hudson.lifecycle.Lifecycle;
+import hudson.util.StreamTaskListener;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+
+public class Jenkins56575Test {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private File jar;
+
+    private AtomicReference<Boolean> restartCalled = new AtomicReference<>(false);
+    private AtomicReference<Boolean> verifyRestartableCalled = new AtomicReference<>(false);
+    private Semaphore restartSemaphore = new Semaphore(0);
+
+    private Lifecycle previousLifecycle;
+    private Field instanceField;
+
+    @Before
+    public void setupMockLifecycle() throws Exception {
+        Main.isUnitTest = false;
+        j.jenkins.setCrumbIssuer(null);
+
+        previousLifecycle = Lifecycle.get();
+
+        instanceField = Lifecycle.class.getDeclaredField("INSTANCE");
+        instanceField.setAccessible(true);
+        instanceField.set(null, new Lifecycle() {
+            @Override
+            public void verifyRestartable() {
+                verifyRestartableCalled.set(true);
+            }
+
+            @Override
+            public void restart() {
+                restartCalled.set(true);
+                restartSemaphore.release();
+            }
+        });
+    }
+
+    @Before
+    public void grabCliJar() throws IOException {
+        jar = tmp.newFile("jenkins-cli.jar");
+        FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
+    }
+
+    @After
+    public void resetSettings() throws Exception {
+        Main.isUnitTest = true;
+
+        instanceField.set(null, previousLifecycle);
+    }
+
+    @Test
+    public void testRestart_regularClient() throws Exception {
+        WebClient wc = j.createWebClient()
+                .withRedirectEnabled(false)
+                .withThrowExceptionOnFailingStatusCode(false);
+        WebRequest request = new WebRequest(new URL(j.getURL() + "restart"), HttpMethod.POST);
+
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+
+        Page page = wc.getPage(request);
+        assertThat(page.getWebResponse().getStatusCode(), is(HttpURLConnection.HTTP_MOVED_TEMP));
+
+        restartSemaphore.acquire(1);
+
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+
+    @Test
+    @Issue("JENKINS-56575")
+    public void testRestartSimple_restClient() throws Exception {
+        WebClient wc = j.createWebClient()
+                .withRedirectEnabled(false)
+                .withThrowExceptionOnFailingStatusCode(false);
+        WebRequest request = new WebRequest(new URL(j.getURL() + "restartSimple"), HttpMethod.POST);
+
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+
+        // we cannot use wc.getPage with a HTTP_NO_CONTENT because the page is null, 
+        // compared to HTTP_ACCEPTED that is managed by WebClient by a blank page
+        WebResponse response = wc.loadWebResponse(request);
+        assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+
+        restartSemaphore.acquire(1);
+
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+
+    @Test
+    public void testRestart_cliClient() throws Exception {
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+
+        assertEquals(0, launchCLI("java",
+                "-jar", jar.getAbsolutePath(),
+                "-s", j.getURL().toString(),
+                "restart"));
+
+        restartSemaphore.acquire(1);
+
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+
+    @Test
+    public void testSafeRestart_regularClient() throws Exception {
+        WebClient wc = j.createWebClient()
+                .withRedirectEnabled(false)
+                .withThrowExceptionOnFailingStatusCode(false);
+        WebRequest request = new WebRequest(new URL(j.getURL() + "safeRestart"), HttpMethod.POST);
+
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+
+        Page page = wc.getPage(request);
+        assertThat(page.getWebResponse().getStatusCode(), is(HttpURLConnection.HTTP_MOVED_TEMP));
+
+        restartSemaphore.acquire(1);
+
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+
+    @Test
+    @Issue("JENKINS-56575")
+    public void testSafeRestartSimple_restClient() throws Exception {
+        WebClient wc = j.createWebClient()
+                .withRedirectEnabled(false)
+                .withThrowExceptionOnFailingStatusCode(false);
+        WebRequest request = new WebRequest(new URL(j.getURL() + "safeRestartSimple"), HttpMethod.POST);
+
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+
+        Page page = wc.getPage(request);
+        assertThat(page.getWebResponse().getStatusCode(), is(HttpURLConnection.HTTP_ACCEPTED));
+
+        restartSemaphore.acquire(1);
+
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+
+    @Test
+    public void testSafeRestart_cliClient() throws Exception {
+        assertThat(verifyRestartableCalled.get(), is(false));
+        assertThat(restartCalled.get(), is(false));
+
+        assertEquals(0, launchCLI("java",
+                "-jar", jar.getAbsolutePath(),
+                "-s", j.getURL().toString(),
+                "safe-restart"));
+
+        restartSemaphore.acquire(1);
+
+        assertThat(verifyRestartableCalled.get(), is(true));
+        assertThat(restartCalled.get(), is(true));
+    }
+
+    private int launchCLI(String... cmdArgs) throws Exception {
+        return new Launcher.LocalLauncher(StreamTaskListener.fromStderr())
+                .launch()
+                .cmds(cmdArgs)
+                .join();
+    }
+}

--- a/test/src/test/java/jenkins/model/Jenkins56575Test.java
+++ b/test/src/test/java/jenkins/model/Jenkins56575Test.java
@@ -112,7 +112,7 @@ public class Jenkins56575Test {
 
     @Test
     public void testRestart_regularClient() throws Exception {
-        WebClient wc = j.createWebClient().withRedirectEnabled(false);
+        WebClient wc = j.createWebClient().withRedirectEnabled(false).withThrowExceptionOnFailingStatusCode(true);
         WebRequest request = preparePostRequest("restart");
 
         assertThat(verifyRestartableCalled.get(), is(false));
@@ -165,7 +165,7 @@ public class Jenkins56575Test {
 
     @Test
     public void testSafeRestart_regularClient() throws Exception {
-        WebClient wc = j.createWebClient().withRedirectEnabled(false);
+        WebClient wc = j.createWebClient().withRedirectEnabled(false).withThrowExceptionOnFailingStatusCode(true);
         WebRequest request = preparePostRequest("safeRestart");
 
         assertThat(verifyRestartableCalled.get(), is(false));


### PR DESCRIPTION
Third version:
- #3937 initial using Referer header as a way to identify REST Client
- #3972 proposal to use Accept header instead that is more reliable (not touched by firewalls/proxies)
- (#4022 redo #3972 due to branch name issue in CI)
- this version that propose different endpoint instead of trying to know if the client is a real browser or not

See [JENKINS-56575](https://issues.jenkins-ci.org/browse/JENKINS-56575).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* New web endpoints are added to ease the scripting of the restart of Jenkins:
  * POST `<jenkinsUrl>/restartSimple`
  * POST `<jenkinsUrl>/safeRestartSimple`

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@P01son6415 @jtnord @jeffret-b 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
