### PR TITLE
Replace compare() implementations with call to Integer.compare or Long.compare

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1203,9 +1203,7 @@ public class Fingerprint implements ModelObject, Saveable {
             public int compare(FingerprintFacet o1, FingerprintFacet o2) {
                 long a = o1.getTimestamp();
                 long b = o2.getTimestamp();
-                if (a < b) return -1;
-                if (a == b) return 0;
-                return 1;
+                return Long.compare(a, b);
             }
         });
         return r;

--- a/core/src/main/java/hudson/model/HealthReport.java
+++ b/core/src/main/java/hudson/model/HealthReport.java
@@ -326,7 +326,7 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
 
     @Override
     public int compareTo(HealthReport o) {
-        return (Integer.compare(this.score, o.score));
+        return Integer.compare(this.score, o.score);
     }
 
     /**

--- a/core/src/main/java/hudson/model/HealthReport.java
+++ b/core/src/main/java/hudson/model/HealthReport.java
@@ -326,7 +326,7 @@ public class HealthReport implements Serializable, Comparable<HealthReport> {
 
     @Override
     public int compareTo(HealthReport o) {
-        return (this.score < o.score ? -1 : (this.score == o.score ? 0 : 1));
+        return (Integer.compare(this.score, o.score));
     }
 
     /**

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2492,13 +2492,7 @@ public class Queue extends ResourceController implements Saveable {
             int r = this.timestamp.getTime().compareTo(that.timestamp.getTime());
             if (r != 0) return r;
 
-            if (this.getId() < that.getId()) {
-                return -1;
-            } else if (this.getId() == that.getId()) {
-                return 0;
-            } else {
-                return 1;
-            }
+            return Long.compare(this.getId(), that.getId());
         }
 
         public CauseOfBlockage getCauseOfBlockage() {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2496,9 +2496,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         public int compare(@Nonnull Run lhs, @Nonnull Run rhs) {
             long lt = lhs.getTimeInMillis();
             long rt = rhs.getTimeInMillis();
-            if(lt>rt)   return -1;
-            if(lt<rt)   return 1;
-            return 0;
+            return Long.compare(rt, lt);
         }
     };
 

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -672,9 +672,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
         public int compareTo(UserInfo that) {
             long rhs = that.ordinal();
             long lhs = this.ordinal();
-            if(rhs>lhs) return 1;
-            if(rhs<lhs) return -1;
-            return 0;
+            return Long.compare(rhs, lhs);
         }
 
         private long ordinal() {

--- a/core/src/main/java/hudson/model/queue/AbstractQueueSorterImpl.java
+++ b/core/src/main/java/hudson/model/queue/AbstractQueueSorterImpl.java
@@ -35,17 +35,13 @@ public abstract class AbstractQueueSorterImpl extends QueueSorter implements Com
      * sign(a-b).
      */
     protected static int compare(long a, long b) {
-        if (a>b)    return 1;
-        if (a<b)    return -1;
-        return 0;
+        return Long.compare(a, b);
     }
 
     /**
      * sign(a-b).
      */
     protected static int compare(int a, int b) {
-        if (a>b)    return 1;
-        if (a<b)    return -1;
-        return 0;
+        return Integer.compare(a, b);
     }
 }

--- a/core/src/main/java/hudson/model/queue/AbstractQueueSorterImpl.java
+++ b/core/src/main/java/hudson/model/queue/AbstractQueueSorterImpl.java
@@ -1,6 +1,9 @@
 package hudson.model.queue;
 
+import hudson.RestrictedSince;
 import hudson.model.Queue.BuildableItem;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.util.Comparator;
 import java.util.List;
@@ -28,19 +31,27 @@ public abstract class AbstractQueueSorterImpl extends QueueSorter implements Com
      * The default implementation does FIFO.
      */
     public int compare(BuildableItem lhs, BuildableItem rhs) {
-        return compare(lhs.buildableStartMilliseconds,rhs.buildableStartMilliseconds);
+        return Long.compare(lhs.buildableStartMilliseconds,rhs.buildableStartMilliseconds);
     }
 
     /**
+     * @deprecated Use Long.compare instead.
      * sign(a-b).
      */
+    @Deprecated
+    @Restricted(NoExternalUse.class)
+    @RestrictedSince("TODO")
     protected static int compare(long a, long b) {
         return Long.compare(a, b);
     }
 
     /**
+     * @deprecated Use Integer.compare instead.
      * sign(a-b).
      */
+    @Deprecated
+    @Restricted(NoExternalUse.class)
+    @RestrictedSince("TODO")
     protected static int compare(int a, int b) {
         return Integer.compare(a, b);
     }

--- a/core/src/main/java/hudson/util/ConsistentHash.java
+++ b/core/src/main/java/hudson/util/ConsistentHash.java
@@ -83,9 +83,7 @@ public class ConsistentHash<T> {
         }
 
         public int compareTo(Point that) {
-            if(this.hash<that.hash) return -1;
-            if(this.hash==that.hash) return 0;
-            return 1;
+            return Integer.compare(this.hash, that.hash);
         }
     }
 

--- a/core/src/main/java/hudson/util/RunList.java
+++ b/core/src/main/java/hudson/util/RunList.java
@@ -97,9 +97,7 @@ public class RunList<R extends Run> extends AbstractList<R> {
             public int compare(R o1, R o2) {
                 long lhs = o1.getTimeInMillis();
                 long rhs = o2.getTimeInMillis();
-                if (lhs > rhs) return -1;
-                if (lhs < rhs) return 1;
-                return 0;
+                return Long.compare(rhs, lhs);
             }
         });
     }

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -240,13 +240,7 @@ public class HistoryPageFilter<T> {
                 long o1QID = HistoryPageEntry.getEntryId(o1);
                 long o2QID = HistoryPageEntry.getEntryId(o2);
 
-                if (o1QID < o2QID) {
-                    return 1;
-                } else if (o1QID == o2QID) {
-                    return 0;
-                } else {
-                    return -1;
-                }
+                return Long.compare(o2QID, o1QID);
             }
         });
     }


### PR DESCRIPTION
I replaced implementation with call to Integer.compare or Long.compare.
This was introduced in Java 1.7. So I guess it is safe to use now. 
* [Oracle reference for Long](https://docs.oracle.com/javase/8/docs/api/java/lang/Long.html#compare-long-long-)
* [Oracle reference for Integer](https://docs.oracle.com/javase/8/docs/api/java/lang/Integer.html#compare-int-int-)

### Proposed changelog entries

* N/A

@mention
