### PR TITLE
Use parallel Maven builds with 1.5 threads per core

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ for(j = 0; j < jdks.size(); j++) {
                                     "MAVEN_OPTS=-Xmx1536m -Xms512m"], buildType, jdk) {
                             // Actually run Maven!
                             // -Dmaven.repo.local=… tells Maven to create a subdir in the temporary directory for the local Maven repository
-                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
+                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -T 1.5C -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
 
                             if(isUnix()) {
                                 sh mvnCmd


### PR DESCRIPTION
I stumbled upon the maven command and wondered why there is no parallel execution.
Maybe it is not useful at all in the environment, but I guess it could speed up the build. So I thought the PR build might show problems with the parallel build.

### Proposed changelog entries

* N/A

### Desired reviewers

If you have already tested it and do not want to use it, just clode the PR. I guess @oleg-nenashev might know if it can work at all.
