### PR TITLE
Bump jenkins-test-harness to 2.56

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -191,8 +191,20 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>1.3</version>
+      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1331,6 +1331,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     /**
      * Orderly terminates all the plugins.
      */
+    @SuppressFBWarnings(value = "DM_GC", justification = "Garbage collection is required to release files held by plugin classloaders")
     public void stop() {
         for (PluginWrapper p : activePlugins) {
             p.stop();
@@ -1340,6 +1341,9 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         // Work around a bug in commons-logging.
         // See http://www.szegedi.org/articles/memleak.html
         LogFactory.release(uberClassLoader);
+        // Java doesn't have any direct means to release unreferenced classloaders,
+        // so we force GC to do that so it becomes possible to delete plugin jar on Windows.
+        System.gc();
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@ THE SOFTWARE.
     <project.patchManagement.url>https://api.github.com</project.patchManagement.url>
     <patch.tracker.serverId>jenkins-jira</patch.tracker.serverId>
 
+    <hamcrest.version>2.1</hamcrest.version>
     <matrix-auth.version>2.3</matrix-auth.version>
     <matrix-project.version>1.14</matrix-project.version>
     <sorcerer.version>0.11</sorcerer.version>

--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -166,8 +166,21 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <!-- for testing JNLP launch. -->

--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -71,7 +71,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2.55</version>
+      <version>2.56</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
This PR is expected to reveal bogus Windows tests that do not shutdown things properly. See jenkinsci/jenkins-test-harness#166

### Proposed changelog entries

None