### PR TITLE
Do not update detached plugins on Jenkins update

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -758,16 +758,21 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     name = normalisePluginName(name);
 
                     // If this was a plugin that was detached some time in the past i.e. not just one of the
-                    // plugins that was bundled "for fun".
+                    // plugins that was bundled as a dependency (or, before 2.199, to promote their use).
                     if (DetachedPluginsUtil.isDetachedPlugin(name)) {
                         VersionNumber installedVersion = getPluginVersion(rootDir, name);
-                        VersionNumber bundledVersion = getPluginVersion(dir, name);
+                        VersionNumber detachedVersion = null;
+                        for (DetachedPluginsUtil.DetachedPlugin detachedPlugin : DetachedPluginsUtil.getDetachedPlugins()) {
+                            if (detachedPlugin.getShortName().equals(name)) {
+                                detachedVersion = detachedPlugin.getRequiredVersion();
+                            }
+                        }
                         // If the plugin is already installed, we need to decide whether to replace it with the bundled version.
-                        if (installedVersion != null && bundledVersion != null) {
-                            // If the installed version is older than the bundled version, then it MUST be upgraded.
-                            // If the installed version is newer than the bundled version, then it MUST NOT be upgraded.
+                        if (installedVersion != null && detachedVersion != null) {
+                            // If the installed version is older than the minimum version, then it MUST be upgraded.
+                            // If the installed version is newer than the minimum version, then it MUST NOT be downgraded.
                             // If the versions are equal we just keep the installed version.
-                            return installedVersion.isOlderThan(bundledVersion);
+                            return installedVersion.isOlderThan(detachedVersion);
                         }
                     }
 


### PR DESCRIPTION
**Only update plugins if they're older than than the _required_ version, not the _bundled_ version.**

@oleg-nenashev made me aware of the current behavior in https://github.com/jenkinsci/jenkins/pull/4245#issuecomment-538891523 which I've since (partially) confirmed through manual testing:

* If a bundled plugin is an original "detached plugin", it will be updated to the currently bundled version when updating Jenkins.
* If a bundled plugin is a dependency of a detached plugin, it will _not_ be updated to the currently bundled version.
* There used to be the entirely ignored promotional bundled plugins, but that's addressed by #4040.

So while script-security 1.65 specifically would not be updated after Jenkins was updated, some other bundled plugins will:

    INFO	hudson.PluginManager#loadDetachedPlugins: Upgraded Jenkins from version 2.197 to version 2.199. Loaded detached plugins (and dependencies): [ant.hpi, mailer.hpi, pam-auth.hpi]

I do not think this approach makes sense with how we're currently treating bundled plugins: A reasonably current release of implied dependencies, needed whenever the Jenkins home directory otherwise would be broken.

Therefore I propose we change this behavior: 

* Bundled plugins will be installed if they've been detached since the previous version of Jenkins that was running, or if they are implied dependencies of installed plugins. (Unchanged)
* Bundled plugins will be updated if they are older than the minimum version declared in the plugin splits file.
  * This is new; previously they would be updated on Jenkins update if they're older than the version currently bundled.

https://github.com/jenkinsci/jenkins/pull/2489 implements basically the same thing, just without a change in Jenkins version. The distinction between the two seems also unnecessary.

(FWIW https://github.com/jenkinsci/jenkins/pull/2489 is likely also the PR I'm referring to in https://github.com/jenkinsci/jenkins/pull/3229/files#r161066845 as I had thought the behavior I'm proposing here was already the behavior.)

Thoughts?

(Untested, let's get a CI build here.)

### Proposed changelog entries

* Do not automatically update detached plugins to their current bundled versions when updating Jenkins.

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
