### PR TITLE
[JENKINS-58595] Add missing ${h} in rss and atom views

### DIFF
--- a/core/src/main/resources/hudson/atom.jelly
+++ b/core/src/main/resources/hudson/atom.jelly
@@ -24,8 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-  <l:view contentType="application/atom+xml;charset=UTF-8">
-    &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+  <l:view contentType="application/atom+xml;charset=UTF-8"><!-- No whitespace before xml header: -->&lt;?xml version="1.0" encoding="UTF-8"?&gt;
     <!-- ATOM. See http://atompub.org/rfc4287.html for the format -->
     <feed xmlns="http://www.w3.org/2005/Atom">
       <title>${title}</title>

--- a/core/src/main/resources/hudson/atom.jelly
+++ b/core/src/main/resources/hudson/atom.jelly
@@ -23,38 +23,40 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"><st:contentType value="application/atom+xml;charset=UTF-8" /><!-- No whitespace before xml header: -->&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+  <l:view contentType="application/atom+xml;charset=UTF-8">
+    &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    <!-- ATOM. See http://atompub.org/rfc4287.html for the format -->
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <title>${title}</title>
+      <link rel="alternate" type="text/html" href="${rootURL}${url}"/>
 
-  <!-- ATOM. See http://atompub.org/rfc4287.html for the format -->
-  <feed xmlns="http://www.w3.org/2005/Atom">
-    <title>${title}</title>
-    <link rel="alternate" type="text/html" href="${rootURL}${url}"/>
+      <j:choose>
+        <j:when test="${empty(entries)}">
+          <updated>2001-01-01T00:00:00Z</updated>
+        </j:when>
+        <j:otherwise>
+          <updated>${h.xsDate(adapter.getEntryTimestamp(entries[0]))}</updated>
+        </j:otherwise>
+      </j:choose>
+      <author>
+        <name>Jenkins Server</name>
+      </author>
+      <id>urn:uuid:903deee0-7bfa-11db-9fe1-0800200c9a66</id>
 
-    <j:choose>
-      <j:when test="${empty(entries)}">
-        <updated>2001-01-01T00:00:00Z</updated>
-      </j:when>
-      <j:otherwise>
-        <updated>${h.xsDate(adapter.getEntryTimestamp(entries[0]))}</updated>
-      </j:otherwise>
-    </j:choose>
-    <author>
-      <name>Jenkins Server</name>
-    </author>
-    <id>urn:uuid:903deee0-7bfa-11db-9fe1-0800200c9a66</id>
-
-    <j:forEach var="e" items="${entries}" >
-      <entry>
-        <title>${adapter.getEntryTitle(e)}</title>
-        <link rel="alternate" type="text/html" href="${rootURL}${h.encode(adapter.getEntryUrl(e))}"/>
-        <id>${adapter.getEntryID(e)}</id>
-        <published>${h.xsDate(adapter.getEntryTimestamp(e))}</published>
-        <updated>${h.xsDate(adapter.getEntryTimestamp(e))}</updated>
-        <j:set var="desc" value="${adapter.getEntryDescription(e)}"/>
-        <j:if test="${desc!=null}">
-          <content>${desc}</content>
-        </j:if>
-      </entry>
-    </j:forEach>
-  </feed>
+      <j:forEach var="e" items="${entries}" >
+        <entry>
+          <title>${adapter.getEntryTitle(e)}</title>
+          <link rel="alternate" type="text/html" href="${rootURL}${h.encode(adapter.getEntryUrl(e))}"/>
+          <id>${adapter.getEntryID(e)}</id>
+          <published>${h.xsDate(adapter.getEntryTimestamp(e))}</published>
+          <updated>${h.xsDate(adapter.getEntryTimestamp(e))}</updated>
+          <j:set var="desc" value="${adapter.getEntryDescription(e)}"/>
+          <j:if test="${desc!=null}">
+            <content>${desc}</content>
+          </j:if>
+        </entry>
+      </j:forEach>
+    </feed>
+  </l:view>
 </j:jelly>

