### PR TITLE
[JENKINS-60554] - EscapedMarkupFormatter did not properly handle a null argument

### DIFF
--- a/core/src/main/java/hudson/markup/EscapedMarkupFormatter.java
+++ b/core/src/main/java/hudson/markup/EscapedMarkupFormatter.java
@@ -47,7 +47,9 @@ public class EscapedMarkupFormatter extends MarkupFormatter {
 
     @Override
     public void translate(String markup, Writer output) throws IOException {
-        output.write(Util.escape(markup));
+        if (markup != null) {
+            output.write(Util.escape(markup));
+        }
     }
 
     @Extension @Symbol("plainText")

--- a/test/src/test/java/hudson/markup/MarkupFormatterTest.java
+++ b/test/src/test/java/hudson/markup/MarkupFormatterTest.java
@@ -69,4 +69,12 @@ public class MarkupFormatterTest {
         @TestExtension
         public static class DescriptorImpl extends MarkupFormatterDescriptor {}
     }
+
+    @Test
+    public void defaultEscaped() throws Exception {
+        assertEquals("&lt;your thing here&gt;", j.jenkins.getMarkupFormatter().translate("<your thing here>"));
+        assertEquals("", j.jenkins.getMarkupFormatter().translate(""));
+        assertEquals("", j.jenkins.getMarkupFormatter().translate(null));
+    }
+
 }


### PR DESCRIPTION
`MarkupFormatter.translate` is supposed to check for null, which `antisamy-markup-formatter` and `pegdown-formatter` do, but the built-in one did not (fixed here), nor did the `escaped-markup` or `anything-goes-formatter` plugins (which I do not much care about).

### Proposed changelog entries

* The text **null** could appear rather than blank text when rendering certain user-controlled strings.