### PR TITLE
Modernize LoginRedirectTest

### DIFF
--- a/test/src/test/java/hudson/bugs/LoginRedirectTest.java
+++ b/test/src/test/java/hudson/bugs/LoginRedirectTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,12 +23,16 @@
  */
 package hudson.bugs;
 
+import static org.junit.Assert.assertEquals;
+
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlFormUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import java.net.HttpURLConnection;
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.recipes.PresetData;
 import org.jvnet.hudson.test.recipes.PresetData.DataSet;
 
@@ -38,33 +42,38 @@ import org.jvnet.hudson.test.recipes.PresetData.DataSet;
  * @author Kohsuke Kawaguchi
  */
 @Issue("JENKINS-2290")
-public class LoginRedirectTest extends HudsonTestCase {
-    protected void setUp() throws Exception {
-        contextPath = "/hudson";
-        super.setUp();
-    }
+public class LoginRedirectTest {
 
-    @PresetData(DataSet.NO_ANONYMOUS_READACCESS)
-    public void testRedirect() throws Exception {
-        WebClient wc = new WebClient();
-        // Hudson first causes 403 FORBIDDEN error, then redirect the browser to the page
-        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-        HtmlPage p = wc.goTo("/");
-        assertEquals(200, p.getWebResponse().getStatusCode());
-        HtmlForm form = p.getFormByName("login");
-        form.getInputByName("j_username").setValueAttribute("alice");
-        form.getInputByName("j_password").setValueAttribute("alice");
-        p = (HtmlPage) HtmlFormUtil.submit(form, null);
-
-        System.out.println(p);
-    }
-
-    /**
-     * Verifies that Hudson is sending 403 first. This is important for machine agents.
+    /*
+     * First sends HTTP 403, then redirects to the login page.
      */
     @PresetData(DataSet.NO_ANONYMOUS_READACCESS)
-    public void testRedirect2() throws Exception {
-        new WebClient().assertFails("/", HttpURLConnection.HTTP_FORBIDDEN);
+    @Test
+    public void redirect1() throws Exception {
+        WebClient wc = j.createWebClient();
+        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+        HtmlPage loginPage = wc.goTo("");
+        assertEquals(HttpURLConnection.HTTP_OK, loginPage.getWebResponse().getStatusCode());
+        assertEquals(j.contextPath + "/login", loginPage.getUrl().getPath());
+
+        HtmlForm form = loginPage.getFormByName("login");
+        form.getInputByName("j_username").setValueAttribute("alice");
+        form.getInputByName("j_password").setValueAttribute("alice");
+        HtmlPage mainPage = j.submit(form);
+        assertEquals(j.contextPath + "/", mainPage.getUrl().getPath());
+    }
+
+    /*
+     * Verifies that HTTP 403 is sent first. This is important for machine agents.
+     */
+    @PresetData(DataSet.NO_ANONYMOUS_READACCESS)
+    @Test
+    public void redirect2() throws Exception {
+        WebClient wc = j.createWebClient();
+        wc.assertFails("", HttpURLConnection.HTTP_FORBIDDEN);
     }
 }


### PR DESCRIPTION
Replace deprecated `HudsonTestCase` and add URL path assertions.