### PR TITLE
Un-restrict the XMLUtils class after SECURITY-521 release

### DIFF
--- a/core/src/main/java/jenkins/util/xml/XMLUtils.java
+++ b/core/src/main/java/jenkins/util/xml/XMLUtils.java
@@ -35,7 +35,8 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 /**
- * Utilities useful when working with various XML types.
+  * Utilities useful when working with various XML types.
+  * @since 1.596.1 and 1.600, unrestricted since TODO
  */
 public final class XMLUtils {
 

--- a/core/src/main/java/jenkins/util/xml/XMLUtils.java
+++ b/core/src/main/java/jenkins/util/xml/XMLUtils.java
@@ -4,8 +4,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import jenkins.util.SystemProperties;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -39,7 +37,6 @@ import javax.xml.xpath.XPathFactory;
 /**
  * Utilities useful when working with various XML types.
  */
-@Restricted(NoExternalUse.class)
 public final class XMLUtils {
 
     private final static Logger LOGGER = LogManager.getLogManager().getLogger(XMLUtils.class.getName());


### PR DESCRIPTION
- It was forgotten since that actually

See [SECURITY-521](https://issues.jenkins-ci.org/browse/SECURITY-521) resolved in Feb 2018.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: Un-restrict the XMLUtils class that was added during a previous security release

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jtnord @MRamonLeon @daniel-beck 