### PR TITLE
[JENKINS-57993] Avoid printing stack traces for some common agent conditions

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -43,13 +43,13 @@ import hudson.slaves.OfflineCause;
 import java.io.DataOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.SocketAddress;
 import java.util.Arrays;
 import jenkins.AgentProtocol;
 
 import java.io.BufferedWriter;
 import java.io.DataInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -286,7 +286,11 @@ public final class TcpSlaveAgentListener extends Thread {
                     // try to clean up the socket
                 }
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING,"Connection #"+id+" failed",e);
+                if (e instanceof EOFException) {
+                    LOGGER.log(Level.INFO, "Connection #{0} failed: {1}", new Object[] {id, e});
+                } else {
+                    LOGGER.log(Level.WARNING, "Connection #" + id + " failed", e);
+                }
                 try {
                     s.close();
                 } catch (IOException ex) {

--- a/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
@@ -1,8 +1,10 @@
 package hudson.node_monitors;
 
+import hudson.Functions;
 import hudson.model.Computer;
 import hudson.remoting.Callable;
 import hudson.remoting.VirtualChannel;
+import hudson.slaves.SlaveComputer;
 import jenkins.model.Jenkins;
 
 import javax.annotation.CheckForNull;
@@ -93,7 +95,7 @@ public abstract class AbstractAsyncNodeMonitorDescriptor<T> extends AbstractNode
                         futures.put(c,ch.callAsync(cc));
                 }
             } catch (RuntimeException | IOException e) {
-                LOGGER.log(WARNING, "Failed to monitor "+c.getDisplayName()+" for "+getDisplayName(), e);
+                error(c, e);
             }
         }
 
@@ -111,7 +113,7 @@ public abstract class AbstractAsyncNodeMonitorDescriptor<T> extends AbstractNode
                 try {
                     data.put(c,f.get(Math.max(0,end-System.currentTimeMillis()), MILLISECONDS));
                 } catch (RuntimeException | TimeoutException | ExecutionException x) {
-                    LOGGER.log(WARNING, "Failed to monitor " + c.getDisplayName() + " for " + getDisplayName(), x);
+                    error(c, x);
                 }
             } else {
                 skipped.add(c);
@@ -119,6 +121,14 @@ public abstract class AbstractAsyncNodeMonitorDescriptor<T> extends AbstractNode
         }
 
         return new Result<>(data, skipped);
+    }
+
+    private void error(Computer c, Throwable x) {
+        if (c instanceof SlaveComputer) {
+            Functions.printStackTrace(x, ((SlaveComputer) c).getListener().error("Failed to monitor for " + getDisplayName()));
+        } else {
+            LOGGER.log(WARNING, "Failed to monitor " + c.getDisplayName() + " for " + getDisplayName(), x);
+        }
     }
 
     private static final Logger LOGGER = Logger.getLogger(AbstractAsyncNodeMonitorDescriptor.class.getName());

--- a/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
+++ b/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
@@ -24,6 +24,7 @@ import jenkins.util.SystemProperties;
 import org.jenkinsci.remoting.engine.JnlpConnectionState;
 
 import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -181,7 +182,9 @@ public class DefaultJnlpSlaveReceiver extends JnlpAgentReceiver {
     public void channelClosed(@NonNull JnlpConnectionState event) {
         final String nodeName = event.getProperty(JnlpConnectionState.CLIENT_NAME_KEY);
         IOException cause = event.getCloseCause();
-        if (cause != null) {
+        if (cause instanceof ClosedChannelException) {
+            LOGGER.log(Level.INFO, "{0} for {1} terminated: {2}", new Object[] {Thread.currentThread().getName(), nodeName, cause});
+        } else if (cause != null) {
             LOGGER.log(Level.WARNING, Thread.currentThread().getName() + " for " + nodeName + " terminated",
                     cause);
         }


### PR DESCRIPTION
See [JENKINS-57993](https://issues.jenkins-ci.org/browse/JENKINS-57993). In the spirit of https://github.com/jenkinsci/remoting/pull/274 etc.

### Proposed changelog entries

* Converting some stack traces related to agent channels into simpler messages.