### PR TITLE
[JENKINS-56217] Create SPI for customizing version info

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1409,7 +1409,7 @@ public class Functions {
     }
 
     public static String getVersion() {
-        return Jenkins.VERSION;
+        return Jenkins.getJenkinsVersion();
     }
 
     /**
@@ -2033,7 +2033,7 @@ public class Functions {
         Jenkins j = Jenkins.getInstanceOrNull();
         if (j!=null) {
             rsp.setHeader("X-Hudson","1.395");
-            rsp.setHeader("X-Jenkins", Jenkins.VERSION);
+            rsp.setHeader("X-Jenkins", Jenkins.getJenkinsVersion());
             rsp.setHeader("X-Jenkins-Session", Jenkins.SESSION_HASH);
 
             TcpSlaveAgentListener tal = j.tcpSlaveAgentListener;

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -747,7 +747,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         if (lastExecVersion.isNewerThan(InstallUtil.NEW_INSTALL_VERSION) && lastExecVersion.isOlderThan(Jenkins.getVersion())) {
 
             LOGGER.log(INFO, "Upgrading Jenkins. The last running version was {0}. This Jenkins is version {1}.",
-                    new Object[] {lastExecVersion, Jenkins.VERSION});
+                    new Object[] {lastExecVersion, Jenkins.getJenkinsVersion()});
 
             final List<DetachedPluginsUtil.DetachedPlugin> detachedPlugins = DetachedPluginsUtil.getDetachedPlugins(lastExecVersion);
 
@@ -783,7 +783,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             });
 
             LOGGER.log(INFO, "Upgraded Jenkins from version {0} to version {1}. Loaded detached plugins (and dependencies): {2}",
-                    new Object[] {lastExecVersion, Jenkins.VERSION, loadedDetached});
+                    new Object[] {lastExecVersion, Jenkins.getJenkinsVersion(), loadedDetached});
 
             InstallUtil.saveLastExecVersion();
         } else {

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -311,7 +311,7 @@ public final class TcpSlaveAgentListener extends Thread {
                     o.write("Content-Type: text/plain;charset=UTF-8\r\n");
                     o.write("\r\n");
                     o.write("Jenkins-Agent-Protocols: " + getAgentProtocolNames()+"\r\n");
-                    o.write("Jenkins-Version: " + Jenkins.VERSION + "\r\n");
+                    o.write("Jenkins-Version: " + Jenkins.getJenkinsVersion() + "\r\n");
                     o.write("Jenkins-Session: " + Jenkins.SESSION_HASH + "\r\n");
                     o.write("Client: " + s.getInetAddress().getHostAddress() + "\r\n");
                     o.write("Server: " + s.getLocalAddress().getHostAddress() + "\r\n");

--- a/core/src/main/java/hudson/UDPBroadcastThread.java
+++ b/core/src/main/java/hudson/UDPBroadcastThread.java
@@ -91,7 +91,7 @@ public class UDPBroadcastThread extends Thread {
                 TcpSlaveAgentListener tal = jenkins.getTcpSlaveAgentListener();
 
                 StringBuilder rsp = new StringBuilder("<hudson>");
-                tag(rsp,"version", Jenkins.VERSION);
+                tag(rsp,"version", Jenkins.getJenkinsVersion());
                 tag(rsp,"url", jenkins.getRootUrl());
                 tag(rsp,"server-id", jenkins.getLegacyInstanceId());
                 tag(rsp,"slave-port",tal==null?null:tal.getPort());

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -456,7 +456,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             
             assert builtOn==null;
             builtOn = node.getNodeName();
-            hudsonVersion = Jenkins.VERSION;
+            hudsonVersion = Jenkins.getJenkinsVersion();
             this.listener = listener;
 
             launcher = createLauncher(listener);

--- a/core/src/main/java/hudson/model/Api.java
+++ b/core/src/main/java/hudson/model/Api.java
@@ -245,7 +245,7 @@ public class Api extends AbstractModelObject {
 
     @Restricted(NoExternalUse.class)
     protected void setHeaders(StaplerResponse rsp) {
-        rsp.setHeader("X-Jenkins", Jenkins.VERSION);
+        rsp.setHeader("X-Jenkins", Jenkins.getJenkinsVersion());
         rsp.setHeader("X-Jenkins-Session", Jenkins.SESSION_HASH);
     }
 

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -100,7 +100,7 @@ public class DownloadService extends PageDecorator {
                        .append(',')
                        .append(QuotedStringTokenizer.quote(mapHttps(d.getUrl())))
                        .append(',')
-                       .append("{version:").append(QuotedStringTokenizer.quote(Jenkins.VERSION)).append('}')
+                       .append("{version:").append(QuotedStringTokenizer.quote(Jenkins.getJenkinsVersion())).append('}')
                        .append(',')
                        .append(QuotedStringTokenizer.quote(Stapler.getCurrentRequest().getContextPath()+'/'+getUrl()+"/byId/"+d.getId()+"/postBack"))
                        .append(',')
@@ -405,7 +405,7 @@ public class DownloadService extends PageDecorator {
                 }
                 String jsonString;
                 try {
-                    jsonString = loadJSONHTML(new URL(site + ".html?id=" + URLEncoder.encode(getId(), "UTF-8") + "&version=" + URLEncoder.encode(Jenkins.VERSION, "UTF-8")));
+                    jsonString = loadJSONHTML(new URL(site + ".html?id=" + URLEncoder.encode(getId(), "UTF-8") + "&version=" + URLEncoder.encode(Jenkins.getJenkinsVersion(), "UTF-8")));
                     toolInstallerMetadataExists = true;
                 } catch (Exception e) {
                     LOGGER.log(Level.FINE, "Could not load json from " + site, e );

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -186,7 +186,7 @@ public class UpdateSite {
 
     @Restricted(NoExternalUse.class)
     public @Nonnull FormValidation updateDirectlyNow(boolean signatureCheck) throws IOException {
-        return updateData(DownloadService.loadJSON(new URL(getUrl() + "?id=" + URLEncoder.encode(getId(), "UTF-8") + "&version=" + URLEncoder.encode(Jenkins.VERSION, "UTF-8"))), signatureCheck);
+        return updateData(DownloadService.loadJSON(new URL(getUrl() + "?id=" + URLEncoder.encode(getId(), "UTF-8") + "&version=" + URLEncoder.encode(Jenkins.getJenkinsVersion(), "UTF-8"))), signatureCheck);
     }
     
     /**
@@ -577,7 +577,7 @@ public class UpdateSite {
          * Is there a new version of the core?
          */
         public boolean hasCoreUpdates() {
-            return core != null && core.isNewerThan(Jenkins.VERSION);
+            return core != null && core.isNewerThan(Jenkins.getJenkinsVersion());
         }
 
         /**
@@ -1137,7 +1137,7 @@ public class UpdateSite {
         public boolean isForNewerHudson() {
             try {
                 return requiredCore!=null && new VersionNumber(requiredCore).isNewerThan(
-                  new VersionNumber(Jenkins.VERSION.replaceFirst("SHOT *\\(private.*\\)", "SHOT")));
+                  new VersionNumber(Jenkins.getJenkinsVersion().replaceFirst("SHOT *\\(private.*\\)", "SHOT")));
             } catch (NumberFormatException nfe) {
                 return true;  // If unable to parse version
             }

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -128,7 +128,7 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
         o.put("stat",1);
         o.put("install", j.getLegacyInstanceId());
         o.put("servletContainer", j.servletContext.getServerInfo());
-        o.put("version", Jenkins.VERSION);
+        o.put("version", Jenkins.getJenkinsVersion());
 
         List<JSONObject> nodes = new ArrayList<>();
         for( Computer c : j.getComputers() ) {

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -208,11 +208,11 @@ public class InstallUtil {
      * is just restarting, or is being upgraded from an earlier version.
      */
     public static void saveLastExecVersion() {
-        if (Jenkins.VERSION.equals(Jenkins.UNCOMPUTED_VERSION)) {
+        if (Jenkins.UNCOMPUTED_VERSION.equals(Jenkins.getJenkinsVersion())) {
             // This should never happen!! Only adding this check in case someone moves the call to this method to the wrong place.
             throw new IllegalStateException("Unexpected call to InstallUtil.saveLastExecVersion(). Jenkins.VERSION has not been initialized. Call computeVersion() first.");
         }
-        saveLastExecVersion(Jenkins.VERSION);
+        saveLastExecVersion(Jenkins.getJenkinsVersion());
     }
 
     /**
@@ -286,11 +286,11 @@ public class InstallUtil {
     }
 
     private static String getCurrentExecVersion() {
-        if (Jenkins.VERSION.equals(Jenkins.UNCOMPUTED_VERSION)) {
+        if (Jenkins.UNCOMPUTED_VERSION.equals(Jenkins.getJenkinsVersion())) {
             // This should never happen!! Only adding this check in case someone moves the call to this method to the wrong place.
             throw new IllegalStateException("Unexpected call to InstallUtil.getCurrentExecVersion(). Jenkins.VERSION has not been initialized. Call computeVersion() first.");
         }
-        return Jenkins.VERSION;
+        return Jenkins.getJenkinsVersion();
     }
 
     /**

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5033,7 +5033,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
 
     private static void computeVersion(ServletContext context) {
-        String ver = getJenkinsVersion();
+        String ver = VERSION_ORACLE_PROVIDER.get().getVersion().orElse(UNCOMPUTED_VERSION);
         context.setAttribute("version",ver);
 
         VERSION_HASH = Util.getDigestOf(ver).substring(0, 8);

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5063,16 +5063,15 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *
      * @since TODO
      */
-    @Nonnull
     @AdaptField(name = "VERSION", was = String.class)
-    public static String getJenkinsVersion() {
-        return VERSION_ORACLE_PROVIDER.get().getVersion().orElse(UNCOMPUTED_VERSION);
+    public static @CheckForNull String getJenkinsVersion() {
+        return VERSION_ORACLE_PROVIDER.get().getVersion().orElse(null);
     }
 
     @Restricted(NoExternalUse.class)
     @VisibleForTesting
     @AdaptField(name = "VERSION", was = String.class)
-    public static void setJenkinsVersion(String version) {
+    public static void setJenkinsVersion(@CheckForNull String version) {
         VersionOracle versionOracle = VERSION_ORACLE_PROVIDER.get();
         if (versionOracle instanceof DefaultVersionOracle) {
             DefaultVersionOracle provider = (DefaultVersionOracle) versionOracle;
@@ -5098,7 +5097,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @Restricted(NoExternalUse.class)
     public @CheckForNull static VersionNumber getStoredVersion() {
-        return toVersion(Jenkins.getActiveInstance().version);
+        return toVersion(Jenkins.get().version);
     }
 
     /**

--- a/core/src/main/java/jenkins/model/version/DefaultVersionOracle.java
+++ b/core/src/main/java/jenkins/model/version/DefaultVersionOracle.java
@@ -1,0 +1,127 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model.version;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Main;
+import jenkins.model.Jenkins;
+import jenkins.util.xml.XMLUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.xml.sax.SAXException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.GuardedBy;
+import javax.xml.xpath.XPathExpressionException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Default implementation of VersionProvider that finds the Jenkins version from an included properties file or
+ * falling back to the Jenkins pom file in {@linkplain Main#isDevelopmentMode development mode}.
+ *
+ * @since TODO
+ */
+public class DefaultVersionOracle implements VersionOracle {
+    private static final Logger LOGGER = Logger.getLogger(DefaultVersionOracle.class.getName());
+
+    @GuardedBy("this")
+    private volatile String version;
+
+    @Nonnull
+    @Override
+    public Optional<String> getVersion() {
+        if (version == null) {
+            synchronized (this) {
+                if (version == null) {
+                    Properties properties = loadJenkinsVersionProperties();
+                    version = properties.getProperty("version", Jenkins.UNCOMPUTED_VERSION);
+                    if (versionRequiresPomLookup(version)) {
+                        version = findJenkinsPomFile()
+                                .flatMap(DefaultVersionOracle::extractVersionFromPom)
+                                .orElse(version);
+                    }
+                }
+            }
+        }
+        return Optional.of(version);
+    }
+
+    private static Properties loadJenkinsVersionProperties() {
+        Properties properties = new Properties();
+        try (InputStream is = Jenkins.class.getResourceAsStream("jenkins-version.properties")) {
+            if (is != null) {
+                properties.load(is);
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Could not read jenkins-version.properties", e);
+        }
+        return properties;
+    }
+
+    private static boolean versionRequiresPomLookup(String version) {
+        return Main.isDevelopmentMode && "${project.version}".equals(version);
+    }
+
+    private static Optional<File> findJenkinsPomFile() {
+        try {
+            for (File dir = new File(".").getAbsoluteFile(); dir != null; dir = dir.getParentFile()) {
+                File pom = new File(dir, "pom.xml");
+                if (pom.exists() && "pom".equals(XMLUtils.getValue("/project/artifactId", pom))) {
+                    return Optional.of(pom.getCanonicalFile());
+                }
+            }
+        } catch (IOException | XPathExpressionException | SAXException e) {
+            LOGGER.log(Level.WARNING, "Could not read Jenkins pom", e);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> extractVersionFromPom(File pom) {
+        LOGGER.info(() -> "Reading Jenkins version from " + pom.getAbsolutePath());
+        try {
+            return Optional.of(XMLUtils.getValue("/project/version", pom));
+        } catch (IOException | XPathExpressionException | SAXException e) {
+            LOGGER.log(Level.WARNING, e, () -> "Could not read Jenkins version from " + pom.getAbsolutePath());
+            return Optional.empty();
+        }
+    }
+
+    @Restricted(NoExternalUse.class)
+    @VisibleForTesting
+    public synchronized void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultVersionOracle{" + version + '}';
+    }
+}

--- a/core/src/main/java/jenkins/model/version/VersionOracle.java
+++ b/core/src/main/java/jenkins/model/version/VersionOracle.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2004-2010, Sun Microsystems, Inc.
+ * Copyright (c) 2019 CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,26 +21,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package hudson.cli;
 
-import hudson.Extension;
-import jenkins.model.Jenkins;
+package jenkins.model.version;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
 
 /**
- * Retrieves the current version.
+ * Strategy to look up the version of Jenkins currently running. Custom implementations may return fake version
+ * numbers or guard access to the version with an authorization check. The configured oracle is obtained via
+ * {@link java.util.ServiceLoader}, so custom implementations should be annotated with {@link org.kohsuke.MetaInfServices}.
+ * If no oracle is available, {@link DefaultVersionOracle} is used. Custom oracles may wish to delegate to
+ * DefaultVersionOracle.
  *
- * @author Kohsuke Kawaguchi
+ * @since TODO
  */
-@Extension
-public class VersionCommand extends CLICommand {
-    @Override
-    public String getShortDescription() {
-        return Messages.VersionCommand_ShortDescription();
-    }
-
-    protected int run() {
-        // CLICommand.main checks Hudson.READ permission.. no other check needed.
-        stdout.println(Jenkins.getJenkinsVersion());
-        return 0;
-    }
+public interface VersionOracle {
+    /**
+     * Returns the version of Jenkins running or empty if it can't be calculated or if it can't be displayed.
+     */
+    @Nonnull
+    Optional<String> getVersion();
 }

--- a/core/src/main/java/jenkins/model/version/VersionOracleProvider.java
+++ b/core/src/main/java/jenkins/model/version/VersionOracleProvider.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model.version;
+
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.concurrent.GuardedBy;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+/**
+ * Supplies a VersionOracle by lazily initializing the service at first use.
+ * This cannot use the ExtensionList mechanism due to startup ordering and being used by the Jenkins constructor.
+ */
+@Restricted(NoExternalUse.class)
+public class VersionOracleProvider implements Supplier<VersionOracle> {
+    private static final Logger LOGGER = Logger.getLogger(VersionOracleProvider.class.getName());
+
+    @GuardedBy("this")
+    private volatile VersionOracle oracle;
+
+    @Override
+    public VersionOracle get() {
+        if (oracle == null) {
+            synchronized (this) {
+                if (oracle == null) {
+                    LOGGER.fine("Initializing VersionOracle");
+                    VersionOracle oracle = findMetaInfProvider().orElseGet(DefaultVersionOracle::new);
+                    LOGGER.fine(() -> "Found VersionOracle: " + oracle);
+                    this.oracle = oracle;
+                }
+            }
+        }
+        LOGGER.fine(() -> "Returning VersionOracle: " + oracle);
+        return oracle;
+    }
+
+    private static Optional<VersionOracle> findMetaInfProvider() {
+        for (VersionOracle oracle : ServiceLoader.load(VersionOracle.class, getClassLoader())) {
+            return Optional.of(oracle);
+        }
+        return Optional.empty();
+    }
+
+    private static ClassLoader getClassLoader() {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        return jenkins != null ? jenkins.pluginManager.uberClassLoader : Thread.currentThread().getContextClassLoader();
+    }
+}

--- a/core/src/main/java/jenkins/model/version/VersionOracleProvider.java
+++ b/core/src/main/java/jenkins/model/version/VersionOracleProvider.java
@@ -57,7 +57,6 @@ public class VersionOracleProvider implements Supplier<VersionOracle> {
                 }
             }
         }
-        LOGGER.fine(() -> "Returning VersionOracle: " + oracle);
         return oracle;
     }
 

--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -25,7 +25,7 @@ public class PluginWrapperTest {
 
     @Before
     public void before() throws Exception {
-        Jenkins.VERSION = "2.0"; // Some value needed - tests will overwrite if necessary
+        Jenkins.setJenkinsVersion("2.0"); // Some value needed - tests will overwrite if necessary
     }
 
     @Test

--- a/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
+++ b/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
@@ -43,7 +43,7 @@ public class TcpSlaveAgentListenerTest {
 
         TextPage text = wc.getPage(new URL("http://localhost:" + p + "/"));
         String c = text.getContent();
-        assertThat(c, containsString(Jenkins.VERSION));
+        assertThat(c, containsString(Jenkins.getJenkinsVersion()));
 
         wc.setThrowExceptionOnFailingStatusCode(false);
         Page page = wc.getPage(new URL("http://localhost:" + p + "/xxx"));

--- a/test/src/test/java/hudson/model/UsageStatisticsTest.java
+++ b/test/src/test/java/hudson/model/UsageStatisticsTest.java
@@ -96,7 +96,7 @@ public class UsageStatisticsTest {
         assertEquals(1, o.getInt("stat"));
         assertEquals(jenkins.getLegacyInstanceId(), o.getString("install"));
         assertEquals(jenkins.servletContext.getServerInfo(), o.getString("servletContainer"));
-        assertEquals(Jenkins.VERSION, o.getString("version"));
+        assertEquals(Jenkins.getJenkinsVersion(), o.getString("version"));
 
         assertTrue(o.has("plugins"));
         assertTrue(o.has("jobs"));

--- a/test/src/test/java/jenkins/install/InstallUtilTest.java
+++ b/test/src/test/java/jenkins/install/InstallUtilTest.java
@@ -134,7 +134,7 @@ public class InstallUtilTest {
     }
 
     private void setStoredVersion(String version) throws Exception {
-        Jenkins.VERSION = version;
+        Jenkins.setJenkinsVersion(version);
         // Force a save of the config.xml
         jenkinsRule.jenkins.save();
         Assert.assertEquals(version, Jenkins.getStoredVersion().toString());

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -35,17 +35,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.WebResponse;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
-import hudson.maven.MavenModuleSet;
-import hudson.maven.MavenModuleSetBuild;
 import hudson.model.Computer;
 import hudson.model.Failure;
 import hudson.model.InvisibleAction;
@@ -66,13 +62,11 @@ import hudson.util.FormValidation;
 import hudson.util.VersionNumber;
 
 import jenkins.AgentProtocol;
-import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
 import jenkins.security.apitoken.ApiTokenTestHelper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.SmokeTest;
@@ -82,7 +76,6 @@ import org.kohsuke.stapler.HttpResponse;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.io.IOError;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.Socket;
@@ -693,13 +686,13 @@ public class JenkinsTest {
     @Issue("JENKINS-42577")
     @Test
     public void versionIsSavedInSave() throws Exception {
-        Jenkins.VERSION = "1.0";
+        Jenkins.setJenkinsVersion("1.0");
         j.jenkins.save();
         VersionNumber storedVersion = Jenkins.getStoredVersion();
         assertNotNull(storedVersion);
         assertEquals(storedVersion.toString(), "1.0");
 
-        Jenkins.VERSION = null;
+        Jenkins.setJenkinsVersion(null);
         j.jenkins.save();
         VersionNumber nullVersion = Jenkins.getStoredVersion();
         assertNull(nullVersion);


### PR DESCRIPTION
This adds a new VersionOracle SPI to allow for plugins to customize
the Jenkins version information. This is useful for implementing
additional authorization checks or faking version numbers.

There will be a follow-up PR for [ESS](https://github.com/jenkinsci/extended-security-settings-plugin) to implement the actual authorization check feature requested in the ticket. Additional tests are provided there. The changes in this Jenkins PR maintain the same behavior as before by default.

See [JENKINS-56217](https://issues.jenkins-ci.org/browse/JENKINS-56217).

Note: I do have one remaining design decision here that could use some feedback. I've removed the public static `VERSION` field and added an `@AdaptField`, though I wonder if it makes sense to remove the field since it makes writing code that targets Jenkins before and after this change non-trivial (i.e., would require reflection).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: Added `VersionOracle` SPI to allow plugins to customize the behavior for obtaining the currently running version of Jenkins.
* Internal: Replaced `Jenkins.VERSION` public static field with new static methods `Jenkins.getJenkinsVersion()` and `Jenkins.setJenkinsVersion()` and adapted existing calls to the field to use the new methods. Newly compiled code should switch to use the method instead.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev @jtnord @jglick @daniel-beck @Wadeck @jeffret-b 