### PR TITLE
IntelliJ/Java: Duplicate declaration -> ApiTokenProperty.checkPermission

### DIFF
--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -209,10 +209,10 @@ public class ApiTokenProperty extends UserProperty {
      */
     private boolean hasPermissionToSeeToken() {
         // Administrators can do whatever they want
-        return checkPermission(SHOW_LEGACY_TOKEN_TO_ADMINS, user);
+        return canCurrentUserControlObject(SHOW_LEGACY_TOKEN_TO_ADMINS, user);
     }
 
-    private static boolean checkPermission(boolean trustAdmins, User user) {
+    private static boolean canCurrentUserControlObject(boolean trustAdmins, User propertyOwner) {
         if (trustAdmins && Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
             return true;
         }
@@ -227,7 +227,7 @@ public class ApiTokenProperty extends UserProperty {
             return true;
         }
 
-        return User.idStrategy().equals(user.getId(), current.getId());
+        return User.idStrategy().equals(propertyOwner.getId(), current.getId());
     }
 
     // only for Jelly
@@ -419,8 +419,8 @@ public class ApiTokenProperty extends UserProperty {
     
         // for Jelly view
         @Restricted(NoExternalUse.class)
-        public boolean hasCurrentUserRightToGenerateNewToken(User propertyOwner){
-            return checkPermission(ADMIN_CAN_GENERATE_NEW_TOKENS, propertyOwner);
+        public boolean hasCurrentUserRightToGenerateNewToken(User propertyOwner) {
+            return canCurrentUserControlObject(ADMIN_CAN_GENERATE_NEW_TOKENS, propertyOwner);
         }
 
         /**

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -209,23 +209,27 @@ public class ApiTokenProperty extends UserProperty {
      */
     private boolean hasPermissionToSeeToken() {
         // Administrators can do whatever they want
-        if (SHOW_LEGACY_TOKEN_TO_ADMINS && Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        return checkPermission(SHOW_LEGACY_TOKEN_TO_ADMINS, user);
+    }
+
+    private static boolean checkPermission(boolean showLegacyTokenToAdmins, User user) {
+        if (showLegacyTokenToAdmins && Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
             return true;
         }
-        
+
         User current = User.current();
         if (current == null) { // Anonymous
             return false;
         }
-        
+
         // SYSTEM user is always eligible to see tokens
         if (Jenkins.getAuthentication() == ACL.SYSTEM) {
             return true;
         }
-        
+
         return User.idStrategy().equals(user.getId(), current.getId());
     }
-    
+
     // only for Jelly
     @Restricted(NoExternalUse.class)
     public Collection<TokenInfoAndStats> getTokenList() {
@@ -416,22 +420,7 @@ public class ApiTokenProperty extends UserProperty {
         // for Jelly view
         @Restricted(NoExternalUse.class)
         public boolean hasCurrentUserRightToGenerateNewToken(User propertyOwner){
-            if (ADMIN_CAN_GENERATE_NEW_TOKENS && Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
-                return true;
-            }
-
-            User currentUser = User.current();
-            if (currentUser == null) {
-                // Anonymous
-                return false;
-            }
-
-            if (Jenkins.getAuthentication() == ACL.SYSTEM) {
-                // SYSTEM user is always eligible to see tokens
-                return true;
-            }
-
-            return User.idStrategy().equals(propertyOwner.getId(), currentUser.getId());
+            return checkPermission(ADMIN_CAN_GENERATE_NEW_TOKENS, propertyOwner);
         }
 
         /**

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -212,8 +212,8 @@ public class ApiTokenProperty extends UserProperty {
         return checkPermission(SHOW_LEGACY_TOKEN_TO_ADMINS, user);
     }
 
-    private static boolean checkPermission(boolean showLegacyTokenToAdmins, User user) {
-        if (showLegacyTokenToAdmins && Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+    private static boolean checkPermission(boolean trustAdmins, User user) {
+        if (trustAdmins && Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
             return true;
         }
 


### PR DESCRIPTION
ApiTokenProperty.checkPermission

This is for discussion.

Notes:
* Most commits were created by IntelliJ
* Individual commits are mostly self contained
* In general, most commits should not change program behavior at all

This is generally a subset of https://github.com/jsoref/jenkins/commits/java-cleanup-full
<!--
for a in $(hg log -T '{rev}\n' -r '. % master'); do echo $a $(d --stat -r master -r $a | tail -1) $(hg log -T '{desc}' -r $a); done |perl -pne 's/^/$.\t/'
--> 

### Proposed changelog entries

* `Internal:` Internal Java code cleanup

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
