### PR TITLE
[JENKINS-57992] clarify that the system user is a jenkins concept

### DIFF
--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.properties
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/message.properties
@@ -1,4 +1,4 @@
-blurb = Builds in Jenkins run as the virtual SYSTEM user with full permissions by default. \
+blurb = Builds in Jenkins run as the virtual Jenkins SYSTEM user with full Jenkins permissions by default. \
   This can be a problem if some users have restricted or no access to some jobs, but can configure others. \
   If that is the case, it is recommended to install a plugin implementing build authentication, and to override this default.
 


### PR DESCRIPTION
See [JENKINS-57992](https://issues.jenkins-ci.org/browse/JENKINS-57992).

### Proposed changelog entries

* Clarify the SYSTEM user is a Jenkins concept

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers
