### PR TITLE
removed powermock dependency because it was not used in cli

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -32,16 +32,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
         <groupId>org.kohsuke</groupId>
         <artifactId>access-modifier-annotation</artifactId>
     </dependency>


### PR DESCRIPTION
Removed powermock dependency because it was not used in CLI tests

### Proposed changelog entries

* Internal: Removed unused powermock dependency in CLI

### Desired reviewers
