### PR TITLE
[INFRA-2396] - Hide the Funding link on GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-custom: https://jenkins.io/donate/


### PR DESCRIPTION
See [INFRA-2396](https://issues.jenkins-ci.org/browse/INFRA-2396) for the context and links. At the moment we do not have an operational and documented way to donate money, and there is no pages which would document other ways of sponsorship. I suggest to remove the link for now until the page is updated.


