### PR TITLE
Add preauth filtering overload of getAllItems(), getItems() and allItems()

### DIFF
--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import hudson.model.listeners.ItemListener;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.io.File;
 import java.util.List;
@@ -55,6 +56,21 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      * Gets all the items in this collection in a read-only view.
      */
     Collection<T> getItems();
+
+    /**
+     * Gets all the items in this collection in a read-only view
+     * that matches supplied Predicate
+     * @since TODO
+     */
+     default Collection<T> getItems(Predicate<T> pred) {
+         List<T> filteredItems = new ArrayList<>();
+         for (T item : getItems()) {
+             if (pred.test(item)) {
+                 filteredItems.add(item);
+             }
+         }
+         return filteredItems;
+     }
 
     /**
      * Returns the path relative to the context root,
@@ -115,6 +131,15 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      */
     default <T extends Item> Iterable<T> allItems(Class<T> type) {
         return Items.allItems(this, type);
+    }
+
+    /**
+     * Gets all the {@link Item}s unordered, lazily and recursively in the {@link ItemGroup} tree
+     * and filter them by the given type and given predicate
+     * @since TODO
+     */
+    default <T extends Item> Iterable<T> allItems(Class<T> type, Predicate<T> pred) {
+        return Items.allItems(this, type, pred);
     }
 
     /**

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import org.acegisecurity.AccessDeniedException;
 
@@ -68,6 +69,23 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
                           .filter(pred)
                           .collect(Collectors.toList());
      }
+
+    /**
+     * Gets a read-only stream of all the items in this collection
+     * @since TODO
+     */
+    default Stream<T> getItemsStream() {
+        return getItems().stream();
+    }
+
+    /**
+     * Gets a read-only stream of all the items in this collection
+     * that matches supplied Predicate
+     * @since TODO
+     */
+    default Stream<T> getItemsStream(Predicate<T> pred) {
+        return getItemsStream().filter(pred);
+    }
 
     /**
      * Returns the path relative to the context root,

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -65,8 +65,7 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      * @since TODO
      */
      default Collection<T> getItems(Predicate<T> pred) {
-         return getItems().stream()
-                          .filter(pred)
+         return getItemsStream(pred)
                           .collect(Collectors.toList());
      }
 

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.io.File;
 import java.util.List;
+import java.util.function.Predicate;
 import javax.annotation.CheckForNull;
 import org.acegisecurity.AccessDeniedException;
 
