### PR TITLE
Unbundle Maven Plugin and Subversion Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@ THE SOFTWARE.
     <project.patchManagement.url>https://api.github.com</project.patchManagement.url>
     <patch.tracker.serverId>jenkins-jira</patch.tracker.serverId>
 
-    <maven-plugin.version>2.14</maven-plugin.version>
     <matrix-auth.version>2.3</matrix-auth.version>
     <matrix-project.version>1.14</matrix-project.version>
     <sorcerer.version>0.11</sorcerer.version>

--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -95,7 +95,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>${maven-plugin.version}</version>
+      <version>2.14</version>
       <exclusions>
         <exclusion> <!-- perhaps unnecessary as of JENKINS-35445? -->
           <groupId>org.apache.httpcomponents</groupId>

--- a/test/src/test/java/hudson/model/AbstractProjectTest.java
+++ b/test/src/test/java/hudson/model/AbstractProjectTest.java
@@ -34,7 +34,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
-import hudson.maven.MavenModuleSet;
+import hudson.matrix.MatrixProject;
 import hudson.scm.NullSCM;
 import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
@@ -410,20 +410,24 @@ public class AbstractProjectTest {
     @Test
     public void configDotXmlSubmissionToDifferentType() throws Exception {
         TestPluginManager tpm = (TestPluginManager) j.jenkins.pluginManager;
-        tpm.installDetachedPlugin("javadoc");
-        tpm.installDetachedPlugin("maven-plugin");
+        tpm.installDetachedPlugin("structs");
+        tpm.installDetachedPlugin("workflow-step-api");
+        tpm.installDetachedPlugin("scm-api");
+        tpm.installDetachedPlugin("workflow-api");
+        tpm.installDetachedPlugin("junit");
+        tpm.installDetachedPlugin("matrix-project");
 
         j.jenkins.setCrumbIssuer(null);
         FreeStyleProject p = j.createFreeStyleProject();
 
-        HttpURLConnection con = postConfigDotXml(p, "<maven2-moduleset />");
+        HttpURLConnection con = postConfigDotXml(p, "<matrix-project />");
 
         // this should fail with a type mismatch error
         // the error message should report both what was submitted and what was expected
         assertEquals(500, con.getResponseCode());
         String msg = IOUtils.toString(con.getErrorStream());
         System.out.println(msg);
-        assertThat(msg, allOf(containsString(FreeStyleProject.class.getName()), containsString(MavenModuleSet.class.getName())));
+        assertThat(msg, allOf(containsString(FreeStyleProject.class.getName()), containsString(MatrixProject.class.getName())));
 
         // control. this should work
         con = postConfigDotXml(p, "<project />");

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -295,12 +295,6 @@ THE SOFTWARE.
                     Detached plugins and their dependencies - detached plugins that used to be bundled plugins
                 -->
                 <artifactItem>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>maven-plugin</artifactId>
-                  <version>${maven-plugin.version}</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>ssh-slaves</artifactId>
                   <version>1.15</version>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -314,12 +314,6 @@ THE SOFTWARE.
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>subversion</artifactId>
-                  <version>1.54</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>cvs</artifactId>
                   <version>2.11</version>
                   <type>hpi</type>


### PR DESCRIPTION
Stop bundling Maven and Subversion Plugins in the Jenkins war.

There are no plugins for installation in `update-center.json` that have a core dependency older than 1.323. Since maven-plugin got split from core in 1.296 and subversion in 1.310, they are no longer being installed in any realistic situation.

Manually tested by putting one of the plugins depending on core 1.323 in `$JENKINS_HOME/plugins` and starting Jenkins. There's no `maven-plugin` or `subversion` being extracted.

Keep the maven-plugin dependency for the tests, as there are quite a few depending on it.

Requesting @jglick for review as IIRC he recently proposed removing `maven-plugin` somewhere.

Supersedes #4146.

### Proposed changelog entries

* Stop bundling Maven Plugin and Subversion Plugin with Jenkins. In very rare cases, this could result in problems when attempting to install plugins compatible with Jenkins before 1.310. The Jenkins project is currently not publishing any such plugins.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
