### PR TITLE
[JENKINS-56793] Set `screenResolution` cookie to root path

### DIFF
--- a/core/src/main/resources/hudson/model/View/index.jelly
+++ b/core/src/main/resources/hudson/model/View/index.jelly
@@ -45,7 +45,9 @@ THE SOFTWARE.
             <!-- for screen resolution detection -->
             <l:yui module="cookie" />
             <script>
-              YAHOO.util.Cookie.set("screenResolution", screen.width+"x"+screen.height);
+              YAHOO.util.Cookie.set("screenResolution", screen.width+"x"+screen.height, {
+                path: "/"
+              });
             </script>
         </l:header>
     </l:layout>


### PR DESCRIPTION
`YUI.util.Cookie` set `screenResolution` cookie for every visited path.

It's redundant since physical screen resolution obviously didn't change between site paths, but pollute cookies of Jenkins installation.

This change is seems minor and backward compatible.

See [JENKINS-56793](https://issues.jenkins-ci.org/browse/JENKINS-56793).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: Avoid `screenResolution` cookie duplication for views

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/code-reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
