### PR TITLE
Unignore tests that aren't failing on stable-2.190

### DIFF
--- a/test/src/test/java/hudson/model/RSSTest.java
+++ b/test/src/test/java/hudson/model/RSSTest.java
@@ -42,10 +42,7 @@ public class RSSTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    //TODO remove the @Ignore 
-    // Seems the XML parser on the CI machine is different / more picky than the one on my machine, will be covered by JENKINS-59231 to improve the code coverage
     @Test
-    @Ignore("XML parser too picky on CI")
     @Issue("JENKINS-59167")
     public void absoluteURLsPresentInRSS_evenWithoutRootUrlSetup() throws Exception {
         XmlPage page = getRssPage();
@@ -76,10 +73,7 @@ public class RSSTest {
         }
     }
 
-    //TODO remove the @Ignore 
-    // Seems the XML parser on the CI machine is different / more picky than the one on my machine, will be covered by JENKINS-59231 to improve the code coverage
     @Test
-    @Ignore("XML parser too picky on CI")
     @Issue("JENKINS-59167")
     public void absoluteURLsPresentInAtom_evenWithoutRootUrlSetup() throws Exception {
         XmlPage page = getAtomPage();


### PR DESCRIPTION
Targeting 2.190 LTS: This test wasn't failing on LTS due to lack of dom4j update.

### Proposed changelog entries

Too minor

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
