### PR TITLE
 [JENKINS-36720] - Fix SpotBugs warnings for "Non-null field is not initialized" values

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -1251,9 +1251,9 @@ public abstract class Launcher {
     }
 
     public static class IOTriplet implements Serializable {
-        @Nonnull
+        @CheckForNull
         InputStream stdout,stderr;
-        @Nonnull
+        @CheckForNull
         OutputStream stdin;
         private static final long serialVersionUID = 1L;
     }

--- a/core/src/main/java/jenkins/security/NonSerializableSecurityContext.java
+++ b/core/src/main/java/jenkins/security/NonSerializableSecurityContext.java
@@ -14,6 +14,7 @@
  */
 package jenkins.security;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextImpl;
 import org.acegisecurity.Authentication;
@@ -40,6 +41,7 @@ import javax.servlet.http.HttpSession;
  * @see hudson.security.HttpSessionContextIntegrationFilter2
  * @since 1.509
  */
+@SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "It is intended to be not serialized and only have defaults in case of deserialization")
 public class NonSerializableSecurityContext implements SecurityContext {
     private transient Authentication authentication;
 

--- a/core/src/main/java/jenkins/security/NonSerializableSecurityContext.java
+++ b/core/src/main/java/jenkins/security/NonSerializableSecurityContext.java
@@ -41,7 +41,7 @@ import javax.servlet.http.HttpSession;
  * @see hudson.security.HttpSessionContextIntegrationFilter2
  * @since 1.509
  */
-@SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "It is intended to be not serialized and only have defaults in case of deserialization")
+@SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "It is not intended to be serialized. Default values will be used in case of deserialization")
 public class NonSerializableSecurityContext implements SecurityContext {
     private transient Authentication authentication;
 


### PR DESCRIPTION
See [JENKINS-36720](https://issues.jenkins-ci.org/browse/JENKINS-36720)

Add one Spotbugs exclude and replaced Nonnull with CheckForNull because assigned variables have CheckForNull annotations

Another one for Hacktoberfest

### Proposed changelog entries

* Internal: Spotbugs issues fixed

### Desired reviewers

