### PR TITLE
[JENKINS-59800] - Add line-height CSS property to fix the "Create Administrator Account" view headlines

### DIFF
--- a/core/src/main/resources/jenkins/install/SetupWizard/setupWizardFirstUser.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/setupWizardFirstUser.jelly
@@ -18,6 +18,7 @@
         #create-admin-user h1 {
           font-family: 'roboto', sans-serif;
           font-size: 48px;
+          line-height: 48px;
           margin-top: 30px;
           font-weight: 500;
         }


### PR DESCRIPTION
See [JENKINS-59800](https://issues.jenkins-ci.org/browse/JENKINS-59800).

This is a hacktoberfest contribution.

### Proposed changelog entries

* Fix the line-height in the headline of the 'create administrator account' view to allow for multiline headlines

Before:
![Bildschirmfoto am 2019-10-16 um 12 04 58](https://user-images.githubusercontent.com/9639382/66911342-9e732500-f010-11e9-96df-ed4a15808250.png)

After:
![Bildschirmfoto am 2019-10-16 um 12 30 20](https://user-images.githubusercontent.com/9639382/66911430-c793b580-f010-11e9-8270-ef773f68992f.png)
