### PR TITLE
[JENKINS-21311] Make the queue/cancelItem API an API.

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -765,7 +765,7 @@ public class Queue extends ResourceController implements Saveable {
      * Called from {@code queue.jelly} and {@code queue-items.jelly}.
      */
     @RequirePOST
-    public HttpResponse doCancelItem(@QueryParameter long id) {
+    public HttpResponse doCancelItem(@QueryParameter long id) throws IOException, ServletException {
         Item item = getItem(id);
         if (item != null) {
             if(item.hasCancelPermission()){
@@ -776,7 +776,7 @@ public class Queue extends ResourceController implements Saveable {
             }
             return HttpResponses.error(422, "Item for id (" + id + ") is not cancellable");
         } // else too late, ignore (JENKINS-14813)
-        return HttpResponses.error(422, "Provided id (" + id + ") does not exist");
+        return HttpResponses.error(HttpServletResponse.SC_NOT_FOUND, "Provided id (" + id + ") not found");
     }
 
     public boolean isEmpty() {

--- a/core/src/main/resources/hudson/model/queue/_api.jelly
+++ b/core/src/main/resources/hudson/model/queue/_api.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+
+  <h2>Canceling the build of an item in the Queue</h2>
+  <p>
+    To programmatically cancel the build of an item in the Queue, post to <a href="../cancelItem">this URL</a>.
+    The id of the item to cancel is expected.
+
+    Response will be:
+    <ul>
+      <li> 204 if the run tied with the given id was successfully cancelled</li>
+      <li> 422 if the provided id does not exist or match an item that cannot be cancelled</li>
+      <li> 500 if the provided id exists but Jenkins could not cancel the run</li>
+    </ul>
+  </p>
+
+</j:jelly>

--- a/core/src/test/java/hudson/model/QueueTest.java
+++ b/core/src/test/java/hudson/model/QueueTest.java
@@ -1,0 +1,72 @@
+package hudson.model;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.Issue;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerResponse;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueueTest {
+
+    @Mock
+    StaplerResponse resp;
+    @Mock
+    Queue.Task task;
+    @Mock
+    PrintWriter writer;
+
+    @Before
+    public void setup() throws IOException {
+        when(resp.getWriter()).thenReturn(writer);
+    }
+
+    @Issue("JENKINS-21311")
+    @Test
+    public void cancelItemOnaValidItemShouldReturnA204() throws IOException, ServletException {
+        when(task.hasAbortPermission()).thenReturn(true);
+        Queue queue = new Queue(LoadBalancer.CONSISTENT_HASH);
+        queue.schedule(task, 6000);
+
+        HttpResponse httpResponse = queue.doCancelItem(Queue.WaitingItem.getCurrentCounterValue());
+        httpResponse.generateResponse(null, resp, null);
+
+        verify(resp).setStatus(HttpServletResponse.SC_NO_CONTENT);
+    }
+
+    @Issue("JENKINS-21311")
+    @Test
+    public void cancelItemOnANonExistingItemShouldReturnA422()  throws IOException, ServletException {
+        Queue queue = new Queue(LoadBalancer.CONSISTENT_HASH);
+        queue.schedule(task, 6000);
+
+        HttpResponse httpResponse = queue.doCancelItem(Queue.WaitingItem.getCurrentCounterValue() + 1);
+        httpResponse.generateResponse(null, resp, null);
+
+        verify(resp).setStatus(422);
+    }
+
+    @Issue("JENKINS-21311")
+    @Test
+    public void cancelItemOnANonCancellableItemShouldReturnA422()  throws IOException, ServletException {
+        when(task.hasAbortPermission()).thenReturn(false);
+        Queue queue = new Queue(LoadBalancer.CONSISTENT_HASH);
+        queue.schedule(task, 6000);
+
+        HttpResponse httpResponse = queue.doCancelItem(Queue.WaitingItem.getCurrentCounterValue());
+        httpResponse.generateResponse(null, resp, null);
+
+        verify(resp).setStatus(422);
+    }
+}

--- a/core/src/test/java/hudson/model/QueueTest.java
+++ b/core/src/test/java/hudson/model/QueueTest.java
@@ -47,14 +47,14 @@ public class QueueTest {
 
     @Issue("JENKINS-21311")
     @Test
-    public void cancelItemOnANonExistingItemShouldReturnA422()  throws IOException, ServletException {
+    public void cancelItemOnANonExistingItemShouldReturnA404()  throws IOException, ServletException {
         Queue queue = new Queue(LoadBalancer.CONSISTENT_HASH);
         queue.schedule(task, 6000);
 
         HttpResponse httpResponse = queue.doCancelItem(Queue.WaitingItem.getCurrentCounterValue() + 1);
         httpResponse.generateResponse(null, resp, null);
 
-        verify(resp).setStatus(422);
+        verify(resp).setStatus(HttpServletResponse.SC_NOT_FOUND);
     }
 
     @Issue("JENKINS-21311")

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -1086,16 +1086,22 @@ public class QueueTest {
     @Test
     @Issue("SECURITY-891")
     public void doCancelItem_PermissionIsChecked() throws Exception {
-        checkCancelOperationUsingUrl(item -> "queue/cancelItem?id=" + item.getId());
+        checkCancelOperationUsingUrl(item -> "queue/cancelItem?id=" + item.getId(), false);
     }
 
     @Test
     @Issue("SECURITY-891")
     public void doCancelQueue_PermissionIsChecked() throws Exception {
-        checkCancelOperationUsingUrl(item -> "queue/item/" + item.getId() + "/cancelQueue");
+        checkCancelOperationUsingUrl(item -> "queue/item/" + item.getId() + "/cancelQueue", true);
     }
 
-    private void checkCancelOperationUsingUrl(Function<Queue.Item, String> urlProvider) throws Exception {
+    /**
+     *
+     * @param urlProvider the endpoint to query
+     * @param legacyRedirect whether the endpoint has the legacy behavior (ie makes a redirect no matter the result)
+     *                       Or it uses the newer response codes introduced by JENKINS-21311
+     */
+    private void checkCancelOperationUsingUrl(Function<Queue.Item, String> urlProvider, boolean legacyRedirect) throws Exception {
         Queue q = r.jenkins.getQueue();
 
         r.jenkins.setCrumbIssuer(null);
@@ -1124,11 +1130,13 @@ public class QueueTest {
                     .withRedirectEnabled(false)
                     .withThrowExceptionOnFailingStatusCode(false);
             wc.login("user");
-            Page p = wc.getPage(request);
-            // currently the endpoint return a redirection to the previously visited page, none in our case
-            // (so force no redirect to avoid false positive error)
-            assertThat(p.getWebResponse().getStatusCode(), lessThan(400));
-
+            if(legacyRedirect) {
+                Page p = wc.getPage(request);
+                // the legacy endpoint returns a redirection to the previously visited page, none in our case
+                // (so force no redirect to avoid false positive error)
+                // see JENKINS-21311
+                assertThat(p.getWebResponse().getStatusCode(), lessThan(400));
+            }
             assertFalse(currentOne.getFuture().isCancelled());
         }
         { // user with right can


### PR DESCRIPTION
This change:
* documents the API
* adds meaningful return codes to help API caller.

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-21311](https://issues.jenkins-ci.org/browse/JENKINS-21311).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Internal: Make the `queue/cancelItem` return meaningful codes instead of a 404.
* Entry 2: Internal: Document the `queue/cancelItem` endpoint.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- ~[ ] For dependency updates: links to external changelogs and, if possible, full diffs~

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
