### PR TITLE
Use actual logger to record Jenkins home and where it was found

### DIFF
--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -130,7 +130,7 @@ public class WebAppMain implements ServletContextListener {
             final FileAndDescription describedHomeDir = getHomeDir(event);
             home = describedHomeDir.file.getAbsoluteFile();
             home.mkdirs();
-            System.out.println("Jenkins home directory: "+home+" found at: "+describedHomeDir.description);
+            LOGGER.info("Jenkins home directory: "+ home +" found at: " + describedHomeDir.description);
 
             // check that home exists (as mkdirs could have failed silently), otherwise throw a meaningful error
             if (!home.exists())


### PR DESCRIPTION
Before:

```
2019-10-19 18:10:43.799+0000 [id=1]	INFO	org.eclipse.jetty.server.Server#doStart: jetty-9.4.z-SNAPSHOT; built: 2019-05-02T00:04:53.875Z; git: e1bc35120a6617ee3df052294e433f3a25ce7097; jvm 1.8.0_222-b10
2019-10-19 18:10:44.493+0000 [id=1]	INFO	o.e.j.w.StandardDescriptorProcessor#visitServlet: NO JSP Support for /, did not find org.eclipse.jetty.jsp.JettyJspServlet
2019-10-19 18:10:44.634+0000 [id=1]	INFO	o.e.j.s.s.DefaultSessionIdManager#doStart: DefaultSessionIdManager workerName=node0
2019-10-19 18:10:44.634+0000 [id=1]	INFO	o.e.j.s.s.DefaultSessionIdManager#doStart: No SessionScavenger set, using defaults
2019-10-19 18:10:44.646+0000 [id=1]	INFO	o.e.j.server.session.HouseKeeper#startScavenging: node0 Scavenging every 660000ms
Jenkins home directory: /var/jenkins_home found at: EnvVars.masterEnvVars.get("JENKINS_HOME")
2019-10-19 18:10:46.056+0000 [id=1]	INFO	o.e.j.s.handler.ContextHandler#doStart: Started w.@26be6ca7{Jenkins v2.200,/,file:///var/jenkins_home/war/,AVAILABLE}{/var/jenkins_home/war}
2019-10-19 18:10:46.133+0000 [id=1]	INFO	o.e.j.server.AbstractConnector#doStart: Started ServerConnector@19932c16{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
2019-10-19 18:10:46.134+0000 [id=1]	INFO	org.eclipse.jetty.server.Server#doStart: Started @8028ms
2019-10-19 18:10:46.139+0000 [id=21]	INFO	winstone.Logger#logInternal: Winstone Servlet Engine v4.0 running: controlPort=disabled
2019-10-19 18:10:48.585+0000 [id=28]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
2019-10-19 18:10:48.654+0000 [id=32]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
2019-10-19 18:10:51.251+0000 [id=30]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
2019-10-19 18:10:51.260+0000 [id=31]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
2019-10-19 18:10:51.272+0000 [id=31]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
```

After:

```
2019-10-19 18:32:38.975+0000 [id=1]     INFO    org.eclipse.jetty.server.Server#doStart: jetty-9.4.z-SNAPSHOT; built: 2019-05-02T00:04:53.875Z; git: e1bc35120a6617ee3df052294e433f3a25ce7097; jvm 1.8.0_222-b10
2019-10-19 18:32:39.221+0000 [id=1]     INFO    o.e.j.w.StandardDescriptorProcessor#visitServlet: NO JSP Support for /, did not find org.eclipse.jetty.jsp.JettyJspServlet
2019-10-19 18:32:39.252+0000 [id=1]     INFO    o.e.j.s.s.DefaultSessionIdManager#doStart: DefaultSessionIdManager workerName=node0
2019-10-19 18:32:39.252+0000 [id=1]     INFO    o.e.j.s.s.DefaultSessionIdManager#doStart: No SessionScavenger set, using defaults
2019-10-19 18:32:39.254+0000 [id=1]     INFO    o.e.j.server.session.HouseKeeper#startScavenging: node0 Scavenging every 600000ms
2019-10-19 18:32:39.512+0000 [id=1]     INFO    hudson.WebAppMain#contextInitialized: Jenkins home directory: /Users/danielbeck/.jenkins found at: $user.home/.jenkins
2019-10-19 18:32:40.301+0000 [id=1]     INFO    o.e.j.s.handler.ContextHandler#doStart: Started w.@d23e042{Jenkins v2.201-SNAPSHOT,/,file:///Users/danielbeck/.jenkins/war/,AVAILABLE}{/Users/danielbeck/.jenkins/war}
2019-10-19 18:32:40.329+0000 [id=1]     INFO    o.e.j.server.AbstractConnector#doStart: Started ServerConnector@2f7a2457{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
2019-10-19 18:32:40.329+0000 [id=1]     INFO    org.eclipse.jetty.server.Server#doStart: Started @1634ms
2019-10-19 18:32:40.329+0000 [id=23]    INFO    winstone.Logger#logInternal: Winstone Servlet Engine v4.0 running: controlPort=disabled
2019-10-19 18:32:41.157+0000 [id=30]    INFO    jenkins.InitReactorRunner$1#onAttained: Started initialization
2019-10-19 18:32:41.171+0000 [id=48]    INFO    jenkins.InitReactorRunner$1#onAttained: Listed all plugins
2019-10-19 18:32:41.914+0000 [id=51]    INFO    jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
2019-10-19 18:32:41.917+0000 [id=41]    INFO    jenkins.InitReactorRunner$1#onAttained: Started all plugins
2019-10-19 18:32:41.922+0000 [id=43]    INFO    jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
```

### Proposed changelog entries

(too minor)

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
