### PR TITLE
minor grammar improvements

### DIFF
--- a/core/src/main/java/hudson/slaves/RetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/RetentionStrategy.java
@@ -50,22 +50,22 @@ import javax.annotation.Nonnull;
 public abstract class RetentionStrategy<T extends Computer> extends AbstractDescribableImpl<RetentionStrategy<?>> implements ExtensionPoint {
 
     /**
-     * This method will be called periodically to allow this strategy to decide what to do with it's owning agent.
+     * This method will be called periodically to allow this strategy to decide what to do with its owning agent.
      *
      * @param c {@link Computer} for which this strategy is assigned. This computer may be online or offline.
      *          This object also exposes a bunch of properties that the callee can use to decide what action to take.
      * @return The number of minutes after which the strategy would like to be checked again. The strategy may be
-     *         rechecked earlier or later that this!
+     *         rechecked earlier or later than this!
      */
     @GuardedBy("hudson.model.Queue.lock")
     public abstract long check(@Nonnull T c);
 
     /**
-     * This method is called to determine whether manual launching of the agent is allowed at this point in time.
+     * This method is called to determine whether manual launching of the agent is allowed right now.
      * @param c {@link Computer} for which this strategy is assigned. This computer may be online or offline.
      *          This object also exposes a bunch of properties that the callee can use to decide if manual launching is
-     * allowed at this time.
-     * @return {@code true} if manual launching of the agent is allowed at this point in time.
+     *          allowed.
+     * @return {@code true} if manual launching of the agent is allowed right now.
      */
     public boolean isManualLaunchAllowed(T c) {
         return true;
@@ -87,7 +87,7 @@ public abstract class RetentionStrategy<T extends Computer> extends AbstractDesc
 
     /**
      * Called when a new {@link Computer} object is introduced (such as when Hudson started, or when
-     * a new agent is added.)
+     * a new agent is added).
      *
      * <p>
      * The default implementation of this method delegates to {@link #check(Computer)},


### PR DESCRIPTION
### Proposed changelog entries

* Minor grammatical improvements to API doc for RetentionStrategy

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers