### PR TITLE
[JENKINS-36720] - Fix Spotbugs issues (SE_COMPARATOR_SHOULD_BE_SERIALIZABLE, ES_COMPARING_STRINGS_WITH_EQ)

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -85,6 +85,7 @@ import hudson.views.ViewsTabBar;
 import hudson.widgets.RenderOnDemandClosure;
 
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -25,6 +25,7 @@
  */
 package hudson;
 
+import com.google.inject.internal.asm.$ByteVector;
 import hudson.model.Slave;
 import hudson.security.*;
 import jenkins.telemetry.impl.AutoRefresh;
@@ -1309,7 +1310,7 @@ public class Functions {
     private static class ThreadSorterBase {
         protected Map<Long,String> map = new HashMap<>();
 
-        private ThreadSorterBase() {
+        public ThreadSorterBase() {
             ThreadGroup tg = Thread.currentThread().getThreadGroup();
             while (tg.getParent() != null) tg = tg.getParent();
             Thread[] threads = new Thread[tg.activeCount()*2];

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -84,7 +84,13 @@ import hudson.views.MyViewsTabBar;
 import hudson.views.ViewsTabBar;
 import hudson.widgets.RenderOnDemandClosure;
 
-import java.io.*;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
 import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -84,11 +84,7 @@ import hudson.views.MyViewsTabBar;
 import hudson.views.ViewsTabBar;
 import hudson.widgets.RenderOnDemandClosure;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
@@ -158,7 +154,7 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import hudson.model.PasswordParameterDefinition;
 import hudson.util.RunList;
-import java.io.PrintStream;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -1326,7 +1322,9 @@ public class Functions {
         }
     }
 
-    public static class ThreadGroupMap extends ThreadSorterBase implements Comparator<ThreadInfo> {
+    public static class ThreadGroupMap extends ThreadSorterBase implements Comparator<ThreadInfo>, Serializable {
+
+        private static final long serialVersionUID = 7803975728695308444L;
 
         /**
          * @return ThreadGroup name or null if unknown
@@ -1343,7 +1341,9 @@ public class Functions {
         }
     }
 
-    private static class ThreadSorter extends ThreadSorterBase implements Comparator<Thread> {
+    private static class ThreadSorter extends ThreadSorterBase implements Comparator<Thread>, Serializable {
+
+        private static final long serialVersionUID = 5053631350439192685L;
 
         public int compare(Thread a, Thread b) {
             int result = compare(a.getId(), b.getId());

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -25,7 +25,6 @@
  */
 package hudson;
 
-import com.google.inject.internal.asm.$ByteVector;
 import hudson.model.Slave;
 import hudson.security.*;
 import jenkins.telemetry.impl.AutoRefresh;

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -50,6 +50,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import javax.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.text.Collator;
 import java.util.*;
 import java.util.logging.Level;
@@ -252,7 +253,9 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
 
     }
     
-    private static class TargetComparator implements Comparator<Target> {
+    private static class TargetComparator implements Comparator<Target>, Serializable {
+
+        private static final long serialVersionUID = 9285340752515798L;
 
         @Override
         public int compare(Target left, Target right) {

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -55,6 +55,7 @@ import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
+import java.io.Serializable;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -198,7 +199,9 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
         return nodes.size() == 1 && nodes.iterator().next().getSelfLabel() == this;
     }
 
-    private static class NodeSorter implements Comparator<Node> {
+    private static class NodeSorter implements Comparator<Node>, Serializable {
+        private static final long serialVersionUID = -7368519598046684532L;
+
         @Override
         public int compare(Node o1, Node o2) {
             if (o1 == o2) {

--- a/core/src/main/java/hudson/model/TimeZoneProperty.java
+++ b/core/src/main/java/hudson/model/TimeZoneProperty.java
@@ -105,7 +105,7 @@ public class TimeZoneProperty extends UserProperty implements Saveable {
         }
 
         TimeZone tz = TimeZone.getTimeZone(tzp.timeZoneName);
-        if (tz.getID() != tzp.timeZoneName) {
+        if (!tz.getID().equals(tzp.timeZoneName)) {
             //TimeZone.getTimeZone returns GMT on invalid time zone so
             //warn the user if the time zone returned is different from
             //the one they specified.

--- a/core/src/main/java/hudson/tasks/Publisher.java
+++ b/core/src/main/java/hudson/tasks/Publisher.java
@@ -23,6 +23,7 @@
  */
 package hudson.tasks;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.ExtensionComponent;
@@ -36,7 +37,6 @@ import hudson.model.Project;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -129,9 +129,10 @@ public abstract class Publisher extends BuildStepCompatibilityLayer implements D
      *
      * @see DescriptorExtensionList#createDescriptorList(hudson.model.Hudson, Class)
      */
+    @SuppressFBWarnings(value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE", justification = "Since the publisher is not Serializable, " +
+            "no need for the Comparator")
     public static final class DescriptorExtensionListImpl extends DescriptorExtensionList<Publisher,Descriptor<Publisher>>
-            implements Comparator<ExtensionComponent<Descriptor<Publisher>>>, Serializable {
-        private static final long serialVersionUID = -5348997484846932619L;
+            implements Comparator<ExtensionComponent<Descriptor<Publisher>>> {
 
         public DescriptorExtensionListImpl(Jenkins hudson) {
             super(hudson,Publisher.class);

--- a/core/src/main/java/hudson/tasks/Publisher.java
+++ b/core/src/main/java/hudson/tasks/Publisher.java
@@ -36,6 +36,7 @@ import hudson.model.Project;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -129,7 +130,9 @@ public abstract class Publisher extends BuildStepCompatibilityLayer implements D
      * @see DescriptorExtensionList#createDescriptorList(hudson.model.Hudson, Class)
      */
     public static final class DescriptorExtensionListImpl extends DescriptorExtensionList<Publisher,Descriptor<Publisher>>
-            implements Comparator<ExtensionComponent<Descriptor<Publisher>>> {
+            implements Comparator<ExtensionComponent<Descriptor<Publisher>>>, Serializable {
+        private static final long serialVersionUID = -5348997484846932619L;
+
         public DescriptorExtensionListImpl(Jenkins hudson) {
             super(hudson,Publisher.class);
         }

--- a/core/src/main/java/jenkins/model/IdStrategy.java
+++ b/core/src/main/java/jenkins/model/IdStrategy.java
@@ -35,6 +35,7 @@ import org.kohsuke.accmod.restrictions.ProtectedExternally;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.function.Function;
@@ -188,7 +189,9 @@ public abstract class IdStrategy extends AbstractDescribableImpl<IdStrategy> imp
     /**
      * The default case insensitive {@link IdStrategy}
      */
-    public static class CaseInsensitive extends IdStrategy {
+    public static class CaseInsensitive extends IdStrategy implements Serializable {
+
+        private static final long serialVersionUID = -7244768200684861085L;
 
         @DataBoundConstructor
         public CaseInsensitive() {}
@@ -224,7 +227,9 @@ public abstract class IdStrategy extends AbstractDescribableImpl<IdStrategy> imp
     /**
      * A case sensitive {@link IdStrategy}
      */
-    public static class CaseSensitive extends IdStrategy {
+    public static class CaseSensitive extends IdStrategy implements Serializable {
+
+        private static final long serialVersionUID = 8339425353883308324L;
 
         @DataBoundConstructor
         public CaseSensitive() {}
@@ -268,7 +273,9 @@ public abstract class IdStrategy extends AbstractDescribableImpl<IdStrategy> imp
      * mailbox. Most sane system administrators do not configure their accounts using case sensitive mailboxes
      * but the RFC does allow them the option to configure that way. Domain names are always case insensitive per RFC.
      */
-    public static class CaseSensitiveEmailAddress extends CaseSensitive {
+    public static class CaseSensitiveEmailAddress extends CaseSensitive implements Serializable {
+
+        private static final long serialVersionUID = -5713655323057260180L;
 
         @DataBoundConstructor
         public CaseSensitiveEmailAddress() {}


### PR DESCRIPTION
Fixed some Spotbugs issues 
One of Type ES_COMPARING_STRINGS_WITH_EQ
And some of [SE_COMPARATOR_SHOULD_BE_SERIALIZABLE](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#se-comparator-doesn-t-implement-serializable-se-comparator-should-be-serializable).
I also added the SerialVersionUID to the comparators, that would otherwise trigger the next Spotbugs error.

If we get this in, the number of spotbugs warnings will be less then 400 😁

See [JENKINS-36720](https://issues.jenkins-ci.org/browse/JENKINS-36720).

### Proposed changelog entries

* N/A
