### PR TITLE
Initial look at removing the "Launch" agent button.

### DIFF
--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -234,19 +234,4 @@ public class JNLPLauncher extends ComputerLauncher {
 
     }
 
-    /**
-     * Returns true if Java Web Start button should be displayed.
-     * Java Web Start is only supported when the Jenkins server is
-     * running with Java 8.  Earlier Java versions are not supported by Jenkins.
-     * Later Java versions do not support Java Web Start.
-     *
-     * This flag is checked in {@code config.jelly} before displaying the
-     * Java Web Start button.
-     * @return {@code true} if Java Web Start button should be displayed.
-     * @since FIXME
-     */
-    @Restricted(NoExternalUse.class) // Jelly use
-    public boolean isJavaWebStartSupported() {
-        return JavaUtils.isRunningWithJava8OrBelow();
-    }
 }

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -38,27 +38,6 @@ THE SOFTWARE.
         </p>
         <ul>
           <j:choose>
-            <j:when test="${it.launcher.javaWebStartSupported}">
-              <li>
-                <p>
-                  <a href="slave-agent.jnlp" id="jnlp-link">
-                    <img src="${imagesURL}/webstart.gif" alt="${%launch agent}" />
-                  </a>
-                  ${%Launch agent from browser}
-                </p>
-              </li>
-            </j:when>
-            <j:otherwise>
-              <li>
-                <p>
-                  <a href="https://jenkins.io/redirect/java11-java-web-start">
-                    ${%Java Web Start is not available for the JVM version running Jenkins}
-                  </a>
-                </p>
-              </li>
-            </j:otherwise>
-          </j:choose>
-          <j:choose>
             <j:when test="${it.ACL.hasPermission(app.ANONYMOUS, it.CONNECT)}">
               <li>
                 <p>
@@ -80,6 +59,8 @@ THE SOFTWARE.
                 </p>
                 <!-- TODO conceal secret w/ JS if possible -->
                 <pre>java${it.launcher.vmargs == null ? '' : ' ' + it.launcher.vmargs} -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${h.inferHudsonURL(request)}${it.url}slave-agent.jnlp -secret ${it.jnlpMac} ${it.launcher.getWorkDirOptions(it)}</pre>
+              </li>
+              <li>
                 <p>
                   ${%Run from agent command line, with the secret stored in a file:}
                 </p>


### PR DESCRIPTION
I'm starting to look at the possibility of removing the agent "Launch" button from the node status page on the master. There have been various discussions about this, so I started putting together something that could start demonstrating what it might look like and how it might behave.

The launch button is the only part of the system that is concerned with Java Web Start and JNLP. The Remoting protocol [JNLP4-connect](https://github.com/jenkinsci/remoting/blob/master/docs/protocols.md#jnlp4-connect) is misnamed and doesn't really have anything to do with JNLP. The launch button causes a JNLP file to be downloaded with the user's browser. If the user has Web Start installed and opens the file with Web Start, it will connect to the server, download the agent.jar, and start the agent.

Web Start has been removed in Java 11. The launch button is not supported if the master is running on Java 11. There is a community project to create a replacement Web Start. There hasn't been much interest in adopting it in Jenkins.

Using the launch button can lead to poor behavior or poor setup. If the user just uses it directly as indicated and starts the agent, they end up with an agent that doesn't restart automatically. This leads to an unreliable system. On Windows, they can navigate the UI to install the agent as a service after it is launched from the button.

If we proceed with this, we need to update the instructions on the node's status page. The existing command line suggestions make the agent run headless, thus preventing the Windows user from installing as a service. Other command line forms run a simple Java UI, but are not well documented.

If anyone knows of any standardized Unix / Linux agent installers, please let me know. I haven't found any. Most things recommend SSH Agents for Unix.

We could see about improving the integration to install as a Windows service. Perhaps it could be invoked via a command-line option.

I'm not sure where we want to go with this yet. Moving forward onto Java 11 adoption the launch button has little future. Maybe now is a good time to proceed with this change.

---
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

