### PR TITLE
[JENKINS-59665] - Fix sorting of the Uninstall column in the Install pane of the Plugin Manager 

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -123,7 +123,7 @@ THE SOFTWARE.
                           <j:set var="uninstallPossible" value="false"/>
                       </j:otherwise>
                   </j:choose>
-                  <td class="test center pane uninstall" data="${uninstallPossible}">
+                  <td class="center pane uninstall" data="${uninstallPossible}">
                     <j:choose>
                       <j:when test="${p.isDeleted()}">
                         <p>${%Uninstallation pending}</p>

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -115,7 +115,15 @@ THE SOFTWARE.
                       </form>
                     </j:if>
                   </td>
-                  <td class="center pane uninstall">
+                  <j:choose>
+                      <j:when test="${p.hasMandatoryDependents() or p.hasMandatoryDependents()}">
+                            <j:set var="uninstallPossible" value="true"/>
+                      </j:when>
+                      <j:otherwise>
+                          <j:set var="uninstallPossible" value="false"/>
+                      </j:otherwise>
+                  </j:choose>
+                  <td class="test center pane uninstall" data="${uninstallPossible}">
                     <j:choose>
                       <j:when test="${p.isDeleted()}">
                         <p>${%Uninstallation pending}</p>


### PR DESCRIPTION
Hacktoberfest contribution (from meetup munich: Hacktoberfest: Contributing to Jenkins and open-source for newcomers)

See [JENKINS-59665](https://issues.jenkins-ci.org/browse/JENKINS-59665).

### Proposed changelog entries

* Fix sorting of the Uninstall column in the Install pane of the Plugin Manager 

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
