### PR TITLE
[JENKINS-60167] - Fix AtomicFileWriter performance issue on CephFS in case of Empty File creation

### DIFF
--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -149,7 +149,7 @@ public class AtomicFileWriter extends Writer {
             integrityOnClose = false;
         }
 
-        core = new FileChannelWriter(tmpPath, charset, integrityOnFlush, integrityOnClose, StandardOpenOption.WRITE);
+        core = new FileChannelWriter(tmpPath, charset, integrityOnFlush, integrityOnClose, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
     }
 
     @Override


### PR DESCRIPTION
Fix for https://issues.jenkins-ci.org/browse/JENKINS-60167

Need to add StandardOpenOption.CREATE when creating FileChannelWriter to avoid full fs cache flush and 5 second operation Create Empty File(ex RunIdMigration scenario) on CephFS


### Suggested changelog entry

* Fix AtomicFileWriter performance issue on CephFS in case of Empty File creation
