### PR TITLE
[JENKINS-60056] Improve Plugin Manager filter usability

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
         <st:adjunct includes="hudson.PluginManager._table"/>
         <div id="filter-container">
             ${%Filter}:
-            <input type="text" id="filter-box"/>
+            <input type="text" id="filter-box" disabled="disabled"/>
         </div>
 
       <j:if test="${app.updateCenter.isRestartRequiredForCompletion()}">

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -52,7 +52,7 @@ THE SOFTWARE.
       
       <div id="filter-container">
         ${%Filter}:
-        <input type="text" id="filter-box"/>
+        <input type="text" id="filter-box" disabled="disabled"/>
       </div>
 
       <form method="post" action="install">

--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -52,7 +52,8 @@ var Sortable = (function() {
 
         var firstRow = this.getFirstRow();
         if (!firstRow) return;
-
+        // Unlock the filter
+        document.getElementById("filter-box").removeAttribute("disabled");
         // We have a first row: assume it's the header, and make its contents clickable links
         firstRow.each(function (cell){
             cell.innerHTML = '<a href="#" class="sortheader">'+this.getInnerText(cell)+'<span class="sortarrow"></span></a>';

--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -52,7 +52,7 @@ var Sortable = (function() {
 
         var firstRow = this.getFirstRow();
         if (!firstRow) return;
-        // Unlock the filter
+        // Active the filter
         document.getElementById("filter-box").removeAttribute("disabled");
         // We have a first row: assume it's the header, and make its contents clickable links
         firstRow.each(function (cell){

--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -53,7 +53,10 @@ var Sortable = (function() {
         var firstRow = this.getFirstRow();
         if (!firstRow) return;
         // Active the filter
-        document.getElementById("filter-box").removeAttribute("disabled");
+        if(document.getElementById("filter-box") !== null && document.getElementById("filter-box").hasAttribute("disabled")){
+            document.getElementById("filter-box").removeAttribute("disabled");
+        }
+        
         // We have a first row: assume it's the header, and make its contents clickable links
         firstRow.each(function (cell){
             cell.innerHTML = '<a href="#" class="sortheader">'+this.getInnerText(cell)+'<span class="sortarrow"></span></a>';


### PR DESCRIPTION
See [JENKINS-60056](https://issues.jenkins-ci.org/browse/JENKINS-60056).


### Proposed changelog entries

* Entry 1: Disabling the search field until the page is fully loaded.
* Entry 2: Applying the filter, if any, once the plugin list is completely available.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers
@daniel-beck @oleg-nenashev

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
