### PR TITLE
[JENKINS-59152] - Reduce the default process soft-kill timeout from 2 minutes to 5 seconds

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -156,7 +156,13 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
      */
     public abstract void killAll(Map<String, String> modelEnvVars) throws InterruptedException;
 
-    private final long softKillWaitSeconds = Integer.getInteger("SoftKillWaitSeconds", 2 * 60); // by default processes get at most 2 minutes to respond to SIGTERM (JENKINS-17116)
+    /**
+     * The time to wait between sending Ctrl+C and killing the process. (JENKINS-17116)
+     *
+     * The default is 5 seconds. Careful! There are other timers in the system that may
+     * interfere with this value here, e.g. in org.jenkinsci.plugins.workflow.cps.CpsThread.stop
+     */
+    private final long softKillWaitSeconds = Integer.getInteger("SoftKillWaitSeconds", 5);
 
     /**
      * Convenience method that does {@link #killAll(Map)} and {@link OSProcess#killRecursively()}.


### PR DESCRIPTION
See [JENKINS-59152](https://issues.jenkins-ci.org/browse/JENKINS-59152) and [analysis](https://github.com/jenkinsci/jenkins/pull/4216) done by @slonopotamus.

Let's reduce the default value for soft-kill to 5 seconds to avoid interference by other mechanisms that want to avoid stalling and stuck processes.

### Proposed changelog entries

* [JENKINS-59152] Default soft-kill timeout reduced to 5 seconds

### Desired reviewers

@oleg-nenashev @slonopotamus 