### PR TITLE
Release Drafter: RFE is used as a changelog filter for RFEs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,7 +35,7 @@ categories:
   - title: Major RFE
     label: major-rfe
   - title: RFEs
-    label: enhancement
+    label: rfe
   - title: Bug fixes
     label: bug
   - title: Localization


### PR DESCRIPTION
Just noticed that I forgot to change the label

@daniel-beck 
