### PR TITLE
Switch Release Drafter to GitHub Actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,18 @@
+# Automates creation of changelog drafts using Release Drafter
+# More Info: https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+name: Changelog Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: oleg-nenashev/jenkins-release-drafter@v5.2.0-jenkins-4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: oleg-nenashev/jenkins-release-drafter@v5.2.0-jenkins-4
+      - uses: release-drafter/release-drafter@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Foundation change for enabling changelog automation for the Jenkins core.
See https://groups.google.com/forum/#!topic/jenkinsci-dev/kVjOddydLEI from @daniel-beck for the context.

My goal is to finalize the changelogs to make them ready-to-go so that we can have automagic deployment later