### PR TITLE
[JENKINS-59859] Make resource root URL tokens work with user names containing :

### DIFF
--- a/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
@@ -275,7 +275,7 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
         }
 
         private String encode() {
-            String value = username + ":" + timestamp.toEpochMilli() + ":" + path;
+            String value = timestamp.toEpochMilli() + ":" + username.length() + ":" + username + ":" + path;
             byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
             byte[] byteValue = ArrayUtils.addAll(KEY.mac(valueBytes), valueBytes);
             return Base64.getUrlEncoder().encodeToString(byteValue);
@@ -291,10 +291,12 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
                     throw new IllegalArgumentException("Failed mac check for " + rest);
                 }
 
-                String[] splits = rest.split(":", 3);
-                String authenticationName = Util.fixEmpty(splits[0]);
-                String epoch = splits[1];
-                String browserUrl = splits[2];
+                String[] splits = rest.split("[:]", 3);
+                String epoch = splits[0];
+                int authenticationNameLength = Integer.parseInt(splits[1]);
+                String authenticationNameAndBrowserUrl = Util.fixEmpty(splits[2]);
+                String authenticationName = authenticationNameAndBrowserUrl.substring(0, authenticationNameLength);
+                String browserUrl = authenticationNameAndBrowserUrl.substring(authenticationNameLength + 1);
                 return new Token(browserUrl, authenticationName, ofEpochMilli(Long.parseLong(epoch)));
             } catch (Exception ex) {
                 // Choose log level that hides people messing with the URLs

--- a/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
@@ -195,7 +195,7 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
         private final String authenticationName;
         private final String browserUrl;
 
-        InternalResourceRequest(@Nonnull String browserUrl, String authenticationName) {
+        InternalResourceRequest(@Nonnull String browserUrl, @Nonnull String authenticationName) {
             this.browserUrl = browserUrl;
             this.authenticationName = authenticationName;
         }
@@ -208,7 +208,7 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
             LOGGER.fine(() -> "Performing a request as authentication: " + authenticationName + " and restOfUrl: " + requestUrlSuffix + " and restOfPath: " + restOfPath);
 
             Authentication auth = Jenkins.ANONYMOUS;
-            if (authenticationName != null) {
+            if (Util.fixEmpty(authenticationName) != null) {
                 User user = User.getById(authenticationName, false);
                 if (user != null) {
                     try {
@@ -268,7 +268,7 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
         private Instant timestamp;
 
         @VisibleForTesting
-        Token (String path, @Nullable String username, Instant timestamp) {
+        Token (@Nonnull String path, @Nullable String username, @Nonnull Instant timestamp) {
             this.path = path;
             this.username = Util.fixNull(username);
             this.timestamp = timestamp;
@@ -294,7 +294,7 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
                 String[] splits = rest.split("[:]", 3);
                 String epoch = splits[0];
                 int authenticationNameLength = Integer.parseInt(splits[1]);
-                String authenticationNameAndBrowserUrl = Util.fixEmpty(splits[2]);
+                String authenticationNameAndBrowserUrl = splits[2];
                 String authenticationName = authenticationNameAndBrowserUrl.substring(0, authenticationNameLength);
                 String browserUrl = authenticationNameAndBrowserUrl.substring(authenticationNameLength + 1);
                 return new Token(browserUrl, authenticationName, ofEpochMilli(Long.parseLong(epoch)));


### PR DESCRIPTION
These users cannot be created manually, but who knows whether there's a security realm that supports this.

### Proposed changelog entries

* Robustness: Properly handle user names containing : characters in resource root URL tokens

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
