### PR TITLE
Remove slave from french messages and correct one accent

### DIFF
--- a/core/src/main/resources/hudson/model/Messages_fr.properties
+++ b/core/src/main/resources/hudson/model/Messages_fr.properties
@@ -101,7 +101,7 @@ Job.NoRecentBuildFailed=Aucun build r\u00e9cent n''a \u00e9chou\u00e9.
 Job.Pronoun=job
 Job.minutes=mn
 
-Queue.AllNodesOffline=Tous les esclaves avec le libell\u00e9 ''{0}'' sont hors ligne
+Queue.AllNodesOffline=Tous les noeuds avec le libell\u00e9 ''{0}'' sont hors ligne
 Queue.BlockedBy=Bloqu\u00e9 par {0}
 Queue.HudsonIsAboutToShutDown=Jenkins est sur le point de se fermer
 Queue.InProgress=Un build est d\u00e9j\u00e0 en cours
@@ -157,7 +157,7 @@ ChoiceParameterDefinition.MissingChoices=Choix requis.
 RunParameterDefinition.DisplayName=Param\u00e8tre d''ex\u00e9cution
 PasswordParameterDefinition.DisplayName=Param\u00e8tre "Mot de passe"
 
-Node.Mode.NORMAL=Utiliser cet esclave autant que possible
+Node.Mode.NORMAL=Utiliser ce noeud autant que possible
 Node.Mode.EXCLUSIVE=R\u00e9server cette machine pour les jobs qui lui sont attach\u00e9s seulement
 
 ListView.DisplayName=Vue liste
@@ -178,5 +178,5 @@ MyViewsProperty.DisplayName=Mes vues
 MyViewsProperty.GlobalAction.DisplayName=Mes vues
 
 ManageJenkinsAction.DisplayName=Administrer Jenkins
-ParametersDefinitionProperty.DisplayName=Ce build a des paramètres
+ParametersDefinitionProperty.DisplayName=Ce build a des param\u00e8tres
 


### PR DESCRIPTION
I replace "slave" word on french message by "node" word, I don't know if they are used but I prefer that the word never exists.

I also see an accent that is not encoded in the same file.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Replace slave word by node word in fr messages.
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
