### PR TITLE
[JENKINS-59094] - Revert "Upgrade to 3.34 version of Remoting."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3.34</remoting.version>
+    <remoting.version>3.33</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.4</remoting.minimum.supported.version>
 


### PR DESCRIPTION
Reverts jenkinsci/jenkins#4165 to fix https://issues.jenkins-ci.org/browse/JENKINS-59094 . The issue affects Jenkins 2.191 and 2.192. The latter one is a security release, and users have to accept the regression in Remoting when using tunneling if they want to have a security fix. Pick your poison....

Since https://github.com/jenkinsci/remoting/pull/345 is not ready IMO, I suggest reverting the remoting upgrade even if it means a temporary removal of new features included there.

## Changelog entry

* major-bug: Revert "Upgrade to 3.34 version of Remoting" which was preventing agents from connecting when tunneling options were set (regression in 2.191)

CC @alxsap 