### PR TITLE
[JENKINS-58520] - Make new Jenkins version notification noticeable in administrative monitors

### DIFF
--- a/core/src/filter/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/message.properties
+++ b/core/src/filter/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/message.properties
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-NewVersionAvailable=New version of Jenkins ({0}) is available for <a href="{1}">download</a> \
+NewVersionAvailable=<strong>New version of Jenkins ({0}) is available</strong> for <a href="{1}">download</a> \
   (<a href="{2}">changelog</a>).
 ChangelogUrl=${changelog.url}
 UpgradeComplete=Upgrade to Jenkins {0} is complete, awaiting <a href="{1}/safeRestart">restart</a>.


### PR DESCRIPTION
See [JENKINS-58520](https://issues.jenkins-ci.org/browse/JENKINS-58520).

### Proposed changelog entries

* rfe, Make new Jenkins version notification noticeable in administrative monitors

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers