### PR TITLE
[JENKINS-59580] Fix WindowsOSProcess.getEnvironmentVariables returning null

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -581,7 +581,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     LOGGER.log(FINEST, "Failed to get the environment variables of process with pid=" + p.getPid(), e);
                 }
             }
-            return null;
+            return env;
         }
         
         private synchronized EnvVars getEnvironmentVariables2() throws WindowsOSProcessException {


### PR DESCRIPTION
`OSProcess.getEnvironmentVariables` javadoc clearly states that method will return empty map if obtaining of environment variables failed.

### Proposed changelog entries

* [JENKINS-59580]: `hudson.util.ProcessTree.OSProcess#getEnvironmentVariables` doesn't return null in case of error anymore