### PR TITLE
Add the maintainer checklist to the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,11 +21,16 @@ If the issue is not fully described in the ticket, add more information here (ju
 <!-- Comment: 
 The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->
 
+### Proposed upgrade guidelines
+
+N/A
+
 ### Submitter checklist
 
 - [ ] JIRA issue is well described
-- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
-      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
+- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
+  * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
+  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
 - [ ] Appropriate autotests or explanation to why this change has no tests
 - [ ] For dependency updates: links to external changelogs and, if possible, full diffs
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,13 +45,12 @@ If you need an accelerated review process by the community (e.g., for critical b
 
 ### Maintainer checklist
 
-Before the changes is marked as `ready-for-merge`: 
+Before the changes are marked as `ready-for-merge`: 
 
-- [ ] There is at least 2 approvals for the pull request and no outstanding requests for change
+- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
 - [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
 - [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
 - [ ] Proper changelog labels are set so that the changelog can be generated automatically
 - [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
-- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and labeled as `lts-candidate`
-
+- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,3 +38,12 @@ The changelogs will be integrated by the core maintainers after the merge.  See 
 <!-- Comment:
 If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
 -->
+
+### Maintainer checklist
+
+Before the changes is marked as `ready-for-merge`: 
+
+- [ ] There is at least 2 approvals for the pull request and no outstanding requests for change
+- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
+- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
+- [ ] Proper changelog labels are set so that the changelog can be generated automatically

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,6 @@ N/A
 
 - [ ] JIRA issue is well described
 - [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
-  * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
   * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
 - [ ] Appropriate autotests or explanation to why this change has no tests
 - [ ] For dependency updates: links to external changelogs and, if possible, full diffs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,3 +47,7 @@ Before the changes is marked as `ready-for-merge`:
 - [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
 - [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
 - [ ] Proper changelog labels are set so that the changelog can be generated automatically
+- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
+- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and labeled as `lts-candidate`
+
+


### PR DESCRIPTION
I noticed that there is some deviation in  how the `ready-for-merge` label is used by reviewers. The initial purpose of this label was that the pull request is ready to go. It includes not only the code readiness, but also sufficient number of reviews, changelogs and the metadata needed for changelog generation and LTS backporting/upgrade guidelines.

The expectations were not documented anywhere, so I propose to do so

CC @jenkinsci/code-reviewers 