### PR TITLE
[JENKINS-60750] Skip CONFIGURE_INSTANCE panel when root URL is set during skipFirstUser

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2344,6 +2344,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /** Exported alias for {@link JenkinsLocationConfiguration#getUrl}. */
     @Exported(name="url")
     @Restricted(DoNotUse.class)
+    @CheckForNull
     public String getConfiguredRootUrl() {
         JenkinsLocationConfiguration config = JenkinsLocationConfiguration.get();
         return config != null ? config.getUrl() : null;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -304,6 +304,7 @@ import hudson.util.LogTaskListener;
 import static java.util.logging.Level.*;
 import javax.annotation.Nonnegative;
 import static javax.servlet.http.HttpServletResponse.*;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.WebMethod;
 
 /**
@@ -2338,6 +2339,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         if(req!=null)
             return getRootUrlFromRequest();
         return null;
+    }
+
+    /** Exported alias for {@link JenkinsLocationConfiguration#getUrl}. */
+    @Exported(name="url")
+    @Restricted(DoNotUse.class)
+    public String getConfiguredRootUrl() {
+        JenkinsLocationConfiguration config = JenkinsLocationConfiguration.get();
+        return config != null ? config.getUrl() : null;
     }
 
     /**

--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -940,7 +940,19 @@ var createPluginSetupWizard = function(appendTarget) {
 	var skipFirstUser = function() {
 		$('button').prop({disabled:true});
 		firstUserSkipped = true;
-		showConfigureInstance();
+                jenkins.get('/api/json?tree=url', function(data) {
+                    if (data.url) {
+                        // as in InstallState.ConfigureInstance.initializeState
+                        showSetupCompletePanel({message: translations.installWizard_firstUserSkippedMessage});
+                    } else {
+                        showConfigureInstance();
+                    }
+                }, {
+                    error: function() {
+                        // give up
+                        showConfigureInstance();
+                    }
+                });
 	};
 	
 	var handleConfigureInstanceResponseSuccess = function (data) {


### PR DESCRIPTION
Amends #3082.

See [JENKINS-60750](https://issues.jenkins-ci.org/browse/JENKINS-60750).

### Proposed changelog entries

* If the Jenkins root URL has been configured by scripts prior to running the setup wizard, skip the location configuration panel even if selecting the option to skip creation of an admin user.