### PR TITLE
Fix online example/documentation for File Access Rules

### DIFF
--- a/core/src/main/resources/jenkins/security/s2m/AdminWhitelistRule/index.jelly
+++ b/core/src/main/resources/jenkins/security/s2m/AdminWhitelistRule/index.jelly
@@ -94,17 +94,17 @@ THE SOFTWARE.
       </p>
 <pre>
 # deny access to anything in the SkunkWorks folder, regardless of what later rules say
-deny read &lt;JENKINS_HOME>/jobs/SkunkWorks/.*
+deny read &amp;lt;JENKINS_HOME>/jobs/SkunkWorks/.*
 
 # allow any access under builds
-allow all &lt;BUILDDIR>/.*
+allow all &amp;lt;BUILDDIR>/.*
 
 # allow read-only access under userContent
-allow read,stat &lt;JENKINS_HOME>/userContent/.*
-
-# GENERAL SYNTAX: (allow|deny) <i>Op,Op,Op,...</i> <i>PathRegExp</i>
+allow read,stat &amp;lt;JENKINS_HOME>/userContent/.*
 </pre>
-
+<p>
+  General syntax: (allow|deny) <i>Op,Op,Op,...</i> <i>PathRegExp,</i>
+</p>
       <div style="margin:1em">
         <f:submit value="${%Update}"/>
       </div>


### PR DESCRIPTION
The online example/documentation for File Access Rules (Manage Jenkins -> Configure Global Security -> Agent/Master Security -> "Rules can be tweaked here") is broken since some < characters are used which break the HTML parsing, missing parts of the example.


So instead of reading:
`deny read <JENKINS_HOME>/jobs/SkunkWorks/.*`
We see:
`deny read /jobs/SkunkWorks/.*`


See screenshot:


![file-access-rules-1](https://user-images.githubusercontent.com/19709142/70067719-00064780-15ef-11ea-99a7-ef22c03bfad2.png)

This is visible also from ie. Firefox source browser:

![file-access-rules-2](https://user-images.githubusercontent.com/19709142/70067777-14e2db00-15ef-11ea-8991-9521dd74eaf7.png)

This PR fixes this. The change correctly escapes now the opening HTML tag (that is once parsed by the Jelly parser as well, so that complicates a bit things) and moves the general syntax out of the preformatted HTML entity so _emphasis_ can be correctly handled.

The final proposed result being:

![file-access-rules-3](https://user-images.githubusercontent.com/19709142/70067911-55daef80-15ef-11ea-8191-eb3ccdb4e429.png)


