### PR TITLE
Race condition in PlainCLIProtocolTest

### DIFF
--- a/cli/src/test/java/hudson/cli/PlainCLIProtocolTest.java
+++ b/cli/src/test/java/hudson/cli/PlainCLIProtocolTest.java
@@ -92,6 +92,13 @@ public class PlainCLIProtocolTest {
             }
             @Override
             protected void onStdin(byte[] chunk) throws IOException {
+                /* To inject a race condition:
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException x) {
+                    throw new IOException(x);
+                }
+                */
                 stdin.write(chunk);
             }
             @Override
@@ -125,6 +132,9 @@ public class PlainCLIProtocolTest {
             while (client.code == -1) {
                 client.wait();
             }
+        }
+        while (server.stdin.size() == 0) {
+            Thread.sleep(100);
         }
         assertEquals("hello", server.stdin.toString());
         assertEquals("command", server.arg);


### PR DESCRIPTION
Flake noticed in #4375 and also seen in `master` prior to #4220:

```
org.opentest4j.AssertionFailedError: expected: <hello> but was: <>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1124)
	at hudson.cli.PlainCLIProtocolTest.ignoreUnknownOperations(PlainCLIProtocolTest.java:129)
```