### PR TITLE
Add note to run mvn hudson-dev:run to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,17 @@ If you want to debug this WAR file without using Maven plugins,
 You can just start the executable with [Remote Debug Flags]
 and then attach IDE Debugger to it.
 
+To compile and launch a development instance, run:
+
+    mvn hudson-dev:run
+
+<!--
+This should be `mvn hudson-dev:run` as long as JENKINS-23364 is not resolved.
+For jenkis-dev:run it is currently necessary to add `org.jenkins-ci.tools` as a plugin group
+to the maven settings.xml.
+See also https://github.com/jenkinsci/jenkins/pull/4331#discussion_r341041470
+-->
+
 ## Testing changes
 
 Jenkins core includes unit and functional tests as a part of the repository.


### PR DESCRIPTION
As I'm new to the Jenkins source, I found it hard to just launch a Jenkins instance, I could not find a documentation for this command except in the source code.
Is this the recommended command used for hacking on Jenkins core?


<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).
-->

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Internal: Add note to run mvn hudson-dev:run to CONTRIBUTING.md

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
Documentation update
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
