### PR TITLE
[JENKINS-60716] Retain causes of a LogRotator failure for diagnosis

### DIFF
--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -28,6 +28,7 @@ import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
@@ -48,6 +49,7 @@ import hudson.model.Job;
 import hudson.model.Run;
 import jenkins.model.BuildDiscarder;
 import jenkins.model.BuildDiscarderDescriptor;
+import jenkins.util.io.CompositeIOException;
 
 /**
  * Default implementation of {@link BuildDiscarder}.
@@ -60,6 +62,8 @@ import jenkins.model.BuildDiscarderDescriptor;
  */
 public class LogRotator extends BuildDiscarder {
     
+    /** @deprecated Replaced by more generic {@link CompositeIOException}. */
+    @Deprecated
     public class CollatedLogRotatorException extends IOException {
         private static final long serialVersionUID = 5944233808072651101L;
         
@@ -139,7 +143,7 @@ public class LogRotator extends BuildDiscarder {
     @SuppressWarnings("rawtypes")
     public void perform(Job<?,?> job) throws IOException, InterruptedException {
         //Exceptions thrown by the deletion submethods are collated and reported
-        HashMultimap<Run<?,?>, Exception> exceptionMap = HashMultimap.create();
+        HashMultimap<Run<?,?>, IOException> exceptionMap = HashMultimap.create();
         
         LOGGER.log(FINE, "Running the log rotation for {0} with numToKeep={1} daysToKeep={2} artifactNumToKeep={3} artifactDaysToKeep={4}", new Object[] {job, numToKeep, daysToKeep, artifactNumToKeep, artifactDaysToKeep});
         
@@ -216,8 +220,7 @@ public class LogRotator extends BuildDiscarder {
                     "Failed to rotate logs for [%s]",
                     Joiner.on(", ").join(exceptionMap.keySet())
             );
-            LOGGER.severe(msg);
-            throw new CollatedLogRotatorException(msg, exceptionMap.values());
+            throw new CompositeIOException(msg, new ArrayList<>(exceptionMap.values()));
         }
     }
 

--- a/core/src/main/java/jenkins/util/io/CompositeIOException.java
+++ b/core/src/main/java/jenkins/util/io/CompositeIOException.java
@@ -29,8 +29,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.io.PrintStream;
-import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +40,7 @@ public class CompositeIOException extends IOException {
     public CompositeIOException(String message, @Nonnull List<IOException> exceptions) {
         super(message);
         this.exceptions = exceptions;
+        exceptions.forEach(this::addSuppressed);
     }
 
     public CompositeIOException(String message, IOException... exceptions) {
@@ -50,22 +49,6 @@ public class CompositeIOException extends IOException {
 
     public List<IOException> getExceptions() {
         return exceptions;
-    }
-
-    @Override
-    public void printStackTrace(PrintStream s) {
-        super.printStackTrace(s);
-        for (IOException exception : exceptions) {
-            exception.printStackTrace(s);
-        }
-    }
-
-    @Override
-    public void printStackTrace(PrintWriter s) {
-        super.printStackTrace(s);
-        for (IOException exception : exceptions) {
-            exception.printStackTrace(s);
-        }
     }
 
     public UncheckedIOException asUncheckedIOException() {


### PR DESCRIPTION
Amends #4138. See [JENKINS-60716](https://issues.jenkins-ci.org/browse/JENKINS-60716).

### Proposed changelog entries

* Include details in the system log when a build rotation fails.