### PR TITLE
Update last links from /people to /asynchPeople

### DIFF
--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index_fr.properties
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index_fr.properties
@@ -21,5 +21,5 @@
 # THE SOFTWARE.
 
 Users=Utilisateurs
-blurb=Ces utilisateurs peuvent se logguer sur Jenkins. C''est le groupe contenant <a href="../people">cette liste</a>, qui contient \u00E9galement les utilisateurs cr\u00E9\u00E9s automatiquement qui ont simplement fait des commits sur certains projets et n''ont pas d''acc\u00E8s direct \u00E0 Jenkins.
+blurb=Ces utilisateurs peuvent se logguer sur Jenkins. C''est le groupe contenant <a href="../asynchPeople">cette liste</a>, qui contient \u00E9galement les utilisateurs cr\u00E9\u00E9s automatiquement qui ont simplement fait des commits sur certains projets et n''ont pas d''acc\u00E8s direct \u00E0 Jenkins.
 Name=Nom

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index_nl.properties
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index_nl.properties
@@ -3,4 +3,4 @@
 Name=Naam
 User\ Id=Gebruikersnaam
 Users=Gebruikers
-blurb=Deze gebruikers kunnen op Jenkins inloggen. Dit is een sub set van <a href="../people">deze lijst</a>, deze bevat ook automatisch aangemaakte gebruikers die hebben bijgedragen bij een of meer projecten maar die geen directe toegang tot Jenkins hebben.
+blurb=Deze gebruikers kunnen op Jenkins inloggen. Dit is een sub set van <a href="../asynchPeople">deze lijst</a>, deze bevat ook automatisch aangemaakte gebruikers die hebben bijgedragen bij een of meer projecten maar die geen directe toegang tot Jenkins hebben.


### PR DESCRIPTION
### Minor Changes

Some translations (FR/NL) kept old link to /people, i updated them onto /asynchPeople link
