### PR TITLE
[JENKINS-47127] - Update maven-war-plugin from 3.0.0 to 3.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@ THE SOFTWARE.
 
     <changelog.url>https://jenkins.io/changelog</changelog.url>
 
-    <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
+    <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
     <remoting.version>3.30</remoting.version>


### PR DESCRIPTION
https://maven.apache.org/plugins/maven-war-plugin/

<!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->

# Proposed changelog entries

 * Internal: update maven-war-plugin from 3.0.0 to 3.2.3

Submitter checklist

JIRA issue is well described
Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). Examples
* Use the Internal: prefix if the change has no user-visible impact (API, test frameworks, etc.)
Appropriate autotests or explanation to why this change has no tests

    For dependency updates: links to external changelogs and, if possible, full diffs

Desired reviewers