### PR TITLE
[JENKINS-57725.] - Wrap Proc.executor in ClassLoaderSanityThreadFactory

### DIFF
--- a/core/src/main/java/hudson/Proc.java
+++ b/core/src/main/java/hudson/Proc.java
@@ -26,6 +26,7 @@ package hudson;
 import hudson.Launcher.ProcStarter;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
+import hudson.util.ClassLoaderSanityThreadFactory;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.ExceptionCatchingThreadFactory;
 import hudson.util.NamingThreadFactory;
@@ -138,7 +139,7 @@ public abstract class Proc {
     @CheckForNull
     public abstract OutputStream getStdin();
 
-    private static final ExecutorService executor = Executors.newCachedThreadPool(new ExceptionCatchingThreadFactory(new NamingThreadFactory(new DaemonThreadFactory(), "Proc.executor")));
+    private static final ExecutorService executor = Executors.newCachedThreadPool(new ExceptionCatchingThreadFactory(new NamingThreadFactory(new ClassLoaderSanityThreadFactory(new DaemonThreadFactory()), "Proc.executor")));
     
     /**
      * Like {@link #join} but can be given a maximum time to wait.


### PR DESCRIPTION
See [JENKINS-57725](https://issues.jenkins-ci.org/browse/JENKINS-57725).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

While investigating a metaspace memory leak I found a `Proc.executor` whose context class loader was a `CleanGroovyClassLoader` from workflow-cps:

<img width="676" alt="Screen Shot 2019-05-17 at 16 34 12" src="https://user-images.githubusercontent.com/1068968/57954701-a859f600-78c1-11e9-823f-6dd0b2e07758.png">

I am not sure if it is the cause of the metaspace memory leak I was investigating, but it certainly seems suspicious, and I don't think we want `Proc.executor` to be inheriting the current context class loader whenever a new thread is created inside of `Proc.joinWithTimeout`, so I think this is a good change either way.

I did not add any tests since the change is very straightforward, but I would be happy to try to come up with a test that reproduces if desired by reviewers.

### Proposed changelog entries

* Bug: A thread pool used to wait for external processes to complete could leak class loaders in some cases.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
