### PR TITLE
[JENKINS-60357] Use XMLUnit to fix test

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -642,6 +642,18 @@ THE SOFTWARE.
       <artifactId>jzlib</artifactId>
       <version>1.1.3-kohsuke-1</version>
     </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-core</artifactId>
+      <version>2.2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-matchers</artifactId>
+      <version>2.2.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/test/java/hudson/util/CopyOnWriteListTest.java
+++ b/core/src/test/java/hudson/util/CopyOnWriteListTest.java
@@ -23,10 +23,14 @@
  */
 package hudson.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 import org.junit.Test;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,9 +54,12 @@ public class CopyOnWriteListTest {
         TestData td = new TestData();
 
         String out = xs.toXML(td);
-        assertEquals("empty lists", "<hudson.util.CopyOnWriteListTest_-TestData>"
-                + "<list1/><list2/></hudson.util.CopyOnWriteListTest_-TestData>",
-                out.replaceAll("\\s+", ""));
+        String expected = "<hudson.util.CopyOnWriteListTest_-TestData>"
+                + "<list1/><list2/></hudson.util.CopyOnWriteListTest_-TestData>";
+        assertThat(out, isSimilarTo(expected).ignoreWhitespace()
+                .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
+
+
         TestData td2 = (TestData)xs.fromXML(out);
         assertTrue(td2.list1.isEmpty());
         assertTrue(td2.list2.isEmpty());
@@ -60,10 +67,11 @@ public class CopyOnWriteListTest {
         td.list1.add("foobar1");
         td.list2.add("foobar2");
         out = xs.toXML(td);
-        assertEquals("lists", "<hudson.util.CopyOnWriteListTest_-TestData>"
+        expected = "<hudson.util.CopyOnWriteListTest_-TestData>"
                 + "<list1><string>foobar1</string></list1><list2><string>foobar2"
-                + "</string></list2></hudson.util.CopyOnWriteListTest_-TestData>",
-                out.replaceAll("\\s+", ""));
+                + "</string></list2></hudson.util.CopyOnWriteListTest_-TestData>";
+        assertThat(out, isSimilarTo(expected).ignoreWhitespace()
+                .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
         td2 = (TestData)xs.fromXML(out);
         assertEquals("foobar1", td2.list1.getView().get(0));
         assertEquals("foobar2", td2.list2.get(0));


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-60357](https://issues.jenkins-ci.org/browse/JENKINS-60357).

This PR proposes to use XMLUnit to fix the problem. It ignores the order of XML elements to make the tests more robust.
<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Make tests more stable by using XMLUnit to compare XML results.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->


