### PR TITLE
[JENKINS-60449] Prevent endless recursion in SezpozModule.resolve

### DIFF
--- a/test/src/test/java/hudson/ExtensionFinderTest.java
+++ b/test/src/test/java/hudson/ExtensionFinderTest.java
@@ -128,4 +128,21 @@ public class ExtensionFinderTest {
             throw new Error();
         }
     }
+
+    @Test
+    public void injectMutualRecursion() {
+        A a = ExtensionList.lookupSingleton(A.class);
+        B b = ExtensionList.lookupSingleton(B.class);
+        assertEquals(b, a.b);
+        assertEquals(a, b.a);
+    }
+    @TestExtension("injectMutualRecursion")
+    public static final class A {
+        @Inject B b;
+    }
+    @TestExtension("injectMutualRecursion")
+    public static final class B {
+        @Inject A a;
+    }
+
 }

--- a/test/src/test/java/hudson/ExtensionFinderTest.java
+++ b/test/src/test/java/hudson/ExtensionFinderTest.java
@@ -25,29 +25,36 @@ package hudson;
 
 import com.google.inject.AbstractModule;
 import hudson.model.PageDecorator;
-import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.TestEnvironment;
-import org.jvnet.hudson.test.TestExtension;
-
-import javax.inject.Inject;
-import javax.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestEnvironment;
+import org.jvnet.hudson.test.TestExtension;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class ExtensionFinderTest extends HudsonTestCase {
+public class ExtensionFinderTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
     /**
      * It's OK for some extensions to fail to load. The system needs to tolerate that.
      */
-    public void testFailingInstance() {
+    @Test
+    public void failingInstance() {
         FailingExtension i = PageDecorator.all().get(FailingExtension.class);
         assertNull("Instantiation should have failed",i);
         assertTrue("Instantiation should have been attempted", FailingExtension.error);
     }
 
-    @TestExtension("testFailingInstance")
+    @TestExtension("failingInstance")
     public static class FailingExtension extends PageDecorator {
         public FailingExtension() {
             super(FailingExtension.class);
@@ -64,13 +71,14 @@ public class ExtensionFinderTest extends HudsonTestCase {
     /**
      * Extensions are Guice components, so it should support injection.
      */
-    public void testInjection() {
+    @Test
+    public void injection() {
         InjectingExtension i = PageDecorator.all().get(InjectingExtension.class);
         assertNotNull(i.foo);
         assertEquals("lion king",i.value);
     }
 
-    @TestExtension("testInjection")
+    @TestExtension("injection")
     public static class InjectingExtension extends PageDecorator {
         @Inject
         Foo foo;
@@ -94,7 +102,7 @@ public class ExtensionFinderTest extends HudsonTestCase {
         protected void configure() {
             TestEnvironment environment = TestEnvironment.get();
             // JMH benchmarks do not initialize TestEnvironment, so check for null
-            if (environment != null && environment.testCase instanceof ExtensionFinderTest) {
+            if (environment != null && ExtensionFinderTest.class.getName().equals(environment.description().getClassName()) && "injection".equals(environment.description().getMethodName())) {
                 bind(String.class).annotatedWith(LionKing.class).toInstance("lion king");
             }
         }
@@ -106,12 +114,13 @@ public class ExtensionFinderTest extends HudsonTestCase {
      *
      * One failure in binding definition shouldn't prevent Jenkins from booting.
      */
-    public void testErrorRecovery() {
+    @Test
+    public void errorRecovery() {
         BrokenExtension i = PageDecorator.all().get(BrokenExtension.class);
         assertNull(i);
     }
 
-    @TestExtension("testErrorRecovery")
+    @TestExtension("errorRecovery")
     public static class BrokenExtension extends PageDecorator {
         public BrokenExtension() {
             super(InjectingExtension.class);


### PR DESCRIPTION
**URGENT**, must be merged before next release or #4393 backed out.

I happened to be running some tests in `workflow-cps-global-lib` against `master` of Jenkins core and noticed that this plugin would cause Jenkins startup to fail without this patch, due to `WorkflowLibRepository` + `UserDefinedGlobalVariableList`. Time to revisit the notion of running PCT on some major plugins before weekly releases?

Test failure without fix:

```
SEVERE	h.ExtensionFinder$GuiceFinder#<init>: Failed to create Guice container from all the plugins
java.lang.StackOverflowError
	at java.lang.Class.searchMethods(Class.java:3003)
	at java.lang.Class.getDeclaredMethod(Class.java:2128)
	at hudson.ExtensionFinder$GuiceFinder$SezpozModule.resolve(ExtensionFinder.java:491)
	at hudson.ExtensionFinder$GuiceFinder$SezpozModule.resolve(ExtensionFinder.java:505)
	at hudson.ExtensionFinder$GuiceFinder$SezpozModule.resolve(ExtensionFinder.java:505)
	at …
org.jvnet.hudson.reactor.ReactorException: java.lang.StackOverflowError
	at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:282)
	at jenkins.InitReactorRunner.run(InitReactorRunner.java:48)
	at jenkins.model.Jenkins.executeReactor(Jenkins.java:1175)
	at jenkins.model.Jenkins.<init>(Jenkins.java:965)
	at hudson.model.Hudson.<init>(Hudson.java:85)
	at org.jvnet.hudson.test.JenkinsRule.newHudson(JenkinsRule.java:671)
	at org.jvnet.hudson.test.JenkinsRule.before(JenkinsRule.java:400)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:591)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.StackOverflowError
	at java.lang.Class.getDeclaredMethod(Class.java:2127)
	at hudson.ExtensionFinder$GuiceFinder$SezpozModule.resolve(ExtensionFinder.java:491)
	at hudson.ExtensionFinder$GuiceFinder$SezpozModule.resolve(ExtensionFinder.java:505)
	at hudson.ExtensionFinder$GuiceFinder$SezpozModule.resolve(ExtensionFinder.java:505)
	at …
```