### PR TITLE
fix javadoc punctuation for Initializer.after

### DIFF
--- a/core/src/main/java/hudson/init/Initializer.java
+++ b/core/src/main/java/hudson/init/Initializer.java
@@ -65,7 +65,7 @@ public @interface Initializer {
      *
      * <p>
      * This has the identical purpose as {@link #requires()}, but it's separated to allow better type-safety
-     * when using {@link InitMilestone} as a requirement (since enum member definitions need to be constant.)
+     * when using {@link InitMilestone} as a requirement (since enum member definitions need to be constant).
      */
     InitMilestone after() default STARTED;
 


### PR DESCRIPTION
### Proposed changelog entries

* Developer: fix javadoc punctuation for Initializer.after

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers