### PR TITLE
[JENKINS-58240] - Plugins should be able to provide onBlur for codemirror textarea.

### DIFF
--- a/core/src/main/resources/lib/form/textarea/textarea.js
+++ b/core/src/main/resources/lib/form/textarea/textarea.js
@@ -11,8 +11,13 @@ Behaviour.specify("TEXTAREA.codemirror", 'textarea', 0, function(e) {
 
         var h = e.clientHeight || getTextareaHeight();
         var config = e.getAttribute("codemirror-config");
-        config += (config ? ", " : " ") + "onBlur: function(editor){editor.save()}";
+        if (!config) {
+            config = '';
+        }
         config = eval('({'+config+'})');
+        if (!config.onBlur) {
+            config.onBlur = function(editor) { editor.save(); };
+        }
         var codemirror = CodeMirror.fromTextArea(e,config);
         e.codemirrorObject = codemirror;
         if(typeof(codemirror.getScrollerElement) !== "function") {


### PR DESCRIPTION
Currently, plugins cannot cleanly provide a custom onBlur handler for their codemirror textareas, because it is being overridden in core. This has been the case since 4e48eaa05ca3a76fcb0e1eee307fd20f222079bc, but it does not look like that side-effect has been intentional.

(Plugins could work around this in a hackish way, by adding `})//` at the end of their codemirror-config.)

### Proposed changelog entries

* RFE, internal: Allow plugins to provide `onBlur()` handlers for codemirror textarea controls
