### PR TITLE
I find a issue about this Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 # If you are looking for official images, see https://github.com/jenkinsci/docker
 FROM maven:3.5.4-jdk-8 as builder
 
+# ? where is the source path, please help update the source path, thanks.
 COPY .mvn/ /jenkins/src/.mvn/
 COPY cli/ /jenkins/src/cli/
 COPY core/ /jenkins/src/core/
@@ -26,3 +27,8 @@ LABEL Description="This is an experimental image for the master branch of the Je
 
 COPY --from=builder /jenkins/src/war/target/jenkins.war /usr/share/jenkins/jenkins.war
 ENTRYPOINT ["tini", "--", "/usr/local/bin/jenkins.sh"]
+
+
+
+
+


### PR DESCRIPTION
# below is my actual test result,

1. Dockerfile
FROM maven:3.5.4-jdk-8 as builder

mkdir -p /jenkins/src/.mvn
mkdir -p /jenkins/src/cli
mkdir -p /jenkins/src/core
mkdir -p /jenkins/src/src
mkdir -p /jenkins/src/test
mkdir -p /jenkins/src/pom
mkdir -p /jenkins/src/jdk8
mkdir -p /jenkins/src/war

COPY .mvn/ /jenkins/src/.mvn/
COPY cli/ /jenkins/src/cli/
COPY core/ /jenkins/src/core/
COPY src/ /jenkins/src/src/
COPY test/ /jenkins/src/test/
COPY test-pom/ /jenkins/src/pom/
COPY test-jdk8/ /jenkins/src/jdk8/
COPY war/ /jenkins/src/war/
COPY *.xml /jenkins/src/
COPY LICENSE.txt /jenkins/src/LICENSE.txt
COPY licenseCompleter.groovy /jenkins/src/licenseCompleter.groovy
COPY show-pom-version.rb /jenkins/src/show-pom-version.rb

WORKDIR /jenkins/src/
RUN mvn clean install --batch-mode -Plight-test


2. test result
[root@CNT7XDCK11D01 jenkins]# docker build -f /opt/dockerfile/jenkins/jenkins-master.Dockerfile .
Sending build context to Docker daemon   2.56kB
Step 1/24 : FROM maven:3.5.4-jdk-8 as builder
3.5.4-jdk-8: Pulling from library/maven
bc9ab73e5b14: Pull complete 
193a6306c92a: Pull complete 
e5c3f8c317dc: Pull complete 
a587a86c9dcb: Pull complete 
a4c7ee7ef122: Pull complete 
a7c0dad691e9: Pull complete 
367a6a68b113: Pull complete 
60c0e52d1ec2: Pull complete 
c9d22bc43935: Pull complete 
41dbcd970503: Pull complete 
72c52bb7e9b7: Pull complete 
275d6d4a835d: Pull complete 
Digest: sha256:b90230c6c65fa00b3404555ad9d3a131101cef791e5583aab18ac420def7d6bb
Status: Downloaded newer image for maven:3.5.4-jdk-8
 ---> 985f3637ded4
Step 2/24 : RUN  ls -al
 ---> Running in 0171116a0fc7
total 0
drwxr-xr-x   1 root root   6 Sep 10 10:14 .
drwxr-xr-x   1 root root   6 Sep 10 10:14 ..
-rwxr-xr-x   1 root root   0 Sep 10 10:14 .dockerenv
drwxr-xr-x   1 root root 179 Oct 16  2018 bin
drwxr-xr-x   2 root root   6 Jun 26  2018 boot
drwxr-xr-x   5 root root 340 Sep 10 10:14 dev
lrwxrwxrwx   1 root root  33 Oct 16  2018 docker-java-home -> /usr/lib/jvm/java-8-openjdk-amd64
drwxr-xr-x   1 root root  66 Sep 10 10:14 etc
drwxr-xr-x   2 root root   6 Jun 26  2018 home
drwxr-xr-x   1 root root  30 Oct 11  2018 lib
drwxr-xr-x   2 root root  34 Oct 11  2018 lib64
drwxr-xr-x   2 root root   6 Oct 11  2018 media
drwxr-xr-x   2 root root   6 Oct 11  2018 mnt
drwxr-xr-x   2 root root   6 Oct 11  2018 opt
dr-xr-xr-x 163 root root   0 Sep 10 10:14 proc
drwx------   2 root root  37 Oct 11  2018 root
drwxr-xr-x   3 root root  30 Oct 11  2018 run
drwxr-xr-x   1 root root  20 Oct 16  2018 sbin
drwxr-xr-x   2 root root   6 Oct 11  2018 srv
dr-xr-xr-x  13 root root   0 Sep 10 10:14 sys
drwxrwxrwt   1 root root   6 Oct 30  2018 tmp
drwxr-xr-x   1 root root  19 Oct 11  2018 usr
drwxr-xr-x   1 root root  41 Oct 11  2018 var
Removing intermediate container 0171116a0fc7
 ---> f2aa6635bba4
Step 3/24 : RUN  mkdir -p /jenkins/src/.mvn
 ---> Running in 03c2d804ed91
Removing intermediate container 03c2d804ed91
 ---> d58ea62fc1d6
Step 4/24 : RUN  mkdir -p /jenkins/src/cli
 ---> Running in e6f20164edef
Removing intermediate container e6f20164edef
 ---> d2e5db2d463b
Step 5/24 : RUN  mkdir -p /jenkins/src/core
 ---> Running in 9e130e14df5d
Removing intermediate container 9e130e14df5d
 ---> 200f372836ba
Step 6/24 : RUN  mkdir -p /jenkins/src/src
 ---> Running in e9a6eaad1ba1
Removing intermediate container e9a6eaad1ba1
 ---> ddb015f8edb2
Step 7/24 : RUN  mkdir -p /jenkins/src/test
 ---> Running in 1c14f09f067f
Removing intermediate container 1c14f09f067f
 ---> 355147fa9a01
Step 8/24 : RUN  mkdir -p /jenkins/src/pom
 ---> Running in 8643373752d3
Removing intermediate container 8643373752d3
 ---> 759e97ea7c5f
Step 9/24 : RUN  mkdir -p /jenkins/src/jdk8
 ---> Running in b8f5c5d27010
Removing intermediate container b8f5c5d27010
 ---> fc959df7f094
Step 10/24 : RUN  mkdir -p /jenkins/src/war
 ---> Running in d21d467db1fe
Removing intermediate container d21d467db1fe
 ---> c172e6076906
Step 11/24 : COPY .mvn/ /jenkins/src/.mvn/
COPY failed: stat /k8s/docker/data/tmp/docker-builder457624793/.mvn: no such file or directory
[root@CNT7XDCK11D01 jenkins]#

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
