### PR TITLE
JENKINS-60513: Added transient to SCMDescriptor#generation AtomicInteger to fix warnings

### DIFF
--- a/core/src/main/java/hudson/scm/SCMDescriptor.java
+++ b/core/src/main/java/hudson/scm/SCMDescriptor.java
@@ -54,7 +54,7 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
      */
     public transient final Class<? extends RepositoryBrowser> repositoryBrowser;
 
-    private final AtomicInteger generation = new AtomicInteger(1);
+    private transient final AtomicInteger generation = new AtomicInteger(1);
 
     protected SCMDescriptor(Class<T> clazz, Class<? extends RepositoryBrowser> repositoryBrowser) {
         super(clazz);

--- a/core/src/main/java/hudson/scm/SCMDescriptor.java
+++ b/core/src/main/java/hudson/scm/SCMDescriptor.java
@@ -53,8 +53,8 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
      * that type. Otherwise this SCM will not have any repository browser.
      */
     public transient final Class<? extends RepositoryBrowser> repositoryBrowser;
-
-    private transient final AtomicInteger generation = new AtomicInteger(1);
+    
+    private transient final AtomicInteger atomicGeneration = new AtomicInteger(1);
 
     protected SCMDescriptor(Class<T> clazz, Class<? extends RepositoryBrowser> repositoryBrowser) {
         super(clazz);
@@ -82,7 +82,7 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
     @Deprecated
     @Restricted(NoExternalUse.class) @RestrictedSince("TODO")
     public int getGeneration() {
-        return generation.get();
+        return atomicGeneration.get();
     }
 
     /**
@@ -92,7 +92,7 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
     @Deprecated
     @Restricted(NoExternalUse.class) @RestrictedSince("TODO")
     public void incrementGeneration() {
-        generation.incrementAndGet();
+        atomicGeneration.incrementAndGet();
     }
 
     // work around HUDSON-4514. The repositoryBrowser field was marked as non-transient until 1.325,

--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -132,7 +132,6 @@ java.util.concurrent.CopyOnWriteArraySet
 java.util.concurrent.CountDownLatch
 java.util.concurrent.CountDownLatch$Sync
 java.util.concurrent.atomic.AtomicBoolean
-java.util.concurrent.atomic.AtomicInteger
 java.util.logging.Level
 java.util.logging.LogRecord
 java.util.regex.Pattern

--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -132,6 +132,7 @@ java.util.concurrent.CopyOnWriteArraySet
 java.util.concurrent.CountDownLatch
 java.util.concurrent.CountDownLatch$Sync
 java.util.concurrent.atomic.AtomicBoolean
+java.util.concurrent.atomic.AtomicInteger
 java.util.logging.Level
 java.util.logging.LogRecord
 java.util.regex.Pattern


### PR DESCRIPTION
This was reported and I think adding the class to the whitelist seems fine.

See [JENKINS-60513](https://issues.jenkins-ci.org/browse/JENKINS-60513).


### Proposed changelog entries

* Regression-Fix: Resolve warnings from AtomicInteger and class-filter

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs


### Desired reviewers

