### PR TITLE
[JENKINS-60098] - Upgrade to winstone 5.4 to take advantage of Jetty 9.4.22

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -101,7 +101,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>5.3</version>
+      <version>5.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Signed-off-by: olivier lamy <olamy@apache.org>

See [JENKINS-60098](https://issues.jenkins-ci.org/browse/JENKINS-60098).

### Proposed changelog entries

* Upgrade to winstone 5.4 to take advantage of Jetty 9.4.22 release (https://github.com/jenkinsci/winstone/blob/master/CHANGELOG.md#54)

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
