### PR TITLE
Omit WEB-INF/lib/jquery-detached-1.2.jar from jenkins.war

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -143,6 +143,12 @@ THE SOFTWARE.
       <artifactId>bootstrap</artifactId>
       <version>1.3.2</version>
       <classifier>core-assets</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.ui</groupId>
+          <artifactId>jquery-detached</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>


### PR DESCRIPTION
This file is a nuisance since it is a plugin JAR and so can confuse PCT runs: `workflow-cps` depends on 1.2.1 and will not be loaded when the tested plugin has this JAR in the test classpath. (#3215 would also fix the symptom, since the improperly bundled version would at least be newer.)

As far as I know this happens only in PCT when `target/test-classes/test-dependencies/jquery-detached.hpi` is 1.2.

Tested `java -jar` style and all the JS I could think of worked as expected:
* setup wizard
* ACE editor in Pipeline
* stage view