### PR TITLE
Change tests to retrieve maven over https due to upstream requiring https only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,11 @@ for(j = 0; j < jdks.size(); j++) {
                             def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -ntp -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
 
                             if(isUnix()) {
+                                sh """
+                                    mkdir -p ~/.m2
+                                    cp settings-azure.xml ~/.m2/settings.xml
+                                """
+
                                 sh mvnCmd
                                 sh 'git add . && git diff --exit-code HEAD'
                             } else {
@@ -114,7 +119,7 @@ void withMavenEnv(List envVars = [], def buildType, def javaVersion, def body) {
             body.call()
         }
     }
-    
+
     // The names here are currently hardcoded for my test environment. This needs
     // to be made more flexible.
     // Using the "tool" Workflow call automatically installs those tools on the

--- a/test/src/test/resources/hudson/model/hudson.tasks.Maven.MavenInstaller.json.html
+++ b/test/src/test/resources/hudson/model/hudson.tasks.Maven.MavenInstaller.json.html
@@ -4,147 +4,147 @@
         {
       "id": "3.2.2",
       "name": "3.2.2",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.2.2-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.2.2-bin.zip"
     },
         {
       "id": "3.2.1",
       "name": "3.2.1",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.2.1-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.2.1-bin.zip"
     },
         {
       "id": "3.1.1",
       "name": "3.1.1",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.1.1-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.1.1-bin.zip"
     },
         {
       "id": "3.1.0",
       "name": "3.1.0",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.1.0-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.1.0-bin.zip"
     },
         {
       "id": "3.0.5",
       "name": "3.0.5",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.5-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.0.5-bin.zip"
     },
         {
       "id": "3.0.4",
       "name": "3.0.4",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.4-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.0.4-bin.zip"
     },
         {
       "id": "3.0.3",
       "name": "3.0.3",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.3-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.0.3-bin.zip"
     },
         {
       "id": "3.0.2",
       "name": "3.0.2",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.2-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.0.2-bin.zip"
     },
         {
       "id": "3.0.1",
       "name": "3.0.1",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.1-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.0.1-bin.zip"
     },
         {
       "id": "3.0",
       "name": "3.0",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip"
     },
         {
       "id": "2.2.1",
       "name": "2.2.1",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.2.1-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-2.2.1-bin.zip"
     },
         {
       "id": "2.2.0",
       "name": "2.2.0",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.2.0-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-2.2.0-bin.zip"
     },
         {
       "id": "2.1.0",
       "name": "2.1.0",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.1.0-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-2.1.0-bin.zip"
     },
         {
       "id": "2.0.11",
       "name": "2.0.11",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.0.11-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-2.0.11-bin.zip"
     },
         {
       "id": "2.0.10",
       "name": "2.0.10",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.0.10-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-2.0.10-bin.zip"
     },
         {
       "id": "2.0.9",
       "name": "2.0.9",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.0.9-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-2.0.9-bin.zip"
     },
         {
       "id": "2.0.8",
       "name": "2.0.8",
-      "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-2.0.8-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-2.0.8-bin.zip"
     },
         {
       "id": "2.0.7",
       "name": "2.0.7",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.7-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.7-bin.zip"
     },
         {
       "id": "2.0.6",
       "name": "2.0.6",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.6-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.6-bin.zip"
     },
         {
       "id": "2.0.5",
       "name": "2.0.5",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.5-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.5-bin.zip"
     },
         {
       "id": "2.0.4",
       "name": "2.0.4",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.4-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.4-bin.zip"
     },
         {
       "id": "2.0.3",
       "name": "2.0.3",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.3-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.3-bin.zip"
     },
         {
       "id": "2.0.2",
       "name": "2.0.2",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.2-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.2-bin.zip"
     },
         {
       "id": "2.0.1",
       "name": "2.0.1",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0.1-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0.1-bin.zip"
     },
         {
       "id": "2.0",
       "name": "2.0",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-2.0-bin.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-2.0-bin.zip"
     },
         {
       "id": "1.1",
       "name": "1.1",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-1.1.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-1.1.zip"
     },
         {
       "id": "1.0.2",
       "name": "1.0.2",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-1.0.2.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-1.0.2.zip"
     },
         {
       "id": "1.0.1",
       "name": "1.0.1",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-1.0.1.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-1.0.1.zip"
     },
         {
       "id": "1.0",
       "name": "1.0",
-      "url": "http://archive.apache.org/dist/maven/binaries/maven-1.0.zip"
+      "url": "https://archive.apache.org/dist/maven/binaries/maven-1.0.zip"
     }
   ],
   "signature":   {

--- a/test/src/test/resources/hudson/model/hudson.tasks.Maven.MavenInstaller1.json
+++ b/test/src/test/resources/hudson/model/hudson.tasks.Maven.MavenInstaller1.json
@@ -2,16 +2,16 @@ downloadService.post('hudson.tasks.Maven.MavenInstaller',{"list": [
   {
     "id": "3.3.9",
     "name": "3.3.9",
-    "url": "http://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip"
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip"
   },
   {
     "id": "3.3.3",
     "name": "3.3.3",
-    "url": "http://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip"
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip"
   },
   {
     "id": "3.3.1",
     "name": "3.3.1",
-    "url": "http://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.1/apache-maven-3.3.1-bin.zip"
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.1/apache-maven-3.3.1-bin.zip"
   }
 ]})

--- a/test/src/test/resources/hudson/model/hudson.tasks.Maven.MavenInstaller2.json
+++ b/test/src/test/resources/hudson/model/hudson.tasks.Maven.MavenInstaller2.json
@@ -2,16 +2,16 @@ downloadService.post('hudson.tasks.Maven.MavenInstaller',{"list": [
   {
     "id": "3.3.1",
     "name": "3.3.1",
-    "url": "http://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.1/apache-maven-3.3.1-bin.zip"
+    "url": "https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.1/apache-maven-3.3.1-bin.zip"
   },
   {
     "id": "3.2.5",
     "name": "3.2.5",
-    "url": "http://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip"
+    "url": "https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip"
   },
   {
     "id": "3.2.3",
     "name": "3.2.3",
-    "url": "http://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.3/apache-maven-3.2.3-bin.zip"
+    "url": "https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.3/apache-maven-3.2.3-bin.zip"
   }
 ]})

--- a/test/src/test/resources/hudson/model/hudson.tasks.Maven.MavenInstaller3.json
+++ b/test/src/test/resources/hudson/model/hudson.tasks.Maven.MavenInstaller3.json
@@ -2,11 +2,11 @@ downloadService.post('hudson.tasks.Maven.MavenInstaller',{"list": [
   {
     "id": "3.3.1",
     "name": "3.3.1",
-    "url": "http://repo2.maven.org/maven2/org/apache/maven/apache-maven/3.3.1/apache-maven-3.3.1-bin.zip"
+    "url": "https://repo2.maven.org/maven2/org/apache/maven/apache-maven/3.3.1/apache-maven-3.3.1-bin.zip"
   },
   {
   "id": "3.0.4",
   "name": "3.0.4",
-  "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.4-bin.zip"
+  "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.0.4-bin.zip"
   }
 ]})

--- a/test/src/test/resources/hudson/model/hudson.tasks.Maven.MavenInstallerResult.json
+++ b/test/src/test/resources/hudson/model/hudson.tasks.Maven.MavenInstallerResult.json
@@ -2,31 +2,31 @@ downloadService.post('hudson.tasks.Maven.MavenInstaller', {"list": [
   {
     "id": "3.3.9",
     "name": "3.3.9",
-    "url": "http://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip"
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip"
   },
   {
     "id": "3.3.3",
     "name": "3.3.3",
-    "url": "http://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip"
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip"
   },
   {
     "id": "3.3.1",
     "name": "3.3.1",
-    "url": "http://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.1/apache-maven-3.3.1-bin.zip"
+    "url": "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.3.1/apache-maven-3.3.1-bin.zip"
   },
   {
     "id": "3.2.5",
     "name": "3.2.5",
-    "url": "http://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip"
+    "url": "https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip"
   },
   {
     "id": "3.2.3",
     "name": "3.2.3",
-    "url": "http://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.3/apache-maven-3.2.3-bin.zip"
+    "url": "https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.2.3/apache-maven-3.2.3-bin.zip"
   },
   {
   "id": "3.0.4",
   "name": "3.0.4",
-  "url": "http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.4-bin.zip"
+  "url": "https://archive.apache.org/dist/maven/binaries/apache-maven-3.0.4-bin.zip"
   }
 ]})


### PR DESCRIPTION
Resubmitting #4435 from @timja to test the Jenkinsfile patch