### PR TITLE
Introduce new Run#getBuildsOverThreshold() method for getting runs above the desired execution result

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -994,19 +994,8 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      *   if not enough builds satisfying the threshold have been found. Never null.
      */
     public List<RunT> getLastBuildsOverThreshold(int numberOfBuilds, Result threshold) {
-        
-        List<RunT> result = new ArrayList<>(numberOfBuilds);
-        
         RunT r = getLastBuild();
-        while (r != null && result.size() < numberOfBuilds) {
-            if (!r.isBuilding() && 
-                 (r.getResult() != null && r.getResult().isBetterOrEqualTo(threshold))) {
-                result.add(r);
-            }
-            r = r.getPreviousBuild();
-        }
-        
-        return result;
+        return r.getBuildsOverThreshold(r, numberOfBuilds, threshold);
     }
     
     /**

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -995,7 +995,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      */
     public List<RunT> getLastBuildsOverThreshold(int numberOfBuilds, Result threshold) {
         RunT r = getLastBuild();
-        return r.getBuildsOverThreshold(r, numberOfBuilds, threshold);
+        return r.getBuildsOverThreshold(numberOfBuilds, threshold);
     }
     
     /**

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -968,7 +968,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      *   if not enough builds satisfying the threshold have been found. Never null.
      * @since TODO
      */
-    protected @Nonnull List<RunT> getBuildsOverThreshold(RunT r, int numberOfBuilds, @Nonnull Result threshold) {
+    protected @Nonnull List<RunT> getBuildsOverThreshold(@CheckForNull RunT r, int numberOfBuilds, @Nonnull Result threshold) {
         List<RunT> builds = new ArrayList<>(numberOfBuilds);
 
         while (r != null && builds.size() < numberOfBuilds) {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -953,17 +953,32 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * @since 1.383
      */  
     public @Nonnull List<RunT> getPreviousBuildsOverThreshold(int numberOfBuilds, @Nonnull Result threshold) {
-        List<RunT> builds = new ArrayList<>(numberOfBuilds);
-        
         RunT r = getPreviousBuild();
+        return getBuildsOverThreshold(r, numberOfBuilds, threshold);
+    }
+
+    /**
+     * Returns the last {@code numberOfBuilds} builds with a build result ≥ {@code threshold}.
+     *
+     * @param r the run to search
+     * @param numberOfBuilds the desired number of builds
+     * @param threshold the build result threshold
+     * @return a list with the builds (youngest build first).
+     *   May be smaller than 'numberOfBuilds' or even empty
+     *   if not enough builds satisfying the threshold have been found. Never null.
+     * @since TODO
+     */
+    protected @Nonnull List<RunT> getBuildsOverThreshold(RunT r, int numberOfBuilds, @Nonnull Result threshold) {
+        List<RunT> builds = new ArrayList<>(numberOfBuilds);
+
         while (r != null && builds.size() < numberOfBuilds) {
-            if (!r.isBuilding() && 
+            if (!r.isBuilding() &&
                  (r.getResult() != null && r.getResult().isBetterOrEqualTo(threshold))) {
                 builds.add(r);
             }
             r = r.getPreviousBuild();
         }
-        
+
         return builds;
     }
 

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -954,13 +954,12 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */  
     public @Nonnull List<RunT> getPreviousBuildsOverThreshold(int numberOfBuilds, @Nonnull Result threshold) {
         RunT r = getPreviousBuild();
-        return getBuildsOverThreshold(r, numberOfBuilds, threshold);
+        return r.getBuildsOverThreshold(numberOfBuilds, threshold);
     }
 
     /**
      * Returns the last {@code numberOfBuilds} builds with a build result ≥ {@code threshold}.
      *
-     * @param r the run to search
      * @param numberOfBuilds the desired number of builds
      * @param threshold the build result threshold
      * @return a list with the builds (youngest build first).
@@ -968,9 +967,10 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      *   if not enough builds satisfying the threshold have been found. Never null.
      * @since TODO
      */
-    protected @Nonnull List<RunT> getBuildsOverThreshold(@CheckForNull RunT r, int numberOfBuilds, @Nonnull Result threshold) {
+    protected @Nonnull List<RunT> getBuildsOverThreshold(int numberOfBuilds, @Nonnull Result threshold) {
         List<RunT> builds = new ArrayList<>(numberOfBuilds);
 
+        RunT r = _this();
         while (r != null && builds.size() < numberOfBuilds) {
             if (!r.isBuilding() &&
                  (r.getResult() != null && r.getResult().isBetterOrEqualTo(threshold))) {


### PR DESCRIPTION
Refactored as Run.getBuildsOverThreshold
This is for discussion.

Notes:
* Most commits were created by IntelliJ
* Individual commits are mostly self contained
* In general, most commits should not change program behavior at all

This is generally a subset of https://github.com/jsoref/jenkins/commits/java-cleanup-full
<!--
for a in $(hg log -T '{rev}\n' -r '. % master'); do echo $a $(d --stat -r master -r $a | tail -1) $(hg log -T '{desc}' -r $a); done |perl -pne 's/^/$.\t/'
--> 

### Proposed changelog entries

* `Internal:` Internal Java code cleanup

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
