### PR TITLE
[JENKINS-60857] Pick up Winstone with fix

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -99,7 +99,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>5.8-rc518.e237e80782ab</version> <!-- TODO https://github.com/jenkinsci/winstone/pull/91 -->
+      <version>5.8</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -99,7 +99,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>5.6</version>
+      <version>5.8-rc518.e237e80782ab</version> <!-- TODO https://github.com/jenkinsci/winstone/pull/91 -->
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/winstone/pull/91.

See [JENKINS-60857](https://issues.jenkins-ci.org/browse/JENKINS-60857).

### Proposed changelog entries

* Fixes a _KeyStores with multiple certificates are not supported_ error from Jetty when passing certain kinds of certificates, such as domain wildcards (regression in 2.217)
  * Changelog: https://github.com/jenkinsci/winstone/releases/tag/winstone-5.8

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

