### PR TITLE
Upgrade to 3.33 version of Remoting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.0.0</maven-war-plugin.version> <!-- JENKINS-47127 bump when 3.2.0 is out. Cf. MWAR-407 -->
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3.29</remoting.version>
+    <remoting.version>3.33</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.4</remoting.minimum.supported.version>
 


### PR DESCRIPTION
See [JENKINS-57959](https://issues.jenkins-ci.org/browse/JENKINS-57959), [JENKINS-50095](https://issues.jenkins-ci.org/browse/JENKINS-50095), and [JENKINS-57713](https://issues.jenkins-ci.org/browse/JENKINS-57713).

See the [Remoting Changelog](https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#333).

This change
-  Rolls back the problematic change from Remoting 3.30 (JENKINS-57713 / JENKINS-57759).
- Checks for Remoting minimum version when connecting to master. 
- Switches to Spotbugs from Findbugs.
- Fixes log message typo.
- Upgrades args4j dependency to 2.33. This dependency should be kept aligned between Remoting and Jenkins, though we do not believe that is strictly required. The Jenkins side of this dependency upgrade is #4063.

### Proposed changelog entries

* Update Remoting from 3.29 to 3.33. ([issue 57959](https://issues.jenkins-ci.org/browse/JENKINS-57959), [issue 50095](https://issues.jenkins-ci.org/browse/JENKINS-50095), [issue 57713](https://issues.jenkins-ci.org/browse/JENKINS-57713), [full changelog](https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#333))

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
