### PR TITLE
DNS comparisons of jenkins.io and www.jenkins.io do not pass.

### DIFF
--- a/test/src/test/java/jenkins/security/Security637Test.java
+++ b/test/src/test/java/jenkins/security/Security637Test.java
@@ -51,6 +51,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import org.junit.Ignore;
 
 public class Security637Test {
     
@@ -88,7 +89,8 @@ public class Security637Test {
             return handler.getClass().getName();
         }
     }
-    
+
+    @Ignore("TODO these map to different IPs now")
     @Test
     @Issue("SECURITY-637")
     public void urlDnsEquivalence() {
@@ -104,6 +106,7 @@ public class Security637Test {
         });
     }
     
+    @Ignore("TODO these map to different IPs now")
     @Test
     @Issue("SECURITY-637")
     public void urlSafeDeserialization_urlBuiltInAgent_inSameJVMRemotingContext() {
@@ -136,6 +139,7 @@ public class Security637Test {
         }
     }
     
+    @Ignore("TODO these map to different IPs now")
     @Test
     @Issue("SECURITY-637")
     public void urlSafeDeserialization_urlBuiltInMaster_inSameJVMRemotingContext() {


### PR DESCRIPTION
Tests from https://github.com/jenkinsci/jenkins/commit/727d58f690abf64f543407e1de3545eca76ad30e are failing for me today:

```
urlDnsEquivalence(jenkins.security.Security637Test)  Time elapsed: 7.213 s  <<< FAILURE!
java.lang.AssertionError: expected:<https://jenkins.io> but was:<https://www.jenkins.io>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at jenkins.security.Security637Test$2.evaluate(Security637Test.java:99)

urlSafeDeserialization_urlBuiltInMaster_inSameJVMRemotingContext(jenkins.security.Security637Test)  Time elapsed: 2.954 s  <<< FAILURE!
java.lang.AssertionError: expected:<https://jenkins.io> but was:<https://www.jenkins.io>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at jenkins.security.Security637Test$4.evaluate(Security637Test.java:156)
```

Indeed

```
$ host jenkins.io
jenkins.io has address 52.147.174.4
jenkins.io mail is handled by 10 mxb.mailgun.org.
jenkins.io mail is handled by 10 mxa.mailgun.org.
$ host www.jenkins.io
www.jenkins.io is an alias for nginx.azure.jenkins.io.
nginx.azure.jenkins.io has address 40.79.70.97
```

Not sure if something changed recently, but anyway tests should never rely on some state in the Internet.