### PR TITLE
Do not show disabled permissions in permission errors

### DIFF
--- a/core/src/main/java/hudson/security/ACL.java
+++ b/core/src/main/java/hudson/security/ACL.java
@@ -69,8 +69,12 @@ public abstract class ACL {
         if (a == SYSTEM) {
             return;
         }
-        if(!hasPermission(a,p))
+        if (!hasPermission(a,p)) {
+            while (!p.enabled && p.impliedBy != null) {
+                p = p.impliedBy;
+            }
             throw new AccessDeniedException2(a,p);
+        }
     }
 
     /**

--- a/test/src/test/java/hudson/cli/GetNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/GetNodeCommandTest.java
@@ -60,7 +60,7 @@ public class GetNodeCommandTest {
                 .invokeWithArgs("MySlave")
         ;
 
-        assertThat(result.stderr(), containsString("ERROR: user is missing the Agent/ExtendedRead permission"));
+        assertThat(result.stderr(), containsString("ERROR: user is missing the Agent/Configure permission"));
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
     }


### PR DESCRIPTION
Currently, some parts of the Jenkins UI are governed by _optional_ permissions. The most common of those is Job/ExtendedRead, which allows access to the configuration form, and to `GET config.xml`.

At the moment, the error message at `/job/myjob/config.xml` looks like this:

> <img width="609" alt="Screenshot before" src="https://user-images.githubusercontent.com/1831569/74042536-05ee1f80-49c8-11ea-92fc-85cf220df4ca.png">

This is confusing: No such permission is available, even with Matrix Authorization Plugin installed! Admins might be "tricked" into installing the Extended Read permission plugin, when they neither want nor need it.

Hence this enhancement: If the missing permission is disabled, show the next implying permission that isn't disabled in the error message instead.

> <img width="843" alt="Screenshot after" src="https://user-images.githubusercontent.com/1831569/74042635-3209a080-49c8-11ea-8988-6ee6e251cea3.png">

Motivated by the recent work around the "Manage" (or "Limited Administer") permission, that would show up in error messages all over the place, but it has applications even without (as described above).

### Testing Notes

Set up your permissions like this:

> <img width="870" alt="Screenshot of permissions" src="https://user-images.githubusercontent.com/1831569/74042655-3cc43580-49c8-11ea-8317-1db36efca7d6.png">

### Proposed changelog entries

* Do not show disabled permissions in permission errors.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

