### PR TITLE
Recommend better Jelly tag for delete buttons in the repeatableProperty taglib item

### DIFF
--- a/core/src/main/resources/lib/form/repeatableProperty.jelly
+++ b/core/src/main/resources/lib/form/repeatableProperty.jelly
@@ -30,11 +30,11 @@ THE SOFTWARE.
 
     Unless that nested config.jelly already adds a delete button (deprecated), you should normally put the following inside this tag:
 
-      	<f:entry title="">
+      	<f:block>
           <div align="right">
             <f:repeatableDeleteButton />
           </div>
-        </f:entry>
+        </f:block>
     ]]>
 
     <st:attribute name="field">


### PR DESCRIPTION
An empty f:entry is basically the same thing as f:block but with extra
steps.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

No entries required.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] ~JIRA issue is well described~
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] ~Appropriate autotests or explanation to why this change has no tests~
- [ ] ~For dependency updates: links to external changelogs and, if possible, full diffs~

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

Whoever.