### PR TITLE
[JENKINS-61004] - Default limits for buildHistoryPage row heights

### DIFF
--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -988,10 +988,12 @@ table.parameters > tbody:hover {
 }
 #buildHistoryPage .build-row-cell > div > .build-link {
     max-height: 3em;
+    max-width: 320px;
     overflow-y: hidden;
 }
 #buildHistoryPage .build-row-cell > div.desc {
     max-height: 5em;
+    max-width: 320px;
     overflow-y: hidden;
 }
 

--- a/war/src/main/webapp/css/style.css
+++ b/war/src/main/webapp/css/style.css
@@ -986,6 +986,14 @@ table.parameters > tbody:hover {
     cursor: pointer;
     top: 6px;
 }
+#buildHistoryPage .build-row-cell > div > .build-link {
+    max-height: 3em;
+    overflow-y: hidden;
+}
+#buildHistoryPage .build-row-cell > div.desc {
+    max-height: 5em;
+    overflow-y: hidden;
+}
 
 #buildHistoryPageNav {
   position: absolute;


### PR DESCRIPTION
See discussion in #4209 and [JENKINS-61004](https://issues.jenkins-ci.org/browse/JENKINS-61004).

### Proposed changelog entries

* Build History rows now have css defined height limits

### Proposed upgrade guidelines

If you want larger build history rows, you will want to use custom css to override the limits.
This applies to people who heavily use the build description fields.

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Before
![image](https://user-images.githubusercontent.com/2119212/73977860-20a59300-48f9-11ea-913f-ef9b1c1b95d2.png)

### After
![image](https://user-images.githubusercontent.com/2119212/73977787-f6ec6c00-48f8-11ea-9a8c-73c88603e781.png)


### Desired reviewers

@daniel-beck @res0nance @timja @oleg-nenashev @MarkEWaite @varyvol @MRamonLeon @halkeye @rsandell @tfennelly @slonopotamus

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

