### PR TITLE
Bundle Maven Plugin 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ THE SOFTWARE.
 
     <guavaVersion>11.0.1</guavaVersion>
     <slf4jVersion>1.7.26</slf4jVersion>
-    <maven-plugin.version>2.14</maven-plugin.version>
+    <maven-plugin.version>3.4</maven-plugin.version>
     <matrix-auth.version>2.3</matrix-auth.version>
     <matrix-project.version>1.14</matrix-project.version>
     <sorcerer.version>0.11</sorcerer.version>


### PR DESCRIPTION
(Untested, let's see whether this works.)

FWIW Maven Plugin is a plugin we should really consider removing from the war. Hudson 1.296? Really?

### Proposed changelog entries

* Update bundled version of Maven Plugin installed in rare circumstances from 2.14 to 3.4.

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
