### PR TITLE
[JENKINS-60579] - Allow the usage of DescriptorVisibilityFilter to filter View properties on UI.

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -338,6 +338,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     /**
      * @return all the {@link ViewPropertyDescriptor}s that can be potentially configured on this View and are visible
      * for the user. Use {@link DescriptorVisibilityFilter} to make a View property invisible for users.
+     * @since 2.214
      */
     public List<ViewPropertyDescriptor> getVisiblePropertyDescriptors() {
         return DescriptorVisibilityFilter.apply(this, getApplicablePropertyDescriptors());

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -322,8 +322,9 @@ public abstract class View extends AbstractModelObject implements AccessControll
     }
 
     /**
-     * Returns all the {@link LabelAtomPropertyDescriptor}s that can be potentially configured
-     * on this label.
+     * Returns all the {@link ViewPropertyDescriptor}s that can be potentially configured
+     * on this view. Returns both {@link ViewPropertyDescriptor}s visible and invisible for user, see
+     * {@link View#getVisiblePropertyDescriptors} to filter invisible one.
      */
     public List<ViewPropertyDescriptor> getApplicablePropertyDescriptors() {
         List<ViewPropertyDescriptor> r = new ArrayList<>();
@@ -332,6 +333,14 @@ public abstract class View extends AbstractModelObject implements AccessControll
                 r.add(pd);
         }
         return r;
