### PR TITLE
Set the HttpOnly flag for the page auto-refresh tokens

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -650,6 +650,7 @@ public class Functions {
             // to avoid conflicts with any other web apps that might be on the same machine.
             c.setPath("/");
             c.setMaxAge(60*60*24*30); // persist it roughly for a month
+            c.setHttpOnly(true); // The HttpOnly flag is a directive to the browser to make sure that the cookie can not be red by malicious script.
             response.addCookie(c);
         }
         if (refresh) {

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -650,7 +650,7 @@ public class Functions {
             // to avoid conflicts with any other web apps that might be on the same machine.
             c.setPath("/");
             c.setMaxAge(60*60*24*30); // persist it roughly for a month
-            c.setHttpOnly(true); // The HttpOnly flag is a directive to the browser to make sure that the cookie can not be red by malicious script.
+            c.setHttpOnly(true);
             response.addCookie(c);
         }
         if (refresh) {


### PR DESCRIPTION
This is a finding by [find-sec-bugs](https://github.com/find-sec-bugs/find-sec-bugs).

And I fixed it by setting the HttpOnly flag to prevent cookie read by a malicious script in browser.
I'm not sure if this is really a security threat. But I guess it does not harm to set it correctly.

### Proposed changelog entries

* Set the HttpOnly flag for the page auto-refresh tokens

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers


