### PR TITLE
Spotbugs: Replaced inefficient Number constructor with static valueOf

### DIFF
--- a/core/src/main/java/hudson/tasks/BatchFile.java
+++ b/core/src/main/java/hudson/tasks/BatchFile.java
@@ -67,7 +67,7 @@ public class BatchFile extends CommandInterpreter {
 
     @CheckForNull
     public final Integer getUnstableReturn() {
-        return new Integer(0).equals(unstableReturn) ? null : unstableReturn;
+        return Integer.valueOf(0).equals(unstableReturn) ? null : unstableReturn;
     }
 
     @DataBoundSetter

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -106,7 +106,7 @@ public class Shell extends CommandInterpreter {
 
     @CheckForNull
     public final Integer getUnstableReturn() {
-        return new Integer(0).equals(unstableReturn) ? null : unstableReturn;
+        return Integer.valueOf(0).equals(unstableReturn) ? null : unstableReturn;
     }
 
     @DataBoundSetter

--- a/core/src/main/java/hudson/widgets/HistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/HistoryWidget.java
@@ -285,7 +285,7 @@ public class HistoryWidget<O extends ModelObject,T> extends Widget {
             return null;
         }
         try {
-            return new Long(paramVal);
+            return Long.valueOf(paramVal);
         } catch (NumberFormatException nfe) {
             return null;
         }


### PR DESCRIPTION
Another Spotbugs Issue Type.
I replaced inefficient Number constructor with static valueOf

> Method invokes inefficient Number constructor; use static valueOf instead
> Using new Integer(int) is guaranteed to always result in a new object whereas Integer.valueOf(int) allows caching of values to be done by the compiler, class library, or JVM. Using of cached values avoids object allocation and the code will be faster.
> Values between -128 and 127 are guaranteed to have corresponding cached instances and using valueOf is approximately 3.5 times faster than using constructor. For values outside the constant range the performance of both styles is the same.
> Unless the class must be compatible with JVMs predating Java 1.5, use either autoboxing or the valueOf() method when creating instances of Long, Integer, Short, Character, and Byte.

### Proposed changelog entries

* No entry needed

### Desired reviewers

