### PR TITLE
Spotbugs: changed order for compare instead of negating result 

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1059,8 +1059,8 @@ public class Functions {
         }
 
         public int compareTo(Tag that) {
-            int r = Double.compare(this.ordinal, that.ordinal);
-            if (r!=0)   return -r; // descending for ordinal
+            int r = Double.compare(that.ordinal, this.ordinal);
+            if (r!=0)   return r; // descending for ordinal by reversing the order for compare
             return this.hierarchy.compareTo(that.hierarchy);
         }
     }

--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -156,7 +156,7 @@ public final class RunMap<R extends Run<?,R>> extends AbstractLazyLoadRunMap<R> 
     @Deprecated
     public static final Comparator<Comparable> COMPARATOR = new Comparator<Comparable>() {
         public int compare(Comparable o1, Comparable o2) {
-            return -o1.compareTo(o2);
+            return o2.compareTo(o1);
         }
     };
 


### PR DESCRIPTION
I fixed another 2 Spotbugs issues of type:
Spotbugs RV_NEGATING_RESULT_OF_COMPARETO

Spotbugs explanation:

> Negating the result of compareTo()/compare()
> This code negatives the return value of a compareTo or compare method. This is a questionable or bad programming practice, since if the return value is Integer.MIN_VALUE, negating the return value won't negate the sign of the result. You can achieve the same intended result by reversing the order of the operands rather than by negating the results.


### Proposed changelog entries

* Not needed


### Desired reviewers

