### PR TITLE
[JENKINS-36720] - Fix SpotBugs warnings for "known as null" values

### DIFF
--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -401,7 +401,7 @@ public class DownloadService extends PageDecorator {
             for (UpdateSite updatesite : Jenkins.getActiveInstance().getUpdateCenter().getSiteList()) {
                 String site = updatesite.getMetadataUrlForDownloadable(url);
                 if (site == null) {
-                    return FormValidation.warning("The update site " + site + " does not look like an update center");
+                    return FormValidation.warning("The update site " + updatesite + " does not look like an update center");
                 }
                 String jsonString;
                 try {

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -401,7 +401,7 @@ public class DownloadService extends PageDecorator {
             for (UpdateSite updatesite : Jenkins.getActiveInstance().getUpdateCenter().getSiteList()) {
                 String site = updatesite.getMetadataUrlForDownloadable(url);
                 if (site == null) {
-                    return FormValidation.warning("The update site " + updatesite + " does not look like an update center");
+                    return FormValidation.warning("The update site " + updatesite.getId() + " does not look like an update center");
                 }
                 String jsonString;
                 try {

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -199,7 +199,7 @@ public class SystemProperties {
         }
         
         if (LOGGER.isLoggable(Level.CONFIG)) {
-            LOGGER.log(Level.CONFIG, "Property (not found): {0} => {1}", new Object[] {key, value});
+            LOGGER.log(Level.CONFIG, "Property (not found): {0} => {1}", new Object[] {key, null});
         }
         return null;
     }

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -23,7 +23,6 @@
  */
 package jenkins.util;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -40,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
@@ -81,7 +81,8 @@ public class SystemProperties {
 
     @FunctionalInterface
     private interface Handler {
-        @CheckForNull String getString(String key);
+        @CheckForNull
+        String getString(String key);
     }
 
     private static final Handler NULL_HANDLER = key -> null;
@@ -199,7 +200,7 @@ public class SystemProperties {
         }
         
         if (LOGGER.isLoggable(Level.CONFIG)) {
-            LOGGER.log(Level.CONFIG, "Property (not found): {0} => {1}", new Object[] {key, null});
+            LOGGER.log(Level.CONFIG, "Property (not found): {0}", key);
         }
         return null;
     }


### PR DESCRIPTION
Replaced a known null value in a string with a non null more reasonable value and replaced a known as null value with null. Both were findings by Spotbugs.

### Proposed changelog entries

* Internal: Fixed spotbugs issues

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

