### PR TITLE
Fixing hint for Jenkins.getInstance

### DIFF
--- a/core/src/main/resources/META-INF/upgrade/Jenkins.hint
+++ b/core/src/main/resources/META-INF/upgrade/Jenkins.hint
@@ -1,2 +1,2 @@
-jenkins.model.Jenkins.get() => jenkins.model.Jenkins.get();;
+jenkins.model.Jenkins.getInstance() => jenkins.model.Jenkins.get();;
 jenkins.model.Jenkins.getActiveInstance() => jenkins.model.Jenkins.get();;


### PR DESCRIPTION
Was introduced in #3195 and broken in #4042.

No changelog entry needed.