### PR TITLE
[JENKINS-43610] Split Trilead out from Core

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
+-Pconsume-incrementals
 -Pmight-produce-incrementals

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -101,6 +101,11 @@ THE SOFTWARE.
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.connectbot.jbcrypt</groupId>
+      <artifactId>jbcrypt</artifactId>
+      <version>1.0.0</version>
+    </dependency>
     <dependency> <!-- for compatibility only; all new code should use JNR -->
       <groupId>org.jruby.ext.posix</groupId>
       <artifactId>jna-posix</artifactId>
@@ -115,11 +120,6 @@ THE SOFTWARE.
       <groupId>org.kohsuke</groupId>
       <artifactId>trilead-putty-extension</artifactId>
       <version>1.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-      <version>build-217-jenkins-14</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>

--- a/core/src/main/resources/jenkins/split-plugin-cycles.txt
+++ b/core/src/main/resources/jenkins/split-plugin-cycles.txt
@@ -32,3 +32,32 @@ junit jaxb
 bouncycastle-api jaxb
 command-launcher jaxb
 jdk-tool jaxb
+
+#JENKINS-43610 Split Trilead out from Core
+BlameSubversion trilead-api
+digitalocean trilead-api
+docker trilead-api
+ec2 trilead-api
+ec2-cloud-axis trilead-api
+ec2-plugin trilead-api
+external-logging-elasticsearch trilead-api
+git-client trilead-api
+jclouds trilead-api
+libvirt-slave trilead-api
+mansion-cloud trilead-api
+nodepool-agents trilead-api
+openstack-cloud trilead-api
+pxe trilead-api
+scaleway-cloud trilead-api
+ssh-agent trilead-api
+ssh-cli trilead-api
+ssh-cli-auth trilead-api
+ssh-credentials trilead-api
+ssh-slaves trilead-api
+ssh2easy trilead-api
+subversion trilead-api
+svn-release-mgr trilead-api
+
+
+
+

--- a/core/src/main/resources/jenkins/split-plugin-cycles.txt
+++ b/core/src/main/resources/jenkins/split-plugin-cycles.txt
@@ -32,32 +32,3 @@ junit jaxb
 bouncycastle-api jaxb
 command-launcher jaxb
 jdk-tool jaxb
-
-#JENKINS-43610 Split Trilead out from Core
-BlameSubversion trilead-api
-digitalocean trilead-api
-docker trilead-api
-ec2 trilead-api
-ec2-cloud-axis trilead-api
-ec2-plugin trilead-api
-external-logging-elasticsearch trilead-api
-git-client trilead-api
-jclouds trilead-api
-libvirt-slave trilead-api
-mansion-cloud trilead-api
-nodepool-agents trilead-api
-openstack-cloud trilead-api
-pxe trilead-api
-scaleway-cloud trilead-api
-ssh-agent trilead-api
-ssh-cli trilead-api
-ssh-cli-auth trilead-api
-ssh-credentials trilead-api
-ssh-slaves trilead-api
-ssh2easy trilead-api
-subversion trilead-api
-svn-release-mgr trilead-api
-
-
-
-

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -30,4 +30,4 @@ jdk-tool 2.112 1.0
 jaxb 2.163 2.3.0 11
 
 #JENKINS-43610 Split Trilead out from Core
-trilead-api 2.182 1.0.3
+trilead-api 2.182 1.0.4

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -30,4 +30,4 @@ jdk-tool 2.112 1.0
 jaxb 2.163 2.3.0 11
 
 #JENKINS-43610 Split Trilead out from Core
-trilead-api 2.182 1.0.4-rc17.8e3daef99f43
+trilead-api 2.184 1.0.4-rc17.8e3daef99f43

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -28,3 +28,6 @@ jdk-tool 2.112 1.0
 
 # JENKINS-55681
 jaxb 2.163 2.3.0 11
+
+#JENKINS-43610 Split Trilead out from Core
+trilead-api 2.181 1.0.3 8

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -30,4 +30,4 @@ jdk-tool 2.112 1.0
 jaxb 2.163 2.3.0 11
 
 #JENKINS-43610 Split Trilead out from Core
-trilead-api 2.181 1.0.3 8
+trilead-api 2.182 1.0.3

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -30,4 +30,4 @@ jdk-tool 2.112 1.0
 jaxb 2.163 2.3.0 11
 
 #JENKINS-43610 Split Trilead out from Core
-trilead-api 2.182 1.0.4
+trilead-api 2.182 1.0.4-rc17.8e3daef99f43

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -420,6 +420,12 @@ THE SOFTWARE.
                   <version>2.3.0</version>
                   <type>hpi</type>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>org.jenkins-ci.plugins</groupId>
+                  <artifactId>trilead-api</artifactId>
+                  <version>1.0.4-rc17.8e3daef99f43</version>
+                  <type>hpi</type>
+                </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/detached-plugins</outputDirectory>
               <stripVersion>true</stripVersion>


### PR DESCRIPTION
See [JENKINS-43610](https://issues.jenkins-ci.org/browse/JENKINS-43610).

Trilead-ssh2 is bundled in Jenkins core this will allow using trilead-api-plugin instead and remove the Jenkins Core dependence of trilead-ssh2.

It is a dependencies change, so it will be tested by the regular test, ATH, and PCT

Changes on trilead-ssh2 version include in the plugin (trilead-ssh2-build-217-jenkins-16, 2019-03-31):

- [JENKINS-55352] update net.i2p.crypto:eddsa to 0.3.0 
- Connection timeout handler not canceled when an exception occurs during a connection attempt. If the Connection instance is reused for further attempts, this can lead to the disconnection of an active connection.
- [JENKINS-56821] Eliminating hot lock from `TimeoutService`

### Proposed changelog entries

* Major RFE: Split Trilead SSH out from Core, [trilead-ssh2](https://github.com/jenkinsci/trilead-ssh2) library is no longer bundle in Jenkins Core, it is provided as a plugin with [trilead-api-plugin](https://github.com/jenkinsci/trilead-api-plugin) for further details see [JENKINS-43610](https://issues.jenkins-ci.org/browse/JENKINS-43610)

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests
- [X] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@oleg-nenashev @MarkEWaite @dwnusbaum @daniel-beck @jvz @Wadeck @batmat @olivergondza @jglick 
