### PR TITLE
[JENKINS-59886] Strengthen the queue to avoid canTake and canRun implementers hanging the queue

### DIFF
--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -406,7 +406,15 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         // Check each NodeProperty to see whether they object to this node
         // taking the task
         for (NodeProperty prop: getNodeProperties()) {
-            CauseOfBlockage c = prop.canTake(item);
+            CauseOfBlockage c;
+            // Commented out to see how the CI fails and it runs successfully when uncommented
+            //try {
+                c = prop.canTake(item);
+//            } catch (Throwable t) {
+//                // We cannot guarantee the task can be taken by this node because something wrong happened
+//                LOGGER.log(Level.WARNING, t, () -> Messages._Queue_ExceptionCanTakeLog(getNodeName(), item.task.getName()).toString());
+//                c = CauseOfBlockage.fromMessage(Messages._Queue_ExceptionCanTake());
+//            }
             if (c!=null)    return c;
         }
 

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -412,7 +412,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
                 c = prop.canTake(item);
             } catch (Throwable t) {
                 // We cannot guarantee the task can be taken by this node because something wrong happened
-                LOGGER.log(Level.WARNING, t, () -> Messages._Queue_ExceptionCanTakeLog(getNodeName(), item.task.getName()).toString());
+                LOGGER.log(Level.WARNING, t, () -> String.format("Exception evaluating if the node '%s' can take the task '%s'", getNodeName(), item.task.getName()));
                 c = CauseOfBlockage.fromMessage(Messages._Queue_ExceptionCanTake());
             }
             if (c!=null)    return c;

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -57,6 +57,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -408,13 +409,13 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         for (NodeProperty prop: getNodeProperties()) {
             CauseOfBlockage c;
             // Commented out to see how the CI fails and it runs successfully when uncommented
-            //try {
+            try {
                 c = prop.canTake(item);
-//            } catch (Throwable t) {
-//                // We cannot guarantee the task can be taken by this node because something wrong happened
-//                LOGGER.log(Level.WARNING, t, () -> Messages._Queue_ExceptionCanTakeLog(getNodeName(), item.task.getName()).toString());
-//                c = CauseOfBlockage.fromMessage(Messages._Queue_ExceptionCanTake());
-//            }
+            } catch (Throwable t) {
+                // We cannot guarantee the task can be taken by this node because something wrong happened
+                LOGGER.log(Level.WARNING, t, () -> Messages._Queue_ExceptionCanTakeLog(getNodeName(), item.task.getName()).toString());
+                c = CauseOfBlockage.fromMessage(Messages._Queue_ExceptionCanTake());
+            }
             if (c!=null)    return c;
         }
 

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -408,7 +408,6 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         // taking the task
         for (NodeProperty prop: getNodeProperties()) {
             CauseOfBlockage c;
-            // Commented out to see how the CI fails and it runs successfully when uncommented
             try {
                 c = prop.canTake(item);
             } catch (Throwable t) {

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -276,7 +276,14 @@ public class Queue extends ResourceController implements Saveable {
                 return reason;
             }
             for (QueueTaskDispatcher d : QueueTaskDispatcher.all()) {
-                reason = d.canTake(node, item);
+                try {
+                    reason = d.canTake(node, item);
+                } catch (Throwable t) {
+                    // We cannot guarantee the task can be taken by the node because something wrong happened
+                    LOGGER.log(Level.WARNING, t, () -> Messages._Queue_ExceptionCanTakeLog(node.getNodeName(), item.task.getName()).toString());
+                    reason = CauseOfBlockage.fromMessage(Messages._Queue_ExceptionCanTake());
+                }
+
                 if (reason != null) {
                     return reason;
                 }
@@ -1192,7 +1199,13 @@ public class Queue extends ResourceController implements Saveable {
         }
 
         for (QueueTaskDispatcher d : QueueTaskDispatcher.all()) {
-            causeOfBlockage = d.canRun(i);
+            try {
+                causeOfBlockage = d.canRun(i);
+            } catch (Throwable t) {
+                // We cannot guarantee the task can be run because something wrong happened
+                LOGGER.log(Level.WARNING, t, () -> Messages._Queue_ExceptionCanRunLog(i.task.getName()).toString());
+                causeOfBlockage = CauseOfBlockage.fromMessage(Messages._Queue_ExceptionCanRun());
+            }
             if (causeOfBlockage != null)
                 return causeOfBlockage;
         }

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -280,7 +280,7 @@ public class Queue extends ResourceController implements Saveable {
                     reason = d.canTake(node, item);
                 } catch (Throwable t) {
                     // We cannot guarantee the task can be taken by the node because something wrong happened
-                    LOGGER.log(Level.WARNING, t, () -> Messages._Queue_ExceptionCanTakeLog(node.getNodeName(), item.task.getName()).toString());
+                    LOGGER.log(Level.WARNING, t, () -> String.format("Exception evaluating if the node '%s' can take the task '%s'", node.getNodeName(), item.task.getName()));
                     reason = CauseOfBlockage.fromMessage(Messages._Queue_ExceptionCanTake());
                 }
 
@@ -1203,7 +1203,7 @@ public class Queue extends ResourceController implements Saveable {
                 causeOfBlockage = d.canRun(i);
             } catch (Throwable t) {
                 // We cannot guarantee the task can be run because something wrong happened
-                LOGGER.log(Level.WARNING, t, () -> Messages._Queue_ExceptionCanRunLog(i.task.getName()).toString());
+                LOGGER.log(Level.WARNING, t, () -> String.format("Exception evaluating if the queue can run the task '%s'", i.task.getName()));
                 causeOfBlockage = CauseOfBlockage.fromMessage(Messages._Queue_ExceptionCanRun());
             }
             if (causeOfBlockage != null)

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -207,9 +207,7 @@ Queue.init=Restoring the build queue
 Queue.node_has_been_removed_from_configuration={0} has been removed from configuration
 Queue.executor_slot_already_in_use=Executor slot already in use
 Queue.ExceptionCanTake=Exception evaluating if the node can take the task
-Queue.ExceptionCanTakeLog=Exception evaluating if the node ''{0}'' can take the task ''{1}''
 Queue.ExceptionCanRun=Exception evaluating if the queue can run the task
-Queue.ExceptionCanRunLog=Exception evaluating if the queue can run the task ''{0}''
 
 ResultTrend.Aborted=Aborted
 ResultTrend.Failure=Failure

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -206,6 +206,10 @@ Queue.WaitingForNextAvailableExecutorOn=Waiting for next available executor on \
 Queue.init=Restoring the build queue
 Queue.node_has_been_removed_from_configuration={0} has been removed from configuration
 Queue.executor_slot_already_in_use=Executor slot already in use
+Queue.ExceptionCanTake=Exception evaluating if the node can take the task
+Queue.ExceptionCanTakeLog=Exception evaluating if the node '{0}' can take the task '{1}'
+Queue.ExceptionCanRun=Exception evaluating if the queue can run the task
+Queue.ExceptionCanRunLog=Exception evaluating if the queue can run the task '{0}'
 
 ResultTrend.Aborted=Aborted
 ResultTrend.Failure=Failure

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -207,9 +207,9 @@ Queue.init=Restoring the build queue
 Queue.node_has_been_removed_from_configuration={0} has been removed from configuration
 Queue.executor_slot_already_in_use=Executor slot already in use
 Queue.ExceptionCanTake=Exception evaluating if the node can take the task
-Queue.ExceptionCanTakeLog=Exception evaluating if the node '{0}' can take the task '{1}'
+Queue.ExceptionCanTakeLog=Exception evaluating if the node ''{0}'' can take the task ''{1}''
 Queue.ExceptionCanRun=Exception evaluating if the queue can run the task
-Queue.ExceptionCanRunLog=Exception evaluating if the queue can run the task '{0}'
+Queue.ExceptionCanRunLog=Exception evaluating if the queue can run the task ''{0}''
 
 ResultTrend.Aborted=Aborted
 ResultTrend.Failure=Failure

--- a/core/src/main/resources/hudson/model/Messages_es.properties
+++ b/core/src/main/resources/hudson/model/Messages_es.properties
@@ -24,30 +24,30 @@ AbstractBuild.BuildingRemotely=Ejecutando remotamente en  {0}
 AbstractBuild.BuildingOnMaster=Ejecutando en el nodo principal
 AbstractBuild.KeptBecause=Conservar porque {0}
 
-AbstractItem.NoSuchJobExists=La tarea ''{0}'' no existe. \u00BFQuiz\u00E1s quieras decir ''{1}''?
+AbstractItem.NoSuchJobExists=La tarea ''{0}'' no existe. \u00bfQuiz\u00e1s quieras decir ''{1}''?
 AbstractItem.NewNameInUse=El nombre {0} ya existe.
-AbstractProject.NewBuildForWorkspace=Lanzando una nueva ejecuci\u00F3n para crear el espacio de trabajo.
+AbstractProject.NewBuildForWorkspace=Lanzando una nueva ejecuci\u00f3n para crear el espacio de trabajo.
 AbstractProject.Pronoun=Proyecto
 AbstractProject.Aborted=Cancelado
-AbstractProject.UpstreamBuildInProgress=El proyecto padre {0} ya se est\u00E1 ejecutando.
-AbstractProject.Disabled=Ejecuci\u00F3n desactivada
+AbstractProject.UpstreamBuildInProgress=El proyecto padre {0} ya se est\u00e1 ejecutando.
+AbstractProject.Disabled=Ejecuci\u00f3n desactivada
 AbstractProject.NoSCM=Sin SCM
 AbstractProject.NoWorkspace=No hay espacio de trabajo, por tanto no se puede comprobar las actualizaciones.
 AbstractProject.PollingABorted=Peticiones SCM abortadas
 AbstractProject.ScmAborted=Actualizacion SCM abortada
-AbstractProject.WorkspaceOffline=El espacio de trabajo est\u00E1 fuera de l\u00EDnea.
+AbstractProject.WorkspaceOffline=El espacio de trabajo est\u00e1 fuera de l\u00ednea.
 AbstractProject.BuildPermission.Description=\
-  Este permiso permite al usuario lanzar una ejecuci\u00F3n.
+  Este permiso permite al usuario lanzar una ejecuci\u00f3n.
 AbstractProject.WorkspacePermission.Description=\
-  Este permiso permite visualizar el contenido de un espacio de trabajo que Jenkins cre\u00F3 para ejecutar tareas. \
-  Si no quieres que un usuario acceda al c\u00F3digo fuente, desactival\u00F3.
+  Este permiso permite visualizar el contenido de un espacio de trabajo que Jenkins cre\u00f3 para ejecutar tareas. \
+  Si no quieres que un usuario acceda al c\u00f3digo fuente, desactival\u00f3.
 AbstractProject.ExtendedReadPermission.Description=\
-  Este permiso garantiza acceso de s\u00F3lo lectura a la configuraci\u00F3n de proyectos. \
-  S\u00E9 consciente que hay informaci\u00F3n delicada en las tareas como puedan ser las contrase\u00F1as que pueden quedar expuestas a todo el mundo.
+  Este permiso garantiza acceso de s\u00f3lo lectura a la configuraci\u00f3n de proyectos. \
+  S\u00e9 consciente que hay informaci\u00f3n delicada en las tareas como puedan ser las contrase\u00f1as que pueden quedar expuestas a todo el mundo.
 
-Api.MultipleMatch=XPath "{0}" encontr\u00F3 coincidencias en {1} nodos. \
-  Crea una expresi\u00F3n XPath que s\u00F3lo encuentre uno, o utiliza el par\u00E1metro "wraper" para que todos los nodos se agrupen bajo un elemento.
-Api.NoXPathMatch=XPath {0} no encontr\u00F3 nada 
+Api.MultipleMatch=XPath "{0}" encontr\u00f3 coincidencias en {1} nodos. \
+  Crea una expresi\u00f3n XPath que s\u00f3lo encuentre uno, o utiliza el par\u00e1metro "wraper" para que todos los nodos se agrupen bajo un elemento.
+Api.NoXPathMatch=XPath {0} no encontr\u00f3 nada 
 Api.WrapperParamInvalid=El par\u00E1metro wrapper s\u00F3lo puede contener caracteres alfanum\u00E9ricos o guiones/puntos/subrayado. El primer car\u00E1cter debe ser una letra o subrayado.
 
 BallColor.Aborted=Abortado
@@ -67,48 +67,48 @@ Computer.DeletePermission.Description=Este permiso permite borrar nodos
 
 ComputerSet.NoSuchSlave=Es nodo {0} no existe
 ComputerSet.SlaveAlreadyExists=Es nodo ''{0}'' ya existe
-ComputerSet.SpecifySlaveToCopy=Especificar qu\u00E9 nodo copiar
+ComputerSet.SpecifySlaveToCopy=Especificar qu\u00e9 nodo copiar
 Executor.NotAvailable=N/D
 
 
 FreeStyleProject.DisplayName=Crear un proyecto de estilo libre
 FreeStyleProject.Description=Esta es la caracter\u00EDstica principal de Jenkins, la de ejecutar el proyecto combinando cualquier tipo de repositorio de software (SCM) con cualquier modo de construcci\u00F3n o ejecuci\u00F3n (make, ant, mvn, rake, script ...). Por tanto se podr\u00E1 tanto compilar y empaquetar software, como ejecutar cualquier proceso que requiera monitorizaci\u00F3n.
 
-Hudson.BadPortNumber=N\u00FAmero err\u00F3neo de puerto {0}
+Hudson.BadPortNumber=N\u00famero err\u00f3neo de puerto {0}
 Hudson.Computer.Caption=Principal
 Hudson.Computer.DisplayName=principal
-Hudson.ControlCodeNotAllowed=El c\u00F3digo de control {0} no est\u00E1 permitido
+Hudson.ControlCodeNotAllowed=El c\u00f3digo de control {0} no est\u00e1 permitido
 Hudson.DisplayName=Jenkins 
 Hudson.JobAlreadyExists=Una tarea con el nombre ''{0}'' ya existe
-Hudson.NoJavaInPath=No se encuentra el comando java en el ''PATH''. Quiz\u00E1s necesite configurar <a href=''{0}/configure''> JDKs</a>?
+Hudson.NoJavaInPath=No se encuentra el comando java en el ''PATH''. Quiz\u00e1s necesite configurar <a href=''{0}/configure''> JDKs</a>?
 Hudson.NoName=No se ha especificado un nombre
 Hudson.NoSuchDirectory=No existe el directorio {0}
-Hudson.NodeBeingRemoved=Se est\u00E1 borrando el nodo
+Hudson.NodeBeingRemoved=Se est\u00e1 borrando el nodo
 Hudson.NotADirectory={0} no es un directorio
 Hudson.NotAPlugin={0} no es un plugin de Jenkins
 Hudson.NotJDKDir={0} no es un directorio JDK
 Hudson.Permissions.Title=Global
-Hudson.USER_CONTENT_README=Los ficheros de este directorio est\u00E1n accesible en http://yourjenkins/userContent/
-Hudson.UnsafeChar=''{0}'' es un car\u00E1cter inseguro
+Hudson.USER_CONTENT_README=Los ficheros de este directorio est\u00e1n accesible en http://yourjenkins/userContent/
+Hudson.UnsafeChar=''{0}'' es un car\u00e1cter inseguro
 Hudson.ViewAlreadyExists=Una vista con el nombre "{0}" ya existe
 Hudson.ViewName=Todo
-Hudson.NotANumber=No es un n\u00FAmero
-Hudson.NotAPositiveNumber=No es un n\u00FAmero positivo
-Hudson.NotANonNegativeNumber=El n\u00FAmero podr\u00EDa no ser negativo
-Hudson.NotANegativeNumber=No es un n\u00FAmero negativo
+Hudson.NotANumber=No es un n\u00famero
+Hudson.NotAPositiveNumber=No es un n\u00famero positivo
+Hudson.NotANonNegativeNumber=El n\u00famero podr\u00eda no ser negativo
+Hudson.NotANegativeNumber=No es un n\u00famero negativo
 Hudson.NotUsesUTF8ToDecodeURL=\
-  El contenedor de servlets no usa UTF-8 para decodificar URLs. Esto causar\u00E1 problemas si se usan nombres \
+  El contenedor de servlets no usa UTF-8 para decodificar URLs. Esto causar\u00e1 problemas si se usan nombres \
   con caracteres no ASCII. Echa un vistazo a \
   <a href=''https://jenkins.io/redirect/configuring-servlet-containers''>Containers</a> y a \
   <a href=''/redirect/troubleshooting/utf8-url-decoding''>Tomcat i18n</a> para mas detalles.
 Hudson.AdministerPermission.Description=\
-  Este permiso garantiza la posibilidad de hacer cambios de configuraci\u00F3n en el sistema, \
-  as\u00ED como el realizar operaciones sobre el sistema de archivos local. \
+  Este permiso garantiza la posibilidad de hacer cambios de configuraci\u00f3n en el sistema, \
+  as\u00ed como el realizar operaciones sobre el sistema de archivos local. \
   (Siempre que lo permita el sistema operativo)
 Hudson.ReadPermission.Description=\
-  El permiso de lectura es necesario para visualizar casi todas las p\u00E1ginas de Jenkins.\
-  Este permiso es \u00FAtil cuando se quiere que usuarios no autenticados puedan ver las p\u00E1ginas. \
-  Elimina este permiso del usuario "anonymous", luego a\u00F1ade "authenticated pseudo-user" con el \
+  El permiso de lectura es necesario para visualizar casi todas las p\u00e1ginas de Jenkins.\
+  Este permiso es \u00fatil cuando se quiere que usuarios no autenticados puedan ver las p\u00e1ginas. \
+  Elimina este permiso del usuario "anonymous", luego a\u00f1ade "authenticated pseudo-user" con el \
   permiso de lectura.
 Hudson.NodeDescription=El nodo principal de Jenkins
 
@@ -116,21 +116,21 @@ Item.Permissions.Title=Tarea
 
 Job.AllRecentBuildFailed=Todas la ejecuciones recientes han fallado
 Job.BuildStability=Estabilidad: {0}
-Job.NOfMFailed={0} de las {1} \u00FAltimas ejecuciones fallaron.
+Job.NOfMFailed={0} de las {1} \u00faltimas ejecuciones fallaron.
 Job.NoRecentBuildFailed=No hay ejecuciones recientes con fallos.
 Job.Pronoun=Proyecto
 Job.minutes=Min
-Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se est\u00E1 ejecutando.
+Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se está ejecutando.
 
 Label.GroupOf=grupo de {0}
-Label.InvalidLabel=etiqueta inv\u00E1lida
+Label.InvalidLabel=etiqueta inv\u00e1lida
 Label.ProvisionedFrom=Suministrado desde {0} 
-Queue.AllNodesOffline=Todos los nodos con la etiqueta ''{0}'' est\u00E1n fuera de l\u00EDnea
+Queue.AllNodesOffline=Todos los nodos con la etiqueta ''{0}'' est\u00e1n fuera de l\u00ednea
 Queue.BlockedBy=Bloqueados por {0}
 Queue.HudsonIsAboutToShutDown=Jenkins va a ser apagado
-Queue.InProgress=Una ejecuci\u00F3n ya est\u00E1 en progreso
+Queue.InProgress=Una ejecuci\u00f3n ya est\u00e1 en progreso
 Queue.InQuietPeriod=En el periodo de gracia. Termina en {0}
-Queue.NodeOffline={0} fuera de l\u00EDnea
+Queue.NodeOffline={0} fuera de l\u00ednea
 Queue.Unknown=?
 Queue.WaitingForNextAvailableExecutor=Esperando por un ejecutor
 Queue.WaitingForNextAvailableExecutorOn=Esperando por un ejecutor en {0}
@@ -140,87 +140,87 @@ Queue.ExceptionCanTakeLog=Excepci\u00f3n evaluando si el nodo '{0}' puede coger 
 Queue.ExceptionCanRun=Excepci\u00f3n evaluando si la cola puede ejecutar la tarea
 Queue.ExceptionCanRunLog=Excepci\u00f3n evaluando si la cola puede ejecutar (canRun) la tarea '{0}'
 
-Run.BuildAborted=La ejecuci\u00F3n fu\u00E9 cancelada
+Run.BuildAborted=La ejecuci\u00f3n fu\u00e9 cancelada
 Run.MarkedExplicitly=marcado para mantener el registro
 Run.Permissions.Title=Ejecutar
 Run.UnableToDelete=Imposible borrar {0}: {1}
 Run.DeletePermission.Description=\
   Este permiso permite borrar manualmente ejecuciones de la historia de trabajos.
 Run.UpdatePermission.Description=\
-  Este permiso permite actualizar la descripci\u00F3n y otras propiedeades de un trabajo, \
+  Este permiso permite actualizar la descripci\u00f3n y otras propiedeades de un trabajo, \
   por ejemplo poner notas acerca de la causa de un fallo.
 
 Run.Summary.Stable=estable
 Run.Summary.Unstable=instable
 Run.Summary.Aborted=cancelado
-Run.Summary.BackToNormal=volvi\u00F3 a normal
+Run.Summary.BackToNormal=volvi\u00f3 a normal
 Run.Summary.BrokenForALongTime=fallido durante un largo periodo
-Run.Summary.BrokenSinceThisBuild=fallido desde esta ejecuci\u00F3n
-Run.Summary.BrokenSince=fallido desde la ejecuci\u00F3n {0}
+Run.Summary.BrokenSinceThisBuild=fallido desde esta ejecuci\u00f3n
+Run.Summary.BrokenSince=fallido desde la ejecuci\u00f3n {0}
 Run.Summary.Unknown=? 
 
-Slave.InvalidConfig.Executors=Configuraci\u00F3n de nodo incorrecta en {0}. El n\u00FAmero de ejecutores es inv\u00E1lido.
-Slave.InvalidConfig.NoName=Configuraci\u00F3n de nodo incorrecta. El nombre est\u00E1 vac\u00EDo
-Slave.Terminated={0} el agente no est\u00E1 en ejecuci\u00F3n
+Slave.InvalidConfig.Executors=Configuraci\u00f3n de nodo incorrecta en {0}. El n\u00famero de ejecutores es inv\u00e1lido.
+Slave.InvalidConfig.NoName=Configuraci\u00f3n de nodo incorrecta. El nombre est\u00e1 vac\u00edo
+Slave.Terminated={0} el agente no est\u00e1 en ejecuci\u00f3n
 Slave.UnixSlave=Este es un nodo Unix
 Slave.WindowsSlave=Este es un nodo Windows
 
 View.Permissions.Title=Vistas
 View.CreatePermission.Description=\
-  Permiso para creaci\u00F3n vistas.
+  Permiso para creaci\u00f3n vistas.
 View.DeletePermission.Description=\
   Este es un permiso para que los usuario puedan borrar vistas.
 View.ConfigurePermission.Description=\
-  Este permiso se usa para que los usuarios cambien la conficuraci\u00F3n de vistas.
+  Este permiso se usa para que los usuarios cambien la conficuraci\u00f3n de vistas.
 
 UpdateCenter.Status.CheckingInternet=Probando conectividad con Internet
 UpdateCenter.Status.CheckingJavaNet=Probando conectividad con jenkins-ci.org
 UpdateCenter.Status.Success=Correcto
 UpdateCenter.Status.UnknownHostException=\
   <span class=error>Nombre de servidor imposible de resolver {0}. \
-  Quiz\u00E1s tengas que configurar to <a href="../pluginManager/advanced">proxy</a></span>
+  Quiz\u00e1s tengas que configurar to <a href="../pluginManager/advanced">proxy</a></span>
 UpdateCenter.Status.ConnectionFailed=\
   <span class=error>Imposible de conectar con {0}. \
-  Quiz\u00E1s tengas que configurar to <a href="../pluginManager/advanced">proxy</a></span>
+  Quiz\u00e1s tengas que configurar to <a href="../pluginManager/advanced">proxy</a></span>
 UpdateCenter.init=Inicializando centro de actualizaciones
 UpdateCenter.PluginCategory.builder=Plugins relacionados con la forma de ejecutar trabajos
-UpdateCenter.PluginCategory.buildwrapper=Plugins que a\u00F1aden tareas relacionadas con la ejecuci\u00F3n
-UpdateCenter.PluginCategory.cli=Plugins para la interfaz de l\u00EDnea de comandos
-UpdateCenter.PluginCategory.cluster=Plugins para la administraci\u00F3n de clusters y trabajos distribuidos
-UpdateCenter.PluginCategory.external=Plugins de integraci\u00F3n con sitios y herramientas externas
+UpdateCenter.PluginCategory.buildwrapper=Plugins que a\u00f1aden tareas relacionadas con la ejecuci\u00f3n
+UpdateCenter.PluginCategory.cli=Plugins para la interfaz de l\u00ednea de comandos
+UpdateCenter.PluginCategory.cluster=Plugins para la administraci\u00f3n de clusters y trabajos distribuidos
+UpdateCenter.PluginCategory.external=Plugins de integraci\u00f3n con sitios y herramientas externas
 UpdateCenter.PluginCategory.maven=Plugins para Maven
 UpdateCenter.PluginCategory.misc=Varios
-UpdateCenter.PluginCategory.notifier=Plugins de notificaci\u00F3n
-UpdateCenter.PluginCategory.page-decorator=Plugins para decorar p\u00E1ginas
-UpdateCenter.PluginCategory.post-build=Plugins que a\u00F1aden acciones de post-ejecuti\u00F3n
+UpdateCenter.PluginCategory.notifier=Plugins de notificaci\u00f3n
+UpdateCenter.PluginCategory.page-decorator=Plugins para decorar p\u00e1ginas
+UpdateCenter.PluginCategory.post-build=Plugins que a\u00f1aden acciones de post-ejecuti\u00f3n
 UpdateCenter.PluginCategory.report=Plugins para generar informes
 UpdateCenter.PluginCategory.scm=Plugins de repositorios de software
-UpdateCenter.PluginCategory.scm-related=Plugins relacionados con la gesti\u00F3n repositorios
+UpdateCenter.PluginCategory.scm-related=Plugins relacionados con la gesti\u00f3n repositorios
 UpdateCenter.PluginCategory.slaves=Plugins para el control de nodos
 
 
 UpdateCenter.PluginCategory.trigger=Plugins lanzadores de tareas
 UpdateCenter.PluginCategory.ui=Plugins de interfaz de usuario
 UpdateCenter.PluginCategory.upload=Plugins para subir o desplegar los paquetes generados
-UpdateCenter.PluginCategory.user=Plugins para la gesti\u00F3n de usuarios y autenticaci\u00F3n
-UpdateCenter.PluginCategory.must-be-labeled=Sin categor\u00EDa
-UpdateCenter.PluginCategory.unrecognized=Miscel\u00E1neo ({0})
+UpdateCenter.PluginCategory.user=Plugins para la gesti\u00f3n de usuarios y autenticaci\u00f3n
+UpdateCenter.PluginCategory.must-be-labeled=Sin categor\u00eda
+UpdateCenter.PluginCategory.unrecognized=Miscel\u00e1neo ({0})
 
-Permalink.LastBuild=\u00DAltima ejecuci\u00F3n
-Permalink.LastStableBuild=\u00DAltima ejecuci\u00F3n estable
-Permalink.LastSuccessfulBuild=\u00DAltima ejecuci\u00F3n correcta
-Permalink.LastFailedBuild=\u00DAltima ejecuci\u00F3n fallida
+Permalink.LastBuild=\u00daltima ejecuci\u00f3n
+Permalink.LastStableBuild=\u00daltima ejecuci\u00f3n estable
+Permalink.LastSuccessfulBuild=\u00daltima ejecuci\u00f3n correcta
+Permalink.LastFailedBuild=\u00daltima ejecuci\u00f3n fallida
 
-ParameterAction.DisplayName=Par\u00E1metros
-StringParameterDefinition.DisplayName=Par\u00E1metro de cadena
-FileParameterDefinition.DisplayName=Par\u00E1metro de fichero
+ParameterAction.DisplayName=Par\u00e1metros
+StringParameterDefinition.DisplayName=Par\u00e1metro de cadena
+FileParameterDefinition.DisplayName=Par\u00e1metro de fichero
 BooleanParameterDefinition.DisplayName=Valor booleano
-ChoiceParameterDefinition.DisplayName=Elecci\u00F3n
-RunParameterDefinition.DisplayName=Par\u00E1metro de ejecuci\u00F3n
-PasswordParameterDefinition.DisplayName=Par\u00E1metro de contrase\u00F1a
+ChoiceParameterDefinition.DisplayName=Elecci\u00f3n
+RunParameterDefinition.DisplayName=Par\u00e1metro de ejecuci\u00f3n
+PasswordParameterDefinition.DisplayName=Par\u00e1metro de contrase\u00f1a
 
 Node.Mode.NORMAL=Utilizar este nodo tanto como sea posible
-Node.Mode.EXCLUSIVE=Dejar esta nodo para ejecutar s\u00F3lamente tareas vinculadas a \u00E9l
+Node.Mode.EXCLUSIVE=Dejar esta nodo para ejecutar s\u00f3lamente tareas vinculadas a \u00e9l
 
 ListView.DisplayName=Lista de vistas
 
@@ -228,14 +228,14 @@ MyView.DisplayName=Mi vista
 
 LoadStatistics.Legends.TotalExecutors=Ejecutores totales
 LoadStatistics.Legends.BusyExecutors=Ejecutores ocupados
-LoadStatistics.Legends.QueueLength=Tama\u00F1o de la cola
+LoadStatistics.Legends.QueueLength=Tama\u00f1o de la cola
 
-Cause.LegacyCodeCause.ShortDescription=Un c\u00F3digo antiguo (legacy) lanz\u00F3 este proceso. No hay informaci\u00F3n de la causa.
-Cause.UpstreamCause.ShortDescription=Lanzada por el proyecto padre  "{0}" ejecuci\u00F3n n\u00FAmero {1}
+Cause.LegacyCodeCause.ShortDescription=Un c\u00f3digo antiguo (legacy) lanz\u00f3 este proceso. No hay informaci\u00f3n de la causa.
+Cause.UpstreamCause.ShortDescription=Lanzada por el proyecto padre  "{0}" ejecuci\u00f3n n\u00famero {1}
 Cause.UserCause.ShortDescription=Lanzada por el usuario {0}
 Cause.UserIdCause.ShortDescription=Lanzada por el usuario {0}
-Cause.RemoteCause.ShortDescription=Lanzada por la m\u00E1quina remota {0}
-Cause.RemoteCause.ShortDescriptionWithNote=Lanzada por la m\u00E1quina remota {0} con la nota: {1}
+Cause.RemoteCause.ShortDescription=Lanzada por la m\u00e1quina remota {0}
+Cause.RemoteCause.ShortDescriptionWithNote=Lanzada por la m\u00e1quina remota {0} con la nota: {1}
 
 ProxyView.NoSuchViewExists=La vista global {0} no existe
 ProxyView.DisplayName=Incluir una vista global
@@ -246,61 +246,61 @@ MyViewsProperty.ViewExistsCheck.AlreadyExists=Una vista con el nombre {0} ya exi
 
 CLI.restart.shortDescription=Reiniciar Jenkins
 CLI.safe-restart.shortDescription=Reiniciar Jenkins de manera segura
-CLI.keep-build.shortDescription=Marcar la ejecuci\u00F3n para ser guardada para siempre.
+CLI.keep-build.shortDescription=Marcar la ejecuci\u00f3n para ser guardada para siempre.
 
 View.MissingMode=No se ha especificado el tipo para la vista
 AbstractProject.NoBuilds=No existen ejecuciones. Lanzando una nueva.
 Slave.Remote.Director.Mandatory=El directorio remoto es obligatorio
-Slave.Network.Mounted.File.System.Warning=\u00BFEst\u00E1s seguro de querer utilizar un directorio de red para el "Filesystem" ra\u00EDz?.\
+Slave.Network.Mounted.File.System.Warning=\u00bfEst\u00e1s seguro de querer utilizar un directorio de red para el "Filesystem" ra\u00edz?.\
   Ten en cuenta que este directorio no necesita estar visible desde el nodo de Jenkins principal.
 HealthReport.EmptyString=
-MultiStageTimeSeries.EMPTY_STRING= 
+MultiStageTimeSeries.EMPTY_STRING=
 ComputerSet.DisplayName=nodos
 Run.InProgressDuration={0} y contando
 Node.LabelMissing={0} no tiene etiqueta {1}
-Node.BecauseNodeIsReserved={0} est\u00E1 reservado para trabajos asignados a este nodo.
-Permalink.LastUnsuccessfulBuild=\u00DAltima ejecuci\u00F3n fallida
-Permalink.LastUnstableBuild=\u00DAltima ejecuci\u00F3n inestable
-Computer.BadChannel=El nodo est\u00E1 apagado o no existe el canal remoto (como puede ocurrir en un nodo principal)
+Node.BecauseNodeIsReserved={0} est\u00e1 reservado para trabajos asignados a este nodo.
+Permalink.LastUnsuccessfulBuild=\u00daltima ejecuci\u00f3n fallida
+Permalink.LastUnstableBuild=\u00daltima ejecuci\u00f3n inestable
+Computer.BadChannel=El nodo est\u00e1 apagado o no existe el canal remoto (como puede ocurrir en un nodo principal)
 MyViewsProperty.DisplayName=Mis vistas
 BuildAuthorizationToken.InvalidTokenProvided=El Token incorrecto
-AbstractProject.AssignedLabelString.NoMatch=No hay ning\u00FAn nodo/nube que cumpla esta asignaci\u00F3n
+AbstractProject.AssignedLabelString.NoMatch=No hay ning\u00fan nodo/nube que cumpla esta asignaci\u00f3n
 AbstractItem.Pronoun=Tarea
-AbstractProject.DownstreamBuildInProgress=El projecto padre {0} todav\u00EDa est\u00E1 en ejecuci\u00F3n
-AbstractProject.AwaitingBuildForWorkspace=El trabajo est\u00E1 esperando para tener un ''espacio de trabajo''
+AbstractProject.DownstreamBuildInProgress=El projecto padre {0} todav\u00eda est\u00e1 en ejecuci\u00f3n
+AbstractProject.AwaitingBuildForWorkspace=El trabajo est\u00e1 esperando para tener un ''espacio de trabajo''
 Run.ArtifactsPermission.Description=\
  Este permiso sirve para poder utilizar los artefactos producidos en los proyectos. 
-AbstractProject.AssignedLabelString.InvalidBooleanExpression=Expresi\u00F3n booleana incorrecta: {0}
+AbstractProject.AssignedLabelString.InvalidBooleanExpression=Expresi\u00f3n booleana incorrecta: {0}
 ManageJenkinsAction.DisplayName=Administrar Jenkins
-Computer.NoSuchSlaveExists=El nodo {0} no existe. \u00BFQuiz\u00E1s se est\u00E9 refiriendo a {1}?
-ResultTrend.StillFailing=Todav\u00EDa falla
-Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de l\u00EDnea.
+Computer.NoSuchSlaveExists=El nodo {0} no existe. ¿Quizás se esté refiriendo a {1}?
+ResultTrend.StillFailing=Todavía falla
+Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de línea.
 Computer.CreatePermission.Description=Este permiso permite que los usuarios puedan crear nuevos nodos.
-ResultTrend.StillUnstable=Todav\u00EDa inestable
+ResultTrend.StillUnstable=Todavía inestable
 View.ReadPermission.Description=Este permiso permite que los usuarion puedan crear vistas (implica acceso de lectura)
 Hudson.RunScriptsPermission.Description=El permiso "run scripts' es necesario para ejecutar scripts de groovy usando la consola groovy o el "cli" de groovy.
 ResultTrend.Fixed=Arreglado
 ResultTrend.Failure=Fallo
 UpdateCenter.PluginCategory.listview-column=Columnas de la lista
 ResultTrend.Aborted=Cancelado
-TextParameterDefinition.DisplayName=Par\u00E1metro de texto
-AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ning\u00FAn nodo que cumpla esta asignaci\u00F3n. \u00BFQuiz\u00E1s se refiera a ''{1}'' en lugar de ''{0}''?
+TextParameterDefinition.DisplayName=Parámetro de texto
+AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ningún nodo que cumpla esta asignación. ¿Quizás se refiera a ''{1}'' en lugar de ''{0}''?
 ResultTrend.Success=Correcto
 AbstractProject.CancelPermission.Description=Este permiso permite que se pueda cancelar un trabajo.
 Run.Summary.NotBuilt=no se ha ejecutado
 AbstractProject.DiscoverPermission.Description=Este permiso garantiza que se pueda descubrir tareas. \
- Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios an\u00F3nimos a la p\u00E1gina de login. \
- Sin este permiso, los usuarios an\u00F3nimos recibir\u00E1n un error 404, no siendo capaces de descubrir esas tareas.
-Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusi\u00F3n en los resultados de b\u00FAsquedas.
+ Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios anónimos a la página de login. \
+ Sin este permiso, los usuarios anónimos recibirán un error 404, no siendo capaces de descubrir esas tareas.
+Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusión en los resultados de búsquedas.
 ResultTrend.NotBuilt=Sin ejecutar
 ResultTrend.NowUnstable=Ahora es inestable
 AbstractBuild.BuildingInWorkspace=en el espacio de trabajo {0}
 Descriptor.From=(desde <a href="{1}">{0}</a>)
 ResultTrend.Unstable=Inestable
-Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se est\u00E1 usando en otro trabajo, pudiendo producir confusi\u00F3n.
+Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se está usando en otro trabajo, pudiendo producir confusión.
 AbstractProject.WipeOutPermission.Description=Este permiso permite que se pueda borrar todo el contenido del espacio de trabajo de una tarea.
-UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activar\u00E1 en el pr\u00F3ximo arranque.
+UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activará en el próximo arranque.
 Computer.ConnectPermission.Description=Este permiso permite que los usuarios puedan conectar nodos o marcarlos como activos.
 BallColor.NotBuilt=Sin ejecutar.
 AbstractBuild_Building=Ejecutando.
-ParametersDefinitionProperty.DisplayName=Esta ejecuci\u00F3n debe parametrizarse
+ParametersDefinitionProperty.DisplayName=Esta ejecución debe parametrizarse

--- a/core/src/main/resources/hudson/model/Messages_es.properties
+++ b/core/src/main/resources/hudson/model/Messages_es.properties
@@ -120,7 +120,7 @@ Job.NOfMFailed={0} de las {1} \u00faltimas ejecuciones fallaron.
 Job.NoRecentBuildFailed=No hay ejecuciones recientes con fallos.
 Job.Pronoun=Proyecto
 Job.minutes=Min
-Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se est� ejecutando.
+Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se est\u00E1 ejecutando.
 
 Label.GroupOf=grupo de {0}
 Label.InvalidLabel=etiqueta inv\u00e1lida
@@ -270,35 +270,35 @@ Run.ArtifactsPermission.Description=\
  Este permiso sirve para poder utilizar los artefactos producidos en los proyectos. 
 AbstractProject.AssignedLabelString.InvalidBooleanExpression=Expresi\u00f3n booleana incorrecta: {0}
 ManageJenkinsAction.DisplayName=Administrar Jenkins
-Computer.NoSuchSlaveExists=El nodo {0} no existe. �Quiz�s se est� refiriendo a {1}?
-ResultTrend.StillFailing=Todav�a falla
-Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de l�nea.
+Computer.NoSuchSlaveExists=El nodo {0} no existe. \u00BFQuiz\u00E1s se est\u00E1 refiriendo a {1}?
+ResultTrend.StillFailing=Todav\u00EDa falla
+Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de l\u00EDnea.
 Computer.CreatePermission.Description=Este permiso permite que los usuarios puedan crear nuevos nodos.
-ResultTrend.StillUnstable=Todav�a inestable
+ResultTrend.StillUnstable=Todav\u00EDa inestable
 View.ReadPermission.Description=Este permiso permite que los usuarion puedan crear vistas (implica acceso de lectura)
 Hudson.RunScriptsPermission.Description=El permiso "run scripts' es necesario para ejecutar scripts de groovy usando la consola groovy o el "cli" de groovy.
 ResultTrend.Fixed=Arreglado
 ResultTrend.Failure=Fallo
 UpdateCenter.PluginCategory.listview-column=Columnas de la lista
 ResultTrend.Aborted=Cancelado
-TextParameterDefinition.DisplayName=Par�metro de texto
-AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ning�n nodo que cumpla esta asignaci�n. �Quiz�s se refiera a ''{1}'' en lugar de ''{0}''?
+TextParameterDefinition.DisplayName=Par\u00E1metro de texto
+AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ning\u00FAn nodo que cumpla esta asignaci\u00F3n. \u00BFQuiz\u00E1s se refiera a ''{1}'' en lugar de ''{0}''?
 ResultTrend.Success=Correcto
 AbstractProject.CancelPermission.Description=Este permiso permite que se pueda cancelar un trabajo.
 Run.Summary.NotBuilt=no se ha ejecutado
 AbstractProject.DiscoverPermission.Description=Este permiso garantiza que se pueda descubrir tareas. \
- Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios an�nimos a la p�gina de login. \
- Sin este permiso, los usuarios an�nimos recibir�n un error 404, no siendo capaces de descubrir esas tareas.
-Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusi�n en los resultados de b�squedas.
+ Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios an\u00EDnimos a la p\u00E1gina de login. \
+ Sin este permiso, los usuarios an\u00F3nimos recibir\u00E1n un error 404, no siendo capaces de descubrir esas tareas.
+Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusi\u00F3n en los resultados de b\u00FAsquedas.
 ResultTrend.NotBuilt=Sin ejecutar
 ResultTrend.NowUnstable=Ahora es inestable
 AbstractBuild.BuildingInWorkspace=en el espacio de trabajo {0}
 Descriptor.From=(desde <a href="{1}">{0}</a>)
 ResultTrend.Unstable=Inestable
-Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se est� usando en otro trabajo, pudiendo producir confusi�n.
+Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se est\u00E1 usando en otro trabajo, pudiendo producir confusi\u00F3n.
 AbstractProject.WipeOutPermission.Description=Este permiso permite que se pueda borrar todo el contenido del espacio de trabajo de una tarea.
-UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activar� en el pr�ximo arranque.
+UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activar\u00E1 en el pr\u00F3ximo arranque.
 Computer.ConnectPermission.Description=Este permiso permite que los usuarios puedan conectar nodos o marcarlos como activos.
 BallColor.NotBuilt=Sin ejecutar.
 AbstractBuild_Building=Ejecutando.
-ParametersDefinitionProperty.DisplayName=Esta ejecuci�n debe parametrizarse
+ParametersDefinitionProperty.DisplayName=Esta ejecuci\u00F3n debe parametrizarse

--- a/core/src/main/resources/hudson/model/Messages_es.properties
+++ b/core/src/main/resources/hudson/model/Messages_es.properties
@@ -24,30 +24,30 @@ AbstractBuild.BuildingRemotely=Ejecutando remotamente en  {0}
 AbstractBuild.BuildingOnMaster=Ejecutando en el nodo principal
 AbstractBuild.KeptBecause=Conservar porque {0}
 
-AbstractItem.NoSuchJobExists=La tarea ''{0}'' no existe. \u00bfQuiz\u00e1s quieras decir ''{1}''?
+AbstractItem.NoSuchJobExists=La tarea ''{0}'' no existe. \u00BFQuiz\u00E1s quieras decir ''{1}''?
 AbstractItem.NewNameInUse=El nombre {0} ya existe.
-AbstractProject.NewBuildForWorkspace=Lanzando una nueva ejecuci\u00f3n para crear el espacio de trabajo.
+AbstractProject.NewBuildForWorkspace=Lanzando una nueva ejecuci\u00F3n para crear el espacio de trabajo.
 AbstractProject.Pronoun=Proyecto
 AbstractProject.Aborted=Cancelado
-AbstractProject.UpstreamBuildInProgress=El proyecto padre {0} ya se est\u00e1 ejecutando.
-AbstractProject.Disabled=Ejecuci\u00f3n desactivada
+AbstractProject.UpstreamBuildInProgress=El proyecto padre {0} ya se est\u00E1 ejecutando.
+AbstractProject.Disabled=Ejecuci\u00F3n desactivada
 AbstractProject.NoSCM=Sin SCM
 AbstractProject.NoWorkspace=No hay espacio de trabajo, por tanto no se puede comprobar las actualizaciones.
 AbstractProject.PollingABorted=Peticiones SCM abortadas
 AbstractProject.ScmAborted=Actualizacion SCM abortada
-AbstractProject.WorkspaceOffline=El espacio de trabajo est\u00e1 fuera de l\u00ednea.
+AbstractProject.WorkspaceOffline=El espacio de trabajo est\u00E1 fuera de l\u00EDnea.
 AbstractProject.BuildPermission.Description=\
-  Este permiso permite al usuario lanzar una ejecuci\u00f3n.
+  Este permiso permite al usuario lanzar una ejecuci\u00F3n.
 AbstractProject.WorkspacePermission.Description=\
-  Este permiso permite visualizar el contenido de un espacio de trabajo que Jenkins cre\u00f3 para ejecutar tareas. \
-  Si no quieres que un usuario acceda al c\u00f3digo fuente, desactival\u00f3.
+  Este permiso permite visualizar el contenido de un espacio de trabajo que Jenkins cre\u00F3 para ejecutar tareas. \
+  Si no quieres que un usuario acceda al c\u00F3digo fuente, desactival\u00F3.
 AbstractProject.ExtendedReadPermission.Description=\
-  Este permiso garantiza acceso de s\u00f3lo lectura a la configuraci\u00f3n de proyectos. \
-  S\u00e9 consciente que hay informaci\u00f3n delicada en las tareas como puedan ser las contrase\u00f1as que pueden quedar expuestas a todo el mundo.
+  Este permiso garantiza acceso de s\u00F3lo lectura a la configuraci\u00F3n de proyectos. \
+  S\u00E9 consciente que hay informaci\u00F3n delicada en las tareas como puedan ser las contrase\u00F1as que pueden quedar expuestas a todo el mundo.
 
-Api.MultipleMatch=XPath "{0}" encontr\u00f3 coincidencias en {1} nodos. \
-  Crea una expresi\u00f3n XPath que s\u00f3lo encuentre uno, o utiliza el par\u00e1metro "wraper" para que todos los nodos se agrupen bajo un elemento.
-Api.NoXPathMatch=XPath {0} no encontr\u00f3 nada 
+Api.MultipleMatch=XPath "{0}" encontr\u00F3 coincidencias en {1} nodos. \
+  Crea una expresi\u00F3n XPath que s\u00F3lo encuentre uno, o utiliza el par\u00E1metro "wraper" para que todos los nodos se agrupen bajo un elemento.
+Api.NoXPathMatch=XPath {0} no encontr\u00F3 nada 
 Api.WrapperParamInvalid=El par\u00E1metro wrapper s\u00F3lo puede contener caracteres alfanum\u00E9ricos o guiones/puntos/subrayado. El primer car\u00E1cter debe ser una letra o subrayado.
 
 BallColor.Aborted=Abortado
@@ -67,48 +67,48 @@ Computer.DeletePermission.Description=Este permiso permite borrar nodos
 
 ComputerSet.NoSuchSlave=Es nodo {0} no existe
 ComputerSet.SlaveAlreadyExists=Es nodo ''{0}'' ya existe
-ComputerSet.SpecifySlaveToCopy=Especificar qu\u00e9 nodo copiar
+ComputerSet.SpecifySlaveToCopy=Especificar qu\u00E9 nodo copiar
 Executor.NotAvailable=N/D
 
 
 FreeStyleProject.DisplayName=Crear un proyecto de estilo libre
 FreeStyleProject.Description=Esta es la caracter\u00EDstica principal de Jenkins, la de ejecutar el proyecto combinando cualquier tipo de repositorio de software (SCM) con cualquier modo de construcci\u00F3n o ejecuci\u00F3n (make, ant, mvn, rake, script ...). Por tanto se podr\u00E1 tanto compilar y empaquetar software, como ejecutar cualquier proceso que requiera monitorizaci\u00F3n.
 
-Hudson.BadPortNumber=N\u00famero err\u00f3neo de puerto {0}
+Hudson.BadPortNumber=N\u00FAmero err\u00F3neo de puerto {0}
 Hudson.Computer.Caption=Principal
 Hudson.Computer.DisplayName=principal
-Hudson.ControlCodeNotAllowed=El c\u00f3digo de control {0} no est\u00e1 permitido
+Hudson.ControlCodeNotAllowed=El c\u00F3digo de control {0} no est\u00E1 permitido
 Hudson.DisplayName=Jenkins 
 Hudson.JobAlreadyExists=Una tarea con el nombre ''{0}'' ya existe
-Hudson.NoJavaInPath=No se encuentra el comando java en el ''PATH''. Quiz\u00e1s necesite configurar <a href=''{0}/configure''> JDKs</a>?
+Hudson.NoJavaInPath=No se encuentra el comando java en el ''PATH''. Quiz\u00E1s necesite configurar <a href=''{0}/configure''> JDKs</a>?
 Hudson.NoName=No se ha especificado un nombre
 Hudson.NoSuchDirectory=No existe el directorio {0}
-Hudson.NodeBeingRemoved=Se est\u00e1 borrando el nodo
+Hudson.NodeBeingRemoved=Se est\u00E1 borrando el nodo
 Hudson.NotADirectory={0} no es un directorio
 Hudson.NotAPlugin={0} no es un plugin de Jenkins
 Hudson.NotJDKDir={0} no es un directorio JDK
 Hudson.Permissions.Title=Global
-Hudson.USER_CONTENT_README=Los ficheros de este directorio est\u00e1n accesible en http://yourjenkins/userContent/
-Hudson.UnsafeChar=''{0}'' es un car\u00e1cter inseguro
+Hudson.USER_CONTENT_README=Los ficheros de este directorio est\u00E1n accesible en http://yourjenkins/userContent/
+Hudson.UnsafeChar=''{0}'' es un car\u00E1cter inseguro
 Hudson.ViewAlreadyExists=Una vista con el nombre "{0}" ya existe
 Hudson.ViewName=Todo
-Hudson.NotANumber=No es un n\u00famero
-Hudson.NotAPositiveNumber=No es un n\u00famero positivo
-Hudson.NotANonNegativeNumber=El n\u00famero podr\u00eda no ser negativo
-Hudson.NotANegativeNumber=No es un n\u00famero negativo
+Hudson.NotANumber=No es un n\u00FAmero
+Hudson.NotAPositiveNumber=No es un n\u00FAmero positivo
+Hudson.NotANonNegativeNumber=El n\u00FAmero podr\u00EDa no ser negativo
+Hudson.NotANegativeNumber=No es un n\u00FAmero negativo
 Hudson.NotUsesUTF8ToDecodeURL=\
-  El contenedor de servlets no usa UTF-8 para decodificar URLs. Esto causar\u00e1 problemas si se usan nombres \
+  El contenedor de servlets no usa UTF-8 para decodificar URLs. Esto causar\u00E1 problemas si se usan nombres \
   con caracteres no ASCII. Echa un vistazo a \
   <a href=''https://jenkins.io/redirect/configuring-servlet-containers''>Containers</a> y a \
   <a href=''/redirect/troubleshooting/utf8-url-decoding''>Tomcat i18n</a> para mas detalles.
 Hudson.AdministerPermission.Description=\
-  Este permiso garantiza la posibilidad de hacer cambios de configuraci\u00f3n en el sistema, \
-  as\u00ed como el realizar operaciones sobre el sistema de archivos local. \
+  Este permiso garantiza la posibilidad de hacer cambios de configuraci\u00F3n en el sistema, \
+  as\u00ED como el realizar operaciones sobre el sistema de archivos local. \
   (Siempre que lo permita el sistema operativo)
 Hudson.ReadPermission.Description=\
-  El permiso de lectura es necesario para visualizar casi todas las p\u00e1ginas de Jenkins.\
-  Este permiso es \u00fatil cuando se quiere que usuarios no autenticados puedan ver las p\u00e1ginas. \
-  Elimina este permiso del usuario "anonymous", luego a\u00f1ade "authenticated pseudo-user" con el \
+  El permiso de lectura es necesario para visualizar casi todas las p\u00E1ginas de Jenkins.\
+  Este permiso es \u00FAtil cuando se quiere que usuarios no autenticados puedan ver las p\u00E1ginas. \
+  Elimina este permiso del usuario "anonymous", luego a\u00F1ade "authenticated pseudo-user" con el \
   permiso de lectura.
 Hudson.NodeDescription=El nodo principal de Jenkins
 
@@ -116,111 +116,107 @@ Item.Permissions.Title=Tarea
 
 Job.AllRecentBuildFailed=Todas la ejecuciones recientes han fallado
 Job.BuildStability=Estabilidad: {0}
-Job.NOfMFailed={0} de las {1} \u00faltimas ejecuciones fallaron.
+Job.NOfMFailed={0} de las {1} \u00FAltimas ejecuciones fallaron.
 Job.NoRecentBuildFailed=No hay ejecuciones recientes con fallos.
 Job.Pronoun=Proyecto
 Job.minutes=Min
-Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se est� ejecutando.
+Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se est\uFFFD ejecutando.
 
 Label.GroupOf=grupo de {0}
-Label.InvalidLabel=etiqueta inv\u00e1lida
+Label.InvalidLabel=etiqueta inv\u00E1lida
 Label.ProvisionedFrom=Suministrado desde {0} 
-Queue.AllNodesOffline=Todos los nodos con la etiqueta ''{0}'' est\u00e1n fuera de l\u00ednea
+Queue.AllNodesOffline=Todos los nodos con la etiqueta ''{0}'' est\u00E1n fuera de l\u00EDnea
 Queue.BlockedBy=Bloqueados por {0}
 Queue.HudsonIsAboutToShutDown=Jenkins va a ser apagado
-Queue.InProgress=Una ejecuci\u00f3n ya est\u00e1 en progreso
+Queue.InProgress=Una ejecuci\u00F3n ya est\u00E1 en progreso
 Queue.InQuietPeriod=En el periodo de gracia. Termina en {0}
-Queue.NodeOffline={0} fuera de l\u00ednea
+Queue.NodeOffline={0} fuera de l\u00EDnea
 Queue.Unknown=?
 Queue.WaitingForNextAvailableExecutor=Esperando por un ejecutor
 Queue.WaitingForNextAvailableExecutorOn=Esperando por un ejecutor en {0}
 Queue.init=Restaurando la cola de tareas
-Queue.ExceptionCanTake=Excepci\u00f3n evaluando si el nodo puede coger la tarea
-Queue.ExceptionCanTakeLog=Excepci\u00f3n evaluando si el nodo '{0}' puede coger (canTake) la tarea '{1}'
-Queue.ExceptionCanRun=Excepci\u00f3n evaluando si la cola puede ejecutar la tarea
-Queue.ExceptionCanRunLog=Excepci\u00f3n evaluando si la cola puede ejecutar (canRun) la tarea '{0}'
 
-Run.BuildAborted=La ejecuci\u00f3n fu\u00e9 cancelada
+Run.BuildAborted=La ejecuci\u00F3n fu\u00E9 cancelada
 Run.MarkedExplicitly=marcado para mantener el registro
 Run.Permissions.Title=Ejecutar
 Run.UnableToDelete=Imposible borrar {0}: {1}
 Run.DeletePermission.Description=\
   Este permiso permite borrar manualmente ejecuciones de la historia de trabajos.
 Run.UpdatePermission.Description=\
-  Este permiso permite actualizar la descripci\u00f3n y otras propiedeades de un trabajo, \
+  Este permiso permite actualizar la descripci\u00F3n y otras propiedeades de un trabajo, \
   por ejemplo poner notas acerca de la causa de un fallo.
 
 Run.Summary.Stable=estable
 Run.Summary.Unstable=instable
 Run.Summary.Aborted=cancelado
-Run.Summary.BackToNormal=volvi\u00f3 a normal
+Run.Summary.BackToNormal=volvi\u00F3 a normal
 Run.Summary.BrokenForALongTime=fallido durante un largo periodo
-Run.Summary.BrokenSinceThisBuild=fallido desde esta ejecuci\u00f3n
-Run.Summary.BrokenSince=fallido desde la ejecuci\u00f3n {0}
+Run.Summary.BrokenSinceThisBuild=fallido desde esta ejecuci\u00F3n
+Run.Summary.BrokenSince=fallido desde la ejecuci\u00F3n {0}
 Run.Summary.Unknown=? 
 
-Slave.InvalidConfig.Executors=Configuraci\u00f3n de nodo incorrecta en {0}. El n\u00famero de ejecutores es inv\u00e1lido.
-Slave.InvalidConfig.NoName=Configuraci\u00f3n de nodo incorrecta. El nombre est\u00e1 vac\u00edo
-Slave.Terminated={0} el agente no est\u00e1 en ejecuci\u00f3n
+Slave.InvalidConfig.Executors=Configuraci\u00F3n de nodo incorrecta en {0}. El n\u00FAmero de ejecutores es inv\u00E1lido.
+Slave.InvalidConfig.NoName=Configuraci\u00F3n de nodo incorrecta. El nombre est\u00E1 vac\u00EDo
+Slave.Terminated={0} el agente no est\u00E1 en ejecuci\u00F3n
 Slave.UnixSlave=Este es un nodo Unix
 Slave.WindowsSlave=Este es un nodo Windows
 
 View.Permissions.Title=Vistas
 View.CreatePermission.Description=\
-  Permiso para creaci\u00f3n vistas.
+  Permiso para creaci\u00F3n vistas.
 View.DeletePermission.Description=\
   Este es un permiso para que los usuario puedan borrar vistas.
 View.ConfigurePermission.Description=\
-  Este permiso se usa para que los usuarios cambien la conficuraci\u00f3n de vistas.
+  Este permiso se usa para que los usuarios cambien la conficuraci\u00F3n de vistas.
 
 UpdateCenter.Status.CheckingInternet=Probando conectividad con Internet
 UpdateCenter.Status.CheckingJavaNet=Probando conectividad con jenkins-ci.org
 UpdateCenter.Status.Success=Correcto
 UpdateCenter.Status.UnknownHostException=\
   <span class=error>Nombre de servidor imposible de resolver {0}. \
-  Quiz\u00e1s tengas que configurar to <a href="../pluginManager/advanced">proxy</a></span>
+  Quiz\u00E1s tengas que configurar to <a href="../pluginManager/advanced">proxy</a></span>
 UpdateCenter.Status.ConnectionFailed=\
   <span class=error>Imposible de conectar con {0}. \
-  Quiz\u00e1s tengas que configurar to <a href="../pluginManager/advanced">proxy</a></span>
+  Quiz\u00E1s tengas que configurar to <a href="../pluginManager/advanced">proxy</a></span>
 UpdateCenter.init=Inicializando centro de actualizaciones
 UpdateCenter.PluginCategory.builder=Plugins relacionados con la forma de ejecutar trabajos
-UpdateCenter.PluginCategory.buildwrapper=Plugins que a\u00f1aden tareas relacionadas con la ejecuci\u00f3n
-UpdateCenter.PluginCategory.cli=Plugins para la interfaz de l\u00ednea de comandos
-UpdateCenter.PluginCategory.cluster=Plugins para la administraci\u00f3n de clusters y trabajos distribuidos
-UpdateCenter.PluginCategory.external=Plugins de integraci\u00f3n con sitios y herramientas externas
+UpdateCenter.PluginCategory.buildwrapper=Plugins que a\u00F1aden tareas relacionadas con la ejecuci\u00F3n
+UpdateCenter.PluginCategory.cli=Plugins para la interfaz de l\u00EDnea de comandos
+UpdateCenter.PluginCategory.cluster=Plugins para la administraci\u00F3n de clusters y trabajos distribuidos
+UpdateCenter.PluginCategory.external=Plugins de integraci\u00F3n con sitios y herramientas externas
 UpdateCenter.PluginCategory.maven=Plugins para Maven
 UpdateCenter.PluginCategory.misc=Varios
-UpdateCenter.PluginCategory.notifier=Plugins de notificaci\u00f3n
-UpdateCenter.PluginCategory.page-decorator=Plugins para decorar p\u00e1ginas
-UpdateCenter.PluginCategory.post-build=Plugins que a\u00f1aden acciones de post-ejecuti\u00f3n
+UpdateCenter.PluginCategory.notifier=Plugins de notificaci\u00F3n
+UpdateCenter.PluginCategory.page-decorator=Plugins para decorar p\u00E1ginas
+UpdateCenter.PluginCategory.post-build=Plugins que a\u00F1aden acciones de post-ejecuti\u00F3n
 UpdateCenter.PluginCategory.report=Plugins para generar informes
 UpdateCenter.PluginCategory.scm=Plugins de repositorios de software
-UpdateCenter.PluginCategory.scm-related=Plugins relacionados con la gesti\u00f3n repositorios
+UpdateCenter.PluginCategory.scm-related=Plugins relacionados con la gesti\u00F3n repositorios
 UpdateCenter.PluginCategory.slaves=Plugins para el control de nodos
 
 
 UpdateCenter.PluginCategory.trigger=Plugins lanzadores de tareas
 UpdateCenter.PluginCategory.ui=Plugins de interfaz de usuario
 UpdateCenter.PluginCategory.upload=Plugins para subir o desplegar los paquetes generados
-UpdateCenter.PluginCategory.user=Plugins para la gesti\u00f3n de usuarios y autenticaci\u00f3n
-UpdateCenter.PluginCategory.must-be-labeled=Sin categor\u00eda
-UpdateCenter.PluginCategory.unrecognized=Miscel\u00e1neo ({0})
+UpdateCenter.PluginCategory.user=Plugins para la gesti\u00F3n de usuarios y autenticaci\u00F3n
+UpdateCenter.PluginCategory.must-be-labeled=Sin categor\u00EDa
+UpdateCenter.PluginCategory.unrecognized=Miscel\u00E1neo ({0})
 
-Permalink.LastBuild=\u00daltima ejecuci\u00f3n
-Permalink.LastStableBuild=\u00daltima ejecuci\u00f3n estable
-Permalink.LastSuccessfulBuild=\u00daltima ejecuci\u00f3n correcta
-Permalink.LastFailedBuild=\u00daltima ejecuci\u00f3n fallida
+Permalink.LastBuild=\u00DAltima ejecuci\u00F3n
+Permalink.LastStableBuild=\u00DAltima ejecuci\u00F3n estable
+Permalink.LastSuccessfulBuild=\u00DAltima ejecuci\u00F3n correcta
+Permalink.LastFailedBuild=\u00DAltima ejecuci\u00F3n fallida
 
-ParameterAction.DisplayName=Par\u00e1metros
-StringParameterDefinition.DisplayName=Par\u00e1metro de cadena
-FileParameterDefinition.DisplayName=Par\u00e1metro de fichero
+ParameterAction.DisplayName=Par\u00E1metros
+StringParameterDefinition.DisplayName=Par\u00E1metro de cadena
+FileParameterDefinition.DisplayName=Par\u00E1metro de fichero
 BooleanParameterDefinition.DisplayName=Valor booleano
-ChoiceParameterDefinition.DisplayName=Elecci\u00f3n
-RunParameterDefinition.DisplayName=Par\u00e1metro de ejecuci\u00f3n
-PasswordParameterDefinition.DisplayName=Par\u00e1metro de contrase\u00f1a
+ChoiceParameterDefinition.DisplayName=Elecci\u00F3n
+RunParameterDefinition.DisplayName=Par\u00E1metro de ejecuci\u00F3n
+PasswordParameterDefinition.DisplayName=Par\u00E1metro de contrase\u00F1a
 
 Node.Mode.NORMAL=Utilizar este nodo tanto como sea posible
-Node.Mode.EXCLUSIVE=Dejar esta nodo para ejecutar s\u00f3lamente tareas vinculadas a \u00e9l
+Node.Mode.EXCLUSIVE=Dejar esta nodo para ejecutar s\u00F3lamente tareas vinculadas a \u00E9l
 
 ListView.DisplayName=Lista de vistas
 
@@ -228,14 +224,14 @@ MyView.DisplayName=Mi vista
 
 LoadStatistics.Legends.TotalExecutors=Ejecutores totales
 LoadStatistics.Legends.BusyExecutors=Ejecutores ocupados
-LoadStatistics.Legends.QueueLength=Tama\u00f1o de la cola
+LoadStatistics.Legends.QueueLength=Tama\u00F1o de la cola
 
-Cause.LegacyCodeCause.ShortDescription=Un c\u00f3digo antiguo (legacy) lanz\u00f3 este proceso. No hay informaci\u00f3n de la causa.
-Cause.UpstreamCause.ShortDescription=Lanzada por el proyecto padre  "{0}" ejecuci\u00f3n n\u00famero {1}
+Cause.LegacyCodeCause.ShortDescription=Un c\u00F3digo antiguo (legacy) lanz\u00F3 este proceso. No hay informaci\u00F3n de la causa.
+Cause.UpstreamCause.ShortDescription=Lanzada por el proyecto padre  "{0}" ejecuci\u00F3n n\u00FAmero {1}
 Cause.UserCause.ShortDescription=Lanzada por el usuario {0}
 Cause.UserIdCause.ShortDescription=Lanzada por el usuario {0}
-Cause.RemoteCause.ShortDescription=Lanzada por la m\u00e1quina remota {0}
-Cause.RemoteCause.ShortDescriptionWithNote=Lanzada por la m\u00e1quina remota {0} con la nota: {1}
+Cause.RemoteCause.ShortDescription=Lanzada por la m\u00E1quina remota {0}
+Cause.RemoteCause.ShortDescriptionWithNote=Lanzada por la m\u00E1quina remota {0} con la nota: {1}
 
 ProxyView.NoSuchViewExists=La vista global {0} no existe
 ProxyView.DisplayName=Incluir una vista global
@@ -246,61 +242,61 @@ MyViewsProperty.ViewExistsCheck.AlreadyExists=Una vista con el nombre {0} ya exi
 
 CLI.restart.shortDescription=Reiniciar Jenkins
 CLI.safe-restart.shortDescription=Reiniciar Jenkins de manera segura
-CLI.keep-build.shortDescription=Marcar la ejecuci\u00f3n para ser guardada para siempre.
+CLI.keep-build.shortDescription=Marcar la ejecuci\u00F3n para ser guardada para siempre.
 
 View.MissingMode=No se ha especificado el tipo para la vista
 AbstractProject.NoBuilds=No existen ejecuciones. Lanzando una nueva.
 Slave.Remote.Director.Mandatory=El directorio remoto es obligatorio
-Slave.Network.Mounted.File.System.Warning=\u00bfEst\u00e1s seguro de querer utilizar un directorio de red para el "Filesystem" ra\u00edz?.\
+Slave.Network.Mounted.File.System.Warning=\u00BFEst\u00E1s seguro de querer utilizar un directorio de red para el "Filesystem" ra\u00EDz?.\
   Ten en cuenta que este directorio no necesita estar visible desde el nodo de Jenkins principal.
 HealthReport.EmptyString= 
 MultiStageTimeSeries.EMPTY_STRING= 
 ComputerSet.DisplayName=nodos
 Run.InProgressDuration={0} y contando
 Node.LabelMissing={0} no tiene etiqueta {1}
-Node.BecauseNodeIsReserved={0} est\u00e1 reservado para trabajos asignados a este nodo.
-Permalink.LastUnsuccessfulBuild=\u00daltima ejecuci\u00f3n fallida
-Permalink.LastUnstableBuild=\u00daltima ejecuci\u00f3n inestable
-Computer.BadChannel=El nodo est\u00e1 apagado o no existe el canal remoto (como puede ocurrir en un nodo principal)
+Node.BecauseNodeIsReserved={0} est\u00E1 reservado para trabajos asignados a este nodo.
+Permalink.LastUnsuccessfulBuild=\u00DAltima ejecuci\u00F3n fallida
+Permalink.LastUnstableBuild=\u00DAltima ejecuci\u00F3n inestable
+Computer.BadChannel=El nodo est\u00E1 apagado o no existe el canal remoto (como puede ocurrir en un nodo principal)
 MyViewsProperty.DisplayName=Mis vistas
 BuildAuthorizationToken.InvalidTokenProvided=El Token incorrecto
-AbstractProject.AssignedLabelString.NoMatch=No hay ning\u00fan nodo/nube que cumpla esta asignaci\u00f3n
+AbstractProject.AssignedLabelString.NoMatch=No hay ning\u00FAn nodo/nube que cumpla esta asignaci\u00F3n
 AbstractItem.Pronoun=Tarea
-AbstractProject.DownstreamBuildInProgress=El projecto padre {0} todav\u00eda est\u00e1 en ejecuci\u00f3n
-AbstractProject.AwaitingBuildForWorkspace=El trabajo est\u00e1 esperando para tener un ''espacio de trabajo''
+AbstractProject.DownstreamBuildInProgress=El projecto padre {0} todav\u00EDa est\u00E1 en ejecuci\u00F3n
+AbstractProject.AwaitingBuildForWorkspace=El trabajo est\u00E1 esperando para tener un ''espacio de trabajo''
 Run.ArtifactsPermission.Description=\
  Este permiso sirve para poder utilizar los artefactos producidos en los proyectos. 
-AbstractProject.AssignedLabelString.InvalidBooleanExpression=Expresi\u00f3n booleana incorrecta: {0}
+AbstractProject.AssignedLabelString.InvalidBooleanExpression=Expresi\u00F3n booleana incorrecta: {0}
 ManageJenkinsAction.DisplayName=Administrar Jenkins
-Computer.NoSuchSlaveExists=El nodo {0} no existe. �Quiz�s se est� refiriendo a {1}?
-ResultTrend.StillFailing=Todav�a falla
-Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de l�nea.
+Computer.NoSuchSlaveExists=El nodo {0} no existe. \uFFFDQuiz\uFFFDs se est\uFFFD refiriendo a {1}?
+ResultTrend.StillFailing=Todav\uFFFDa falla
+Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de l\uFFFDnea.
 Computer.CreatePermission.Description=Este permiso permite que los usuarios puedan crear nuevos nodos.
-ResultTrend.StillUnstable=Todav�a inestable
+ResultTrend.StillUnstable=Todav\uFFFDa inestable
 View.ReadPermission.Description=Este permiso permite que los usuarion puedan crear vistas (implica acceso de lectura)
 Hudson.RunScriptsPermission.Description=El permiso "run scripts' es necesario para ejecutar scripts de groovy usando la consola groovy o el "cli" de groovy.
 ResultTrend.Fixed=Arreglado
 ResultTrend.Failure=Fallo
 UpdateCenter.PluginCategory.listview-column=Columnas de la lista
 ResultTrend.Aborted=Cancelado
-TextParameterDefinition.DisplayName=Par�metro de texto
-AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ning�n nodo que cumpla esta asignaci�n. �Quiz�s se refiera a ''{1}'' en lugar de ''{0}''?
+TextParameterDefinition.DisplayName=Par\uFFFDmetro de texto
+AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ning\uFFFDn nodo que cumpla esta asignaci\uFFFDn. \uFFFDQuiz\uFFFDs se refiera a ''{1}'' en lugar de ''{0}''?
 ResultTrend.Success=Correcto
 AbstractProject.CancelPermission.Description=Este permiso permite que se pueda cancelar un trabajo.
 Run.Summary.NotBuilt=no se ha ejecutado
 AbstractProject.DiscoverPermission.Description=Este permiso garantiza que se pueda descubrir tareas. \
- Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios an�nimos a la p�gina de login. \
- Sin este permiso, los usuarios an�nimos recibir�n un error 404, no siendo capaces de descubrir esas tareas.
-Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusi�n en los resultados de b�squedas.
+ Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios an\uFFFDnimos a la p\uFFFDgina de login. \
+ Sin este permiso, los usuarios an\uFFFDnimos recibir\uFFFDn un error 404, no siendo capaces de descubrir esas tareas.
+Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusi\uFFFDn en los resultados de b\uFFFDsquedas.
 ResultTrend.NotBuilt=Sin ejecutar
 ResultTrend.NowUnstable=Ahora es inestable
 AbstractBuild.BuildingInWorkspace=en el espacio de trabajo {0}
 Descriptor.From=(desde <a href="{1}">{0}</a>)
 ResultTrend.Unstable=Inestable
-Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se est� usando en otro trabajo, pudiendo producir confusi�n.
+Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se est\uFFFD usando en otro trabajo, pudiendo producir confusi\uFFFDn.
 AbstractProject.WipeOutPermission.Description=Este permiso permite que se pueda borrar todo el contenido del espacio de trabajo de una tarea.
-UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activar� en el pr�ximo arranque.
+UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activar\uFFFD en el pr\uFFFDximo arranque.
 Computer.ConnectPermission.Description=Este permiso permite que los usuarios puedan conectar nodos o marcarlos como activos.
 BallColor.NotBuilt=Sin ejecutar.
 AbstractBuild_Building=Ejecutando.
-ParametersDefinitionProperty.DisplayName=Esta ejecuci�n debe parametrizarse
+ParametersDefinitionProperty.DisplayName=Esta ejecuci\uFFFDn debe parametrizarse

--- a/core/src/main/resources/hudson/model/Messages_es.properties
+++ b/core/src/main/resources/hudson/model/Messages_es.properties
@@ -120,7 +120,7 @@ Job.NOfMFailed={0} de las {1} \u00faltimas ejecuciones fallaron.
 Job.NoRecentBuildFailed=No hay ejecuciones recientes con fallos.
 Job.Pronoun=Proyecto
 Job.minutes=Min
-Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se está ejecutando.
+Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se estï¿½ ejecutando.
 
 Label.GroupOf=grupo de {0}
 Label.InvalidLabel=etiqueta inv\u00e1lida
@@ -135,6 +135,10 @@ Queue.Unknown=?
 Queue.WaitingForNextAvailableExecutor=Esperando por un ejecutor
 Queue.WaitingForNextAvailableExecutorOn=Esperando por un ejecutor en {0}
 Queue.init=Restaurando la cola de tareas
+Queue.ExceptionCanTake=Excepci\u00f3n evaluando si el nodo puede coger la tarea
+Queue.ExceptionCanTakeLog=Excepci\u00f3n evaluando si el nodo '{0}' puede coger (canTake) la tarea '{1}'
+Queue.ExceptionCanRun=Excepci\u00f3n evaluando si la cola puede ejecutar la tarea
+Queue.ExceptionCanRunLog=Excepci\u00f3n evaluando si la cola puede ejecutar (canRun) la tarea '{0}'
 
 Run.BuildAborted=La ejecuci\u00f3n fu\u00e9 cancelada
 Run.MarkedExplicitly=marcado para mantener el registro
@@ -268,35 +272,35 @@ Run.ArtifactsPermission.Description=\
  Este permiso sirve para poder utilizar los artefactos producidos en los proyectos. 
 AbstractProject.AssignedLabelString.InvalidBooleanExpression=Expresi\u00f3n booleana incorrecta: {0}
 ManageJenkinsAction.DisplayName=Administrar Jenkins
-Computer.NoSuchSlaveExists=El nodo {0} no existe. ¿Quizás se esté refiriendo a {1}?
-ResultTrend.StillFailing=Todavía falla
-Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de línea.
+Computer.NoSuchSlaveExists=El nodo {0} no existe. ï¿½Quizï¿½s se estï¿½ refiriendo a {1}?
+ResultTrend.StillFailing=Todavï¿½a falla
+Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de lï¿½nea.
 Computer.CreatePermission.Description=Este permiso permite que los usuarios puedan crear nuevos nodos.
-ResultTrend.StillUnstable=Todavía inestable
+ResultTrend.StillUnstable=Todavï¿½a inestable
 View.ReadPermission.Description=Este permiso permite que los usuarion puedan crear vistas (implica acceso de lectura)
 Hudson.RunScriptsPermission.Description=El permiso "run scripts' es necesario para ejecutar scripts de groovy usando la consola groovy o el "cli" de groovy.
 ResultTrend.Fixed=Arreglado
 ResultTrend.Failure=Fallo
 UpdateCenter.PluginCategory.listview-column=Columnas de la lista
 ResultTrend.Aborted=Cancelado
-TextParameterDefinition.DisplayName=Parámetro de texto
-AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ningún nodo que cumpla esta asignación. ¿Quizás se refiera a ''{1}'' en lugar de ''{0}''?
+TextParameterDefinition.DisplayName=Parï¿½metro de texto
+AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ningï¿½n nodo que cumpla esta asignaciï¿½n. ï¿½Quizï¿½s se refiera a ''{1}'' en lugar de ''{0}''?
 ResultTrend.Success=Correcto
 AbstractProject.CancelPermission.Description=Este permiso permite que se pueda cancelar un trabajo.
 Run.Summary.NotBuilt=no se ha ejecutado
 AbstractProject.DiscoverPermission.Description=Este permiso garantiza que se pueda descubrir tareas. \
- Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios anónimos a la página de login. \
- Sin este permiso, los usuarios anónimos recibirán un error 404, no siendo capaces de descubrir esas tareas.
-Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusión en los resultados de búsquedas.
+ Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios anï¿½nimos a la pï¿½gina de login. \
+ Sin este permiso, los usuarios anï¿½nimos recibirï¿½n un error 404, no siendo capaces de descubrir esas tareas.
+Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusiï¿½n en los resultados de bï¿½squedas.
 ResultTrend.NotBuilt=Sin ejecutar
 ResultTrend.NowUnstable=Ahora es inestable
 AbstractBuild.BuildingInWorkspace=en el espacio de trabajo {0}
 Descriptor.From=(desde <a href="{1}">{0}</a>)
 ResultTrend.Unstable=Inestable
-Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se está usando en otro trabajo, pudiendo producir confusión.
+Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se estï¿½ usando en otro trabajo, pudiendo producir confusiï¿½n.
 AbstractProject.WipeOutPermission.Description=Este permiso permite que se pueda borrar todo el contenido del espacio de trabajo de una tarea.
-UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activará en el próximo arranque.
+UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activarï¿½ en el prï¿½ximo arranque.
 Computer.ConnectPermission.Description=Este permiso permite que los usuarios puedan conectar nodos o marcarlos como activos.
 BallColor.NotBuilt=Sin ejecutar.
 AbstractBuild_Building=Ejecutando.
-ParametersDefinitionProperty.DisplayName=Esta ejecución debe parametrizarse
+ParametersDefinitionProperty.DisplayName=Esta ejecuciï¿½n debe parametrizarse

--- a/core/src/main/resources/hudson/model/Messages_es.properties
+++ b/core/src/main/resources/hudson/model/Messages_es.properties
@@ -253,8 +253,8 @@ AbstractProject.NoBuilds=No existen ejecuciones. Lanzando una nueva.
 Slave.Remote.Director.Mandatory=El directorio remoto es obligatorio
 Slave.Network.Mounted.File.System.Warning=\u00bfEst\u00e1s seguro de querer utilizar un directorio de red para el "Filesystem" ra\u00edz?.\
   Ten en cuenta que este directorio no necesita estar visible desde el nodo de Jenkins principal.
-HealthReport.EmptyString=
-MultiStageTimeSeries.EMPTY_STRING=
+HealthReport.EmptyString= 
+MultiStageTimeSeries.EMPTY_STRING= 
 ComputerSet.DisplayName=nodos
 Run.InProgressDuration={0} y contando
 Node.LabelMissing={0} no tiene etiqueta {1}

--- a/core/src/main/resources/hudson/model/Messages_es.properties
+++ b/core/src/main/resources/hudson/model/Messages_es.properties
@@ -120,7 +120,7 @@ Job.NOfMFailed={0} de las {1} \u00faltimas ejecuciones fallaron.
 Job.NoRecentBuildFailed=No hay ejecuciones recientes con fallos.
 Job.Pronoun=Proyecto
 Job.minutes=Min
-Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se está ejecutando.
+Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se estï¿½ ejecutando.
 
 Label.GroupOf=grupo de {0}
 Label.InvalidLabel=etiqueta inv\u00e1lida
@@ -136,9 +136,7 @@ Queue.WaitingForNextAvailableExecutor=Esperando por un ejecutor
 Queue.WaitingForNextAvailableExecutorOn=Esperando por un ejecutor en {0}
 Queue.init=Restaurando la cola de tareas
 Queue.ExceptionCanTake=Excepci\u00f3n evaluando si el nodo puede coger la tarea
-Queue.ExceptionCanTakeLog=Excepci\u00f3n evaluando si el nodo '{0}' puede coger (canTake) la tarea '{1}'
 Queue.ExceptionCanRun=Excepci\u00f3n evaluando si la cola puede ejecutar la tarea
-Queue.ExceptionCanRunLog=Excepci\u00f3n evaluando si la cola puede ejecutar (canRun) la tarea '{0}'
 
 Run.BuildAborted=La ejecuci\u00f3n fu\u00e9 cancelada
 Run.MarkedExplicitly=marcado para mantener el registro
@@ -272,35 +270,35 @@ Run.ArtifactsPermission.Description=\
  Este permiso sirve para poder utilizar los artefactos producidos en los proyectos. 
 AbstractProject.AssignedLabelString.InvalidBooleanExpression=Expresi\u00f3n booleana incorrecta: {0}
 ManageJenkinsAction.DisplayName=Administrar Jenkins
-Computer.NoSuchSlaveExists=El nodo {0} no existe. ¿Quizás se esté refiriendo a {1}?
-ResultTrend.StillFailing=Todavía falla
-Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de línea.
+Computer.NoSuchSlaveExists=El nodo {0} no existe. ï¿½Quizï¿½s se estï¿½ refiriendo a {1}?
+ResultTrend.StillFailing=Todavï¿½a falla
+Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de lï¿½nea.
 Computer.CreatePermission.Description=Este permiso permite que los usuarios puedan crear nuevos nodos.
-ResultTrend.StillUnstable=Todavía inestable
+ResultTrend.StillUnstable=Todavï¿½a inestable
 View.ReadPermission.Description=Este permiso permite que los usuarion puedan crear vistas (implica acceso de lectura)
 Hudson.RunScriptsPermission.Description=El permiso "run scripts' es necesario para ejecutar scripts de groovy usando la consola groovy o el "cli" de groovy.
 ResultTrend.Fixed=Arreglado
 ResultTrend.Failure=Fallo
 UpdateCenter.PluginCategory.listview-column=Columnas de la lista
 ResultTrend.Aborted=Cancelado
-TextParameterDefinition.DisplayName=Parámetro de texto
-AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ningún nodo que cumpla esta asignación. ¿Quizás se refiera a ''{1}'' en lugar de ''{0}''?
+TextParameterDefinition.DisplayName=Parï¿½metro de texto
+AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ningï¿½n nodo que cumpla esta asignaciï¿½n. ï¿½Quizï¿½s se refiera a ''{1}'' en lugar de ''{0}''?
 ResultTrend.Success=Correcto
 AbstractProject.CancelPermission.Description=Este permiso permite que se pueda cancelar un trabajo.
 Run.Summary.NotBuilt=no se ha ejecutado
 AbstractProject.DiscoverPermission.Description=Este permiso garantiza que se pueda descubrir tareas. \
- Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios anónimos a la página de login. \
- Sin este permiso, los usuarios anónimos recibirán un error 404, no siendo capaces de descubrir esas tareas.
-Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusión en los resultados de búsquedas.
+ Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios anï¿½nimos a la pï¿½gina de login. \
+ Sin este permiso, los usuarios anï¿½nimos recibirï¿½n un error 404, no siendo capaces de descubrir esas tareas.
+Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusiï¿½n en los resultados de bï¿½squedas.
 ResultTrend.NotBuilt=Sin ejecutar
 ResultTrend.NowUnstable=Ahora es inestable
 AbstractBuild.BuildingInWorkspace=en el espacio de trabajo {0}
 Descriptor.From=(desde <a href="{1}">{0}</a>)
 ResultTrend.Unstable=Inestable
-Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se está usando en otro trabajo, pudiendo producir confusión.
+Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se estï¿½ usando en otro trabajo, pudiendo producir confusiï¿½n.
 AbstractProject.WipeOutPermission.Description=Este permiso permite que se pueda borrar todo el contenido del espacio de trabajo de una tarea.
-UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activará en el próximo arranque.
+UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activarï¿½ en el prï¿½ximo arranque.
 Computer.ConnectPermission.Description=Este permiso permite que los usuarios puedan conectar nodos o marcarlos como activos.
 BallColor.NotBuilt=Sin ejecutar.
 AbstractBuild_Building=Ejecutando.
-ParametersDefinitionProperty.DisplayName=Esta ejecución debe parametrizarse
+ParametersDefinitionProperty.DisplayName=Esta ejecuciï¿½n debe parametrizarse

--- a/core/src/main/resources/hudson/model/Messages_es.properties
+++ b/core/src/main/resources/hudson/model/Messages_es.properties
@@ -120,7 +120,7 @@ Job.NOfMFailed={0} de las {1} \u00FAltimas ejecuciones fallaron.
 Job.NoRecentBuildFailed=No hay ejecuciones recientes con fallos.
 Job.Pronoun=Proyecto
 Job.minutes=Min
-Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se est\uFFFD ejecutando.
+Job.NoRenameWhileBuilding=No es posible renombrar un proyecto mientras se est\u00E1 ejecutando.
 
 Label.GroupOf=grupo de {0}
 Label.InvalidLabel=etiqueta inv\u00E1lida
@@ -135,6 +135,10 @@ Queue.Unknown=?
 Queue.WaitingForNextAvailableExecutor=Esperando por un ejecutor
 Queue.WaitingForNextAvailableExecutorOn=Esperando por un ejecutor en {0}
 Queue.init=Restaurando la cola de tareas
+Queue.ExceptionCanTake=Excepci\u00f3n evaluando si el nodo puede coger la tarea
+Queue.ExceptionCanTakeLog=Excepci\u00f3n evaluando si el nodo '{0}' puede coger (canTake) la tarea '{1}'
+Queue.ExceptionCanRun=Excepci\u00f3n evaluando si la cola puede ejecutar la tarea
+Queue.ExceptionCanRunLog=Excepci\u00f3n evaluando si la cola puede ejecutar (canRun) la tarea '{0}'
 
 Run.BuildAborted=La ejecuci\u00F3n fu\u00E9 cancelada
 Run.MarkedExplicitly=marcado para mantener el registro
@@ -249,7 +253,7 @@ AbstractProject.NoBuilds=No existen ejecuciones. Lanzando una nueva.
 Slave.Remote.Director.Mandatory=El directorio remoto es obligatorio
 Slave.Network.Mounted.File.System.Warning=\u00BFEst\u00E1s seguro de querer utilizar un directorio de red para el "Filesystem" ra\u00EDz?.\
   Ten en cuenta que este directorio no necesita estar visible desde el nodo de Jenkins principal.
-HealthReport.EmptyString= 
+HealthReport.EmptyString=
 MultiStageTimeSeries.EMPTY_STRING= 
 ComputerSet.DisplayName=nodos
 Run.InProgressDuration={0} y contando
@@ -268,35 +272,35 @@ Run.ArtifactsPermission.Description=\
  Este permiso sirve para poder utilizar los artefactos producidos en los proyectos. 
 AbstractProject.AssignedLabelString.InvalidBooleanExpression=Expresi\u00F3n booleana incorrecta: {0}
 ManageJenkinsAction.DisplayName=Administrar Jenkins
-Computer.NoSuchSlaveExists=El nodo {0} no existe. \uFFFDQuiz\uFFFDs se est\uFFFD refiriendo a {1}?
-ResultTrend.StillFailing=Todav\uFFFDa falla
-Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de l\uFFFDnea.
+Computer.NoSuchSlaveExists=El nodo {0} no existe. \u00BFQuiz\u00E1s se est\u00E9 refiriendo a {1}?
+ResultTrend.StillFailing=Todav\u00EDa falla
+Computer.DisconnectPermission.Description=Este permiso permite que los usuarios puedan desconectar nodos o marcarlos como fuera de l\u00EDnea.
 Computer.CreatePermission.Description=Este permiso permite que los usuarios puedan crear nuevos nodos.
-ResultTrend.StillUnstable=Todav\uFFFDa inestable
+ResultTrend.StillUnstable=Todav\u00EDa inestable
 View.ReadPermission.Description=Este permiso permite que los usuarion puedan crear vistas (implica acceso de lectura)
 Hudson.RunScriptsPermission.Description=El permiso "run scripts' es necesario para ejecutar scripts de groovy usando la consola groovy o el "cli" de groovy.
 ResultTrend.Fixed=Arreglado
 ResultTrend.Failure=Fallo
 UpdateCenter.PluginCategory.listview-column=Columnas de la lista
 ResultTrend.Aborted=Cancelado
-TextParameterDefinition.DisplayName=Par\uFFFDmetro de texto
-AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ning\uFFFDn nodo que cumpla esta asignaci\uFFFDn. \uFFFDQuiz\uFFFDs se refiera a ''{1}'' en lugar de ''{0}''?
+TextParameterDefinition.DisplayName=Par\u00E1metro de texto
+AbstractProject.AssignedLabelString_NoMatch_DidYouMean=No hay ning\u00FAn nodo que cumpla esta asignaci\u00F3n. \u00BFQuiz\u00E1s se refiera a ''{1}'' en lugar de ''{0}''?
 ResultTrend.Success=Correcto
 AbstractProject.CancelPermission.Description=Este permiso permite que se pueda cancelar un trabajo.
 Run.Summary.NotBuilt=no se ha ejecutado
 AbstractProject.DiscoverPermission.Description=Este permiso garantiza que se pueda descubrir tareas. \
- Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios an\uFFFDnimos a la p\uFFFDgina de login. \
- Sin este permiso, los usuarios an\uFFFDnimos recibir\uFFFDn un error 404, no siendo capaces de descubrir esas tareas.
-Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusi\uFFFDn en los resultados de b\uFFFDsquedas.
+ Siendo de menos valor que el permiso de lectura, permite que puedas redireccionar a usuarios an\u00F3nimos a la p\u00E1gina de login. \
+ Sin este permiso, los usuarios an\u00F3nimos recibir\u00E1n un error 404, no siendo capaces de descubrir esas tareas.
+Jenkins.CheckDisplayName.NameNotUniqueWarning=El nombre "{0}" ya se usa para el numbre de una tarea, lo que puede producir confusi\u00F3n en los resultados de b\u00FAsquedas.
 ResultTrend.NotBuilt=Sin ejecutar
 ResultTrend.NowUnstable=Ahora es inestable
 AbstractBuild.BuildingInWorkspace=en el espacio de trabajo {0}
 Descriptor.From=(desde <a href="{1}">{0}</a>)
 ResultTrend.Unstable=Inestable
-Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se est\uFFFD usando en otro trabajo, pudiendo producir confusi\uFFFDn.
+Jenkins.CheckDisplayName.DisplayNameNotUniqueWarning=El nombre "{0}" ya se est\u00E1 usando en otro trabajo, pudiendo producir confusi\u00F3n.
 AbstractProject.WipeOutPermission.Description=Este permiso permite que se pueda borrar todo el contenido del espacio de trabajo de una tarea.
-UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activar\uFFFD en el pr\uFFFDximo arranque.
+UpdateCenter.DownloadButNotActivated=Descarga correcta. Se activar\u00E1 en el pr\u00F3ximo arranque.
 Computer.ConnectPermission.Description=Este permiso permite que los usuarios puedan conectar nodos o marcarlos como activos.
 BallColor.NotBuilt=Sin ejecutar.
 AbstractBuild_Building=Ejecutando.
-ParametersDefinitionProperty.DisplayName=Esta ejecuci\uFFFDn debe parametrizarse
+ParametersDefinitionProperty.DisplayName=Esta ejecuci\u00F3n debe parametrizarse

--- a/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengthening.java
+++ b/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengthening.java
@@ -1,0 +1,80 @@
+package hudson.model.queue;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Messages;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.labels.LabelExpression;
+import hudson.slaves.DumbSlave;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import java.util.logging.Level;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+public class MaintainCanTakeStrengthening {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule().record(Node.class.getName(), Level.ALL).capture(100);
+
+    private QueueTaskFuture scheduleBuild(String name, String label) throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject(name);
+
+        project.setAssignedLabel(LabelExpression.get(label));
+        return project.scheduleBuild2(0);
+    }
+
+    @Issue("JENKINS-59886")
+    @Test
+    public void testExceptionOnNodeProperty() throws Exception {
+        // A node throwing the exception because of the canTake method of the attached FaultyNodeProperty
+        DumbSlave faultyAgent = r.createOnlineSlave(LabelExpression.get("faulty"));
+        faultyAgent.getNodeProperties().add(new FaultyNodeProperty());
+
+        // A good agent
+        r.createOnlineSlave(LabelExpression.get("good"));
+
+        // Only the good ones will be run and the latest doesn't get hung because of the second
+        QueueTaskFuture[] taskFuture = new QueueTaskFuture[3];
+        taskFuture[0] = scheduleBuild("good1", "good");
+        taskFuture[1] = scheduleBuild("theFaultyOne", "faulty");
+        taskFuture[2] = scheduleBuild("good2", "good");
+
+        // Wait until the good ones are completed
+        while (r.getInstance().getQueue().getLeftItems().size() < 2) {
+            Thread.sleep(200);
+
+            // Forcing rescheduling
+            r.getInstance().getQueue().maintain();
+        }
+
+        // The faulty one is still in the queue
+        assertThat(r.getInstance().getQueue().getBuildableItems().get(0).task.getName(), equalTo("theFaultyOne"));
+        // The good ones are completed
+        r.assertBuildStatusSuccess(taskFuture[0]);
+        r.assertBuildStatusSuccess(taskFuture[2]);
+
+        // The new error is shown in the logs
+        assertThat(logging.getMessages(), hasItem(Messages._Queue_ExceptionCanTakeLog(faultyAgent.getDisplayName(), "theFaultyOne").toString()));
+    }
+
+    /**
+     * A node property throwing an exception to cause the canTake method fails.
+     */
+    @TestExtension
+    public static class FaultyNodeProperty extends hudson.slaves.NodeProperty<Node> {
+        @Override
+        public CauseOfBlockage canTake(Queue.BuildableItem item) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+    }
+}

--- a/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengthening.java
+++ b/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengthening.java
@@ -51,8 +51,6 @@ public class MaintainCanTakeStrengthening {
 
         // Wait until the good ones are completed
         while (r.getInstance().getQueue().getLeftItems().size() < 2) {
-            Thread.sleep(200);
-
             // Forcing rescheduling
             r.getInstance().getQueue().maintain();
         }

--- a/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengtheningTest.java
+++ b/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengtheningTest.java
@@ -60,7 +60,7 @@ public class MaintainCanTakeStrengtheningTest {
         assertThat(r.getInstance().getQueue().getBuildableItems().get(0).task.getName(), equalTo("theFaultyOne"));
 
         // The new error is shown in the logs
-        assertThat(logging.getMessages(), hasItem(Messages._Queue_ExceptionCanTakeLog(faultyAgent.getDisplayName(), "theFaultyOne").toString()));
+        assertThat(logging.getMessages(), hasItem(String.format("Exception evaluating if the node '%s' can take the task '%s'", new Object[]{faultyAgent.getDisplayName(), "theFaultyOne"})));
     }
 
     /**

--- a/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengtheningTest.java
+++ b/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengtheningTest.java
@@ -55,7 +55,8 @@ public class MaintainCanTakeStrengtheningTest {
         taskFuture[0].getStartCondition().get(15, TimeUnit.SECONDS);
         taskFuture[2].getStartCondition().get(15, TimeUnit.SECONDS);
 
-        // The faulty one is still in the queue
+        // The faulty one is the only one in the queue
+        assertThat(r.getInstance().getQueue().getBuildableItems().size(), equalTo(1));
         assertThat(r.getInstance().getQueue().getBuildableItems().get(0).task.getName(), equalTo("theFaultyOne"));
 
         // The new error is shown in the logs


### PR DESCRIPTION


<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-59886](https://issues.jenkins-ci.org/browse/JENKINS-59886).

Strengthen the `canTake` and `canRun` methods of Queue and Node to avoid that a faulty implementer may hang the queue if it throws an exception.

I push a commit with a test that will fail with an exception thrown because of this issue and the code commented.

After the CI fails, I will push a new commit uncommenting the code.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Improvement, Avoid hanging the jobs queue due to faulty plugins
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [N/A] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->
N/A
### Desired reviewers
@varyvol @fcojfernandez @jenkinsci/core-pr-reviewers @rsandell @alecharp 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
