### PR TITLE
[JENKINS-59904] avoid NullPointerException when there are no cookies in the request

### DIFF
--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -325,14 +325,17 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
          * responsibility not to send them to us in the first place.
          */
         final String cookieName = "JSESSIONID.";
-        for (Cookie cookie : req.getCookies()) {
-            if (cookie.getName().startsWith(cookieName)) {
-                LOGGER.log(Level.FINE, "Removing cookie {0} during logout", cookie.getName());
-                // one reason users log out is to clear their session(s)
-                // so tell the browser to drop all old sessions
-                cookie.setMaxAge(0);
-                cookie.setValue("");
-                rsp.addCookie(cookie);
+        Cookie[] cookies = req.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().startsWith(cookieName)) {
+                    LOGGER.log(Level.FINE, "Removing cookie {0} during logout", cookie.getName());
+                    // one reason users log out is to clear their session(s)
+                    // so tell the browser to drop all old sessions
+                    cookie.setMaxAge(0);
+                    cookie.setValue("");
+                    rsp.addCookie(cookie);
+                }
             }
         }
     }


### PR DESCRIPTION
avoid NullPointerException when there are no cookies in the request.

See [JENKINS-59904](https://issues.jenkins-ci.org/browse/JENKINS-59904).

Very simple change in a private method of a class that has no tests at all so far. So no tests added.

Not sure if this needs to be reported in the changelog. This issue will be hardly encountered by anyone.

### Proposed changelog entries

* Entry 1: JENKINS-59904, avoid NPE during logout without cookies

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
