### PR TITLE
IntelliJ/Java: Duplicate code -> SettingsPath.getSettings

### DIFF
--- a/core/src/main/java/jenkins/mvn/FilePathGlobalSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/FilePathGlobalSettingsProvider.java
@@ -38,24 +38,7 @@ public class FilePathGlobalSettingsProvider extends GlobalSettingsProvider {
         }
 
         try {
-            EnvVars env = build.getEnvironment(listener);
-            String targetPath = Util.replaceMacro(this.path, build.getBuildVariableResolver());
-            targetPath = env.expand(targetPath);
-
-            if (IOUtils.isAbsolute(targetPath)) {
-                return new FilePath(new File(targetPath));
-            } else {
-                FilePath mrSettings = build.getModuleRoot().child(targetPath);
-                FilePath wsSettings = build.getWorkspace().child(targetPath);
-                try {
-                    if (!wsSettings.exists() && mrSettings.exists()) {
-                        wsSettings = mrSettings;
-                    }
-                } catch (Exception e) {
-                    throw new IllegalStateException("failed to find settings.xml at: " + wsSettings.getRemote());
-                }
-                return wsSettings;
-            }
+            return SettingsPathHelper.getSettings(build, listener, getPath());
         } catch (Exception e) {
             throw new IllegalStateException("failed to prepare global settings.xml");
         }

--- a/core/src/main/java/jenkins/mvn/FilePathSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/FilePathSettingsProvider.java
@@ -39,24 +39,7 @@ public class FilePathSettingsProvider extends SettingsProvider {
         }
 
         try {
-            EnvVars env = build.getEnvironment(listener);
-            String targetPath = Util.replaceMacro(this.path, build.getBuildVariableResolver());
-            targetPath = env.expand(targetPath);
-
-            if (IOUtils.isAbsolute(targetPath)) {
-                return new FilePath(new File(targetPath));
-            } else {
-                FilePath mrSettings = build.getModuleRoot().child(targetPath);
-                FilePath wsSettings = build.getWorkspace().child(targetPath);
-                try {
-                    if (!wsSettings.exists() && mrSettings.exists()) {
-                        wsSettings = mrSettings;
-                    }
-                } catch (Exception e) {
-                    throw new IllegalStateException("failed to find settings.xml at: " + wsSettings.getRemote());
-                }
-                return wsSettings;
-            }
+            return SettingsPathHelper.getSettings(build, listener, getPath());
         } catch (Exception e) {
             throw new IllegalStateException("failed to prepare settings.xml");
         }

--- a/core/src/main/java/jenkins/mvn/SettingsPathHelper.java
+++ b/core/src/main/java/jenkins/mvn/SettingsPathHelper.java
@@ -1,0 +1,37 @@
+package jenkins.mvn;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+import hudson.util.IOUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.io.File;
+import java.io.IOException;
+
+@Restricted(NoExternalUse.class)
+class SettingsPathHelper {
+    static FilePath getSettings(AbstractBuild<?, ?> build, TaskListener listener, String path) throws IOException, InterruptedException {
+        EnvVars env = build.getEnvironment(listener);
+        String targetPath = Util.replaceMacro(path, build.getBuildVariableResolver());
+        targetPath = env.expand(targetPath);
+
+        if (IOUtils.isAbsolute(targetPath)) {
+            return new FilePath(new File(targetPath));
+        } else {
+            FilePath mrSettings = build.getModuleRoot().child(targetPath);
+            FilePath wsSettings = build.getWorkspace().child(targetPath);
+            try {
+                if (!wsSettings.exists() && mrSettings.exists()) {
+                    wsSettings = mrSettings;
+                }
+            } catch (Exception e) {
+                throw new IllegalStateException("failed to find settings.xml at: " + wsSettings.getRemote());
+            }
+            return wsSettings;
+        }
+    }
+}


### PR DESCRIPTION
Refactored as SettingsPath.getSettings
This is for discussion.

Notes:
* Most commits were created by IntelliJ
* Individual commits are mostly self contained
* In general, most commits should not change program behavior at all

This is generally a subset of https://github.com/jsoref/jenkins/commits/java-cleanup-full
<!--
for a in $(hg log -T '{rev}\n' -r '. % master'); do echo $a $(d --stat -r master -r $a | tail -1) $(hg log -T '{desc}' -r $a); done |perl -pne 's/^/$.\t/'
--> 

### Proposed changelog entries

* `Internal:` Internal Java code cleanup

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
