### PR TITLE
[JENKINS-26008] Add an option to disable gzip compression for StandardArtifactManager

### DIFF
--- a/core/src/main/java/jenkins/model/StandardArtifactManager.java
+++ b/core/src/main/java/jenkins/model/StandardArtifactManager.java
@@ -45,6 +45,10 @@ public class StandardArtifactManager extends ArtifactManager {
 
     private static final Logger LOG = Logger.getLogger(StandardArtifactManager.class.getName());
 
+    private static FilePath.TarCompression TAR_COMPRESSION = Boolean.getBoolean(StandardArtifactManager.class.getName() + ".disableTrafficCompression")
+            ? FilePath.TarCompression.NONE
+            : FilePath.TarCompression.GZIP;
+
     protected transient Run<?,?> build;
 
     public StandardArtifactManager(Run<?,?> build) {
@@ -58,7 +62,7 @@ public class StandardArtifactManager extends ArtifactManager {
     @Override public void archive(FilePath workspace, Launcher launcher, BuildListener listener, final Map<String,String> artifacts) throws IOException, InterruptedException {
         File dir = getArtifactsDir();
         String description = "transfer of " + artifacts.size() + " files"; // TODO improve when just one file
-        workspace.copyRecursiveTo(new FilePath.ExplicitlySpecifiedDirScanner(artifacts), new FilePath(dir), description);
+        workspace.copyRecursiveTo(new FilePath.ExplicitlySpecifiedDirScanner(artifacts), new FilePath(dir), description, TAR_COMPRESSION);
     }
 
     @Override public final boolean delete() throws IOException, InterruptedException {

--- a/core/src/main/java/jenkins/model/StandardArtifactManager.java
+++ b/core/src/main/java/jenkins/model/StandardArtifactManager.java
@@ -24,6 +24,7 @@
 
 package jenkins.model;
 
+import com.google.common.annotations.VisibleForTesting;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
@@ -35,6 +36,8 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.util.VirtualFile;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Default artifact manager which transfers files over the remoting channel and stores them inside the build directory.
@@ -45,7 +48,9 @@ public class StandardArtifactManager extends ArtifactManager {
 
     private static final Logger LOG = Logger.getLogger(StandardArtifactManager.class.getName());
 
-    private static FilePath.TarCompression TAR_COMPRESSION = Boolean.getBoolean(StandardArtifactManager.class.getName() + ".disableTrafficCompression")
+    @Restricted(NoExternalUse.class)
+    @VisibleForTesting
+    public static FilePath.TarCompression TAR_COMPRESSION = Boolean.getBoolean(StandardArtifactManager.class.getName() + ".disableTrafficCompression")
             ? FilePath.TarCompression.NONE
             : FilePath.TarCompression.GZIP;
 


### PR DESCRIPTION
1. There are cases where saving CPU is more important than network bandwidth between Jenkins master and slaves
2. According to [benchmarks](https://github.com/lz4/lz4#benchmarks), gzip compression is unable to saturate 1Gbps network even on high-end desktop CPUs, so can easily become a bottleneck.

See [JENKINS-26008](https://issues.jenkins-ci.org/browse/JENKINS-26008).

### Proposed changelog entries

* [JENKINS-26008] Artifact traffic gzip-compression can be disabled via system property `jenkins.model.StandardArtifactManager.disableTrafficCompression=true`
