### PR TITLE
Add an example how to launch agent with secret not on command line

### DIFF
--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -80,6 +80,11 @@ THE SOFTWARE.
                 </p>
                 <!-- TODO conceal secret w/ JS if possible -->
                 <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp -secret ${it.jnlpMac} ${it.launcher.getWorkDirOptions(it)}</pre>
+                <p>
+                  ${%Run from agent command line, with the secret stored in a file:}
+                </p>
+                <pre>echo ${it.jnlpMac} > secret-file
+java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp -secret @secret-file ${it.launcher.getWorkDirOptions(it)}</pre>
               </li>
             </j:otherwise>
           </j:choose>


### PR DESCRIPTION
Some agent setups might not want to expose the secret via process command line args, and there's an (essentially undocumented) alternative.

> ![Screen Shot](https://user-images.githubusercontent.com/1831569/57881144-d89d8800-7820-11e9-920d-69a0c34119cf.png)


### Proposed changelog entries

(too minor)

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
