### PR TITLE
set locale for test, because test fails on german system

### DIFF
--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -59,7 +59,6 @@ public class PluginWrapperTest {
 
     @Test
     public void jenkinsCoreTooOld() throws Exception {
-
         PluginWrapper pw = pluginWrapper("fake").requiredCoreVersion("3.0").buildLoaded();
         try {
             pw.resolvePluginDependencies();
@@ -67,7 +66,6 @@ public class PluginWrapperTest {
         } catch (IOException ex) {
             assertContains(ex, "Failed to load: fake (42)", "Jenkins (3.0) or higher required");
         }
-        Locale.setDefault(loc);
     }
 
     @Test

--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -9,10 +9,8 @@ import java.util.Locale;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-import hudson.util.ProcessTree;
 import jenkins.model.Jenkins;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;

--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -5,10 +5,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
+import hudson.util.ProcessTree;
 import jenkins.model.Jenkins;
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -23,11 +27,20 @@ import static org.mockito.Mockito.when;
 
 public class PluginWrapperTest {
 
+    private Locale loc;
+    
     @Before
     public void before() throws Exception {
         Jenkins.VERSION = "2.0"; // Some value needed - tests will overwrite if necessary
+        loc = Locale.getDefault();
+        Locale.setDefault(new Locale("en", "GB"));
     }
 
+    @After
+    public void after() {
+        Locale.setDefault(loc);
+    }
+    
     @Test
     public void dependencyTest() {
         String version = "plugin:0.0.2";
@@ -48,6 +61,7 @@ public class PluginWrapperTest {
 
     @Test
     public void jenkinsCoreTooOld() throws Exception {
+
         PluginWrapper pw = pluginWrapper("fake").requiredCoreVersion("3.0").buildLoaded();
         try {
             pw.resolvePluginDependencies();
@@ -55,6 +69,7 @@ public class PluginWrapperTest {
         } catch (IOException ex) {
             assertContains(ex, "Failed to load: fake (42)", "Jenkins (3.0) or higher required");
         }
+        Locale.setDefault(loc);
     }
 
     @Test


### PR DESCRIPTION
On not english systems, the test will fail because the actual message is localized. So I set the locale before the test and reset it afterwards.

### Proposed changelog entries

* Internal

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

