### PR TITLE
[JENKINS-53322] Remove patched dom4j fork

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.257.2</stapler.version>
+    <stapler.version>1.258-rc1374.fe004ac647e0</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.12</groovy.version>
   </properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@ THE SOFTWARE.
 
   <properties>
     <staplerFork>true</staplerFork>
-    <stapler.version>1.258-rc1374.fe004ac647e0</stapler.version>
+    <stapler.version>1.258</stapler.version>
     <spring.version>2.5.6.SEC03</spring.version>
     <groovy.version>2.4.12</groovy.version>
   </properties>

--- a/test/src/test/java/jenkins/security/stapler/StaplerDispatchValidatorTest.java
+++ b/test/src/test/java/jenkins/security/stapler/StaplerDispatchValidatorTest.java
@@ -79,7 +79,7 @@ public class StaplerDispatchValidatorTest {
         String[] urls = {"annotated/root", "groovy/root", "jelly/root", "whitelist/root"};
         for (String url : urls) {
             HtmlPage root = j.createWebClient().goTo(url);
-            assertEquals("Fragment", root.getElementById("frag").asText());
+            assertEquals("Fragment", root.getElementById("frag").getChildNodes().get(0).getNodeValue());
         }
     }
 


### PR DESCRIPTION
Remove an ancient, forked dom4j library. 

This library has been removed from Stapler in release 1.258 (stapler/stapler#164). Another [PR](jenkinsci/ec2-plugin#372) in ec2-plugin version 1.45 enabled it to work with either the standard or forked library. An earlier [Jenkins PR]( #4088) allowed it to work with either standard or forked library.

This PR moves Jenkins, via Stapler, to the standard dom4j library. After this is integrated the Jenkins dom4j project can be archived.

This PR also includes a minor test fix for a test that was introduced between the earlier Jenkins PR and this one.

See [JENKINS-53322](https://issues.jenkins-ci.org/browse/JENKINS-53322).

### Proposed changelog entries

* Internal: Update dom4j library from Jenkins fork to standard release 2.1.1. ([issue 53322](https://issues.jenkins-ci.org/browse/JENKINS-53322))

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
This change relies on all existing tests to check for regressions. It does not introduce new capabilities or fix behavior.
- [x] For dependency updates: links to external changelogs and, if possible, full diffs
[Stapler changelog](https://github.com/stapler/stapler/releases)

### Desired reviewers

@Wadeck @jvz