### PR TITLE
[JENKINS-58779] LogRotator stops, if build was deleted externally

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1602,9 +1602,19 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             }
             boolean renamingSucceeded = true;
             try {
-                Path path = Files.move(rootDir.toPath(), tmp.toPath(), StandardCopyOption.ATOMIC_MOVE);
+                Path path = Files.move(
+                        Util.fileToPath(rootDir),
+                        Util.fileToPath(tmp),
+                        StandardCopyOption.ATOMIC_MOVE
+                );
             } catch (UnsupportedOperationException | IOException | SecurityException ex) {
                 // Fall back to previous < Java 7 variant
+                LOGGER.fine(String.format(
+                        "Atomic move of '%s' failed. Reason: [%s] %s. Retry with simple renaming",
+                        rootDir.getPath(),
+                        ex.getClass().getName(),
+                        ex.getMessage()
+                ));
                 renamingSucceeded = rootDir.renameTo(tmp);
             }
             

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -4,7 +4,6 @@
  * Copyright (c) 2004-2012, Sun Microsystems, Inc., Kohsuke Kawaguchi,
  * Daniel Dyer, Red Hat, Inc., Tom Huybrechts, Romain Seguy, Yahoo! Inc.,
  * Darek Ostolski, CloudBees, Inc.
- *
  * Copyright (c) 2012, Martin Schroeder, Intel Mobile Communications GmbH
  * Copyright (c) 2019 Intel Corporation
  * 

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -6,6 +6,7 @@
  * Darek Ostolski, CloudBees, Inc.
  *
  * Copyright (c) 2012, Martin Schroeder, Intel Mobile Communications GmbH
+ * Copyright (c) 2019 Intel Corporation
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,6 +45,8 @@ import hudson.console.PlainTextConsoleOutputStream;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.Path;
+import java.nio.file.AtomicMoveNotSupportedException;
 import jenkins.util.SystemProperties;
 import hudson.Util;
 import hudson.XmlFile;
@@ -74,8 +77,12 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.io.Reader;
+import java.lang.UnsupportedOperationException;
+import java.lang.SecurityException;
 import java.io.Serializable;
 import java.nio.charset.Charset;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.Files;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -119,6 +126,7 @@ import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.Authentication;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.jelly.XMLOutput;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -1566,34 +1574,52 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     public void delete() throws IOException {
         File rootDir = getRootDir();
         if (!rootDir.isDirectory()) {
-            throw new IOException(this + ": " + rootDir + " looks to have already been deleted; siblings: " + Arrays.toString(project.getBuildDir().list()));
+            //No root directory found to delete. Somebody seems to have nuked
+            //it externally. Logging a warning before dropping the build
+            LOGGER.warning(String.format(
+                    "%s: %s looks to have already been deleted, assuming build dir was already cleaned up",
+                    this, rootDir
+            ));
+            //Still firing the delete listeners; just no need to clean up rootDir
+            RunListener.fireDeleted(this);
+            synchronized (this) { // avoid holding a lock while calling plugin impls of onDeleted
+                removeRunFromParent();
+            }
+            return;
         }
         
+        //The root dir exists and is a directory that needs to be purged
         RunListener.fireDeleted(this);
-
+        
         if (artifactManager != null) {
             deleteArtifacts();
         } // for StandardArtifactManager, deleting the whole build dir suffices
-
-        synchronized (this) { // avoid holding a lock while calling plugin impls of onDeleted
-        File tmp = new File(rootDir.getParentFile(),'.'+rootDir.getName());
         
-        if (tmp.exists()) {
+        synchronized (this) { // avoid holding a lock while calling plugin impls of onDeleted
+            File tmp = new File(rootDir.getParentFile(),'.'+rootDir.getName());
+            
+            if (tmp.exists()) {
+                Util.deleteRecursive(tmp);
+            }
+            boolean renamingSucceeded = true;
+            try {
+                Path path = Files.move(rootDir.toPath(), tmp.toPath(), StandardCopyOption.ATOMIC_MOVE);
+            } catch (UnsupportedOperationException | IOException | SecurityException ex) {
+                // Fall back to previous < Java 7 variant
+                renamingSucceeded = rootDir.renameTo(tmp);
+            }
+            
             Util.deleteRecursive(tmp);
-        }
-        // TODO on Java 7 prefer: Files.move(rootDir.toPath(), tmp.toPath(), StandardCopyOption.ATOMIC_MOVE)
-        boolean renamingSucceeded = rootDir.renameTo(tmp);
-        Util.deleteRecursive(tmp);
-        // some user reported that they see some left-over .xyz files in the workspace,
-        // so just to make sure we've really deleted it, schedule the deletion on VM exit, too.
-        if(tmp.exists())
-            tmp.deleteOnExit();
-
-        if(!renamingSucceeded)
-            throw new IOException(rootDir+" is in use");
-        LOGGER.log(FINE, "{0}: {1} successfully deleted", new Object[] {this, rootDir});
-
-        removeRunFromParent();
+            // some user reported that they see some left-over .xyz files in the workspace,
+            // so just to make sure we've really deleted it, schedule the deletion on VM exit, too.
+            if (tmp.exists()) {
+                tmp.deleteOnExit();
+            }
+            if (!renamingSucceeded) {
+                throw new IOException(rootDir + " is in use");
+            }
+            LOGGER.log(FINE, "{0}: {1} successfully deleted", new Object[] {this, rootDir});
+            removeRunFromParent();
         }
     }
 

--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -114,6 +114,7 @@ public class LogRotator extends BuildDiscarder {
      * properly caught and reported in the log.
      * 
      * @param r the run to delete, must not be null.
+     * @since TODO
      */
     protected void deleteRun(Run<?,?> r) {
         try {
@@ -132,6 +133,7 @@ public class LogRotator extends BuildDiscarder {
      * properly caught and reported in the log.
      * 
      * @param r the run for which to delete artifacts, must not be null.
+     * @since TODO
      */
     protected void deleteArtifacts(Run<?,?> r) {
         try {


### PR DESCRIPTION
The deletion of a build/run in Jenkins is handled by the delete() method.

It throws an exception, when the build directory on disk has already been
removed and stops deleting the build.

Unfortunately, the hudson.tasks.LogRotator.perform(Job<?, ?>) method does
not check for this exception and will STOP cleaning up, once even just one
build throws that exception.

This behaviour is fixed in the following ways in this change:

1.) The Run.delete() method must still unlink the job, even if the build
    directory has been removed externally.

2.) The log output of Run.delete() must be made less verbose (it prints the
    ENTIRE folder content by default, into the job that is doing the cleanup)

3.) The LogRotator.perform() method must handle the exceptions being thrown
    by delete() gracefully.

Signed-off-by: Martin H Schroeder <martin.h.schroeder@intel.com>

See [JENKINS-58779](https://issues.jenkins-ci.org/browse/JENKINS-58779).
