### PR TITLE
 Trim whitespaces at the end of line in es_ES Messages.properties file (JENKINS-58842) workaround

### DIFF
--- a/core/src/main/resources/hudson/model/Messages_es.properties
+++ b/core/src/main/resources/hudson/model/Messages_es.properties
@@ -1,17 +1,17 @@
 # The MIT License
-# 
+#
 # Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Eric Lefevre-Ardant, Erik Ramfelt, Seiji Sogabe, id:cactusman
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -47,7 +47,7 @@ AbstractProject.ExtendedReadPermission.Description=\
 
 Api.MultipleMatch=XPath "{0}" encontr\u00f3 coincidencias en {1} nodos. \
   Crea una expresi\u00f3n XPath que s\u00f3lo encuentre uno, o utiliza el par\u00e1metro "wraper" para que todos los nodos se agrupen bajo un elemento.
-Api.NoXPathMatch=XPath {0} no encontr\u00f3 nada 
+Api.NoXPathMatch=XPath {0} no encontr\u00f3 nada
 Api.WrapperParamInvalid=El par\u00E1metro wrapper s\u00F3lo puede contener caracteres alfanum\u00E9ricos o guiones/puntos/subrayado. El primer car\u00E1cter debe ser una letra o subrayado.
 
 BallColor.Aborted=Abortado
@@ -78,7 +78,7 @@ Hudson.BadPortNumber=N\u00famero err\u00f3neo de puerto {0}
 Hudson.Computer.Caption=Principal
 Hudson.Computer.DisplayName=principal
 Hudson.ControlCodeNotAllowed=El c\u00f3digo de control {0} no est\u00e1 permitido
-Hudson.DisplayName=Jenkins 
+Hudson.DisplayName=Jenkins
 Hudson.JobAlreadyExists=Una tarea con el nombre ''{0}'' ya existe
 Hudson.NoJavaInPath=No se encuentra el comando java en el ''PATH''. Quiz\u00e1s necesite configurar <a href=''{0}/configure''> JDKs</a>?
 Hudson.NoName=No se ha especificado un nombre
@@ -120,11 +120,11 @@ Job.NOfMFailed={0} de las {1} \u00faltimas ejecuciones fallaron.
 Job.NoRecentBuildFailed=No hay ejecuciones recientes con fallos.
 Job.Pronoun=Proyecto
 Job.minutes=Min
-Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se está ejecutando.
+Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se estÃ¡ ejecutando.
 
 Label.GroupOf=grupo de {0}
 Label.InvalidLabel=etiqueta inv\u00e1lida
-Label.ProvisionedFrom=Suministrado desde {0} 
+Label.ProvisionedFrom=Suministrado desde {0}
 Queue.AllNodesOffline=Todos los nodos con la etiqueta ''{0}'' est\u00e1n fuera de l\u00ednea
 Queue.BlockedBy=Bloqueados por {0}
 Queue.HudsonIsAboutToShutDown=Jenkins va a ser apagado
@@ -153,7 +153,7 @@ Run.Summary.BackToNormal=volvi\u00f3 a normal
 Run.Summary.BrokenForALongTime=fallido durante un largo periodo
 Run.Summary.BrokenSinceThisBuild=fallido desde esta ejecuci\u00f3n
 Run.Summary.BrokenSince=fallido desde la ejecuci\u00f3n {0}
-Run.Summary.Unknown=? 
+Run.Summary.Unknown=?
 
 Slave.InvalidConfig.Executors=Configuraci\u00f3n de nodo incorrecta en {0}. El n\u00famero de ejecutores es inv\u00e1lido.
 Slave.InvalidConfig.NoName=Configuraci\u00f3n de nodo incorrecta. El nombre est\u00e1 vac\u00edo
@@ -249,8 +249,8 @@ AbstractProject.NoBuilds=No existen ejecuciones. Lanzando una nueva.
 Slave.Remote.Director.Mandatory=El directorio remoto es obligatorio
 Slave.Network.Mounted.File.System.Warning=\u00bfEst\u00e1s seguro de querer utilizar un directorio de red para el "Filesystem" ra\u00edz?.\
   Ten en cuenta que este directorio no necesita estar visible desde el nodo de Jenkins principal.
-HealthReport.EmptyString= 
-MultiStageTimeSeries.EMPTY_STRING= 
+HealthReport.EmptyString=
+MultiStageTimeSeries.EMPTY_STRING=
 ComputerSet.DisplayName=nodos
 Run.InProgressDuration={0} y contando
 Node.LabelMissing={0} no tiene etiqueta {1}
