### PR TITLE
JENKINS-59505 - Fix typo in plugin setup wizard

### DIFF
--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -91,7 +91,7 @@ installWizard_installingConsole_dependencyIndicatorNote=** - required dependency
 installWizard_websiteLinkLabel=Website
 installWizard_pluginInstallFailure_title=Installation Failures
 installWizard_pluginInstallFailure_message=Some plugins failed to install properly, you may retry installing them or continue \
-with the failed plugins
+without the failed plugins
 installWizard_continue=Continue
 installWizard_retry=Retry
 installWizard_upgradePanel_title=Upgrade


### PR DESCRIPTION
Minor typo fix on line `93|94` [JENKINS-59505](https://issues.jenkins-ci.org/browse/JENKINS-59505)

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* None

### Description


The pluginSetupWizard.properties file says on line `93|94`,

"Some plugins failed to install properly, you may retry installing them or continue with the failed plugins."

I think that should instead have been

"Some plugins failed to install properly, you may retry installing them or continue without the failed plugins"


<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
This change has no autotests because none is necessary.