### PR TITLE
[JENKINS-49316] Create Item: OK button disabled until TAB pressed

### DIFF
--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -260,7 +260,7 @@ $.when(getItems()).done(function(data) {
     });
 
     // Init CopyFromField
-    $('input[name="from"]', '#createItem').blur(function() {
+    $('input[name="from"]', '#createItem').on("blur input", function() {
       if (getCopyFromValue() === '') {
         $('#createItem').find('input[type="radio"][value="copy"]').removeAttr('checked');
       } else {


### PR DESCRIPTION
change Init CopyFromField function and let the ok button in newJob page be changed when user input words to CopyFromField

See [JENKINS-49316](https://issues.jenkins-ci.org/browse/JENKINS-49316).

