### PR TITLE
IntelliJ/Java: Duplicate code -- Refactored as ExtensionFinder.getClassFromIndex

### DIFF
--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -697,18 +697,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
 
             for (IndexItem<Extension,Object> item : indices) {
                 try {
-                    AnnotatedElement e = item.element();
-                    Class<?> extType;
-                    if (e instanceof Class) {
-                        extType = (Class) e;
-                    } else
-                    if (e instanceof Field) {
-                        extType = ((Field)e).getType();
-                    } else
-                    if (e instanceof Method) {
-                        extType = ((Method)e).getReturnType();
-                    } else
-                        throw new AssertionError();
+                    Class<?> extType = getClassFromIndex(item);
 
                     if(type.isAssignableFrom(extType)) {
                         Object instance = item.instance();
@@ -733,18 +722,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                     // but we can't synchronize this --- if we do, the one thread that's supposed to load a class
                     // can block while other threads wait for the entry into the element call().
                     // looking at the sezpoz code, it should be safe to do so
-                    AnnotatedElement e = item.element();
-                    Class<?> extType;
-                    if (e instanceof Class) {
-                        extType = (Class) e;
-                    } else
-                    if (e instanceof Field) {
-                        extType = ((Field)e).getType();
-                    } else
-                    if (e instanceof Method) {
-                        extType = ((Method)e).getReturnType();
-                    } else
-                        throw new AssertionError();
+                    Class<?> extType = getClassFromIndex(item);
                     // according to JDK-4993813 this is the only way to force class initialization
                     Class.forName(extType.getName(),true,extType.getClassLoader());
                 } catch (Exception | LinkageError e) {
@@ -756,6 +734,20 @@ public abstract class ExtensionFinder implements ExtensionPoint {
         private Level logLevel(IndexItem<Extension, Object> item) {
             return item.annotation().optional() ? Level.FINE : Level.WARNING;
         }
+    }
+
+    private static Class<?> getClassFromIndex(IndexItem<Extension, Object> item) throws InstantiationException {
+        AnnotatedElement e = item.element();
+        Class<?> extType;
+        if (e instanceof Class) {
+            extType = (Class) e;
+        } else if (e instanceof Field) {
+            extType = ((Field) e).getType();
+        } else if (e instanceof Method) {
+            extType = ((Method) e).getReturnType();
+        } else
+            throw new AssertionError();
+        return extType;
     }
 
     private static final Logger LOGGER = Logger.getLogger(ExtensionFinder.class.getName());

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -533,8 +533,9 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                             } else
                             if (e instanceof Method) {
                                 extType = ((Method)e).getReturnType();
-                            } else
+                            } else {
                                 throw new AssertionError();
+                            }
 
                             resolve(extType);
 
@@ -745,8 +746,9 @@ public abstract class ExtensionFinder implements ExtensionPoint {
             extType = ((Field) e).getType();
         } else if (e instanceof Method) {
             extType = ((Method) e).getReturnType();
-        } else
+        } else {
             throw new AssertionError();
+        }
         return extType;
     }
 


### PR DESCRIPTION
This is for discussion.

Notes:
* Commits was probably created by IntelliJ for #4034
* In general, commits should not change program behavior at all

### Proposed changelog entries

* `Internal:` Internal Java code cleanup

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
@Wadeck 