### PR TITLE
[JENKINS-60278] Prevent Oops when Whitelisted Commands input is empty

### DIFF
--- a/core/src/main/java/jenkins/security/s2m/AdminWhitelistRule.java
+++ b/core/src/main/java/jenkins/security/s2m/AdminWhitelistRule.java
@@ -162,7 +162,7 @@ public class AdminWhitelistRule implements StaplerProxy {
     @RequirePOST
     public HttpResponse doSubmit(StaplerRequest req) throws IOException {
         StringBuilder whitelist = new StringBuilder(Util.fixNull(req.getParameter("whitelist")));
-        if (whitelist.charAt(whitelist.length() - 1) != '\n')
+        if ((whitelist.length() > 0) && (whitelist.charAt(whitelist.length() - 1) != '\n'))
             whitelist.append("\n");
 
         Enumeration e = req.getParameterNames();


### PR DESCRIPTION
Minor fix to prevent an Oops if the "_Currently Whitelisted Commands_" in "_Agent → Master Access Control_" is left totally empty and form is submitted with the button "_Update_".

> 
> A problem occurred while processing the request. Please check our bug tracker to see if a similar problem has already been reported. If it is already reported, please vote and put a comment on it to let us gauge the impact of the problem. If you think this is a new issue, please file a new issue. When you file an issue, make sure to add the entire stack trace, along with the version of Jenkins and relevant plugins. The users list might be also useful in understanding what has happened.
> Stack trace
> 
> java.lang.StringIndexOutOfBoundsException: String index out of range: -1
> 	at java.lang.AbstractStringBuilder.charAt(AbstractStringBuilder.java:237)
> 	at java.lang.StringBuilder.charAt(StringBuilder.java:76)
> 	at jenkins.security.s2m.AdminWhitelistRule.doSubmit(AdminWhitelistRule.java:165)
> 	at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
> 	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:396)
> 	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:408)
> 	at org.kohsuke.stapler.interceptor.RequirePOST$Processor.invoke(RequirePOST.java:77)
> 	at org.kohsuke.stapler.PreInvokeInterceptedFunction.invoke(PreInvokeInterceptedFunction.java:26)
> 	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:212)
> 	at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:145)
> 	at org.kohsuke.stapler.MetaClass$11.doDispatch(MetaClass.java:535)
> 	at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
> 	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:747)

Due to the Oops then the settings will not be saved as well.

The PR just check that the string length is > 0 so an access to _charAt(-1)_ is prevented.

Retested manually with success after change.