### PR TITLE
Increase ant from 1.9.14 -> 1.10.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.9.14</version>
+        <version>1.10.6</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Version 1.10.x is based off 1.9.x but now requires Java 8 runtime.

https://archive.apache.org/dist/ant/RELEASE-NOTES-1.10.6.html