### PR TITLE
[JENKINS-60189] - Open plugin and license links on a separate tab

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -79,7 +79,7 @@ THE SOFTWARE.
                   </td>
                   <td class="pane details">
                     <div>
-                      <a href="${p.url}" class="display-name">
+                      <a href="${p.url}" target="_blank" class="display-name">
                         ${p.updateInfo.displayName?:p.displayName}
                       </a>
                     </div>

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -96,7 +96,7 @@ THE SOFTWARE.
                     </td>
                     <td class="pane" data="${h.xmlEscape(p.displayName)}" data-id="${h.xmlEscape(p.name+':'+p.version)}">
                       <div>
-                        <a href="${p.wiki}"><st:out value="${p.displayName}"/></a>
+                        <a href="${p.wiki}" target="_blank"><st:out value="${p.displayName}"/></a>
                       </div>
                       <j:if test="${p.excerpt!=null}">
                         <div class="excerpt"><j:out value="${p.excerpt}" /></div>

--- a/core/src/main/resources/lib/hudson/thirdPartyLicenses.jelly
+++ b/core/src/main/resources/lib/hudson/thirdPartyLicenses.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
     <d:tag name="dependency">
       <tr>
         <td>
-          <a href="${attrs.url}">${attrs.name}</a>
+          <a href="${attrs.url}" target="_blank">${attrs.name}</a>
         </td>
         <td>
           ${attrs.groupId}:${attrs.artifactId}:${attrs.version}
@@ -51,7 +51,7 @@ THE SOFTWARE.
     </d:tag>
     <d:tag name="description"/>
     <d:tag name="license">
-      <a href="${attrs.url}">${attrs.name}</a><br/>
+      <a href="${attrs.url}" target="_blank">${attrs.name}</a><br/>
     </d:tag>
   </d:taglib>
   <d:invokeBody/>


### PR DESCRIPTION
See [JENKINS-60189](https://issues.jenkins-ci.org/browse/JENKINS-60189).

Work on [JENKINS-59679](https://issues.jenkins-ci.org/browse/JENKINS-59679) may have conflicts with this one.


### Proposed changelog entries

* [JENKINS-60189](https://issues.jenkins-ci.org/browse/JENKINS-60189) Minor UI changes.
    Links to plugin and license pages on the plugin manager now open on a separate tab.

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers
