### PR TITLE
[JENKINS-58733] Avoid a file handle leak in PeepholePermalink

### DIFF
--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
@@ -144,8 +145,8 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
         Map<String, Integer> cache = new TreeMap<>();
         File storage = storageFor(buildDir);
         if (storage.isFile()) {
-            try {
-                Files.lines(storage.toPath(), StandardCharsets.UTF_8).forEach(line -> {
+            try (Stream<String> lines = Files.lines(storage.toPath(), StandardCharsets.UTF_8)) {
+                lines.forEach(line -> {
                     int idx = line.indexOf(' ');
                     if (idx == -1) {
                         return;


### PR DESCRIPTION
See [JENKINS-58733](https://issues.jenkins-ci.org/browse/JENKINS-58733). Not sure how to efficiently test effectiveness but this seems like the simplest explanation for the error: I did not notice that `Stream`s can be closed, or that `Files.lines` expects this.

### Proposed changelog entries

* A file handle leak in `$JENKINS_HOME/jobs/*/builds/permalinks` could prevent jobs from being deleted on Windows.