### PR TITLE
[JENKINS-59267] Increase ping frequency to prevent timeouts, and make it configurable

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -335,11 +335,11 @@ public class CLI {
                 @Override
                 public void run() {
                     try {
-                        Thread.sleep(10_000);
+                        Thread.sleep(PING_INTERVAL);
                         while (!connection.complete) {
                             LOGGER.fine("sending ping");
                             connection.sendEncoding(Charset.defaultCharset().name()); // no-op at this point
-                            Thread.sleep(10_000);
+                            Thread.sleep(PING_INTERVAL);
                         }
                     } catch (IOException | InterruptedException x) {
                         LOGGER.log(Level.WARNING, null, x);
@@ -406,4 +406,6 @@ public class CLI {
     }
 
     static final Logger LOGGER = Logger.getLogger(CLI.class.getName());
+
+    private static final int PING_INTERVAL = Integer.getInteger(CLI.class.getName() + ".pingInterval", 3_000); // JENKINS-59267
 }


### PR DESCRIPTION
See [JENKINS-59267](https://issues.jenkins-ci.org/browse/JENKINS-59267) and https://github.com/jenkinsci/jenkins/pull/3011#issuecomment-529142365.

Manually tested this and it works (both sending pings and preventing the timeout). `-logger FINE` on the `jenkins-cli.jar` invocation helps see the effect.

Untested with reverse proxies, but still an improvement.

### Proposed changelog entries

* Increase client-side keep-alive ping frequency on the HTTP-based CLI to prevent timeouts.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs
