### PR TITLE
[JENKINS-58548] Remove extra whitespace from scriptText

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/_scriptText.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_scriptText.jelly
@@ -26,8 +26,8 @@ THE SOFTWARE.
   Called from doScriptText() to display the execution result.
 -->
 <?jelly escape-by-default='true'?>
-<st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
     <l:view contentType="text/plain;charset=UTF-8">
         <j:out value="${output}"/>
     </l:view>
-</st:compress>
+</j:jelly>

--- a/core/src/main/resources/lib/layout/view.jelly
+++ b/core/src/main/resources/lib/layout/view.jelly
@@ -35,6 +35,9 @@
         <st:contentType value="${attrs.contentType}"/>
     </j:if>
     <j:new var="h" className="hudson.Functions"/>
-    ${h.initPageVariables(context)}
+    <!-- JENKINS-58548: avoid using a JEXL expression here as it outputs untrimmed whitespace -->
+    <j:invoke on="${h}" method="initPageVariables">
+        <j:arg value="${context}"/>
+    </j:invoke>
     <d:invokeBody/>
 </j:jelly>

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -331,7 +331,7 @@ public class JenkinsTest {
 
     @Test
     @Issue("JENKINS-58548")
-    public void testDoScriptDoesNotOutputExtraWhitespace() throws Exception {
+    public void testDoScriptTextDoesNotOutputExtraWhitespace() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         WebClient wc = j.createWebClient().login("admin");
         TextPage page = wc.getPage(new WebRequest(wc.createCrumbedUrl("scriptText?script=print 'hello'"), HttpMethod.POST));

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.fail;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
@@ -326,6 +327,15 @@ public class JenkinsTest {
 
         wc.withBasicApiToken(User.getById("charlie", true));
         wc.assertFails("script", HttpURLConnection.HTTP_FORBIDDEN);
+    }
+
+    @Test
+    @Issue("JENKINS-58548")
+    public void testDoScriptDoesNotOutputExtraWhitespace() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        WebClient wc = j.createWebClient().login("admin");
+        TextPage page = wc.getPage(new WebRequest(wc.createCrumbedUrl("scriptText?script=print 'hello'"), HttpMethod.POST));
+        assertEquals("hello", page.getContent());
     }
 
     @Test


### PR DESCRIPTION
This removes the unnecessary whitespace being output in scriptText
and anywhere else that has non-XML whitespace semantics in its output
when using <l:view>.

Signed-off-by: Matt Sicker <boards@gmail.com>

See [JENKINS-58548](https://issues.jenkins-ci.org/browse/JENKINS-58548).

### Proposed changelog entries

* Internal: Removed extra whitespace output from `/scriptText` endpoint

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @jeffret-b @Wadeck @daniel-beck 