### PR TITLE
[JENKINS-57888, JENKINS-60821] -  Winstone 5.7: Restore java.util.logging.config.file property support and change the Jetty thread pull name

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -99,7 +99,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>5.6</version>
+      <version>5.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Integrates https://github.com/jenkinsci/winstone/releases/tag/winstone-5.7

I suggest adding both entries to the changelog, because the internal thread pool naming change affects monitoring and diagnostics tools which might be used by Jenkins users.

### Proposed changelog entries

* JENKINS-57888, bug - Winstone 5.7: Fix support of system logging customization (regression in 2.177)
  * Full changelog: https://github.com/jenkinsci/winstone/releases/tag/winstone-5.7
* JENKINS-60821, rfe - Winstone 5.7:: Change the Jetty thread pool name to "Jetty (winstone)"
  * Full changelog: https://github.com/jenkinsci/winstone/releases/tag/winstone-5.7

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@lrpg @jtnord 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

