### PR TITLE
Add more data points to MultiStageTimeSeries

### DIFF
--- a/core/src/main/java/hudson/model/MultiStageTimeSeries.java
+++ b/core/src/main/java/hudson/model/MultiStageTimeSeries.java
@@ -60,10 +60,6 @@ import javax.servlet.ServletException;
 /**
  * Maintains several {@link TimeSeries} with different update frequencies to satisfy three goals;
  * (1) retain data over long timespan, (2) save memory, and (3) retain accurate data for the recent past.
- *
- * All in all, one instance uses about 8KB space.
- *
- * @author Kohsuke Kawaguchi
  */
 @ExportedBean
 public class MultiStageTimeSeries implements Serializable {
@@ -101,9 +97,9 @@ public class MultiStageTimeSeries implements Serializable {
     public MultiStageTimeSeries(Localizable title, Color color, float initialValue, float decay) {
         this.title = title;
         this.color = color;
-        this.sec10 = new TimeSeries(initialValue,decay,6*60);
-        this.min = new TimeSeries(initialValue,decay,60*24);
-        this.hour = new TimeSeries(initialValue,decay,28*24);
+        this.sec10 = new TimeSeries(initialValue, decay, 6 * (int) TimeUnit.HOURS.toMinutes(6));
+        this.min = new TimeSeries(initialValue, decay, (int) TimeUnit.DAYS.toMinutes(2));
+        this.hour = new TimeSeries(initialValue, decay, (int) TimeUnit.DAYS.toHours(56));
     }
 
     /**


### PR DESCRIPTION
Record more data for MultiStageTimeSeries to make especially the 10sec and hourly resolutions more useful.

Compare the number of visible data points:

### Before:

* [360 for 10 second resolution for 1 hr of data](https://ci.jenkins.io/load-statistics?type=sec10)
* [1440 for minute resolution for 1 day of data](https://ci.jenkins.io/load-statistics?type=min)
* [672 for hour resolution for 4 weeks of data](https://ci.jenkins.io/load-statistics?type=hour) (not shown fully due to restart)

### After:

* 2160 for 10 second resolution for 6 hrs of data (6x)
* 2880 for minute resolution for 2 days of data (2x)
* 1344 for hour resolution for 8 weeks of data (2x, should be unusual but whatever)

If memory usage is linear, this would increase the memory needed from 8KB per the removed comment to around 20KB, or 2.5x that.

Untested.

### Proposed changelog entries

* Increase the number of datapoints recorded for multistage time series graphs such as those used for load statistics to display data for 6 hours, 48 hours, and 56 days (up from 1 hour, 24 hours, and 28 days).

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs
