### PR TITLE
[JENKINS-19760], [JENKINS-31209] Stop limiting build description in build list view to 100 characters

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -667,7 +667,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     /**
      * Returns the length-limited description.
      * @return The length-limited description.
-     */   
+     * @deprecated truncated description uses arbitrary and unconfigurable limit of 100 symbols
+     */
+    @Deprecated
     public @Nonnull String getTruncatedDescription() {
         final int maxDescrLength = 100;
         if (description == null || description.length() < maxDescrLength) {

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -69,7 +69,7 @@ THE SOFTWARE.
       </div>
       <j:if test="${!empty build.description}">
         <div class="pane desc indent-multiline">
-          <j:out value="${app.markupFormatter.translate(build.truncatedDescription)}"/>
+          <j:out value="${app.markupFormatter.translate(build.description)}"/>
         </div>
       </j:if>
       <div class="left-bar" />


### PR DESCRIPTION
This limit:
1. Isn't justified by anything
2. Cannot be configured by users
3. Doesn't properly interact with nontrivial HTML markup. For example, it sums text in `<option>` elements even though they do not actually take up more visual space on page and instead only longest `<option>` text matters
4. Doesn't handle Markdown syntax

### Proposed changelog entries

* [JENKINS-19760], [JENKINS-31209] Build description is no longer limited to 100 characters in build list view
