### PR TITLE
Use type inference instead of specifying it

### DIFF
--- a/core/src/main/java/hudson/DependencyRunner.java
+++ b/core/src/main/java/hudson/DependencyRunner.java
@@ -47,7 +47,7 @@ public class DependencyRunner implements Runnable {
 	
     ProjectRunnable runnable;
 
-    List<AbstractProject> polledProjects = new ArrayList<AbstractProject>();
+    List<AbstractProject> polledProjects = new ArrayList<>();
 
     public DependencyRunner(ProjectRunnable runnable) {
         this.runnable = runnable;
@@ -56,7 +56,7 @@ public class DependencyRunner implements Runnable {
     public void run() {
         SecurityContext oldContext = ACL.impersonate(ACL.SYSTEM);
         try {
-            Set<AbstractProject> topLevelProjects = new HashSet<AbstractProject>();
+            Set<AbstractProject> topLevelProjects = new HashSet<>();
             // Get all top-level projects
             LOGGER.fine("assembling top level projects");
             for (AbstractProject p : Jenkins.get().allItems(AbstractProject.class))

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -951,7 +951,7 @@ public class Functions {
     @Restricted(DoNotUse.class)
     @RestrictedSince("2.12")
     public static List<NodePropertyDescriptor> getNodePropertyDescriptors(Class<? extends Node> clazz) {
-        List<NodePropertyDescriptor> result = new ArrayList<NodePropertyDescriptor>();
+        List<NodePropertyDescriptor> result = new ArrayList<>();
         Collection<NodePropertyDescriptor> list = (Collection) Jenkins.get().getDescriptorList(NodeProperty.class);
         for (NodePropertyDescriptor npd : list) {
             if (npd.isApplicable(clazz)) {
@@ -967,7 +967,7 @@ public class Functions {
      * @since 1.520
      */
     public static List<NodePropertyDescriptor> getGlobalNodePropertyDescriptors() {
-        List<NodePropertyDescriptor> result = new ArrayList<NodePropertyDescriptor>();
+        List<NodePropertyDescriptor> result = new ArrayList<>();
         Collection<NodePropertyDescriptor> list = (Collection) Jenkins.get().getDescriptorList(NodeProperty.class);
         for (NodePropertyDescriptor npd : list) {
             if (npd.isApplicableAsGlobal()) {
@@ -996,7 +996,7 @@ public class Functions {
      */
     public static Collection<Descriptor> getSortedDescriptorsForGlobalConfig(Predicate<GlobalConfigurationCategory> predicate) {
         ExtensionList<Descriptor> exts = ExtensionList.lookup(Descriptor.class);
-        List<Tag> r = new ArrayList<Tag>(exts.size());
+        List<Tag> r = new ArrayList<>(exts.size());
 
         for (ExtensionComponent<Descriptor> c : exts.getComponents()) {
             Descriptor d = c.getInstance();
@@ -1008,7 +1008,7 @@ public class Functions {
         }
         Collections.sort(r);
 
-        List<Descriptor> answer = new ArrayList<Descriptor>(r.size());
+        List<Descriptor> answer = new ArrayList<>(r.size());
         for (Tag d : r) answer.add(d.d);
 
         return DescriptorVisibilityFilter.apply(Jenkins.get(),answer);
@@ -1090,7 +1090,7 @@ public class Functions {
      * Computes the relative path from the current page to the given item.
      */
     public static String getRelativeLinkTo(Item p) {
-        Map<Object,String> ancestors = new HashMap<Object,String>();
+        Map<Object,String> ancestors = new HashMap<>();
         View view=null;
 
         StaplerRequest request = Stapler.getCurrentRequest();
@@ -1166,7 +1166,7 @@ public class Functions {
         String separationString = useDisplayName ? " » " : "/";
         
         // first list up all the parents
-        Map<ItemGroup,Integer> parents = new HashMap<ItemGroup,Integer>();
+        Map<ItemGroup,Integer> parents = new HashMap<>();
         int depth=0;
         while (g!=null) {
             parents.put(g, depth++);
@@ -1233,7 +1233,7 @@ public class Functions {
     }
 
     public static Map<Thread,StackTraceElement[]> dumpAllThreads() {
-        Map<Thread,StackTraceElement[]> sorted = new TreeMap<Thread,StackTraceElement[]>(new ThreadSorter());
+        Map<Thread,StackTraceElement[]> sorted = new TreeMap<>(new ThreadSorter());
         sorted.putAll(Thread.getAllStackTraces());
         return sorted;
     }
@@ -1251,7 +1251,7 @@ public class Functions {
 
     // Common code for sorting Threads/ThreadInfos by ThreadGroup
     private static class ThreadSorterBase {
-        protected Map<Long,String> map = new HashMap<Long,String>();
+        protected Map<Long,String> map = new HashMap<>();
 
         private ThreadSorterBase() {
             ThreadGroup tg = Thread.currentThread().getThreadGroup();
@@ -1475,7 +1475,7 @@ public class Functions {
             return Messages.Functions_NoExceptionDetails();
         }
         StringBuilder s = new StringBuilder();
-        doPrintStackTrace(s, t, null, "", new HashSet<Throwable>());
+        doPrintStackTrace(s, t, null, "", new HashSet<>());
         return s.toString();
     }
     private static void doPrintStackTrace(@Nonnull StringBuilder s, @Nonnull Throwable t, @CheckForNull Throwable higher, @Nonnull String prefix, @Nonnull Set<Throwable> encountered) {
@@ -1840,7 +1840,7 @@ public class Functions {
     public List<String> getLoggerNames() {
         while (true) {
             try {
-                List<String> r = new ArrayList<String>();
+                List<String> r = new ArrayList<>();
                 Enumeration<String> e = LogManager.getLogManager().getLoggerNames();
                 while (e.hasMoreElements())
                     r.add(e.nextElement());
@@ -1933,7 +1933,7 @@ public class Functions {
     }
 
     public static List<String> getRequestHeaders(String name) {
-        List<String> r = new ArrayList<String>();
+        List<String> r = new ArrayList<>();
         Enumeration e = Stapler.getCurrentRequest().getHeaders(name);
         while (e.hasMoreElements()) {
             r.add(e.nextElement().toString());
@@ -1949,7 +1949,7 @@ public class Functions {
     }
 
     public static ArrayList<CLICommand> getCLICommands() {
-        ArrayList<CLICommand> all = new ArrayList<CLICommand>(CLICommand.all());
+        ArrayList<CLICommand> all = new ArrayList<>(CLICommand.all());
         Collections.sort(all, new Comparator<CLICommand>() {
             public int compare(CLICommand cliCommand, CLICommand cliCommand1) {
                 return cliCommand.getName().compareTo(cliCommand1.getName());

--- a/core/src/main/java/hudson/PluginFirstClassLoader.java
+++ b/core/src/main/java/hudson/PluginFirstClassLoader.java
@@ -50,7 +50,7 @@ public class PluginFirstClassLoader
         super(null, false);
     }
 
-    private List<URL> urls = new ArrayList<URL>();
+    private List<URL> urls = new ArrayList<>();
 
     public void addPathFiles( Collection<File> paths )
         throws IOException

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2131,7 +2131,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      * Stores {@link Plugin} instances.
      */
     /*package*/ static final class PluginInstanceStore {
-        final Map<PluginWrapper,Plugin> store = new ConcurrentHashMap<PluginWrapper,Plugin>();
+        final Map<PluginWrapper,Plugin> store = new ConcurrentHashMap<>();
     }
 
     /**
@@ -2174,7 +2174,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @Extension @Symbol("pluginUpdate")
     public static final class PluginUpdateMonitor extends AdministrativeMonitor {
 
-        private Map<String, PluginUpdateInfo> pluginsToBeUpdated = new HashMap<String, PluginManager.PluginUpdateMonitor.PluginUpdateInfo>();
+        private Map<String, PluginUpdateInfo> pluginsToBeUpdated = new HashMap<>();
 
         /**
          * Convenience method to ease access to this monitor, this allows other plugins to register required updates.

--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -294,7 +294,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
      */
     @Restricted(NoExternalUse.class)
     public Iterator<VersionNumber> getVersionList() {
-        TreeSet<VersionNumber> set = new TreeSet<VersionNumber>();
+        TreeSet<VersionNumber> set = new TreeSet<>();
         for (VersionRange vr : data.values()) {
             if (vr.max != null) {
                 set.add(vr.max);
@@ -364,7 +364,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
          * does occur: just means the user will be prompted to discard less than they should have been (and
          * would see the warning again after next restart).
          */
-        List<SaveableReference> removed = new ArrayList<SaveableReference>();
+        List<SaveableReference> removed = new ArrayList<>();
         for (Map.Entry<SaveableReference,VersionRange> entry : data.entrySet()) {
             if (matchingPredicate.apply(entry)) {
                 Saveable s = entry.getKey().get();

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -262,7 +262,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
 
     private static final class SetLevel extends MasterToSlaveCallable<Void,Error> {
         /** known loggers (kept per agent), to avoid GC */
-        @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") private static final Set<Logger> loggers = new HashSet<Logger>();
+        @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") private static final Set<Logger> loggers = new HashSet<>();
         private final String name;
         private final Level level;
         SetLevel(String name, Level level) {
@@ -421,8 +421,9 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
      * @since 1.519
      */
     public Map<Computer,List<LogRecord>> getSlaveLogRecords() {
-        Map<Computer,List<LogRecord>> result = new TreeMap<Computer,List<LogRecord>>(new Comparator<Computer>() {
+        Map<Computer,List<LogRecord>> result = new TreeMap<>(new Comparator<Computer>() {
             final Collator COLL = Collator.getInstance();
+
             public int compare(Computer c1, Computer c2) {
                 return COLL.compare(c1.getDisplayName(), c2.getDisplayName());
             }
@@ -431,7 +432,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
             if (c.getName().length() == 0) {
                 continue; // master
             }
-            List<LogRecord> recs = new ArrayList<LogRecord>();
+            List<LogRecord> recs = new ArrayList<>();
             try {
                 for (LogRecord rec : c.getLogRecords()) {
                     for (Target t : targets) {

--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -93,7 +93,7 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
     * Package-protected, but accessed API
     * ============================================================================================================== */
 
-    /*package*/ final CopyOnWriteArraySet<String> disabledAdministrativeMonitors = new CopyOnWriteArraySet<String>();
+    /*package*/ final CopyOnWriteArraySet<String> disabledAdministrativeMonitors = new CopyOnWriteArraySet<>();
 
     @Restricted(NoExternalUse.class)
     public CopyOnWriteArraySet<String> getDisabledAdministrativeMonitors(){
@@ -192,11 +192,11 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
      */
     protected void updateComputerList(final boolean automaticSlaveLaunch) {
         final Map<Node,Computer> computers = getComputerMap();
-        final Set<Computer> old = new HashSet<Computer>(computers.size());
+        final Set<Computer> old = new HashSet<>(computers.size());
         Queue.withLock(new Runnable() {
             @Override
             public void run() {
-                Map<String,Computer> byName = new HashMap<String,Computer>();
+                Map<String,Computer> byName = new HashMap<>();
                 for (Computer c : computers.values()) {
                     old.add(c);
                     Node node = c.getNode();

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -981,7 +981,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
     /**
      * Replaceable pronoun of that points to a job. Defaults to "Job"/"Project" depending on the context.
      */
-    public static final Message<AbstractItem> PRONOUN = new Message<AbstractItem>();
+    public static final Message<AbstractItem> PRONOUN = new Message<>();
 
     /**
      * Replaceable noun for describing the kind of task that this item represents. Defaults to "Build".

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -232,7 +232,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * List of all {@link Trigger}s for this project.
      */
     @AdaptField(was=List.class)
-    protected volatile DescribableList<Trigger<?>,TriggerDescriptor> triggers = new DescribableList<Trigger<?>,TriggerDescriptor>(this);
+    protected volatile DescribableList<Trigger<?>,TriggerDescriptor> triggers = new DescribableList<>(this);
     private static final AtomicReferenceFieldUpdater<AbstractProject,DescribableList> triggersUpdater
             = AtomicReferenceFieldUpdater.newUpdater(AbstractProject.class,DescribableList.class,"triggers");
 
@@ -244,7 +244,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * come and go as configuration change, so it's kept separate.
      */
     @CopyOnWrite
-    protected transient volatile List<Action> transientActions = new Vector<Action>();
+    protected transient volatile List<Action> transientActions = new Vector<>();
 
     private boolean concurrentBuild;
 
@@ -320,7 +320,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             scm = new NullSCM(); // perhaps it was pointing to a plugin that no longer exists.
 
         if(transientActions==null)
-            transientActions = new Vector<Action>();    // happens when loaded from disk
+            transientActions = new Vector<>();    // happens when loaded from disk
         updateTransientActions();
     }
 
@@ -731,7 +731,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     }
 
     protected List<Action> createTransientActions() {
-        Vector<Action> ta = new Vector<Action>();
+        Vector<Action> ta = new Vector<>();
 
         for (JobProperty<? super P> p : Util.fixNull(properties))
             ta.addAll(p.getJobActions((P)this));
@@ -817,7 +817,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      */
     @WithBridgeMethods(Future.class)
     public QueueTaskFuture<R> scheduleBuild2(int quietPeriod, Cause c, Collection<? extends Action> actions) {
-        List<Action> queueActions = new ArrayList<Action>(actions);
+        List<Action> queueActions = new ArrayList<>(actions);
         if (c != null) {
             queueActions.add(new CauseAction(c));
         }
@@ -987,7 +987,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     @Override
     public List<Action> getActions() {
         // add all the transient actions, too
-        List<Action> actions = new Vector<Action>(super.getActions());
+        List<Action> actions = new Vector<>(super.getActions());
         actions.addAll(transientActions);
         // return the read only list to cause a failure on plugins who try to add an action here
         return Collections.unmodifiableList(actions);
@@ -1127,7 +1127,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     }
 
     public List<SubTask> getSubTasks() {
-        List<SubTask> r = new ArrayList<SubTask>();
+        List<SubTask> r = new ArrayList<>();
         r.add(this);
         for (SubTaskContributor euc : SubTaskContributor.all())
             r.addAll(euc.forProject(this));
@@ -1173,7 +1173,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      */
     public ResourceList getResourceList() {
         final Set<ResourceActivity> resourceActivities = getResourceActivities();
-        final List<ResourceList> resourceLists = new ArrayList<ResourceList>(1 + resourceActivities.size());
+        final List<ResourceList> resourceLists = new ArrayList<>(1 + resourceActivities.size());
         for (ResourceActivity activity : resourceActivities) {
             if (activity != this && activity != null) {
                 // defensive infinite recursion and null check
@@ -1605,7 +1605,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * @return A List of upstream projects that has a {@link BuildTrigger} to this project.
      */
     public final List<AbstractProject> getBuildTriggerUpstreamProjects() {
-        ArrayList<AbstractProject> result = new ArrayList<AbstractProject>();
+        ArrayList<AbstractProject> result = new ArrayList<>();
         for (AbstractProject<?,?> ap : getUpstreamProjects()) {
             BuildTrigger buildTrigger = ap.getPublishersList().get(BuildTrigger.class);
             if (buildTrigger != null)
@@ -1642,7 +1642,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      *      numbers of that project.
      */
     public SortedMap<Integer, RangeSet> getRelationship(AbstractProject that) {
-        TreeMap<Integer,RangeSet> r = new TreeMap<Integer,RangeSet>(REVERSE_INTEGER_COMPARATOR);
+        TreeMap<Integer,RangeSet> r = new TreeMap<>(REVERSE_INTEGER_COMPARATOR);
 
         checkAndRecord(that, r, this.getBuilds());
         // checkAndRecord(that, r, that.getBuilds());
@@ -1815,7 +1815,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         throws FormException, ServletException {
 
         JSONObject data = req.getSubmittedForm();
-        List<T> r = new Vector<T>();
+        List<T> r = new Vector<>();
         for (Descriptor<T> d : descriptors) {
             String safeName = d.getJsonSafeClassName();
             if (req.getParameter(safeName) != null) {
@@ -2016,7 +2016,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             }
 
             List<String> getSeeds() {
-                ArrayList<String> terms = new ArrayList<String>();
+                ArrayList<String> terms = new ArrayList<>();
                 boolean trailingQuote = source.endsWith("\"");
                 boolean leadingQuote = source.startsWith("\"");
                 boolean trailingSpace = source.endsWith(" ");
@@ -2082,7 +2082,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * @deprecated Use {@link ParameterizedJobMixIn#BUILD_NOW_TEXT}.
      */
     @Deprecated
-    public static final Message<AbstractProject> BUILD_NOW_TEXT = new Message<AbstractProject>();
+    public static final Message<AbstractProject> BUILD_NOW_TEXT = new Message<>();
 
     /**
      * Used for CLI binding.

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -413,7 +413,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
      * from a string like "/foo/bar/zot".
      */
     private List<Path> buildParentPath(String pathList, int restSize) {
-        List<Path> r = new ArrayList<Path>();
+        List<Path> r = new ArrayList<>();
         StringTokenizer tokens = new StringTokenizer(pathList, "/");
         int total = tokens.countTokens();
         int current=1;
@@ -669,7 +669,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
      * (this mechanism is used to skip empty intermediate directory.)
      */
     private static List<List<Path>> buildChildPaths(VirtualFile cur, Locale locale) throws IOException {
-            List<List<Path>> r = new ArrayList<List<Path>>();
+            List<List<Path>> r = new ArrayList<>();
 
             VirtualFile[] files = cur.list();
                 Arrays.sort(files,new FileComparator(locale));
@@ -680,12 +680,12 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                         r.add(Collections.singletonList(p));
                     } else {
                         // find all empty intermediate directory
-                        List<Path> l = new ArrayList<Path>();
+                        List<Path> l = new ArrayList<>();
                         l.add(p);
                         String relPath = Util.rawEncode(f.getName());
                         while(true) {
                             // files that don't start with '.' qualify for 'meaningful files', nor SCM related files
-                            List<VirtualFile> sub = new ArrayList<VirtualFile>();
+                            List<VirtualFile> sub = new ArrayList<>();
                             for (VirtualFile vf : f.list()) {
                                 String name = vf.getName();
                                 if (!name.startsWith(".") && !name.equals("CVS") && !name.equals(".svn")) {
@@ -714,7 +714,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
             Collection<String> files = baseDir.list(pattern, null, /* TODO what is the user expectation? */true);
 
             if (!files.isEmpty()) {
-                List<List<Path>> r = new ArrayList<List<Path>>(files.size());
+                List<List<Path>> r = new ArrayList<>(files.size());
                 for (String match : files) {
                     List<Path> file = buildPathList(baseDir, baseDir.child(match), baseRef);
                     r.add(file);
@@ -729,7 +729,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
          * Builds a path list from the current workspace directory down to the specified file path.
          */
         private static List<Path> buildPathList(VirtualFile baseDir, VirtualFile filePath, String baseRef) throws IOException {
-            List<Path> pathList = new ArrayList<Path>();
+            List<Path> pathList = new ArrayList<>();
             StringBuilder href = new StringBuilder(baseRef);
 
             buildPathList(baseDir, filePath, pathList, href);

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -282,7 +282,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
      * Return the possibly empty tag cloud for the labels of this node.
      */
     public TagCloud<LabelAtom> getLabelCloud() {
-        return new TagCloud<LabelAtom>(getAssignedLabels(),new WeightFunction<LabelAtom>() {
+        return new TagCloud<>(getAssignedLabels(), new WeightFunction<LabelAtom>() {
             public float weight(LabelAtom item) {
                 return item.getTiedJobCount();
             }
@@ -313,7 +313,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
      * @return HashSet<Label>.
      */
     private HashSet<LabelAtom> getDynamicLabels() {
-        HashSet<LabelAtom> result = new HashSet<LabelAtom>();
+        HashSet<LabelAtom> result = new HashSet<>();
         for (LabelFinder labeler : LabelFinder.all()) {
             // Filter out any bad(null) results from plugins
             // for compatibility reasons, findLabels may return LabelExpression and not atom.
@@ -526,7 +526,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
                 }
 
                 try {
-                    DescribableList<NodeProperty<?>, NodePropertyDescriptor> tmp = new DescribableList<NodeProperty<?>, NodePropertyDescriptor>(Saveable.NOOP,getNodeProperties().toList());
+                    DescribableList<NodeProperty<?>, NodePropertyDescriptor> tmp = new DescribableList<>(Saveable.NOOP, getNodeProperties().toList());
                     tmp.rebuild(req, jsonForProperties, NodeProperty.all());
                     return tmp.toList();
                 } catch (FormException e) {

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2871,7 +2871,7 @@ public class Queue extends ResourceController implements Saveable {
         private final WeakReference<Queue> queue;
 
         MaintainTask(Queue queue) {
-            this.queue = new WeakReference<Queue>(queue);
+            this.queue = new WeakReference<>(queue);
         }
 
         private void periodic() {
@@ -2902,7 +2902,7 @@ public class Queue extends ResourceController implements Saveable {
     	}
 
     	public List<T> getAll(Task task) {
-    		List<T> result = new ArrayList<T>();
+    		List<T> result = new ArrayList<>();
     		for (T item: this) {
     			if (item.task.equals(task)) {
     				result.add(item);
@@ -2949,7 +2949,7 @@ public class Queue extends ResourceController implements Saveable {
                 justification = "It will invoke the inherited clear() method according to Java semantics. "
                               + "FindBugs recommends suppressing warnings in such case")
         public void cancelAll() {
-            for (T t : new ArrayList<T>(this))
+            for (T t : new ArrayList<>(this))
                 t.cancel(Queue.this);
             clear();
         }
@@ -2963,10 +2963,10 @@ public class Queue extends ResourceController implements Saveable {
 
         public Snapshot(Set<WaitingItem> waitingList, List<BlockedItem> blockedProjects, List<BuildableItem> buildables,
                         List<BuildableItem> pendings) {
-            this.waitingList = new LinkedHashSet<WaitingItem>(waitingList);
-            this.blockedProjects = new ArrayList<BlockedItem>(blockedProjects);
-            this.buildables = new ArrayList<BuildableItem>(buildables);
-            this.pendings = new ArrayList<BuildableItem>(pendings);
+            this.waitingList = new LinkedHashSet<>(waitingList);
+            this.blockedProjects = new ArrayList<>(blockedProjects);
+            this.buildables = new ArrayList<>(buildables);
+            this.pendings = new ArrayList<>(pendings);
         }
 
         @Override

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1482,7 +1482,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      * Tests the internet connectivity.
      */
     public final class ConnectionCheckJob extends UpdateCenterJob {
-        private final Vector<String> statuses= new Vector<String>();
+        private final Vector<String> statuses= new Vector<>();
 
         final Map<String, ConnectionStatus> connectionStates = new ConcurrentHashMap<>();
 

--- a/core/src/main/java/hudson/scm/SCM.java
+++ b/core/src/main/java/hudson/scm/SCM.java
@@ -741,7 +741,7 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
         if(project==null)   return all();
         
         final Descriptor pd = Jenkins.get().getDescriptor((Class) project.getClass());
-        List<SCMDescriptor<?>> r = new ArrayList<SCMDescriptor<?>>();
+        List<SCMDescriptor<?>> r = new ArrayList<>();
         for (SCMDescriptor<?> scmDescriptor : all()) {
             if(!scmDescriptor.isApplicable(project))    continue;
 

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -194,7 +194,7 @@ public class Search implements StaplerProxy {
     @ExportedBean
     public static class Result {
         @Exported
-        public List<Item> suggestions = new ArrayList<Item>();
+        public List<Item> suggestions = new ArrayList<>();
     }
 
     @ExportedBean(defaultVisibility=999)
@@ -310,7 +310,7 @@ public class Search implements StaplerProxy {
             }
         }
 
-        List<Tag> buf = new ArrayList<Tag>();
+        List<Tag> buf = new ArrayList<>();
         List<SuggestedItem> items = find(Mode.SUGGEST, index, tokenList, searchContext);
 
         // sort them
@@ -372,9 +372,9 @@ public class Search implements StaplerProxy {
 
         List<SuggestedItem>[] paths = new List[tokens.length()+1]; // we won't use [0].
         for(int i=1;i<=tokens.length();i++)
-            paths[i] = new ArrayList<SuggestedItem>();
+            paths[i] = new ArrayList<>();
 
-        List<SearchItem> items = new ArrayList<SearchItem>(); // items found in 1 step
+        List<SearchItem> items = new ArrayList<>(); // items found in 1 step
 
         LOGGER.log(Level.FINE, "tokens={0}", tokens);
         

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -552,7 +552,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
      * All users who can login to the system.
      */
     public List<User> getAllUsers() {
-        List<User> r = new ArrayList<User>();
+        List<User> r = new ArrayList<>();
         for (User u : User.getAll()) {
             if(u.getProperty(Details.class)!=null)
                 r.add(u);
@@ -587,7 +587,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
          * Keys are field names (e.g. {@code password2}), values are the messages.
          */
         // TODO i18n?
-        public HashMap<String, String> errors = new HashMap<String, String>();
+        public HashMap<String, String> errors = new HashMap<>();
 
         public SignupInfo() {
         }

--- a/core/src/main/java/hudson/slaves/DelegatingComputerLauncher.java
+++ b/core/src/main/java/hudson/slaves/DelegatingComputerLauncher.java
@@ -82,7 +82,7 @@ public abstract class DelegatingComputerLauncher extends ComputerLauncher {
          */
         public List<Descriptor<ComputerLauncher>> applicableDescriptors(@CheckForNull Slave it,
                                                                         @Nonnull Slave.SlaveDescriptor itDescriptor) {
-            List<Descriptor<ComputerLauncher>> r = new ArrayList<Descriptor<ComputerLauncher>>();
+            List<Descriptor<ComputerLauncher>> r = new ArrayList<>();
             for (Descriptor<ComputerLauncher> d : itDescriptor.computerLauncherDescriptors(it)) {
                 if (DelegatingComputerLauncher.class.isAssignableFrom(d.getKlass().toJavaClass()))  continue;
                 r.add(d);
@@ -98,7 +98,7 @@ public abstract class DelegatingComputerLauncher extends ComputerLauncher {
         @Restricted(DoNotUse.class)
         @RestrictedSince("2.12")
         public List<Descriptor<ComputerLauncher>> getApplicableDescriptors() {
-            List<Descriptor<ComputerLauncher>> r = new ArrayList<Descriptor<ComputerLauncher>>();
+            List<Descriptor<ComputerLauncher>> r = new ArrayList<>();
             for (Descriptor<ComputerLauncher> d :
                     Jenkins.get().getDescriptorList(ComputerLauncher.class)) {
                 if (DelegatingComputerLauncher.class.isAssignableFrom(d.getKlass().toJavaClass()))  continue;

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -285,7 +285,7 @@ public class SCMTrigger extends Trigger<Item> {
 
          // originally List<SCMedItem> but known to be used only for logging, in which case the instances are not actually cast to SCMedItem anyway
         public List<SCMTriggerItem> getItemsBeingPolled() {
-            List<SCMTriggerItem> r = new ArrayList<SCMTriggerItem>();
+            List<SCMTriggerItem> r = new ArrayList<>();
             for (Runner i : getRunners())
                 r.add(i.getTarget());
             return r;
@@ -467,7 +467,7 @@ public class SCMTrigger extends Trigger<Item> {
         }
 
         public AnnotatedLargeText getPollingLogText() {
-            return new AnnotatedLargeText<BuildAction>(getPollingLogFile(), Charset.defaultCharset(), true, this);
+            return new AnnotatedLargeText<>(getPollingLogFile(), Charset.defaultCharset(), true, this);
         }
         
         /**
@@ -509,7 +509,7 @@ public class SCMTrigger extends Trigger<Item> {
         }
 
         public String getDisplayName() {
-            Set<SCMDescriptor<?>> descriptors = new HashSet<SCMDescriptor<?>>();
+            Set<SCMDescriptor<?>> descriptors = new HashSet<>();
             for (SCM scm : job().getSCMs()) {
                 descriptors.add(scm.getDescriptor());
             }
@@ -529,7 +529,7 @@ public class SCMTrigger extends Trigger<Item> {
          * @since 1.350
          */
         public void writeLogTo(XMLOutput out) throws IOException {
-            new AnnotatedLargeText<SCMAction>(getLogFile(),Charset.defaultCharset(),true,this).writeHtmlTo(0,out.asWriter());
+            new AnnotatedLargeText<>(getLogFile(), Charset.defaultCharset(), true, this).writeHtmlTo(0,out.asWriter());
         }
     }
 

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -229,7 +229,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
          * Immediate child processes.
          */
         public final List<OSProcess> getChildren() {
-            List<OSProcess> r = new ArrayList<OSProcess>();
+            List<OSProcess> r = new ArrayList<>();
             for (OSProcess p : ProcessTree.this)
                 if(p.getParent()==this)
                     r.add(p);
@@ -953,7 +953,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             public synchronized List<String> getArguments() {
                 if(arguments!=null)
                     return arguments;
-                arguments = new ArrayList<String>();
+                arguments = new ArrayList<>();
                 try {
                     byte[] cmdline = readFileToByteArray(getFile("cmdline"));
                     int pos=0;
@@ -1183,7 +1183,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 if (arguments != null)
                     return arguments;
 
-                arguments = new ArrayList<String>(argc);
+                arguments = new ArrayList<>(argc);
                 if (argc == 0) {
                     return arguments;
                 }
@@ -1470,7 +1470,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 if(arguments!=null)
                     return arguments;
 
-                arguments = new ArrayList<String>(argc);
+                arguments = new ArrayList<>(argc);
 		if (argc == 0) {
 		    return arguments;
 		}
@@ -1678,7 +1678,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 try {
 // allocate them first, so that the parse error wil result in empty data
                     // and avoid retry.
-                    arguments = new ArrayList<String>();
+                    arguments = new ArrayList<>();
                     envVars = new EnvVars();
 
                     IntByReference intByRef = new IntByReference();

--- a/core/src/main/java/hudson/util/spring/DefaultRuntimeSpringConfiguration.java
+++ b/core/src/main/java/hudson/util/spring/DefaultRuntimeSpringConfiguration.java
@@ -47,9 +47,9 @@ import java.util.logging.Logger;
 class DefaultRuntimeSpringConfiguration implements RuntimeSpringConfiguration {
     private static final Logger LOGGER = Logger.getLogger(DefaultRuntimeSpringConfiguration.class.getName());
     private StaticWebApplicationContext context;
-    private Map<String,BeanConfiguration> beanConfigs = new HashMap<String,BeanConfiguration>();
-    private Map<String,BeanDefinition> beanDefinitions = new HashMap<String,BeanDefinition>();
-    private List<String> beanNames = new ArrayList<String>();
+    private Map<String,BeanConfiguration> beanConfigs = new HashMap<>();
+    private Map<String,BeanDefinition> beanDefinitions = new HashMap<>();
+    private List<String> beanNames = new ArrayList<>();
 
     public DefaultRuntimeSpringConfiguration() {
         super();

--- a/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
+++ b/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
@@ -403,7 +403,7 @@ public class XStreamDOM {
         private static class Pending {
             final String tagName;
             List<XStreamDOM> children;
-            List<String> attributes = new ArrayList<String>();
+            List<String> attributes = new ArrayList<>();
             String value;
 
             private Pending(String tagName) {
@@ -412,7 +412,7 @@ public class XStreamDOM {
 
             void addChild(XStreamDOM dom) {
                 if (children==null)
-                    children = new ArrayList<XStreamDOM>();
+                    children = new ArrayList<>();
                 children.add(dom);
             }
 
@@ -421,7 +421,7 @@ public class XStreamDOM {
             }
         }
 
-        private final Stack<Pending> pendings = new Stack<Pending>();
+        private final Stack<Pending> pendings = new Stack<>();
 
         public WriterImpl() {
             pendings.push(new Pending(null));   // to get the final result
@@ -522,7 +522,7 @@ public class XStreamDOM {
             List<XStreamDOM> children = null;
             String value = null;
             if (r.hasMoreChildren()) {
-                children = new ArrayList<XStreamDOM>();
+                children = new ArrayList<>();
                 while (r.hasMoreChildren()) {
                     children.add(unmarshal(r, context));
                 }

--- a/core/src/test/java/hudson/EnvVarsTest.java
+++ b/core/src/test/java/hudson/EnvVarsTest.java
@@ -138,6 +138,6 @@ public class EnvVarsTest {
         OverrideOrderCalculator calc = new OverrideOrderCalculator(env, overrides);
         List<String> order = calc.getOrderedVariableNames();
         assertEquals(Arrays.asList("B", "A", "C"), order.subList(0, 3));
-        assertEquals(Sets.newHashSet("E", "D"), new HashSet<String>(order.subList(3, order.size())));
+        assertEquals(Sets.newHashSet("E", "D"), new HashSet<>(order.subList(3, order.size())));
     }
 }

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -132,7 +132,7 @@ public class FilePathTest {
     }
     
     private List<Future<Integer>> whenFileIsCopied100TimesConcurrently(final File file) throws InterruptedException {
-        List<Callable<Integer>> r = new ArrayList<Callable<Integer>>();
+        List<Callable<Integer>> r = new ArrayList<>();
         for (int i=0; i<100; i++) {
             r.add(new Callable<Integer>() {
                 public Integer call() throws Exception {
@@ -371,36 +371,36 @@ public class FilePathTest {
 
     @Test public void list() throws Exception {
         File baseDir = temp.getRoot();
-            final Set<FilePath> expected = new HashSet<FilePath>();
+            final Set<FilePath> expected = new HashSet<>();
             expected.add(createFilePath(baseDir, "top", "sub", "app.log"));
             expected.add(createFilePath(baseDir, "top", "sub", "trace.log"));
             expected.add(createFilePath(baseDir, "top", "db", "db.log"));
             expected.add(createFilePath(baseDir, "top", "db", "trace.log"));
             final FilePath[] result = new FilePath(baseDir).list("**");
-            assertEquals(expected, new HashSet<FilePath>(Arrays.asList(result)));
+            assertEquals(expected, new HashSet<>(Arrays.asList(result)));
     }
 
     @Test public void listWithExcludes() throws Exception {
         File baseDir = temp.getRoot();
-            final Set<FilePath> expected = new HashSet<FilePath>();
+            final Set<FilePath> expected = new HashSet<>();
             expected.add(createFilePath(baseDir, "top", "sub", "app.log"));
             createFilePath(baseDir, "top", "sub", "trace.log");
             expected.add(createFilePath(baseDir, "top", "db", "db.log"));
             createFilePath(baseDir, "top", "db", "trace.log");
             final FilePath[] result = new FilePath(baseDir).list("**", "**/trace.log");
-            assertEquals(expected, new HashSet<FilePath>(Arrays.asList(result)));
+            assertEquals(expected, new HashSet<>(Arrays.asList(result)));
     }
 
     @Test public void listWithDefaultExcludes() throws Exception {
         File baseDir = temp.getRoot();
-            final Set<FilePath> expected = new HashSet<FilePath>();
+            final Set<FilePath> expected = new HashSet<>();
             expected.add(createFilePath(baseDir, "top", "sub", "backup~"));
             expected.add(createFilePath(baseDir, "top", "CVS", "somefile,v"));
             expected.add(createFilePath(baseDir, "top", ".git", "config"));
             // none of the files are included by default (default includes true)
             assertEquals(0, new FilePath(baseDir).list("**", "").length);
             final FilePath[] result = new FilePath(baseDir).list("**", "", false);
-            assertEquals(expected, new HashSet<FilePath>(Arrays.asList(result)));
+            assertEquals(expected, new HashSet<>(Arrays.asList(result)));
     }
 
     @Issue("JENKINS-11073")

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -62,7 +62,7 @@ public class UtilTest {
 
     @Test
     public void testReplaceMacro() {
-        Map<String,String> m = new HashMap<String,String>();
+        Map<String,String> m = new HashMap<>();
         m.put("A","a");
         m.put("A.B","a-b");
         m.put("AA","aa");

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -178,11 +178,11 @@ public class ListJobsCommandTest {
             @Override
             protected boolean matchesSafely(ByteArrayOutputStream item) {
 
-                final HashSet<String> jobs = new HashSet<String>(
+                final HashSet<String> jobs = new HashSet<>(
                         Arrays.asList(item.toString().split(System.getProperty("line.separator")))
                 );
 
-                return new HashSet<String>(Arrays.asList(expected)).equals(jobs);
+                return new HashSet<>(Arrays.asList(expected)).equals(jobs);
             }
 
             @Override

--- a/core/src/test/java/hudson/model/ActionableTest.java
+++ b/core/src/test/java/hudson/model/ActionableTest.java
@@ -54,7 +54,7 @@ public class ActionableTest {
     }
 
     static class ActionableOverride extends Actionable {
-        ArrayList<Action> specialActions = new ArrayList<Action>();
+        ArrayList<Action> specialActions = new ArrayList<>();
 
         @Override
         public String getDisplayName() {

--- a/core/src/test/java/hudson/model/ParametersActionTest.java
+++ b/core/src/test/java/hudson/model/ParametersActionTest.java
@@ -112,7 +112,7 @@ public class ParametersActionTest {
         assertEquals(2, vars.size());   
         parametersAction.createVariableResolver(build);
         
-        LinkedList<BuildWrapper> wrappers = new LinkedList<BuildWrapper>();
+        LinkedList<BuildWrapper> wrappers = new LinkedList<>();
         parametersAction.createBuildWrappers(build, wrappers);
         assertEquals(0, wrappers.size());
         

--- a/core/src/test/java/hudson/model/ViewTest.java
+++ b/core/src/test/java/hudson/model/ViewTest.java
@@ -46,7 +46,7 @@ public class ViewTest {
         TopLevelItem item2 = Mockito.mock(TopLevelItem.class);
         Mockito.when(item2.getSearchUrl()).thenReturn(url2);
         Mockito.when(item2.getDisplayName()).thenReturn(displayName2);
-        Collection<TopLevelItem> items = new ArrayList<TopLevelItem>();
+        Collection<TopLevelItem> items = new ArrayList<>();
         items.add(item1);
         items.add(item2);
         
@@ -62,7 +62,7 @@ public class ViewTest {
         SearchIndex index = sib.make();
         
         // now make sure we can fetch item1 from the index
-        List<SearchItem> result = new ArrayList<SearchItem>();
+        List<SearchItem> result = new ArrayList<>();
         index.find(displayName1, result);
         assertEquals(1, result.size());
         SearchItem actual = result.get(0);

--- a/core/src/test/java/hudson/scheduler/CronTabDayOfWeekLocaleTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabDayOfWeekLocaleTest.java
@@ -29,7 +29,7 @@ public class CronTabDayOfWeekLocaleTest {
     @Parameters
     public static Collection<Object[]> parameters() {
         final Locale[] locales = Locale.getAvailableLocales();
-        final Collection<Object[]> parameters = new ArrayList<Object[]>();
+        final Collection<Object[]> parameters = new ArrayList<>();
         for (final Locale locale : locales) {
             final Calendar cal = Calendar.getInstance(locale);
             if (GregorianCalendar.class.equals(cal.getClass())) {

--- a/core/src/test/java/hudson/scheduler/CronTabEventualityTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabEventualityTest.java
@@ -20,7 +20,7 @@ import java.util.GregorianCalendar;
 public class CronTabEventualityTest {
     @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
-        Collection<Object[]> parameters = new ArrayList<Object[]>();
+        Collection<Object[]> parameters = new ArrayList<>();
         parameters.add(new Object[]{"zero", Hash.zero()});
         parameters.add(new Object[]{"seed1", Hash.from("seed1")});
         parameters.add(new Object[]{"seed2", Hash.from("seed2")});

--- a/core/src/test/java/hudson/scheduler/CronTabTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabTest.java
@@ -272,7 +272,7 @@ public class CronTabTest {
 
     @Test public void repeatedHash() throws Exception {
         CronTabList tabs = CronTabList.create("H * * * *\nH * * * *", Hash.from("seed"));
-        List<Integer> times = new ArrayList<Integer>();
+        List<Integer> times = new ArrayList<>();
         for (int i = 0; i < 60; i++) {
             if (tabs.check(new GregorianCalendar(2013, 3, 3, 11, i, 0))) {
                 times.add(i);
@@ -306,7 +306,7 @@ public class CronTabTest {
     @Issue("JENKINS-9283")
     @Test public void testTimezone() throws Exception {
         CronTabList tabs = CronTabList.create("TZ=Australia/Sydney\nH * * * *\nH * * * *", Hash.from("seed"));
-        List<Integer> times = new ArrayList<Integer>();
+        List<Integer> times = new ArrayList<>();
         for (int i = 0; i < 60; i++) {
             GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
             calendar.set(2013, Calendar.APRIL, 3, 11, i, 0);

--- a/core/src/test/java/hudson/search/SearchTest.java
+++ b/core/src/test/java/hudson/search/SearchTest.java
@@ -93,7 +93,7 @@ public class SearchTest {
 
         SuggestedItem suggestedHit = new SuggestedItem(searchItemHit);
         SuggestedItem suggestedNoHit = new SuggestedItem(searchItemNoHit);
-        ArrayList<SuggestedItem> list = new ArrayList<SuggestedItem>();
+        ArrayList<SuggestedItem> list = new ArrayList<>();
         list.add(suggestedNoHit);
         list.add(suggestedHit); // make sure the hit is the second item
 

--- a/core/src/test/java/hudson/slaves/ChannelPingerTest.java
+++ b/core/src/test/java/hudson/slaves/ChannelPingerTest.java
@@ -27,7 +27,7 @@ public class ChannelPingerTest {
 
     @Mock private Channel mockChannel;
 
-    private Map<String, String> savedSystemProperties = new HashMap<String, String>();
+    private Map<String, String> savedSystemProperties = new HashMap<>();
 
     @Before
     public void setUp() throws Exception {

--- a/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
+++ b/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
@@ -200,9 +200,9 @@ public class ArgumentListBuilderTest {
 
     @Test
     public void addKeyValuePairsFromPropertyString() throws IOException {
-        final Map<String, String> map = new HashMap<String, String>();
+        final Map<String, String> map = new HashMap<>();
         map.put("PATH", "C:\\Windows");
-        final VariableResolver<String> resolver = new VariableResolver.ByMap<String>(map);
+        final VariableResolver<String> resolver = new VariableResolver.ByMap<>(map);
 
         final String properties = "my.path=$PATH";
 
@@ -217,7 +217,7 @@ public class ArgumentListBuilderTest {
 
     @Test
     public void numberOfBackslashesInPropertiesShouldBePreservedAfterMacroExpansion() throws IOException {
-        final Map<String, String> map = new HashMap<String, String>();
+        final Map<String, String> map = new HashMap<>();
         map.put("ONE", "one\\backslash");
         map.put("TWO", "two\\\\backslashes");
         map.put("FOUR", "four\\\\\\\\backslashes");
@@ -230,7 +230,7 @@ public class ArgumentListBuilderTest {
         ;
 
         final String args = new ArgumentListBuilder()
-                .addKeyValuePairsFromPropertyString("", properties, new VariableResolver.ByMap<String>(map))
+                .addKeyValuePairsFromPropertyString("", properties, new VariableResolver.ByMap<>(map))
                 .toString()
         ;
 

--- a/core/src/test/java/hudson/util/ConsistentHashTest.java
+++ b/core/src/test/java/hudson/util/ConsistentHashTest.java
@@ -45,7 +45,7 @@ public class ConsistentHashTest {
      */
     @Test
     public void basic() {
-        ConsistentHash<String> hash = new ConsistentHash<String>();
+        ConsistentHash<String> hash = new ConsistentHash<>();
         hash.add("data1");
         hash.add("data2");
         hash.add("data3");
@@ -60,7 +60,7 @@ public class ConsistentHashTest {
 
         // list them up
         Iterator<String> itr = hash.list(Integer.MIN_VALUE).iterator();
-        Set<String> all = new HashSet<String>();
+        Set<String> all = new HashSet<>();
         String z = itr.next();
         all.add(z);
         assertEquals(z,x);
@@ -75,7 +75,7 @@ public class ConsistentHashTest {
      */
     @Test
     public void unevenDistribution() {
-        ConsistentHash<String> hash = new ConsistentHash<String>();
+        ConsistentHash<String> hash = new ConsistentHash<>();
         hash.add("even",10);
         hash.add("odd",100);
 
@@ -97,12 +97,12 @@ public class ConsistentHashTest {
      */
     @Test
     public void removal() {
-        ConsistentHash<Integer> hash = new ConsistentHash<Integer>();
+        ConsistentHash<Integer> hash = new ConsistentHash<>();
         for( int i=0; i<10; i++ )
             hash.add(i);
 
         // what was the mapping before the mutation?
-        Map<Integer,Integer> before = new HashMap<Integer, Integer>();
+        Map<Integer,Integer> before = new HashMap<>();
         Random r = new Random(0);
         for(int i=0; i<1000; i++) {
             int q = r.nextInt();
@@ -121,7 +121,7 @@ public class ConsistentHashTest {
 
     @Test
     public void emptyBehavior() {
-        ConsistentHash<String> hash = new ConsistentHash<String>();
+        ConsistentHash<String> hash = new ConsistentHash<>();
         assertEquals(0, hash.countAllPoints());
         assertFalse(hash.list(0).iterator().hasNext());
         assertNull(hash.lookup(0));
@@ -130,7 +130,7 @@ public class ConsistentHashTest {
 
     @Test
     public void countAllPoints() {
-        ConsistentHash<String> hash = new ConsistentHash<String>();
+        ConsistentHash<String> hash = new ConsistentHash<>();
         assertEquals(0, hash.countAllPoints());
         hash.add("foo", 10);
         assertEquals(10, hash.countAllPoints());
@@ -142,7 +142,7 @@ public class ConsistentHashTest {
 
     @Test
     public void defaultReplicationIsOneHundred() {
-        ConsistentHash<String> hash = new ConsistentHash<String>();
+        ConsistentHash<String> hash = new ConsistentHash<>();
         assertEquals(0, hash.countAllPoints());
         hash.add("foo");
         assertEquals(100, hash.countAllPoints());
@@ -150,7 +150,7 @@ public class ConsistentHashTest {
 
     @Test
     public void setCustomDefaultReplication() {
-        ConsistentHash<String> hash = new ConsistentHash<String>((ConsistentHash.Hash<String>) ConsistentHash.DEFAULT_HASH, 7);
+        ConsistentHash<String> hash = new ConsistentHash<>((ConsistentHash.Hash<String>) ConsistentHash.DEFAULT_HASH, 7);
         assertEquals(0, hash.countAllPoints());
         hash.add("foo");
         assertEquals(7, hash.countAllPoints());
@@ -166,7 +166,7 @@ public class ConsistentHashTest {
         };
 
         try {
-            ConsistentHash<String> hash = new ConsistentHash<String>(hashFunction);
+            ConsistentHash<String> hash = new ConsistentHash<>(hashFunction);
             hash.add("foo");
             fail("Didn't use custom hash function");
         } catch (RuntimeException e) {
@@ -179,14 +179,14 @@ public class ConsistentHashTest {
      */
     @Test
     public void speed() {
-        Map<String,Integer> data = new Hash<String, Integer>();
+        Map<String,Integer> data = new Hash<>();
         for (int i = 0; i < 1000; i++)
             data.put("node" + i,100);
         data.put("tail",100);
 
         long start = System.currentTimeMillis();
         for (int j=0; j<10; j++) {
-            ConsistentHash<String> b = new ConsistentHash<String>();
+            ConsistentHash<String> b = new ConsistentHash<>();
             b.addAll(data);
         }
 

--- a/core/src/test/java/hudson/util/CopyOnWriteMapTest.java
+++ b/core/src/test/java/hudson/util/CopyOnWriteMapTest.java
@@ -35,8 +35,8 @@ import org.junit.Test;
  */
 public class CopyOnWriteMapTest {
     public static final class HashData {
-        CopyOnWriteMap.Hash<String,String> map1 = new CopyOnWriteMap.Hash<String,String>();
-        HashMap<String,String> map2 = new HashMap<String,String>();
+        CopyOnWriteMap.Hash<String,String> map1 = new CopyOnWriteMap.Hash<>();
+        HashMap<String,String> map2 = new HashMap<>();
     }
 
     /**
@@ -71,12 +71,12 @@ public class CopyOnWriteMapTest {
         CopyOnWriteMap.Tree<String,String> map1;
         TreeMap<String,String> map2;
         TreeData() {
-            map1 = new CopyOnWriteMap.Tree<String,String>();
-            map2 = new TreeMap<String,String>();
+            map1 = new CopyOnWriteMap.Tree<>();
+            map2 = new TreeMap<>();
         }
         TreeData(Comparator<String> comparator) {
-            map1 = new CopyOnWriteMap.Tree<String,String>(comparator);
-            map2 = new TreeMap<String,String>(comparator);
+            map1 = new CopyOnWriteMap.Tree<>(comparator);
+            map2 = new TreeMap<>(comparator);
         }
     }
 
@@ -115,8 +115,8 @@ public class CopyOnWriteMapTest {
     }
 
     @Test public void equalsHashCodeToString() throws Exception {
-        Map<String,Integer> m1 = new TreeMap<String,Integer>();
-        Map<String,Integer> m2 = new CopyOnWriteMap.Tree<String,Integer>();
+        Map<String,Integer> m1 = new TreeMap<>();
+        Map<String,Integer> m2 = new CopyOnWriteMap.Tree<>();
         m1.put("foo", 5);
         m1.put("bar", 7);
         m2.put("foo", 5);

--- a/core/src/test/java/hudson/util/CyclicGraphDetectorTest.java
+++ b/core/src/test/java/hudson/util/CyclicGraphDetectorTest.java
@@ -32,7 +32,7 @@ public class CyclicGraphDetectorTest {
         }
 
         Set<String> nodes() {
-            Set<String> nodes = new LinkedHashSet<String>();
+            Set<String> nodes = new LinkedHashSet<>();
             for (Edge e : this) {
                 nodes.add(e.src);
                 nodes.add(e.dst);
@@ -41,7 +41,7 @@ public class CyclicGraphDetectorTest {
         }
 
         Set<String> edges(String from) {
-            Set<String> edges = new LinkedHashSet<String>();
+            Set<String> edges = new LinkedHashSet<>();
             for (Edge e : this) {
                 if (e.src.equals(from))
                     edges.add(e.dst);

--- a/core/src/test/java/hudson/util/PackedMapTest.java
+++ b/core/src/test/java/hudson/util/PackedMapTest.java
@@ -21,7 +21,7 @@ public class PackedMapTest {
 
     @Test
     public void basic() {
-        Map<String,String> o = new TreeMap<String, String>();
+        Map<String,String> o = new TreeMap<>();
         o.put("a","b");
         o.put("c","d");
 

--- a/core/src/test/java/hudson/util/RunListTest.java
+++ b/core/src/test/java/hudson/util/RunListTest.java
@@ -58,7 +58,7 @@ public class RunListTest {
 		when(r1.getTimeInMillis()).thenReturn(200L);
 		when(r2.getTimeInMillis()).thenReturn(300L);
 
-		ArrayList<Run> list = new ArrayList<Run>();
+		ArrayList<Run> list = new ArrayList<>();
 		list.add(r2);
 		list.add(r1);
 

--- a/core/src/test/java/hudson/util/XStream2Test.java
+++ b/core/src/test/java/hudson/util/XStream2Test.java
@@ -271,7 +271,7 @@ public class XStream2Test {
     }
 
     public static class Foo2 {
-        ConcurrentHashMap<String,String> m = new ConcurrentHashMap<String,String>();
+        ConcurrentHashMap<String,String> m = new ConcurrentHashMap<>();
     }
 
     @Issue("SECURITY-105")

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -73,7 +73,7 @@ public class AbstractLazyLoadRunMapTest {
             return new FakeMap(getDir()) {
                 @Override
                 protected BuildReference<Build> createReference(Build r) {
-                    return new BuildReference<Build>(Integer.toString(r.n), /* pretend referent expired */ null);
+                    return new BuildReference<>(Integer.toString(r.n), /* pretend referent expired */ null);
                 }
             };
         }

--- a/core/src/test/java/jenkins/model/lazy/SortedListTest.java
+++ b/core/src/test/java/jenkins/model/lazy/SortedListTest.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
  * @author Kohsuke Kawaguchi
  */
 public class SortedListTest {
-    SortedList<String> l = new SortedList<String>(new ArrayList<String>(Arrays.asList("B","D","F")));
+    SortedList<String> l = new SortedList<>(new ArrayList<>(Arrays.asList("B", "D", "F")));
 
     @Test
     public void testCeil() {
@@ -106,7 +106,7 @@ public class SortedListTest {
     @Test
     public void testClone() {
         final int originalSize = l.size();
-        SortedList<String> l2 = new SortedList<String>(l);
+        SortedList<String> l2 = new SortedList<>(l);
         assertEquals(originalSize, l2.size());
         assertEquals(originalSize, l.size());
         for (int i = 0; i < originalSize; i++) {

--- a/core/src/test/java/jenkins/security/ConfidentialStoreRule.java
+++ b/core/src/test/java/jenkins/security/ConfidentialStoreRule.java
@@ -24,6 +24,6 @@ public class ConfidentialStoreRule extends ExternalResource {
     }
 
     static {
-        ConfidentialStore.TEST = new ThreadLocal<ConfidentialStore>();
+        ConfidentialStore.TEST = new ThreadLocal<>();
     }
 }

--- a/core/src/test/java/jenkins/util/xstream/XStreamDOMTest.java
+++ b/core/src/test/java/jenkins/util/xstream/XStreamDOMTest.java
@@ -124,7 +124,7 @@ public class XStreamDOMTest {
     public static class Name_That_Gets_Escaped {}
 
     public static class DomInMap {
-        Map<String,XStreamDOM> values = new HashMap<String, XStreamDOM>();
+        Map<String,XStreamDOM> values = new HashMap<>();
     }
 
     @Test


### PR DESCRIPTION
Simple cleanup to use type inference instead of having the type specified

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Not needed

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

