### PR TITLE
[JENKINS-56809] LAST_COMPLETED_BUILD should be a PeepholePermalink

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -983,10 +983,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     @Exported
     @QuickSilver
     public RunT getLastCompletedBuild() {
-        RunT r = getLastBuild();
-        while (r != null && r.isBuilding())
-            r = r.getPreviousBuild();
-        return r;
+        return (RunT)Permalink.LAST_COMPLETED_BUILD.resolve(this);
     }
     
     /**

--- a/core/src/main/java/hudson/model/PermalinkProjectAction.java
+++ b/core/src/main/java/hudson/model/PermalinkProjectAction.java
@@ -179,7 +179,7 @@ public interface PermalinkProjectAction extends Action {
                 return !run.isBuilding() && run.getResult()!=Result.SUCCESS;
             }
         };
-        public static final Permalink LAST_COMPLETED_BUILD = new Permalink() {
+        public static final Permalink LAST_COMPLETED_BUILD = new PeepholePermalink() {
             public String getDisplayName() {
                 return Messages.Permalink_LastCompletedBuild();
             }
@@ -188,8 +188,9 @@ public interface PermalinkProjectAction extends Action {
                 return "lastCompletedBuild";
             }
 
-            public Run<?,?> resolve(Job<?,?> job) {
-                return job.getLastCompletedBuild();
+            @Override
+            public boolean apply(Run<?, ?> run) {
+                return !run.isBuilding();
             }
         };
 


### PR DESCRIPTION
See [JENKINS-56809](https://issues.jenkins-ci.org/browse/JENKINS-56809).

Amends #1508. Not sure if #3982 made this more significant or not.

### Proposed changelog entries

* The `lastCompletedBuild` permalink was not being cached in the `…/builds/permalinks` file.