### PR TITLE
doQuietDown() cannot actually throw IOException

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3836,10 +3836,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     @RequirePOST
-    public synchronized HttpRedirect doQuietDown() throws IOException {
+    public synchronized HttpRedirect doQuietDown() {
         try {
             return doQuietDown(false,0);
-        } catch (InterruptedException e) {
+        } catch (IOException | InterruptedException e) {
             throw new AssertionError(); // impossible
         }
     }


### PR DESCRIPTION
A little nit I noticed: an `IOException` is impossible here for the same reason an `InterruptedException` is impossible—that is only thrown when `block` is `true`.

### Proposed changelog entries

* None needed.