### PR TITLE
[JENKINS-60553][SECURITY-1605] Remove teamconcert with security warning from wizard

### DIFF
--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -68,7 +68,6 @@
             { "name": "p4" },
             { "name": "repo" },
             { "name": "subversion", "suggested": true },
-            { "name": "teamconcert" },
             { "name": "tfs" }
         ]
     },


### PR DESCRIPTION
The setup wizard has no way to indicate active security warnings for plugins, so just remove this plugin for the time being to prevent annoying users right after initial setup.

https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1605%20(1)
https://jenkins.io/security/advisory/2019-12-17/#SECURITY-1605%20(2)

### Proposed changelog entries

* Remove Team Concert Plugin from setup wizard

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs