### PR TITLE
[JENKINS-58892] - Remove build-pipeline-plugin from setup wizard

### DIFF
--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -49,7 +49,6 @@
             { "name": "github-branch-source", "suggested": true, "added": "2.0" },
             { "name": "pipeline-github-lib", "suggested": true, "added": "2.0" },
             { "name": "pipeline-stage-view", "suggested": true, "added": "2.0" },
-            { "name": "build-pipeline-plugin" },
             { "name": "conditional-buildstep" },
             { "name": "jenkins-multijob-plugin" },
             { "name": "parameterized-trigger" },


### PR DESCRIPTION
[I announced an unfixed security vulnerability in Build Pipeline Plugin today](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-879), after a year or so without a response by the maintainer. I tried contacting them via email too.

Sure, this may be one of the less notable security issues, but IMO it's still a problem for a plugin present in the setup wizard – especially given that there's no warning support here. Right now, users might "Select All" and be greeted with a security warning afterwards. Not good. (I cannot enable/disable them based on core version, only plugin version.)

### Proposed changelog entries

* (Too minor)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
