### PR TITLE
[JENKINS-48375] - Make Atom the default feed type in UI and the response application type (Former RSS feeds use Atom)

### DIFF
--- a/core/src/main/resources/hudson/model/Job/rssHeader.jelly
+++ b/core/src/main/resources/hudson/model/Job/rssHeader.jelly
@@ -24,8 +24,8 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <link rel="alternate" title="Jenkins:${it.name} (all builds)" href="rssAll" type="application/rss+xml" />
+  <link rel="alternate" title="Jenkins:${it.name} (all builds)" href="rssAll" type="application/atom+xml" />
   <link rel="alternate" title="Jenkins:${it.name} (all builds) (RSS 2.0)" href="rssAll?flavor=rss20" type="application/rss+xml" />
-  <link rel="alternate" title="Jenkins:${it.name} (failed builds)" href="rssFailed" type="application/rss+xml" />
+  <link rel="alternate" title="Jenkins:${it.name} (failed builds)" href="rssFailed" type="application/atom+xml" />
   <link rel="alternate" title="Jenkins:${it.name} (failed builds) (RSS 2.0)" href="rssFailed?flavor=rss20" type="application/rss+xml" />
 </j:jelly>

--- a/core/src/main/resources/hudson/model/View/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/View/sidepanel.jelly
@@ -29,9 +29,9 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:header title="Jenkins">
-    <link rel="alternate" title="Jenkins:${it.viewName} (all builds)" href="${rootURL}/${it.url}rssAll" type="application/rss+xml" />
+    <link rel="alternate" title="Jenkins:${it.viewName} (all builds)" href="${rootURL}/${it.url}rssAll" type="application/atom+xml" />
     <link rel="alternate" title="Jenkins:${it.viewName} (all builds) (RSS 2.0)" href="${rootURL}/${it.url}rssAll?flavor=rss20" type="application/rss+xml" />
-    <link rel="alternate" title="Jenkins:${it.viewName} (failed builds)" href="${rootURL}/${it.url}rssFailed" type="application/rss+xml" />
+    <link rel="alternate" title="Jenkins:${it.viewName} (failed builds)" href="${rootURL}/${it.url}rssFailed" type="application/atom+xml" />
     <link rel="alternate" title="Jenkins:${it.viewName} (failed builds) (RSS 2.0)" href="${rootURL}/${it.url}rssFailed?flavor=rss20" type="application/rss+xml" />
   </l:header>
   <l:side-panel>

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -41,13 +41,13 @@ THE SOFTWARE.
       RSS link
     -->
     <span class="build-rss-links">
-        <a class="build-rss-all-icon" href="${it.baseUrl}/rssAll"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+        <a class="build-rss-all-icon" href="${it.baseUrl}/rssAll"><img src="${imagesURL}/atom.gif" border="0" alt="Atom feed" height="16" width="16"/></a>
         <st:nbsp/>
-        <a class="build-rss-all-link" href="${it.baseUrl}/rssAll">RSS ${%for all}</a>
+        <a class="build-rss-all-link" href="${it.baseUrl}/rssAll">Atom feed ${%for all}</a>
         <st:nbsp/>
-        <a class="build-rss-failed-icon" href="${it.baseUrl}/rssFailed"><img src="${imagesURL}/atom.gif" border="0" alt="Feed" height="16" width="16"/></a>
+        <a class="build-rss-failed-icon" href="${it.baseUrl}/rssFailed"><img src="${imagesURL}/atom.gif" border="0" alt="Atom feed" height="16" width="16"/></a>
         <st:nbsp/>
-        <a class="build-rss-failed-link" href="${it.baseUrl}/rssFailed">RSS ${%for failures}</a>
+        <a class="build-rss-failed-link" href="${it.baseUrl}/rssFailed">Atom feed ${%for failures}</a>
     </span>
   </j:parse>
 

--- a/core/src/main/resources/lib/hudson/rssBar.jelly
+++ b/core/src/main/resources/lib/hudson/rssBar.jelly
@@ -27,19 +27,19 @@ THE SOFTWARE.
   <div id="rss-bar">
     <a href="${rootURL}/legend" class="rss-bar-legend-link">${%Legend}</a>
     <span class="rss-bar-item">
-      <a href="rssAll" class="rss-bar-item-icon-link"><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Feed"/></a>
+      <a href="rssAll" class="rss-bar-item-icon-link"><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Atom feed"/></a>
       <st:nbsp/>
-      <a href="rssAll" class="rss-bar-item-link">RSS ${%for all}</a>
+      <a href="rssAll" class="rss-bar-item-link">Atom feed ${%for all}</a>
     </span>
     <span class="rss-bar-item">
-      <a href="rssFailed" class="rss-bar-item-icon-link"><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Feed"/></a>
+      <a href="rssFailed" class="rss-bar-item-icon-link"><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Atom feed"/></a>
       <st:nbsp/>
-      <a href="rssFailed" class="rss-bar-item-link">RSS ${%for failures}</a>
+      <a href="rssFailed" class="rss-bar-item-link">Atom feed ${%for failures}</a>
     </span>
     <span class="rss-bar-item">
-      <a href="rssLatest" class="rss-bar-item-icon-link" ><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Feed"/></a>
+      <a href="rssLatest" class="rss-bar-item-icon-link" ><img src="${imagesURL}/atom.gif" class="icon-rss icon-sm" alt="Atom feed"/></a>
       <st:nbsp/>
-      <a href="rssLatest" class="rss-bar-item-link">RSS ${%for just latest builds}</a>
+      <a href="rssLatest" class="rss-bar-item-link">Atom feed ${%for just latest builds}</a>
     </span>
   </div>
 </j:jelly>


### PR DESCRIPTION
See [JENKINS-48375](https://issues.jenkins-ci.org/browse/JENKINS-48375).

### Proposed changelog entries

* 48375: Fix RSS/Atom links inconsistencies

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@daniel-beck 
