### PR TITLE
Release drafter: Order changelog entries using categories

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,7 +4,6 @@ name-template: $NEXT_PATCH_VERSION
 version-template: $MAJOR.$MINOR
 tag-template: jenkins-$NEXT_MINOR_VERSION
 
-# TODO: categories are YAGNI for now, until we can extract `type` somehow
 exclude-labels:
   - reverted
   - no-changelog
@@ -17,6 +16,7 @@ change-template: |-
     pull: $NUMBER
     authors:
       - $AUTHOR
+
 template: |
   **Disclaimer**: This is an automatically generated changelog draft for Jenkins weekly releases. 
   See https://jenkins.io/changelog/ for the official changelogs. 
@@ -24,6 +24,26 @@ template: |
   ```yaml
   $CHANGES
   ```
+
+# Categories will be commented out, because we use YAML
+# Now we use categories only for sorting
+categories:
+  - title: Major BUGs and regressions
+    labels: 
+      - major-bug
+      - regression-fix
+  - title: Major RFE
+    label: major-rfe
+  - title: RFEs
+    label: enhancement
+  - title: Bug fixes
+    label: bug
+  - title: Localization
+    label: localization
+  # TODO: consider merging category or changing emojis
+  - title: Internal/Developer changes
+    label: internal
+
 replacers:
   - search: '/\[*JENKINS-(\d+)\]*\s*-*\s*/g'
     replace: |-
@@ -34,3 +54,6 @@ replacers:
       message: |-
           issue:
     replace: "issue:"
+
+  - search: "##"
+    replace: "#"


### PR DESCRIPTION
Categories match what we have on https://jenkins.io/changelog/ , except localization fixes which get a new category in the bottom.

## Changelog entry

* N/A