### PR TITLE
Fix Fingerprinter.Recording typo in german translation

### DIFF
--- a/core/src/main/resources/hudson/tasks/Messages_de.properties
+++ b/core/src/main/resources/hudson/tasks/Messages_de.properties
@@ -58,7 +58,7 @@ Fingerprinter.DigestFailed=Berechnung der Pr\u00FCfsumme f\u00FCr {0} fehlgeschl
 Fingerprinter.DisplayName=Fingerabdr\u00FCcke von Dateien aufzeichnen, um deren Verwendung zu verfolgen
 Fingerprinter.Failed=Aufzeichnen der Fingerabdr\u00FCcke fehlgeschlagen
 Fingerprinter.FailedFor=Aufzeichnen des Fingerabdrucks f\u00FCr {0} fehlgeschlagen
-Fingerprinter.Recording=Zeichne Fingerabr\u00FCcke auf
+Fingerprinter.Recording=Zeichne Fingerabdr\u00FCcke auf
 
 InstallFromApache=Installiere von Apache
 


### PR DESCRIPTION
There is a Typo in the german translation of Fingerprinter.Recording. This PR fixes this typo

### Proposed changelog entries

* Fix german translation: Fingerprinter.Recording is fixed to Fingerabdrücke not Fingerabrücke
