### PR TITLE
Introduce new AntClassLoader.getUrl() method to prevent code duplication

### DIFF
--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -893,14 +893,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
         } else {
             // try and load from this loader if the parent either didn't find
             // it or wasn't consulted.
-            Enumeration e = pathComponents.elements();
-            while (e.hasMoreElements() && url == null) {
-                File pathComponent = (File) e.nextElement();
-                url = getResourceURL(pathComponent, name);
-                if (url != null) {
-                    log("Resource " + name + " loaded from ant loader", Project.MSG_DEBUG);
-                }
-            }
+            url = getUrl(pathComponents, name);
         }
         if (url == null && !isParentFirst(name)) {
             // this loader was first but it didn't find it - try the parent
@@ -915,6 +908,27 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
         }
         if (url == null) {
             log("Couldn't load Resource " + name, Project.MSG_DEBUG);
+        }
+        return url;
+    }
+
+    /**
+     * Finds a matching file by iterating pathComponents.
+     *
+     * @param pathComponents Path to a folder, split into the individual folder names
+     * @param name File to find
+     * @return Url to found object
+     */
+    @CheckForNull
+    protected URL getUrl(Vector pathComponents, String name) {
+        Enumeration e = pathComponents.elements();
+        URL url = null;
+        while (e.hasMoreElements() && url == null) {
+            File pathComponent = (File) e.nextElement();
+            url = getResourceURL(pathComponent, name);
+            if (url != null) {
+                log("Resource " + name + " loaded from ant loader", Project.MSG_DEBUG);
+            }
         }
         return url;
     }

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -919,7 +919,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
      * @return Url to found object
      */
     @CheckForNull
-    protected URL getUrl(ArrayList<File> pathComponents, String name) {
+    protected URL getUrl(Iterable<File> pathComponents, String name) {
         URL url = null;
         for (File pathComponent : pathComponents) {
             url = getResourceURL(pathComponent, name);

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -550,13 +550,13 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
     public String getClasspath() {
         StringBuilder sb = new StringBuilder();
         boolean firstPass = true;
-        for (Iterator<File> iter = pathComponents.iterator(); iter.hasNext(); ) {
+        for (File pathComponent : pathComponents) {
             if (!firstPass) {
                 sb.append(System.getProperty("path.separator"));
             } else {
                 firstPass = false;
             }
-            sb.append(iter.next().getAbsolutePath());
+            sb.append(pathComponent.getAbsolutePath());
         }
         return sb.toString();
     }
@@ -752,8 +752,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
         // find the class we want.
         InputStream stream = null;
 
-        for (Iterator<File> iter = pathComponents.iterator(); iter.hasNext() && stream == null; ) {
-            File pathComponent = iter.next();
+        for (File pathComponent : pathComponents) {
             stream = getResourceStream(pathComponent, name);
         }
         return stream;
@@ -922,11 +921,11 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
     @CheckForNull
     protected URL getUrl(ArrayList<File> pathComponents, String name) {
         URL url = null;
-        for (Iterator<File> iter = pathComponents.iterator(); iter.hasNext() && url == null; ) {
-            File pathComponent = iter.next();
+        for (File pathComponent : pathComponents) {
             url = getResourceURL(pathComponent, name);
             if (url != null) {
                 log("Resource " + name + " loaded from ant loader", Project.MSG_DEBUG);
+                break;
             }
         }
         return url;
@@ -1376,8 +1375,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
         // we need to search the components of the path to see if
         // we can find the class we want.
         String classFilename = getClassFilename(name);
-        for (Iterator<File> iter = pathComponents.iterator(); iter.hasNext(); ) {
-            File pathComponent = iter.next();
+        for (File pathComponent : pathComponents) {
             try (final InputStream stream = getResourceStream(pathComponent, classFilename)) {
                 if (stream != null) {
                     log("Loaded from " + pathComponent + " "

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -33,6 +33,7 @@ import org.apache.tools.ant.util.VectorSet;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+import javax.annotation.CheckForNull;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -156,7 +156,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
             URL url = null;
             while ((pathElementsIndex < pathComponents.size()) && (url == null)) {
                 try {
-                    File pathComponent = (File) pathComponents.get(pathElementsIndex);
+                    File pathComponent = pathComponents.get(pathElementsIndex);
                     url = getResourceURL(pathComponent, this.resourceName);
                     pathElementsIndex++;
                 } catch (BuildException e) {
@@ -182,7 +182,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
      * The components of the classpath that the classloader searches
      * for classes.
      */
-    private ArrayList<File> pathComponents = new ArrayList<File>();
+    private ArrayList<File> pathComponents = new ArrayList<>();
 
     /**
      * The project to which this class loader belongs.

--- a/core/src/main/java/jenkins/util/AntWithFindResourceClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntWithFindResourceClassLoader.java
@@ -7,16 +7,15 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Enumeration;
-import java.util.Vector;
 
 /**
  * As of 1.8.0, {@link org.apache.tools.ant.AntClassLoader} doesn't implement {@link #findResource(String)}
  * in any meaningful way, which breaks fast lookup. Implement it properly.
  */
 public class AntWithFindResourceClassLoader extends AntClassLoader implements Closeable {
-    private final Vector pathComponents;
+    private final ArrayList<File> pathComponents;
 
     public AntWithFindResourceClassLoader(ClassLoader parent, boolean parentFirst) {
         super(parent, parentFirst);
@@ -24,7 +23,7 @@ public class AntWithFindResourceClassLoader extends AntClassLoader implements Cl
         try {
             Field $pathComponents = AntClassLoader.class.getDeclaredField("pathComponents");
             $pathComponents.setAccessible(true);
-            pathComponents = (Vector)$pathComponents.get(this);
+            pathComponents = (ArrayList<File>)$pathComponents.get(this);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new Error(e);
         }

--- a/core/src/main/java/jenkins/util/AntWithFindResourceClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntWithFindResourceClassLoader.java
@@ -41,20 +41,9 @@ public class AntWithFindResourceClassLoader extends AntClassLoader implements Cl
 
     @Override
     protected URL findResource(String name) {
-        URL url = null;
-
         // try and load from this loader if the parent either didn't find
         // it or wasn't consulted.
-        Enumeration e = pathComponents.elements();
-        while (e.hasMoreElements() && url == null) {
-            File pathComponent = (File) e.nextElement();
-            url = getResourceURL(pathComponent, name);
-            if (url != null) {
-                log("Resource " + name + " loaded from ant loader", Project.MSG_DEBUG);
-            }
-        }
-
-        return url;
+        return getUrl(pathComponents, name);
     }
 
 }


### PR DESCRIPTION
AntClassLoader.getUrl

This is for discussion.

Notes:
* Most commits were created by IntelliJ
* Individual commits are mostly self contained
* In general, most commits should not change program behavior at all

This is generally a subset of https://github.com/jsoref/jenkins/commits/java-cleanup-full
<!--
for a in $(hg log -T '{rev}\n' -r '. % master'); do echo $a $(d --stat -r master -r $a | tail -1) $(hg log -T '{desc}' -r $a); done |perl -pne 's/^/$.\t/'
--> 

### Proposed changelog entries

* `Internal:` Internal Java code cleanup

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
