### PR TITLE
Add findsecbugs plugin to spotbugs.

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -191,7 +191,7 @@ public class CLI {
             	continue;
             }
             if(head.equals("-i") && args.size()>=2) {
-                File f = new File(args.get(1));
+                File f = getFileFromArguments(args);
                 if (!f.exists()) {
                     printUsage(Messages.CLI_NoSuchFileExists(f));
                     return -1;
@@ -293,7 +293,7 @@ public class CLI {
         if (userInfo != null) {
             factory = factory.basicAuth(userInfo);
         } else if (auth != null) {
-            factory = factory.basicAuth(auth.startsWith("@") ? FileUtils.readFileToString(new File(auth.substring(1)), Charset.defaultCharset()).trim() : auth);
+            factory = factory.basicAuth(auth.startsWith("@") ? readAuthFromFile(auth).trim() : auth);
         }
 
         if (mode == Mode.HTTP) {
@@ -305,6 +305,16 @@ public class CLI {
         }
 
         throw new AssertionError();
+    }
+
+    @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "URLCONNECTION_SSRF_FD"}, justification = "User provided values for running the program.")
+    private static String readAuthFromFile(String auth) throws IOException {
+        return FileUtils.readFileToString(new File(auth.substring(1)), Charset.defaultCharset());
+    }
+
+    @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "URLCONNECTION_SSRF_FD"}, justification = "User provided values for running the program.")
+    private static File getFileFromArguments(List<String> args) {
+        return new File(args.get(1));
     }
 
     private static int webSocketConnection(String url, List<String> args, CLIConnectionFactory factory) throws Exception {

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -105,7 +105,6 @@ public class CLI {
     }
 
     private enum Mode {HTTP, SSH, WEB_SOCKET}
-    @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "URLCONNECTION_SSRF_FD"}, justification = "User provided values for running the program.")
     public static int _main(String[] _args) throws Exception {
         List<String> args = Arrays.asList(_args);
         PrivateKeyProvider provider = new PrivateKeyProvider();

--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -23,6 +23,7 @@
  */
 package hudson.cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.cli.client.Messages;
 import java.io.DataInputStream;
 import javax.net.ssl.HostnameVerifier;
@@ -104,6 +105,7 @@ public class CLI {
     }
 
     private enum Mode {HTTP, SSH, WEB_SOCKET}
+    @SuppressFBWarnings(value = {"PATH_TRAVERSAL_IN", "URLCONNECTION_SSRF_FD"}, justification = "User provided values for running the program.")
     public static int _main(String[] _args) throws Exception {
         List<String> args = Arrays.asList(_args);
         PrivateKeyProvider provider = new PrivateKeyProvider();
@@ -175,6 +177,7 @@ public class CLI {
                 HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
                 // bypass host name check, too.
                 HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {
+                    @SuppressFBWarnings(value = "WEAK_HOSTNAME_VERIFIER", justification = "User set parameter to skip verifier.")
                     public boolean verify(String s, SSLSession sslSession) {
                         return true;
                     }

--- a/cli/src/main/java/hudson/cli/DiagnosedStreamCorruptionException.java
+++ b/cli/src/main/java/hudson/cli/DiagnosedStreamCorruptionException.java
@@ -1,7 +1,5 @@
 package hudson.cli;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.io.PrintWriter;
 import java.io.StreamCorruptedException;
 import java.io.StringWriter;
@@ -13,7 +11,6 @@ import java.io.StringWriter;
  *
  * @author Kohsuke Kawaguchi
  */
-@SuppressFBWarnings(value = "INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE")
 class DiagnosedStreamCorruptionException extends StreamCorruptedException {
     private final Exception diagnoseFailure;
     private final byte[] readBack;

--- a/cli/src/main/java/hudson/cli/DiagnosedStreamCorruptionException.java
+++ b/cli/src/main/java/hudson/cli/DiagnosedStreamCorruptionException.java
@@ -1,5 +1,7 @@
 package hudson.cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.PrintWriter;
 import java.io.StreamCorruptedException;
 import java.io.StringWriter;
@@ -11,6 +13,7 @@ import java.io.StringWriter;
  *
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value = "INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE")
 class DiagnosedStreamCorruptionException extends StreamCorruptedException {
     private final Exception diagnoseFailure;
     private final byte[] readBack;

--- a/cli/src/main/java/hudson/cli/FullDuplexHttpStream.java
+++ b/cli/src/main/java/hudson/cli/FullDuplexHttpStream.java
@@ -1,5 +1,7 @@
 package hudson.cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -44,6 +46,7 @@ public class FullDuplexHttpStream {
      * @param authorization
      *      The value of the authorization header, if non-null.
      */
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Client-side code doesn't involve SSRF.")
     public FullDuplexHttpStream(URL base, String relativeTarget, String authorization) throws IOException {
         if (!base.toString().endsWith("/")) {
             throw new IllegalArgumentException(base.toString());
@@ -93,6 +96,7 @@ public class FullDuplexHttpStream {
     }
 
     // As this transport mode is using POST, it is necessary to resolve possible redirections using GET first.
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Client-side code doesn't involve SSRF.")
     private URL tryToResolveRedirects(URL base, String authorization) {
         try {
             HttpURLConnection con = (HttpURLConnection) base.openConnection();

--- a/cli/src/main/java/hudson/cli/NoCheckTrustManager.java
+++ b/cli/src/main/java/hudson/cli/NoCheckTrustManager.java
@@ -9,14 +9,16 @@ import java.security.cert.X509Certificate;
 /**
  * @author Kohsuke Kawaguchi
  */
-@SuppressFBWarnings(value = "WEAK_TRUST_MANAGER", justification = "User set parameter to skip verifier.")
 public class NoCheckTrustManager implements X509TrustManager {
+    @SuppressFBWarnings(value = "WEAK_TRUST_MANAGER", justification = "User set parameter to skip verifier.")
     public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
     }
 
+    @SuppressFBWarnings(value = "WEAK_TRUST_MANAGER", justification = "User set parameter to skip verifier.")
     public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
     }
 
+    @SuppressFBWarnings(value = "WEAK_TRUST_MANAGER", justification = "User set parameter to skip verifier.")
     public X509Certificate[] getAcceptedIssuers() {
         return new X509Certificate[0];
     }

--- a/cli/src/main/java/hudson/cli/NoCheckTrustManager.java
+++ b/cli/src/main/java/hudson/cli/NoCheckTrustManager.java
@@ -1,5 +1,7 @@
 package hudson.cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.net.ssl.X509TrustManager;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -7,6 +9,7 @@ import java.security.cert.X509Certificate;
 /**
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value = "WEAK_TRUST_MANAGER", justification = "User set parameter to skip verifier.")
 public class NoCheckTrustManager implements X509TrustManager {
     public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
     }

--- a/cli/src/main/java/hudson/cli/SSHCLI.java
+++ b/cli/src/main/java/hudson/cli/SSHCLI.java
@@ -61,11 +61,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 class SSHCLI {
 
-    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Client-side code doesn't involve SSRF.")
     static int sshConnection(String jenkinsUrl, String user, List<String> args, PrivateKeyProvider provider, final boolean strictHostKey) throws IOException {
         Logger.getLogger(SecurityUtils.class.getName()).setLevel(Level.WARNING); // suppress: BouncyCastle not registered, using the default JCE provider
         URL url = new URL(jenkinsUrl + "login");
-        URLConnection conn = url.openConnection();
+        URLConnection conn = openConnection(url);
         CLI.verifyJenkinsConnection(conn);
         String endpointDescription = conn.getHeaderField("X-SSH-Endpoint");
 
@@ -129,6 +128,11 @@ class SSHCLI {
                 client.stop();
             }
         }
+    }
+
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Client-side code doesn't involve SSRF.")
+    private static URLConnection openConnection(URL url) throws IOException {
+        return url.openConnection();
     }
 
     private SSHCLI() {}

--- a/cli/src/main/java/hudson/cli/SSHCLI.java
+++ b/cli/src/main/java/hudson/cli/SSHCLI.java
@@ -61,7 +61,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 class SSHCLI {
 
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE", justification = "Due to whatever reason FindBugs reports it fot try-with-resources")
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Client-side code doesn't involve SSRF.")
     static int sshConnection(String jenkinsUrl, String user, List<String> args, PrivateKeyProvider provider, final boolean strictHostKey) throws IOException {
         Logger.getLogger(SecurityUtils.class.getName()).setLevel(Level.WARNING); // suppress: BouncyCastle not registered, using the default JCE provider
         URL url = new URL(jenkinsUrl + "login");

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -78,7 +78,6 @@ import java.util.logging.Logger;
 
 import static org.apache.commons.io.FilenameUtils.getBaseName;
 
-@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Administrator action installing a plugin, which could do far worse.")
 public class ClassicPluginStrategy implements PluginStrategy {
 
     private static final Logger LOGGER = Logger.getLogger(ClassicPluginStrategy.class.getName());
@@ -432,6 +431,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
         return null;
     }
 
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Administrator action installing a plugin, which could do far worse.")
     private static File resolve(File base, String relative) {
         File rel = new File(relative);
         if(rel.isAbsolute())

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -78,6 +78,7 @@ import java.util.logging.Logger;
 
 import static org.apache.commons.io.FilenameUtils.getBaseName;
 
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Admistrator action installing a plugin, which could do far worse.")
 public class ClassicPluginStrategy implements PluginStrategy {
 
     private static final Logger LOGGER = Logger.getLogger(ClassicPluginStrategy.class.getName());

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -78,7 +78,7 @@ import java.util.logging.Logger;
 
 import static org.apache.commons.io.FilenameUtils.getBaseName;
 
-@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Admistrator action installing a plugin, which could do far worse.")
+@SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Administrator action installing a plugin, which could do far worse.")
 public class ClassicPluginStrategy implements PluginStrategy {
 
     private static final Logger LOGGER = Logger.getLogger(ClassicPluginStrategy.class.getName());

--- a/core/src/main/java/hudson/Proc.java
+++ b/core/src/main/java/hudson/Proc.java
@@ -23,6 +23,7 @@
  */
 package hudson;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Launcher.ProcStarter;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
@@ -215,6 +216,7 @@ public abstract class Proc {
          * @param err
          *      null to redirect stderr to stdout.
          */
+        @SuppressFBWarnings("COMMAND_INJECTION")
         public LocalProc(String[] cmd,String[] env,InputStream in,OutputStream out,OutputStream err,File workDir) throws IOException {
             this( calcName(cmd),
                   stderr(environment(new ProcessBuilder(cmd),env).directory(workDir), err==null || err== SELFPUMP_OUTPUT),

--- a/core/src/main/java/hudson/Proc.java
+++ b/core/src/main/java/hudson/Proc.java
@@ -216,7 +216,7 @@ public abstract class Proc {
          * @param err
          *      null to redirect stderr to stdout.
          */
-        @SuppressFBWarnings("COMMAND_INJECTION")
+        @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "Command injection is the point of this old, barely used class.")
         public LocalProc(String[] cmd,String[] env,InputStream in,OutputStream out,OutputStream err,File workDir) throws IOException {
             this( calcName(cmd),
                   stderr(environment(new ProcessBuilder(cmd),env).directory(workDir), err==null || err== SELFPUMP_OUTPUT),

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -596,6 +596,8 @@ public class Util {
      * @see DigestUtils#md5Hex(InputStream)
      */
     @Nonnull
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification =
+            "This method should only be used for non-security applications where their weakness is not a problem.")
     public static String getDigestOf(@Nonnull InputStream source) throws IOException {
         try {
             MessageDigest md5 = MessageDigest.getInstance("MD5");

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -589,6 +589,8 @@ public class Util {
     /**
      * Computes MD5 digest of the given input stream.
      *
+     * This method should only be used for non-security applications where the MD5 weakness is not a problem.
+     *
      * @param source
      *      The stream will be closed by this method at the end of this method.
      * @return
@@ -596,11 +598,9 @@ public class Util {
      * @see DigestUtils#md5Hex(InputStream)
      */
     @Nonnull
-    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification =
-            "This method should only be used for non-security applications where their weakness is not a problem.")
     public static String getDigestOf(@Nonnull InputStream source) throws IOException {
         try {
-            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            MessageDigest md5 = getMd5();
             DigestInputStream in = new DigestInputStream(source, md5);
             // Note: IOUtils.copy() buffers the input internally, so there is no
             // need to use a BufferedInputStream.
@@ -618,6 +618,13 @@ public class Util {
             source.close();
         }
         */
+    }
+
+    // TODO JENKINS-60563 remove MD5 from all usages in Jenkins
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification =
+            "This method should only be used for non-security applications where the MD5 weakness is not a problem.")
+    private static MessageDigest getMd5() throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance("MD5");
     }
 
     @Nonnull

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -623,6 +623,7 @@ public class Util {
     // TODO JENKINS-60563 remove MD5 from all usages in Jenkins
     @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification =
             "This method should only be used for non-security applications where the MD5 weakness is not a problem.")
+    @Deprecated
     private static MessageDigest getMd5() throws NoSuchAlgorithmException {
         return MessageDigest.getInstance("MD5");
     }

--- a/core/src/main/java/hudson/cli/Connection.java
+++ b/core/src/main/java/hudson/cli/Connection.java
@@ -23,6 +23,7 @@
  */
 package hudson.cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.ClassFilter;
 import hudson.remoting.ObjectInputStreamEx;
 import hudson.remoting.SocketChannelStream;
@@ -113,6 +114,7 @@ public class Connection {
     /**
      * Receives an object sent by {@link #writeObject(Object)}
      */
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Not used. We should just remove it.")
     public <T> T readObject() throws IOException, ClassNotFoundException {
         ObjectInputStream ois = new ObjectInputStreamEx(in,
                 getClass().getClassLoader(), ClassFilter.DEFAULT);
@@ -192,6 +194,7 @@ public class Connection {
      * @return
      *      A new {@link Connection} object that includes the transport encryption.
      */
+    @SuppressFBWarnings(value = "STATIC_IV", justification = "Not used. We should just remove it.")
     public Connection encryptConnection(SecretKey sessionKey, String algorithm) throws IOException, GeneralSecurityException {
         Cipher cout = Cipher.getInstance(algorithm);
         cout.init(Cipher.ENCRYPT_MODE, sessionKey, new IvParameterSpec(sessionKey.getEncoded()));

--- a/core/src/main/java/hudson/cli/Connection.java
+++ b/core/src/main/java/hudson/cli/Connection.java
@@ -114,7 +114,8 @@ public class Connection {
     /**
      * Receives an object sent by {@link #writeObject(Object)}
      */
-    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Not used. We should just remove it.")
+    // TODO JENKINS-60562 remove this class
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Not used. We should just remove it. Class is deprecated.")
     public <T> T readObject() throws IOException, ClassNotFoundException {
         ObjectInputStream ois = new ObjectInputStreamEx(in,
                 getClass().getClassLoader(), ClassFilter.DEFAULT);
@@ -194,17 +195,20 @@ public class Connection {
      * @return
      *      A new {@link Connection} object that includes the transport encryption.
      */
-    @SuppressFBWarnings(value = "STATIC_IV", justification = "Not used. We should just remove it.")
     public Connection encryptConnection(SecretKey sessionKey, String algorithm) throws IOException, GeneralSecurityException {
         Cipher cout = Cipher.getInstance(algorithm);
-        cout.init(Cipher.ENCRYPT_MODE, sessionKey, new IvParameterSpec(sessionKey.getEncoded()));
+        cout.init(Cipher.ENCRYPT_MODE, sessionKey, createIv(sessionKey));
         CipherOutputStream o = new CipherOutputStream(out, cout);
 
         Cipher cin = Cipher.getInstance(algorithm);
-        cin.init(Cipher.DECRYPT_MODE, sessionKey, new IvParameterSpec(sessionKey.getEncoded()));
+        cin.init(Cipher.DECRYPT_MODE, sessionKey, createIv(sessionKey));
         CipherInputStream i = new CipherInputStream(in, cin);
 
         return new Connection(i,o);
+    }
+
+    private IvParameterSpec createIv(SecretKey sessionKey) {
+        return new IvParameterSpec(sessionKey.getEncoded());
     }
 
     /**

--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -117,7 +117,6 @@ public class AnnotatedLargeText<T> extends LargeText {
         rsp.setContentType(isHtml() ? "text/html;charset=UTF-8" : "text/plain;charset=UTF-8");
     }
 
-    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Deserialization is protected by logic.")
     private ConsoleAnnotator<T> createAnnotator(StaplerRequest req) throws IOException {
         try {
             String base64 = req!=null ? req.getHeader("X-ConsoleAnnotator") : null;
@@ -130,7 +129,7 @@ public class AnnotatedLargeText<T> extends LargeText {
                     long timestamp = ois.readLong();
                     if (TimeUnit.HOURS.toMillis(1) > abs(System.currentTimeMillis()-timestamp))
                         // don't deserialize something too old to prevent a replay attack
-                        return (ConsoleAnnotator) ois.readObject();
+                        return getConsoleAnnotator(ois);
                 } catch (RuntimeException ex) {
                     throw new IOException("Could not decode input", ex);
                 }
@@ -140,6 +139,11 @@ public class AnnotatedLargeText<T> extends LargeText {
         }
         // start from scratch
         return ConsoleAnnotator.initial(context);
+    }
+
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Deserialization is protected by logic.")
+    private ConsoleAnnotator getConsoleAnnotator(ObjectInputStream ois) throws IOException, ClassNotFoundException {
+        return (ConsoleAnnotator) ois.readObject();
     }
 
     @CheckReturnValue

--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -25,6 +25,7 @@
  */
 package hudson.console;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.model.Jenkins;
 import hudson.remoting.ObjectInputStreamEx;
 import java.util.concurrent.TimeUnit;
@@ -116,6 +117,7 @@ public class AnnotatedLargeText<T> extends LargeText {
         rsp.setContentType(isHtml() ? "text/html;charset=UTF-8" : "text/plain;charset=UTF-8");
     }
 
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION")
     private ConsoleAnnotator<T> createAnnotator(StaplerRequest req) throws IOException {
         try {
             String base64 = req!=null ? req.getHeader("X-ConsoleAnnotator") : null;

--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -117,7 +117,7 @@ public class AnnotatedLargeText<T> extends LargeText {
         rsp.setContentType(isHtml() ? "text/html;charset=UTF-8" : "text/plain;charset=UTF-8");
     }
 
-    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION")
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Deserialization is protected by logic.")
     private ConsoleAnnotator<T> createAnnotator(StaplerRequest req) throws IOException {
         try {
             String base64 = req!=null ? req.getHeader("X-ConsoleAnnotator") : null;

--- a/core/src/main/java/hudson/console/ConsoleNote.java
+++ b/core/src/main/java/hudson/console/ConsoleNote.java
@@ -23,6 +23,7 @@
  */
 package hudson.console;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.ExtensionPoint;
 import hudson.Functions;
 import hudson.MarkupText;
@@ -232,6 +233,7 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
      *
      * @return null if the encoded form is malformed.
      */
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION")
     public static ConsoleNote readFrom(DataInputStream in) throws IOException, ClassNotFoundException {
         try {
             byte[] preamble = new byte[PREAMBLE.length];

--- a/core/src/main/java/hudson/console/ConsoleNote.java
+++ b/core/src/main/java/hudson/console/ConsoleNote.java
@@ -233,7 +233,7 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
      *
      * @return null if the encoded form is malformed.
      */
-    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION")
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Deserialization is protected by logic.")
     public static ConsoleNote readFrom(DataInputStream in) throws IOException, ClassNotFoundException {
         try {
             byte[] preamble = new byte[PREAMBLE.length];

--- a/core/src/main/java/hudson/console/ConsoleNote.java
+++ b/core/src/main/java/hudson/console/ConsoleNote.java
@@ -233,7 +233,6 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
      *
      * @return null if the encoded form is malformed.
      */
-    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Deserialization is protected by logic.")
     public static ConsoleNote readFrom(DataInputStream in) throws IOException, ClassNotFoundException {
         try {
             byte[] preamble = new byte[PREAMBLE.length];
@@ -277,13 +276,18 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
             try (ObjectInputStream ois = new ObjectInputStreamEx(new GZIPInputStream(new ByteArrayInputStream(buf)),
                     jenkins != null ? jenkins.pluginManager.uberClassLoader : ConsoleNote.class.getClassLoader(),
                     ClassFilter.DEFAULT)) {
-                return (ConsoleNote) ois.readObject();
+                return getConsoleNote(ois);
             }
         } catch (Error e) {
             // for example, bogus 'sz' can result in OutOfMemoryError.
             // package that up as IOException so that the caller won't fatally die.
             throw new IOException(e);
         }
+    }
+
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Deserialization is protected by logic.")
+    private static ConsoleNote getConsoleNote(ObjectInputStream ois) throws IOException, ClassNotFoundException {
+        return (ConsoleNote) ois.readObject();
     }
 
     /**

--- a/core/src/main/java/hudson/scheduler/Hash.java
+++ b/core/src/main/java/hudson/scheduler/Hash.java
@@ -23,6 +23,8 @@
  */
 package hudson.scheduler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -51,7 +53,8 @@ public abstract class Hash {
      * Produces an integer in [0,n)
      */
     public abstract int next(int n);
-    
+
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Not used for security.")
     public static Hash from(String seed) {
         try {
             MessageDigest md5 = MessageDigest.getInstance("MD5");

--- a/core/src/main/java/hudson/scheduler/Hash.java
+++ b/core/src/main/java/hudson/scheduler/Hash.java
@@ -54,10 +54,9 @@ public abstract class Hash {
      */
     public abstract int next(int n);
 
-    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Not used for security.")
     public static Hash from(String seed) {
         try {
-            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            MessageDigest md5 = getMd5();
             md5.update(seed.getBytes(StandardCharsets.UTF_8));
             byte[] digest = md5.digest();
 
@@ -78,6 +77,12 @@ public abstract class Hash {
         } catch (NoSuchAlgorithmException e) {
             throw new AssertionError(e);    // MD5 is a part of JRE
         }
+    }
+
+    // TODO JENKINS-60563 remove MD5 from all usages in Jenkins
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Should not be used for security.")
+    private static MessageDigest getMd5() throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance("MD5");
     }
 
     /**

--- a/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
+++ b/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
@@ -98,7 +98,7 @@ public class BasicAuthenticationFilter implements Filter {
     }
 
     @SuppressWarnings("ACL.impersonate")
-    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT")
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "Redirect is validated as processed.")
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse rsp = (HttpServletResponse) response;

--- a/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
+++ b/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
@@ -23,6 +23,7 @@
  */
 package hudson.security;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.User;
 import jenkins.model.Jenkins;
 import hudson.util.Scrambler;
@@ -97,6 +98,7 @@ public class BasicAuthenticationFilter implements Filter {
     }
 
     @SuppressWarnings("ACL.impersonate")
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT")
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse rsp = (HttpServletResponse) response;

--- a/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
+++ b/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
@@ -98,7 +98,6 @@ public class BasicAuthenticationFilter implements Filter {
     }
 
     @SuppressWarnings("ACL.impersonate")
-    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "Redirect is validated as processed.")
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse rsp = (HttpServletResponse) response;
@@ -164,13 +163,18 @@ public class BasicAuthenticationFilter implements Filter {
             path += '?'+q;
 
         // prepare a redirect
-        rsp.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
-        rsp.setHeader("Location",path);
+        prepareRedirect(rsp, path);
 
         // ... but first let the container authenticate this request
         RequestDispatcher d = servletContext.getRequestDispatcher("/j_security_check?j_username="+
             URLEncoder.encode(username,"UTF-8")+"&j_password="+URLEncoder.encode(password,"UTF-8"));
         d.include(req,rsp);
+    }
+
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "Redirect is validated as processed.")
+    private void prepareRedirect(HttpServletResponse rsp, String path) {
+        rsp.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
+        rsp.setHeader("Location",path);
     }
 
     //public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {

--- a/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
+++ b/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
@@ -61,7 +61,7 @@ import java.text.MessageFormat;
  */
 public class HudsonAuthenticationEntryPoint extends AuthenticationProcessingFilterEntryPoint {
     @Override
-    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "Interemediate step for redirecting users to login page.")
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "Intermediate step for redirecting users to login page.")
     public void commence(ServletRequest request, ServletResponse response, AuthenticationException reason) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse rsp = (HttpServletResponse) response;

--- a/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
+++ b/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
@@ -23,6 +23,7 @@
  */
 package hudson.security;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Functions;
 
 import com.google.common.base.Strings;
@@ -60,6 +61,7 @@ import java.text.MessageFormat;
  */
 public class HudsonAuthenticationEntryPoint extends AuthenticationProcessingFilterEntryPoint {
     @Override
+    @SuppressFBWarnings(value = "XSS_SERVLET")
     public void commence(ServletRequest request, ServletResponse response, AuthenticationException reason) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse rsp = (HttpServletResponse) response;

--- a/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
+++ b/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
@@ -61,7 +61,6 @@ import java.text.MessageFormat;
  */
 public class HudsonAuthenticationEntryPoint extends AuthenticationProcessingFilterEntryPoint {
     @Override
-    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "Intermediate step for redirecting users to login page.")
     public void commence(ServletRequest request, ServletResponse response, AuthenticationException reason) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse rsp = (HttpServletResponse) response;
@@ -102,15 +101,7 @@ public class HudsonAuthenticationEntryPoint extends AuthenticationProcessingFilt
             } catch (IllegalStateException e) {
                 out = rsp.getWriter();
             }
-            out.printf(
-                "<html><head>" +
-                "<meta http-equiv='refresh' content='1;url=%1$s'/>" +
-                "<script>window.location.replace('%1$s');</script>" +
-                "</head>" +
-                "<body style='background-color:white; color:white;'>%n" +
-                "%n%n"+
-                "Authentication required%n"+
-                "<!--%n",loginForm);
+            printResponse(loginForm, out);
 
             if (cause!=null)
                 cause.report(out);
@@ -124,5 +115,18 @@ public class HudsonAuthenticationEntryPoint extends AuthenticationProcessingFilt
                 out.print("                              ");
             out.close();
         }
+    }
+
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "Intermediate step for redirecting users to login page.")
+    private void printResponse(String loginForm, PrintWriter out) {
+        out.printf(
+            "<html><head>" +
+            "<meta http-equiv='refresh' content='1;url=%1$s'/>" +
+            "<script>window.location.replace('%1$s');</script>" +
+            "</head>" +
+            "<body style='background-color:white; color:white;'>%n" +
+            "%n%n"+
+            "Authentication required%n"+
+            "<!--%n",loginForm);
     }
 }

--- a/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
+++ b/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
@@ -61,7 +61,7 @@ import java.text.MessageFormat;
  */
 public class HudsonAuthenticationEntryPoint extends AuthenticationProcessingFilterEntryPoint {
     @Override
-    @SuppressFBWarnings(value = "XSS_SERVLET")
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "Interemediate step for redirecting users to login page.")
     public void commence(ServletRequest request, ServletResponse response, AuthenticationException reason) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse rsp = (HttpServletResponse) response;

--- a/core/src/main/java/hudson/util/ConsistentHash.java
+++ b/core/src/main/java/hudson/util/ConsistentHash.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.Iterators.DuplicateFilterIterator;
 
 /**
@@ -60,6 +61,7 @@ import hudson.util.Iterators.DuplicateFilterIterator;
  * @author Kohsuke Kawaguchi
  * @since 1.302
  */
+@SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Not used for security.")
 public class ConsistentHash<T> {
     /**
      * All the items in the hash, to their replication factors.

--- a/core/src/main/java/hudson/util/ConsistentHash.java
+++ b/core/src/main/java/hudson/util/ConsistentHash.java
@@ -26,6 +26,7 @@ package hudson.util;
 import java.lang.RuntimeException;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,7 +62,6 @@ import hudson.util.Iterators.DuplicateFilterIterator;
  * @author Kohsuke Kawaguchi
  * @since 1.302
  */
-@SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Not used for security.")
 public class ConsistentHash<T> {
     /**
      * All the items in the hash, to their replication factors.
@@ -292,7 +292,7 @@ public class ConsistentHash<T> {
      */
     private int md5(String s) {
         try {
-            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            MessageDigest md5 = getMd5();
             md5.update(s.getBytes());
             byte[] digest = md5.digest();
 
@@ -303,6 +303,12 @@ public class ConsistentHash<T> {
         } catch (GeneralSecurityException e) {
             throw new RuntimeException("Could not generate MD5 hash", e);
         }
+    }
+
+    // TODO JENKINS-60563 remove MD5 from all usages in Jenkins
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Not used for security.")
+    private MessageDigest getMd5() throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance("MD5");
     }
 
     /**

--- a/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
+++ b/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
@@ -1,5 +1,6 @@
 package hudson.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Util;
 import org.kohsuke.accmod.Restricted;
@@ -16,6 +17,7 @@ class DOSToUnixPathHelper {
         void error(String string);
         void validate(File fexe);
     }
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN")
     static private boolean checkPrefix(String prefix, Helper helper) {
         File f = new File(prefix);
         if(f.exists()) {
@@ -30,6 +32,7 @@ class DOSToUnixPathHelper {
         }
         return false;
     }
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN")
     static void iteratePath(String exe, Helper helper) {
         exe = fixEmpty(exe);
         if(exe==null) {

--- a/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
+++ b/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
@@ -17,15 +17,14 @@ class DOSToUnixPathHelper {
         void error(String string);
         void validate(File fexe);
     }
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Limited use for locating shell executable by administrator.")
     static private boolean checkPrefix(String prefix, Helper helper) {
-        File f = new File(prefix);
+        File f = constructFile(prefix);
         if(f.exists()) {
             helper.checkExecutable(f);
             return true;
         }
 
-        File fexe = new File(prefix+".exe");
+        File fexe = constructFile(prefix+".exe");
         if(fexe.exists()) {
             helper.checkExecutable(fexe);
             return true;
@@ -33,6 +32,9 @@ class DOSToUnixPathHelper {
         return false;
     }
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Limited use for locating shell executable by administrator.")
+    private static File constructFile(String prefix) {
+        return new File(prefix);
+    }
     static void iteratePath(String exe, Helper helper) {
         exe = fixEmpty(exe);
         if(exe==null) {

--- a/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
+++ b/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
@@ -17,7 +17,7 @@ class DOSToUnixPathHelper {
         void error(String string);
         void validate(File fexe);
     }
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN")
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Limited use for locating shell executable by administrator.")
     static private boolean checkPrefix(String prefix, Helper helper) {
         File f = new File(prefix);
         if(f.exists()) {
@@ -32,7 +32,7 @@ class DOSToUnixPathHelper {
         }
         return false;
     }
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN")
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Limited use for locating shell executable by administrator.")
     static void iteratePath(String exe, Helper helper) {
         exe = fixEmpty(exe);
         if(exe==null) {

--- a/core/src/main/java/hudson/util/FormFieldValidator.java
+++ b/core/src/main/java/hudson/util/FormFieldValidator.java
@@ -320,7 +320,6 @@ public abstract class FormFieldValidator {
             super(request, response);
         }
 
-        @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not used.")
         protected void check() throws IOException, ServletException {
             String value = fixEmpty(request.getParameter("value"));
             if(value==null) {// nothing entered yet
@@ -332,7 +331,7 @@ public abstract class FormFieldValidator {
 
             try {
                 URL url = new URL(value);
-                HttpURLConnection con = (HttpURLConnection)url.openConnection();
+                HttpURLConnection con = openConnection(url);
                 con.connect();
                 if(con.getResponseCode()!=200
                 || con.getHeaderField("X-Hudson")==null) {
@@ -344,6 +343,11 @@ public abstract class FormFieldValidator {
             } catch (IOException e) {
                 handleIOException(value,e);
             }
+        }
+
+        @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not used.")
+        private HttpURLConnection openConnection(URL url) throws IOException {
+            return (HttpURLConnection)url.openConnection();
         }
     }
 
@@ -516,7 +520,6 @@ public abstract class FormFieldValidator {
             super(request, response, true);
         }
 
-        @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Not used.")
         protected void check() throws IOException, ServletException {
             String exe = fixEmpty(request.getParameter("value"));
             FormFieldValidator.Executable self = this;

--- a/core/src/main/java/hudson/util/FormFieldValidator.java
+++ b/core/src/main/java/hudson/util/FormFieldValidator.java
@@ -320,7 +320,7 @@ public abstract class FormFieldValidator {
             super(request, response);
         }
 
-        @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD")
+        @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not used.")
         protected void check() throws IOException, ServletException {
             String value = fixEmpty(request.getParameter("value"));
             if(value==null) {// nothing entered yet

--- a/core/src/main/java/hudson/util/FormFieldValidator.java
+++ b/core/src/main/java/hudson/util/FormFieldValidator.java
@@ -23,6 +23,7 @@
  */
 package hudson.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
 import hudson.ProxyConfiguration;
 import hudson.Util;
@@ -145,6 +146,7 @@ public abstract class FormFieldValidator {
     /**
      * Gets the parameter as a file.
      */
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Not used.")
     protected final File getFileParameter(String paramName) {
         return new File(Util.fixNull(request.getParameter(paramName)));
     }
@@ -318,6 +320,7 @@ public abstract class FormFieldValidator {
             super(request, response);
         }
 
+        @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD")
         protected void check() throws IOException, ServletException {
             String value = fixEmpty(request.getParameter("value"));
             if(value==null) {// nothing entered yet
@@ -513,6 +516,7 @@ public abstract class FormFieldValidator {
             super(request, response, true);
         }
 
+        @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Not used.")
         protected void check() throws IOException, ServletException {
             String exe = fixEmpty(request.getParameter("value"));
             FormFieldValidator.Executable self = this;

--- a/core/src/main/java/jenkins/model/RunIdMigrator.java
+++ b/core/src/main/java/jenkins/model/RunIdMigrator.java
@@ -24,6 +24,7 @@
 
 package jenkins.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Job;
@@ -309,6 +310,7 @@ public final class RunIdMigrator {
      * Reverses the migration, in case you want to revert to the older format.
      * @param args one parameter, {@code $JENKINS_HOME}
      */
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Only used as an command-line process.")
     public static void main(String... args) throws Exception {
         if (args.length != 1) {
             throw new Exception("pass one parameter, $JENKINS_HOME");

--- a/core/src/main/java/jenkins/model/RunIdMigrator.java
+++ b/core/src/main/java/jenkins/model/RunIdMigrator.java
@@ -322,7 +322,7 @@ public final class RunIdMigrator {
         new RunIdMigrator().unmigrateJobsDir(jobs);
     }
 
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Only used as an command-line process.")
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Only invoked from the command line as a standalone utility")
     private static File constructFile(String arg) {
         return new File(arg);
     }

--- a/core/src/main/java/jenkins/model/RunIdMigrator.java
+++ b/core/src/main/java/jenkins/model/RunIdMigrator.java
@@ -310,18 +310,23 @@ public final class RunIdMigrator {
      * Reverses the migration, in case you want to revert to the older format.
      * @param args one parameter, {@code $JENKINS_HOME}
      */
-    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Only used as an command-line process.")
     public static void main(String... args) throws Exception {
         if (args.length != 1) {
             throw new Exception("pass one parameter, $JENKINS_HOME");
         }
-        File root = new File(args[0]);
+        File root = constructFile(args[0]);
         File jobs = new File(root, "jobs");
         if (!jobs.isDirectory()) {
             throw new FileNotFoundException("no such $JENKINS_HOME " + root);
         }
         new RunIdMigrator().unmigrateJobsDir(jobs);
     }
+
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Only used as an command-line process.")
+    private static File constructFile(String arg) {
+        return new File(arg);
+    }
+
     private void unmigrateJobsDir(File jobs) throws Exception {
         File[] jobDirs = jobs.listFiles();
         if (jobDirs == null) {

--- a/core/src/main/java/jenkins/model/identity/IdentityRootAction.java
+++ b/core/src/main/java/jenkins/model/identity/IdentityRootAction.java
@@ -1,5 +1,6 @@
 package jenkins.model.identity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import java.security.MessageDigest;
@@ -61,6 +62,7 @@ public class IdentityRootAction implements UnprotectedRootAction {
      *
      * @return the fingerprint of the public key.
      */
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Not used for security. ")
     public String getFingerprint() {
         RSAPublicKey key = InstanceIdentityProvider.RSA.getPublicKey();
         if (key == null) {

--- a/core/src/main/java/jenkins/model/identity/IdentityRootAction.java
+++ b/core/src/main/java/jenkins/model/identity/IdentityRootAction.java
@@ -70,7 +70,7 @@ public class IdentityRootAction implements UnprotectedRootAction {
         }
         // TODO replace with org.jenkinsci.remoting.util.KeyUtils once JENKINS-36871 changes are merged
         try {
-            MessageDigest digest = MessageDigest.getInstance("MD5");
+            MessageDigest digest = getMd5();
             digest.reset();
             byte[] bytes = digest.digest(key.getEncoded());
             StringBuilder result = new StringBuilder(Math.max(0, bytes.length * 3 - 1));
@@ -85,5 +85,11 @@ public class IdentityRootAction implements UnprotectedRootAction {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("JLS mandates MD5 support");
         }
+    }
+
+    // TODO JENKINS-60563 remove MD5 from all usages in Jenkins
+    @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "Not used for security. ")
+    private MessageDigest getMd5() throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance("MD5");
     }
 }

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
@@ -23,7 +23,6 @@
  */
 package jenkins.slaves;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Computer;
@@ -99,7 +98,6 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
      * @throws KeyManagementException if things go wrong.
      * @throws IOException            if things go wrong.
      */
-    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD", justification = "Password doesn't need to be protected.")
     public JnlpSlaveAgentProtocol4() throws KeyStoreException, KeyManagementException, IOException {
         // prepare our local identity and certificate
         X509Certificate identityCertificate = InstanceIdentityProvider.RSA.getCertificate();
@@ -113,7 +111,7 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
 
         // prepare our keyStore so we can provide our authentication
         keyStore = KeyStore.getInstance("JKS");
-        char[] password = "password".toCharArray();
+        char[] password = constructPassword();
         try {
             keyStore.load(null, password);
         } catch (IOException e) {
@@ -146,6 +144,10 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
             throw new IllegalStateException("Java runtime specification requires support for TLS algorithm", e);
         }
         sslContext.init(kmf.getKeyManagers(), trustManagers, null);
+    }
+
+    private char[] constructPassword() {
+        return "password".toCharArray();
     }
 
     /**
@@ -184,7 +186,7 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
                 LOGGER.log(Level.INFO, "Updating {0} TLS certificate to retain validity", getName());
                 X509Certificate identityCertificate = InstanceIdentityProvider.RSA.getCertificate();
                 RSAPrivateKey privateKey = InstanceIdentityProvider.RSA.getPrivateKey();
-                char[] password = "password".toCharArray();
+                char[] password = constructPassword();
                 keyStore.setKeyEntry("jenkins", privateKey, password, new X509Certificate[]{identityCertificate});
             }
         } catch (KeyStoreException e) {

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
@@ -23,6 +23,7 @@
  */
 package jenkins.slaves;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Computer;
@@ -98,6 +99,7 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
      * @throws KeyManagementException if things go wrong.
      * @throws IOException            if things go wrong.
      */
+    @SuppressFBWarnings("HARD_CODE_PASSWORD")
     public JnlpSlaveAgentProtocol4() throws KeyStoreException, KeyManagementException, IOException {
         // prepare our local identity and certificate
         X509Certificate identityCertificate = InstanceIdentityProvider.RSA.getCertificate();

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
@@ -99,7 +99,7 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
      * @throws KeyManagementException if things go wrong.
      * @throws IOException            if things go wrong.
      */
-    @SuppressFBWarnings("HARD_CODE_PASSWORD")
+    @SuppressFBWarnings(value = "HARD_CODE_PASSWORD", justification = "Password doesn't need to be protected.")
     public JnlpSlaveAgentProtocol4() throws KeyStoreException, KeyManagementException, IOException {
         // prepare our local identity and certificate
         X509Certificate identityCertificate = InstanceIdentityProvider.RSA.getCertificate();

--- a/pom.xml
+++ b/pom.xml
@@ -407,6 +407,20 @@ THE SOFTWARE.
 	        <groupId>org.codehaus.mojo</groupId>
 	        <artifactId>animal-sniffer-maven-plugin</artifactId>
         </plugin>
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <configuration>
+            <plugins>
+              <plugin>
+                <groupId>com.h3xstream.findsecbugs</groupId>
+                <artifactId>findsecbugs-plugin</artifactId>
+                <version>1.10.1</version>
+              </plugin>
+            </plugins>
+            <maxHeap>768</maxHeap>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/src/findbugs/findbugs-excludes.xml
+++ b/src/findbugs/findbugs-excludes.xml
@@ -13,4 +13,12 @@
       <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
     </Or>
   </Match>
+  <Match>
+    <!--We don't care about this behavior.-->
+    <Bug pattern="CRLF_INJECTION_LOGS"/>
+  </Match>
+  <Match>
+    <!--Jenkins handles this issue differently or doesn't care about it.-->
+    <Bug pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Add findsecbugs plugin to spotbugs. And suppress existing warnings. We should clean some of them up, but that's for different PRs at a later time.

Some of the issues findsecbugs just misidentifies. With some it doesn't understand enough context.

As always with these sort of of analysis tools, adding them to existing code correctly can be a bit of a challenge. It's easier to suppress things that aren't really problems than to clean all of them up. Most of the benefit from applying these tools comes from checking newly added code and preventing new issues from creeping in.

### Proposed changelog entries

* Developer: Add findsecbug plugins to spotbugs build plugin.

### Submitter checklist

- [n/a ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
The findsecbugs plugin provides a form of testing. The PR changes no production behavior. Existing tests serve to verify consistent behavior.
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs