### PR TITLE
[JENKINS-56217] Require Overall/Read to get Jenkins version

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1409,7 +1409,7 @@ public class Functions {
     }
 
     public static String getVersion() {
-        return Jenkins.VERSION;
+        return Jenkins.getJenkinsVersion();
     }
 
     /**
@@ -2033,7 +2033,7 @@ public class Functions {
         Jenkins j = Jenkins.getInstanceOrNull();
         if (j!=null) {
             rsp.setHeader("X-Hudson","1.395");
-            rsp.setHeader("X-Jenkins", Jenkins.VERSION);
+            rsp.setHeader("X-Jenkins", Jenkins.getJenkinsVersion());
             rsp.setHeader("X-Jenkins-Session", Jenkins.SESSION_HASH);
 
             TcpSlaveAgentListener tal = j.tcpSlaveAgentListener;

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -747,7 +747,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         if (lastExecVersion.isNewerThan(InstallUtil.NEW_INSTALL_VERSION) && lastExecVersion.isOlderThan(Jenkins.getVersion())) {
 
             LOGGER.log(INFO, "Upgrading Jenkins. The last running version was {0}. This Jenkins is version {1}.",
-                    new Object[] {lastExecVersion, Jenkins.VERSION});
+                    new Object[] {lastExecVersion, Jenkins.getJenkinsVersion()});
 
             final List<DetachedPluginsUtil.DetachedPlugin> detachedPlugins = DetachedPluginsUtil.getDetachedPlugins(lastExecVersion);
 
@@ -783,7 +783,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             });
 
             LOGGER.log(INFO, "Upgraded Jenkins from version {0} to version {1}. Loaded detached plugins (and dependencies): {2}",
-                    new Object[] {lastExecVersion, Jenkins.VERSION, loadedDetached});
+                    new Object[] {lastExecVersion, Jenkins.getJenkinsVersion(), loadedDetached});
 
             InstallUtil.saveLastExecVersion();
         } else {

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -311,7 +311,7 @@ public final class TcpSlaveAgentListener extends Thread {
                     o.write("Content-Type: text/plain;charset=UTF-8\r\n");
                     o.write("\r\n");
                     o.write("Jenkins-Agent-Protocols: " + getAgentProtocolNames()+"\r\n");
-                    o.write("Jenkins-Version: " + Jenkins.VERSION + "\r\n");
+                    o.write("Jenkins-Version: " + Jenkins.getJenkinsVersion() + "\r\n");
                     o.write("Jenkins-Session: " + Jenkins.SESSION_HASH + "\r\n");
                     o.write("Client: " + s.getInetAddress().getHostAddress() + "\r\n");
                     o.write("Server: " + s.getLocalAddress().getHostAddress() + "\r\n");

--- a/core/src/main/java/hudson/UDPBroadcastThread.java
+++ b/core/src/main/java/hudson/UDPBroadcastThread.java
@@ -91,7 +91,7 @@ public class UDPBroadcastThread extends Thread {
                 TcpSlaveAgentListener tal = jenkins.getTcpSlaveAgentListener();
 
                 StringBuilder rsp = new StringBuilder("<hudson>");
-                tag(rsp,"version", Jenkins.VERSION);
+                tag(rsp,"version", Jenkins.getJenkinsVersion());
                 tag(rsp,"url", jenkins.getRootUrl());
                 tag(rsp,"server-id", jenkins.getLegacyInstanceId());
                 tag(rsp,"slave-port",tal==null?null:tal.getPort());

--- a/core/src/main/java/hudson/cli/VersionCommand.java
+++ b/core/src/main/java/hudson/cli/VersionCommand.java
@@ -40,7 +40,7 @@ public class VersionCommand extends CLICommand {
 
     protected int run() {
         // CLICommand.main checks Hudson.READ permission.. no other check needed.
-        stdout.println(Jenkins.VERSION);
+        stdout.println(Jenkins.getJenkinsVersion());
         return 0;
     }
 }

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -456,7 +456,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             
             assert builtOn==null;
             builtOn = node.getNodeName();
-            hudsonVersion = Jenkins.VERSION;
+            hudsonVersion = Jenkins.getJenkinsVersion();
             this.listener = listener;
 
             launcher = createLauncher(listener);

--- a/core/src/main/java/hudson/model/Api.java
+++ b/core/src/main/java/hudson/model/Api.java
@@ -245,7 +245,7 @@ public class Api extends AbstractModelObject {
 
     @Restricted(NoExternalUse.class)
     protected void setHeaders(StaplerResponse rsp) {
-        rsp.setHeader("X-Jenkins", Jenkins.VERSION);
+        rsp.setHeader("X-Jenkins", Jenkins.getJenkinsVersion());
         rsp.setHeader("X-Jenkins-Session", Jenkins.SESSION_HASH);
     }
 

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -100,7 +100,7 @@ public class DownloadService extends PageDecorator {
                        .append(',')
                        .append(QuotedStringTokenizer.quote(mapHttps(d.getUrl())))
                        .append(',')
-                       .append("{version:").append(QuotedStringTokenizer.quote(Jenkins.VERSION)).append('}')
+                       .append("{version:").append(QuotedStringTokenizer.quote(Jenkins.getJenkinsVersion())).append('}')
                        .append(',')
                        .append(QuotedStringTokenizer.quote(Stapler.getCurrentRequest().getContextPath()+'/'+getUrl()+"/byId/"+d.getId()+"/postBack"))
                        .append(',')
@@ -405,7 +405,7 @@ public class DownloadService extends PageDecorator {
                 }
                 String jsonString;
                 try {
-                    jsonString = loadJSONHTML(new URL(site + ".html?id=" + URLEncoder.encode(getId(), "UTF-8") + "&version=" + URLEncoder.encode(Jenkins.VERSION, "UTF-8")));
+                    jsonString = loadJSONHTML(new URL(site + ".html?id=" + URLEncoder.encode(getId(), "UTF-8") + "&version=" + URLEncoder.encode(Jenkins.getJenkinsVersion(), "UTF-8")));
                     toolInstallerMetadataExists = true;
                 } catch (Exception e) {
                     LOGGER.log(Level.FINE, "Could not load json from " + site, e );

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -186,7 +186,7 @@ public class UpdateSite {
 
     @Restricted(NoExternalUse.class)
     public @Nonnull FormValidation updateDirectlyNow(boolean signatureCheck) throws IOException {
-        return updateData(DownloadService.loadJSON(new URL(getUrl() + "?id=" + URLEncoder.encode(getId(), "UTF-8") + "&version=" + URLEncoder.encode(Jenkins.VERSION, "UTF-8"))), signatureCheck);
+        return updateData(DownloadService.loadJSON(new URL(getUrl() + "?id=" + URLEncoder.encode(getId(), "UTF-8") + "&version=" + URLEncoder.encode(Jenkins.getJenkinsVersion(), "UTF-8"))), signatureCheck);
     }
     
     /**
@@ -577,7 +577,7 @@ public class UpdateSite {
          * Is there a new version of the core?
          */
         public boolean hasCoreUpdates() {
-            return core != null && core.isNewerThan(Jenkins.VERSION);
+            return core != null && core.isNewerThan(Jenkins.getJenkinsVersion());
         }
 
         /**
@@ -1135,9 +1135,10 @@ public class UpdateSite {
         }
         
         public boolean isForNewerHudson() {
+            String jenkinsVersion = Jenkins.getJenkinsVersion();
             try {
-                return requiredCore!=null && new VersionNumber(requiredCore).isNewerThan(
-                  new VersionNumber(Jenkins.VERSION.replaceFirst("SHOT *\\(private.*\\)", "SHOT")));
+                return jenkinsVersion != null && requiredCore!=null && new VersionNumber(requiredCore).isNewerThan(
+                  new VersionNumber(jenkinsVersion.replaceFirst("SHOT *\\(private.*\\)", "SHOT")));
             } catch (NumberFormatException nfe) {
                 return true;  // If unable to parse version
             }

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -128,7 +128,7 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
         o.put("stat",1);
         o.put("install", j.getLegacyInstanceId());
         o.put("servletContainer", j.servletContext.getServerInfo());
-        o.put("version", Jenkins.VERSION);
+        o.put("version", Jenkins.getJenkinsVersion());
 
         List<JSONObject> nodes = new ArrayList<>();
         for( Computer c : j.getComputers() ) {

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -208,11 +208,11 @@ public class InstallUtil {
      * is just restarting, or is being upgraded from an earlier version.
      */
     public static void saveLastExecVersion() {
-        if (Jenkins.VERSION.equals(Jenkins.UNCOMPUTED_VERSION)) {
+        if (Jenkins.UNCOMPUTED_VERSION.equals(Jenkins.getJenkinsVersion())) {
             // This should never happen!! Only adding this check in case someone moves the call to this method to the wrong place.
             throw new IllegalStateException("Unexpected call to InstallUtil.saveLastExecVersion(). Jenkins.VERSION has not been initialized. Call computeVersion() first.");
         }
-        saveLastExecVersion(Jenkins.VERSION);
+        saveLastExecVersion(Jenkins.getJenkinsVersion());
     }
 
     /**
@@ -286,11 +286,11 @@ public class InstallUtil {
     }
 
     private static String getCurrentExecVersion() {
-        if (Jenkins.VERSION.equals(Jenkins.UNCOMPUTED_VERSION)) {
+        if (Jenkins.UNCOMPUTED_VERSION.equals(Jenkins.getJenkinsVersion())) {
             // This should never happen!! Only adding this check in case someone moves the call to this method to the wrong place.
             throw new IllegalStateException("Unexpected call to InstallUtil.getCurrentExecVersion(). Jenkins.VERSION has not been initialized. Call computeVersion() first.");
         }
-        return Jenkins.VERSION;
+        return Jenkins.getJenkinsVersion();
     }
 
     /**

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -213,6 +213,7 @@ import org.acegisecurity.ui.AbstractProcessingFilter;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.Script;
 import org.apache.commons.logging.LogFactory;
+import org.jenkinsci.bytecode.AdaptField;
 import org.jvnet.hudson.reactor.Executable;
 import org.jvnet.hudson.reactor.Milestone;
 import org.jvnet.hudson.reactor.Reactor;
@@ -5080,10 +5081,20 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @Restricted(NoExternalUse.class)
     public static final String UNCOMPUTED_VERSION = "?";
 
+    private static String VERSION = UNCOMPUTED_VERSION;
+
     /**
      * Version number of this Jenkins.
      */
-    public static String VERSION = UNCOMPUTED_VERSION;
+    @AdaptField(name = "VERSION", was = String.class)
+    public static @CheckForNull String getJenkinsVersion() {
+        Jenkins jenkins = getInstanceOrNull();
+        return jenkins != null && jenkins.hasPermission(READ) ? VERSION : null;
+    }
+
+    public static void setJenkinsVersion(String version) {
+        Jenkins.VERSION = version;
+    }
 
     /**
      * Parses {@link #VERSION} into {@link VersionNumber}, or null if it's not parseable as a version number

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5092,6 +5092,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return jenkins != null && jenkins.hasPermission(READ) ? VERSION : null;
     }
 
+    @Restricted(NoExternalUse.class)
     public static void setJenkinsVersion(String version) {
         Jenkins.VERSION = version;
     }

--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -25,7 +25,7 @@ public class PluginWrapperTest {
 
     @Before
     public void before() throws Exception {
-        Jenkins.VERSION = "2.0"; // Some value needed - tests will overwrite if necessary
+        Jenkins.setJenkinsVersion("2.0"); // Some value needed - tests will overwrite if necessary
     }
 
     @Test

--- a/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
+++ b/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
@@ -43,7 +43,7 @@ public class TcpSlaveAgentListenerTest {
 
         TextPage text = wc.getPage(new URL("http://localhost:" + p + "/"));
         String c = text.getContent();
-        assertThat(c, containsString(Jenkins.VERSION));
+        assertThat(c, containsString(Jenkins.getJenkinsVersion()));
 
         wc.setThrowExceptionOnFailingStatusCode(false);
         Page page = wc.getPage(new URL("http://localhost:" + p + "/xxx"));

--- a/test/src/test/java/hudson/model/UsageStatisticsTest.java
+++ b/test/src/test/java/hudson/model/UsageStatisticsTest.java
@@ -96,7 +96,7 @@ public class UsageStatisticsTest {
         assertEquals(1, o.getInt("stat"));
         assertEquals(jenkins.getLegacyInstanceId(), o.getString("install"));
         assertEquals(jenkins.servletContext.getServerInfo(), o.getString("servletContainer"));
-        assertEquals(Jenkins.VERSION, o.getString("version"));
+        assertEquals(Jenkins.getJenkinsVersion(), o.getString("version"));
 
         assertTrue(o.has("plugins"));
         assertTrue(o.has("jobs"));

--- a/test/src/test/java/jenkins/install/InstallUtilTest.java
+++ b/test/src/test/java/jenkins/install/InstallUtilTest.java
@@ -134,7 +134,7 @@ public class InstallUtilTest {
     }
 
     private void setStoredVersion(String version) throws Exception {
-        Jenkins.VERSION = version;
+        Jenkins.setJenkinsVersion(version);
         // Force a save of the config.xml
         jenkinsRule.jenkins.save();
         Assert.assertEquals(version, Jenkins.getStoredVersion().toString());

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -35,17 +35,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.WebResponse;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
-import hudson.maven.MavenModuleSet;
-import hudson.maven.MavenModuleSetBuild;
 import hudson.model.Computer;
 import hudson.model.Failure;
 import hudson.model.InvisibleAction;
@@ -66,13 +62,11 @@ import hudson.util.FormValidation;
 import hudson.util.VersionNumber;
 
 import jenkins.AgentProtocol;
-import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
 import jenkins.security.apitoken.ApiTokenTestHelper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.SmokeTest;
@@ -82,7 +76,6 @@ import org.kohsuke.stapler.HttpResponse;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.io.IOError;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.Socket;
@@ -693,13 +686,13 @@ public class JenkinsTest {
     @Issue("JENKINS-42577")
     @Test
     public void versionIsSavedInSave() throws Exception {
-        Jenkins.VERSION = "1.0";
+        Jenkins.setJenkinsVersion("1.0");
         j.jenkins.save();
         VersionNumber storedVersion = Jenkins.getStoredVersion();
         assertNotNull(storedVersion);
         assertEquals(storedVersion.toString(), "1.0");
 
-        Jenkins.VERSION = null;
+        Jenkins.setJenkinsVersion(null);
         j.jenkins.save();
         VersionNumber nullVersion = Jenkins.getStoredVersion();
         assertNull(nullVersion);


### PR DESCRIPTION
This adds a permission check for getting the Jenkins version to avoid
leaking this to unauthenticated users.

See [JENKINS-56217](https://issues.jenkins-ci.org/browse/JENKINS-56217).

This PR is initially for testing purposes, though depending on the test results, this may also be the implementation.

### Proposed changelog entries

* Removed `X-Jenkins` header and other Jenkins version information for unauthenticated users. This now requires the _Overall/Read_ permission.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

Will update later.