### PR TITLE
IntelliJ/Java: Duplicate code -> View.makeSearchIndex

### DIFF
--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -246,15 +246,7 @@ public class ListView extends View implements DirectlyModifiableView {
     @Override
     public SearchIndexBuilder makeSearchIndex() {
         SearchIndexBuilder sib = new SearchIndexBuilder().addAllAnnotations(this);
-        sib.add(new CollectionSearchIndex<TopLevelItem>() {// for jobs in the view
-            protected TopLevelItem get(String key) { return getItem(key); }
-            protected Collection<TopLevelItem> all() { return getItems(); }
-            @Override
-            protected String getName(TopLevelItem o) {
-                // return the name instead of the display for suggestion searching
-                return o.getName();
-            }
-        });
+        makeSearchIndex(sib);
         // add the display name for each item in the search index
         addDisplayNamesToSearchIndex(sib, getItems(true));
         return sib;

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -949,19 +949,29 @@ public abstract class View extends AbstractModelObject implements AccessControll
             sib.add(item.getSearchUrl(), item.getDisplayName());
         }        
     }
-    
+
+    /**
+     * Add a simple CollectionSearchIndex object to sib
+     *
+     * @param sib the SearchIndexBuilder
+     * @since TODO
+     */
+    protected void makeSearchIndex(SearchIndexBuilder sib) {
+        sib.add(new CollectionSearchIndex<TopLevelItem>() {// for jobs in the view
+            protected TopLevelItem get(String key) { return getItem(key); }
+            protected Collection<TopLevelItem> all() { return getItems(); }
+            @Override
+            protected String getName(TopLevelItem o) {
+                // return the name instead of the display for suggestion searching
+                return o.getName();
+            }
+        });
+    }
+
     @Override
     public SearchIndexBuilder makeSearchIndex() {
         SearchIndexBuilder sib = super.makeSearchIndex();
-        sib.add(new CollectionSearchIndex<TopLevelItem>() {// for jobs in the view
-                protected TopLevelItem get(String key) { return getItem(key); }
-                protected Collection<TopLevelItem> all() { return getItems(); }
-                @Override
-                protected String getName(TopLevelItem o) {
-                    // return the name instead of the display for suggestion searching
-                    return o.getName();
-                }
-            });
+        makeSearchIndex(sib);
         
         // add the display name for each item in the search index
         addDisplayNamesToSearchIndex(sib, getItems());


### PR DESCRIPTION
Refactored as View.makeSearchIndex
This is for discussion.

Notes:
* Most commits were created by IntelliJ
* Individual commits are mostly self contained
* In general, most commits should not change program behavior at all

This is generally a subset of https://github.com/jsoref/jenkins/commits/java-cleanup-full
<!--
for a in $(hg log -T '{rev}\n' -r '. % master'); do echo $a $(d --stat -r master -r $a | tail -1) $(hg log -T '{desc}' -r $a); done |perl -pne 's/^/$.\t/'
--> 

### Proposed changelog entries

* `Internal:` Internal Java code cleanup

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
