### PR TITLE
[JENKINS-58362] Also skip detached plugin installation if a *.[jh]pl file exists

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -601,7 +601,10 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
 
     void considerDetachedPlugin(String shortName) {
-        if (new File(rootDir, shortName + ".jpi").isFile() || new File(rootDir, shortName + ".hpi").isFile()) {
+        if (new File(rootDir, shortName + ".jpi").isFile() ||
+            new File(rootDir, shortName + ".hpi").isFile() ||
+            new File(rootDir, shortName + ".jpl").isFile() ||
+            new File(rootDir, shortName + ".hpl").isFile()) {
             LOGGER.fine(() -> "not considering loading a detached dependency " + shortName + " as it is already on disk");
             return;
         }


### PR DESCRIPTION
Extends #4039 to cover also cases encountered when using `plugin-compat-tester`. See also #4099.

Without this patch **and** https://github.com/jenkinsci/jenkins-test-harness/pull/146,

```
mvn -f ../command-launcher-plugin surefire:test -Djenkins.version=2.184-SNAPSHOT -Dtest=CommandLauncher2Test\#requireApproval
```

fails and during test startup you can see

```
INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: …/command-launcher.jpi
```

The bug should only affect PCT usage, `Jenkinsfile` builds against newer core lines, `hpi:run`, etc.