### PR TITLE
[JENKINS-59017] disable ForceSetupWizardFilter if setup complete

### DIFF
--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -607,7 +607,7 @@ public class SetupWizard extends PageDecorator {
         @Override
         public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
             // Force root requests to the setup wizard
-            if (request instanceof HttpServletRequest) {
+            if (request instanceof HttpServletRequest && !Jenkins.get().getInstallState().isSetupComplete()) {
                 HttpServletRequest req = (HttpServletRequest) request;
                 String requestURI = req.getRequestURI();
                 if (requestURI.equals(req.getContextPath()) && !requestURI.endsWith("/")) {


### PR DESCRIPTION
See [JENKINS-59017](https://issues.jenkins-ci.org/browse/JENKINS-59017).
This change is as minimal as possible. It can't be autotested without massive SetupWizard refactoring. 
I tested this logic by plugin, which adds filter just like FORCE_SETUP_WIZARD_FILTER.
And tested the work of Setup Wizard - OK.

### Proposed changelog entries

* Bug: Sometimes after Setup Wizard completion user saw only blank page

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change).
- [X] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@jenkinsci/code-reviewers