### PR TITLE
Behave robustly in the face of errors from AdministrativeMonitor.isActivated

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2174,7 +2174,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 2.64
      */
     public List<AdministrativeMonitor> getActiveAdministrativeMonitors() {
-        return administrativeMonitors.stream().filter(m -> m.isEnabled() && m.isActivated()).collect(Collectors.toList());
+        return administrativeMonitors.stream().filter(m -> {
+            try {
+                return m.isEnabled() && m.isActivated();
+            } catch (Throwable x) {
+                LOGGER.log(Level.WARNING, null, x);
+                return false;
+            }
+        }).collect(Collectors.toList());
     }
 
     public NodeDescriptor getDescriptor() {


### PR DESCRIPTION
Due to a misconfiguration in a proprietary plugin, I had Jenkins start up but not be able to serve any content—even `/script` for diagnosis—due to

```
java.lang.NoClassDefFoundError: …
	at ….isActivated(….java:…)
	at jenkins.model.Jenkins.lambda$getActiveAdministrativeMonitors$0(Jenkins.java:2154)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at jenkins.model.Jenkins.getActiveAdministrativeMonitors(Jenkins.java:2154)
	at jenkins.management.AdministrativeMonitorsDecorator.getActiveAdministrativeMonitors(AdministrativeMonitorsDecorator.java:77)
	at jenkins.management.AdministrativeMonitorsDecorator.getActiveAdministrativeMonitorsCount(AdministrativeMonitorsDecorator.java:72)
	at jenkins.management.AdministrativeMonitorsDecorator.shouldDisplay(AdministrativeMonitorsDecorator.java:135)
```