### PR TITLE
[JENKINS-60625] Prevent Jenkins page rendering from being blocked when the update center data parsing is in progress

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -117,6 +117,7 @@ import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
+import jenkins.util.Timer;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -206,6 +207,9 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     private UpdateCenterConfiguration config;
 
     private boolean requiresRestart;
+
+    /** @see #isSiteDataReady */
+    private transient volatile boolean siteDataLoading;
 
     static {
         Logger logger = Logger.getLogger(UpdateCenter.class.getName());
@@ -537,6 +541,27 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     @StaplerDispatchable // referenced by _api.jelly
     public PersistedList<UpdateSite> getSites() {
         return sites;
+    }
+
+    /**
+     * Whether it is <em>probably</em> safe to call all {@link UpdateSite#getData} without blocking.
+     * @return true if all data is <em>currently</em> ready (or absent);
+     *         false if some is not ready now (but it will be loaded in the background)
+     */
+    @Restricted(NoExternalUse.class)
+    public boolean isSiteDataReady() {
+        if (sites.stream().anyMatch(UpdateSite::hasUnparsedData)) {
+            if (!siteDataLoading) {
+                siteDataLoading = true;
+                Timer.get().submit(() -> {
+                    sites.forEach(UpdateSite::getData);
+                    siteDataLoading = false;
+                });
+            }
+            return false;
+        } else {
+            return true;
+        }
     }
 
     /**
@@ -927,6 +952,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 sites.add(createDefaultUpdateSite());
             }
         }
+        siteDataLoading = false;
     }
 
     protected UpdateSite createDefaultUpdateSite() {
@@ -1061,7 +1087,12 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             return Messages.UpdateCenter_CoreUpdateMonitor_DisplayName();
         }
 
+        @Override
         public boolean isActivated() {
+            if (!Jenkins.get().getUpdateCenter().isSiteDataReady()) {
+                // Do not display monitor during this page load, but possibly later.
+                return false;
+            }
             Data data = getData();
             return data!=null && data.hasCoreUpdates();
         }

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -316,13 +316,23 @@ public class UpdateSite {
     }
 
     /**
+     * Whether {@link #getData} might be blocking.
+     */
+    boolean hasUnparsedData() {
+        return data == null && getDataFile().exists();
+    }
+
+    /**
      * Gets the raw update center JSON data.
      */
     public JSONObject getJSONObject() {
         TextFile df = getDataFile();
         if(df.exists()) {
+            long start = System.nanoTime();
             try {
-                return JSONObject.fromObject(df.read());
+                JSONObject o = JSONObject.fromObject(df.read());
+                LOGGER.info(() -> String.format("Loaded and parsed %s in %.01fs", df, (System.nanoTime() - start) / 1_000_000_000.0));
+                return o;
             } catch (JSONException | IOException e) {
                 LOGGER.log(Level.SEVERE,"Failed to parse "+df,e);
                 df.delete(); // if we keep this file, it will cause repeated failures

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -331,7 +331,7 @@ public class UpdateSite {
             long start = System.nanoTime();
             try {
                 JSONObject o = JSONObject.fromObject(df.read());
-                LOGGER.info(() -> String.format("Loaded and parsed %s in %.01fs", df, (System.nanoTime() - start) / 1_000_000_000.0));
+                LOGGER.fine(() -> String.format("Loaded and parsed %s in %.01fs", df, (System.nanoTime() - start) / 1_000_000_000.0));
                 return o;
             } catch (JSONException | IOException e) {
                 LOGGER.log(Level.SEVERE,"Failed to parse "+df,e);

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -318,6 +318,7 @@ public class UpdateSite {
     /**
      * Whether {@link #getData} might be blocking.
      */
+    // Internal use only
     boolean hasUnparsedData() {
         return data == null && getDataFile().exists();
     }

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
@@ -82,6 +82,9 @@ import java.util.Set;
 public class UpdateSiteWarningsMonitor extends AdministrativeMonitor {
     @Override
     public boolean isActivated() {
+        if (!Jenkins.get().getUpdateCenter().isSiteDataReady()) {
+            return false;
+        }
         return !getActiveCoreWarnings().isEmpty() || !getActivePluginWarningsByPlugin().isEmpty();
     }
 


### PR DESCRIPTION
See [JENKINS-60625](https://issues.jenkins-ci.org/browse/JENKINS-60625).

### Proposed changelog entries

* Parsing update center metadata could be slow; Jenkins no longer blocks page rendering just to do so from administrative monitors.