### PR TITLE
Diffblue Sift: Security vulnerabilities in Maven dependencies

### DIFF
--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -23,7 +23,6 @@
  */
 package hudson.util;
 
-import com.google.common.annotations.Beta;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 
@@ -408,7 +407,7 @@ public class Iterators {
     }
 
     /**
-     * Similar to {@link com.google.common.collect.Iterators#skip} except not {@link Beta}.
+     * Similar to {@link com.google.common.collect.Iterators#advance}.
      * @param iterator some iterator
      * @param count a nonnegative count
      */

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ THE SOFTWARE.
     <project.patchManagement.url>https://api.github.com</project.patchManagement.url>
     <patch.tracker.serverId>jenkins-jira</patch.tracker.serverId>
 
-    <guavaVersion>11.0.1</guavaVersion>
+    <guavaVersion>24.1.1-jre</guavaVersion>
     <slf4jVersion>1.7.25</slf4jVersion>
     <maven-plugin.version>2.14</maven-plugin.version>
     <matrix-project.version>1.4.1</matrix-project.version>

--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -207,7 +207,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.0</version>
+      <version>4.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
I've analysed your codebase using [Diffblue](https://www.diffblue.com/labs) Sift, and have found that the dependencies in the following files contain security vulnerabilities:

### pom.xml
#### Dependency: [org.apache.commons:commons-collections4](https://mvnrepository.com/artifact/org.apache.commons/commons-collections4)

- Your Version: [4.0](https://mvnrepository.com/artifact/org.apache.commons/commons-collections4/4.0)
- Recommended Version: [4.1](https://mvnrepository.com/artifact/org.apache.commons/commons-collections4/4.1)
- Vulnerability: [CVE-2015-6420](http://www.securityfocus.com/bid/78872)
- CVSS Severity: High
- CVSS Score: 7.5

### test-pom/pom.xml
#### Dependency: [com.google.guava:guava-testlib](https://mvnrepository.com/artifact/com.google.guava/guava-testlib)

- Your Version: [11.0.2](https://mvnrepository.com/artifact/com.google.guava/guava-testlib/11.0.2)
- Recommended Version: [24.1.1-jre](https://mvnrepository.com/artifact/com.google.guava/guava-testlib/24.1.1-jre)
- Vulnerability: [CVE-2018-10237](http://www.securitytracker.com/id/1041707)
- CVSS Severity: Medium
- CVSS Score: 4.3


If you have any questions feel free to contact me on info@diffblue.com.