### PR TITLE
Use a proper example domain in hudson.FunctionsTest#testGetActionUrl_unparseable()

### DIFF
--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -280,7 +280,7 @@ public class FunctionsTest {
     @Test
     @PrepareForTest(Stapler.class)
     public void testGetActionUrl_unparseable() throws Exception{
-        assertEquals(null, Functions.getActionUrl(null, createMockAction("http://nowhere.net/stuff?something=^woohoo")));
+        assertEquals(null, Functions.getActionUrl(null, createMockAction("http://example.net/stuff?something=^woohoo")));
     }
 
     private static Action createMockAction(String uri) {


### PR DESCRIPTION
See RFC6761

### Proposed changelog entries

* Internal: change test url domain

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers