### PR TITLE
[JENKINS-59844] Process Launcher shouldn't throw ArrayIndexOutOfBoundException on empty command

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -455,7 +455,7 @@ public abstract class Launcher {
          */
         public Proc start() throws IOException {
             if (cmds().isEmpty()) {
-                LOGGER.log(Level.INFO, "Trying to start a process without setting a command. This might cause "
+                LOGGER.log(Level.WARNING, "Trying to start a process without setting a command. This might cause "
                                        + "an ArrayIndexOutOfBounds exception");
             }
             return launch(this);

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -452,6 +452,10 @@ public abstract class Launcher {
          * Starts the new process as configured.
          */
         public Proc start() throws IOException {
+            if(cmds().isEmpty()){
+                LOGGER.log(Level.INFO, "Trying to start a process without setting a command. This might cause "
+                                       + "an unexpected exception");
+            }
             return launch(this);
         }
 

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -454,7 +454,7 @@ public abstract class Launcher {
          * @throws RuntimeException can be thrown if {@link #cmds()} is empty
          */
         public Proc start() throws IOException {
-            if(cmds().isEmpty()){
+            if (cmds().isEmpty()) {
                 LOGGER.log(Level.INFO, "Trying to start a process without setting a command. This might cause "
                                        + "an unexpected exception");
             }

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -450,6 +450,8 @@ public abstract class Launcher {
 
         /**
          * Starts the new process as configured.
+         *
+         * @throws RuntimeException can be thrown if {@link #cmds()} is empty
          */
         public Proc start() throws IOException {
             if(cmds().isEmpty()){
@@ -703,6 +705,8 @@ public abstract class Launcher {
 
     /**
      * Primarily invoked from {@link ProcStarter#start()} to start a process with a specific launcher.
+     *
+     * @throws RuntimeException can be thrown if {@link ProcStarter#cmds()} is empty
      */
     public abstract Proc launch(@Nonnull ProcStarter starter) throws IOException;
 

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -451,12 +451,12 @@ public abstract class Launcher {
         /**
          * Starts the new process as configured.
          *
-         * @throws RuntimeException can be thrown if {@link #cmds()} is empty
+         * @throws ArrayIndexOutOfBoundsException when {@link #cmds()} is empty
          */
         public Proc start() throws IOException {
             if (cmds().isEmpty()) {
                 LOGGER.log(Level.INFO, "Trying to start a process without setting a command. This might cause "
-                                       + "an unexpected exception");
+                                       + "an ArrayIndexOutOfBounds exception");
             }
             return launch(this);
         }
@@ -706,7 +706,7 @@ public abstract class Launcher {
     /**
      * Primarily invoked from {@link ProcStarter#start()} to start a process with a specific launcher.
      *
-     * @throws RuntimeException can be thrown if {@link ProcStarter#cmds()} is empty
+     * @throws ArrayIndexOutOfBoundsException when {@link ProcStarter#cmds()} is empty
      */
     public abstract Proc launch(@Nonnull ProcStarter starter) throws IOException;
 

--- a/test/src/test/java/hudson/ProcStarterTest.java
+++ b/test/src/test/java/hudson/ProcStarterTest.java
@@ -45,7 +45,6 @@ import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.tasks.Builder;
 
-
 /**
  * Contains tests for {@link ProcStarter} class.
  * @author Oleg Nenashev, Synopsys Inc.

--- a/test/src/test/java/hudson/ProcStarterTest.java
+++ b/test/src/test/java/hudson/ProcStarterTest.java
@@ -98,8 +98,6 @@ public class ProcStarterTest {
 
         //The command is invalid, it should fail
         rule.assertBuildStatus(Result.FAILURE, run);
-        //But the error shouldn't be this exception
-        rule.assertLogNotContains("ArrayIndexOutOfBoundsException", run);
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-59844](https://issues.jenkins-ci.org/browse/JENKINS-59844).

### Proposed changelog entries

* Entry 1: internal: Log when Launcher is invoked with an empty command, informing that it can throw an unexpected exception

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developers, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention @MRamonLeon 
