### PR TITLE
Make disk usage checker period configurable

### DIFF
--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -31,6 +31,7 @@ import hudson.model.ComputerSet;
 import hudson.model.AdministrativeMonitor;
 import hudson.triggers.SafeTimerTask;
 import hudson.slaves.OfflineCause;
+import jenkins.util.SystemProperties;
 import jenkins.util.Timer;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -53,13 +54,15 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMonitor> {
+    private static long PERIOD = SystemProperties.getLong(AbstractNodeMonitorDescriptor.class.getName() + ".period", TimeUnit.MINUTES.toMillis(5));
+
     /**
      * @deprecated as of 1.522
      *      Extend from {@link AbstractAsyncNodeMonitorDescriptor}
      */
     @Deprecated
     protected AbstractNodeMonitorDescriptor() {
-        this(HOUR);
+        this(PERIOD);
     }
 
     /**
@@ -77,7 +80,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
      */
     @Deprecated
     protected AbstractNodeMonitorDescriptor(Class<? extends NodeMonitor> clazz) {
-        this(clazz,HOUR);
+        this(clazz,PERIOD);
     }
 
     /**
@@ -321,6 +324,4 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
     }
 
     private static final Logger LOGGER = Logger.getLogger(AbstractNodeMonitorDescriptor.class.getName());
-
-    private static final long HOUR = 1000*60*60L;
 }

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -54,7 +54,7 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMonitor> {
-    private static int PERIOD_MINUTES = SystemProperties.getInteger(AbstractNodeMonitorDescriptor.class.getName() + ".periodMinutes", 5);
+    private static int PERIOD_MINUTES = SystemProperties.getInteger(AbstractNodeMonitorDescriptor.class.getName() + ".periodMinutes", 60);
 
     /**
      * @deprecated as of 1.522

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -54,7 +54,7 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMonitor> {
-    private static long PERIOD = SystemProperties.getLong(AbstractNodeMonitorDescriptor.class.getName() + ".period", TimeUnit.MINUTES.toMillis(5));
+    private static int PERIOD_MINUTES = SystemProperties.getInteger(AbstractNodeMonitorDescriptor.class.getName() + ".periodMinutes", 5);
 
     /**
      * @deprecated as of 1.522
@@ -62,7 +62,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
      */
     @Deprecated
     protected AbstractNodeMonitorDescriptor() {
-        this(PERIOD);
+        this(TimeUnit.MINUTES.toMillis(PERIOD_MINUTES));
     }
 
     /**
@@ -80,7 +80,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
      */
     @Deprecated
     protected AbstractNodeMonitorDescriptor(Class<? extends NodeMonitor> clazz) {
-        this(clazz,PERIOD);
+        this(clazz,TimeUnit.MINUTES.toMillis(PERIOD_MINUTES));
     }
 
     /**

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -54,7 +54,7 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMonitor> {
-    private static int PERIOD_MINUTES = SystemProperties.getInteger(AbstractNodeMonitorDescriptor.class.getName() + ".periodMinutes", 60);
+    private static long PERIOD = TimeUnit.MINUTES.toMillis(SystemProperties.getInteger(AbstractNodeMonitorDescriptor.class.getName() + ".periodMinutes", 60));
 
     /**
      * @deprecated as of 1.522
@@ -62,7 +62,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
      */
     @Deprecated
     protected AbstractNodeMonitorDescriptor() {
-        this(TimeUnit.MINUTES.toMillis(PERIOD_MINUTES));
+        this(PERIOD);
     }
 
     /**
@@ -80,7 +80,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
      */
     @Deprecated
     protected AbstractNodeMonitorDescriptor(Class<? extends NodeMonitor> clazz) {
-        this(clazz,TimeUnit.MINUTES.toMillis(PERIOD_MINUTES));
+        this(clazz, PERIOD);
     }
 
     /**


### PR DESCRIPTION
Disk usage checker also used by `Free Space Threshold` to take nodes without enough free space offline. As a result, this threshold can be triggered with an hour delay.

See [JENKINS-13246](https://issues.jenkins-ci.org/browse/JENKINS-13246)

### Proposed changelog entries

 * Make disk usage checker period configurable by `hudson.node_monitors.AbstractNodeMonitorDescriptor.period` (milliseconds) property;
 * Change default disk usage checker period: 60 min -> 5 min.

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
