### PR TITLE
Adapt some tests to newer Jetty

### DIFF
--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -71,7 +71,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2.55</version>
+      <version>2.57</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test-pom/pom.xml
+++ b/test-pom/pom.xml
@@ -167,7 +167,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <version>2.2</version>
     </dependency>
     <dependency>
       <!-- for testing JNLP launch. -->

--- a/test/src/test/java/hudson/security/csrf/DefaultCrumbIssuerSEC1491Test.java
+++ b/test/src/test/java/hudson/security/csrf/DefaultCrumbIssuerSEC1491Test.java
@@ -4,23 +4,19 @@ import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
+import static org.hamcrest.Matchers.*;
 import org.junit.Assert;
+import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
-
-import java.net.HttpURLConnection;
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 //TODO merge back to DefaultCrumbIssuerTest
 public class DefaultCrumbIssuerSEC1491Test {
@@ -72,7 +68,8 @@ public class DefaultCrumbIssuerSEC1491Test {
             r.createWebClient().getPage(request1);
             fail();
         } catch (FailingHttpStatusCodeException e) {
-            assertTrue(e.getMessage().contains("No valid crumb"));
+            assertEquals(HttpServletResponse.SC_FORBIDDEN, e.getStatusCode());
+            assertThat(e.getResponse().getContentAsString(), containsString("No valid crumb"));
         }
         // cannot create new job due to missing crumb
         assertNull(r.jenkins.getItem(jobName1));

--- a/test/src/test/java/hudson/security/csrf/DefaultCrumbIssuerSEC626Test.java
+++ b/test/src/test/java/hudson/security/csrf/DefaultCrumbIssuerSEC626Test.java
@@ -10,16 +10,15 @@ import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.html.DomElement;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.User;
+import javax.servlet.http.HttpServletResponse;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author dty
@@ -74,7 +73,8 @@ public class DefaultCrumbIssuerSEC626Test { //TODO merge back to DefaultCrumbIss
                 r.submit(p.getFormByName("config"));
                 fail();
             } catch (FailingHttpStatusCodeException e) {
-                assertTrue(e.getMessage().contains("No valid crumb"));
+                assertEquals(HttpServletResponse.SC_FORBIDDEN, e.getStatusCode());
+                assertThat(e.getResponse().getContentAsString(), containsString("No valid crumb"));
             }
         }
     }

--- a/test/src/test/java/jenkins/security/ResourceDomainTest.java
+++ b/test/src/test/java/jenkins/security/ResourceDomainTest.java
@@ -10,6 +10,7 @@ import hudson.model.Item;
 import hudson.model.UnprotectedRootAction;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
+import static org.hamcrest.Matchers.*;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -176,7 +177,7 @@ public class ResourceDomainTest {
             String modifiedUrl = resourceResponseUrl.replaceAll("static[-]files[/]....", "static-files/aaaa");
             Page page = webClient.getPage(modifiedUrl);
             Assert.assertEquals("resource not found", 404, page.getWebResponse().getStatusCode());
-            Assert.assertEquals("resource not found", ResourceDomainFilter.ERROR_RESPONSE, page.getWebResponse().getStatusMessage());
+            Assert.assertThat("resource not found", page.getWebResponse().getContentAsString(), containsString(ResourceDomainFilter.ERROR_RESPONSE));
         }
 
 
@@ -219,7 +220,7 @@ public class ResourceDomainTest {
         // and we get a 403 response
         page = webClient.getPage(anonUrl);
         Assert.assertEquals("page is not found", 403, page.getWebResponse().getStatusCode());
-        Assert.assertTrue("Response mentions workspace permission", page.getWebResponse().getStatusMessage().contains("Failed permission check: anonymous is missing the Job/Workspace permission"));
+        Assert.assertThat("Response mentions workspace permission", page.getWebResponse().getContentAsString(), containsString("Failed permission check: anonymous is missing the Job/Workspace permission"));
 
         // now remove Job/Read permission from all users (but grant Discover)
         a = new MockAuthorizationStrategy();
@@ -230,7 +231,7 @@ public class ResourceDomainTest {
         // and we get a 403 response asking to log in (Job/Discover is basically meant to be granted to anonymous only)
         page = webClient.getPage(anonUrl);
         Assert.assertEquals("page is not found", 403, page.getWebResponse().getStatusCode());
-        Assert.assertTrue("Response mentions workspace permission", page.getWebResponse().getStatusMessage().contains("Failed permission check: Please login to access job"));
+        Assert.assertThat("Response mentions workspace permission", page.getWebResponse().getContentAsString(), containsString("Failed permission check: Please login to access job"));
     }
 
     @Test


### PR DESCRIPTION
Adapts to https://github.com/jenkinsci/jenkins-test-harness/pull/175 and specifically https://github.com/eclipse/jetty.project/issues/4154. Also adapts to https://github.com/jenkinsci/jenkins-test-harness/pull/161 + https://github.com/jenkinsci/jenkins-test-harness/pull/173. Should fix a few tests failing in https://github.com/jenkinsci/jenkins/pull/4369 solely due to the `jenkins-test-harness` update.