### PR TITLE
Release Drafter: Split developer and internal changes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,8 +40,9 @@ categories:
     label: bug
   - title: Localization
     label: localization
-  # TODO: consider merging category or changing emojis
-  - title: Internal/Developer changes
+  - title: Developer-facing changes (APIs, extensions, etc.)
+    label: developer
+  - title: Internal changes
     label: internal
 
 replacers:


### PR DESCRIPTION
This change just gives a bit more granularity to the changelog