### PR TITLE
Update commons-compress from 1.10 to 1.19

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -311,7 +311,7 @@ THE SOFTWARE.
     <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.10</version>
+        <version>1.19</version>
     </dependency>
     <dependency>
       <groupId>javax.mail</groupId>


### PR DESCRIPTION
Dependency update.

**Full changelog:**

http://commons.apache.org/proper/commons-compress/changes-report.html

**API compatibility:**

Based on the below, looks like an exception was removed from a `throws`, `AbstractLZ77CompressorInputStream` no longer overrides some supertype methods, and a serialVersionUid of an exception changed. Otherwise, just additions (excluded from output below).

<details>

<summary>japicmp output</summary>

```
$ java -jar japicmp-0.14.1-jar-with-dependencies.jar --old commons-compress-1.10.jar --new commons-compress-1.19.jar --only-incompatible
Comparing binary compatibility of /Users/danielbeck/Downloads/commons-compress/commons-compress-1.19.jar against /Users/danielbeck/Downloads/commons-compress/commons-compress-1.10.jar
===  UNCHANGED CLASS: PUBLIC org.apache.commons.compress.archivers.zip.UnsupportedZipFeatureException  (serialVersionUID modified)
	***! CLASS FILE FORMAT VERSION: 51.0 <- 49.0

$ java -jar japicmp-0.14.1-jar-with-dependencies.jar --old commons-compress-1.10.jar --new commons-compress-1.19.jar --only-modified | fgrep -v '+++  NEW' | fgrep -v 'CLASS FILE FORMAT VERSION'
Comparing source compatibility of /Users/danielbeck/Downloads/commons-compress/commons-compress-1.19.jar against /Users/danielbeck/Downloads/commons-compress/commons-compress-1.10.jar
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.ArchiveStreamFactory  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.arj.ArjArchiveEntry  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.cpio.CpioArchiveEntry  (not serializable)
	===  UNCHANGED METHOD: PUBLIC int getHeaderPadCount()
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.sevenz.SevenZFile  (not serializable)
***  MODIFIED ENUM: PUBLIC FINAL org.apache.commons.compress.archivers.sevenz.SevenZMethod  (compatible)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.sevenz.SevenZMethodConfiguration  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.sevenz.SevenZOutputFile  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.tar.TarArchiveEntry  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.tar.TarArchiveInputStream  (not serializable)
===  UNCHANGED CLASS: PUBLIC org.apache.commons.compress.archivers.tar.TarArchiveOutputStream  (not serializable)
	===  UNCHANGED CONSTRUCTOR: PUBLIC TarArchiveOutputStream(java.io.OutputStream, int, int)
	===  UNCHANGED CONSTRUCTOR: PUBLIC TarArchiveOutputStream(java.io.OutputStream, int, int, java.lang.String)
	===  UNCHANGED METHOD: PUBLIC int getRecordSize()
***  MODIFIED INTERFACE: PUBLIC ABSTRACT org.apache.commons.compress.archivers.tar.TarConstants  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.zip.ExtraFieldUtils  (not serializable)
***  MODIFIED CLASS: PUBLIC STATIC FINAL org.apache.commons.compress.archivers.zip.ExtraFieldUtils$UnparseableExtraField  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.zip.ParallelScatterZipCreator  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.zip.ScatterZipOutputStream  (not serializable)
***  MODIFIED INTERFACE: PUBLIC ABSTRACT org.apache.commons.compress.archivers.zip.UnixStat  (not serializable)
===  UNCHANGED CLASS: PUBLIC org.apache.commons.compress.archivers.zip.UnsupportedZipFeatureException  (serialVersionUID modified)
***  MODIFIED CLASS: PUBLIC STATIC org.apache.commons.compress.archivers.zip.UnsupportedZipFeatureException$Feature  (compatible)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.zip.ZipArchiveEntry  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.zip.ZipArchiveInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream  (not serializable)
***  MODIFIED INTERFACE: PUBLIC ABSTRACT org.apache.commons.compress.archivers.zip.ZipExtraField  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.archivers.zip.ZipFile  (not serializable)
	***  MODIFIED METHOD: PUBLIC java.io.InputStream getInputStream(org.apache.commons.compress.archivers.zip.ZipArchiveEntry)
		===  UNCHANGED EXCEPTION: java.io.IOException
		---  REMOVED EXCEPTION: java.util.zip.ZipException
	***  MODIFIED METHOD: PUBLIC (<- PRIVATE) java.io.InputStream getRawInputStream(org.apache.commons.compress.archivers.zip.ZipArchiveEntry)
***  MODIFIED CLASS: PUBLIC FINAL org.apache.commons.compress.archivers.zip.ZipLong  (compatible)
***  MODIFIED ENUM: PUBLIC FINAL org.apache.commons.compress.archivers.zip.ZipMethod  (compatible)
***  MODIFIED CLASS: PUBLIC FINAL org.apache.commons.compress.archivers.zip.ZipShort  (compatible)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC ABSTRACT org.apache.commons.compress.compressors.CompressorInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.compressors.CompressorStreamFactory  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.compressors.deflate.DeflateCompressorInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.compressors.lzma.LZMACompressorInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC ABSTRACT org.apache.commons.compress.compressors.lzw.LZWInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.compressors.snappy.FramedSnappyCompressorInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream  (not serializable)
	***  MODIFIED SUPERCLASS: org.apache.commons.compress.compressors.lz77support.AbstractLZ77CompressorInputStream (<- org.apache.commons.compress.compressors.CompressorInputStream)
	---  REMOVED METHOD: PUBLIC(-) int available()
	---  REMOVED METHOD: PUBLIC(-) void close()
		---  REMOVED EXCEPTION: java.io.IOException
	---  REMOVED METHOD: PUBLIC(-) int read()
		---  REMOVED EXCEPTION: java.io.IOException
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.compressors.xz.XZCompressorInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.compressors.z.ZCompressorInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.utils.ArchiveUtils  (not serializable)
***  MODIFIED CLASS: PUBLIC org.apache.commons.compress.utils.BitInputStream  (not serializable)
***  MODIFIED CLASS: PUBLIC FINAL org.apache.commons.compress.utils.IOUtils  (not serializable)
```

</details>

### Proposed changelog entries

```
* Update commons-compress from 1.10 to 1.19.
  full changelog: https://commons.apache.org/proper/commons-compress/changes-report.html
```


### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
