### PR TITLE
Fix misspellings in doc for hudson.model.Cause

### DIFF
--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -47,7 +47,7 @@ import javax.annotation.Nonnull;
 /**
  * Cause object base class.  This class hierarchy is used to keep track of why
  * a given build was started. This object encapsulates the UI rendering of the cause,
- * as well as providing more useful information in respective subypes.
+ * as well as providing more useful information in respective subtypes.
  *
  * The Cause object is connected to a build via the {@link CauseAction} object.
  *


### PR DESCRIPTION
Please merge as this fixes bad documentation in the class.