### PR TITLE
[JENKINS-60866] Un-inline JavaScript / CSS from HudsonPrivateSecurity…

### DIFF
--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -490,7 +490,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         }
     }
 
-    @Restricted(NoExternalUse.class)
+    @Restricted(NoExternalUse.class) // _entryForm.jelly and signup.jelly
     public boolean isMailerPluginPresent() {
         try {
             // mail support has moved to a separate plugin

--- a/core/src/main/resources/hudson/model/View/AsynchPeople/index.jelly
+++ b/core/src/main/resources/hudson/model/View/AsynchPeople/index.jelly
@@ -100,7 +100,7 @@ THE SOFTWARE.
       <l:progressiveRendering handler="${it}" callback="display"/>
       <table class="sortable pane bigtable" id="people">
         <tr>
-          <th />
+          <th class="minimum-width" />
           <th>${%User ID}</th>
           <th>${%Name}</th>
           <th initialSortDir="up">${%Last Commit Activity}</th>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
@@ -24,23 +24,41 @@ THE SOFTWARE.
 
 <!-- tag file used by both signup.jelly and addUser.jelly -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <st:documentation>
+    <st:attribute name="it" use="required" type="hudson.security.HudsonPrivateSecurityRealm">
+      Context where the page is loaded.
+    </st:attribute>
+    <st:attribute name="title" use="required">
+      Title of the HTML page. Rendered in the page content inside a &lt;h1>.
+    </st:attribute>
+    <st:attribute name="action" use="required">
+      The method to call from within the HudsonPrivateSecurityRealm.
+    </st:attribute>
+    <st:attribute name="captcha" use="optional">
+      Determines if the tag will include the captcha.
+    </st:attribute>
+    <st:attribute name="data" use="optional" type="hudson.security.HudsonPrivateSecurityRealm.SignupInfo">
+      The wrapper for the data provided by the user and the error message(s) if any. Is null on first form display.
+    </st:attribute>
+  </st:documentation>
+
   <h1>${title}</h1>
-  <div style="margin: 2em;">
+  <div class="form-content">
     <j:if test="${data.errorMessage!=null}">
-      <div class="error" style="margin-bottom:1em">
+      <div class="error">
         ${data.errorMessage}
       </div>
     </j:if>
     <j:forEach var="error" items="${data.errors}">
-      <div class="error" style="margin-bottom:1em">
+      <div class="error">
         ${error.value}
       </div>
     </j:forEach>
       <table>
         <tr>
           <td>${%Username}:</td>
-          <td><input type="text" name="username" id="username" value="${data.username}" /></td>
+          <td><input type="text" name="username" id="username" value="${data.username}" autofocus="autofocus" /></td>
         </tr>
         <tr>
           <td>${%Password}:</td>
@@ -55,17 +73,17 @@ THE SOFTWARE.
           <td><input type="text" name="fullname" value="${data.fullname}" /></td>
         </tr>
         <j:if test="${it.mailerPluginPresent}">
-        <tr>
-          <td>${%E-mail address}:</td>
-          <td><input type="text" name="email" value="${data.email}" /></td>
-        </tr>
+          <tr>
+            <td>${%E-mail address}:</td>
+            <td><input type="text" name="email" value="${data.email}" /></td>
+          </tr>
         </j:if>
         <j:if test="${captcha}">
           <tr>
             <td>${%Enter text as shown}:</td>
             <td>
               <input type="text" name="captcha" autocomplete="off" /><br />
-              <img src="${rootURL}/securityRealm/captcha" alt="[${%captcha}]"/>
+              <img src="${rootURL}/securityRealm/captcha" alt="[${%captcha}]" />
             </td>
           </tr>
         </j:if>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryFormPage.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryFormPage.jelly
@@ -22,28 +22,36 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<!-- tag file used by both signup.jelly and addUser.jelly -->
+<!-- tag file used by signupWithFederatedIdentity.jelly, addUser.jelly and firstUser.jelly -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm">
+  <st:documentation>
+    <st:attribute name="host" use="required" type="hudson.security.HudsonPrivateSecurityRealm">
+      Corresponds to the "it" of Jelly, meaning the context where the page is loaded.
+    </st:attribute>
+    <st:attribute name="title" use="required">
+      Title of the HTML page. 
+      Rendered into &lt;title> tag, in the page content inside a &lt;h1> and as the label of the submit button.
+    </st:attribute>
+    <st:attribute name="action" use="required">
+      The method to call from within the HudsonPrivateSecurityRealm.
+    </st:attribute>
+    <st:attribute name="captcha" use="optional" type="boolean">
+      Determines if the tag will include the captcha.
+    </st:attribute>
+    <st:attribute name="data" use="optional" type="hudson.security.HudsonPrivateSecurityRealm.SignupInfo">
+      The wrapper for the data provided by the user and the error message(s) if any. Is null on first form display.
+    </st:attribute>
+  </st:documentation>
   <l:layout norefresh="true" title="${title}">
-    <l:header>
-      <style>
-        <!-- match width with captcha image -->
-        INPUT {
-          width:200px;
-        }
-      </style>
-    </l:header>
+    <st:adjunct includes="hudson.security.HudsonPrivateSecurityRealm._entryFormPage.resources" />
     <l:hasPermission permission="${app.READ}" it="${host}">
       <st:include page="sidepanel.jelly" it="${host}" />
     </l:hasPermission>
     <l:main-panel>
-      <form action="${rootURL}/securityRealm/${action}" method="post" style="text-size:smaller">
-        <local:_entryForm title="${title}" action="${action}" captcha="${captcha}" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm" />
+      <form action="${rootURL}/securityRealm/${action}" method="post">
+        <local:_entryForm title="${title}" action="${action}" captcha="${captcha}" it="${host}" data="${data}" />
         <f:submit value="${title}" />
-        <script>
-          $('username').focus();
-        </script>
       </form>
     </l:main-panel>
   </l:layout>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryFormPage/resources.css
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryFormPage/resources.css
@@ -1,0 +1,12 @@
+input {
+	/* match width with captcha image */
+	width:200px;
+}
+
+.form-content {
+	margin: 2em;
+}
+
+.form-content .error {
+	margin-bottom: 1em;
+}

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/addUser.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/addUser.jelly
@@ -26,6 +26,6 @@ THE SOFTWARE.
   Page for admin to create a new user
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <local:_entryFormPage host="${it}" title="${%Create User}" action="createAccountByAdmin" captcha="${false}" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm" />
+<j:jelly xmlns:j="jelly:core" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm">
+  <local:_entryFormPage host="${it}" title="${%Create User}" action="createAccountByAdmin" captcha="${false}" data="${data}" />
 </j:jelly>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/config.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/config.jelly
@@ -23,8 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
-  xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
   <f:entry field="allowsSignup">
     <f:checkbox default="false" title="${%Allow users to sign up}" />
   </f:entry>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/firstUser.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/firstUser.jelly
@@ -26,6 +26,6 @@ THE SOFTWARE.
   This is used to create the first user.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <local:_entryFormPage host="${it}" title="${%Create First Admin User}" action="createFirstAccount" captcha="${false}" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm" />
+<j:jelly xmlns:j="jelly:core" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm">
+  <local:_entryFormPage host="${it}" title="${%Create First Admin User}" action="createFirstAccount" captcha="${false}" data="${data}"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
   <l:layout permission="${app.ADMINISTER}" title="${%Users}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
@@ -32,20 +32,20 @@ THE SOFTWARE.
       
       <table class="sortable pane bigtable" id="people">
         <tr>
-          <th style="width:32px"/>
+          <th class="minimum-width" />
           <th>${%User ID}</th>
           <th>${%Name}</th>
-          <th style="width:32px"/>
+          <th class="minimum-width" />
         </tr>
         <j:forEach var="user" items="${it.allUsers}">
           <tr>
-            <td><a href="${user.url}/" class="model-link inside"><img src="${h.getUserAvatar(user,'32x32')}" alt="" height="32" width="32"/></a></td>
+            <td><a href="${user.url}/" class="model-link inside"><img src="${h.getUserAvatar(user,'32x32')}" alt="" height="32" width="32" /></a></td>
             <td><a href="${user.url}/">${user.id}</a></td>
             <td><a href="${user.url}/">${user}</a></td>
             <td>
-              <a href="${user.url}/configure"><l:icon class="icon-gear2 icon-lg"/></a>
+              <a href="${user.url}/configure"><l:icon class="icon-gear2 icon-lg" /></a>
               <j:if test="${user.canDelete()}">
-                <a href="${user.url}/delete"><l:icon class="icon-edit-delete icon-md"/></a>
+                <a href="${user.url}/delete"><l:icon class="icon-edit-delete icon-md" /></a>
               </j:if>
             </td>
           </tr>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/loginLink.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/loginLink.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:include page="/hudson/security/SecurityRealm/loginLink.jelly" />
   <j:if test="${it.allowsSignup()}">
     |

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/sidepanel.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/sidepanel.jelly
@@ -23,13 +23,13 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
-      <l:task href="${rootURL}/manage" icon="icon-gear2 icon-md" permission="${app.ADMINISTER}" title="${%Manage Jenkins}"/>
-      <l:task href="addUser" icon="icon-new-user icon-md" permission="${app.ADMINISTER}" title="${%Create User}"/>
+      <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}" />
+      <l:task href="${rootURL}/manage" icon="icon-gear2 icon-md" permission="${app.ADMINISTER}" title="${%Manage Jenkins}" />
+      <l:task href="addUser" icon="icon-new-user icon-md" permission="${app.ADMINISTER}" title="${%Create User}" />
     </l:tasks>
   </l:side-panel>
 </j:jelly>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signupWithFederatedIdentity.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signupWithFederatedIdentity.jelly
@@ -26,6 +26,6 @@ THE SOFTWARE.
   User self sign up page.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <local:_entryFormPage host="${app}" title="${%Sign up}" action="createAccountWithFederatedIdentity" captcha="${true}" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm" />
+<j:jelly xmlns:j="jelly:core" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm">
+  <local:_entryFormPage host="${app}" title="${%Sign up}" action="createAccountWithFederatedIdentity" captcha="${true}" data="${data}" />
 </j:jelly>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/success.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/success.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
   <l:layout norefresh="true">
     <l:hasPermission permission="${app.READ}" it="${app}">
       <st:include page="sidepanel.jelly" it="${app}" />

--- a/core/src/main/resources/hudson/security/SecurityRealm/signup.jelly
+++ b/core/src/main/resources/hudson/security/SecurityRealm/signup.jelly
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <st:statusCode value="404" />
     <st:include page="sidepanel.jelly" from="${app}" it="${app}" />
     <l:layout title="${%Signup not supported}">

--- a/core/src/main/resources/lib/layout/hasPermission.jelly
+++ b/core/src/main/resources/lib/layout/hasPermission.jelly
@@ -26,7 +26,13 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler">
   <st:documentation>
     Renders the body only if the current user has the specified permission
-    <st:attribute name="permission" use="required" type="Permission">
+    <st:attribute name="it" use="optional">
+      By default it will reuse the current context.
+      If the provided value does not inherit from hudson.security.AccessControlled, 
+      the tag will look for the first ancestor satisfying the condition.
+      The hasPermission will be performed against that value.
+    </st:attribute>
+    <st:attribute name="permission" use="required" type="hudson.security.Permission">
       permission object to check. If this is null, the body will be also rendered.
     </st:attribute>
   </st:documentation>

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -522,6 +522,10 @@ table.bigtable.pane > tbody > tr > td:last-child {
   white-space: nowrap;
 }
 
+.bigtable th.minimum-width {
+  width: 1px;
+}
+
 .bigtable td {
   vertical-align: middle;
   padding: 3px 4px 3px 4px;


### PR DESCRIPTION
Un-inline the JavaScript and CSS from the jelly views of the security realm except `signup.jelly`.

- "changes" have a comment in the PR to explain reasons.
- cleanup / standardize the jelly namespaces
- add / improve the documentation of the taglib inside the embedded security realm, that should clarify where the different variables are coming from

**Testing notes:**
- `docker run --rm -it -p 8080:8080 -e ID=4455 jenkins/core-pr-tester`
- for `firstUser.jelly`, you need to setup an instance with the embedded security realm, disallow the signup and ensure you do not have any user
- for `addUser.jelly`, you need to setup the embedded security realm and go to `<jenkins-url>/securityRealm/addUser`
- ⚠️ No way found to test the `signupWithFederatedIdentity.jelly`

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-60866](https://issues.jenkins-ci.org/browse/JENKINS-60866).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* (internal) Remove inline resources from HudsonPrivateSecurityRealm views

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

