### PR TITLE
use StandardCharsets.UTF_8 instead of string

### DIFF
--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -59,6 +59,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -943,7 +944,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
                 // TODO: generalize macro expansion and perhaps even support JEXL
                 rsp.setContentType("text/html;charset=UTF-8");
                 try (InputStream in = url.openStream()) {
-                    String literal = IOUtils.toString(in,"UTF-8");
+                    String literal = IOUtils.toString(in, StandardCharsets.UTF_8);
                     rsp.getWriter().println(Util.replaceMacro(literal, Collections.singletonMap("rootURL",req.getContextPath())));
                 }
                 return;

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -43,6 +43,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -111,7 +112,7 @@ public class DownloadService {
             ((HttpURLConnection) con).setInstanceFollowRedirects(true);
         }
         try (InputStream is = con.getInputStream()) {
-            String jsonp = IOUtils.toString(is, "UTF-8");
+            String jsonp = IOUtils.toString(is, StandardCharsets.UTF_8);
             int start = jsonp.indexOf('{');
             int end = jsonp.lastIndexOf('}');
             if (start >= 0 && end > start) {
@@ -136,7 +137,7 @@ public class DownloadService {
             ((HttpURLConnection) con).setInstanceFollowRedirects(true);
         }
         try (InputStream is = con.getInputStream()) {
-            String jsonp = IOUtils.toString(is, "UTF-8");
+            String jsonp = IOUtils.toString(is, StandardCharsets.UTF_8);
             String preamble = "window.parent.postMessage(JSON.stringify(";
             int start = jsonp.indexOf(preamble);
             int end = jsonp.lastIndexOf("),'*');");

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -4,6 +4,7 @@ import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.apache.commons.lang.StringUtils.defaultIfBlank;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -453,7 +454,7 @@ public class SetupWizard extends PageDecorator {
                         }
                     }
                     
-                    String initialPluginJson = IOUtils.toString(connection.getInputStream(), "utf-8");
+                    String initialPluginJson = IOUtils.toString(connection.getInputStream(), StandardCharsets.UTF_8);
                     initialPluginList = JSONArray.fromObject(initialPluginJson);
                     break updateSiteList;
                 } catch(Exception e) {
@@ -470,7 +471,7 @@ public class SetupWizard extends PageDecorator {
             try {
                 ClassLoader cl = getClass().getClassLoader();
                 URL localPluginData = cl.getResource("jenkins/install/platform-plugins.json");
-                String initialPluginJson = IOUtils.toString(localPluginData.openStream(), "utf-8");
+                String initialPluginJson = IOUtils.toString(localPluginData.openStream(), StandardCharsets.UTF_8);
                 initialPluginList =  JSONArray.fromObject(initialPluginJson);
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);

--- a/core/src/test/java/hudson/util/SecretTest.java
+++ b/core/src/test/java/hudson/util/SecretTest.java
@@ -24,6 +24,7 @@
 
 package hudson.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Random;
 import java.util.regex.Pattern;
@@ -124,7 +125,7 @@ public class SecretTest {
         for (String str : new String[] {"Hello world", "", "\u0000unprintable"}) {
             Cipher cipher = Secret.getCipher("AES");
             cipher.init(Cipher.ENCRYPT_MODE, legacy);
-            String old = new String(Base64.getEncoder().encode(cipher.doFinal((str + HistoricalSecrets.MAGIC).getBytes("UTF-8"))));
+            String old = new String(Base64.getEncoder().encode(cipher.doFinal((str + HistoricalSecrets.MAGIC).getBytes(StandardCharsets.UTF_8))));
             Secret s = Secret.fromString(old);
             assertEquals("secret by the old key should decrypt", str, s.getPlainText());
             assertNotEquals("but when encrypting, ConfidentialKey should be in use", old, s.getEncryptedValue());

--- a/core/src/test/java/hudson/util/XStream2EncodingTest.java
+++ b/core/src/test/java/hudson/util/XStream2EncodingTest.java
@@ -28,6 +28,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import static org.hamcrest.CoreMatchers.*;
 import org.junit.After;
 import static org.junit.Assert.*;
@@ -70,7 +72,7 @@ public class XStream2EncodingTest {
         Thing t = (Thing) xs.fromXML(new ByteArrayInputStream(ambiguousXml));
         assertThat(t.field, not(msg));
         ByteArrayOutputStream baos2 = new ByteArrayOutputStream();
-        baos2.write("<?xml version='1.0' encoding='UTF-8'?>\n".getBytes("UTF-8"));
+        baos2.write("<?xml version='1.0' encoding='UTF-8'?>\n".getBytes(StandardCharsets.UTF_8));
         baos2.write(ambiguousXml);
         t = (Thing) xs.fromXML(new ByteArrayInputStream(ambiguousXml));
         assertThat(t.field, not(msg));

--- a/core/src/test/java/jenkins/security/RSADigitalSignatureConfidentialKeyTest.java
+++ b/core/src/test/java/jenkins/security/RSADigitalSignatureConfidentialKeyTest.java
@@ -23,6 +23,7 @@
  */
 package jenkins.security;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Signature;
 import java.util.Base64;
 import static org.junit.Assert.assertTrue;
@@ -44,7 +45,7 @@ public class RSADigitalSignatureConfidentialKeyTest {
 
         Signature sig = Signature.getInstance("SHA256withRSA");
         sig.initVerify(key.getPublicKey());
-        sig.update(plainText.getBytes("UTF-8"));
+        sig.update(plainText.getBytes(StandardCharsets.UTF_8));
 
         assertTrue(sig.verify(Base64.getDecoder().decode(msg)));
     }

--- a/core/src/test/java/jenkins/util/MarkFindingOutputStreamTest.java
+++ b/core/src/test/java/jenkins/util/MarkFindingOutputStreamTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
@@ -75,7 +76,7 @@ public class MarkFindingOutputStreamTest {
     }
 
     private void write(String s) throws IOException {
-        m.write(s.getBytes("UTF-8"));
+        m.write(s.getBytes(StandardCharsets.UTF_8));
     }
 
     private void writeOneByOne(String s) throws IOException {


### PR DESCRIPTION
This is just a minor code cleanup. Just replaced "utf_8" strings with StandardCharsets.UTF_8.

### Proposed changelog entries

* N/A

