### PR TITLE
Upgrade to 3.34 version of Remoting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3.33</remoting.version>
+    <remoting.version>3.34</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.4</remoting.minimum.supported.version>
 


### PR DESCRIPTION
See [JENKINS-53461](https://issues.jenkins-ci.org/browse/JENKINS-53461). This enables a new connection mode for inbound TCP agents whereby they can skip the initial HTTP connection step by providing sufficient information to connect directly. This is documented, along with a few other existing behaviors, at [Launching inbound TCP agents](https://github.com/jenkinsci/remoting/blob/master/docs/tcpAgent.md). The PR for this change is located at jenkinsci/remoting#338.

This Remoting release also contains a few other minor cleanup changes, which didn't need a JIRA filed.

See the [Remoting changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-3.34)

### Proposed changelog entries

* Update Remoting from 3.33 to 3.34. ([issue 53461](https://issues.jenkins-ci.org/browse/JENKINS-53461), [full changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-3.34))

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jvz @oleg-nenashev @alxsap
