### PR TITLE
Adding some nullability annotations related to Label

### DIFF
--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -71,6 +71,7 @@ import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import javax.annotation.Nonnull;
 
 /**
  * Group of {@link Node}s.
@@ -84,16 +85,19 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     /**
      * Display name of this label.
      */
+    @Nonnull
     protected transient final String name;
     private transient volatile Set<Node> nodes;
     private transient volatile Set<Cloud> clouds;
     private transient volatile int tiedJobsCount;
 
     @Exported
+    @Nonnull
     public transient final LoadStatistics loadStatistics;
+    @Nonnull
     public transient final NodeProvisioner nodeProvisioner;
 
-    public Label(String name) {
+    public Label(@Nonnull String name) {
         this.name = name;
          // passing these causes an infinite loop - getTotalExecutors(),getBusyExecutors());
         this.loadStatistics = new LoadStatistics(0,0) {
@@ -137,6 +141,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     /**
      * Returns a human-readable text that represents this label.
      */
+    @Nonnull
     public String getDisplayName() {
         return name;
     }

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -35,6 +35,7 @@ import jenkins.util.SystemProperties;
 import jenkins.util.Timer;
 import org.jenkinsci.Symbol;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 import java.awt.Color;
@@ -126,6 +127,7 @@ public class NodeProvisioner {
      * Null if this {@link NodeProvisioner} is working for the entire Hudson,
      * for jobs that are unassigned to any particular node.
      */
+    @CheckForNull
     private final Label label;
 
     private final AtomicReference<List<PlannedNode>> pendingLaunches
@@ -149,7 +151,7 @@ public class NodeProvisioner {
     private final MultiStageTimeSeries plannedCapacitiesEMA =
             new MultiStageTimeSeries(Messages._NodeProvisioner_EmptyString(),Color.WHITE,0,DECAY);
 
-    public NodeProvisioner(Label label, LoadStatistics loadStatistics) {
+    public NodeProvisioner(@CheckForNull Label label, LoadStatistics loadStatistics) {
         this.label = label;
         this.stat = loadStatistics;
     }
@@ -395,6 +397,7 @@ public class NodeProvisioner {
         /**
          * The label under consideration.
          */
+        @CheckForNull
         private final Label label;
         /**
          * The planned capacity for this {@link #label}.
@@ -416,7 +419,7 @@ public class NodeProvisioner {
          * @param label the label.
          * @param plannedCapacitySnapshot the planned executor count.
          */
-        private StrategyState(LoadStatistics.LoadStatisticsSnapshot snapshot, Label label, int plannedCapacitySnapshot) {
+        private StrategyState(LoadStatistics.LoadStatisticsSnapshot snapshot, @CheckForNull Label label, int plannedCapacitySnapshot) {
             this.snapshot = snapshot;
             this.label = label;
             this.plannedCapacitySnapshot = plannedCapacitySnapshot;
@@ -425,6 +428,7 @@ public class NodeProvisioner {
         /**
          * The label under consideration.
          */
+        @CheckForNull
         public Label getLabel() {
             return label;
         }


### PR DESCRIPTION
In the course of (attempting to) track down a plugin NPE, it was unclear whether `StrategyState.label` or `Label.nodeProvisioner` could be null. I am inferring these annotations from usages and surrounding code.