### PR TITLE
Update at-since in Javadoc, make script work on Mac OS X

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2357,7 +2357,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * @param description a description of the fileset, for logging purposes
      * @param compression compression to use
      * @return the number of files copied
-     * @since TODO
+     * @since 2.196
      */
     public int copyRecursiveTo(final DirScanner scanner, final FilePath target, final String description, @Nonnull TarCompression compression) throws IOException, InterruptedException {
         if(this.channel==target.channel) {

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -732,7 +732,7 @@ public class Functions {
      * Shortcut function for calling {@link URLEncoder#encode(String,String)} (with UTF-8 encoding).<br>
      * Useful for encoding URL query parameters in jelly code (as in {@code "...?param=${h.urlEncode(something)}"}).
      *
-     * @since TODO
+     * @since 2.200
      */
     public static String urlEncode(String s) {
         try {

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -277,7 +277,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * Like {@link #getDependents} but excluding optional dependencies.
-     * @since TODO
+     * @since 2.181
      */
     public @Nonnull Set<String> getMandatoryDependents() {
         Set<String> s = new HashSet<>(dependents);
@@ -312,7 +312,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * Like {@link #hasDependents} but excluding optional dependencies.
-     * @since TODO
+     * @since 2.181
      */
     public boolean hasMandatoryDependents() {
         if (isBundled) {
@@ -357,7 +357,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * Like {@link #hasDependencies} but omitting optional dependencies.
-     * @since TODO
+     * @since 2.181
      */
     public boolean hasMandatoryDependencies() {
         return dependencies.stream().anyMatch(d -> !d.optional);
@@ -486,7 +486,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * Like {@link #getDependencies} but omits optional dependencies.
-     * @since TODO
+     * @since 2.181
      */
     public List<Dependency> getMandatoryDependencies() {
         return dependencies.stream().filter(d -> !d.optional).collect(Collectors.toList());
@@ -600,7 +600,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      *
      * @see <a href="https://github.com/jenkinsci/maven-hpi-plugin/pull/75">maven-hpi-plugin#PR-75</a>.
      *
-     * @since TODO
+     * @since 2.158
      */
     @Exported
     public @CheckForNull String getMinimumJavaVersion() {
@@ -1002,7 +1002,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * Same as {@link DetachedPluginsUtil#isDetachedPlugin}.
-     * @since TODO
+     * @since 2.185
      */
     @Exported
     public boolean isDetached() {

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -135,7 +135,7 @@ public final class TcpSlaveAgentListener extends Thread {
 
     /**
      * Gets the host name that we advertise protocol clients to connect to.
-     * @since TODO
+     * @since 2.198
      */
     public String getAdvertisedHost() {
         if (CLI_HOST_NAME != null) {

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1671,7 +1671,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
 
         /**
          * Display name used for the GUI.
-         * @since TODO
+         * @since 2.189
          */
         public String getDisplayName() {
             return getName();

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -956,7 +956,7 @@ public class UpdateSite {
         /**
          * Version of Java this plugin requires to run.
          *
-         * @since TODO
+         * @since 2.158
          */
         @Exported
         public final String minimumJavaVersion;
@@ -1035,7 +1035,7 @@ public class UpdateSite {
          * Returns true if the plugin and its dependencies are fully compatible with the current installation
          * This is set to restricted for now, since it is only being used by Jenkins UI at the moment.
          *
-         * @since TODO
+         * @since 2.175
          */
         @Restricted(NoExternalUse.class)
         public boolean isCompatible() {
@@ -1132,7 +1132,7 @@ public class UpdateSite {
 
         /**
          * Returns true iff the plugin declares a minimum Java version and it's newer than what the Jenkins master is running on.
-         * @since TODO
+         * @since 2.158
          */
         public boolean isForNewerJava() {
             try {
@@ -1161,7 +1161,7 @@ public class UpdateSite {
 
         /**
          * Returns the minimum Java version needed to use the plugin and all its dependencies.
-         * @since TODO
+         * @since 2.158
          * @return the minimum Java version needed to use the plugin and all its dependencies, or null if unspecified.
          */
         @CheckForNull
@@ -1208,7 +1208,7 @@ public class UpdateSite {
         /**
          * Returns true iff any of the plugin dependencies require a newer Java than Jenkins is running on.
          *
-         * @since TODO
+         * @since 2.158
          */
         public boolean isNeededDependenciesForNewerJava() {
             for (Plugin p: getNeededDependencies()) {

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -954,7 +954,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
      * Add a simple CollectionSearchIndex object to sib
      *
      * @param sib the SearchIndexBuilder
-     * @since TODO
+     * @since 2.200
      */
     protected void makeSearchIndex(SearchIndexBuilder sib) {
         sib.add(new CollectionSearchIndex<TopLevelItem>() {// for jobs in the view

--- a/core/src/main/java/hudson/model/ViewGroup.java
+++ b/core/src/main/java/hudson/model/ViewGroup.java
@@ -67,7 +67,7 @@ public interface ViewGroup extends Saveable, ModelObject, AccessControlled {
      * @return
      *      can be empty but never null.
      *
-     * @since TODO
+     * @since 2.174
      */
     @Nonnull
     default Collection<View> getAllViews() {

--- a/core/src/main/java/hudson/os/WindowsUtil.java
+++ b/core/src/main/java/hudson/os/WindowsUtil.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  * Adapted from:
  * https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
  *
- * @since TODO
+ * @since 2.183
  */
 public class WindowsUtil {
     private static final Pattern NEEDS_QUOTING = Pattern.compile("[\\s\"]");

--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -44,7 +44,7 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration implements
      * If disabled, the application will no longer check for URL validity in the configuration page.
      * This will lead to an instance vulnerable to SECURITY-1471.
      *
-     * @since TODO
+     * @since 2.176.4 / 2.197
      */
     @Restricted(NoExternalUse.class)
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")

--- a/core/src/main/java/jenkins/plugins/DetachedPluginsUtil.java
+++ b/core/src/main/java/jenkins/plugins/DetachedPluginsUtil.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
  * <p>
  * This code was originally moved from {@link ClassicPluginStrategy}.
  *
- * @since TODO
+ * @since 2.163
  */
 @Restricted(NoExternalUse.class)
 public class DetachedPluginsUtil {

--- a/core/src/main/java/jenkins/security/ResourceDomainConfiguration.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainConfiguration.java
@@ -61,7 +61,7 @@ import static jenkins.security.ResourceDomainFilter.ERROR_RESPONSE;
  * @see ResourceDomainFilter
  * @see ResourceDomainRootAction
  *
- * @since TODO
+ * @since 2.200
  */
 @Extension(ordinal = JenkinsLocationConfiguration.ORDINAL-1) // sort just below the regular location config
 @Restricted(NoExternalUse.class)

--- a/core/src/main/java/jenkins/security/ResourceDomainFilter.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainFilter.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
  * Prohibit requests to Jenkins coming through a resource domain URL configured with
  * {@link ResourceDomainConfiguration}, except anything going to {@link ResourceDomainRootAction}.
  *
- * @since TODO
+ * @since 2.200
  */
 @Restricted(NoExternalUse.class)
 public class ResourceDomainFilter implements Filter {

--- a/core/src/main/java/jenkins/security/ResourceDomainRecommendation.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainRecommendation.java
@@ -43,7 +43,7 @@ import java.io.IOException;
  *
  * @see ResourceDomainConfiguration
  *
- * @since TODO
+ * @since 2.200
  */
 @Extension
 @Restricted(NoExternalUse.class)

--- a/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
@@ -62,7 +62,7 @@ import static java.time.temporal.ChronoUnit.MINUTES;
  * @see ResourceDomainConfiguration
  * @see ResourceDomainFilter
  *
- * @since TODO
+ * @since 2.200
  */
 @Extension
 @Restricted(NoExternalUse.class)

--- a/core/src/main/java/jenkins/security/SecurityListener.java
+++ b/core/src/main/java/jenkins/security/SecurityListener.java
@@ -69,7 +69,7 @@ public abstract class SecurityListener implements ExtensionPoint {
     protected void loggedIn(@Nonnull String username){}
 
     /**
-     * @since TODO
+     * @since 2.161
      *
      * Fired after a new user account has been created and saved to disk.
      *
@@ -106,7 +106,7 @@ public abstract class SecurityListener implements ExtensionPoint {
         }
     }
 
-    /** @since TODO */
+    /** @since 2.161 */
     public static void fireUserCreated(@Nonnull String username) {
         LOGGER.log(Level.FINE, "new user created: {0}", username);
         for (SecurityListener l : all()) {

--- a/core/src/main/java/jenkins/security/stapler/StaplerDispatchValidator.java
+++ b/core/src/main/java/jenkins/security/stapler/StaplerDispatchValidator.java
@@ -79,7 +79,7 @@ import java.util.logging.Logger;
  * {@code jenkins.security.stapler.StaplerDispatchValidator.disabled=true} or setting {@link #DISABLED} to
  * {@code true} in the script console.</p>
  *
- * @since TODO
+ * @since 2.176.2 / 2.186
  */
 @Restricted(NoExternalUse.class)
 public class StaplerDispatchValidator implements DispatchValidator {

--- a/update-since-todo.sh
+++ b/update-since-todo.sh
@@ -26,6 +26,7 @@ do
         echo -e "\tUpdating file in place"
         sedExpr="${line}s/@since TODO/@since ${firstTag//jenkins-/}/"
         sed -i.bak "$sedExpr" "$file"
+        rm -f "$file.bak"
     else
         echo -e "\tNot updating file, no tag found. Normal if the associated PR/commit is not merged and released yet"
     fi

--- a/update-since-todo.sh
+++ b/update-since-todo.sh
@@ -25,7 +25,7 @@ do
         echo -e "\tfirst tag was $firstTag"
         echo -e "\tUpdating file in place"
         sedExpr="${line}s/@since TODO/@since ${firstTag//jenkins-/}/"
-        sed -i $sedExpr $file
+        sed -i.bak $sedExpr $file
     else
         echo -e "\tNot updating file, no tag found. Normal if the associated PR/commit is not merged and released yet"
     fi

--- a/update-since-todo.sh
+++ b/update-since-todo.sh
@@ -5,27 +5,27 @@
 
 set -euo pipefail
 
-me=`basename "$0"`
+me="$( basename "$0" )"
 
 IFS=$'\n'
 for todo in $( git grep --line-number '@since TODO' | grep -v "$me" )
 do
     #echo "TODO: $todo"
-    file=$( echo $todo | cut -d : -f 1 )
-    line=$( echo $todo | cut -d : -f 2 )
+    file=$( echo "$todo" | cut -d : -f 1 )
+    line=$( echo "$todo" | cut -d : -f 2 )
 
     echo "Analyzing $file:$line"
 
-    lineSha=$( git blame --porcelain -L $line,$line $file | head -1 | cut -d ' ' -f 1 )
+    lineSha=$( git blame --porcelain -L "$line,$line" "$file" | head -1 | cut -d ' ' -f 1 )
     echo -e "\tfirst sha: $lineSha"
 
-    firstTag=$( git tag --sort=creatordate --contains $lineSha | head -1 )
+    firstTag=$( git tag --sort=creatordate --contains "$lineSha" | head -1 )
 
-    if [[ ! -z $firstTag ]]; then
+    if [[ -n $firstTag ]]; then
         echo -e "\tfirst tag was $firstTag"
         echo -e "\tUpdating file in place"
         sedExpr="${line}s/@since TODO/@since ${firstTag//jenkins-/}/"
-        sed -i.bak $sedExpr $file
+        sed -i.bak "$sedExpr" "$file"
     else
         echo -e "\tNot updating file, no tag found. Normal if the associated PR/commit is not merged and released yet"
     fi


### PR DESCRIPTION
`sed` on Mac OS requires an argument to `-i`, which is also supported by GNU sed if there's no space, so just do that. Users will have to manually `find . -name '*.java.bak' -delete` or equivalent afterwards, but should be easy enough.