### PR TITLE
[JENKINS-60866] Un-inline restarts pages

### DIFF
--- a/core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/_restart.jelly
+++ b/core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/_restart.jelly
@@ -21,21 +21,44 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:statusCode value="503" /><!-- SERVICE NOT AVAILABLE -->
-  <l:layout permission="${app.ADMINISTER}">
-    <st:include it="${app}" page="sidepanel.jelly" />
-    <l:main-panel>
-      <h1 style="margin-top:4em">
-        ${%Please wait while Jenkins is restarting}<span id="progress">...</span>
-      </h1>
-      <p style="color:gray;">
-        ${%blurb}
-      </p>
-      
-      <script>applySafeRedirector('${rootURL}/')</script>
-    </l:main-panel>
-  </l:layout>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml">
+    <j:new var="h" className="hudson.Functions" />
+    <st:statusCode value="503" /><!-- SERVICE NOT AVAILABLE -->
+    <st:header name="Expires" value="0" />
+    <st:header name="Cache-Control" value="no-cache,no-store,must-revalidate" />
+    <!-- response contentType header -->
+    <st:contentType value="text/html;charset=UTF-8" />
+    <!-- get default/common page variable -->
+    ${h.initPageVariables(context)}
+    <x:doctype name="html" />
+    <html lang="${request.getLocale().toLanguageTag()}">
+        <head data-rooturl="${rootURL}" data-resurl="${resURL}" resURL="${resURL}">
+            <title>${%Restarting Jenkins}</title>
+            <!-- we do not want bots on this page -->
+            <meta name="ROBOTS" content="NOFOLLOW" />
+            <!-- mobile friendly layout -->
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <link rel="stylesheet" href="${resURL}/css/simple-page.css" type="text/css" />
+            <link rel="stylesheet" href="${resURL}/css/simple-page.theme.css" type="text/css" />
+            <link rel="stylesheet" href="${resURL}/css/loading.css" type="text/css" />
+        </head>
+        <body>
+            <div class="simple-page" role="main">
+                <div class="modal signup">
+                    <div class="signupIntroDefault">
+                        <div class="logo" />
+                        <h1 class="loading">
+                            ${%Please wait while Jenkins is restarting}
+                            <span>.</span><span>.</span><span>.</span>
+                        </h1>
+                        <p>
+                            ${%blurb}
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <script src="${resURL}/scripts/loading.js" type="text/javascript" />
+        </body>
+    </html>
 </j:jelly>

--- a/core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/index.jelly
+++ b/core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/index.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout permission="${app.ADMINISTER}" title="${%Install as Windows Service}">
     <st:include it="${app}" page="sidepanel.jelly" />
     <l:main-panel>

--- a/core/src/main/resources/hudson/util/HudsonIsLoading/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonIsLoading/index.jelly
@@ -21,26 +21,24 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-
 <?jelly escape-by-default='true'?>
-
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml">
     <j:new var="h" className="hudson.Functions" />
-    <st:statusCode value="503"/><!-- SERVICE NOT AVAILABLE -->
-    <st:setHeader name="Expires" value="0"/>
-    <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate"/>
+    <st:statusCode value="503" /><!-- SERVICE NOT AVAILABLE -->
+    <st:header name="Expires" value="0" />
+    <st:header name="Cache-Control" value="no-cache,no-store,must-revalidate" />
     <!-- response contentType header -->
-    <st:contentType value="text/html;charset=UTF-8"/>
+    <st:contentType value="text/html;charset=UTF-8" />
     <!-- get default/common page variable -->
     ${h.initPageVariables(context)}
-    <x:doctype name="html"/>
+    <x:doctype name="html" />
     <html lang="${request.getLocale().toLanguageTag()}">
         <head data-rooturl="${rootURL}" data-resurl="${resURL}" resURL="${resURL}">
             <title>${%Starting Jenkins}</title>
             <!-- we do not want bots on this page -->
-            <meta name="ROBOTS" content="NOFOLLOW"/>
+            <meta name="ROBOTS" content="NOFOLLOW" />
             <!-- mobile friendly layout -->
-            <meta name="viewport" content="width=device-width, initial-scale=1"/>
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
             <link rel="stylesheet" href="${resURL}/css/simple-page.css" type="text/css" />
             <link rel="stylesheet" href="${resURL}/css/simple-page.theme.css" type="text/css" />
             <link rel="stylesheet" href="${resURL}/css/loading.css" type="text/css" />
@@ -49,7 +47,7 @@ THE SOFTWARE.
             <div class="simple-page" role="main">
                 <div class="modal signup">
                     <div class="signupIntroDefault">
-                        <div class="logo"></div>
+                        <div class="logo" />
                         <h1 class="loading">
                             ${%Please wait while Jenkins is getting ready to work}
                             <span>.</span><span>.</span><span>.</span>
@@ -60,8 +58,7 @@ THE SOFTWARE.
                     </div>
                 </div>
             </div>
-            <script src="${resURL}/scripts/loading.js" type="text/javascript"></script>
-            <script>safeRedirector(window.location.href);</script>
+            <script src="${resURL}/scripts/loading.js" type="text/javascript" />
         </body>
     </html>
 </j:jelly>

--- a/core/src/main/resources/hudson/util/HudsonIsRestarting/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonIsRestarting/index.jelly
@@ -21,26 +21,24 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-
 <?jelly escape-by-default='true'?>
-
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml">
     <j:new var="h" className="hudson.Functions" />
-    <st:statusCode value="503"/><!-- SERVICE NOT AVAILABLE -->
-    <st:setHeader name="Expires" value="0"/>
-    <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate"/>
+    <st:statusCode value="503" /><!-- SERVICE NOT AVAILABLE -->
+    <st:header name="Expires" value="0" />
+    <st:header name="Cache-Control" value="no-cache,no-store,must-revalidate" />
     <!-- response contentType header -->
