### PR TITLE
[JENKINS-59393] - Fix malformed XML in Atom and RSS 2.0 feeds and [JENKINS-59231] - Improve test coverage on the RSS feature

### DIFF
--- a/core/src/main/java/hudson/model/RSS.java
+++ b/core/src/main/java/hudson/model/RSS.java
@@ -82,6 +82,12 @@ public final class RSS {
         if(flavor==null)    flavor="atom";
         flavor = flavor.replace('/', '_'); // Don't allow path to any jelly
 
+        if (flavor.equals("atom")) {
+            rsp.setContentType("application/atom+xml; charset=UTF-8");
+        } else {
+            rsp.setContentType("text/xml; charset=UTF-8");
+        }
+
         req.getView(Jenkins.get(),"/hudson/"+flavor+".jelly").forward(req,rsp);
     }
 }

--- a/test/src/test/java/hudson/model/RSSTest.java
+++ b/test/src/test/java/hudson/model/RSSTest.java
@@ -42,10 +42,7 @@ public class RSSTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    //TODO remove the @Ignore 
-    // Seems the XML parser on the CI machine is different / more picky than the one on my machine, will be covered by JENKINS-59231 to improve the code coverage
     @Test
-    @Ignore("XML parser too picky on CI")
     @Issue("JENKINS-59167")
     public void absoluteURLsPresentInRSS_evenWithoutRootUrlSetup() throws Exception {
         XmlPage page = getRssPage();
@@ -76,10 +73,7 @@ public class RSSTest {
         }
     }
 
-    //TODO remove the @Ignore 
-    // Seems the XML parser on the CI machine is different / more picky than the one on my machine, will be covered by JENKINS-59231 to improve the code coverage
     @Test
-    @Ignore("XML parser too picky on CI")
     @Issue("JENKINS-59167")
     public void absoluteURLsPresentInAtom_evenWithoutRootUrlSetup() throws Exception {
         XmlPage page = getAtomPage();


### PR DESCRIPTION
See [JENKINS-59393](https://issues.jenkins-ci.org/browse/JENKINS-59393) and [JENKINS-59231](https://issues.jenkins-ci.org/browse/JENKINS-59231).

### Problem

jenkinsci/jenkins#4188 added a test for RSS feed support, but the test is ignored by default. When I run the test locally, I get the following error:

```
[...]
2.018 [id=29]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
2.843 [id=14]	WARNING	c.g.htmlunit.xml.XmlPage#<init>: Failed parsing XML document http://localhost:34837/jenkins/rssAll: The element type "link" must be terminated by the matching end-tag "</link>".
2.962 [id=14]	INFO	jenkins.model.Jenkins#cleanUp: Stopping Jenkins
3.028 [id=14]	INFO	jenkins.model.Jenkins#cleanUp: Jenkins stopped

java.lang.NullPointerException
	at hudson.model.RSSTest.absoluteURLsPresentInAtom_evenWithoutRootUrlSetup(RSSTest.java:80)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:600)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```

### Evaluation

The warning printed while running the test provides a clue as to what is going on:

> Failed parsing XML document http://localhost:34837/jenkins/rssAll: The element type "`link`" must be terminated by the matching end-tag "`</link>`".

Inserting an interactive break and fetching the URL, we see that Jenkins is returning malformed XML:

```
$ curl http://localhost:43969/jenkins/rssAll
<?xml version="1.0" encoding="UTF-8"?>

<feed xmlns="http://www.w3.org/2005/Atom"><title>All all builds</title><link rel="alternate" type="text/html" href="http://localhost:43969/jenkins/"><updated>2001-01-01T00:00:00Z</updated><author><name>Jenkins Server</name></author><id>urn:uuid:903deee0-7bfa-11db-9fe1-0800200c9a66</id></feed>
```

Note that the `<link>` tag doesn't have a closing `</link>` tag, just as the warning said. Why not? After all, one is present in the template:

```
$ grep link core/src/main/resources/hudson/atom.jelly
<link rel="alternate" type="text/html" href="${app.rootUrl}${url}"/>
<link rel="alternate" type="text/html" href="${app.rootUrl}${h.encode(adapter.getEntryUrl(e))}"/>
```

So Jelly must be screwing this up when filling in the template. Where is that happening? Stepping through the code in the debuggers reveals this stack trace:

```
createXMLOutput:68, DefaultScriptInvoker (org.kohsuke.stapler.jelly)
invokeScript:51, DefaultScriptInvoker (org.kohsuke.stapler.jelly)
execute:56, ScriptInvoker (org.kohsuke.stapler.jelly)
execute:43, ScriptInvoker (org.kohsuke.stapler.jelly)
forward:95, ScriptRequestDispatcher (org.kohsuke.stapler)
forwardToRss:91, RSS (hudson.model)
```

`CreateXMLOutput` looks like this:

```java
protected XMLOutput createXMLOutput(StaplerRequest req, StaplerResponse rsp, Script script, Object it) throws IOException {
    // TODO: make XMLOutput auto-close OutputStream to avoid leak
    String ct = rsp.getContentType();
    XMLOutput output;
    if (ct != null && !ct.startsWith("text/html")) {
        output = XMLOutput.createXMLOutput(createOutputStream(req, rsp, script, it));
    } else {
        output = HTMLWriterOutput.create(createOutputStream(req, rsp, script, it));

    }
    return output;
}
```

As you can see, there are two paths, one for XML output and one for HTML output. Stepping through this, I see that for RSS feeds `rsp.getContentType()` is null, so we go through the (incorrect) HTML output path. This results in malformed XML.

### Solution

Set the content type appropriately on the response in `RSS#forwardToRss`. I stole the existing content types from `core/src/main/resources/hudson/atom.jelly` and `core/src/main/resources/hudson/rss20.jelly`. With this set, we now use the XML output path in `RSS#forwardToRss` and produce well-formed XML:

```
$ curl  http://localhost:43831/jenkins/rssAll
<?xml version="1.0" encoding="UTF-8"?>

<feed xmlns="http://www.w3.org/2005/Atom"><title>All all builds</title><link rel="alternate" type="text/html" href="http://localhost:43831/jenkins/"></link><updated>2019-09-13T20:13:05Z</updated><author><name>Jenkins Server</name></author><id>urn:uuid:903deee0-7bfa-11db-9fe1-0800200c9a66</id><entry><title>test0 #1 (stable)</title><link rel="alternate" type="text/html" href="http://localhost:43831/jenkins/job/test0/1/"></link><id>tag:hudson.dev.java.net,2019:test0:1</id><published>2019-09-13T20:13:05Z</published><updated>2019-09-13T20:13:05Z</updated></entry></feed>
```

### Proposed changelog entries

* Fix malformed XML in Atom and RSS 2.0 feeds.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@jeffret-b 
@jvz
@Wadeck 