### PR TITLE
[JENKINS-58157] - Fix handling of long build names in Web UI

### DIFF
--- a/core/src/main/resources/lib/layout/breadcrumbs.css
+++ b/core/src/main/resources/lib/layout/breadcrumbs.css
@@ -24,6 +24,7 @@
     margin: 0;
     height: 2em;
     border-bottom: 1px solid #d3d7cf;
+    display:block;
 }
 
 #breadcrumbs LI {
@@ -31,6 +32,8 @@
     line-height:2em;
     height: 2em;
     color:#555753;
+    display:inline-block;
+
 }
 
 #breadcrumbs LI A {
@@ -46,6 +49,12 @@
 #breadcrumbs LI A:link, #breadcrumbs LI A:visited {
     text-decoration:none;
     color:#555753;
+    display: block;
+    max-width: 1330px;
+    float: left;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 #breadcrumbs LI A:hover, #crumbs LI A:focus {

--- a/core/src/main/resources/lib/layout/breadcrumbs.css
+++ b/core/src/main/resources/lib/layout/breadcrumbs.css
@@ -33,7 +33,6 @@
     height: 2em;
     color:#555753;
     display:inline-block;
-
 }
 
 #breadcrumbs LI A {

--- a/war/src/main/webapp/css/layout-common.css
+++ b/war/src/main/webapp/css/layout-common.css
@@ -93,6 +93,7 @@ body {
 
 body.two-column #main-panel {
   margin-left: 320px;
+  display:block;
 }
 
 body.full-screen {
@@ -112,6 +113,7 @@ body.full-screen #main-panel {
 
   body.two-column #main-panel {
     margin-left: 0;
+    display:block;
   }
 }
 
@@ -122,6 +124,7 @@ body.full-screen #main-panel {
 
   body.two-column #main-panel {
     margin-left: 360px;
+    display:block;
   }
 }
 

--- a/war/src/main/webapp/css/responsive-grid.css
+++ b/war/src/main/webapp/css/responsive-grid.css
@@ -13,6 +13,12 @@
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
+h1.build-caption.page-headline {
+    max-width: 1200px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
 *:before,
 *:after {
   -webkit-box-sizing: border-box;

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -26,12 +26,16 @@
 
 #tasks {
   margin-bottom: 20px;
+  display: inline-block;
 }
 
 #tasks .task {
   margin-bottom: 4px;
   font-size: 14px;
+  max-width: 325px;
+  overflow: hidden;
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 /* buildQueue */


### PR DESCRIPTION
See [JENKINS-58157](https://issues.jenkins-ci.org/browse/JENKINS-58157).

### Proposed changelog entries

* Entry 1: Minor UI changes: 
When build name is too long, for 'Delete Build', 'Build-caption page-headline' and 'Breadcrumbs name', the overflowed content is hidden and ellipsis are displayed 

### Submitter checklist: All Done

### Desired reviewers
@jenkinsci/jenkins

![image](https://user-images.githubusercontent.com/43251978/61518420-4cddde80-a9be-11e9-95a1-fbd699616e91.png)
