### PR TITLE
[JENKINS-58041] Add support for IPv6 when getting "Jenkins URL"

### DIFF
--- a/core/src/test/java/jenkins/model/JenkinsGetRootUrlTest.java
+++ b/core/src/test/java/jenkins/model/JenkinsGetRootUrlTest.java
@@ -141,7 +141,31 @@ public class JenkinsGetRootUrlTest {
         withHeader("X-Forwarded-Proto", "https");
         rootUrlFromRequestIs("https://ci/jenkins/");
     }
-    
+
+    @Issue("JENKINS-58041")
+    @Test
+    public void useForwardedProtoWithIPv6WhenPresent() {
+        configured("http://[::1]/jenkins/");
+
+        // Without a forwarded protocol, it should use the request protocol
+        accessing("http://[::1]/jenkins/");
+        rootUrlFromRequestIs("http://[::1]/jenkins/");
+        
+        accessing("http://[::1]:8080/jenkins/");
+        rootUrlFromRequestIs("http://[::1]:8080/jenkins/");
+
+        // With a forwarded protocol, it should use the forwarded protocol
+        accessing("http://[::1]/jenkins/");
+        withHeader("X-Forwarded-Host", "[::2]");
+        rootUrlFromRequestIs("http://[::2]/jenkins/");
+
+        accessing("http://[::1]:8080/jenkins/");
+        withHeader("X-Forwarded-Proto", "https");
+        withHeader("X-Forwarded-Host", "[::1]:8443");
+        rootUrlFromRequestIs("https://[::1]:8443/jenkins/");
+
+    }
+
     private void rootUrlFromRequestIs(final String expectedRootUrl) {
         
         assertThat(jenkins.getRootUrlFromRequest(), equalTo(expectedRootUrl));


### PR DESCRIPTION
See [JENKINS-58041](https://issues.jenkins-ci.org/browse/JENKINS-58041).

### Proposed changelog entries

* Issue:  Add support for IPv6 when getting "Jenkins URL"， since the default function "Jenkins.getRootUrlFromRequest()" do not support IPv6 address.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers