### PR TITLE
Unwrap some meaningless exceptions and get the cause thrown

### DIFF
--- a/core/src/main/java/hudson/init/TaskMethodFinder.java
+++ b/core/src/main/java/hudson/init/TaskMethodFinder.java
@@ -2,7 +2,6 @@ package hudson.init;
 
 import com.google.inject.Injector;
 import hudson.model.Hudson;
-import hudson.model.Run;
 import jenkins.model.Jenkins;
 import org.jvnet.hudson.annotation_indexer.Index;
 import org.jvnet.hudson.reactor.Milestone;

--- a/core/src/main/java/hudson/init/TaskMethodFinder.java
+++ b/core/src/main/java/hudson/init/TaskMethodFinder.java
@@ -2,6 +2,7 @@ package hudson.init;
 
 import com.google.inject.Injector;
 import hudson.model.Hudson;
+import hudson.model.Run;
 import jenkins.model.Jenkins;
 import org.jvnet.hudson.annotation_indexer.Index;
 import org.jvnet.hudson.reactor.Milestone;
@@ -107,7 +108,19 @@ abstract class TaskMethodFinder<T extends Annotation> extends TaskBuilder {
         } catch (IllegalAccessException x) {
             throw (Error)new IllegalAccessError().initCause(x);
         } catch (InvocationTargetException x) {
-            throw new Error(x);
+            rethrow(x);
+        }
+    }
+
+    // Unwrap the useless InvocationTargetException and rethrow the cause as-is unless it is a checked exception
+    private void rethrow(InvocationTargetException x) {
+        Throwable cause = x.getCause();
+        if (cause instanceof RuntimeException) {
+            throw (RuntimeException) cause;
+        } else if (cause instanceof Error) {
+            throw (Error) cause;
+        } else {
+            throw new Error(cause);
         }
     }
 


### PR DESCRIPTION
Remove some `java.lang.Error` and `java.lang.reflect.InvocationTargetException` cluttering the stacktrace when `@Initializer` fails.

The main motivation here is to de-clutter the JCasC exceptions which needs to be understood by end users. Ex.:

```
Jul 01, 2019 6:06:43 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed ConfigurationAsCode.init
java.lang.Error: java.lang.reflect.InvocationTargetException
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:110)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1096)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
	... 8 more
Caused by: java.lang.IllegalArgumentException: No hudson.security.SecurityRealm implementation found for ldap
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$lookupDescriptor$11(HeteroDescribableConfigurator.java:212)
	at io.vavr.control.Option.orElse(Option.java:302)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lookupDescriptor(HeteroDescribableConfigurator.java:211)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$configure$3(HeteroDescribableConfigurator.java:84)
	at io.vavr.Tuple2.apply(Tuple2.java:239)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.configure(HeteroDescribableConfigurator.java:83)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.check(HeteroDescribableConfigurator.java:92)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.check(HeteroDescribableConfigurator.java:55)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:353)
	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:288)
	at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$6(ConfigurationAsCode.java:672)
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:634)
	at io.jenkins.plugins.casc.ConfigurationAsCode.checkWith(ConfigurationAsCode.java:672)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:656)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:555)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:278)
	at io.jenkins.plugins.casc.ConfigurationAsCode.init(ConfigurationAsCode.java:270)
	... 13 more

Jul 01, 2019 6:06:43 AM hudson.util.BootFailure publish
SEVERE: Failed to initialize Jenkins
hudson.util.HudsonFailedToLoad: org.jvnet.hudson.reactor.ReactorException: java.lang.Error: java.lang.reflect.InvocationTargetException
	at hudson.WebAppMain$3.run(WebAppMain.java:250)
Caused by: org.jvnet.hudson.reactor.ReactorException: java.lang.Error: java.lang.reflect.InvocationTargetException
	at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:282)
	at jenkins.InitReactorRunner.run(InitReactorRunner.java:48)
	at jenkins.model.Jenkins.executeReactor(Jenkins.java:1130)
	at jenkins.model.Jenkins.<init>(Jenkins.java:932)
	at hudson.model.Hudson.<init>(Hudson.java:85)
	at hudson.model.Hudson.<init>(Hudson.java:81)
	at hudson.WebAppMain$3.run(WebAppMain.java:233)
Caused by: java.lang.Error: java.lang.reflect.InvocationTargetException
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:110)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1096)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
	... 8 more
Caused by: java.lang.IllegalArgumentException: No hudson.security.SecurityRealm implementation found for ldap
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$lookupDescriptor$11(HeteroDescribableConfigurator.java:212)
	at io.vavr.control.Option.orElse(Option.java:302)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lookupDescriptor(HeteroDescribableConfigurator.java:211)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$configure$3(HeteroDescribableConfigurator.java:84)
	at io.vavr.Tuple2.apply(Tuple2.java:239)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.configure(HeteroDescribableConfigurator.java:83)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.check(HeteroDescribableConfigurator.java:92)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.check(HeteroDescribableConfigurator.java:55)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:353)
	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:288)
	at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$6(ConfigurationAsCode.java:672)
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:634)
	at io.jenkins.plugins.casc.ConfigurationAsCode.checkWith(ConfigurationAsCode.java:672)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:656)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:555)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:278)
	at io.jenkins.plugins.casc.ConfigurationAsCode.init(ConfigurationAsCode.java:270)
	... 13 more

```

### Proposed changelog entries

* *Too minor*

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [N/A] JIRA issue is well described
- [N/A] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [N/A] Appropriate autotests or explanation to why this change has no tests
- [N/A] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