@@ -97,6 +98,14 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      */
     default <T extends Item> List<T> getAllItems(Class<T> type) {
         return Items.getAllItems(this, type);
+    }
+
+    /**
+     * Similar to {@link #getAllItems(Class)} with additional predicate filtering
+     * @since TODO
+     */
+    default <T extends Item> List<T> getAllItems(Class<T> type, Predicate<T> pred) {
+        return Items.getAllItems(this, type, pred);
     }
 
     /**

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.io.File;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import org.acegisecurity.AccessDeniedException;
 
@@ -63,13 +64,9 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      * @since TODO
      */
      default Collection<T> getItems(Predicate<T> pred) {
-         List<T> filteredItems = new ArrayList<>();
-         for (T item : getItems()) {
-             if (pred.test(item)) {
-                 filteredItems.add(item);
-             }
-         }
-         return filteredItems;
+         return getItems().stream()
+                          .filter(pred)
+                          .collect(Collectors.toList());
      }
 
     /**

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -486,7 +486,7 @@ public class Items {
      * @since 2.37
      */
     public static <T extends Item> Iterable<T> allItems(Authentication authentication, ItemGroup root, Class<T> type) {
-        return allItems(authentication, root, type, t->true);
+        return allItems(authentication, root, type, t -> true);
     }
 
     /**

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -292,6 +292,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -1775,12 +1776,21 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @Exported(name="jobs")
     public List<TopLevelItem> getItems() {
+        return getItems(t->true);
+    }
+
+    /**
+     * Gets just the immediate children of {@link Jenkins} based on supplied predicate.
+     *
+     * @see #getAllItems(Class)
+     * @since TODO
+     */
+    public List<TopLevelItem> getItems(Predicate<TopLevelItem> pred) {
         List<TopLevelItem> viewableItems = new ArrayList<>();
         for (TopLevelItem item : items.values()) {
-            if (item.hasPermission(Item.READ))
+            if (pred.test(item) && item.hasPermission(Item.READ))
                 viewableItems.add(item);
         }
-
         return viewableItems;
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1776,7 +1776,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @Exported(name="jobs")
     public List<TopLevelItem> getItems() {
-        return getItems(t->true);
+        return getItems(t -> true);
     }
 
     /**

--- a/test/src/test/java/hudson/model/ItemsTest.java
+++ b/test/src/test/java/hudson/model/ItemsTest.java
@@ -134,6 +134,27 @@ public class ItemsTest {
                 sub2BRAVO, sub2c, sub2cp, sub2charlie));
     }
 
+    @Test public void allItemsPredicate() throws Exception {
+        MockFolder d = r.createFolder("d");
+        MockFolder sub2 = d.createProject(MockFolder.class, "sub2");
+        MockFolder sub2a = sub2.createProject(MockFolder.class, "a");
+        MockFolder sub2c = sub2.createProject(MockFolder.class, "c");
+        MockFolder sub2b = sub2.createProject(MockFolder.class, "b");
+        MockFolder sub1 = d.createProject(MockFolder.class, "sub1");
+        FreeStyleProject root = r.createFreeStyleProject("root");
+        FreeStyleProject dp = d.createProject(FreeStyleProject.class, "p");
+        FreeStyleProject sub1q = sub1.createProject(FreeStyleProject.class, "q");
+        FreeStyleProject sub1p = sub1.createProject(FreeStyleProject.class, "p");
+        FreeStyleProject sub2ap = sub2a.createProject(FreeStyleProject.class, "p");
+        FreeStyleProject sub2bp = sub2b.createProject(FreeStyleProject.class, "p");
+        FreeStyleProject sub2cp = sub2c.createProject(FreeStyleProject.class, "p");
+        FreeStyleProject sub2alpha = sub2.createProject(FreeStyleProject.class, "alpha");
+        FreeStyleProject sub2BRAVO = sub2.createProject(FreeStyleProject.class, "BRAVO");
+        FreeStyleProject sub2charlie = sub2.createProject(FreeStyleProject.class, "charlie");
+        assertThat(d.allItems(FreeStyleProject.class, t -> t.getName().equals("p")), containsInAnyOrder(dp, sub1p, sub2ap, sub2bp, sub2cp));
+        assertThat(sub2.allItems(Item.class, t -> t.getName().startsWith("a")), containsInAnyOrder(sub2a, sub2alpha));
+    }
+
     @Issue("JENKINS-24825")
     @Test public void moveItem() throws Exception {
         File tmp = tmpRule.getRoot();

--- a/test/src/test/java/hudson/model/ItemsTest.java
+++ b/test/src/test/java/hudson/model/ItemsTest.java
@@ -88,6 +88,27 @@ public class ItemsTest {
         assertEquals(Arrays.<Item>asList(sub2a, sub2ap, sub2alpha, sub2b, sub2bp, sub2BRAVO, sub2c, sub2cp, sub2charlie), sub2.getAllItems(Item.class));
     }
 
+    @Test public void getAllItemsPredicate() throws Exception {
+        MockFolder d = r.createFolder("d");
+        MockFolder sub2 = d.createProject(MockFolder.class, "sub2");
+        MockFolder sub2a = sub2.createProject(MockFolder.class, "a");
+        MockFolder sub2c = sub2.createProject(MockFolder.class, "c");
+        MockFolder sub2b = sub2.createProject(MockFolder.class, "b");
+        MockFolder sub1 = d.createProject(MockFolder.class, "sub1");
+        FreeStyleProject root = r.createFreeStyleProject("root");
+        FreeStyleProject dp = d.createProject(FreeStyleProject.class, "p");
+        FreeStyleProject sub1q = sub1.createProject(FreeStyleProject.class, "q");
+        FreeStyleProject sub1p = sub1.createProject(FreeStyleProject.class, "p");
+        FreeStyleProject sub2ap = sub2a.createProject(FreeStyleProject.class, "p");
+        FreeStyleProject sub2bp = sub2b.createProject(FreeStyleProject.class, "p");
+        FreeStyleProject sub2cp = sub2c.createProject(FreeStyleProject.class, "p");
+        FreeStyleProject sub2alpha = sub2.createProject(FreeStyleProject.class, "alpha");
+        FreeStyleProject sub2BRAVO = sub2.createProject(FreeStyleProject.class, "BRAVO");
+        FreeStyleProject sub2charlie = sub2.createProject(FreeStyleProject.class, "charlie");
+        assertEquals(Arrays.asList(dp, sub1p, sub2ap, sub2bp, sub2cp), d.getAllItems(FreeStyleProject.class, t -> t.getName().equals("p")));
+        assertEquals(Arrays.<Item>asList(sub2a, sub2alpha), sub2.getAllItems(Item.class, t -> t.getName().startsWith("a")));
+    }
+
     @Issue("JENKINS-40252")
     @Test
     public void allItems() throws Exception {


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

Adding a new API that filters items based on a predicate so we don't have to check permissions unnecessarily.

~I'd love to introduce a `getItems()` with a predicate to have allItems also get this performance benefit but I don't see an elegant way of introducing that method to the existing ItemGroup interface~

~On method is obviously just doing getItems then filtering that as a default which has no speed-up. Which is ok but doesn't really encourage devs to implement the interface.~

EDIT: I tried implementing it for allItems as well

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Developer, Introduce filtering overload to `getAllItems()`, `allItems()` and `getItems()`
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

