### PR TITLE
IntelliJ/Java: Duplicate code -- Refactored as UnstableAwareCommandInterpreter.helpCheckUnstableReturn

### DIFF
--- a/core/src/main/java/hudson/tasks/BatchFile.java
+++ b/core/src/main/java/hudson/tasks/BatchFile.java
@@ -45,7 +45,7 @@ import javax.annotation.CheckForNull;
  *
  * @author Kohsuke Kawaguchi
  */
-public class BatchFile extends CommandInterpreter {
+public class BatchFile extends UnstableAwareCommandInterpreter {
     @DataBoundConstructor
     public BatchFile(String command) {
         super(LineEndingConversion.convertEOL(command, LineEndingConversion.EOLType.Windows));
@@ -102,27 +102,19 @@ public class BatchFile extends CommandInterpreter {
          */
         @Restricted(DoNotUse.class)
         public FormValidation doCheckUnstableReturn(@QueryParameter String value) {
-            value = Util.fixEmptyAndTrim(value);
-            if (value == null) {
-                return FormValidation.ok();
-            }
-            long unstableReturn;
-            try {
-                unstableReturn = Long.parseLong(value);
-            } catch (NumberFormatException e) {
-                return FormValidation.error(hudson.model.Messages.Hudson_NotANumber());
-            }
-            if (unstableReturn == 0) {
-                return FormValidation.warning(hudson.tasks.Messages.BatchFile_invalid_exit_code_zero());
-            }
-            if (unstableReturn < Integer.MIN_VALUE || unstableReturn > Integer.MAX_VALUE) {
-                return FormValidation.error(hudson.tasks.Messages.BatchFile_invalid_exit_code_range(unstableReturn));
-            }
-            return FormValidation.ok();
+            return helpCheckUnstableReturn(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
         }
+    }
+
+    static String invalidExitCodeZero() {
+        return hudson.tasks.Messages.BatchFile_invalid_exit_code_zero();
+    }
+
+    static String invalidExitCodeRange(long unstableReturn) {
+        return hudson.tasks.Messages.BatchFile_invalid_exit_code_range((Object) unstableReturn);
     }
 }

--- a/core/src/main/java/hudson/tasks/BatchFile.java
+++ b/core/src/main/java/hudson/tasks/BatchFile.java
@@ -25,7 +25,6 @@ package hudson.tasks;
 
 import hudson.FilePath;
 import hudson.Extension;
-import hudson.Util;
 import hudson.model.AbstractProject;
 import hudson.util.FormValidation;
 import hudson.util.LineEndingConversion;
@@ -101,20 +100,32 @@ public class BatchFile extends UnstableAwareCommandInterpreter {
          * Performs on-the-fly validation of the errorlevel.
          */
         @Restricted(DoNotUse.class)
-        public FormValidation doCheckUnstableReturn(@QueryParameter String value) {
-            return helpCheckUnstableReturn(value);
+        static public FormValidation doCheckUnstableReturn(@QueryParameter String value) {
+            return helpCheckUnstableReturn(value, new InvalidExitCodeHelper() {
+                @Override
+                public String messageZero() {
+                    return hudson.tasks.Messages.BatchFile_invalid_exit_code_zero();
+                }
+
+                @Override
+                public String messageRange(Object unstableReturn) {
+                    return hudson.tasks.Messages.BatchFile_invalid_exit_code_range((Object) unstableReturn);
+                }
+
+                @Override
+                public int min() {
+                    return Integer.MIN_VALUE;
+                }
+
+                @Override
+                public int max() {
+                    return Integer.MAX_VALUE;
+                }
+            });
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
         }
-    }
-
-    static String invalidExitCodeZero() {
-        return hudson.tasks.Messages.BatchFile_invalid_exit_code_zero();
-    }
-
-    static String invalidExitCodeRange(long unstableReturn) {
-        return hudson.tasks.Messages.BatchFile_invalid_exit_code_range((Object) unstableReturn);
     }
 }

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -57,7 +57,7 @@ import javax.annotation.CheckForNull;
  *
  * @author Kohsuke Kawaguchi
  */
-public class Shell extends CommandInterpreter {
+public class Shell extends UnstableAwareCommandInterpreter {
 
     @DataBoundConstructor
     public Shell(String command) {
@@ -188,23 +188,15 @@ public class Shell extends CommandInterpreter {
          */
         @Restricted(DoNotUse.class)
         public FormValidation doCheckUnstableReturn(@QueryParameter String value) {
-            value = Util.fixEmptyAndTrim(value);
-            if (value == null) {
-                return FormValidation.ok();
-            }
-            long unstableReturn;
-            try {
-                unstableReturn = Long.parseLong(value);
-            } catch (NumberFormatException e) {
-                return FormValidation.error(hudson.model.Messages.Hudson_NotANumber());
-            }
-            if (unstableReturn == 0) {
-                return FormValidation.warning(hudson.tasks.Messages.Shell_invalid_exit_code_zero());
-            }
-            if (unstableReturn < 1 || unstableReturn > 255) {
-                return FormValidation.error(hudson.tasks.Messages.Shell_invalid_exit_code_range(unstableReturn));
-            }
-            return FormValidation.ok();
+            return helpCheckUnstableReturn(value);
+        }
+
+        static String invalidExitCodeZero() {
+            return hudson.tasks.Messages.Shell_invalid_exit_code_zero();
+        }
+
+        static String invalidExitCodeRange(Object unstableReturn) {
+            return hudson.tasks.Messages.Shell_invalid_exit_code_range(unstableReturn);
         }
 
         @Override

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -187,16 +187,28 @@ public class Shell extends UnstableAwareCommandInterpreter {
          * Performs on-the-fly validation of the exit code.
          */
         @Restricted(DoNotUse.class)
-        public FormValidation doCheckUnstableReturn(@QueryParameter String value) {
-            return helpCheckUnstableReturn(value);
-        }
+        public static FormValidation doCheckUnstableReturn(@QueryParameter String value) {
+            return helpCheckUnstableReturn(value, new InvalidExitCodeHelper() {
+                @Override
+                public String messageZero() {
+                    return hudson.tasks.Messages.Shell_invalid_exit_code_zero();
+                }
 
-        static String invalidExitCodeZero() {
-            return hudson.tasks.Messages.Shell_invalid_exit_code_zero();
-        }
+                @Override
+                public String messageRange(Object unstableReturn) {
+                    return hudson.tasks.Messages.Shell_invalid_exit_code_range(unstableReturn);
+                }
 
-        static String invalidExitCodeRange(Object unstableReturn) {
-            return hudson.tasks.Messages.Shell_invalid_exit_code_range(unstableReturn);
+                @Override
+                public int min() {
+                    return 1;
+                }
+
+                @Override
+                public int max() {
+                    return 25;
+                }
+            });
         }
 
         @Override

--- a/core/src/main/java/hudson/tasks/UnstableAwareCommandInterpreter.java
+++ b/core/src/main/java/hudson/tasks/UnstableAwareCommandInterpreter.java
@@ -1,0 +1,39 @@
+package hudson.tasks;
+
+import hudson.Util;
+import hudson.util.FormValidation;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.stapler.QueryParameter;
+
+public abstract class UnstableAwareCommandInterpreter extends CommandInterpreter {
+    public UnstableAwareCommandInterpreter(String command) {
+        super(command);
+    }
+
+    static String invalidExitCodeZero() { return null; };
+    static String invalidExitCodeRange(Object o) { return null; };
+    /**
+     * Performs on-the-fly validation of the exit code.
+     */
+    protected static FormValidation helpCheckUnstableReturn(@QueryParameter String value) {
+        value = Util.fixEmptyAndTrim(value);
+        if (value == null) {
+            return FormValidation.ok();
+        }
+        long unstableReturn;
+        try {
+            unstableReturn = Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return FormValidation.error(hudson.model.Messages.Hudson_NotANumber());
+        }
+        if (unstableReturn == 0) {
+            return FormValidation.warning(invalidExitCodeZero());
+        }
+        if (unstableReturn < 1 || unstableReturn > 255) {
+            return FormValidation.error(invalidExitCodeRange(unstableReturn));
+        }
+        return FormValidation.ok();
+    }
+
+}


### PR DESCRIPTION
This is for discussion.

Notes:
* Commits was probably created by IntelliJ for #4034
* In general, commits should not change program behavior at all

### Proposed changelog entries

* `Internal:` Internal Java code cleanup

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
@Wadeck 