### PR TITLE
[JENKINS-58434] Add ComputerListener.onRemoved(Computer) method.

### DIFF
--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -163,16 +163,16 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
     }
 
     /*package*/ void removeComputer(final Computer computer) {
-        Queue.withLock(new Runnable() {
-            @Override
-            public void run() {
-                Map<Node,Computer> computers = getComputerMap();
-                for (Map.Entry<Node, Computer> e : computers.entrySet()) {
-                    if (e.getValue() == computer) {
-                        computers.remove(e.getKey());
-                        computer.onRemoved();
-                        return;
+        Queue.withLock(() -> {
+            Map<Node,Computer> computers = getComputerMap();
+            for (Map.Entry<Node, Computer> e : computers.entrySet()) {
+                if (e.getValue() == computer) {
+                    computers.remove(e.getKey());
+                    for (ComputerListener cl : ComputerListener.all()) {
+                       cl.onRemoved(computer);
                     }
+                    computer.onRemoved();
+                    return;
                 }
             }
         });

--- a/core/src/main/java/hudson/slaves/ComputerListener.java
+++ b/core/src/main/java/hudson/slaves/ComputerListener.java
@@ -200,6 +200,14 @@ public abstract class ComputerListener implements ExtensionPoint {
      */
     public void onTemporarilyOffline(Computer c, OfflineCause cause) {}
 
+
+    /**
+     * Called right before Computer will be removed.
+     *
+     * @since FIXME
+     */
+    public void onRemoved(Computer computer) {}
+
     /**
      * Called when configuration of the node was changed, a node is added/removed, etc.
      *


### PR DESCRIPTION
See [JENKINS-58434](https://issues.jenkins-ci.org/browse/JENKINS-58434).

If i didn't miss in lifecycles there is no way to be informed right before `Computer` is deleted from jenkins.
What kind of test is needed? Add/delete node and verify that method was called? Or some mocked call?

Should listener be called after computer call or keep as is?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jenkins/4108)
<!-- Reviewable:end -->
