### PR TITLE
Replaced deprecated getActiveInstance() with get()

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -633,7 +633,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     protected @Nonnull Set<String> loadPluginsFromWar(@Nonnull String fromPath, @CheckForNull FilenameFilter filter) {
         Set<String> names = new HashSet();
 
-        ServletContext context = Jenkins.getActiveInstance().servletContext;
+        ServletContext context = Jenkins.get().servletContext;
         Set<String> plugins = Util.fixNull(context.getResourcePaths(fromPath));
         Set<URL> copiedPlugins = new HashSet<>();
         Set<URL> dependencies = new HashSet<>();
@@ -697,7 +697,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         String dependencySpec = manifest.getMainAttributes().getValue("Plugin-Dependencies");
         if (dependencySpec != null) {
             String[] dependencyTokens = dependencySpec.split(",");
-            ServletContext context = Jenkins.getActiveInstance().servletContext;
+            ServletContext context = Jenkins.get().servletContext;
 
             for (String dependencyToken : dependencyTokens) {
                 if (dependencyToken.endsWith(";resolution:=optional")) {
@@ -709,7 +709,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 String artifactId = artifactIdVersionPair[0];
                 VersionNumber dependencyVersion = new VersionNumber(artifactIdVersionPair[1]);
 
-                PluginManager manager = Jenkins.getActiveInstance().getPluginManager();
+                PluginManager manager = Jenkins.get().getPluginManager();
                 VersionNumber installedVersion = manager.getPluginVersion(manager.rootDir, artifactId);
                 if (installedVersion != null && !installedVersion.isOlderThan(dependencyVersion)) {
                     // Do not downgrade dependencies that are already installed.
@@ -1374,7 +1374,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             }
             response.add(pluginInfo);
         }
-        for (UpdateSite site : Jenkins.getActiveInstance().getUpdateCenter().getSiteList()) {
+        for (UpdateSite site : Jenkins.get().getUpdateCenter().getSiteList()) {
             for (UpdateSite.Plugin plugin: site.getAvailables()) {
                 JSONObject pluginInfo = allPlugins.get(plugin.name);
                 if(pluginInfo == null) {

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -1236,7 +1236,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     @RequirePOST
     public HttpResponse doDoUninstall() throws IOException {
-        Jenkins jenkins = Jenkins.getActiveInstance();
+        Jenkins jenkins = Jenkins.get();
         
         jenkins.checkPermission(Jenkins.ADMINISTER);
         archive.delete();

--- a/core/src/main/java/hudson/cli/CLIAction.java
+++ b/core/src/main/java/hudson/cli/CLIAction.java
@@ -85,7 +85,7 @@ public class CLIAction implements UnprotectedRootAction, StaplerProxy {
     }
 
     public void doCommand(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
-        final Jenkins jenkins = Jenkins.getActiveInstance();
+        final Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.READ);
 
         // Strip trailing slash

--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -242,10 +242,10 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
             sc.setAuthentication(auth = getTransportAuthentication());
 
             if (!(this instanceof HelpCommand || this instanceof WhoAmICommand))
-                Jenkins.getActiveInstance().checkPermission(Jenkins.READ);
+                Jenkins.get().checkPermission(Jenkins.READ);
             p.parseArgument(args.toArray(new String[0]));
             if (!(this instanceof HelpCommand || this instanceof WhoAmICommand))
-                Jenkins.getActiveInstance().checkPermission(Jenkins.READ);
+                Jenkins.get().checkPermission(Jenkins.READ);
             LOGGER.log(Level.FINE, "Invoking CLI command {0}, with {1} arguments, as user {2}.",
                     new Object[] {getName(), args.size(), auth.getName()});
             int res = run();
@@ -502,7 +502,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
      */
     protected void registerOptionHandlers() {
         try {
-            for (Class c : Index.list(OptionHandlerExtension.class, Jenkins.getActiveInstance().pluginManager.uberClassLoader,Class.class)) {
+            for (Class c : Index.list(OptionHandlerExtension.class, Jenkins.get().pluginManager.uberClassLoader,Class.class)) {
                 Type t = Types.getBaseClass(c, OptionHandler.class);
                 CmdLineParser.registerHandler(Types.erasure(Types.getTypeArgument(t,0)), c);
             }

--- a/core/src/main/java/hudson/cli/CancelQuietDownCommand.java
+++ b/core/src/main/java/hudson/cli/CancelQuietDownCommand.java
@@ -47,7 +47,7 @@ public class CancelQuietDownCommand extends CLICommand {
 
     @Override
     protected int run() throws Exception {
-        Jenkins.getActiveInstance().doCancelQuietDown();
+        Jenkins.get().doCancelQuietDown();
         return 0;
     }
 }

--- a/core/src/main/java/hudson/cli/ClearQueueCommand.java
+++ b/core/src/main/java/hudson/cli/ClearQueueCommand.java
@@ -47,7 +47,7 @@ public class ClearQueueCommand extends CLICommand {
 
     @Override
     protected int run() throws Exception {
-        Jenkins.getActiveInstance().getQueue().clear();
+        Jenkins.get().getQueue().clear();
         return 0;
     }
 

--- a/core/src/main/java/hudson/cli/ConnectNodeCommand.java
+++ b/core/src/main/java/hudson/cli/ConnectNodeCommand.java
@@ -61,7 +61,7 @@ public class ConnectNodeCommand extends CLICommand {
     @Override
     protected int run() throws Exception {
         boolean errorOccurred = false;
-        final Jenkins jenkins = Jenkins.getActiveInstance();
+        final Jenkins jenkins = Jenkins.get();
 
         final HashSet<String> hs = new HashSet<>(nodes);
 

--- a/core/src/main/java/hudson/cli/CopyJobCommand.java
+++ b/core/src/main/java/hudson/cli/CopyJobCommand.java
@@ -50,7 +50,7 @@ public class CopyJobCommand extends CLICommand {
     public String dst;
 
     protected int run() throws Exception {
-        Jenkins jenkins = Jenkins.getActiveInstance();
+        Jenkins jenkins = Jenkins.get();
 
         if (jenkins.getItemByFullName(dst)!=null) {
             throw new IllegalStateException("Job '"+dst+"' already exists");

--- a/core/src/main/java/hudson/cli/CreateJobCommand.java
+++ b/core/src/main/java/hudson/cli/CreateJobCommand.java
@@ -45,7 +45,7 @@ public class CreateJobCommand extends CLICommand {
     public String name;
 
     protected int run() throws Exception {
-        Jenkins h = Jenkins.getActiveInstance();
+        Jenkins h = Jenkins.get();
 
         if (h.getItemByFullName(name)!=null) {
             throw new IllegalStateException("Job '"+name+"' already exists");

--- a/core/src/main/java/hudson/cli/CreateNodeCommand.java
+++ b/core/src/main/java/hudson/cli/CreateNodeCommand.java
@@ -52,7 +52,7 @@ public class CreateNodeCommand extends CLICommand {
     @Override
     protected int run() throws Exception {
 
-        final Jenkins jenkins = Jenkins.getActiveInstance();
+        final Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Computer.CREATE);
 
         final Node newNode = (Node) Jenkins.XSTREAM2.fromXML(stdin);

--- a/core/src/main/java/hudson/cli/CreateViewCommand.java
+++ b/core/src/main/java/hudson/cli/CreateViewCommand.java
@@ -49,7 +49,7 @@ public class CreateViewCommand extends CLICommand {
     @Override
     protected int run() throws Exception {
 
-        final Jenkins jenkins = Jenkins.getActiveInstance();
+        final Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(View.CREATE);
 
         View newView;

--- a/core/src/main/java/hudson/cli/DeleteJobCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteJobCommand.java
@@ -54,7 +54,7 @@ public class DeleteJobCommand extends CLICommand {
     protected int run() throws Exception {
 
         boolean errorOccurred = false;
-        final Jenkins jenkins = Jenkins.getActiveInstance();
+        final Jenkins jenkins = Jenkins.get();
 
         final HashSet<String> hs = new HashSet<>(jobs);
 

--- a/core/src/main/java/hudson/cli/DeleteNodeCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteNodeCommand.java
@@ -54,7 +54,7 @@ public class DeleteNodeCommand extends CLICommand {
     protected int run() throws Exception {
 
         boolean errorOccurred = false;
-        final Jenkins jenkins = Jenkins.getActiveInstance();
+        final Jenkins jenkins = Jenkins.get();
 
         final HashSet<String> hs = new HashSet<>(nodes);
 

--- a/core/src/main/java/hudson/cli/DisconnectNodeCommand.java
+++ b/core/src/main/java/hudson/cli/DisconnectNodeCommand.java
@@ -59,7 +59,7 @@ public class DisconnectNodeCommand extends CLICommand {
     @Override
     protected int run() throws Exception {
         boolean errorOccurred = false;
-        final Jenkins jenkins = Jenkins.getActiveInstance();
+        final Jenkins jenkins = Jenkins.get();
 
         final HashSet<String> hs = new HashSet<>(nodes);
 

--- a/core/src/main/java/hudson/cli/GroovyCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyCommand.java
@@ -59,7 +59,7 @@ public class GroovyCommand extends CLICommand {
 
     protected int run() throws Exception {
         // this allows the caller to manipulate the JVM state, so require the execute script privilege.
-        Jenkins.getActiveInstance().checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
 
         Binding binding = new Binding();
         binding.setProperty("out",new PrintWriter(stdout,true));
@@ -67,7 +67,7 @@ public class GroovyCommand extends CLICommand {
         binding.setProperty("stdout",stdout);
         binding.setProperty("stderr",stderr);
 
-        GroovyShell groovy = new GroovyShell(Jenkins.getActiveInstance().getPluginManager().uberClassLoader, binding);
+        GroovyShell groovy = new GroovyShell(Jenkins.get().getPluginManager().uberClassLoader, binding);
         groovy.run(loadScript(),"RemoteClass",remaining.toArray(new String[0]));
         return 0;
     }

--- a/core/src/main/java/hudson/cli/GroovyshCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyshCommand.java
@@ -60,7 +60,7 @@ public class GroovyshCommand extends CLICommand {
     @Override
     protected int run() {
         // this allows the caller to manipulate the JVM state, so require the admin privilege.
-        Jenkins.getActiveInstance().checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
 
         // this being remote means no jline capability is available
         System.setProperty("jline.terminal", UnsupportedTerminal.class.getName());
@@ -85,12 +85,12 @@ public class GroovyshCommand extends CLICommand {
         Binding binding = new Binding();
         // redirect "println" to the CLI
         binding.setProperty("out", new PrintWriter(stdout,true));
-        binding.setProperty("hudson", Jenkins.getActiveInstance()); // backward compatibility
-        binding.setProperty("jenkins", Jenkins.getActiveInstance());
+        binding.setProperty("hudson", Jenkins.get()); // backward compatibility
+        binding.setProperty("jenkins", Jenkins.get());
 
         IO io = new IO(new BufferedInputStream(stdin),stdout,stderr);
 
-        final ClassLoader cl = Jenkins.getActiveInstance().pluginManager.uberClassLoader;
+        final ClassLoader cl = Jenkins.get().pluginManager.uberClassLoader;
         Closure registrar = new Closure(null, null) {
             private static final long serialVersionUID = 1L;
 

--- a/core/src/main/java/hudson/cli/HelpCommand.java
+++ b/core/src/main/java/hudson/cli/HelpCommand.java
@@ -51,7 +51,7 @@ public class HelpCommand extends CLICommand {
 
     @Override
     protected int run() throws Exception {
-        if (!Jenkins.getActiveInstance().hasPermission(Jenkins.READ)) {
+        if (!Jenkins.get().hasPermission(Jenkins.READ)) {
             throw new AccessDeniedException("You must authenticate to access this Jenkins.\n"
                     + CLI.usage());
         }

--- a/core/src/main/java/hudson/cli/ListJobsCommand.java
+++ b/core/src/main/java/hudson/cli/ListJobsCommand.java
@@ -49,7 +49,7 @@ public class ListJobsCommand extends CLICommand {
     public String name;
 
     protected int run() throws Exception {
-        Jenkins h = Jenkins.getActiveInstance();
+        Jenkins h = Jenkins.get();
         final Collection<TopLevelItem> jobs;
 
         // If name is given retrieve jobs for the given view.

--- a/core/src/main/java/hudson/cli/OnlineNodeCommand.java
+++ b/core/src/main/java/hudson/cli/OnlineNodeCommand.java
@@ -55,7 +55,7 @@ public class OnlineNodeCommand extends CLICommand {
     @Override
     protected int run() throws Exception {
         boolean errorOccurred = false;
-        final Jenkins jenkins = Jenkins.getActiveInstance();
+        final Jenkins jenkins = Jenkins.get();
         final HashSet<String> hs = new HashSet<>(nodes);
         List<String> names = null;
 

--- a/core/src/main/java/hudson/cli/QuietDownCommand.java
+++ b/core/src/main/java/hudson/cli/QuietDownCommand.java
@@ -54,7 +54,7 @@ public class QuietDownCommand extends CLICommand {
 
     @Override
     protected int run() throws Exception {
-        Jenkins.getActiveInstance().doQuietDown(block, timeout);
+        Jenkins.get().doQuietDown(block, timeout);
         return 0;
     }
 }

--- a/core/src/main/java/hudson/cli/ReloadJobCommand.java
+++ b/core/src/main/java/hudson/cli/ReloadJobCommand.java
@@ -60,7 +60,7 @@ public class ReloadJobCommand extends CLICommand {
     protected int run() throws Exception {
 
         boolean errorOccurred = false;
-        final Jenkins jenkins = Jenkins.getActiveInstance();
+        final Jenkins jenkins = Jenkins.get();
 
         final HashSet<String> hs = new HashSet<>(jobs);
 

--- a/core/src/main/java/hudson/cli/handlers/ViewOptionHandler.java
+++ b/core/src/main/java/hudson/cli/handlers/ViewOptionHandler.java
@@ -94,7 +94,7 @@ public class ViewOptionHandler extends OptionHandler<View> {
     @CheckForNull
     public View getView(final String name) {
 
-        ViewGroup group = Jenkins.getActiveInstance();
+        ViewGroup group = Jenkins.get();
         View view = null;
 
         final StringTokenizer tok = new StringTokenizer(name, "/");

--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -175,7 +175,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
         } else {
             lastRotateMillis = System.currentTimeMillis();
             // migrate old log files the first time we start-up
-            File oldFile = new File(Jenkins.getActiveInstance().getRootDir(), f.getName());
+            File oldFile = new File(Jenkins.get().getRootDir(), f.getName());
             if (oldFile.isFile()) {
                 File newFile = new File(f.getParentFile(), f.getName() + ".1");
                 if (!newFile.isFile()) {

--- a/core/src/main/java/hudson/model/AsyncPeriodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncPeriodicWork.java
@@ -158,7 +158,7 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
         } else {
             lastRotateMillis = System.currentTimeMillis();
             // migrate old log files the first time we start-up
-            File oldFile = new File(Jenkins.getActiveInstance().getRootDir(), f.getName());
+            File oldFile = new File(Jenkins.get().getRootDir(), f.getName());
             if (oldFile.isFile()) {
                 File newFile = new File(f.getParentFile(), f.getName() + ".1");
                 if (!newFile.isFile()) {

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1484,7 +1484,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         }
 
         if ((!proposedName.equals(nodeName))
-                && Jenkins.getActiveInstance().getNode(proposedName) != null) {
+                && Jenkins.get().getNode(proposedName) != null) {
             throw new FormException(Messages.ComputerSet_SlaveAlreadyExists(proposedName), "name");
         }
 

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -644,7 +644,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
             if (isApplicable(actualType, json)) {
                 LOGGER.log(Level.FINE, "switching to newInstance {0} {1}", new Object[] {actualType.getName(), json});
                 try {
-                    final Descriptor descriptor = Jenkins.getActiveInstance().getDescriptor(actualType);
+                    final Descriptor descriptor = Jenkins.get().getDescriptor(actualType);
                     if (descriptor != null) {
                         return descriptor.newInstance(Stapler.getCurrentRequest(), json);
                     } else {
@@ -670,7 +670,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
                 if (isApplicable(targetTypeErasure, json)) {
                     LOGGER.log(Level.FINE, "switching to newInstance {0} {1}", new Object[] {targetTypeErasure.getName(), json});
                     try {
-                        return Jenkins.getActiveInstance().getDescriptor(targetTypeErasure).newInstance(Stapler.getCurrentRequest(), json);
+                        return Jenkins.get().getDescriptor(targetTypeErasure).newInstance(Stapler.getCurrentRequest(), json);
                     } catch (Exception x) {
                         LOGGER.log(Level.WARNING, "falling back to default instantiation " + targetTypeErasure.getName() + " " + json, x);
                     }

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -310,7 +310,7 @@ public class DownloadService extends PageDecorator {
          */
         public List<String> getUrls() {
             List<String> updateSites = new ArrayList<>();
-            for (UpdateSite site : Jenkins.getActiveInstance().getUpdateCenter().getSiteList()) {
+            for (UpdateSite site : Jenkins.get().getUpdateCenter().getSiteList()) {
                 String siteUrl = site.getUrl();
                 int baseUrlEnd = siteUrl.indexOf("update-center.json");
                 if (baseUrlEnd != -1) {
@@ -398,7 +398,7 @@ public class DownloadService extends PageDecorator {
         public FormValidation updateNow() throws IOException {
             List<JSONObject> jsonList = new ArrayList<>();
             boolean toolInstallerMetadataExists = false;
-            for (UpdateSite updatesite : Jenkins.getActiveInstance().getUpdateCenter().getSiteList()) {
+            for (UpdateSite updatesite : Jenkins.get().getUpdateCenter().getSiteList()) {
                 String site = updatesite.getMetadataUrlForDownloadable(url);
                 if (site == null) {
                     return FormValidation.warning("The update site " + site + " does not look like an update center");

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -547,7 +547,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     public Map<JobPropertyDescriptor, JobProperty<? super JobT>> getProperties() {
         Map result = Descriptor.toMap((Iterable) properties);
         if (logRotator != null) {
-            result.put(Jenkins.getActiveInstance().getDescriptorByType(BuildDiscarderProperty.DescriptorImpl.class), new BuildDiscarderProperty(logRotator));
+            result.put(Jenkins.get().getDescriptorByType(BuildDiscarderProperty.DescriptorImpl.class), new BuildDiscarderProperty(logRotator));
         }
         return result;
     }

--- a/core/src/main/java/hudson/model/OverallLoadStatistics.java
+++ b/core/src/main/java/hudson/model/OverallLoadStatistics.java
@@ -72,7 +72,7 @@ public class OverallLoadStatistics extends LoadStatistics {
 
     @Override
     protected Iterable<Node> getNodes() {
-        return Jenkins.getActiveInstance().getNodes();
+        return Jenkins.get().getNodes();
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5128,7 +5128,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @Restricted(NoExternalUse.class)
     public @CheckForNull static VersionNumber getStoredVersion() {
-        return toVersion(Jenkins.getActiveInstance().version);
+        return toVersion(Jenkins.get().version);
     }
 
     /**

--- a/core/src/main/java/jenkins/model/UnlabeledLoadStatistics.java
+++ b/core/src/main/java/jenkins/model/UnlabeledLoadStatistics.java
@@ -102,7 +102,7 @@ public class UnlabeledLoadStatistics extends LoadStatistics {
     private static class UnlabeledNodesIterator extends Iterators.FilterIterator<Node> {
 
         protected UnlabeledNodesIterator() {
-            super(Jenkins.getActiveInstance().getNodes().iterator());
+            super(Jenkins.get().getNodes().iterator());
         }
 
         @Override

--- a/core/src/main/java/jenkins/util/groovy/GroovyHookScript.java
+++ b/core/src/main/java/jenkins/util/groovy/GroovyHookScript.java
@@ -46,7 +46,7 @@ public class GroovyHookScript {
 
     @Deprecated
     public GroovyHookScript(String hook) {
-        this(hook, Jenkins.getActiveInstance());
+        this(hook, Jenkins.get());
     }
 
     private GroovyHookScript(String hook, Jenkins j) {

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -50,7 +50,6 @@ public class ListJobsCommandTest {
         jenkins = mock(Jenkins.class);
         mockStatic(Jenkins.class);
         when(Jenkins.get()).thenReturn(jenkins);
-        when(Jenkins.getActiveInstance()).thenReturn(jenkins);
         command = mock(ListJobsCommand.class, Mockito.CALLS_REAL_METHODS);
         command.stdout = new PrintStream(stdout);
         command.stderr = new PrintStream(stderr);

--- a/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
+++ b/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
@@ -84,7 +84,6 @@ public class ViewOptionHandlerTest {
 
         PowerMockito.mockStatic(Jenkins.class);
         PowerMockito.when(Jenkins.get()).thenReturn(jenkins);
-        PowerMockito.when(Jenkins.getActiveInstance()).thenReturn(jenkins);
         when(jenkins.getView("outer")).thenReturn(outer);
         when(jenkins.getDisplayName()).thenReturn("Jenkins");
         when(jenkins.getACL()).thenReturn(new ACL() {

--- a/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
@@ -80,7 +80,7 @@ public class CancelQuietDownCommandTest {
 
     @Test
     public void cancelQuietDownShouldSuccessOnQuietDownedJenkins() throws Exception {
-        j.jenkins.getActiveInstance().doQuietDown();
+        j.jenkins.get().doQuietDown();
         QuietDownCommandTest.assertJenkinsInQuietMode(j);
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
@@ -133,7 +133,7 @@ public class CancelQuietDownCommandTest {
         Future<FreeStyleBuild> build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
         assertThat(project.isBuilding(), equalTo(true));
-        j.jenkins.getActiveInstance().doQuietDown();
+        j.jenkins.get().doQuietDown();
         QuietDownCommandTest.assertJenkinsInQuietMode(j);
 
         final CLICommandInvoker.Result result = command

--- a/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
@@ -80,7 +80,7 @@ public class CancelQuietDownCommandTest {
 
     @Test
     public void cancelQuietDownShouldSuccessOnQuietDownedJenkins() throws Exception {
-        j.jenkins.get().doQuietDown();
+        j.jenkins.doQuietDown();
         QuietDownCommandTest.assertJenkinsInQuietMode(j);
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
@@ -133,7 +133,7 @@ public class CancelQuietDownCommandTest {
         Future<FreeStyleBuild> build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
         assertThat(project.isBuilding(), equalTo(true));
-        j.jenkins.get().doQuietDown();
+        j.jenkins.doQuietDown();
         QuietDownCommandTest.assertJenkinsInQuietMode(j);
 
         final CLICommandInvoker.Result result = command

--- a/test/src/test/java/hudson/cli/ConnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConnectNodeCommandTest.java
@@ -174,7 +174,7 @@ public class ConnectNodeCommandTest {
     }
 
     @Test public void connectNodeShouldSucceedOnMaster() throws Exception {
-        final Computer masterComputer = j.jenkins.get().getComputer("");
+        final Computer masterComputer = j.jenkins.getComputer("");
 
         CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.CONNECT, Jenkins.READ)

--- a/test/src/test/java/hudson/cli/ConnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConnectNodeCommandTest.java
@@ -174,7 +174,7 @@ public class ConnectNodeCommandTest {
     }
 
     @Test public void connectNodeShouldSucceedOnMaster() throws Exception {
-        final Computer masterComputer = j.jenkins.getActiveInstance().getComputer("");
+        final Computer masterComputer = j.jenkins.get().getComputer("");
 
         CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.CONNECT, Jenkins.READ)

--- a/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
@@ -266,7 +266,7 @@ public class DisconnectNodeCommandTest {
     }
 
     public void disconnectNodeShouldSucceedOnMaster() throws Exception {
-        final Computer masterComputer = j.jenkins.getActiveInstance().getComputer("");
+        final Computer masterComputer = j.jenkins.get().getComputer("");
         assertThat(masterComputer.isOnline(), equalTo(true));
         assertThat(masterComputer.getOfflineCause(), equalTo(null));
 

--- a/test/src/test/java/hudson/cli/OfflineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OfflineNodeCommandTest.java
@@ -454,7 +454,7 @@ public class OfflineNodeCommandTest {
 
     @Test
     public void offlineNodeShouldSucceedOnMaster() throws Exception {
-        final Computer masterComputer = Jenkins.getActiveInstance().getComputer("");
+        final Computer masterComputer = Jenkins.get().getComputer("");
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
@@ -468,7 +468,7 @@ public class OfflineNodeCommandTest {
 
     @Test
     public void offlineNodeShouldSucceedOnMasterWithCause() throws Exception {
-        final Computer masterComputer = Jenkins.getActiveInstance().getComputer("");
+        final Computer masterComputer = Jenkins.get().getComputer("");
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)

--- a/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
@@ -287,7 +287,7 @@ public class OnlineNodeCommandTest {
     }
 
     @Test public void onlineNodeShouldSucceedOnMaster() throws Exception {
-        final Computer masterComputer = j.jenkins.getActiveInstance().getComputer("");
+        final Computer masterComputer = j.jenkins.get().getComputer("");
 
         CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.CONNECT, Jenkins.READ)

--- a/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
@@ -287,7 +287,7 @@ public class OnlineNodeCommandTest {
     }
 
     @Test public void onlineNodeShouldSucceedOnMaster() throws Exception {
-        final Computer masterComputer = j.jenkins.get().getComputer("");
+        final Computer masterComputer = j.jenkins.getComputer("");
 
         CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.CONNECT, Jenkins.READ)

--- a/test/src/test/java/hudson/cli/QuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/QuietDownCommandTest.java
@@ -129,7 +129,7 @@ public class QuietDownCommandTest {
 
     @Test
     public void quietDownShouldSuccessOnAlreadyQuietDownedJenkins() throws Exception {
-        j.jenkins.getActiveInstance().doQuietDown();
+        j.jenkins.get().doQuietDown();
         assertJenkinsInQuietMode();
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
@@ -140,7 +140,7 @@ public class QuietDownCommandTest {
 
     @Test
     public void quietDownShouldSuccessWithBlockOnAlreadyQuietDownedJenkins() throws Exception {
-        j.jenkins.getActiveInstance().doQuietDown(true, 0);
+        j.jenkins.get().doQuietDown(true, 0);
         assertJenkinsInQuietMode();
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
@@ -151,7 +151,7 @@ public class QuietDownCommandTest {
 
     @Test
     public void quietDownShouldSuccessWithBlockAndTimeoutOnAlreadyQuietDownedJenkins() throws Exception {
-        j.jenkins.getActiveInstance().doQuietDown(true, 0);
+        j.jenkins.get().doQuietDown(true, 0);
         assertJenkinsInQuietMode();
         final long time_before = System.currentTimeMillis();
         final CLICommandInvoker.Result result = command
@@ -484,7 +484,7 @@ public class QuietDownCommandTest {
     public static final void assertJenkinsInQuietMode(final JenkinsRule j) {
         await().pollInterval(250, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
-                .until(() -> j.jenkins.getActiveInstance().getQueue().isBlockedByShutdown(task));
+                .until(() -> j.jenkins.get().getQueue().isBlockedByShutdown(task));
     }
 
     /**
@@ -494,6 +494,6 @@ public class QuietDownCommandTest {
     public static final void assertJenkinsNotInQuietMode(final JenkinsRule j) {
         await().pollInterval(250, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
-                .until(() -> !j.jenkins.getActiveInstance().getQueue().isBlockedByShutdown(task));
+                .until(() -> !j.jenkins.get().getQueue().isBlockedByShutdown(task));
     }
 }

--- a/test/src/test/java/hudson/cli/QuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/QuietDownCommandTest.java
@@ -484,7 +484,7 @@ public class QuietDownCommandTest {
     public static final void assertJenkinsInQuietMode(final JenkinsRule j) {
         await().pollInterval(250, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
-                .until(() -> j.jenkins.get().getQueue().isBlockedByShutdown(task));
+                .until(() -> j.jenkins.getQueue().isBlockedByShutdown(task));
     }
 
     /**
@@ -494,6 +494,6 @@ public class QuietDownCommandTest {
     public static final void assertJenkinsNotInQuietMode(final JenkinsRule j) {
         await().pollInterval(250, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
-                .until(() -> !j.jenkins.get().getQueue().isBlockedByShutdown(task));
+                .until(() -> !j.jenkins.getQueue().isBlockedByShutdown(task));
     }
 }

--- a/test/src/test/java/hudson/model/UsageStatisticsTest.java
+++ b/test/src/test/java/hudson/model/UsageStatisticsTest.java
@@ -90,7 +90,7 @@ public class UsageStatisticsTest {
         InputStreamReader r = new InputStreamReader(new GZIPInputStream(
                 new CombinedCipherInputStream(new ByteArrayInputStream(cipherText),priv,"AES")), "UTF-8");
         JSONObject o = JSONObject.fromObject(IOUtils.toString(r));
-        Jenkins jenkins = Jenkins.getActiveInstance();
+        Jenkins jenkins = Jenkins.get();
         // A bit intrusive with UsageStatistics internals, but done to prevent undetected changes
         // that would cause issues with parsing/analyzing uploaded usage statistics
         assertEquals(1, o.getInt("stat"));
@@ -136,7 +136,7 @@ public class UsageStatisticsTest {
      * @throws InterruptedException
      */
     private void warmUpNodeMonitorCache() throws InterruptedException {
-        Jenkins j = Jenkins.getActiveInstance();
+        Jenkins j = Jenkins.get();
         ArchitectureMonitor.DescriptorImpl descriptor = j.getDescriptorByType(ArchitectureMonitor.DescriptorImpl.class);
         String value = null;
         int count = 1;


### PR DESCRIPTION
Replaced all usages of **getActiveInstance()** with simple **get()** as suggested.

### Proposed changelog entries

* No changelog needed

### Submitter checklist
