### PR TITLE
[JENKINS-55945] IllegalStateException trying to get user.

### DIFF
--- a/core/src/main/java/hudson/security/HttpSessionContextIntegrationFilter2.java
+++ b/core/src/main/java/hudson/security/HttpSessionContextIntegrationFilter2.java
@@ -84,7 +84,13 @@ public class HttpSessionContextIntegrationFilter2 extends HttpSessionContextInte
             return false;
         }
 
-        User userFromSession = User.getById(authentication.getName(), false);
+        User userFromSession;
+        try {
+            userFromSession = User.getById(authentication.getName(), false);
+        } catch (IllegalStateException ise) {
+            logger.warn("Encountered IllegalStateException trying to get a user. System init may not have completed yet. Invalidating user session.");
+            return false;
+        }
         if (userFromSession == null) {
             // no requirement for further test as there is no user inside
             return false;


### PR DESCRIPTION
This change catches the exception and returns false, invalidating the user session. This behavior is sensible, because if we are unable to validate the user we must assume the session is invalid.
Catching the error at this point reportedly helps with some scenarios and shouldn't cause any further harm.

This error shows up only in some scenarios or environments and I have been unable to reproduce it myself despite hours spent trying. This change is based upon one proposed and tested on the Jira ticket by Pavel Roskin. Without the change, Pavel reports encountering the error reliably. With the change, it didn't manifest.

There is a deeper problem here, as the exception is correctly thrown because of an illegal state. There must be one instance of AllUsers once the init sequence is complete and Jenkins shouldn't respond if it isn't. I encountered a similar error once, but in that case it originated in `Jenkins.get()`. It would be nice to figure out what to do about the illegal state, but I haven't been able to dig up any clues. I figure that this minor change will at least address the situation seen by some users.

As I haven't been able to reproduce the problem or determine any cause, I haven't been able to readily provide any autotests for the illegal state. I could try inserting some mocks, but those are notoriously clumsy and difficult, particularly for these sorts of things.

See [JENKINS-55945](https://issues.jenkins-ci.org/browse/JENKINS-55945).

### Proposed changelog entries

* Catch an occasional IllegalStateException on Jenkins restart and invalidate the user session. ([JENKINS-55945](https://issues.jenkins-ci.org/browse/JENKINS-55945))

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [N/A] For dependency updates: links to external changelogs and, if possible, full diffs
