### PR TITLE
Release Drafter: Do not use `regression-fix` label for the changelog, use the global template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -17,13 +17,12 @@ template: |
 # Categories will be commented out, because we use YAML
 # Now we use categories only for sorting
 categories:
-  - title: Major BUGs and regressions
+  - title: Major bug fixes
     labels: 
       - major-bug
-      - regression-fix
-  - title: Major RFE
+  - title: Major new features and enhancements
     label: major-rfe
-  - title: RFEs
+  - title: New features and enhancements
     label: rfe
   - title: Bug fixes
     label: bug

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,22 +13,3 @@ template: |
   $CHANGES
   
   All contributors: $CONTRIBUTORS
-
-# Categories will be commented out, because we use YAML
-# Now we use categories only for sorting
-categories:
-  - title: Major bug fixes
-    labels: 
-      - major-bug
-  - title: Major new features and enhancements
-    label: major-rfe
-  - title: New features and enhancements
-    label: rfe
-  - title: Bug fixes
-    label: bug
-  - title: Localization
-    label: localization
-  - title: Developer-facing changes (APIs, extensions, etc.)
-    label: developer
-  - title: Internal changes
-    label: internal


### PR DESCRIPTION
Regression fixes are always bug fixes, and using both tags leads to the entry duplication. Also, not all regressions are really severe, for example #4471 has a quite limited impact and IMHO can be considered as a common defect. So I suggest to just stop using `regression-fix` in clhangelog categorization. Downstream fix in https://github.com/jenkinsci/jenkins-core-changelog-generator/ will be also needed if there is a consensus in this PR.

I also changed the category headers while I was around. I will probably add `major-bug` and `major-rfe` to the org-wide release drafter later so that we can cleanup the Core customization
