### PR TITLE
[JENKINS-57304] - Add call to oneOffExecutors.remove in Computer.removeExecutor

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1097,6 +1097,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             public void run() {
                 synchronized (Computer.this) {
                     executors.remove(e);
+                    oneOffExecutors.remove(e);
                     addNewExecutorIfNecessary();
                     if (!isAlive()) {
                         AbstractCIBase ciBase = Jenkins.getInstanceOrNull();


### PR DESCRIPTION
This PR attempts to stop "zombie executors" from appearing in the status list.

There are several issues describing this problem, for instance [JENKINS-55484](https://issues.jenkins-ci.org/browse/JENKINS-55484), [JENKINS-55811](https://issues.jenkins-ci.org/browse/JENKINS-55811), [JENKINS-57304](https://issues.jenkins-ci.org/browse/JENKINS-57304). I am not certain that this PR fixes all of these issues.

It is possible to reliably create these zombie executors:
- Install Jenkins with SSH Slave + Pipeline plugins
- Configure an SSH Slave and set amount of master executors to 0
- Create a pipeline job
- **Turn off (temporarily mark offline) the master node & trigger the pipeline job**
- Re-enable the master node
- One zombie executor for each time the build now button was pressed has been created

The issue is the one-off executor not being removed in https://github.com/jenkinsci/jenkins/blob/a8853c26e2d395aaa3a03461c3ab6daf6ffbeb68/core/src/main/java/hudson/model/Executor.java#L322 The easiest fix would be to also remove items from oneOffExecutors.


### Proposed changelog entries

* Computer.removeExecutor now also removes one-off executors