### PR TITLE
hudson.Proc#isAlive no longer throws any exceptions

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -1146,7 +1146,7 @@ public abstract class Launcher {
             }
 
             @Override
-            public boolean isAlive() throws IOException, InterruptedException {
+            public boolean isAlive() {
                 return process.isAlive();
             }
 
@@ -1263,7 +1263,7 @@ public abstract class Launcher {
     public interface RemoteProcess {
         int join() throws InterruptedException, IOException;
         void kill() throws IOException, InterruptedException;
-        boolean isAlive() throws IOException, InterruptedException;
+        boolean isAlive();
         
         @Nonnull
         IOTriplet getIOtriplet();
@@ -1344,7 +1344,7 @@ public abstract class Launcher {
                     p.kill();
                 }
 
-                public boolean isAlive() throws IOException, InterruptedException {
+                public boolean isAlive() {
                     return p.isAlive();
                 }
 

--- a/core/src/main/java/hudson/Proc.java
+++ b/core/src/main/java/hudson/Proc.java
@@ -68,7 +68,7 @@ public abstract class Proc {
     /**
      * Checks if the process is still alive.
      */
-    public abstract boolean isAlive() throws IOException, InterruptedException;
+    public abstract boolean isAlive();
 
     /**
      * Terminates the process.
@@ -363,13 +363,8 @@ public abstract class Proc {
         }
 
         @Override
-        public boolean isAlive() throws IOException, InterruptedException {
-            try {
-                proc.exitValue();
-                return false;
-            } catch (IllegalThreadStateException e) {
-                return true;
-            }
+        public boolean isAlive() {
+            return proc.isAlive();
         }
 
         @Override
@@ -479,7 +474,7 @@ public abstract class Proc {
         }
 
         @Override
-        public boolean isAlive() throws IOException, InterruptedException {
+        public boolean isAlive() {
             return !process.isDone();
         }
 


### PR DESCRIPTION
Subj, because there's no need to.

### Proposed changelog entries

* Internal: `hudson.Proc#isAlive` no longer throws any exceptions
