### PR TITLE
[JENKINS-60740] - Rely on GitHub Actions to generate the release draft YAMLs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,29 +1,16 @@
 # Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
-name-template: $NEXT_PATCH_VERSION
-# Uses a more common 2-digit versioning in Jenkins weekly releases.
+extends: .github
+# We use the 2-digit versioning in Jenkins weekly releases.
 version-template: $MAJOR.$MINOR
+name-template: $NEXT_MINOR_VERSION
 tag-template: jenkins-$NEXT_MINOR_VERSION
-
-exclude-labels:
-  - reverted
-  - no-changelog
-  - skip-changelog
-  - invalid
-change-template: |-
-  - type: todo
-    message: |-
-      $TITLE
-    pull: $NUMBER
-    authors:
-      - $AUTHOR
 
 template: |
   **Disclaimer**: This is an automatically generated changelog draft for Jenkins weekly releases. 
-  See https://jenkins.io/changelog/ for the official changelogs. 
+  See https://jenkins.io/changelog/ for the official changelogs.
+  See the attached `changelog.yaml` for a draft machine-readable changelog for jenkins.io
 
-  ```yaml
   $CHANGES
-  ```
 
 # Categories will be commented out, because we use YAML
 # Now we use categories only for sorting
@@ -44,17 +31,3 @@ categories:
     label: developer
   - title: Internal changes
     label: internal
-
-replacers:
-  - search: '/\[*JENKINS-(\d+)\]*\s*-*\s*/g'
-    replace: |-
-      issue: $1
-        message: |-
-          
-  - search: |-
-      message: |-
-          issue:
-    replace: "issue:"
-
-  - search: "##"
-    replace: "#"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,8 @@ template: |
   See the attached `changelog.yaml` for a draft machine-readable changelog for jenkins.io
 
   $CHANGES
+  
+  All contributors: $CONTRIBUTORS
 
 # Categories will be commented out, because we use YAML
 # Now we use categories only for sorting

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,7 +8,7 @@ tag-template: jenkins-$NEXT_MINOR_VERSION
 template: |
   **Disclaimer**: This is an automatically generated changelog draft for Jenkins weekly releases. 
   See https://jenkins.io/changelog/ for the official changelogs.
-  See the attached `changelog.yaml` for a draft machine-readable changelog for jenkins.io
+  For `changelog.yaml` drafts see GitHub action artifacts attached to release commits.
 
   $CHANGES
   

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,14 +24,20 @@ jobs:
         uses: jenkinsci/jenkins-core-changelog-generator@master
         env:
           GITHUB_AUTH: github-actions:${{ secrets.GITHUB_TOKEN }}
-      # Upload YAML to the release draft assets
-      - name: Upload changelog.yaml to the Release Draft
-        id: upload-changelog-yaml
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Changelog YAML
+        uses: actions/upload-artifact@v1
         with:
-          upload_url: ${{ steps.release-drafter.outputs.upload_url }}
-          asset_path: ./changelog.yaml
-          asset_name: changelog.yaml
-          asset_content_type: text/yaml
+          name: changelog.yaml
+          path: changelog.yaml
+#TODO(oleg-nenashev): It will not work well with Release Drafter which does not recreated releases. Asset does not get overwritten, and there is no ready-to-go API for overriding assets
+      # Upload YAML to the release draft assets
+#      - name: Upload changelog.yaml to the Release Draft
+#        id: upload-changelog-yaml
+#        uses: actions/upload-release-asset@v1.0.1
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          upload_url: ${{ steps.release-drafter.outputs.upload_url }}
+#          asset_path: ./changelog.yaml
+#          asset_name: changelog.yaml
+#          asset_content_type: text/yaml

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Generate GitHub Release Draft
         id: release-drafter
-        uses: release-drafter/release-drafter@v5.4.0
+        uses: release-drafter/release-drafter@v5.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Generates a YAML changelog file using https://github.com/jenkinsci/jenkins-core-changelog-generator

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,11 +14,24 @@ jobs:
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Generate GitHub Release Draft
+        id: release-drafter
         uses: release-drafter/release-drafter@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Generates a YAML changelog file using https://github.com/jenkinsci/jenkins-core-changelog-generator
       - name: Generate YAML changelog draft
+        id: jenkins-core-changelog-generator
         uses: jenkinsci/jenkins-core-changelog-generator@master
         env:
           GITHUB_AUTH: github-actions:${{ secrets.GITHUB_TOKEN }}
+      # Upload YAML to the release draft assets
+      - name: Upload changelog.yaml to the Release Draft
+        id: upload-changelog.yaml
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release-drafter.outputs.upload_url }}
+          asset_path: ./changelog.yaml
+          asset_name: changelog.yaml
+          asset_content_type: text/yaml

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_AUTH: github-actions:${{ secrets.GITHUB_TOKEN }}
       # Upload YAML to the release draft assets
       - name: Upload changelog.yaml to the Release Draft
-        id: upload-changelog.yaml
+        id: upload-changelog-yaml
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After the recent patches https://github.com/jenkinsci/jenkins-core-changelog-generator generates decent changelog drafts, so we do not longer need Release Drafter's YAML hacks. Instead of that, I suggest using a standard Markdown format. 

Draft YAMLs will be attached to public GitHub Action runs, so they will be visible to all @jenkinsci/core-pr-reviewers going forward. CC @MarkEWaite 