### PR TITLE
Spotbugs: remove UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS from global exclude

### DIFF
--- a/src/findbugs/findbugs-excludes.xml
+++ b/src/findbugs/findbugs-excludes.xml
@@ -6,8 +6,6 @@
       <!-- Various debug probes have non final static fields -->
       <!-- TODO: Replace by in-code annotations -->
       <Bug pattern="MS_SHOULD_BE_FINAL"/>
-      <!-- Groovy generates this -->
-      <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
       <!-- TODO: It's a real issue, but the code is flooded by it right now-->
       <Bug pattern="DM_DEFAULT_ENCODING"/>
       <!-- TODO: Remove once we migrate to SpotBugs with full Java support (JENKINS-53720)-->


### PR DESCRIPTION
I checked the exclude list and thought that one exclude might not be needed anymore, and yes, it seems UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS  to be not needed anymore.
See [JENKINS-36720](https://issues.jenkins-ci.org/browse/JENKINS-36720).

### Proposed changelog entries

* N/A : Internal
