### PR TITLE
Fix invalid condition in toEmailSafeString

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1664,7 +1664,7 @@ public class Functions {
         for( int i=0; i<projectName.length(); i++ ) {
             char ch = projectName.charAt(i);
             if(('a'<=ch && ch<='z')
-            || ('z'<=ch && ch<='Z')
+            || ('A'<=ch && ch<='Z')
             || ('0'<=ch && ch<='9')
             || "-_.".indexOf(ch)>=0)
                 buf.append(ch);


### PR DESCRIPTION
Condition `'z'<=ch && ch<='Z'` is always false. See http://www.asciitable.com/