### PR TITLE
[JENKINS-60966] Order admin monitors in Global Configuration

### DIFF
--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
@@ -34,7 +34,8 @@ f.section(title: _("Administrative monitors configuration")) {
         f.entry(title: _("Enabled administrative monitors")) {
             p(_("blurb"))
             table(width: "100%") {
-                for (AdministrativeMonitor am : AdministrativeMonitor.all()) {
+                for (AdministrativeMonitor am : new ArrayList<>(AdministrativeMonitor.all())
+                        .sort({ o1, o2 -> o1.getDisplayName() <=> o2.getDisplayName() })) {
                     f.block() {
                         f.checkbox(name: "administrativeMonitor",
                                 title: am.displayName,


### PR DESCRIPTION
See [JENKINS-60966](https://issues.jenkins-ci.org/browse/JENKINS-60966): Order Administrative Monitors by displayName in the global configuration page.

### Proposed changelog entries

* Order Admin Monitors in Global Configuration page

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- ~[ ] For dependency updates: links to external changelogs and, if possible, full diffs~

### Desired reviewers

@reviewbybees 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

