### PR TITLE
Add java.util.concurrent.ConcurrentLinkedDeque to the class deserialization whitelist (JEP-200)

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -124,8 +124,8 @@ java.util.TreeSet
 java.util.UUID
 java.util.Vector
 java.util.concurrent.ConcurrentHashMap
-java.util.concurrent.ConcurrentLinkedQueue
 java.util.concurrent.ConcurrentLinkedDeque
+java.util.concurrent.ConcurrentLinkedQueue
 java.util.concurrent.ConcurrentSkipListMap
 java.util.concurrent.CopyOnWriteArrayList
 java.util.concurrent.CopyOnWriteArraySet

--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -125,6 +125,7 @@ java.util.UUID
 java.util.Vector
 java.util.concurrent.ConcurrentHashMap
 java.util.concurrent.ConcurrentLinkedQueue
+java.util.concurrent.ConcurrentLinkedDeque
 java.util.concurrent.ConcurrentSkipListMap
 java.util.concurrent.CopyOnWriteArrayList
 java.util.concurrent.CopyOnWriteArraySet


### PR DESCRIPTION
We recently upgraded Jenkins and one of our in-house plugins failed due to:

Caused by: java.lang.UnsupportedOperationException: Refusing to marshal java.util.concurrent.ConcurrentLinkedDeque

Since both java.util.ArrayDeque and java.util.concurrent.ConcurrentLinkedQueue are whitelisted, it makes sense to also whitelist this class.
