### PR TITLE
Export the plugin compatibility flag in Update Site REST API

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -1127,7 +1127,6 @@ public class UpdateSite {
             return deps;
         }
 
-        @Exported
         public boolean isForNewerHudson() {
             try {
                 return requiredCore!=null && new VersionNumber(requiredCore).isNewerThan(
@@ -1141,7 +1140,6 @@ public class UpdateSite {
          * Returns true iff the plugin declares a minimum Java version and it's newer than what the Jenkins master is running on.
          * @since 2.158
          */
-        @Exported
         public boolean isForNewerJava() {
             try {
                 final JavaSpecificationVersion currentRuntimeJavaVersion = JavaUtils.getCurrentJavaRuntimeVersionNumber();
@@ -1218,7 +1216,6 @@ public class UpdateSite {
          *
          * @since 2.158
          */
-        @Exported
         public boolean isNeededDependenciesForNewerJava() {
             for (Plugin p: getNeededDependencies()) {
                 if (p.isForNewerJava() || p.isNeededDependenciesForNewerJava()) {

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -1202,7 +1202,6 @@ public class UpdateSite {
         }
 
         @Restricted(NoExternalUse.class) // table.jelly
-        @Exported
         public boolean isNeededDependenciesForNewerJenkins(PluginManager.MetadataCache cache) {
             return cache.of("isNeededDependenciesForNewerJenkins:" + name, Boolean.class, () -> {
                 for (Plugin p : getNeededDependencies()) {
@@ -1242,7 +1241,6 @@ public class UpdateSite {
         }
 
         @Restricted(NoExternalUse.class) // table.jelly
-        @Exported
         public boolean isNeededDependenciesCompatibleWithInstalledVersion(PluginManager.MetadataCache cache) {
             return getDependenciesIncompatibleWithInstalledVersion(cache).isEmpty();
         }

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -1038,11 +1038,12 @@ public class UpdateSite {
 
         /**
          * Returns true if the plugin and its dependencies are fully compatible with the current installation
-         * This is set to restricted for now, since it is only being used by Jenkins UI at the moment.
+         * This is set to restricted for now, since it is only being used by Jenkins UI or Restful API at the moment.
          *
          * @since 2.175
          */
         @Restricted(NoExternalUse.class)
+        @Exported
         public boolean isCompatible() {
             return isCompatible(new PluginManager.MetadataCache());
         }
@@ -1125,7 +1126,8 @@ public class UpdateSite {
 
             return deps;
         }
-        
+
+        @Exported
         public boolean isForNewerHudson() {
             try {
                 return requiredCore!=null && new VersionNumber(requiredCore).isNewerThan(
@@ -1139,6 +1141,7 @@ public class UpdateSite {
          * Returns true iff the plugin declares a minimum Java version and it's newer than what the Jenkins master is running on.
          * @since 2.158
          */
+        @Exported
         public boolean isForNewerJava() {
             try {
                 final JavaSpecificationVersion currentRuntimeJavaVersion = JavaUtils.getCurrentJavaRuntimeVersionNumber();
@@ -1199,6 +1202,7 @@ public class UpdateSite {
         }
 
         @Restricted(NoExternalUse.class) // table.jelly
+        @Exported
         public boolean isNeededDependenciesForNewerJenkins(PluginManager.MetadataCache cache) {
             return cache.of("isNeededDependenciesForNewerJenkins:" + name, Boolean.class, () -> {
                 for (Plugin p : getNeededDependencies()) {
@@ -1215,6 +1219,7 @@ public class UpdateSite {
          *
          * @since 2.158
          */
+        @Exported
         public boolean isNeededDependenciesForNewerJava() {
             for (Plugin p: getNeededDependencies()) {
                 if (p.isForNewerJava() || p.isNeededDependenciesForNewerJava()) {
@@ -1237,6 +1242,7 @@ public class UpdateSite {
         }
 
         @Restricted(NoExternalUse.class) // table.jelly
+        @Exported
         public boolean isNeededDependenciesCompatibleWithInstalledVersion(PluginManager.MetadataCache cache) {
             return getDependenciesIncompatibleWithInstalledVersion(cache).isEmpty();
         }


### PR DESCRIPTION
We wish I can upgrade all compatible plugins by [jcli](https://github.com/jenkins-zh/jenkins-cli).
See also the [PR link](https://github.com/jenkins-zh/jenkins-cli/pull/258).

### Proposed changelog entries

* Export the plugin compatibility flag in Update Site REST API
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@romenrg

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->