### PR TITLE
[JENKINS-57805] Guard against exceptions thrown by implementations of Queue.Task.getAffinityKey

### DIFF
--- a/core/src/main/java/hudson/model/LoadBalancer.java
+++ b/core/src/main/java/hudson/model/LoadBalancer.java
@@ -112,7 +112,14 @@ public abstract class LoadBalancer implements ExtensionPoint {
         private boolean assignGreedily(Mapping m, Task task, List<ConsistentHash<ExecutorChunk>> hashes, int i) {
             if (i==hashes.size())   return true;    // fully assigned
 
-            String key = task.getAffinityKey() + (i>0 ? String.valueOf(i) : "");
+            String key;
+            try {
+                key = task.getAffinityKey();
+            } catch (RuntimeException e) {
+                // Default implementation of Queue.Task.getAffinityKey, we assume it doesn't fail.
+                key = task.getFullDisplayName();
+            }
+            key += i > 0 ? String.valueOf(i) : "";
 
             for (ExecutorChunk ec : hashes.get(i).list(key)) {
                 // let's attempt this assignment

--- a/core/src/main/java/hudson/model/LoadBalancer.java
+++ b/core/src/main/java/hudson/model/LoadBalancer.java
@@ -36,6 +36,8 @@ import hudson.util.ConsistentHash.Hash;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Strategy that decides which {@link Task} gets run on which {@link Executor}.
@@ -116,6 +118,7 @@ public abstract class LoadBalancer implements ExtensionPoint {
             try {
                 key = task.getAffinityKey();
             } catch (RuntimeException e) {
+                LOGGER.log(Level.FINE, null, e);
                 // Default implementation of Queue.Task.getAffinityKey, we assume it doesn't fail.
                 key = task.getFullDisplayName();
             }
@@ -173,5 +176,7 @@ public abstract class LoadBalancer implements ExtensionPoint {
             }
         };
     }
+
+    private static final Logger LOGGER = Logger.getLogger(LoadBalancer.class.getName());
 
 }

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -33,6 +33,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlFormUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.xml.XmlPage;
+import hudson.ExtensionList;
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.XmlFile;
@@ -1133,6 +1134,57 @@ public class QueueTest {
             assertThat(p.getWebResponse().getStatusCode(), lessThan(400));
 
             assertTrue(currentOne.getFuture().isCancelled());
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-57805")
+    public void brokenAffinityKey() throws Exception {
+        BrokenAffinityKeyProject brokenProject = r.createProject(BrokenAffinityKeyProject.class, "broken-project");
+        // Before the JENKINS-57805 fix, the test times out because the `NullPointerException` repeatedly thrown from
+        // `BrokenAffinityKeyProject.getAffinityKey()` prevents `Queue.maintain()` from completing.
+        r.buildAndAssertSuccess(brokenProject);
+    }
+
+    public static class BrokenAffinityKeyProject extends Project<BrokenAffinityKeyProject, BrokenAffinityKeyBuild> implements TopLevelItem {
+        public BrokenAffinityKeyProject(ItemGroup parent, String name) {
+            super(parent, name);
+        }
+        @Override
+        public String getAffinityKey() {
+            throw new NullPointerException("oops!");
+        }
+        @Override
+        protected Class<BrokenAffinityKeyBuild> getBuildClass() {
+            return BrokenAffinityKeyBuild.class;
+        }
+        @Override
+        public TopLevelItemDescriptor getDescriptor() {
+            return ExtensionList.lookupSingleton(DescriptorImpl.class);
+        }
+        @TestExtension("brokenAffinityKey")
+        public static class DescriptorImpl extends AbstractProjectDescriptor {
+            @Override
+            public TopLevelItem newInstance(ItemGroup parent, String name) {
+                return new BrokenAffinityKeyProject(parent, name);
+            }
+            @Override
+            public String getDisplayName() {
+                return "Broken Affinity Key Project";
+            }
+        }
+    }
+
+    public static class BrokenAffinityKeyBuild extends Build<BrokenAffinityKeyProject, BrokenAffinityKeyBuild> {
+        public BrokenAffinityKeyBuild(BrokenAffinityKeyProject project) throws IOException {
+            super(project);
+        }
+        public BrokenAffinityKeyBuild(BrokenAffinityKeyProject project, File buildDir) throws IOException {
+            super(project, buildDir);
+        }
+        @Override
+        public void run() {
+            execute(new BuildExecution());
         }
     }
 }


### PR DESCRIPTION
See [JENKINS-57805](https://issues.jenkins-ci.org/browse/JENKINS-57805).

Pipeline's new implementation of `getAffinityKey` has been observed to throw exceptions in some cases when it is called after Jenkins is restarted. I am working on fixing the cause for those exceptions in Pipeline, but I think it also makes sense to harden `LoadBalancer` (the only caller of `getAffinityKey` in core) so that we do not completely break `Queue.maintain` if an exception is thrown by some implementation of `getAffinityKey`.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fix: Exceptions thrown while scheduling jobs in the queue could prevent other jobs from being scheduled in some cases.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
