### PR TITLE
Introduce a new summary description field for jobs

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2381,7 +2381,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */
     public void setSummary(@CheckForNull String summary) throws IOException {
         checkPermission(UPDATE);
-        this.description = description;
+        this.summary = summary;
         save();
     }
     
@@ -2401,7 +2401,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public synchronized void doSubmitSummary( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
-        setDescription(req.getParameter("summary"));
+        setSummary(req.getParameter("summary"));
         rsp.sendRedirect(".");  // go to the top page
     }
 

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -715,19 +715,20 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         }
 
         final int maxDescrLength = TRUNCATED_DESCRIPTION_LIMIT;
-        if (description == null || description.length() < maxDescrLength) {
-            return description;
+        final String localDescription = description;
+        if (localDescription == null || localDescription.length() < maxDescrLength) {
+            return localDescription;
         }
 
         final String ending = "...";
-        final int sz = description.length(), maxTruncLength = maxDescrLength - ending.length();
+        final int sz = localDescription.length(), maxTruncLength = maxDescrLength - ending.length();
 
         boolean inTag = false;
         int displayChars = 0;
         int lastTruncatablePoint = -1;
 
         for (int i=0; i<sz; i++) {
-            char ch = description.charAt(i);
+            char ch = localDescription.charAt(i);
             if(ch == '<') {
                 inTag = true;
             } else if (ch == '>') {
@@ -744,7 +745,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             }
         }
 
-        String truncDesc = description;
+        String truncDesc = localDescription;
 
         // Could not find a preferred truncatable index, force a trunc at maxTruncLength
         if (lastTruncatablePoint == -1)

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2542,7 +2542,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     protected void submit(JSONObject json) throws IOException {
         setDisplayName(Util.fixEmptyAndTrim(json.getString("displayName")));
         setDescription(json.getString("description"));
-        setSummary(json.getString("summary"));
+        setSummary(json.optString("summary", null));
     }
 
     public static final XStream XSTREAM = new XStream2();

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -706,7 +706,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * @deprecated truncated description based on the {@link #TRUNCATED_DESCRIPTION_LIMIT} setting.
      */
     @Deprecated
-    public @Nonnull String getTruncatedDescription() {
+    public @CheckForNull String getTruncatedDescription() {
         if (TRUNCATED_DESCRIPTION_LIMIT < 0) { // disabled
             return description;
         }

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -71,9 +71,10 @@ THE SOFTWARE.
           </div>
         </j:if>
       </div>
-      <j:if test="${!empty build.description}">
+      <j:set var="buildSummary" value="${build.summary}"/>
+      <j:if test="${!empty buildSummary}">
         <div class="pane desc indent-multiline">
-          <j:out value="${app.markupFormatter.translate(build.summary)}"/>
+          <j:out value="${app.markupFormatter.translate(buildSummary)}"/>
         </div>
       </j:if>
       <div class="left-bar" />

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -73,7 +73,7 @@ THE SOFTWARE.
       </div>
       <j:if test="${!empty build.description}">
         <div class="pane desc indent-multiline">
-          <j:out value="${app.markupFormatter.translate(build.description)}"/>
+          <j:out value="${app.markupFormatter.translate(build.summary)}"/>
         </div>
       </j:if>
       <div class="left-bar" />


### PR DESCRIPTION
Draft implementation for my suggestion in https://github.com/jenkinsci/jenkins/pull/4477 which could be a solution which is acceptable to both sides (or not)


### Proposed changelog entries

* Bug: Reintroduce Build History truncation by default, allow managing it via a system property
* Developer: Add support of a `summary` field for runs

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

