### PR TITLE
[JENKINS-24752] Avoid nodeprovisioner delay after consulting strategies

### DIFF
--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -172,21 +172,23 @@ public class NodeProvisioner {
      * @since 1.415
      */
     public void suggestReviewNow() {
-        long delay = TimeUnit.SECONDS.toMillis(1) - (System.currentTimeMillis() - lastSuggestedReview);
-        if (delay < 0) {
-            lastSuggestedReview = System.currentTimeMillis();
-            Computer.threadPoolForRemoting.submit(() -> {
-                LOGGER.fine(() -> "running suggested review for " + label);
-                update();
-            });
-        } else if (!queuedReview) {
-            queuedReview = true;
-            LOGGER.fine(() -> "running suggested review in " + delay + " ms for " + label);
-            Timer.get().schedule(() -> {
+        if (!queuedReview) {
+            long delay = TimeUnit.SECONDS.toMillis(1) - (System.currentTimeMillis() - lastSuggestedReview);
+            if (delay < 0) {
                 lastSuggestedReview = System.currentTimeMillis();
-                LOGGER.fine(() -> "running suggested review for " + label + " after " + delay + " ms");
-                update();
-            }, delay, TimeUnit.MILLISECONDS);
+                Computer.threadPoolForRemoting.submit(() -> {
+                    LOGGER.fine(() -> "running suggested review for " + label);
+                    update();
+                });
+            } else {
+                queuedReview = true;
+                LOGGER.fine(() -> "running suggested review in " + delay + " ms for " + label);
+                Timer.get().schedule(() -> {
+                    lastSuggestedReview = System.currentTimeMillis();
+                    LOGGER.fine(() -> "running suggested review for " + label + " after " + delay + " ms");
+                    update();
+                }, delay, TimeUnit.MILLISECONDS);
+            }
         } else {
             LOGGER.fine(() -> "ignoring suggested review for " + label);
         }

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -174,14 +174,17 @@ public class NodeProvisioner {
     public void suggestReviewNow() {
         long delay = TimeUnit.SECONDS.toMillis(1) - (System.currentTimeMillis() - lastSuggestedReview);
         if (delay < 0) {
-            LOGGER.fine("running update for " + label);
             lastSuggestedReview = System.currentTimeMillis();
-            Computer.threadPoolForRemoting.submit(() -> update());
+            Computer.threadPoolForRemoting.submit(() -> {
+                LOGGER.fine("running suggested review for " + label);
+                update();
+            });
         } else if (!queuedReview) {
             queuedReview = true;
-            LOGGER.fine(() -> "running update in " + delay + " ms for " + label);
+            LOGGER.fine(() -> "running suggested review in " + delay + " ms for " + label);
             Timer.get().schedule(() -> {
                 lastSuggestedReview = System.currentTimeMillis();
+                LOGGER.fine("running suggested review for " + label + " after " + delay + " ms");
                 update();
             }, delay, TimeUnit.MILLISECONDS);
         } else {

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -176,12 +176,14 @@ public class NodeProvisioner {
         if (delay < 0) {
             LOGGER.fine("running update for " + label);
             lastSuggestedReview = System.currentTimeMillis();
-            Computer.threadPoolForRemoting.submit(new Runnable() {
-                public void run() {
-                    LOGGER.fine(() -> "running suggested review for " + label);
-                    update();
-                }
-            });
+            Computer.threadPoolForRemoting.submit(() -> update());
+        } else if (!queuedReview) {
+            queuedReview = true;
+            LOGGER.fine(() -> "running update in " + delay + " ms for " + label);
+            Timer.get().schedule(() -> {
+                lastSuggestedReview = System.currentTimeMillis();
+                update();
+            }, delay, TimeUnit.MILLISECONDS);
         } else {
             LOGGER.fine(() -> "ignoring suggested review for " + label);
         }

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -176,7 +176,7 @@ public class NodeProvisioner {
         if (delay < 0) {
             lastSuggestedReview = System.currentTimeMillis();
             Computer.threadPoolForRemoting.submit(() -> {
-                LOGGER.fine("running suggested review for " + label);
+                LOGGER.fine(() -> "running suggested review for " + label);
                 update();
             });
         } else if (!queuedReview) {
@@ -184,7 +184,7 @@ public class NodeProvisioner {
             LOGGER.fine(() -> "running suggested review in " + delay + " ms for " + label);
             Timer.get().schedule(() -> {
                 lastSuggestedReview = System.currentTimeMillis();
-                LOGGER.fine("running suggested review for " + label + " after " + delay + " ms");
+                LOGGER.fine(() -> "running suggested review for " + label + " after " + delay + " ms");
                 update();
             }, delay, TimeUnit.MILLISECONDS);
         } else {

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -32,6 +32,7 @@ import static hudson.model.LoadStatistics.DECAY;
 import hudson.model.MultiStageTimeSeries.TimeScale;
 import hudson.Extension;
 import jenkins.util.SystemProperties;
+import jenkins.util.Timer;
 import org.jenkinsci.Symbol;
 
 import javax.annotation.Nonnull;
@@ -136,6 +137,7 @@ public class NodeProvisioner {
     private StrategyState provisioningState = null;
 
     private transient volatile long lastSuggestedReview;
+    private transient volatile boolean queuedReview;
 
     /**
      * Exponential moving average of the "planned capacity" over time, which is the number of
@@ -165,18 +167,18 @@ public class NodeProvisioner {
 
     /**
      * Give the {@link NodeProvisioner} a hint that now would be a good time to think about provisioning some nodes.
-     * The hint will be ignored if subjected to excessive pestering by callers.
+     * Hints are rate limited to one every second.
      *
      * @since 1.415
      */
     public void suggestReviewNow() {
-        if (System.currentTimeMillis() > lastSuggestedReview + TimeUnit.SECONDS.toMillis(1)) {
-            lastSuggestedReview = System.currentTimeMillis();
-            Computer.threadPoolForRemoting.submit(new Runnable() {
-                public void run() {
-                    update();
-                }
-            });
+        long now = System.currentTimeMillis();
+        if (now > lastSuggestedReview + TimeUnit.SECONDS.toMillis(1)) {
+            lastSuggestedReview = now;
+            Computer.threadPoolForRemoting.submit(() -> update());
+        } else if (!queuedReview) {
+            queuedReview = true;
+            Timer.get().schedule(() -> update(), now - lastSuggestedReview, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -191,124 +193,121 @@ public class NodeProvisioner {
         provisioningLock.lock();
         try {
             lastSuggestedReview = System.currentTimeMillis();
-            Runnable launchReadyNodes = () -> {
-                // We need to get the lock on Queue for two reasons:
-                // 1. We will potentially adding a lot of nodes and we don't want to fight with Queue#maintain to acquire
-                //    the Queue#lock in order to add each node. Much better is to hold the Queue#lock until all nodes
-                //    that were provisioned since last we checked have been added.
-                // 2. We want to know the idle executors count, which can only be measured if you hold the Queue#lock
-                //    Strictly speaking we don't need an accurate measure for this, but as we had to get the Queue#lock
-                //    anyway, we might as well get an accurate measure.
-                //
-                // We do not need the Queue#lock to get the count of items in the queue as that is a lock-free call
-                // Since adding a node should not (in principle) confuse Queue#maintain (it is only removal of nodes
-                // that causes issues in Queue#maintain) we should be able to remove the need for Queue#lock
-                //
-                // TODO once Nodes#addNode is made lock free, we should be able to remove the requirement for Queue#lock
-                Queue.withLock(() -> {
-                    Jenkins jenkins = Jenkins.get();
-                    // clean up the cancelled launch activity, then count the # of executors that we are about to
-                    // bring up.
+            queuedReview = false;
+            // We need to get the lock on Queue for two reasons:
+            // 1. We will potentially adding a lot of nodes and we don't want to fight with Queue#maintain to acquire
+            //    the Queue#lock in order to add each node. Much better is to hold the Queue#lock until all nodes
+            //    that were provisioned since last we checked have been added.
+            // 2. We want to know the idle executors count, which can only be measured if you hold the Queue#lock
+            //    Strictly speaking we don't need an accurate measure for this, but as we had to get the Queue#lock
+            //    anyway, we might as well get an accurate measure.
+            //
+            // We do not need the Queue#lock to get the count of items in the queue as that is a lock-free call
+            // Since adding a node should not (in principle) confuse Queue#maintain (it is only removal of nodes
+            // that causes issues in Queue#maintain) we should be able to remove the need for Queue#lock
+            //
+            // TODO once Nodes#addNode is made lock free, we should be able to remove the requirement for Queue#lock
+            Queue.withLock(() -> {
+                Jenkins jenkins = Jenkins.get();
+                // clean up the cancelled launch activity, then count the # of executors that we are about to
+                // bring up.
 
-                    int plannedCapacitySnapshot = 0;
+                int plannedCapacitySnapshot = 0;
 
-                    List<PlannedNode> snapPendingLaunches = new ArrayList<>(pendingLaunches.get());
-                    for (PlannedNode f : snapPendingLaunches) {
-                        if (f.future.isDone()) {
+                List<PlannedNode> snapPendingLaunches = new ArrayList<>(pendingLaunches.get());
+                for (PlannedNode f : snapPendingLaunches) {
+                    if (f.future.isDone()) {
+                        try {
+                            Node node = null;
                             try {
-                                Node node = null;
+                                node = f.future.get();
+                            } catch (InterruptedException e) {
+                                throw new AssertionError("InterruptedException occurred", e); // since we confirmed that the future is already done
+                            } catch (ExecutionException e) {
+                                Throwable cause = e.getCause();
+                                if (!(cause instanceof AbortException)) {
+                                    LOGGER.log(Level.WARNING,
+                                            "Unexpected exception encountered while provisioning agent "
+                                                    + f.displayName,
+                                            cause);
+                                }
+                                fireOnFailure(f, cause);
+                            }
+
+                            if (node != null) {
+                                fireOnComplete(f, node);
+
                                 try {
-                                    node = f.future.get();
-                                } catch (InterruptedException e) {
-                                    throw new AssertionError("InterruptedException occurred", e); // since we confirmed that the future is already done
-                                } catch (ExecutionException e) {
-                                    Throwable cause = e.getCause();
-                                    if (!(cause instanceof AbortException)) {
-                                        LOGGER.log(Level.WARNING,
-                                                "Unexpected exception encountered while provisioning agent "
-                                                        + f.displayName,
-                                                cause);
-                                    }
-                                    fireOnFailure(f, cause);
+                                    jenkins.addNode(node);
+                                    LOGGER.log(Level.INFO,
+                                            "{0} provisioning successfully completed. "
+                                                    + "We have now {1,number,integer} computer(s)",
+                                            new Object[]{f.displayName, jenkins.getComputers().length});
+                                    fireOnCommit(f, node);
+                                } catch (IOException e) {
+                                    LOGGER.log(Level.WARNING,
+                                            "Provisioned agent " + f.displayName + " failed to launch",
+                                            e);
+                                    fireOnRollback(f, node, e);
                                 }
-
-                                if (node != null) {
-                                    fireOnComplete(f, node);
-
-                                    try {
-                                        jenkins.addNode(node);
-                                        LOGGER.log(Level.INFO,
-                                                "{0} provisioning successfully completed. "
-                                                        + "We have now {1,number,integer} computer(s)",
-                                                new Object[]{f.displayName, jenkins.getComputers().length});
-                                        fireOnCommit(f, node);
-                                    } catch (IOException e) {
-                                        LOGGER.log(Level.WARNING,
-                                                "Provisioned agent " + f.displayName + " failed to launch",
-                                                e);
-                                        fireOnRollback(f, node, e);
-                                    }
-                                }
-                            } catch (Error e) {
-                                // we are not supposed to try and recover from Errors
-                                throw e;
-                            } catch (Throwable e) {
-                                // Just log it
-                                LOGGER.log(Level.SEVERE,
-                                        "Unexpected uncaught exception encountered while processing agent "
-                                                + f.displayName,
-                                        e);
-                            } finally {
-                                while (true) {
-                                    List<PlannedNode> orig = pendingLaunches.get();
-                                    List<PlannedNode> repl = new ArrayList<>(orig);
-                                    // the contract for List.remove(o) is that the first element i where
-                                    // (o==null ? get(i)==null : o.equals(get(i)))
-                                    // is true will be removed from the list
-                                    // since PlannedNode.equals(o) is not final and we cannot assume
-                                    // that subclasses do not override with an equals which does not
-                                    // assure object identity comparison, we need to manually
-                                    // do the removal based on instance identity not equality
-                                    boolean changed = false;
-                                    for (Iterator<PlannedNode> iterator = repl.iterator(); iterator.hasNext(); ) {
-                                        PlannedNode p = iterator.next();
-                                        if (p == f) {
-                                            iterator.remove();
-                                            changed = true;
-                                            break;
-                                        }
-                                    }
-                                    if (!changed || pendingLaunches.compareAndSet(orig, repl)) {
+                            }
+                        } catch (Error e) {
+                            // we are not supposed to try and recover from Errors
+                            throw e;
+                        } catch (Throwable e) {
+                            // Just log it
+                            LOGGER.log(Level.SEVERE,
+                                    "Unexpected uncaught exception encountered while processing agent "
+                                            + f.displayName,
+                                    e);
+                        } finally {
+                            while (true) {
+                                List<PlannedNode> orig = pendingLaunches.get();
+                                List<PlannedNode> repl = new ArrayList<>(orig);
+                                // the contract for List.remove(o) is that the first element i where
+                                // (o==null ? get(i)==null : o.equals(get(i)))
+                                // is true will be removed from the list
+                                // since PlannedNode.equals(o) is not final and we cannot assume
+                                // that subclasses do not override with an equals which does not
+                                // assure object identity comparison, we need to manually
+                                // do the removal based on instance identity not equality
+                                boolean changed = false;
+                                for (Iterator<PlannedNode> iterator = repl.iterator(); iterator.hasNext(); ) {
+                                    PlannedNode p = iterator.next();
+                                    if (p == f) {
+                                        iterator.remove();
+                                        changed = true;
                                         break;
                                     }
                                 }
-                                f.spent();
+                                if (!changed || pendingLaunches.compareAndSet(orig, repl)) {
+                                    break;
+                                }
                             }
-                        } else {
-                            plannedCapacitySnapshot += f.numExecutors;
+                            f.spent();
                         }
-                    }
-
-                    float plannedCapacity = plannedCapacitySnapshot;
-                    plannedCapacitiesEMA.update(plannedCapacity);
-
-                    final LoadStatistics.LoadStatisticsSnapshot snapshot = stat.computeSnapshot();
-
-                    int availableSnapshot = snapshot.getAvailableExecutors();
-                    int queueLengthSnapshot = snapshot.getQueueLength();
-
-                    if (queueLengthSnapshot <= availableSnapshot) {
-                        LOGGER.log(Level.FINER,
-                                "Queue length {0} is less than the available capacity {1}. No provisioning strategy required",
-                                new Object[]{queueLengthSnapshot, availableSnapshot});
-                        provisioningState = null;
                     } else {
-                        provisioningState = new StrategyState(snapshot, label, plannedCapacitySnapshot);
+                        plannedCapacitySnapshot += f.numExecutors;
                     }
-                });
-            };
-            // Launch nodes that got ready since last clock tick
-            launchReadyNodes.run();
+                }
+
+                float plannedCapacity = plannedCapacitySnapshot;
+                plannedCapacitiesEMA.update(plannedCapacity);
+
+                final LoadStatistics.LoadStatisticsSnapshot snapshot = stat.computeSnapshot();
+
+                int availableSnapshot = snapshot.getAvailableExecutors();
+                int queueLengthSnapshot = snapshot.getQueueLength();
+
+                if (queueLengthSnapshot <= availableSnapshot) {
+                    LOGGER.log(Level.FINER,
+                            "Queue length {0} is less than the available capacity {1}. No provisioning strategy required",
+                            new Object[]{queueLengthSnapshot, availableSnapshot});
+                    provisioningState = null;
+                } else {
+                    provisioningState = new StrategyState(snapshot, label, plannedCapacitySnapshot);
+                }
+            });
             if (provisioningState != null) {
                 List<Strategy> strategies = Jenkins.get().getExtensionList(Strategy.class);
                 for (Strategy strategy : strategies.isEmpty()
@@ -321,10 +320,6 @@ public class NodeProvisioner {
                                 strategy);
                         break;
                     }
-                }
-                if (provisioningState.getAdditionalPlannedCapacity() > 0) {
-                    // Launch nodes which are already ready without waiting for the next clock tick
-                    launchReadyNodes.run();
                 }
             }
         } finally {

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -175,11 +175,15 @@ public class NodeProvisioner {
         long delay = TimeUnit.SECONDS.toMillis(1) - (System.currentTimeMillis() - lastSuggestedReview);
         if (delay < 0) {
             LOGGER.finest("running update");
+            lastSuggestedReview = System.currentTimeMillis();
             Computer.threadPoolForRemoting.submit(() -> update());
         } else if (!queuedReview) {
             queuedReview = true;
             LOGGER.finest(() -> "running update in " + delay + " ms");
-            Timer.get().schedule(() -> update(), delay, TimeUnit.MILLISECONDS);
+            Timer.get().schedule(() -> {
+                lastSuggestedReview = System.currentTimeMillis();
+                update();
+            }, delay, TimeUnit.MILLISECONDS);
         } else {
             LOGGER.finest("ignored");
         }


### PR DESCRIPTION
For some cloud implementations (container based), the planned node is almost immediate. With the current implementation, one either has to call https://github.com/jenkinsci/jenkins/blob/bc40ab3ae57178d477fe919b12ed761080df7d6b/core/src/main/java/hudson/slaves/NodeProvisioner.java#L166-L181 but has to wait at least 1 second before doing so. 

The following is changing the behaviour to throttle the calls to `suggestReviewNow` every second instead of ignoring the calls happening within the next second. This allows to process quickly planned nodes without having to wait for a full clock tick.

See the following downstream change as illustration https://github.com/jenkinsci/kubernetes-plugin/pull/515