### PR TITLE
Replace Charset.forName with StandardCharsets

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -27,7 +27,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayInputStream;
 import java.io.SequenceInputStream;
 import java.io.Writer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPublicKey;
 import javax.annotation.Nullable;
@@ -140,7 +139,7 @@ public final class TcpSlaveAgentListener extends Thread {
     @Nullable
     public String getIdentityPublicKey() {
         RSAPublicKey key = InstanceIdentityProvider.RSA.getPublicKey();
-        return key == null ? null : new String(Base64.encodeBase64(key.getEncoded()), Charset.forName("UTF-8"));
+        return key == null ? null : new String(Base64.encodeBase64(key.getEncoded()), StandardCharsets.UTF_8);
     }
 
     /**

--- a/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
@@ -5,7 +5,7 @@
  */
 package hudson.security.csrf;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.logging.Level;
@@ -118,8 +118,8 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
             String newCrumb = issueCrumb(request, salt);
             if ((newCrumb != null) && (crumb != null)) {
                 // String.equals() is not constant-time, but this is
-                return MessageDigest.isEqual(newCrumb.getBytes(Charset.forName("US-ASCII")),
-                        crumb.getBytes(Charset.forName("US-ASCII")));
+                return MessageDigest.isEqual(newCrumb.getBytes(StandardCharsets.US_ASCII),
+                        crumb.getBytes(StandardCharsets.US_ASCII));
             }
         }
         return false;

--- a/core/src/main/java/hudson/util/HttpResponses.java
+++ b/core/src/main/java/hudson/util/HttpResponses.java
@@ -33,7 +33,7 @@ import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -142,8 +142,6 @@ public class HttpResponses extends org.kohsuke.stapler.HttpResponses {
      */
     static class JSONObjectResponse implements HttpResponse {
 
-        private static final Charset UTF8 = Charset.forName("UTF-8");
-
         private final JSONObject jsonObject;
 
         /**
@@ -210,7 +208,7 @@ public class HttpResponses extends org.kohsuke.stapler.HttpResponses {
          */
         @Override
         public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
-            byte[] bytes = jsonObject.toString().getBytes(UTF8);
+            byte[] bytes = jsonObject.toString().getBytes(StandardCharsets.UTF_8);
             rsp.setContentType("application/json; charset=UTF-8");
             rsp.setContentLength(bytes.length);
             rsp.getOutputStream().write(bytes);

--- a/core/src/main/java/hudson/util/WriterOutputStream.java
+++ b/core/src/main/java/hudson/util/WriterOutputStream.java
@@ -30,6 +30,7 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.CoderResult;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.*;
 
@@ -127,7 +128,7 @@ public class WriterOutputStream extends OutputStream {
             String encoding = System.getProperty("file.encoding");
             return Charset.forName(encoding);
         } catch (UnsupportedCharsetException e) {
-            return Charset.forName("UTF-8");
+            return StandardCharsets.UTF_8;
         }
     }
 }

--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -70,7 +70,7 @@ import java.io.Writer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -308,7 +308,7 @@ public class XStream2 extends XStream {
      * @since 1.504
      */
     public void toXMLUTF8(Object obj, OutputStream out) throws IOException {
-        Writer w = new OutputStreamWriter(out, Charset.forName("UTF-8"));
+        Writer w = new OutputStreamWriter(out, StandardCharsets.UTF_8);
         w.write("<?xml version=\"1.1\" encoding=\"UTF-8\"?>\n");
         toXML(obj, w);
     }

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -83,7 +83,7 @@ public class AtomicFileWriterTest {
 
         final Path childFileInSymlinkToDir = Paths.get(zeSymlink.toString(), "childFileInSymlinkToDir");
 
-        new AtomicFileWriter(childFileInSymlinkToDir, Charset.forName("UTF-8"));
+        new AtomicFileWriter(childFileInSymlinkToDir, StandardCharsets.UTF_8);
     }
 
     @Test
@@ -154,7 +154,7 @@ public class AtomicFileWriterTest {
         assertFalse(parentExistsAndIsAFile.exists());
 
         try {
-            new AtomicFileWriter(parentExistsAndIsAFile.toPath(), Charset.forName("UTF-8"));
+            new AtomicFileWriter(parentExistsAndIsAFile.toPath(), StandardCharsets.UTF_8);
             fail("Expected a failure");
         } catch (IOException e) {
             assertThat(e.getMessage(),

--- a/test/src/test/java/hudson/model/UsageStatisticsTest.java
+++ b/test/src/test/java/hudson/model/UsageStatisticsTest.java
@@ -42,7 +42,6 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.security.KeyFactory;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -172,7 +171,7 @@ public class UsageStatisticsTest {
     private void compareWithFile(String fileName, Object object) throws IOException {
 
         Class clazz = this.getClass();
-        String fileContent = Resources.toString(clazz.getResource(clazz.getSimpleName() + "/" + fileName), Charset.forName("UTF-8"));
+        String fileContent = Resources.toString(clazz.getResource(clazz.getSimpleName() + "/" + fileName), StandardCharsets.UTF_8);
         fileContent = fileContent.replace("JVMVENDOR", System.getProperty("java.vendor"));
         fileContent = fileContent.replace("JVMNAME", System.getProperty("java.vm.name"));
         fileContent = fileContent.replace("JVMVERSION", System.getProperty("java.version"));


### PR DESCRIPTION
This refactors usage of Charset::forName on common character sets that
now have an equivalent value in StandardCharsets.

### Proposed changelog entries

Too trivial

### Submitter checklist

- [ ] ~~JIRA issue is well described~~
- [ ] ~~Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)~~
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] ~~Appropriate autotests or explanation to why this change has no tests~~
- [ ] ~~For dependency updates: links to external changelogs and, if possible, full diffs~~

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

Might need to bring in the special ops reviewers for this one.