### PR TITLE
Spotbugs: Check for null issue

### DIFF
--- a/core/src/main/java/hudson/model/listeners/ItemListener.java
+++ b/core/src/main/java/hudson/model/listeners/ItemListener.java
@@ -183,11 +183,11 @@ public class ItemListener implements ExtensionPoint {
     }
 
     public static void fireOnCopied(final Item src, final Item result) {
-        forAll(new Function<ItemListener,Void>() {
-            @Override public Void apply(ItemListener l) {
+        forAll(l -> {
+            if (l != null) {
                 l.onCopied(src, result);
-                return null;
             }
+            return null;
         });
     }
 
@@ -213,30 +213,30 @@ public class ItemListener implements ExtensionPoint {
     }
 
     public static void fireOnCreated(final Item item) {
-        forAll(new Function<ItemListener,Void>() {
-            @Override public Void apply(ItemListener l) {
+        forAll(l -> {
+            if (l != null) {
                 l.onCreated(item);
-                return null;
             }
+            return null;
         });
     }
 
     public static void fireOnUpdated(final Item item) {
-        forAll(new Function<ItemListener,Void>() {
-            @Override public Void apply(ItemListener l) {
+        forAll(l -> {
+            if (l != null) {
                 l.onUpdated(item);
-                return null;
             }
+            return null;
         });
     }
 
     /** @since 1.548 */
     public static void fireOnDeleted(final Item item) {
-        forAll(new Function<ItemListener,Void>() {
-            @Override public Void apply(ItemListener l) {
+        forAll(l -> {
+            if (l != null) {
                 l.onDeleted(item);
-                return null;
             }
+            return null;
         });
     }
 
@@ -258,18 +258,18 @@ public class ItemListener implements ExtensionPoint {
             final String oldName = oldFullName.substring(prefixS);
             final String newName = rootItem.getName();
             assert newName.equals(newFullName.substring(prefixS));
-            forAll(new Function<ItemListener, Void>() {
-                @Override public Void apply(ItemListener l) {
+            forAll(l -> {
+                if (l != null) {
                     l.onRenamed(rootItem, oldName, newName);
-                    return null;
                 }
+                return null;
             });
         }
-        forAll(new Function<ItemListener, Void>() {
-            @Override public Void apply(ItemListener l) {
+        forAll(l -> {
+            if (l!= null) {
                 l.onLocationChanged(rootItem, oldFullName, newFullName);
-                return null;
             }
+            return null;
         });
         if (rootItem instanceof ItemGroup) {
             for (final Item child : Items.allItems(ACL.SYSTEM, (ItemGroup)rootItem, Item.class)) {
@@ -277,11 +277,11 @@ public class ItemListener implements ExtensionPoint {
                 assert childNew.startsWith(newFullName);
                 assert childNew.charAt(newFullName.length()) == '/';
                 final String childOld = oldFullName + childNew.substring(newFullName.length());
-                forAll(new Function<ItemListener, Void>() {
-                    @Override public Void apply(ItemListener l) {
+                forAll(l -> {
+                    if (l != null) {
                         l.onLocationChanged(child, childOld, childNew);
-                        return null;
                     }
+                    return null;
                 });
             }
         }


### PR DESCRIPTION
I fixed a couple of possible null-related Spotbugs Issues. I'm not sure if they might happen at all, but I guess the null check does not harm at all. Because I thought the readability could be improved by lambdas, I used them.

See [JENKINS-36720](https://issues.jenkins-ci.org/browse/JENKINS-36720).


### Proposed changelog entries

* N/A: Internal

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers


### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