-    <st:contentType value="text/html;charset=UTF-8"/>
+    <st:contentType value="text/html;charset=UTF-8" />
     <!-- get default/common page variable -->
     ${h.initPageVariables(context)}
-    <x:doctype name="html"/>
+    <x:doctype name="html" />
     <html lang="${request.getLocale().toLanguageTag()}">
         <head data-rooturl="${rootURL}" data-resurl="${resURL}" resURL="${resURL}">
             <title>${%Restarting Jenkins}</title>
             <!-- we do not want bots on this page -->
-            <meta name="ROBOTS" content="NOFOLLOW"/>
+            <meta name="ROBOTS" content="NOFOLLOW" />
             <!-- mobile friendly layout -->
-            <meta name="viewport" content="width=device-width, initial-scale=1"/>
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
             <link rel="stylesheet" href="${resURL}/css/simple-page.css" type="text/css" />
             <link rel="stylesheet" href="${resURL}/css/simple-page.theme.css" type="text/css" />
             <link rel="stylesheet" href="${resURL}/css/loading.css" type="text/css" />
@@ -49,7 +47,7 @@ THE SOFTWARE.
             <div class="simple-page" role="main">
                 <div class="modal signup">
                     <div class="signupIntroDefault">
-                        <div class="logo"></div>
+                        <div class="logo" />
                         <h1 class="loading">
                             ${%Please wait while Jenkins is restarting}
                             <span>.</span><span>.</span><span>.</span>
@@ -60,8 +58,7 @@ THE SOFTWARE.
                     </div>
                 </div>
             </div>
-            <script src="${resURL}/scripts/loading.js" type="text/javascript"></script>
-            <script>safeRedirector(window.location.href);</script>
+            <script src="${resURL}/scripts/loading.js" type="text/javascript" />
         </body>
     </html>
 </j:jelly>

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2750,53 +2750,6 @@ function loadScript(href,callback) {
     head.insertBefore( script, head.firstChild );
 }
 
-/*
-redirects to a page once the page is ready.
-
-    @param url
-        Specifies the URL to redirect the user.
-*/
-function applySafeRedirector(url) {
-    var i=0;
-    new PeriodicalExecuter(function() {
-      i = (i+1)%4;
-      var s = "";
-      var j=0;
-      for( j=0; j<i; j++ )
-        s+='.';
-      // put the rest of dots as hidden so that the layout doesn't change
-      // depending on the # of dots.
-      s+="<span style='visibility:hidden'>";
-      for( ; j<4; j++ )
-        s+='.';
-      s+="</span>";
-      $('progress').innerHTML = s;
-    },1);
-
-    window.setTimeout(function() {
-      var statusChecker = arguments.callee;
-        new Ajax.Request(url, {
-            method: "get",
-            onFailure: function(rsp) {
-                if((rsp.status >= 502 && rsp.status <= 504) && rsp.getHeader("X-Jenkins-Interactive")==null) {
-                  // redirect as long as we are still loading
-                  window.setTimeout(statusChecker,5000);
-                } else {
-                  window.location.replace(url);
-                }
-            },
-            onSuccess: function(rsp) {
-                if(rsp.status!=200) {
-                    // if connection fails, somehow Prototype thinks it's a success
-                    window.setTimeout(statusChecker,5000);
-                } else {
-                    window.location.replace(url);
-                }
-            }
-        });
-    }, 5000);
-}
-
 // logic behind <f:validateButton />
 function safeValidateButton(yuiButton) {
     var button = yuiButton._button;

--- a/war/src/main/webapp/scripts/loading.js
+++ b/war/src/main/webapp/scripts/loading.js
@@ -58,3 +58,6 @@ function safeRedirector(url) {
         })
     }, timeout);
 }
+
+const rootUrl = document.head.getAttribute("data-rooturl");
+safeRedirector(rootUrl + '/');


### PR DESCRIPTION
Un-inline the JavaScript and CSS from the jelly views of the restarts mechanism. Actually the revamp done with login/signup/restart was not applied to the WindowsInstaller one.

- cleanup / standardize the jelly namespaces
- removed the `applySafeRedirector` function as it was only used by the view that is now also revamped
- I looked for the potential usage of loading.js in the ecosystem, nothing. So changing its behavior is not that terrible
- I tested the restart with a contextPath and without. Side note, when you install the windows service when coming from a contextPath, the service will not have one, as before.
- ⚠️ the `data-rooturl` is actually the context path and not the real root URL that you could expect (compared to the one configured in Jenkins, being absolute)

<details>

<summary>Screenshots of WindowsInstaller restart screen</summary>

#### Before
![windows-installer-previous-restart](https://user-images.githubusercontent.com/2662497/73135893-0d1c4180-4048-11ea-9950-714733d40034.png)


#### After (similar to login/signup/restarts)
![windows-installer-new-restart](https://user-images.githubusercontent.com/2662497/73135897-186f6d00-4048-11ea-974f-a675544d6386.png)


</details>

**Testing notes:**
- `docker run --rm -it -p 8080:8080 -e ID=4457 jenkins/core-pr-tester`
- To see the WindowsInstaller, you need to run the war with `java -jar <jenkins.war>` and go to /manage and do the service installation. You will see this restart screen only once as you cannot re-install the service. You can uninstall it to re-do the process. [More instructions here](https://wiki.jenkins.io/display/JENKINS/Installing+Jenkins+as+a+Windows+service).

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-60866](https://issues.jenkins-ci.org/browse/JENKINS-60866).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* (internal) Remove inline resources from restart views

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@scherler as the author of the re-vamp of other page if you want to ensure consistency

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

