### PR TITLE
[JENKINS-59631] Fix styling issue in build history table

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -457,9 +457,10 @@ td.pane {
   vertical-align: middle;
 }
 
-table.stripped tr:nth-child(even) {
+table.stripped tr:nth-of-type(even) {
   background: #fbfbfb;
 }
+
 table.stripped-even tr:nth-child(even) {
   background: #fbfbfb;
 }


### PR DESCRIPTION
See [JENKINS-59631 ](https://issues.jenkins-ci.org/browse/JENKINS-59631 ).

As this is a UI change,no test have been written.

### Proposed changelog entries

* Update style.css to use nth of child property instead of nth child for the 'table' classe

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@daniel-beck 

