### PR TITLE
Add a new `Functions#urlEncode(String)` method for encoding URLs in Jelly views

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -99,6 +99,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -724,6 +726,20 @@ public class Functions {
 
     public static String encode(String s) {
         return Util.encode(s);
+    }
+
+    /**
+     * Shortcut function for calling {@link URLEncoder#encode(String,String)} (with UTF-8 encoding).<br>
+     * Useful for encoding URL query parameters in jelly code (as in {@code "...?param=${h.urlEncode(something)}"}).
+     *
+     * @since TODO
+     */
+    public static String urlEncode(String s) {
+        try {
+            return URLEncoder.encode(s, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new Error(e); // impossible
+        }
     }
 
     public static String escape(String s) {

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -29,8 +29,6 @@ import hudson.Util;
 import hudson.util.EditDistance;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -68,10 +66,6 @@ import org.kohsuke.stapler.export.Flavor;
  * @see SearchableModelObject
  */
 public class Search implements StaplerProxy {
-    @Restricted(NoExternalUse.class) // used from stapler views only
-    public static String encodeQuery(String query) throws UnsupportedEncodingException {
-        return URLEncoder.encode(query, "UTF-8");
-    }
 
     public void doIndex(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         List<Ancestor> l = req.getAncestors();

--- a/core/src/main/resources/hudson/search/Search/search-failed.jelly
+++ b/core/src/main/resources/hudson/search/Search/search-failed.jelly
@@ -43,13 +43,13 @@ THE SOFTWARE.
           <ol>
             <j:forEach var="i" items="${items}">
               <li id="item_${i.path}">
-                <a href="?q=${it.encodeQuery(i.path)}">${i.path}</a>
+                <a href="?q=${h.urlEncode(i.path)}">${i.path}</a>
               </li>
             </j:forEach>
           </ol>
             <j:if test="${items.hasMoreResults()}">
                 <j:set var="max" value="${request.hasParameter('max')?request.getParameter('max'):100}"/>
-                <em>result has been truncated, <a href="?q=${it.encodeQuery(q)}&amp;max=${max+100}">see 100 more</a></em>
+                <em>result has been truncated, <a href="?q=${h.urlEncode(q)}&amp;max=${max+100}">see 100 more</a></em>
             </j:if>
         </j:otherwise>
       </j:choose>

--- a/core/src/main/resources/lib/hudson/project/upstream-downstream.jelly
+++ b/core/src/main/resources/lib/hudson/project/upstream-downstream.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
     <d:tag name="relationship">
       <j:if test="${lhs.fingerprintConfigured and rhs.fingerprintConfigured}">
         <st:nbsp/>
-        <a href="${rootURL}/projectRelationship?lhs=${lhs.name}&amp;rhs=${rhs.name}">
+        <a href="${rootURL}/projectRelationship?lhs=${h.urlEncode(lhs.name)}&amp;rhs=${h.urlEncode(rhs.name)}">
           <l:icon class="icon-fingerprint icon-sm"/>
         </a>
       </j:if>


### PR DESCRIPTION
Following [discussion](https://github.com/jenkinsci/jenkins/pull/4264#discussion_r332667578) in PR #4264, here is an addition to `Functions`, to replace (in jelly files) code like this:

```
<j:invokeStatic var="blah" className="java.net.URLEncoder" method="encode">
  <j:arg value="${foo}" />
  <j:arg value="UTF-8" />
</j:invokeStatic>
<a href="${rootURL}/...?param=${blah}">...
```

...with this:

`<a href="${rootURL}/...?param=${h.urlEncode(foo)}">...`

I will update PR #4264 if this gets merged.

This PR also removes a similar utility function from `hudson.search.Search` (it was `@Restricted(NoExternalUse.class)`, so I guess it's OK to delete it and use the alternative in jelly views).

Finally, this PR uses `h.urlEncode` to fix a tiny UI bug, which could be reproduced like this:
- create two freestyle jobs, named `job+a` and `job+b`
- add an `echo x > x` shell step in each job, enable fingerprinting (with `x` as a files pattern), and enable build trigger of `job+b` after build of `job+a`
- run `job+a` (and thus also `job+b`)
- in the main view of these jobs, in the _{Upstream,Downstream} Projects_ section, there is now an icon with a link to the _Project Relationship_ page: `.../jenkins/projectRelationship?lhs=job+a&rhs=job+b`
- this link opens the relationship search for `job a` and `job b` instead of `job+a` and `job+b`, because query parameters were not encoded

### Proposed changelog entries

* Internal: added `Functions.urlEncode(String)` (`h.urlEncode(String)` in Jelly), to ease encoding of URL query parameters from Jelly code.

### Submitter checklist

- [ ] JIRA issue is well described => _simple internal change, no need for a JIRA issue I think?_
- [X] Changelog entry appropriate for the audience affected by the change
- [X] Appropriate autotests or explanation to why this change has no tests => _there is not much to test..._

### Desired reviewers

@jvz 
@stephenc (because I'm replacing `Search.encodeQuery(String)`, which you had introduced in 5d92057)