### PR TITLE
[JENKINS-58625] Cancel older builds of a given branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,8 @@
  * It makes assumptions about plugins being installed, labels mapping to nodes that can build what is needed, etc.
  */
 
+def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumber - 1); milestone(buildNumber) // JENKINS-43353 / JENKINS-58625
+
 // TEST FLAG - to make it easier to turn on/off unit tests for speeding up access to later stuff.
 def runTests = true
 def failFast = false


### PR DESCRIPTION
I noticed three builds of #4178 running, which is pointless. There is not much purpose in wasting CI resources on older builds of a PR or `master`, especially since these builds are so expensive and our server capacity is limited. The downside is that if you are rapidly iterating on a PR which introduces test failures in surprising places, you will not find out about them until [at least two hours](https://ci.jenkins.io/job/Core/job/jenkins/job/master/buildTimeTrend) after you stop pushing changes.

This idiom is already in use in `jenkinsci/bom`. Arguably it should be added to `buildPlugin` too.

Internal only; no changelog entry required.