### PR TITLE
Fix bug when matrix axis value contain "/"

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -263,6 +263,8 @@ import java.io.PrintWriter;
 import java.net.BindException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -2909,6 +2911,37 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return new File(new File(getRootDir(),"jobs"), name);
     }
 
+    public static String urlEncodeMatrixConfigString(String fullName) {
+        String html_escaped_string = "";
+        StringTokenizer parameter_tokens = new StringTokenizer(fullName, "=");
+        while (parameter_tokens.hasMoreTokens()) {
+            String before_equal = parameter_tokens.nextToken();
+            String after_equal = "";
+            if (parameter_tokens.hasMoreTokens()) {
+                after_equal = parameter_tokens.nextToken();
+            } else {
+                after_equal = before_equal;
+                before_equal = "";
+            }
+            try {
+                //encode only after =. If you escape before_equal then it will break logic
+                html_escaped_string = html_escaped_string + before_equal + "=" + URLEncoder.encode(after_equal, "UTF-8");
+            } catch (Exception e) {
+                // TODO
+            }
+        }
+        return html_escaped_string;
+    }
+
+    public static String urlDecodeMatrixConfigToken(String token_in) {
+        String token = "";
+        try {
+            token = URLDecoder.decode(token_in, "UTF-8");
+        } catch (Exception e) {
+            //TODO
+        }
+        return token;
+    }
     /**
      * Gets the {@link Item} object by its full name.
      * Full names are like path names, where each name of {@link Item} is
@@ -2920,13 +2953,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @throws AccessDeniedException as per {@link ItemGroup#getItem}
      */
     public @CheckForNull <T extends Item> T getItemByFullName(@Nonnull String fullName, Class<T> type) throws AccessDeniedException {
+        fullName = urlEncodeMatrixConfigString(fullName);
         StringTokenizer tokens = new StringTokenizer(fullName,"/");
         ItemGroup parent = this;
 
         if(!tokens.hasMoreTokens()) return null;    // for example, empty full name.
 
         while(true) {
-            Item item = parent.getItem(tokens.nextToken());
+            Item item = parent.getItem(urlDecodeMatrixConfigToken(tokens.nextToken()));
             if(!tokens.hasMoreTokens()) {
                 if(type.isInstance(item))
                     return type.cast(item);


### PR DESCRIPTION

[MatrixAxisWithForwardSlashValueProblem.java.zip](https://github.com/jenkinsci/jenkins/files/4097688/MatrixAxisWithForwardSlashValueProblem.java.zip)
When a Matrix job contains axis with values containing "/" then this function fails to return the correct Job. The function assumes the matrix axis values will NOT contain "/" or forward slash and tokenizes the string based on "/". For example, "matrixtest/MOUNTPOINT=/jenkins/workspace/default", this is a valid configuration but fails.

Other Notes:

You encounter this issue when you use "envinject" plugin to "Prepare an environment to run" and use "Groovy script" option. The Groovy script will fail to inject currentJob or currentBuild correctly and set them to null since you can't retrieve the Job object correctly.

The fix provided could be a potential fix but it encodes only the values but not the AXIS name variable. I believe this is reasonable.

The following sample code explains this problem.

import java.util.StringTokenizer;
import java.net.URLEncoder;
import java.net.URLDecoder;

public class MatrixAxisWithForwardSlashValueProblem {

public static String urlEncodeMatrixConfigString(String fullName) {
    String html_escaped_string = "";
    StringTokenizer parameter_tokens = new StringTokenizer(fullName, "=");
    while (parameter_tokens.hasMoreTokens()) {
        String before_equal = parameter_tokens.nextToken();
        String after_equal = "";
        if (parameter_tokens.hasMoreTokens()) {
            after_equal = parameter_tokens.nextToken();
        } else {
            after_equal = before_equal;
            before_equal = "";
        }
        try {
            //encode only after =. If you escape before_equal then it will break logic
            html_escaped_string = html_escaped_string + before_equal + "=" + URLEncoder.encode(after_equal, "UTF-8");
        } catch (Exception e) {
            // TODO
        }
    }
    return html_escaped_string;
}

public static String urlDecodeMatrixConfigToken(String token_in) {
    String token = "";
    try {
        token = URLDecoder.decode(token_in, "UTF-8");
    } catch (Exception e) {
        //TODO
    }
    return token;
}

//public <T extends Item> T getItemByFullName(String fullName, Class<T> type) throws AccessDeniedException {
public static Object getItemByFullName(String fullName) {
    fullName = urlEncodeMatrixConfigString(fullName);
    System.out.println(" fullName after encoding = " + fullName);
    StringTokenizer tokens = new StringTokenizer(fullName, "/");
    //ItemGroup parent = this;
    Object parent;
    if (!tokens.hasMoreTokens()) {
        return null;
    } else {
        while (true) {
            String token = urlDecodeMatrixConfigToken(tokens.nextToken());
            System.out.println(" Found token -> " + token);
            //Item item = ((ItemGroup)parent).getItem(tokens.nextToken());
            // to
            //Item item = ((ItemGroup)parent).getItem(urlDecodeMatrixConfigToken(tokens.nextToken()));
            if (!tokens.hasMoreTokens()) {
                //if (type.isInstance(item)) {
                //    return (Item)type.cast(item);
                //}
                System.out.println("====no more tokens====");
                return null;
            }

            //if (!(item instanceof ItemGroup)) {
            //    return null;
            //}

            //if (!item.hasPermission(Item.READ)) {
            //    return null;
            //}

            //parent = (ItemGroup)item;
        }
    }
}

public static Object getItemByFullNameOriginal(String fullName) {
    StringTokenizer tokens = new StringTokenizer(fullName, "/");
    //ItemGroup parent = this;
    Object parent;
    if (!tokens.hasMoreTokens()) {
        return null;
    } else {
        while (true) {
            String token = tokens.nextToken();
            System.out.println(" Found token -> " + token);
            //Item item = ((ItemGroup)parent).getItem(tokens.nextToken());
            // to
            //Item item = ((ItemGroup)parent).getItem(urlDecodeMatrixConfigToken(tokens.nextToken()));
            if (!tokens.hasMoreTokens()) {
                //if (type.isInstance(item)) {
                //    return (Item)type.cast(item);
                //}
                System.out.println("====no more tokens====");
                return null;
            }

            //if (!(item instanceof ItemGroup)) {
            //    return null;
            //}

            //if (!item.hasPermission(Item.READ)) {
            //    return null;
            //}

            //parent = (ItemGroup)item;
        }
    }
}

public static void main(String args[]) {
    String test_normal = "matrixtest2/A=2,B=4";
    String test_problem = "matrixtest/MOUNTPOINT=/jenkins/workspace/default";
    System.out.println("====Testing with normal string original function = " + test_normal);
    getItemByFullNameOriginal(test_normal);
    System.out.println("====Testing with normal string modified function = " + test_normal);
    getItemByFullName(test_normal);
    System.out.println("====Testing with problem string original function =" + test_problem);
    getItemByFullNameOriginal(test_problem);
    System.out.println("====Testing with problem string modified function =" + test_problem);
    getItemByFullName(test_problem);
}
}

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

