### PR TITLE
Disable failing test in UDP broadcast

### DIFF
--- a/test/src/test/java/hudson/UDPBroadcastThreadTest.java
+++ b/test/src/test/java/hudson/UDPBroadcastThreadTest.java
@@ -55,7 +55,8 @@ public class UDPBroadcastThreadTest {
      * Old unicast based clients should still be able to receive some reply,
      * as we haven't changed the port.
      */
-    @Test public void legacy() throws Exception {
+    // @Test ignore all the test related to UDP due to failures with Java 11, whole feature pending complete removal
+    public void legacy() throws Exception {
         updatePort(33848);
         DatagramSocket s = new DatagramSocket();
         sendQueryTo(s, InetAddress.getLocalHost());
@@ -114,7 +115,7 @@ public class UDPBroadcastThreadTest {
         }
     }
 
-    @Test
+    // @Test ignore all the test related to UDP due to failures with Java 11, whole feature pending complete removal
     public void ensureTheThreadIsRunningWithSysProp() throws Exception {
         UDPBroadcastThread thread = getPrivateThread(j.jenkins);
         assertNotNull(thread);


### PR DESCRIPTION
Currently all builds are failing due to failures in UDP broadcast tests. We have a pending PR to remove the feature completely due to security vulnerabilities but before the PR is merged, we need to keep the other PRs passing tests.

Reference for the other one: https://github.com/jenkinsci/jenkins/pull/4460

FYI @jeffret-b 