### PR TITLE
[INFRA-2028] The timestamps step is no longer necessary

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,6 @@ for(j = 0; j < jdks.size(); j++) {
     def jdk = jdks[j]
     builds["${buildType}-jdk${jdk}"] = {
         node(buildType.toLowerCase()) {
-            timestamps {
                 // First stage is actually checking out the source. Since we're using Multibranch
                 // currently, we can use "checkout scm".
                 stage('Checkout') {
@@ -73,7 +72,6 @@ for(j = 0; j < jdks.size(); j++) {
                         }
                     }
                 }
-            }
         }
     }
 }}


### PR DESCRIPTION
Analogue of https://github.com/jenkins-infra/pipeline-library/pull/90.

### Proposed changelog entries

* N/A