### PR TITLE
[JENKINS-60926] - Fix agent installation as a service on Windows. (regression in 2.217)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>4.0.1</remoting.version>
+    <remoting.version>4.2</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -115,7 +115,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>slave-installer</artifactId>
-      <version>1.6</version>
+      <version>1.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
See [JENKINS-60926](https://issues.jenkins-ci.org/browse/JENKINS-60926).

This corrects a minor regression introduced in Remoting 4.0 and Jenkins 2.217 (2020-01-23). A renaming broke agent Windows service installation. Combined with an upcoming release of slave-installer-module this will fix the issue. Supersedes #4464.

See the [Remoting changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-4.2). It contains this change plus a couple of minor cleanup PRs.

### Proposed changelog entries

* Fix agent installation as a service on Windows. (regression in 2.217) (issue 60926)
  * Remoting 4.2 changelog: https://github.com/jenkinsci/remoting/releases/tag/remoting-4.2
  * Agent Installer Module 1.7 changelog: https://github.com/jenkinsci/slave-installer-module/blob/master/CHANGELOG.md#17

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
Tests for this capability would be nice but would involve significant system setup.
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

