### PR TITLE
[JENKINS-21837] Do not record user creating an agent

### DIFF
--- a/core/src/main/java/hudson/cli/CreateNodeCommand.java
+++ b/core/src/main/java/hudson/cli/CreateNodeCommand.java
@@ -63,11 +63,6 @@ public class CreateNodeCommand extends CLICommand {
             newNode.setNodeName(nodeName);
         }
 
-        if(newNode instanceof Slave) { //change userId too
-            User user = User.current();
-            ((Slave) newNode).setUserId(user==null ? "anonymous" : user.getId());
-        }
-
         if (jenkins.getNode(newNode.getNodeName()) != null) {
             throw new IllegalStateException("Node '" + newNode.getNodeName() + "' already exists");
         }

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -258,10 +258,6 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
             String xml = Jenkins.XSTREAM.toXML(src);
             Node result = (Node) Jenkins.XSTREAM.fromXML(xml);
             result.setNodeName(name);
-            if(result instanceof Slave){ //change userId too
-                User user = User.current();
-                ((Slave)result).setUserId(user==null ? "anonymous" : user.getId());
-             }
             result.holdOffLaunchUntilSave = true;
 
             app.addNode(result);

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -30,6 +30,7 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Launcher.RemoteLauncher;
+import hudson.RestrictedSince;
 import hudson.Util;
 import hudson.cli.CLI;
 import hudson.model.Descriptor.FormException;
@@ -73,6 +74,7 @@ import jenkins.util.SystemProperties;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.HttpResponse;
@@ -155,9 +157,10 @@ public abstract class Slave extends Node implements Serializable {
     private transient volatile Set<Label> labels;
 
     /**
-     * Id of user which creates this agent {@link User}.
+     * Removed with no replacement.
      */
-    private String userId;
+    @Deprecated
+    private transient String userId;
 
     /**
      * Use {@link #Slave(String, String, ComputerLauncher)} and set the rest through setters.
@@ -204,13 +207,6 @@ public abstract class Slave extends Node implements Serializable {
         this.nodeProperties.replaceBy(nodeProperties);
          Slave node = (Slave) Jenkins.get().getNode(name);
 
-       if(node!=null){
-            this.userId= node.getUserId(); //agent has already existed
-        }
-       else{
-            User user = User.current();
-            userId = user!=null ? user.getId() : "anonymous";
-        }
         if (name.equals(""))
             throw new FormException(Messages.Slave_InvalidConfig_NoName(), null);
 
@@ -225,13 +221,25 @@ public abstract class Slave extends Node implements Serializable {
      * Return id of user which created this agent
      *
      * @return id of user
+     *
+     * @deprecated Removed with no replacement
      */
+    @Deprecated
+    @Restricted(DoNotUse.class)
+    @RestrictedSince("TODO")
     public String getUserId() {
         return userId;
     }
 
+    /**
+     * This method no longer does anything.
+     *
+     * @deprecated Removed with no replacement
+     */
+    @Deprecated
+    @Restricted(DoNotUse.class)
+    @RestrictedSince("TODO")
     public void setUserId(String userId){
-        this.userId = userId;
     }
 
     public ComputerLauncher getLauncher() {

--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -71,22 +71,6 @@ THE SOFTWARE.
         <p>${%title.no_manual_launch(it.retentionStrategy.descriptor.displayName)}</p>
       </j:if>
 
-     <!-- Display user which created this node -->
-     <j:set var="user" value="${app.getUser(it.node.userId)}"/>
-     <j:if test="${it.node.userId !=null and user!=null}">
-       <p>
-          ${%Created by} 
-         <j:choose>
-            <j:when test="${it.node.userId.equals('anonymous')}">
-             ${%anonymous user}
-            </j:when>
-           <j:otherwise>
-             <a href="${app.rootUrl}${user.url}">${user.displayName}</a>
-            </j:otherwise>
-         </j:choose>
-       </p>
-      </j:if>
-
         <j:if test="${it.node.assignedLabels.size() gt 1}">
         <div>
           <h2>${%Labels}</h2>

--- a/test/src/test/java/hudson/cli/CreateNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/CreateNodeCommandTest.java
@@ -78,7 +78,6 @@ public class CreateNodeCommandTest {
         final Slave updatedSlave = (Slave) j.jenkins.getNode("SlaveFromXML");
         assertThat(updatedSlave.getNodeName(), equalTo("SlaveFromXML"));
         assertThat(updatedSlave.getNumExecutors(), equalTo(42));
-        assertThat(updatedSlave.getUserId(), equalTo(command.user().getId()));
     }
 
     @Test public void createNodeSpecifyingNameExplicitly() throws Exception {
@@ -96,7 +95,6 @@ public class CreateNodeCommandTest {
         final Slave updatedSlave = (Slave) j.jenkins.getNode("CustomSlaveName");
         assertThat(updatedSlave.getNodeName(), equalTo("CustomSlaveName"));
         assertThat(updatedSlave.getNumExecutors(), equalTo(42));
-        assertThat(updatedSlave.getUserId(), equalTo(command.user().getId()));
     }
 
     @Test public void createNodeSpecifyingDifferentNameExplicitly() throws Exception {
@@ -116,7 +114,6 @@ public class CreateNodeCommandTest {
         final Slave updatedSlave = (Slave) j.jenkins.getNode("CustomSlaveName");
         assertThat(updatedSlave.getNodeName(), equalTo("CustomSlaveName"));
         assertThat(updatedSlave.getNumExecutors(), equalTo(42));
-        assertThat(updatedSlave.getUserId(), equalTo(command.user().getId()));
     }
 
     @Test public void createNodeShouldFailIfNodeAlreadyExist() throws Exception {


### PR DESCRIPTION
See [JENKINS-21837](https://issues.jenkins-ci.org/browse/JENKINS-21837).

Way back when we first discussed this, more than five years ago, the idea was to extract this functionality into a plugin etc.

However, this feature broke in Jenkins 2.2 (probably #2293) for new agents created from the UI (copying existing agents and from the CLI probably still worked), and nobody noticed for almost four years. This is an indicator we can just go without, without having to go through the plugin detachment dance.

<details>
<summary>Screenshots of agents created in 2.1 and 2.2</summary>

#### Agent created on 2.1

<img width="1439" alt="Screenshot 2020-02-05 at 10 16 51" src="https://user-images.githubusercontent.com/1831569/73828055-eb1d7e80-4800-11ea-821e-a66f946706bd.png">

#### Agent created on 2.2

<img width="1439" alt="Screenshot 2020-02-05 at 10 16 59" src="https://user-images.githubusercontent.com/1831569/73828085-f53f7d00-4800-11ea-83c3-7a9bca0c5049.png">

</details>

Untested.

### Proposed changelog entries

* RFE: Do not longer record the user creating an agent in some circumstances.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] (not applicable) If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] (not applicable) If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

