### PR TITLE
Replaced SCMDescriptor#generation integer with AtomicInteger to fix the concurrency issue reported by SpotBugs

### DIFF
--- a/core/src/main/java/hudson/scm/AutoBrowserHolder.java
+++ b/core/src/main/java/hudson/scm/AutoBrowserHolder.java
@@ -60,7 +60,7 @@ final class AutoBrowserHolder {
             cacheGeneration = -1;
             return cache;
         }
-        int g = d.generation;
+        int g = d.generation.get();
         if(g!=cacheGeneration) {
             cacheGeneration = g;
             cache = infer();

--- a/core/src/main/java/hudson/scm/AutoBrowserHolder.java
+++ b/core/src/main/java/hudson/scm/AutoBrowserHolder.java
@@ -60,7 +60,7 @@ final class AutoBrowserHolder {
             cacheGeneration = -1;
             return cache;
         }
-        int g = d.generation.get();
+        int g = d.getGeneration();
         if(g!=cacheGeneration) {
             cacheGeneration = g;
             cache = infer();

--- a/core/src/main/java/hudson/scm/SCMDescriptor.java
+++ b/core/src/main/java/hudson/scm/SCMDescriptor.java
@@ -54,16 +54,7 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
      */
     public transient final Class<? extends RepositoryBrowser> repositoryBrowser;
 
-    /**
-     * Incremented every time a new {@link SCM} instance is created from this descriptor. 
-     * This is used to invalidate cache of {@link SCM#getEffectiveBrowser}. Due to the lack of synchronization and serialization,
-     * this field doesn't really count the # of instances created to date,
-     * but it's good enough for the cache invalidation.
-     * @deprecated No longer used by default.
-     */
-    @Deprecated
-    @Restricted(NoExternalUse.class) @RestrictedSince("TODO")
-    public final AtomicInteger generation = new AtomicInteger(1);
+    private final AtomicInteger generation = new AtomicInteger(1);
 
     protected SCMDescriptor(Class<T> clazz, Class<? extends RepositoryBrowser> repositoryBrowser) {
         super(clazz);
@@ -79,6 +70,29 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
      */
     protected SCMDescriptor(Class<? extends RepositoryBrowser> repositoryBrowser) {
         this.repositoryBrowser = repositoryBrowser;
+    }
+
+    /**
+     * Incremented every time a new {@link SCM} instance is created from this descriptor.
+     * This is used to invalidate cache of {@link SCM#getEffectiveBrowser}. Due to the lack of synchronization and serialization,
+     * this field doesn't really count the # of instances created to date,
+     * but it's good enough for the cache invalidation.
+     * @deprecated No longer used by default.
+     */
+    @Deprecated
+    @Restricted(NoExternalUse.class) @RestrictedSince("TODO")
+    public int getGeneration() {
+        return generation.get();
+    }
+
+    /**
+     * Increments the generation value {@Link SCMDescriptor#getGeneration} by one atomically.
+     * @deprecated No longer used by default.
+     */
+    @Deprecated
+    @Restricted(NoExternalUse.class) @RestrictedSince("TODO")
+    public void incrementGeneration() {
+        generation.incrementAndGet();
     }
 
     // work around HUDSON-4514. The repositoryBrowser field was marked as non-transient until 1.325,

--- a/core/src/main/java/hudson/scm/SCMDescriptor.java
+++ b/core/src/main/java/hudson/scm/SCMDescriptor.java
@@ -86,7 +86,7 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
     }
 
     /**
-     * Increments the generation value {@Link SCMDescriptor#getGeneration} by one atomically.
+     * Increments the generation value {@link SCMDescriptor#getGeneration} by one atomically.
      * @deprecated No longer used by default.
      */
     @Deprecated

--- a/core/src/main/java/hudson/scm/SCMDescriptor.java
+++ b/core/src/main/java/hudson/scm/SCMDescriptor.java
@@ -31,6 +31,8 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 import static java.util.logging.Level.WARNING;
+
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 /**
@@ -56,7 +58,7 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
      * @deprecated No longer used by default.
      */
     @Deprecated
-    public volatile int generation = 1;
+    public volatile AtomicInteger generation = new AtomicInteger(1);
 
     protected SCMDescriptor(Class<T> clazz, Class<? extends RepositoryBrowser> repositoryBrowser) {
         super(clazz);

--- a/core/src/main/java/hudson/scm/SCMDescriptor.java
+++ b/core/src/main/java/hudson/scm/SCMDescriptor.java
@@ -63,7 +63,7 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
      */
     @Deprecated
     @Restricted(NoExternalUse.class) @RestrictedSince("TODO")
-    public volatile AtomicInteger generation = new AtomicInteger(1);
+    public final AtomicInteger generation = new AtomicInteger(1);
 
     protected SCMDescriptor(Class<T> clazz, Class<? extends RepositoryBrowser> repositoryBrowser) {
         super(clazz);

--- a/core/src/main/java/hudson/scm/SCMDescriptor.java
+++ b/core/src/main/java/hudson/scm/SCMDescriptor.java
@@ -23,10 +23,14 @@
  */
 package hudson.scm;
 
+import hudson.RestrictedSince;
 import hudson.Util;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.model.Job;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
@@ -58,6 +62,7 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
      * @deprecated No longer used by default.
      */
     @Deprecated
+    @Restricted(NoExternalUse.class) @RestrictedSince("TODO")
     public volatile AtomicInteger generation = new AtomicInteger(1);
 
     protected SCMDescriptor(Class<T> clazz, Class<? extends RepositoryBrowser> repositoryBrowser) {

--- a/core/src/main/java/hudson/scm/SCMS.java
+++ b/core/src/main/java/hudson/scm/SCMS.java
@@ -60,7 +60,7 @@ public class SCMS {
         if (scm == null) {
             scm = new NullSCM(); // JENKINS-36043 workaround for AbstractMultiBranchProject.submit
         }
-        scm.getDescriptor().generation.incrementAndGet();
+        scm.getDescriptor().incrementGeneration();
         return scm;
     }
 

--- a/core/src/main/java/hudson/scm/SCMS.java
+++ b/core/src/main/java/hudson/scm/SCMS.java
@@ -60,7 +60,7 @@ public class SCMS {
         if (scm == null) {
             scm = new NullSCM(); // JENKINS-36043 workaround for AbstractMultiBranchProject.submit
         }
-        scm.getDescriptor().generation++;
+        scm.getDescriptor().generation.incrementAndGet();
         return scm;
     }
 


### PR DESCRIPTION
Replaced integer with AtomicInteger to fix spotbugs issue [vo-volatile-increment](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#vo-an-increment-to-a-volatile-field-isn-t-atomic-vo-volatile-increment) in SCMS class

### Proposed changelog entries

* Fix the potential synchronization issue in SCMDescriptor#generation. The field was changed from public to private, and new API methods were added to allow accessing it
