### PR TITLE
[JENKINS-58571] Check if name is editable on item before doing rename.

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -277,10 +277,6 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     @Restricted(NoExternalUse.class)
     public @Nonnull FormValidation doCheckNewName(@QueryParameter String newName) {
 
-        if (!isNameEditable()) {
-            return FormValidation.error("This item has not an editable name.");
-        }
-
         // TODO: Create an Item.RENAME permission to use here, see JENKINS-18649.
         if (!hasPermission(Item.CONFIGURE)) {
             if (parent instanceof AccessControlled) {
@@ -359,7 +355,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     protected void renameTo(final String newName) throws IOException {
 
         if (!isNameEditable()) {
-            throw new IllegalArgumentException("Trying to rename an item that has not editable name.");
+            throw new IOException("Trying to rename an item that has not editable name.");
         }
 
         // always synchronize from bigger objects first

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -255,7 +255,6 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public HttpResponse doConfirmRename(@QueryParameter String newName) throws IOException {
-
         newName = newName == null ? null : newName.trim();
         FormValidation validationError = doCheckNewName(newName);
         if (validationError.kind != FormValidation.Kind.OK) {

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -256,10 +256,6 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     @Restricted(NoExternalUse.class)
     public HttpResponse doConfirmRename(@QueryParameter String newName) throws IOException {
 
-        if (!isNameEditable()) {
-            throw new IllegalArgumentException("Trying to rename an item that has not editable name.");
-        }
-
         newName = newName == null ? null : newName.trim();
         FormValidation validationError = doCheckNewName(newName);
         if (validationError.kind != FormValidation.Kind.OK) {
@@ -280,6 +276,11 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      */
     @Restricted(NoExternalUse.class)
     public @Nonnull FormValidation doCheckNewName(@QueryParameter String newName) {
+
+        if (!isNameEditable()) {
+            return FormValidation.error("This item has not an editable name.");
+        }
+
         // TODO: Create an Item.RENAME permission to use here, see JENKINS-18649.
         if (!hasPermission(Item.CONFIGURE)) {
             if (parent instanceof AccessControlled) {

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -277,6 +277,10 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     @Restricted(NoExternalUse.class)
     public @Nonnull FormValidation doCheckNewName(@QueryParameter String newName) {
 
+        if (!isNameEditable()) {
+            return FormValidation.error("Trying to rename an item that does not support this operation.");
+        }
+
         // TODO: Create an Item.RENAME permission to use here, see JENKINS-18649.
         if (!hasPermission(Item.CONFIGURE)) {
             if (parent instanceof AccessControlled) {
@@ -355,7 +359,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     protected void renameTo(final String newName) throws IOException {
 
         if (!isNameEditable()) {
-            throw new IOException("Trying to rename an item that has not editable name.");
+            throw new IOException("Trying to rename an item that does not support this operation.");
         }
 
         // always synchronize from bigger objects first

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -255,6 +255,11 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public HttpResponse doConfirmRename(@QueryParameter String newName) throws IOException {
+
+        if (!isNameEditable()) {
+            throw new IllegalArgumentException("Trying to rename an item that has not editable name.");
+        }
+
         newName = newName == null ? null : newName.trim();
         FormValidation validationError = doCheckNewName(newName);
         if (validationError.kind != FormValidation.Kind.OK) {
@@ -351,6 +356,11 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      * you can use this method.
      */
     protected void renameTo(final String newName) throws IOException {
+
+        if (!isNameEditable()) {
+            throw new IllegalArgumentException("Trying to rename an item that has not editable name.");
+        }
+
         // always synchronize from bigger objects first
         final ItemGroup parent = getParent();
         String oldName = this.name;

--- a/core/src/test/java/hudson/model/AbstractItemTest.java
+++ b/core/src/test/java/hudson/model/AbstractItemTest.java
@@ -4,16 +4,14 @@
 package hudson.model;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Collection;
 
 import org.junit.Test;
-import org.kohsuke.stapler.HttpResponse;
+import org.jvnet.hudson.test.Issue;
 
 /**
  * @author kingfai
@@ -115,7 +113,8 @@ public class AbstractItemTest {
     }
 
     @Test
-    public void renameMethodShouldThrowExceptionWhenNotIsNameEditable() throws IOException {
+    @Issue("JENKINS-58571")
+    public void renameMethodShouldThrowExceptionWhenNotIsNameEditable() {
 
         //GIVEN
         NameNotEditableItem item = new NameNotEditableItem(null,"NameNotEditableItem");
@@ -124,7 +123,7 @@ public class AbstractItemTest {
         try {
             item.renameTo("NewName");
             fail("An item with isNameEditable false must throw exception when trying to rename it.");
-        } catch (IllegalArgumentException e) {
+        } catch (IOException e) {
 
             //THEN
             assertEquals(e.getMessage(),"Trying to rename an item that has not editable name.");
@@ -132,21 +131,4 @@ public class AbstractItemTest {
         }
     }
 
-    @Test
-    public void doConfirmRenameMustThrowExceptionWhenNotIsNameEditable() throws IOException {
-
-        //GIVEN
-        NameNotEditableItem item = new NameNotEditableItem(null,"NameNotEditableItem");
-
-        //WHEN
-        try {
-            item.doConfirmRename("MyNewName");
-            fail("An item with isNameEditable false must throw exception when trying to call doConfirmRename.");
-        } catch (Failure f) {
-
-            //THEN
-            assertEquals(f.getMessage(),"This item has not an editable name.");
-            assertEquals("NameNotEditableItem",item.getName());
-        }
-    }
 }

--- a/core/src/test/java/hudson/model/AbstractItemTest.java
+++ b/core/src/test/java/hudson/model/AbstractItemTest.java
@@ -126,7 +126,26 @@ public class AbstractItemTest {
         } catch (IOException e) {
 
             //THEN
-            assertEquals(e.getMessage(),"Trying to rename an item that has not editable name.");
+            assertEquals(e.getMessage(),"Trying to rename an item that does not support this operation.");
+            assertEquals("NameNotEditableItem",item.getName());
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-58571")
+    public void doConfirmRenameMustThrowFormFailureWhenNotIsNameEditable() throws IOException {
+
+        //GIVEN
+        NameNotEditableItem item = new NameNotEditableItem(null,"NameNotEditableItem");
+
+        //WHEN
+        try {
+            item.doConfirmRename("MyNewName");
+            fail("An item with isNameEditable false must throw exception when trying to call doConfirmRename.");
+        } catch (Failure f) {
+
+            //THEN
+            assertEquals(f.getMessage(),"Trying to rename an item that does not support this operation.");
             assertEquals("NameNotEditableItem",item.getName());
         }
     }

--- a/core/src/test/java/hudson/model/AbstractItemTest.java
+++ b/core/src/test/java/hudson/model/AbstractItemTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.Collection;
 
 import org.junit.Test;
+import org.kohsuke.stapler.HttpResponse;
 
 /**
  * @author kingfai
@@ -141,10 +142,10 @@ public class AbstractItemTest {
         try {
             item.doConfirmRename("MyNewName");
             fail("An item with isNameEditable false must throw exception when trying to call doConfirmRename.");
-        } catch (IllegalArgumentException e) {
+        } catch (Failure f) {
 
             //THEN
-            assertEquals(e.getMessage(),"Trying to rename an item that has not editable name.");
+            assertEquals(f.getMessage(),"This item has not an editable name.");
             assertEquals("NameNotEditableItem",item.getName());
         }
     }

--- a/core/src/test/java/hudson/model/AbstractItemTest.java
+++ b/core/src/test/java/hudson/model/AbstractItemTest.java
@@ -4,8 +4,12 @@
 package hudson.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.util.Collection;
 
 import org.junit.Test;
@@ -90,5 +94,58 @@ public class AbstractItemTest {
         i.setDisplayNameOrNull(displayName);
         assertEquals(displayName, i.getDisplayNameOrNull());
         assertEquals(displayName, i.getDisplayName());
+    }
+
+    private class NameNotEditableItem extends AbstractItem {
+
+        protected NameNotEditableItem(ItemGroup parent, String name){
+            super(parent, name);
+        }
+
+        @Override
+        public Collection<? extends Job> getAllJobs() {
+            return null;
+        }
+
+        @Override
+        public boolean isNameEditable() {
+            return false; //so far it's the default value, but it's good to be explicit for test.
+        }
+    }
+
+    @Test
+    public void renameMethodShouldThrowExceptionWhenNotIsNameEditable() throws IOException {
+
+        //GIVEN
+        NameNotEditableItem item = new NameNotEditableItem(null,"NameNotEditableItem");
+
+        //WHEN
+        try {
+            item.renameTo("NewName");
+            fail("An item with isNameEditable false must throw exception when trying to rename it.");
+        } catch (IllegalArgumentException e) {
+
+            //THEN
+            assertEquals(e.getMessage(),"Trying to rename an item that has not editable name.");
+            assertEquals("NameNotEditableItem",item.getName());
+        }
+    }
+
+    @Test
+    public void doConfirmRenameMustThrowExceptionWhenNotIsNameEditable() throws IOException {
+
+        //GIVEN
+        NameNotEditableItem item = new NameNotEditableItem(null,"NameNotEditableItem");
+
+        //WHEN
+        try {
+            item.doConfirmRename("MyNewName");
+            fail("An item with isNameEditable false must throw exception when trying to call doConfirmRename.");
+        } catch (IllegalArgumentException e) {
+
+            //THEN
+            assertEquals(e.getMessage(),"Trying to rename an item that has not editable name.");
+            assertEquals("NameNotEditableItem",item.getName());
+        }
     }
 }

--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -64,7 +64,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2.55-rc1222.dbdd2bc9bc9b</version>
+      <version>2.55</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -64,7 +64,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2.54</version>
+      <version>2.55-rc1222.dbdd2bc9bc9b</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
See [JENKINS-58571](https://issues.jenkins-ci.org/browse/JENKINS-58571).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: Trying to rename items with non editable name is protected by exception raising.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ X ] JIRA issue is well described
- [ X ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ X ] Appropriate autotests or explanation to why this change has no tests
- [ X ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
