### PR TITLE
Note that CSRF crumbs aren't really needed anymore for API clients

### DIFF
--- a/core/src/main/java/hudson/security/csrf/CrumbExclusion.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbExclusion.java
@@ -17,6 +17,10 @@ import java.io.IOException;
 /**
  * Allows plugins to define exceptions to the CSRF protection filter.
  *
+ * Please note that Jenkins 2.96 and newer accepts HTTP POST requests without CSRF crumb, if
+ * HTTP Basic authentication uses an API token instead of a password, so many use cases
+ * (simple API clients that support authentication but not obtaining a crumb) should be obsolete.
+ *
  * @author Kohsuke Kawaguchi
  * @since 1.446
  */


### PR DESCRIPTION
Perhaps even deprecate it just so people read the Javadoc, and note that it's not _really_ deprecated?

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs
