### PR TITLE
[JENKINS-59486] - Load icons in Plugin Manager while Jenkins is restarting

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -188,5 +188,11 @@ THE SOFTWARE.
         <d:invokeBody />
       </form>
     </l:main-panel>
+    <div class="grey-anime-preload" style="display:none">
+      <l:icon class="icon-grey-anime icon-md"/>
+      <l:icon class="icon-blue icon-md"/>
+      <l:icon class="icon-red icon-md"/>
+      <l:icon class="icon-grey icon-md"/>
+    </div>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
@@ -42,6 +42,12 @@ THE SOFTWARE.
           <a href="${rootURL}/">${%Go back to the top page}</a> <br/>
           (${%you can start using the installed plugins right away}) <!-- leave this text in for a while until users are retrained to expect plugins to work right away without restart -->
         </p>
+        <div class="grey-anime-preload" style="display:none">
+          <l:icon class="icon-grey-anime icon-md"/>
+          <l:icon class="icon-blue icon-md"/>
+          <l:icon class="icon-red icon-md"/>
+          <l:icon class="icon-grey icon-md"/>
+        </div>
         <p class="info" style="font-weight: normal">
           <j:if test="${app.lifecycle.canRestart()}">
             <j:if test="${app.isQuietingDown() or it.isRestartScheduled()}">


### PR DESCRIPTION
See [JENKINS-59486](https://issues.jenkins-ci.org/browse/JENKINS-59486).

### Proposed changelog entries

* Update Plugin manager pages to show icons while Jenkins is restarting

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387)) (not applicable)
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate` (not applicable)

