### PR TITLE
[JENKINS-43610] use trilead-api 1.0.4

### DIFF
--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -30,4 +30,4 @@ jdk-tool 2.112 1.0
 jaxb 2.163 2.3.0 11
 
 #JENKINS-43610 Split Trilead out from Core
-trilead-api 2.184 1.0.4-rc17.8e3daef99f43
+trilead-api 2.184 1.0.4

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -423,7 +423,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>trilead-api</artifactId>
-                  <version>1.0.4-rc17.8e3daef99f43</version>
+                  <version>1.0.4</version>
                   <type>hpi</type>
                 </artifactItem>
               </artifactItems>


### PR DESCRIPTION
See [JENKINS-43610](https://issues.jenkins-ci.org/browse/JENKINS-43610).

this PR is a follow up of https://github.com/jenkinsci/jenkins/pull/4085 to only set the final version of Trilead-api

@oleg-nenashev 