### PR TITLE
[JENKINS-60884] - Fix NPE in Run API when using getPreviousBuildsOverThreshold

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -954,7 +954,11 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */  
     public @Nonnull List<RunT> getPreviousBuildsOverThreshold(int numberOfBuilds, @Nonnull Result threshold) {
         RunT r = getPreviousBuild();
-        return r.getBuildsOverThreshold(numberOfBuilds, threshold);
+        if( r!=null ) {
+            return r.getBuildsOverThreshold(numberOfBuilds, threshold);
+            
+        }
+        return new ArrayList<>(numberOfBuilds);
     }
 
     /**

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -956,7 +956,6 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         RunT r = getPreviousBuild();
         if( r!=null ) {
             return r.getBuildsOverThreshold(numberOfBuilds, threshold);
-            
         }
         return new ArrayList<>(numberOfBuilds);
     }

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -954,7 +954,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */  
     public @Nonnull List<RunT> getPreviousBuildsOverThreshold(int numberOfBuilds, @Nonnull Result threshold) {
         RunT r = getPreviousBuild();
-        if( r!=null ) {
+        if (r != null) {
             return r.getBuildsOverThreshold(numberOfBuilds, threshold);
         }
         return new ArrayList<>(numberOfBuilds);


### PR DESCRIPTION
See [JENKINS-60884](https://issues.jenkins-ci.org/browse/JENKINS-60884).

This is fix for a NullPointerException in Run.getPreviousBuildsOverThreshold that was introduced by a refactor to add a new Run.getBuildsOverThreshold method in revision PR #4259

### Proposed changelog entries

* Fix NullPointerException when getting a list of runs with a status threshold (regression in 2.202)

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

