### PR TITLE
Upgrade to 3.36 version of Remoting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3.35</remoting.version>
+    <remoting.version>3.36</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 


### PR DESCRIPTION
Minor maintenance improvements. The only change involves adding command-line parameters for "-help" and "-version". No changes to existing functionality. None of the changes were significant enough to need a Jira filed.

See the [Remoting changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-3.36)
### Proposed changelog entries

* Update Remoting from 3.35 to 3.36 for minor maintenance improvements and two new command line options "-help" and "-version".. ([full changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-3.36))

### Submitter checklist

- [n/a] JIRA issue is well described
- [*] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
