### PR TITLE
Adjust Deprecation tree according to Slave javadocs.

### DIFF
--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -159,6 +159,11 @@ public abstract class Slave extends Node implements Serializable {
      */
     private String userId;
 
+    /**
+     * Use {@link #Slave(String, String, ComputerLauncher)} and set the rest through setters.
+     * @deprecated since FIXME
+     */
+    @Deprecated
     public Slave(String name, String nodeDescription, String remoteFS, String numExecutors,
                  Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties) throws FormException, IOException {
         this(name,nodeDescription,remoteFS,Util.tryParseNumber(numExecutors, 1).intValue(),mode,labelString,launcher,retentionStrategy, nodeProperties);

--- a/core/src/main/java/hudson/slaves/AbstractCloudSlave.java
+++ b/core/src/main/java/hudson/slaves/AbstractCloudSlave.java
@@ -30,6 +30,7 @@ import hudson.model.Slave;
 import hudson.model.TaskListener;
 import hudson.util.StreamTaskListener;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
@@ -43,11 +44,33 @@ import java.util.logging.Logger;
  * @since 1.382
  */
 public abstract class AbstractCloudSlave extends Slave {
-    public AbstractCloudSlave(String name, String nodeDescription, String remoteFS, String numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties) throws FormException, IOException {
+
+    public AbstractCloudSlave(@Nonnull String name, String remoteFS, ComputerLauncher launcher)
+            throws FormException, IOException {
+        super(name, remoteFS, launcher);
+    }
+
+    /**
+     * Use {@link #AbstractCloudSlave(java.lang.String, java.lang.String, hudson.slaves.ComputerLauncher)}
+     * @deprecated since FIXME
+     */
+    @Deprecated
+    public AbstractCloudSlave(String name, String nodeDescription, String remoteFS, String numExecutors,
+                              Mode mode, String labelString, ComputerLauncher launcher,
+                              RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties)
+            throws FormException, IOException {
         super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
     }
 
-    public AbstractCloudSlave(String name, String nodeDescription, String remoteFS, int numExecutors, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties) throws FormException, IOException {
+    /**
+     * Use {@link #AbstractCloudSlave(java.lang.String, java.lang.String, hudson.slaves.ComputerLauncher)}
+     * @deprecated since FIXME
+     */
+    @Deprecated
+    public AbstractCloudSlave(String name, String nodeDescription, String remoteFS, int numExecutors,
+                              Mode mode, String labelString, ComputerLauncher launcher,
+                              RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties)
+            throws FormException, IOException {
         super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
     }
 


### PR DESCRIPTION
Slave constructor wants implementations to use setters,
but AbstractCloudSlave has no corresponding constructor.

Related to [JENKINS-51203](https://issues.jenkins-ci.org/browse/JENKINS-51203) that fails during constructor creation chain when constructor touches nodeProperties.
And there is confusing with extra actions in Slave constructor https://github.com/jenkinsci/jenkins/blob/1d0d8069d0a2eab07629943329a051f92046e956/core/src/main/java/hudson/model/Slave.java#L197-L216 constructor itself deprecated, but do unique stuff

### Proposed changelog entries

* Deprecate/add new constructors in AbstractCloudSlave.class

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jenkins/4086)
<!-- Reviewable:end -->
