### PR TITLE
[JENKINS-59793] Avoid hanging jobs with faulty SubTasks

### DIFF
--- a/core/src/main/java/hudson/model/queue/WorkUnitContext.java
+++ b/core/src/main/java/hudson/model/queue/WorkUnitContext.java
@@ -108,12 +108,17 @@ public final class WorkUnitContext {
      * All the {@link Executor}s that jointly execute a {@link Task} call this method to synchronize on the start.
      */
     public void synchronizeStart() throws InterruptedException {
-        startLatch.synchronize();
-        // the main thread will send a notification
-        Executor e = Executor.currentExecutor();
-        WorkUnit wu = e.getCurrentWorkUnit();
-        if (wu.isMainWork()) {
-            future.start.set(e.getCurrentExecutable());
+        // Let code waiting for the start (future.start.get()) finishes when there is a faulty SubTask by setting the
+        // future always.
+        try {
+            startLatch.synchronize();
+        } finally {
+            // the main thread will send a notification
+            Executor e = Executor.currentExecutor();
+            WorkUnit wu = e.getCurrentWorkUnit();
+            if (wu.isMainWork()) {
+                future.start.set(e.getCurrentExecutable());
+            }
         }
     }
 
@@ -130,17 +135,21 @@ public final class WorkUnitContext {
      *      the member threads will report {@link InterruptedException}.
      */
     public void synchronizeEnd(Executor e, Queue.Executable executable, Throwable problems, long duration) throws InterruptedException {
-        endLatch.synchronize();
-
-        // the main thread will send a notification
-        WorkUnit wu = e.getCurrentWorkUnit();
-        if (wu.isMainWork()) {
-            if (problems == null) {
-                future.set(executable);
-                e.getOwner().taskCompleted(e, task, duration);
-            } else {
-                future.set(problems);
-                e.getOwner().taskCompletedWithProblems(e, task, duration, problems);
+        // Let code waiting for the build to finish (future.get()) finishes when there is a faulty SubTask by setting 
+        // the future always.
+        try {
+            endLatch.synchronize();
+        } finally {
+            // the main thread will send a notification
+            WorkUnit wu = e.getCurrentWorkUnit();
+            if (wu.isMainWork()) {
+                if (problems == null) {
+                    future.set(executable);
+                    e.getOwner().taskCompleted(e, task, duration);
+                } else {
+                    future.set(problems);
+                    e.getOwner().taskCompletedWithProblems(e, task, duration, problems);
+                }
             }
         }
     }

--- a/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
+++ b/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
@@ -1,7 +1,6 @@
 package hudson.model.queue;
 
 import hudson.model.AbstractProject;
-import hudson.model.Executor;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
@@ -12,39 +11,32 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class BuildKeepsRunningWhenFaultySubTasksTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
-    
-    @Rule
-    public LoggerRule logs = new LoggerRule().record(Executor.class.getName(), Level.SEVERE).capture(100); //just in case future versions add more logs
 
     public static final String ERROR_MESSAGE = "My unexpected exception";
     
     // When using SubTaskContributor (FailingSubTaskContributor) the build never ends
     @Test
     @Issue("JENKINS-59793")
-    public void buildDoesntFinishWhenSubTaskFails() throws Exception {
+    public void buildFinishesWhenSubTaskFails() throws Exception {
         FreeStyleProject p = j.createProject(FreeStyleProject.class);
         QueueTaskFuture<FreeStyleBuild> future = p.scheduleBuild2(0);
         assertThat("Build should be actually scheduled by Jenkins", future, notNullValue());
 
-        // We get stalled waiting the finalization of the job
-        FreeStyleBuild build = future.get(5, TimeUnit.SECONDS);
-        assertTrue("The message is printed in the log", logs.getRecords().stream().anyMatch(r -> r.getThrown().getMessage().equals(ERROR_MESSAGE)));
+        // We don't get stalled waiting the finalization of the job
+        future.get(5, TimeUnit.SECONDS);
     }
     
     // A SubTask failing with an exception

--- a/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
+++ b/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
@@ -1,0 +1,105 @@
+package hudson.model.queue;
+
+import hudson.model.AbstractProject;
+import hudson.model.Executor;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.ResourceList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class BuildKeepsRunningWhenFaultySubTasksTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    @Rule
+    public LoggerRule logs = new LoggerRule().record(Executor.class.getName(), Level.SEVERE).capture(100); //just in case future versions add more logs
+
+    public static final String ERROR_MESSAGE = "My unexpected exception";
+    
+    // When using SubTaskContributor (FailingSubTaskContributor) the build never ends
+    @Test
+    @Issue("JENKINS-59793")
+    public void buildDoesntFinishWhenSubTaskFails() throws Exception {
+        FreeStyleProject p = j.createProject(FreeStyleProject.class);
+        QueueTaskFuture<FreeStyleBuild> future = p.scheduleBuild2(0);
+        assertThat("Build should be actually scheduled by Jenkins", future, notNullValue());
+
+        // We get stalled waiting the finalization of the job
+        FreeStyleBuild build = future.get(5, TimeUnit.SECONDS);
+        assertTrue("The message is printed in the log", logs.getRecords().stream().anyMatch(r -> r.getThrown().getMessage().equals(ERROR_MESSAGE)));
+    }
+    
+    // A SubTask failing with an exception
+    @TestExtension
+    public static class FailingSubTaskContributor extends SubTaskContributor {
+        @Override
+        public Collection<? extends SubTask> forProject(final AbstractProject<?, ?> p) {
+            return Collections.singleton(new SubTask() {
+                private final SubTask outer = this;
+
+                public Queue.Executable createExecutable() throws IOException {
+                    return new Queue.Executable() {
+                        public SubTask getParent() {
+                            return outer;
+                        }
+
+                        public void run() {
+                            throw new ArrayIndexOutOfBoundsException(ERROR_MESSAGE);
+                        }
+
+                        public long getEstimatedDuration() {
+                            return 0;
+                        }
+                    };
+                }
+
+                @Override
+                public Label getAssignedLabel() {
+                    return null;
+                }
+                @Override
+                public Node getLastBuiltOn() {
+                    return null;
+                }
+                @Override
+                public long getEstimatedDuration() {
+                    return 0;
+                }
+                @Override
+                public Queue.Task getOwnerTask() {
+                    return p;
+                }
+                @Override
+                public Object getSameNodeConstraint() {
+                    return null;
+                }
+                @Override
+                public ResourceList getResourceList() {
+                    return ResourceList.EMPTY;
+                }
+                @Override
+                public String getDisplayName() {
+                    return "Subtask of " + p.getDisplayName();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-59793](https://issues.jenkins-ci.org/browse/JENKINS-59793).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->
I have created a test to reproduce the status reached by several private Jenkins instances which have thousand of *Metric Plugin* threads (_QueueSubTaskMetrics_) running. It's all because if a Job has faulty SubTasks (throwing an unmanaged exception), the `future` object is not set in the _**WorkUnitContext#synchronizeEnd**_ method. It may also happen in WorkUnitContext#synchronizeStart but I have not reproduced this case).

Whatever code that keeps waiting for the start or the end of the build will stay there forever. The Metrics Plugin is impacted by this here:
* Waiting for the build to finish: https://github.com/jenkinsci/metrics-plugin/blob/24bf92ebd59095d8f77b2552696b3f210a024bdc/src/main/java/jenkins/metrics/impl/JenkinsMetricProviderImpl.java#L1142

Called from: https://github.com/jenkinsci/metrics-plugin/blob/24bf92ebd59095d8f77b2552696b3f210a024bdc/src/main/java/jenkins/metrics/impl/JenkinsMetricProviderImpl.java#L944

I will let the CI fail and then I will push the fix.

### Proposed changelog entries

* Entry 1: Improve the resilience to faulty subtask contributors which may keep the build running forever.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [X] Appropriate autotests or explanation to why this change has no tests
- [N/A] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck @varyvol @batmat @alecharp @rsandell @fcojfernandez @stephenc 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