+    }
+
+    /**
+     * @return all the {@link ViewPropertyDescriptor}s that can be potentially configured on this View and are visible
+     * for the user. Use {@link DescriptorVisibilityFilter} to make a View property invisible for users.
+     */
+    public List<ViewPropertyDescriptor> getVisiblePropertyDescriptors() {
+        return DescriptorVisibilityFilter.apply(this, getApplicablePropertyDescriptors());
     }
 
     public void save() throws IOException {

--- a/core/src/main/resources/hudson/model/View/configure.jelly
+++ b/core/src/main/resources/hudson/model/View/configure.jelly
@@ -52,7 +52,7 @@ THE SOFTWARE.
         <st:include page="configure-entries.jelly" optional="true" />
 
         <!-- view property configurations -->
-        <f:descriptorList descriptors="${it.getApplicablePropertyDescriptors()}" instances="${it.properties}" />
+        <f:descriptorList descriptors="${it.getVisiblePropertyDescriptors()}" instances="${it.properties}" />
 
         <f:bottomButtonBar>
           <f:submit value="${%OK}" />

--- a/test/src/test/java/hudson/model/ViewDescriptorTest.java
+++ b/test/src/test/java/hudson/model/ViewDescriptorTest.java
@@ -26,13 +26,23 @@ package hudson.model;
 
 import java.util.Arrays;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
 import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import static org.junit.Assert.*;
+
+import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.StaplerRequest;
+import net.sf.json.JSONObject;
 
 public class ViewDescriptorTest {
 
@@ -73,6 +83,98 @@ public class ViewDescriptorTest {
 
     private void assertContains(AutoCompletionCandidates c, String... values) {
         assertEquals(new TreeSet<>(Arrays.asList(values)), new TreeSet<>(c.getValues()));
+    }
+
+
+    @Test
+    @Issue("JENKINS-60579")
+    public void invisiblePropertiesOnViewShoudBePersisted() throws Exception {
+
+        //GIVEN a listView that have an invisible property
+        ListView myListView = new ListView("Rock");
+        myListView.setRecurse(true);
+        myListView.setIncludeRegex(".*");
+
+        CustomInvisibleProperty invisibleProperty = new CustomInvisibleProperty();
+        invisibleProperty.setSomeProperty("You cannot see me.");
+        invisibleProperty.setView(myListView);
+        myListView.getProperties().add(invisibleProperty);
+
+        r.jenkins.addView(myListView);
+
+        assertEquals(r.jenkins.getView("Rock").getProperties().get(CustomInvisibleProperty.class).getSomeProperty(),
+                     "You cannot see me.");
+
+        //WHEN the users goes with "Edit View" on the configure page
+        JenkinsRule.WebClient webClient = r.createWebClient();
+        HtmlPage editViewPage = webClient.getPage(myListView, "configure");
+
+        //THEN the invisible property is not displayed on page
+        assertFalse("CustomInvisibleProperty should not be displayed on the View edition page UI.",
+                    editViewPage.asText().contains("CustomInvisibleProperty"));
+
+
+        HtmlForm editViewForm = editViewPage.getFormByName("viewConfig");
+        editViewForm.getTextAreaByName("description").type("This list view is awesome !");
+        r.submit(editViewForm);
+
+        //Check that the description is updated on view
+        Awaitility.waitAtMost(3, TimeUnit.SECONDS).until(() -> webClient.getPage(myListView)
+                                                                        .asText()
+                                                                        .contains("This list view is awesome !"));
+
+
+        //AND THEN after View save, the invisible property is still persisted with the View.
+        assertNotNull("The CustomInvisibleProperty should be persisted on the View.",
+                      r.jenkins.getView("Rock").getProperties().get(CustomInvisibleProperty.class));
+        assertEquals(r.jenkins.getView("Rock").getProperties().get(CustomInvisibleProperty.class).getSomeProperty(),
+                     "You cannot see me.");
+
+    }
+
+    private static class CustomInvisibleProperty extends ViewProperty {
+
+        private String someProperty;
+
+        public void setSomeProperty(String someProperty) {
+            this.someProperty = someProperty;
+        }
+
+        public String getSomeProperty() {
+            return this.someProperty;
+        }
+
+        public CustomInvisibleProperty() {
+            this.someProperty = "undefined";
+        }
+
+        @Override
+        public ViewProperty reconfigure(StaplerRequest req, JSONObject form) {
+            return this;
+        }
+
+        @TestExtension
+        public static final class CustomInvisibleDescriptorImpl extends ViewPropertyDescriptor {
+
+            @Override
+            public String getId() {
+                return "CustomInvisibleDescriptorImpl";
+            }
+
+            @Override
+            public boolean isEnabledFor(View view) {
+                return true;
+            }
+        }
+
+        @TestExtension
+        public static final class CustomInvisibleDescriptorVisibilityFilterImpl extends DescriptorVisibilityFilter {
+
+            @Override
+            public boolean filter(Object context, Descriptor descriptor) {
+                return false;
+            }
+        }
     }
 
 }

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -685,7 +685,7 @@ public class ViewTest {
 
 
         //AND THEN after View save, the invisible property is still persisted with the View.
-        assertNotNull("The InvisiblePropertyImpl should be present on the View.",
+        assertNotNull("The InvisiblePropertyImpl should be persisted on the View.",
                       j.jenkins.getView("Rock").getProperties().get(InvisiblePropertyImpl.class));
         assertEquals(j.jenkins.getView("Rock").getProperties().get(InvisiblePropertyImpl.class).getSomeProperty(),
                      "You cannot see me.");

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -648,6 +648,7 @@ public class ViewTest {
     }
 
     @Test
+    @Issue("JENKINS-60579")
     public void invisiblePropertiesOnViewShoudBePersisted() throws Exception {
 
         //GIVEN a listView that have an invisible property
@@ -655,14 +656,14 @@ public class ViewTest {
         myListView.setRecurse(true);
         myListView.setIncludeRegex(".*");
 
-        InvisiblePropertyImpl invisibleProperty = new InvisiblePropertyImpl();
+        CustomInvisibleProperty invisibleProperty = new CustomInvisibleProperty();
         invisibleProperty.setSomeProperty("You cannot see me.");
         invisibleProperty.setView(myListView);
         myListView.getProperties().add(invisibleProperty);
 
         j.jenkins.addView(myListView);
 
-        assertEquals(j.jenkins.getView("Rock").getProperties().get(InvisiblePropertyImpl.class).getSomeProperty(),
+        assertEquals(j.jenkins.getView("Rock").getProperties().get(CustomInvisibleProperty.class).getSomeProperty(),
                      "You cannot see me.");
 
         //WHEN the users goes with "Edit View" on the configure page
@@ -670,8 +671,8 @@ public class ViewTest {
         HtmlPage editViewPage = webClient.getPage(myListView,"configure");
 
         //THEN the invisible property is not displayed on page
-        assertFalse("InvisiblePropertyImpl should not be displayed on the View edition page UI.",
-                    editViewPage.asText().contains("InvisiblePropertyImpl"));
+        assertFalse("CustomInvisibleProperty should not be displayed on the View edition page UI.",
+                    editViewPage.asText().contains("CustomInvisibleProperty"));
 
 
         HtmlForm editViewForm = editViewPage.getFormByName("viewConfig");
@@ -685,14 +686,14 @@ public class ViewTest {
 
 
         //AND THEN after View save, the invisible property is still persisted with the View.
-        assertNotNull("The InvisiblePropertyImpl should be persisted on the View.",
-                      j.jenkins.getView("Rock").getProperties().get(InvisiblePropertyImpl.class));
-        assertEquals(j.jenkins.getView("Rock").getProperties().get(InvisiblePropertyImpl.class).getSomeProperty(),
+        assertNotNull("The CustomInvisibleProperty should be persisted on the View.",
+                      j.jenkins.getView("Rock").getProperties().get(CustomInvisibleProperty.class));
+        assertEquals(j.jenkins.getView("Rock").getProperties().get(CustomInvisibleProperty.class).getSomeProperty(),
                      "You cannot see me.");
 
     }
 
-    public static class InvisiblePropertyImpl extends ViewProperty {
+    private static class CustomInvisibleProperty extends ViewProperty {
 
         private String someProperty;
 
@@ -704,17 +705,17 @@ public class ViewTest {
             return this.someProperty;
         }
 
-        InvisiblePropertyImpl() {
+        CustomInvisibleProperty() {
             this.someProperty = "undefined";
         }
 
         @Override
-        public ViewProperty reconfigure(StaplerRequest req, JSONObject form) throws Descriptor.FormException {
+        public ViewProperty reconfigure(StaplerRequest req, JSONObject form) {
             return this;
         }
 
-        @Extension
-        public static final class DescriptorImpl extends ViewPropertyDescriptor {
+        @TestExtension
+        public static final class CustomInvisibleDescriptorImpl extends ViewPropertyDescriptor {
 
             @Override
             public boolean isEnabledFor(View view) {
@@ -722,8 +723,8 @@ public class ViewTest {
             }
         }
 
-        @Extension
-        public static final class DescriptorVisibilityFilterImpl extends DescriptorVisibilityFilter {
+        @TestExtension
+        public static final class CustomInvisibleDescriptorVisibilityFilterImpl extends DescriptorVisibilityFilter {
 
             @Override
             public boolean filter(Object context, Descriptor descriptor) {


### PR DESCRIPTION
See [JENKINS-60579](https://issues.jenkins-ci.org/browse/JENKINS-60579).
Make it possible to have invisible properties on View that are persisted, in the same way that Jobs can have invisible properties.

### Proposed changelog entries

* Entry 1: Allow the usage of DescriptorVisibilityFilter to filter View properties on UI.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
