### PR TITLE
[JENKINS-58836] Wrong spanish argentinian translation for 'logout'

### DIFF
--- a/core/src/main/resources/lib/layout/layout_es_AR.properties
+++ b/core/src/main/resources/lib/layout/layout_es_AR.properties
@@ -21,5 +21,5 @@
 # THE SOFTWARE.
 
 Page\ generated=P\u00E1gina generada
-logout=Volver al proyecto
+logout=Desconectar
 search=Buscar


### PR DESCRIPTION
Modificed logout key.

See [JENKINS-58836](https://issues.jenkins-ci.org/browse/JENKINS-58836).

### Proposed changelog entries

* Entry 1: Improved Spanish Argentine translation.

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs