### PR TITLE
[JENKINS-27413]  Handle file parameters on pipeline builds

### DIFF
--- a/test/src/test/java/hudson/cli/BuildCommandTest.java
+++ b/test/src/test/java/hudson/cli/BuildCommandTest.java
@@ -27,47 +27,33 @@ package hudson.cli;
 import hudson.Extension;
 import hudson.Functions;
 import hudson.Launcher;
-import static hudson.cli.CLICommandInvoker.Matcher.*;
-import hudson.model.AbstractBuild;
-import hudson.model.Action;
-import hudson.model.BuildListener;
-import hudson.model.Executor;
-import hudson.model.FileParameterDefinition;
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
-import hudson.model.ParameterDefinition.ParameterDescriptor;
-import hudson.model.ParameterValue;
-import hudson.model.ParametersAction;
-import hudson.model.ParametersDefinitionProperty;
+import hudson.model.*;
 import hudson.model.Queue.QueueDecisionHandler;
 import hudson.model.Queue.Task;
-import hudson.model.SimpleParameterDefinition;
-import hudson.model.StringParameterDefinition;
-import hudson.model.StringParameterValue;
-import hudson.model.TopLevelItem;
 import hudson.slaves.DumbSlave;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
 import hudson.util.OneShotEvent;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.List;
-
 import net.sf.json.JSONObject;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import org.apache.commons.io.FileUtils;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.jvnet.hudson.test.BuildWatcher;
-import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
-import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.SmokeTest;
-import org.jvnet.hudson.test.TestBuilder;
-import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.*;
 import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
