### PR TITLE
Test shouldn't be interactively breaking

### DIFF
--- a/test/src/test/java/jenkins/triggers/TriggerTest.java
+++ b/test/src/test/java/jenkins/triggers/TriggerTest.java
@@ -44,7 +44,6 @@ public class TriggerTest {
             Thread.sleep(100);
         }
         j.waitUntilNoActivity();
-        j.interactiveBreak();
         assertThat(l.getMessages().toArray(new String[0]) [0],
                 containsString("Trigger " + BadTimerTrigger.class.getName()
                         + ".run() triggered by " + p.toString() + " spent too much time "));


### PR DESCRIPTION
This causes the test to time out. What I don't understand is how this
test got merged in the first place.

See [ML thread](https://groups.google.com/d/msgid/jenkinsci-dev/1bd559a1-7c52-4a60-91ad-9c2f97ebe8d5%40googlegroups.com?utm_medium=email&utm_source=footer)

### Proposed changelog entries

None. This isn't impacting users

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

It appears that @pjanouse wrote the original code, so hopefully he can shed some light