### PR TITLE
[JENKINS-60907] add Buffered{In,Out}putStream to FilePath.TarCompression.NONE

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -59,7 +59,7 @@ import hudson.util.NamingThreadFactory;
 import hudson.util.io.Archiver;
 import hudson.util.io.ArchiverFactory;
 
-
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileFilter;
@@ -758,10 +758,10 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     public enum TarCompression {
         NONE {
             public InputStream extract(InputStream in) {
-                return in;
+                return new BufferedInputStream(in);
             }
             public OutputStream compress(OutputStream out) {
-                return out;
+                return new BufferedOutputStream(out);
             }
         },
         GZIP {


### PR DESCRIPTION
See [JENKINS-60907](https://issues.jenkins-ci.org/browse/JENKINS-60907).

Manual tests in my environment show a significant performance improvement (50 secs with defaults settings, 240 secs with compression disabled and no patch, 30 secs with compression disabled and this patch).

### Proposed changelog entries

* Bug: fix poor performance of artifacts archiving when using  `jenkins.model.StandardArtifactManager.disableTrafficCompression=true` ([JENKINS-60907](https://issues.jenkins-ci.org/browse/JENKINS-60907))

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] JIRA issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change
- [ ] Appropriate autotests or explanation to why this change has no tests *=> it should be enough to check that this change does not break existing tests* 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs *=> N/A*

### Desired reviewers




### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

