### PR TITLE
[JENKINS-58736] Correction of /assets throwing 500

### DIFF
--- a/core/src/main/java/jenkins/model/AssetManager.java
+++ b/core/src/main/java/jenkins/model/AssetManager.java
@@ -3,10 +3,14 @@ package jenkins.model;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -74,7 +78,11 @@ public class AssetManager implements UnprotectedRootAction {
      * look for child classloader first. But to support plugins that get split, if the child classloader
      * doesn't find it, fall back to the parent classloader.
      */
-    private URL findResource(String path) throws IOException {
+    private @CheckForNull URL findResource(@Nonnull String path) throws IOException {
+        if (StringUtils.isBlank(path)) {
+            return null;
+        }
+
         try {
             if (path.contains("..")) // crude avoidance of directory traversal attack
                 throw new IllegalArgumentException(path);

--- a/test/src/test/java/jenkins/model/AssetManagerTest.java
+++ b/test/src/test/java/jenkins/model/AssetManagerTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+public class AssetManagerTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-58736")
+    public void emptyAssetDoesNotThrowError() throws Exception {
+        URL url = new URL(j.getURL() + "assets");
+        HttpURLConnection httpCon = (HttpURLConnection) url.openConnection();
+        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, httpCon.getResponseCode());
+    }
+
+    @Test
+    @Issue("JENKINS-9598")
+    public void jqueryLoad() throws Exception {
+        // webclient does not work because it tries to parse the jquery2.js and there is a missing comma
+        URL url = new URL(j.getURL() + "assets/jquery-detached/jsmodules/jquery2.js");
+        HttpURLConnection httpCon = (HttpURLConnection) url.openConnection();
+        assertEquals(HttpURLConnection.HTTP_OK, httpCon.getResponseCode());
+    }
+}


### PR DESCRIPTION
See [JENKINS-58736](https://issues.jenkins-ci.org/browse/JENKINS-58736).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: prevent an exception to be thrown when requesting empty asset name

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

