### PR TITLE
[JENKINS-58734] Use SHA-256 for crumbs

### DIFF
--- a/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
@@ -49,14 +49,8 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
 
     @DataBoundConstructor
     public DefaultCrumbIssuer(boolean excludeClientIPFromCrumb) {
-        try {
-            this.md = MessageDigest.getInstance("SHA-256");
-            this.excludeClientIPFromCrumb = excludeClientIPFromCrumb;
-        } catch (NoSuchAlgorithmException e) {
-            this.md = null;
-            this.excludeClientIPFromCrumb = false;
-            LOGGER.log(Level.SEVERE, "Can't find MD5", e);
-        }
+        this.excludeClientIPFromCrumb = excludeClientIPFromCrumb;
+        initializeMessageDigest();
     }
 
     public boolean isExcludeClientIPFromCrumb() {
@@ -64,14 +58,17 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
     }
     
     private Object readResolve() {
-        try {
-            this.md = MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException e) {
-            this.md = null;
-            LOGGER.log(Level.SEVERE, "Can't find MD5", e);
-        }
-        
+        initializeMessageDigest();
         return this;
+    }
+
+    private void initializeMessageDigest() {
+        try {
+            md = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            md = null;
+            LOGGER.log(Level.SEVERE, e, () -> "Cannot find SHA-256 MessageDigest implementation.");
+        }
     }
     
     /**

--- a/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
@@ -50,7 +50,7 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
     @DataBoundConstructor
     public DefaultCrumbIssuer(boolean excludeClientIPFromCrumb) {
         try {
-            this.md = MessageDigest.getInstance("MD5");
+            this.md = MessageDigest.getInstance("SHA-256");
             this.excludeClientIPFromCrumb = excludeClientIPFromCrumb;
         } catch (NoSuchAlgorithmException e) {
             this.md = null;


### PR DESCRIPTION
Signed-off-by: Matt Sicker <boards@gmail.com>

See [JENKINS-58734](https://issues.jenkins-ci.org/browse/JENKINS-58734). I ran all the unit tests locally and had no problems there, and I know there are numerous tests that implicitly exercise crumb issuance. I suppose there's a potentially open question regarding whether or not we should allow a user to fall back to using the old algorithm via a system property feature flag.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: Use SHA-256 instead of MD5 for generating crumbs/CSRF tokens.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @daniel-beck @Wadeck @jeffret-b @jglick @oleg-nenashev 