### PR TITLE
[JENKINS-60634] Define $WORKSPACE_TMP for (non-Pipeline) builds

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -863,8 +863,10 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     public EnvVars getEnvironment(TaskListener log) throws IOException, InterruptedException {
         EnvVars env = super.getEnvironment(log);
         FilePath ws = getWorkspace();
-        if (ws!=null)   // if this is done very early on in the build, workspace may not be decided yet. see HUDSON-3997
+        if (ws != null) { // if this is done very early on in the build, workspace may not be decided yet. see HUDSON-3997
             env.put("WORKSPACE", ws.getRemote());
+            env.put("WORKSPACE_TMP", WorkspaceList.tempDir(ws).getRemote()); // JENKINS-60634
+        }
 
         project.getScm().buildEnvVars(this,env);
 

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
@@ -3,7 +3,7 @@ package jenkins.model.CoreEnvironmentContributor
 def l = namespace(lib.JenkinsTagLib)
 
 // also advertises those contributed by Run.getCharacteristicEnvVars()
-["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME", "JOB_BASE_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
+["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME", "JOB_BASE_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","WORKSPACE_TMP","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
@@ -12,6 +12,9 @@ EXECUTOR_NUMBER.blurb=\
 NODE_NAME.blurb=Name of the agent if the build is on an agent, or "master" if run on master
 NODE_LABELS.blurb=Whitespace-separated list of labels that the node is assigned.
 WORKSPACE.blurb=The absolute path of the directory assigned to the build as a workspace.
+WORKSPACE_TMP.blurb=\
+  A temporary directory near the workspace that will not be browsable and will not interfere with SCM checkouts. \
+  May not initially exist, so be sure to create the directory as needed (e.g., <code>mkdir -p</code> on Linux).
 JENKINS_HOME.blurb=The absolute path of the directory assigned on the master node for Jenkins to store data.
 JENKINS_URL.blurb=Full URL of Jenkins, like <tt>http://server:port/jenkins/</tt> (note: only available if <i>Jenkins URL</i> set in system configuration)
 BUILD_URL.blurb=Full URL of this build, like <tt>http://server:port/jenkins/job/foo/15/</tt> (<i>Jenkins URL</i> must be set)


### PR DESCRIPTION
See [JENKINS-60634](https://issues.jenkins-ci.org/browse/JENKINS-60634).

### Proposed changelog entries

* The environment variable `WORKSPACE_TMP` may now be used from (non-Pipeline) builds to access a temporary directory associated with the build workspace.