+import static hudson.cli.CLICommandInvoker.Matcher.succeeded;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.*;
 
 /**
  * {@link BuildCommand} test.
@@ -281,6 +267,8 @@ public class BuildCommandTest {
     @Test
     public void fileParameter() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject("myjob");
+        Path tempDirWithPrefix = Files.createTempDirectory("fileParameter_canStillUse_internalHierarchy");
+        p.setCustomWorkspace(tempDirWithPrefix.toString());
         p.addProperty(new ParametersDefinitionProperty(new FileParameterDefinition("file", null)));
         p.getBuildersList().add(new TestBuilder() {
             @Override
@@ -296,6 +284,8 @@ public class BuildCommandTest {
         FreeStyleBuild b = p.getBuildByNumber(1);
         assertNotNull(b);
         j.assertLogContains("uploaded content here", b);
+
+        FileUtils.deleteDirectory(tempDirWithPrefix.toFile());
     }
 
 }

--- a/test/src/test/java/hudson/model/FileParameterValueTest.java
+++ b/test/src/test/java/hudson/model/FileParameterValueTest.java
@@ -34,17 +34,15 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.kohsuke.stapler.Function;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -63,6 +61,8 @@ public class FileParameterValueTest {
         FilePath root = j.jenkins.getRootPath();
         
         FreeStyleProject p = j.createFreeStyleProject();
+        Path tempDirWithPrefix = Files.createTempDirectory("fileParameter_cannotCreateFile_outsideOfBuildFolder");
+        p.setCustomWorkspace(tempDirWithPrefix.toString());
         p.addProperty(new ParametersDefinitionProperty(Collections.singletonList(
                 new FileParameterDefinition("../../../../../root-level.txt", null)
         )));
@@ -93,6 +93,8 @@ public class FileParameterValueTest {
         checkUrlNot200AndNotContains(wc, build.getUrl() + "parameters/parameter/%252e%252e%252f%252e%252e%252f%252e%252e%252f%252e%252e%252f%252e%252e%252froot-level.txt/uploaded-file.txt", uploadedContent);
         // overlong utf-8 encoding
         checkUrlNot200AndNotContains(wc, build.getUrl() + "parameters/parameter/%c0%2e%c0%2e%c0%af%c0%2e%c0%2e%c0%af%c0%2e%c0%2e%c0%af%c0%2e%c0%2e%c0%af%c0%2e%c0%2e%c0%afroot-level.txt/uploaded-file.txt", uploadedContent);
+
+        FileUtils.deleteDirectory(tempDirWithPrefix.toFile());
     }
     
     private void checkUrlNot200AndNotContains(JenkinsRule.WebClient wc, String url, String contentNotPresent) throws Exception {
@@ -111,10 +113,12 @@ public class FileParameterValueTest {
         FilePath root = j.jenkins.getRootPath();
         
         FreeStyleProject p = j.createFreeStyleProject();
+        Path tempDirWithPrefix = Files.createTempDirectory("fileParameter_cannotCreateFile_outsideOfBuildFolder_backslashEdition");
+        p.setCustomWorkspace(tempDirWithPrefix.toString());
         p.addProperty(new ParametersDefinitionProperty(Collections.singletonList(
                 new FileParameterDefinition("..\\..\\..\\..\\..\\root-level.txt", null)
         )));
-        
+
         assertThat(root.child("root-level.txt").exists(), equalTo(false));
         
         String uploadedContent = "test-content";
@@ -134,6 +138,8 @@ public class FileParameterValueTest {
         
         checkUrlNot200AndNotContains(wc, build.getUrl() + "parameters/parameter/..\\..\\..\\..\\..\\root-level.txt/uploaded-file.txt", uploadedContent);
         checkUrlNot200AndNotContains(wc, build.getUrl() + "parameters/parameter/..%2F..%2F..%2F..%2F..%2Froot-level.txt/uploaded-file.txt", uploadedContent);
+
+        FileUtils.deleteDirectory(tempDirWithPrefix.toFile());
     }
     
     @Test
@@ -142,6 +148,8 @@ public class FileParameterValueTest {
         // this case was not working even before the patch
         
         FreeStyleProject p = j.createFreeStyleProject();
+        Path tempDirWithPrefix = Files.createTempDirectory("fileParameter_withSingleDot");
+        p.setCustomWorkspace(tempDirWithPrefix.toString());
         p.addProperty(new ParametersDefinitionProperty(Collections.singletonList(
                 new FileParameterDefinition(".", null)
         )));
@@ -162,6 +170,8 @@ public class FileParameterValueTest {
         
         checkUrlNot200AndNotContains(wc, build.getUrl() + "parameters/parameter/uploaded-file.txt", uploadedContent);
         checkUrlNot200AndNotContains(wc, build.getUrl() + "parameters/parameter/./uploaded-file.txt", uploadedContent);
+
+        FileUtils.deleteDirectory(tempDirWithPrefix.toFile());
     }
     
     @Test
@@ -170,6 +180,8 @@ public class FileParameterValueTest {
         // this case was not working even before the patch
         
         FreeStyleProject p = j.createFreeStyleProject();
+        Path tempDirWithPrefix = Files.createTempDirectory("fileParameter_withDoubleDot");
+        p.setCustomWorkspace(tempDirWithPrefix.toString());
         p.addProperty(new ParametersDefinitionProperty(Collections.singletonList(
                 new FileParameterDefinition("..", null)
         )));
@@ -190,6 +202,8 @@ public class FileParameterValueTest {
         
         checkUrlNot200AndNotContains(wc, build.getUrl() + "parameters/uploaded-file.txt", uploadedContent);
         checkUrlNot200AndNotContains(wc, build.getUrl() + "parameters/parameter/../uploaded-file.txt", uploadedContent);
+
+        FileUtils.deleteDirectory(tempDirWithPrefix.toFile());
     }
     
     @Test
@@ -200,6 +214,8 @@ public class FileParameterValueTest {
         FilePath root = j.jenkins.getRootPath();
         
         FreeStyleProject p = j.createFreeStyleProject();
+        Path tempDirWithPrefix = Files.createTempDirectory("fileParameter_cannotEraseFile_outsideOfBuildFolder");
+        p.setCustomWorkspace(tempDirWithPrefix.toString());
         p.addProperty(new ParametersDefinitionProperty(Collections.singletonList(
                 new FileParameterDefinition("../../../../../root-level.txt", null)
         )));
@@ -224,11 +240,15 @@ public class FileParameterValueTest {
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
     
         checkUrlNot200AndNotContains(wc, build.getUrl() + "parameters/parameter/..%2F..%2F..%2F..%2F..%2Froot-level.txt/uploaded-file.txt", uploadedContent);
+
+        FileUtils.deleteDirectory(tempDirWithPrefix.toFile());
     }
     
     @Test
     public void fileParameter_canStillUse_internalHierarchy() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
+        Path tempDirWithPrefix = Files.createTempDirectory("fileParameter_canStillUse_internalHierarchy");
+        p.setCustomWorkspace(tempDirWithPrefix.toString());
         p.addProperty(new ParametersDefinitionProperty(Arrays.asList(
                 new FileParameterDefinition("direct-child1.txt", null),
                 new FileParameterDefinition("parent/child2.txt", null)
@@ -243,7 +263,7 @@ public class FileParameterValueTest {
                 new FileParameterValue("direct-child1.txt", uploadedFile1, "uploaded-file-1.txt"),
                 new FileParameterValue("parent/child2.txt", uploadedFile2, "uploaded-file-2.txt")
         )));
-        
+
         // files are correctly saved in the build "fileParameters" folder
         File directChild = new File(build.getRootDir(), "fileParameters/" + "direct-child1.txt");
         assertTrue(directChild.exists());
@@ -266,5 +286,7 @@ public class FileParameterValueTest {
         HtmlPage workspaceParentPage = wc.goTo(p.getUrl() + "ws" + "/parent");
         String workspaceParentContent = workspaceParentPage.getWebResponse().getContentAsString();
         assertThat(workspaceParentContent, containsString("child2.txt"));
+
+        FileUtils.deleteDirectory(tempDirWithPrefix.toFile());
     }
 }


### PR DESCRIPTION
Fixes [JENKINS-27413] and [JENKINS-47333] (duplicate).

Adds file parameter support on pipeline jobs, while maintaining compatibility
with freestyle projects.

[JENKINS-27413]: https://issues.jenkins-ci.org/browse/JENKINS-27413
[JENKINS-47333]: https://issues.jenkins-ci.org/browse/JENKINS-47333

#### Detailed report of the bug
Freestyle Jobs are executed by `hudson.model.Build`. As part of the workflow, `ParameterAction` `BuildWrapper`'s are created and invoked, which in the case of a `FileParameterValue` results in copying the file to the desired location within the workspace.

When working with pipelines (executed by `org.jenkinsci.plugins.workflow.job.WorkflowJob`), there are no calls to the parameters `BuildWrapper`, so the side effect is not triggered and the files not copied, thus the bug.


#### Proposal

`FileParameterValue` is the only `ParameterValue` that requires execution of side effects (via `BuildWrapper`). The rest of `ParameterValue` subclasses are properly set once `ParameterValue.buildEnvironment()` is called. This call to `buildEnvironment()` is performed both by Freestyle jobs and Pipelines alike.

My proposal moves the execution of the side effect of copying the file from the `BuildWrapper` to `buildEnvironment()` itself. I've added an internal variable to keep track of the `FileParameterValue` so the copying is only performed once.

#### Pipeline example
Example pipeline to showcase the fix working

	pipeline {
	    agent any

	    parameters {
	        file(
	            name: 'example.txt',
	            description: 'This is an example to showcase JENKINS-27413'
	        )
	    }

	    stages {
	        stage('showcase JENKINS-27413') {
	            steps {
	                // Install conda environment
	                sh """
	                    cat example.txt
	                """
	            }
	        }
	    }
	}

### Proposed changelog entries

- Fixed file build parameters with pipeline jobs
- Moved `FileParameterValue` side effects from `createBuildWrapper()` to `buildEnvironment()` to add compatibility with workflow jobs
- Fixed `FileParameterValue.doDynamic()` to allow for parameter inspection once the task has been executed (previous cast was dependant on FreeStyleJob)

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

- @jglick
- @huybrechts 