### PR TITLE
[JENKINS-58780] Jenkins cancels the wrong build, when using QTF.cancel()

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1,11 +1,9 @@
 /*
  * The MIT License
  * 
- * Copyright (c) 2018-2019 Intel Corporation
- * Copyright (c) 2015-2017, Intel Deutschland GmbH
- * 
  * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi,
  * Stephen Connolly, Tom Huybrechts, InfraDNA, Inc.
+ * Copyright (c) 2019 Intel Corporation
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/main/java/hudson/model/queue/FutureImpl.java
+++ b/core/src/main/java/hudson/model/queue/FutureImpl.java
@@ -1,10 +1,8 @@
 /*
  * The MIT License
  * 
- * Copyright (c) 2018-2019 Intel Corporation
- * Copyright (c) 2015-2017, Intel Deutschland GmbH
- *
  * Copyright (c) 2010, InfraDNA, Inc.
+ * Copyright (c) 2019 Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -2,8 +2,7 @@
  * The MIT License
  *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * Copyright (c) 2015-2017, Intel Deutschland GmbH
- * Copyright (c) 2018-2019 Intel Corporation
+ * Copyright (c) 2019 Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
When cancelling a build for a specific Future object, Jenkins currently does not care about actually cancelling the queue item that corresponds to the given future. Instead, it simply cancel the first build for the same task that it can find.

This can be easily replicated by starting two jobs with different parameters via a Groovy script without having any build hosts online (so that they get queued).

The script should hold onto the returned QueueTaskFuture instances and then issue a cancellation on only one of them.

Current Jenkins behaviour is to always cancel the first of the tasks, no matter which of the two future objects were called.

This does not just affect programmatic calling of builds, but can also happen in downstream-triggered tasks and other build starting methods that rely on a cancellation via the QueueTaskFuture instance being reliable.

A new Unittest is being provided in this commit for this scenario.

Signed-off-by: Martin H Schroeder <martin.h.schroeder@intel.com>

See [JENKINS-58780](https://issues.jenkins-ci.org/browse/JENKINS-58780).

## Changelog entry

* Bug: Prevent cancelling wrong tasks in the Jenkins queue when the `QueueTaskFuture#cancel()` API is called