### PR TITLE
[JENKINS-59107] User is no longer logged out when authenticating another user

### DIFF
--- a/core/src/main/java/jenkins/security/seed/UserSeedSecurityListener.java
+++ b/core/src/main/java/jenkins/security/seed/UserSeedSecurityListener.java
@@ -44,15 +44,15 @@ import javax.servlet.http.HttpSession;
 public class UserSeedSecurityListener extends SecurityListener {
     @Override 
     protected void loggedIn(@Nonnull String username) {
-        putUserSeedInSession(username);
+        putUserSeedInSession(username, true);
     }
     
     @Override 
     protected void authenticated(@Nonnull UserDetails details) {
-        putUserSeedInSession(details.getUsername());
+        putUserSeedInSession(details.getUsername(), false);
     }
 
-    private void putUserSeedInSession(String username) {
+    private static void putUserSeedInSession(String username, boolean overwriteSessionSeed) {
         StaplerRequest req = Stapler.getCurrentRequest();
         if (req == null) {
             // expected case: CLI
@@ -67,6 +67,10 @@ public class UserSeedSecurityListener extends SecurityListener {
         }
 
         if (!UserSeedProperty.DISABLE_USER_SEED) {
+            if (!overwriteSessionSeed && session.getAttribute(UserSeedProperty.USER_SESSION_SEED) != null) {
+                return;
+            }
+
             User user = User.getById(username, true);
 
             UserSeedProperty userSeed = user.getProperty(UserSeedProperty.class);

--- a/test/src/test/java/jenkins/security/seed/UserSeedSecurityListenerTest.java
+++ b/test/src/test/java/jenkins/security/seed/UserSeedSecurityListenerTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security.seed;
+
+import org.acegisecurity.AuthenticationManager;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.stapler.Stapler;
+
+import javax.servlet.http.HttpSession;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class UserSeedSecurityListenerTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-59107")
+    public void authenticateSecondaryUserWhileLoggedIn_shouldNotOverwritePrimaryUserSessionSeed() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        AuthenticationManager authenticationManager = j.jenkins.getSecurityRealm().getSecurityComponents().manager;
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login("alice").executeOnServer(() -> {
+            HttpSession session = Stapler.getCurrentRequest().getSession();
+            String existingSeed = (String) session.getAttribute(UserSeedProperty.USER_SESSION_SEED);
+            assertNotNull(existingSeed);
+            authenticationManager.authenticate(new UsernamePasswordAuthenticationToken("bob", "bob"));
+            String updatedSeed = (String) session.getAttribute(UserSeedProperty.USER_SESSION_SEED);
+            assertEquals(existingSeed, updatedSeed);
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
This fixes a regression introduced in SECURITY-901 where performing an authentication check on another user while logged in caused the user to get logged out.

See [JENKINS-59107](https://issues.jenkins-ci.org/browse/JENKINS-59107).

### Proposed changelog entries

* Fixed regression where authenticating a secondary user while logged in causes the primary user to be logged out.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@Wadeck @jeffret-b @daniel-beck 