### PR TITLE
Introduce new hudson.TcpSlaveAgentListener.getAdvertisedHost() method

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -43,6 +43,7 @@ import java.io.DataOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.SocketAddress;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Base64;
 import jenkins.AgentProtocol;
@@ -55,6 +56,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.BindException;
 import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
 import java.net.Socket;
 import java.nio.channels.ServerSocketChannel;
 import java.util.logging.Level;
@@ -129,6 +131,18 @@ public final class TcpSlaveAgentListener extends Thread {
      */
     public int getAdvertisedPort() {
         return CLI_PORT != null ? CLI_PORT : getPort();
+    }
+
+    /**
+     * Gets the host name that we advertise protocol clients to connect to.
+     */
+    public String getAdvertisedHost() {
+        if(CLI_HOST_NAME != null) return CLI_HOST_NAME;
+        try {
+            return new URL(Jenkins.getInstanceOrNull().getRootUrl()).getHost();
+        } catch (MalformedURLException | NullPointerException e) {
+            throw new IllegalStateException("Could not get Jenkins host name", e);
+        }
     }
 
     /**

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -135,11 +135,14 @@ public final class TcpSlaveAgentListener extends Thread {
 
     /**
      * Gets the host name that we advertise protocol clients to connect to.
+     * @since TODO
      */
     public String getAdvertisedHost() {
-        if(CLI_HOST_NAME != null) return CLI_HOST_NAME;
+        if (CLI_HOST_NAME != null) {
+          return CLI_HOST_NAME;
+        }
         try {
-            return new URL(Jenkins.getInstanceOrNull().getRootUrl()).getHost();
+            return new URL(Jenkins.get().getRootUrl()).getHost();
         } catch (MalformedURLException | NullPointerException e) {
             throw new IllegalStateException("Could not get Jenkins host name", e);
         }

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -144,7 +144,7 @@ public final class TcpSlaveAgentListener extends Thread {
         try {
             return new URL(Jenkins.get().getRootUrl()).getHost();
         } catch (MalformedURLException | NullPointerException e) {
-            throw new IllegalStateException("Could not get Jenkins host name", e);
+            throw new IllegalStateException("Could not get TcpSlaveAgentListener host name", e);
         }
     }
 


### PR DESCRIPTION
See [JENKINS-59538](https://issues.jenkins-ci.org/browse/JENKINS-59538).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

    Developer: Add <code>TcpSlaveAgentListener#getAdvertisedHost()</code>.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jglick

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
