### PR TITLE
Make pipeline container scrollable

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -265,6 +265,16 @@ THE SOFTWARE.
         </div>
       </j:if>
       <div id="main-panel">
+         
+         <h1 class="job-index-headline page-headline">Some title here</h1>
+         ...
+         <div class="cbwf-stage-view">
+            <!-- NOTE: I;'ve just added style="overflow: scroll" part to make container scrollable.
+                       All the rest remailing as it is in the current version. Just made container scrollable.
+            -->
+            <div objecturl='...' cbwf-controller="pipeline-staged" style="overflow: scroll">...</div>
+         </div>
+
          <j:set var="mode" value="main-panel" />
          <d:invokeBody/>
       </div>


### PR DESCRIPTION
Hi,

I've added a hint how to do pipeline container scrollable and more intuitive to use. Currently it becomes too wide when I use many columns and page design becomes broken.

I'm not familiar with the actual template engine and ap logic, but see how it's entered and fixed it in my browser. Now I ask you to make the final change in the code to make this naive error disappear for all of us.

Thank you