--- a/core/src/main/resources/hudson/rss20.jelly
+++ b/core/src/main/resources/hudson/rss20.jelly
@@ -24,8 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
-  <l:view contentType="text/xml;charset=UTF-8">
-    &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+  <l:view contentType="text/xml;charset=UTF-8"><!-- No whitespace before xml header: -->&lt;?xml version="1.0" encoding="UTF-8"?&gt;
     <!-- RSS 2.0 feed. See http://cyber.law.harvard.edu/rss/rss.html for the format -->
     <rss version="2.0">
       <channel>

--- a/core/src/main/resources/hudson/rss20.jelly
+++ b/core/src/main/resources/hudson/rss20.jelly
@@ -23,28 +23,30 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"><st:contentType value="text/xml;charset=UTF-8" /><!-- No whitespace before xml header: -->&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <l:view contentType="text/xml;charset=UTF-8">
+    &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    <!-- RSS 2.0 feed. See http://cyber.law.harvard.edu/rss/rss.html for the format -->
+    <rss version="2.0">
+      <channel>
+        <title>${title}</title>
+        <link>${rootURL}${url}</link>
+        <description>${title}</description>
 
-  <!-- RSS 2.0 feed. See http://cyber.law.harvard.edu/rss/rss.html for the format -->
-  <rss version="2.0">
-    <channel>
-      <title>${title}</title>
-      <link>${rootURL}${url}</link>
-      <description>${title}</description>
-
-      <j:forEach var="e" items="${entries}" >
-        <item>
-          <title>${adapter.getEntryTitle(e)}</title>
-          <link>${rootURL}${h.encode(adapter.getEntryUrl(e))}</link>
-          <guid isPermaLink="false">${adapter.getEntryID(e)}</guid>
-          <pubDate>${h.rfc822Date(adapter.getEntryTimestamp(e))}</pubDate>
-          <author><st:out value="${adapter.getEntryAuthor(e)}"/></author>
-          <j:set var="desc" value="${adapter.getEntryDescription(e)}"/>
-          <j:if test="${desc!=null}">
-            <description>${desc}</description>
-          </j:if>
-        </item>
-      </j:forEach>
-    </channel>
-  </rss>
+        <j:forEach var="e" items="${entries}" >
+          <item>
+            <title>${adapter.getEntryTitle(e)}</title>
+            <link>${rootURL}${h.encode(adapter.getEntryUrl(e))}</link>
+            <guid isPermaLink="false">${adapter.getEntryID(e)}</guid>
+            <pubDate>${h.rfc822Date(adapter.getEntryTimestamp(e))}</pubDate>
+            <author><st:out value="${adapter.getEntryAuthor(e)}"/></author>
+            <j:set var="desc" value="${adapter.getEntryDescription(e)}"/>
+            <j:if test="${desc!=null}">
+              <description>${desc}</description>
+            </j:if>
+          </item>
+        </j:forEach>
+      </channel>
+    </rss>
+  </l:view>
 </j:jelly>


### PR DESCRIPTION
Now that l:view was fixed not to output whitespace, these views can be
updated to directly use l:view. Otherwise, they needed to initialize
the ${h} Jelly variable which is done via l:view normally.

This fixes a regression introduced in SECURITY-534.

I looked through [the diff](https://github.com/jenkinsci/jenkins/commit/279d8109eddb7a494428baf25af9756c2e33576b) to see if there were any other places that accidentally removed `${h}`, and it looks like these two files were the only ones.

See [JENKINS-58595](https://issues.jenkins-ci.org/browse/JENKINS-58595).

### Proposed changelog entries

* Fixed regression in RSS and Atom feeds where an uninitialized variable resulted in partial entries.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@reviewbybees @daniel-beck @Wadeck @jeffret-b 
