### PR TITLE
Improve logging for Computer.getLogDir failures

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -62,6 +62,7 @@ import hudson.util.RemotingDiagnostics;
 import hudson.util.RemotingDiagnostics.HeapDump;
 import hudson.util.RunList;
 import hudson.util.Futures;
+import hudson.util.IOUtils;
 import hudson.util.NamingThreadFactory;
 import jenkins.model.Jenkins;
 import jenkins.util.ContextResettingExecutorService;
@@ -300,8 +301,10 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     protected @Nonnull File getLogDir() {
         File dir = new File(Jenkins.get().getRootDir(),"logs/slaves/"+nodeName);
-        if (!dir.exists() && !dir.mkdirs()) {
-            LOGGER.severe("Failed to create agent log directory " + dir.getAbsolutePath());
+        try {
+            IOUtils.mkdirs(dir);
+        } catch (IOException x) {
+            LOGGER.log(Level.SEVERE, "Failed to create agent log directory " + dir, x);
         }
         return dir;
     }


### PR DESCRIPTION
I saw a flake of https://github.com/jenkinsci/kubernetes-plugin/pull/503 with a one-line error

```
Failed to create agent log directory /…/target/tmp/j h4252863025719703833/logs/slaves/null
```

Now the null `nodeName` looks wrong, but even still it should have been able to create a directory of that name. The `File.mkdirs` call does not tell us why it failed. Nor does the log message indicate what code was calling `getLogDir`, which may be relevant.

### Proposed changelog entries

* Better diagnostics in a failure message from `Computer.getLogDir`.