### PR TITLE
Replace internal search implementation in SortedIntList with java.util.Arrays.binarySearch

### DIFF
--- a/core/src/main/java/jenkins/model/lazy/SortedIntList.java
+++ b/core/src/main/java/jenkins/model/lazy/SortedIntList.java
@@ -60,7 +60,7 @@ class SortedIntList extends AbstractList<Integer> {
      *      That is, -1 means the probe would be inserted at the very beginning.
      */
     public int find(int probe) {
-        return binarySearch(data, 0, size, probe);
+        return Arrays.binarySearch(data, 0, size, probe);
     }
 
     @Override
@@ -151,26 +151,5 @@ class SortedIntList extends AbstractList<Integer> {
         if (idx<0)  return;
         System.arraycopy(data,idx+1,data,idx,size-(idx+1));
         size--;
-    }
-
-    /**
-     * Switch to {@code java.util.Arrays.binarySearch} when we depend on Java6.
-     */
-    private static int binarySearch(int[] a, int start, int end, int key) {
-        int lo = start, hi = end-1; // search range is [lo,hi]
-
-        // invariant lo<=hi
-        while (lo <= hi) {
-            int pivot = (lo + hi)/2;
-            int v = a[pivot];
-
-            if (v < key)        // needs to search upper half
-                lo = pivot+1;
-            else if (v > key)   // needs to search lower half
-                hi = pivot-1;
-            else    // eureka!
-                return pivot;
-        }
-        return -(lo + 1); // insertion point
     }
 }


### PR DESCRIPTION
I looked for spotbugs issues and found a IM_AVERAGE_COMPUTATION_COULD_OVERFLOW.
But since the comment was to replace the whole function with a java util function I did as suggested instead of fixing just the error.

### Proposed changelog entries

* Internal: Replaced internal function with java.util.Arrays.binarySearch

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs


### Desired reviewers
