### PR TITLE
Spotbugs findings (catch runtime ex. and known null)

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -980,8 +980,10 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         if (category==null)
             return Messages.UpdateCenter_PluginCategory_misc();
         try {
-            return (String)Messages.class.getMethod(
+            return (String) Messages.class.getMethod(
                     "UpdateCenter_PluginCategory_" + category.replace('-', '_')).invoke(null);
+        } catch (RuntimeException ex) {
+            throw ex;
         } catch (Exception ex) {
             return Messages.UpdateCenter_PluginCategory_unrecognized(category);
         }

--- a/core/src/main/java/hudson/scheduler/CronTabList.java
+++ b/core/src/main/java/hudson/scheduler/CronTabList.java
@@ -106,11 +106,12 @@ public final class CronTabList {
             line = line.trim();
             
             if(lineNumber == 1 && line.startsWith("TZ=")) {
-                timezone = getValidTimezone(line.replace("TZ=",""));
+                final String timezoneString = line.replace("TZ=", "");
+                timezone = getValidTimezone(timezoneString);
                 if(timezone != null) {
                     LOGGER.log(Level.CONFIG, "CRON with timezone {0}", timezone);
                 } else {
-                    throw new ANTLRException("Invalid or unsupported timezone '" + timezone + "'");
+                    throw new ANTLRException("Invalid or unsupported timezone '" + timezoneString + "'");
                 }
                 continue;
             }

--- a/core/src/main/java/hudson/util/DoubleLaunchChecker.java
+++ b/core/src/main/java/hudson/util/DoubleLaunchChecker.java
@@ -133,7 +133,9 @@ public class DoubleLaunchChecker {
         String contextPath="";
         try {
             Method m = ServletContext.class.getMethod("getContextPath");
-            contextPath=" contextPath=\""+m.invoke(h.servletContext)+"\"";
+            contextPath = " contextPath=\"" + m.invoke(h.servletContext) + "\"";
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             // maybe running with Servlet 2.4
         }


### PR DESCRIPTION
Three small Spotbugs issues.
- A known as null value replaced with a more useful string in an exception message.
- Do not catch runtime exceptions

See [JENKINS-36720](https://issues.jenkins-ci.org/browse/JENKINS-36720).

### Proposed changelog entries

* N/A