### PR TITLE
Enforce singleton pattern in CaseInsensitiveComparator

### DIFF
--- a/core/src/main/java/hudson/util/CaseInsensitiveComparator.java
+++ b/core/src/main/java/hudson/util/CaseInsensitiveComparator.java
@@ -39,6 +39,13 @@ public final class CaseInsensitiveComparator implements Comparator<String>, Seri
     public int compare(String lhs, String rhs) {
         return lhs.compareToIgnoreCase(rhs);
     }
+    
+    /**
+     * Enforce singleton pattern when serializing/deserializing
+     */
+    private Object readResolve() {
+        return INSTANCE;
+    }
 
     private static final long serialVersionUID = 1L;
 }


### PR DESCRIPTION
Make sure that new instances of CaseInsensitiveComparator are not created when serializing/deserializing.
