### PR TITLE
[JENKINS-60816] Missing null check when traversing type hierarchy of interfaces

### DIFF
--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -497,7 +497,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                         m.setAccessible(true);
                         m.invoke(ecl, c);
                     }
-                    for (Class cc = c; cc != Object.class; cc = cc.getSuperclass()) {
+                    for (Class<?> cc = c; cc != Object.class && cc != null; cc = cc.getSuperclass()) {
                         /**
                          * See {@link com.google.inject.spi.InjectionPoint#getInjectionPoints(TypeLiteral, boolean, Errors)}
                          */

--- a/test/src/test/java/hudson/ExtensionFinderTest.java
+++ b/test/src/test/java/hudson/ExtensionFinderTest.java
@@ -24,14 +24,17 @@
 package hudson;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.ImplementedBy;
 import hudson.model.PageDecorator;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import javax.inject.Inject;
 import javax.inject.Qualifier;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestEnvironment;
 import org.jvnet.hudson.test.TestExtension;
@@ -144,5 +147,19 @@ public class ExtensionFinderTest {
     public static final class B {
         @Inject A a;
     }
+
+    @Issue("JENKINS-60816")
+    @Test
+    public void injectInterface() {
+        assertThat(ExtensionList.lookupSingleton(X.class).xface, instanceOf(Impl.class));
+    }
+    @TestExtension("injectInterface")
+    public static final class X {
+        @Inject
+        XFace xface;
+    }
+    @ImplementedBy(Impl.class)
+    public interface XFace {}
+    public static final class Impl implements XFace {}
 
 }


### PR DESCRIPTION
Amends #4393.

See [JENKINS-60816](https://issues.jenkins-ci.org/browse/JENKINS-60816).

### Proposed changelog entries

* Jenkins 2.212+ failed to load certain injected fields such as used by the Bitbucket Server Integration plugin.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

