### PR TITLE
[JENKINS-60180] Disable HTTP TRACE

### DIFF
--- a/war/src/main/webapp/WEB-INF/web.xml
+++ b/war/src/main/webapp/WEB-INF/web.xml
@@ -188,6 +188,16 @@ THE SOFTWARE.
     </auth-constraint>
   </security-constraint>
   
+  <!-- Disable TRACE method with security constraint (copied from jetty/webdefaults.xml) -->
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>Disable TRACE</web-resource-name>
+      <url-pattern>/*</url-pattern>
+      <http-method>TRACE</http-method>
+    </web-resource-collection>
+    <auth-constraint />
+  </security-constraint>
+  
   <security-constraint>
     <web-resource-collection>
       <web-resource-name>other</web-resource-name>


### PR DESCRIPTION
Disable the TRACE method in the web.xml to avoid security scanner reporting stuff like this. It could be done in the firewall, WAF or reverse proxy as an alternative.

Please see the description of the ticket for more information.

See [JENKINS-60180](https://issues.jenkins-ci.org/browse/JENKINS-60180).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Disable the HTTP TRACE to prevent security scanner to complain. The risk was huge in 2003, but nowadays the modern browsers forbid the TRACE requests to prevent cross-site tracing (XST) attacks, so there is no real risk.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@omehegan 

