### PR TITLE
[JENKINS-36720] - Add missing null checks in `FilePath#installIfNecessaryFrom()` logging

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -845,10 +845,13 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * @since 1.299
      */
     public boolean installIfNecessaryFrom(@Nonnull URL archive, @CheckForNull TaskListener listener, @Nonnull String message) throws IOException, InterruptedException {
+        if (listener == null) {
+            listener = TaskListener.NULL;
+        }
         return installIfNecessaryFrom(archive, listener, message, MAX_REDIRECTS);
     }
 
-    private boolean installIfNecessaryFrom(@Nonnull URL archive, @CheckForNull TaskListener listener, @Nonnull String message, int maxRedirects) throws InterruptedException, IOException {
+    private boolean installIfNecessaryFrom(@Nonnull URL archive, @Nonnull TaskListener listener, @Nonnull String message, int maxRedirects) throws InterruptedException, IOException {
         try {
             FilePath timestamp = this.child(".timestamp");
             long lastModified = timestamp.lastModified();
@@ -862,9 +865,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
             } catch (IOException x) {
                 if (this.exists()) {
                     // Cannot connect now, so assume whatever was last unpacked is still OK.
-                    if (listener != null) {
-                        listener.getLogger().println("Skipping installation of " + archive + " to " + remote + ": " + x);
-                    }
+                    listener.getLogger().println("Skipping installation of " + archive + " to " + remote + ": " + x);
                     return false;
                 } else {
                     throw x;
@@ -906,8 +907,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                 this.mkdirs();
             }
 
-            if(listener!=null)
-                listener.getLogger().println(message);
+            listener.getLogger().println(message);
 
             if (isRemote()) {
                 // First try to download from the agent machine.
@@ -916,9 +916,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                     timestamp.touch(sourceTimestamp);
                     return true;
                 } catch (IOException x) {
-                    if (listener != null) {
-                        Functions.printStackTrace(x, listener.error("Failed to download " + archive + " from agent; will retry from master"));
-                    }
+                    Functions.printStackTrace(x, listener.error("Failed to download " + archive + " from agent; will retry from master"));
                 }
             }
 

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -664,9 +664,8 @@ public class FilePathTest {
         when(con2.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
         when(con2.getInputStream()).thenReturn(someZippedContent());
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
         String message = "going ahead";
-        assertTrue(d.installIfNecessaryFrom(url, new StreamTaskListener(baos), message));
+        assertTrue(d.installIfNecessaryFrom(url, null, message));
     }
 
     private URL someUrlToZipFile(final URLConnection con) throws IOException {


### PR DESCRIPTION
According to method signature, 'listener' argument is marked @CheckForNull. Some null checks were missing which this commit adds.
No user visible impact.


<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
