### PR TITLE
Fix NPE in ProcessTree#killAll if proc is null and add a test for it

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -167,8 +167,12 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
      */
     public void killAll(Process proc, Map<String, String> modelEnvVars) throws InterruptedException {
         LOGGER.fine("killAll: process="+proc+" and envs="+modelEnvVars);
-        OSProcess p = get(proc);
-        if(p!=null) p.killRecursively();
+
+        if (proc != null) {
+            OSProcess p = get(proc);
+            if (p != null) p.killRecursively();
+        }
+
         if(modelEnvVars!=null)
             killAll(modelEnvVars);
     }

--- a/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
+++ b/test/src/test/java/hudson/util/ProcessTreeKillerTest.java
@@ -66,6 +66,12 @@ public class ProcessTreeKillerTest {
 	}
 
     @Test
+    public void killNullProcess() throws Exception {
+        ProcessTree.enabled = true;
+        ProcessTree.get().killAll(null, null);
+    }
+
+    @Test
     @Issue("JENKINS-22641")
     public void processProperlyKilledUnix() throws Exception {
         ProcessTree.enabled = true;


### PR DESCRIPTION
Javadoc for ProcessTree#killAll says that "either of the parameter can be null",
but it wasn't true for proc.

Relevant Javadoc: https://javadoc.jenkins.io/hudson/util/ProcessTree.html#killAll-java.lang.Process-java.util.Map-

### Proposed changelog entries

* Internal: `ProcessTree#killAll` no longer fails with NPE if `proc` is null
