### PR TITLE
[DO NOT MERGE] Hide password form fields by default + JavaScript disabled

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -380,6 +380,11 @@ public class Functions {
         return null;
     }
 
+    @Restricted(NoExternalUse.class)
+    public static boolean useHidingPasswordFields() {
+        return SystemProperties.getBoolean(Functions.class.getName() + "hidingPasswordFields", true);
+    }
+
     /**
      * URL decomposed for easier computation of relevant URLs.
      *

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -382,7 +382,7 @@ public class Functions {
 
     @Restricted(NoExternalUse.class)
     public static boolean useHidingPasswordFields() {
-        return SystemProperties.getBoolean(Functions.class.getName() + "hidingPasswordFields", true);
+        return SystemProperties.getBoolean(Functions.class.getName() + ".hidingPasswordFields", true);
     }
 
     /**

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -68,7 +68,7 @@ THE SOFTWARE.
       <div class="hidden-password">
         <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
                  class="hidden-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
-                 name ="${attrs.name ?: '_.'+attrs.field}"
+                 name="${attrs.name ?: '_.'+attrs.field}"
                  value="${value}"
                  type="hidden"
                  checkMethod="post"

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -106,13 +106,14 @@ THE SOFTWARE.
       </div>
     </j:when>
     <j:otherwise>
-  <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
-         class="setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
-         name ="${attrs.name ?: '_.'+attrs.field}"
-         value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"
-         type="password"
-         checkMethod="post"
-         ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
+      <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
+               class="setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
+               name="${attrs.name ?: '_.'+attrs.field}"
+               value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"
+               type="text"
+               oninput="this.setAttribute('type', 'password'); return true;"
+               checkMethod="post"
+               ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
   <!-- TODO consider customizedFields -->
     </j:otherwise>
   </j:choose>

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -64,10 +64,19 @@ THE SOFTWARE.
   <j:choose>
     <j:when test="${h.useHidingPasswordFields()}">
       <j:set var="value" value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"/>
+      <st:adjunct includes="lib.form.password.password"/>
       <j:choose>
         <j:when test="${ value != null }">
-          <st:adjunct includes="lib.form.password.password"/>
           <div class="hidden-password">
+            <noscript>
+              <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
+                       class="setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
+                       name ="${attrs.name ?: '_.'+attrs.field}"
+                       value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"
+                       type="password"
+                       checkMethod="post"
+                       ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
+            </noscript>
             <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
                      class="complex-password-field hidden-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
                      name="${attrs.name ?: '_.'+attrs.field}"
@@ -75,7 +84,7 @@ THE SOFTWARE.
                      type="hidden"
                      checkMethod="post"
                      ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
-            <div class="hidden-password-placeholder">
+            <div class="hidden-for-noscript hidden-password-placeholder">
               <div class="hidden-password-legend">
                 <svg width="20px" height="25px" viewBox="0 0 25 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
                   <!--
@@ -108,8 +117,17 @@ THE SOFTWARE.
           </div>
         </j:when>
         <j:otherwise>
+          <noscript>
+            <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
+                     class="complex-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
+                     name="${attrs.name ?: '_.'+attrs.field}"
+                     value="${value}"
+                     type="password"
+                     checkMethod="post"
+                     ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
+          </noscript>
           <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
-                   class="complex-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
+                   class="hidden-for-noscript complex-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
                    name="${attrs.name ?: '_.'+attrs.field}"
                    value="${value}"
                    type="text"

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -69,7 +69,7 @@ THE SOFTWARE.
           <st:adjunct includes="lib.form.password.password"/>
           <div class="hidden-password">
             <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
-                     class="hidden-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
+                     class="complex-password-field hidden-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
                      name="${attrs.name ?: '_.'+attrs.field}"
                      value="${value}"
                      type="hidden"
@@ -109,7 +109,7 @@ THE SOFTWARE.
         </j:when>
         <j:otherwise>
           <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
-                   class="setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
+                   class="complex-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
                    name="${attrs.name ?: '_.'+attrs.field}"
                    value="${value}"
                    type="text"

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -109,7 +109,7 @@ THE SOFTWARE.
       <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
                class="setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
                name="${attrs.name ?: '_.'+attrs.field}"
-               value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"
+               value="${value}"
                type="text"
                oninput="this.setAttribute('type', 'password'); return true;"
                checkMethod="post"

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -61,60 +61,73 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
   <f:prepareDatabinding />
-  <j:set var="value" value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"/>
   <j:choose>
-    <j:when test="${ value != null }">
-      <st:adjunct includes="lib.form.password.password"/>
-      <div class="hidden-password">
-        <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
-                 class="hidden-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
-                 name="${attrs.name ?: '_.'+attrs.field}"
-                 value="${value}"
-                 type="hidden"
-                 checkMethod="post"
-                 ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
-        <div class="hidden-password-placeholder">
-          <div class="hidden-password-legend">
-            <svg width="20px" height="25px" viewBox="0 0 25 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
-              <!--
-                  Based on Material Design.
+    <j:when test="${h.useHidingPasswordFields()}">
+      <j:set var="value" value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"/>
+      <j:choose>
+        <j:when test="${ value != null }">
+          <st:adjunct includes="lib.form.password.password"/>
+          <div class="hidden-password">
+            <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
+                     class="hidden-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
+                     name="${attrs.name ?: '_.'+attrs.field}"
+                     value="${value}"
+                     type="hidden"
+                     checkMethod="post"
+                     ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
+            <div class="hidden-password-placeholder">
+              <div class="hidden-password-legend">
+                <svg width="20px" height="25px" viewBox="0 0 25 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
+                  <!--
+                      Based on Material Design.
 
-                  Licensed under the Apache License, Version 2.0 (the "License");
-                  you may not use this file except in compliance with the License.
-                  You may obtain a copy of the License at
+                      Licensed under the Apache License, Version 2.0 (the "License");
+                      you may not use this file except in compliance with the License.
+                      You may obtain a copy of the License at
 
-                      http://www.apache.org/licenses/LICENSE-2.0
+                          http://www.apache.org/licenses/LICENSE-2.0
 
-                  Unless required by applicable law or agreed to in writing, software
-                  distributed under the License is distributed on an "AS IS" BASIS,
-                  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                  See the License for the specific language governing permissions and
-                  limitations under the License.
-              -->
-              <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                <g transform="translate(-504.000000, -199.000000)" fill="#788594">
-                  <path d="M520.914667,209.666667 L511.466667,209.666667 L511.466667,206.619333 C511.466667,204.014 513.584667,201.895333 516.190667,201.895333 C518.796667,201.895333 520.914667,204.014 520.914667,206.619333 L520.914667,209.666667 Z M516.190667,223.381333 C514.514,223.381333 513.143333,222.01 513.143333,220.333333 C513.143333,218.657333 514.514,217.286 516.190667,217.286 C517.867333,217.286 519.238,218.657333 519.238,220.333333 C519.238,222.01 517.867333,223.381333 516.190667,223.381333 Z M516.190667,199 C511.984667,199 508.571333,202.414 508.571333,206.619333 L508.571333,209.666667 L507.048,209.666667 C505.372,209.666667 504,211.038 504,212.714667 L504,227.952667 C504,229.628667 505.372,231 507.048,231 L525.334,231 C527.01,231 528.380667,229.628667 528.380667,227.952667 L528.380667,212.714667 C528.380667,211.038 527.01,209.666667 525.334,209.666667 L523.81,209.666667 L523.81,206.619333 C523.81,202.414 520.396667,199 516.190667,199 Z"/>
-                </g>
-              </g>
-            </svg>
-            <span>${%Concealed}</span>
+                      Unless required by applicable law or agreed to in writing, software
+                      distributed under the License is distributed on an "AS IS" BASIS,
+                      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                      See the License for the specific language governing permissions and
+                      limitations under the License.
+                  -->
+                  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                    <g transform="translate(-504.000000, -199.000000)" fill="#788594">
+                      <path d="M520.914667,209.666667 L511.466667,209.666667 L511.466667,206.619333 C511.466667,204.014 513.584667,201.895333 516.190667,201.895333 C518.796667,201.895333 520.914667,204.014 520.914667,206.619333 L520.914667,209.666667 Z M516.190667,223.381333 C514.514,223.381333 513.143333,222.01 513.143333,220.333333 C513.143333,218.657333 514.514,217.286 516.190667,217.286 C517.867333,217.286 519.238,218.657333 519.238,220.333333 C519.238,222.01 517.867333,223.381333 516.190667,223.381333 Z M516.190667,199 C511.984667,199 508.571333,202.414 508.571333,206.619333 L508.571333,209.666667 L507.048,209.666667 C505.372,209.666667 504,211.038 504,212.714667 L504,227.952667 C504,229.628667 505.372,231 507.048,231 L525.334,231 C527.01,231 528.380667,229.628667 528.380667,227.952667 L528.380667,212.714667 C528.380667,211.038 527.01,209.666667 525.334,209.666667 L523.81,209.666667 L523.81,206.619333 C523.81,202.414 520.396667,199 516.190667,199 Z"/>
+                    </g>
+                  </g>
+                </svg>
+                <span>${%Concealed}</span>
+              </div>
+              <div class="hidden-password-update">
+                <input type="button" class="hidden-password-update-btn" value="${%Change Password}"/>
+              </div>
+            </div>
           </div>
-          <div class="hidden-password-update">
-            <input type="button" class="hidden-password-update-btn" value="${%Change Password}"/>
-          </div>
-        </div>
-      </div>
+        </j:when>
+        <j:otherwise>
+          <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
+                   class="setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
+                   name="${attrs.name ?: '_.'+attrs.field}"
+                   value="${value}"
+                   type="text"
+                   oninput="this.setAttribute('type', 'password'); return true;"
+                   checkMethod="post"
+                   ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
+      <!-- TODO consider customizedFields -->
+    </j:otherwise>
+  </j:choose>
     </j:when>
     <j:otherwise>
       <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
                class="setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
-               name="${attrs.name ?: '_.'+attrs.field}"
-               value="${value}"
-               type="text"
-               oninput="this.setAttribute('type', 'password'); return true;"
+               name ="${attrs.name ?: '_.'+attrs.field}"
+               value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"
+               type="password"
                checkMethod="post"
                ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
-  <!-- TODO consider customizedFields -->
     </j:otherwise>
   </j:choose>
 </j:jelly>

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -61,6 +61,51 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
   <f:prepareDatabinding />
+  <j:set var="value" value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"/>
+  <j:choose>
+    <j:when test="${ value != null }">
+      <st:adjunct includes="lib.form.password.password"/>
+      <div class="hidden-password">
+        <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
+                 class="hidden-password-field setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
+                 name ="${attrs.name ?: '_.'+attrs.field}"
+                 value="${value}"
+                 type="hidden"
+                 checkMethod="post"
+                 ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
+        <div class="hidden-password-placeholder">
+          <div class="hidden-password-legend">
+            <svg width="20px" height="25px" viewBox="0 0 25 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
+              <!--
+                  Based on Material Design.
+
+                  Licensed under the Apache License, Version 2.0 (the "License");
+                  you may not use this file except in compliance with the License.
+                  You may obtain a copy of the License at
+
+                      http://www.apache.org/licenses/LICENSE-2.0
+
+                  Unless required by applicable law or agreed to in writing, software
+                  distributed under the License is distributed on an "AS IS" BASIS,
+                  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                  See the License for the specific language governing permissions and
+                  limitations under the License.
+              -->
+              <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g transform="translate(-504.000000, -199.000000)" fill="#788594">
+                  <path d="M520.914667,209.666667 L511.466667,209.666667 L511.466667,206.619333 C511.466667,204.014 513.584667,201.895333 516.190667,201.895333 C518.796667,201.895333 520.914667,204.014 520.914667,206.619333 L520.914667,209.666667 Z M516.190667,223.381333 C514.514,223.381333 513.143333,222.01 513.143333,220.333333 C513.143333,218.657333 514.514,217.286 516.190667,217.286 C517.867333,217.286 519.238,218.657333 519.238,220.333333 C519.238,222.01 517.867333,223.381333 516.190667,223.381333 Z M516.190667,199 C511.984667,199 508.571333,202.414 508.571333,206.619333 L508.571333,209.666667 L507.048,209.666667 C505.372,209.666667 504,211.038 504,212.714667 L504,227.952667 C504,229.628667 505.372,231 507.048,231 L525.334,231 C527.01,231 528.380667,229.628667 528.380667,227.952667 L528.380667,212.714667 C528.380667,211.038 527.01,209.666667 525.334,209.666667 L523.81,209.666667 L523.81,206.619333 C523.81,202.414 520.396667,199 516.190667,199 Z"/>
+                </g>
+              </g>
+            </svg>
+            <span>${%Concealed}</span>
+          </div>
+          <div class="hidden-password-update">
+            <input type="button" class="hidden-password-update-btn" value="${%Change Password}"/>
+          </div>
+        </div>
+      </div>
+    </j:when>
+    <j:otherwise>
   <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
          class="setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
          name ="${attrs.name ?: '_.'+attrs.field}"
@@ -69,4 +114,6 @@ THE SOFTWARE.
          checkMethod="post"
          ATTRIBUTES="${attrs}" EXCEPT="field clazz value" />
   <!-- TODO consider customizedFields -->
+    </j:otherwise>
+  </j:choose>
 </j:jelly>

--- a/core/src/main/resources/lib/form/password/password.css
+++ b/core/src/main/resources/lib/form/password/password.css
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+.hidden-password-placeholder {
+    display: flex;
+}
+
+.hidden-password-legend {
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    background: #f9f9f9;
+    flex-grow: 1;
+    align-items: center;
+    display: inline-flex;
+}
+
+.hidden-password-legend > svg {
+    margin-right: 1em;
+    margin-left: 0.5em;
+}
+
+.hidden-password input[type='button'] {
+    background: #4b99d0;
+    color: #fff;
+    border-radius: 4px;
+    border: none;
+    padding: 7px;
+    margin-left: 5px;
+}
+
+.hidden-password input[type='button']:hover {
+    background: #5092be;
+    cursor: pointer;
+}

--- a/core/src/main/resources/lib/form/password/password.css
+++ b/core/src/main/resources/lib/form/password/password.css
@@ -53,3 +53,7 @@
     background: #5092be;
     cursor: pointer;
 }
+
+.hidden-for-noscript {
+    display: none !important;
+}

--- a/core/src/main/resources/lib/form/password/password.js
+++ b/core/src/main/resources/lib/form/password/password.js
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+Behaviour.specify('.hidden-password', 'hidden-password-button', 0, function (e) {
+    var secretUpdateBtn = e.querySelector('.hidden-password-update-btn');
+    if (secretUpdateBtn === null) return;
+
+    var id = 'hidden-password-' + (iota++);
+
+    secretUpdateBtn.onclick = function () {
+        e.querySelector('.hidden-password-field').setAttribute('type', 'password');
+        e.querySelector('.hidden-password-placeholder').remove();
+        secretUpdateBtn.remove();
+        // fix UI bug when DOM changes
+        Event.fire(window, 'jenkins:bottom-sticker-adjust');
+    };
+});

--- a/core/src/main/resources/lib/form/password/password.js
+++ b/core/src/main/resources/lib/form/password/password.js
@@ -36,3 +36,8 @@ Behaviour.specify('.hidden-password', 'hidden-password-button', 0, function (e) 
         Event.fire(window, 'jenkins:bottom-sticker-adjust');
     };
 });
+
+Behaviour.specify('.hidden-for-noscript', 'hidden-for-noscript', 0, function (e) {
+    console.info('Element', e, 'set visible');
+    e.classList.remove('hidden-for-noscript');
+});

--- a/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
@@ -82,6 +82,7 @@ public class PasswordParameterDefinitionTest {
 
         // Another control case: anyone can enter a different value.
         HtmlForm form = wc.withBasicApiToken(dev).getPage(p, "build?delay=0sec").getFormByName("parameters");
+        form.getElementsByAttribute("input", "class", "hidden-password-update-btn").get(0).click();
         HtmlPasswordInput input = form.getInputByName("value");
         input.setText("rumor");
         j.submit(form);
@@ -99,6 +100,7 @@ public class PasswordParameterDefinitionTest {
 
         // Another control case: blank values.
         form = wc.withBasicApiToken(dev).getPage(p, "build?delay=0sec").getFormByName("parameters");
+        form.getElementsByAttribute("input", "class", "hidden-password-update-btn").get(0).click();
         input = form.getInputByName("value");
         input.setText("");
         j.submit(form);

--- a/test/src/test/java/jenkins/security/RedactSecretJsonInErrorMessageSanitizerHtmlTest.java
+++ b/test/src/test/java/jenkins/security/RedactSecretJsonInErrorMessageSanitizerHtmlTest.java
@@ -82,10 +82,9 @@ public class RedactSecretJsonInErrorMessageSanitizerHtmlTest {
         
         String textLevelOne = "plain-2";
         String pwdLevelOneA = "secret-2";
-        String pwdLevelOneB = "secret-3";
+        String pwdLevelOneB = "pre-set secret"; // set in Jelly
         ((HtmlInput) page.getElementById("text-level-one")).setValueAttribute(textLevelOne);
         ((HtmlInput) page.getElementById("pwd-level-one-a")).setValueAttribute(pwdLevelOneA);
-        ((HtmlInput) page.getElementById("pwd-level-one-b")).setValueAttribute(pwdLevelOneB);
         
         HtmlForm form = page.getFormByName("config");
         Page formSubmitPage = j.submit(form);

--- a/test/src/test/java/lib/form/PasswordTest.java
+++ b/test/src/test/java/lib/form/PasswordTest.java
@@ -26,7 +26,7 @@ package lib.form;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlPasswordInput;
+import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 import hudson.cli.CopyJobCommand;
 import hudson.cli.GetJobCommand;
 import hudson.model.*;
@@ -186,8 +186,8 @@ public class PasswordTest {
     @Issue("SECURITY-616")
     public void testCheckMethod() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject("p");
-        p.addProperty(new VulnerableProperty(Secret.fromString("")));
-        HtmlPasswordInput field = j.createWebClient().getPage(p, "configure").getFormByName("config").getInputByName("_.secret");
+        p.addProperty(new VulnerableProperty(null));
+        HtmlTextInput field = j.createWebClient().getPage(p, "configure").getFormByName("config").getInputByName("_.secret");
         while (VulnerableProperty.DescriptorImpl.incomingURL == null) { // waitForBackgroundJavaScript does not work well
             Thread.sleep(100); // form validation of saved value
         }

--- a/test/src/test/resources/jenkins/security/RedactSecretJsonInErrorMessageSanitizerHtmlTest/TestPassword/index.jelly
+++ b/test/src/test/resources/jenkins/security/RedactSecretJsonInErrorMessageSanitizerHtmlTest/TestPassword/index.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
                         <f:password id="pwd-level-one-a"/>
                     </f:entry>
                     <f:entry field="pwd-level-one-b">
-                        <f:password id="pwd-level-one-b"/>
+                        <f:password id="pwd-level-one-b" value="pre-set secret" />
                     </f:entry>
                 </f:section>
     

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2615,6 +2615,9 @@ function buildFormTree(form) {
             default:
                 p = findParent(e);
                 addProperty(p, e.name, e.value);
+                if (e.hasClassName("complex-password-field")) {
+                    addProperty(p, "$redact", shortenName(e.name));
+                }
                 break;
             }
         }


### PR DESCRIPTION
Proposal on top of https://github.com/jenkinsci/jenkins/pull/3991 filed as a separate PR to let people play nicely with core-pr-tester. Only https://github.com/jenkinsci/jenkins/pull/4280/commits/b315e38fd6831165bd18c0fde843b0bec4707377 matters here.

ℹ️ For Firefox, you can disable JavaScript by entering the URL `about:config`, then searching for `javascript` and double clicking on `javascript.enabled`

#### Original version
`docker run --rm -it -p 8081:8080 -e ID=3991 jenkins/core-pr-tester`

#### With JavaScript disabled support
`docker run --rm -it -p 8082:8080 -e ID=4280 jenkins/core-pr-tester`


⚠️ The goal of this addition is not to support a no-JavaScript version of Jenkins, but to prevent accidental disclosure of password being written in a text field of type "text" while the user thinks it's just a regular password field.