### PR TITLE
[WEBSITE-634] - Add Release Drafter configuration for drafting Weekly release YAMLs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,6 +18,9 @@ change-template: |-
     authors:
       - $AUTHOR
 template: |
+  **Disclaimer**: This is an automatically generated changelog draft for Jenkins weekly releases. 
+  See https://jenkins.io/changelog/ for the official changelogs. 
+
   ```yaml
   $CHANGES
   ```

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+name-template: $NEXT_PATCH_VERSION
+# Uses a more common 2-digit versioning in Jenkins weekly releases.
+version-template: $MAJOR.$MINOR
+tag-template: jenkins-$NEXT_MINOR_VERSION
+
+# TODO: categories are YAGNI for now, until we can extract `type` somehow
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+change-template: |-
+  - type: todo
+    message: |-
+      $TITLE
+    pull: $NUMBER
+    authors:
+      - $AUTHOR
+template: |
+  ```yaml
+  $CHANGES
+  ```
+replacers:
+  - search: '/\[*JENKINS-(\d+)\]*\s*-*\s*/g'
+    replace: |-
+      issue: $1
+        message: |-
+          
+  - search: |-
+      message: |-
+          issue:
+    replace: "issue:"


### PR DESCRIPTION
This is a follow-up to the common issues with delayed weekly release changelogs. Neither @daniel-beck nor me commit to deliver changelogs on the weekends when Jenkins weekly gets usually released, and often there are significant delays between a release and availability of changelog on https://jenkins.io/changelog/ . In order to solve the issue, I suggest using Release Drafter which has been already successfully adopted in plugins ([Documentation](https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc)). See [WEBSITE-634](https://issues.jenkins-ci.org/browse/WEBSITE-634) for more context.

Sample changelog YAML generated in my test environment:

![ReleaseDrafter_YAML](https://user-images.githubusercontent.com/3000480/60589015-b217ba00-9d98-11e9-938b-d262244e890e.PNG)

Considerations:

* There is no automatic type resolution, See https://github.com/toolmantim/release-drafter/issues/139 for the RFE
* Release Drafter is generally not designed for YAML generation, so the implementation is quite hacky. There is https://github.com/toolmantim/release-drafter/issues/253 for better YAML support

### Proposed changelog entries

* Internal: Automate drafting changelog YAMLs using Release Drafter (drafts are accessible only to Jenkins Core team members for now) 
  * Changelog drafts: https://github.com/jenkinsci/jenkins/releases

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Wishlist

* [ ] Type resolution
* [ ] Sorting by categories: `rfe`, then `bug` and then `internal`
* [ ] Putting Major fixes on the top

### Desired reviewers

@jenkinsci/core esp. @daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
