### PR TITLE
[JENKINS-59383] Fix the DiskMonitorSpaceDescriptor toString() message when the monitor alert is not triggered

### DIFF
--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorDescriptor.java
@@ -71,7 +71,10 @@ public abstract class DiskSpaceMonitorDescriptor extends AbstractAsyncNodeMonito
 
         @Override
         public String toString() {
-            return Messages.DiskSpaceMonitorDescriptor_DiskSpace_FreeSpaceTooLow(getGbLeft(), path);
+            if(triggered) {
+                return Messages.DiskSpaceMonitorDescriptor_DiskSpace_FreeSpaceTooLow(getGbLeft(), path);
+            }
+            return Messages.DiskSpaceMonitorDescriptor_DiskSpace_FreeSpace(getGbLeft(), path);
         }
         
         /**

--- a/core/src/main/resources/hudson/node_monitors/Messages.properties
+++ b/core/src/main/resources/hudson/node_monitors/Messages.properties
@@ -32,4 +32,5 @@ SwapSpaceMonitor.DisplayName=Free Swap Space
 TemporarySpaceMonitor.DisplayName=Free Temp Space
 AbstractNodeMonitorDescriptor.NoDataYet=Not yet
 DiskSpaceMonitorDescriptor.DiskSpace.FreeSpaceTooLow=Disk space is too low. Only {0}GB left on {1}.
+DiskSpaceMonitorDescriptor.DiskSpace.FreeSpace={0}GB left on {1}.
 MonitorMarkedNodeOffline.DisplayName=Node Marked Offline Due to Health Check

--- a/test/src/test/java/hudson/node_monitors/DiskSpaceMonitorDescriptorTest.java
+++ b/test/src/test/java/hudson/node_monitors/DiskSpaceMonitorDescriptorTest.java
@@ -49,4 +49,14 @@ public class DiskSpaceMonitorDescriptorTest {
         assertEquals(1024*1024*1024,DiskSpace.parse("1GB").size);
         assertEquals(512*1024*1024,DiskSpace.parse("0.5GB").size);
     }
+
+    @Test
+    @WithoutJenkins
+    @Issue("JENKINS-59383")
+    public void string() {
+        DiskSpace du = new DiskSpace("/tmp", 123*1024*1024);
+        assertEquals("0.123GB left on /tmp.", du.toString());
+        du.setTriggered(true);
+        assertEquals("Disk space is too low. Only 0.123GB left on /tmp.", du.toString());
+    }
 }


### PR DESCRIPTION
See [JENKINS-59383](https://issues.jenkins-ci.org/browse/JENKINS-59383).

### Proposed changelog entries

* [JENKINS-59383] Fix the DiskMonitorSpaceDescriptor toString() message

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@mention @reviewbybees 