@@ -265,38 +265,38 @@ AbstractItem.Pronoun=Tarea
 AbstractProject.DownstreamBuildInProgress=El projecto padre {0} todav\u00eda est\u00e1 en ejecuci\u00f3n
 AbstractProject.AwaitingBuildForWorkspace=El trabajo est\u00e1 esperando para tener un ''espacio de trabajo''
 Run.ArtifactsPermission.Description=\
- Este permiso sirve para poder utilizar los artefactos producidos en los proyectos. 
+ Este permiso sirve para poder utilizar los artefactos producidos en los proyectos.
 AbstractProject.AssignedLabelString.InvalidBooleanExpression=Expresi\u00f3n booleana incorrecta: {0}
 ManageJenkinsAction.DisplayName=Administrar Jenkins
-Computer.NoSuchSlaveExists=El nodo {0} no existe. ¿Quizás se esté refiriendo a {1}?
-ResultTrend.StillFailing=Todavía falla
-Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de línea.
+Computer.NoSuchSlaveExists=El nodo {0} no existe. Â¿QuizÃ¡s se estÃ© refiriendo a {1}?
+ResultTrend.StillFailing=TodavÃ­a falla
+Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de lÃ­nea.
 Computer.CreatePermission.Description=Este permiso permite que los usuarios puedan crear nuevos nodos.
-ResultTrend.StillUnstable=Todavía inestable
+ResultTrend.StillUnstable=TodavÃ­a inestable
 View.ReadPermission.Description=Este permiso permite que los usuarion puedan crear vistas (implica acceso de lectura)
 Hudson.RunScriptsPermission.Description=El permiso "run scripts' es necesario para ejecutar scripts de groovy usando la consola groovy o el "cli" de groovy.
 ResultTrend.Fixed=Arreglado
 ResultTrend.Failure=Fallo
 UpdateCenter.PluginCategory.listview-column=Columnas de la lista
 ResultTrend.Aborted=Cancelado
-TextParameterDefinition.DisplayName=Parámetro de texto
-AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ningún nodo que cumpla esta asignación. ¿Quizás se refiera a ''{1}'' en lugar de ''{0}''?
+TextParameterDefinition.DisplayName=ParÃ¡metro de texto
+AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ningÃºn nodo que cumpla esta asignaciÃ³n. Â¿QuizÃ¡s se refiera a ''{1}'' en lugar de ''{0}''?
 ResultTrend.Success=Correcto
 AbstractProject.CancelPermission.Description=Este permiso permite que se pueda cancelar un trabajo.
 Run.Summary.NotBuilt=no se ha ejecutado
 AbstractProject.DiscoverPermission.Description=Este permiso garantiza que se pueda descubrir tareas. \
- Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios anónimos a la página de login. \
- Sin este permiso, los usuarios anónimos recibirán un error 404, no siendo capaces de descubrir esas tareas.
-Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusión en los resultados de búsquedas.
+ Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios anÃ³nimos a la pÃ¡gina de login. \
+ Sin este permiso, los usuarios anÃ³nimos recibirÃ¡n un error 404, no siendo capaces de descubrir esas tareas.
+Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusiÃ³n en los resultados de bÃºsquedas.
 ResultTrend.NotBuilt=Sin ejecutar
 ResultTrend.NowUnstable=Ahora es inestable
 AbstractBuild.BuildingInWorkspace=en el espacio de trabajo {0}
 Descriptor.From=(desde <a href="{1}">{0}</a>)
 ResultTrend.Unstable=Inestable
-Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se está usando en otro trabajo, pudiendo producir confusión.
+Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se estÃ¡ usando en otro trabajo, pudiendo producir confusiÃ³n.
 AbstractProject.WipeOutPermission.Description=Este permiso permite que se pueda borrar todo el contenido del espacio de trabajo de una tarea.
-UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activará en el próximo arranque.
+UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activarÃ¡ en el prÃ³ximo arranque.
 Computer.ConnectPermission.Description=Este permiso permite que los usuarios puedan conectar nodos o marcarlos como activos.
 BallColor.NotBuilt=Sin ejecutar.
 AbstractBuild_Building=Ejecutando.
-ParametersDefinitionProperty.DisplayName=Esta ejecución debe parametrizarse
+ParametersDefinitionProperty.DisplayName=Esta ejecuciÃ³n debe parametrizarse


### PR DESCRIPTION
Trim whitespaces at the end of line.

See [JENKINS-58842](https://issues.jenkins-ci.org/browse/JENKINS-58842).

### Proposed changelog entries

* Entry 1: Trim whitespaces at the end of line in es_ES Messages.properties file

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
