### PR TITLE
Update script-security to 1.65

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -405,7 +405,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>script-security</artifactId>
-                  <version>1.63</version>
+                  <version>1.65</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
Update Script Security to 1.65 so we don't bundle https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1579

### Proposed changelog entries

* Update bundled version of Script Security Plugin to 1.65

### Proposed upgrade guidelines

TODO

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs
