### PR TITLE
Add Jenkins Changelog Generator to the GitHub Actions release drafter Pipeline

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5.4.0
+      - name: Generate GitHub Release Draft
+        uses: release-drafter/release-drafter@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Generates a YAML changelog file using https://github.com/daniel-beck/jenkins-changelog-generator
+      - name: Generate YAML changelog draft
+        uses: jenkinsci/jenkins-changelog-generator@master
+        env:
+          GITHUB_AUTH: github-actions:${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,8 +17,8 @@ jobs:
         uses: release-drafter/release-drafter@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Generates a YAML changelog file using https://github.com/daniel-beck/jenkins-changelog-generator
+      # Generates a YAML changelog file using https://github.com/jenkinsci/jenkins-core-changelog-generator
       - name: Generate YAML changelog draft
-        uses: jenkinsci/jenkins-changelog-generator@master
+        uses: jenkinsci/jenkins-core-changelog-generator@master
         env:
           GITHUB_AUTH: github-actions:${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a continuation of the changelog drafter generation. It includes [Jenkins Core Changelog Generator](https://github.com/jenkinsci/jenkins-core-changelog-generator) runs for every push to the master branch. The changelog drafts will be printed in the GitHub Actions log.

Demo: https://github.com/oleg-nenashev/jenkins/commit/5a151fa56d6159e5939004fb221d25cca6bc027f/checks?check_suite_id=378668269

Sample output:

![image](https://user-images.githubusercontent.com/3000480/71587890-d3771a00-2b1f-11ea-8336-3883b2cfc9b9.png)

