### PR TITLE
Remove references to Azure maven cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ for(j = 0; j < jdks.size(); j++) {
                                     "MAVEN_OPTS=-Xmx1536m -Xms512m"], buildType, jdk) {
                             // Actually run Maven!
                             // -Dmaven.repo.local=… tells Maven to create a subdir in the temporary directory for the local Maven repository
-                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -ntp -Dmaven.repo.local=$m2repo -s settings-azure.xml -e"
+                            def mvnCmd = "mvn -Pdebug -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install ${runTests ? '-Dmaven.test.failure.ignore' : '-DskipTests'} -V -B -ntp -Dmaven.repo.local=$m2repo -e"
 
                             if(isUnix()) {
                                 sh mvnCmd
@@ -87,7 +87,7 @@ builds.ath = {
             checkout scm
             withMavenEnv(["JAVA_OPTS=-Xmx1536m -Xms512m",
                           "MAVEN_OPTS=-Xmx1536m -Xms512m"], 8) {
-                sh "mvn --batch-mode --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DskipTests -am -pl war package -Dmaven.repo.local=${pwd tmp: true}/m2repo -s settings-azure.xml"
+                sh "mvn --batch-mode --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -DskipTests -am -pl war package -Dmaven.repo.local=${pwd tmp: true}/m2repo"
             }
             dir("war/target") {
                 fileUri = "file://" + pwd() + "/jenkins.war"

--- a/settings-azure.xml
+++ b/settings-azure.xml
@@ -1,9 +1,0 @@
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <mirrors>
-        <mirror>
-            <id>azure</id>
-            <url>https://repo.azure.jenkins.io/public/</url> <!-- INFRA-1176 -->
-            <mirrorOf>repo.jenkins-ci.org</mirrorOf>
-        </mirror>
-    </mirrors>
-</settings>


### PR DESCRIPTION
# Remove references to Azure maven cache

Azure maven cache was used to reduce data transfer overhead and costs. Cache was removed at the end of January 2020.  When a terraform apply (correctly) removed the DNS entry for repo.azure.jenkins.io, builds began to fail.

No changelog needed for this internal fix. No Jira ticket for this internal fix. No automated tests for this internal fix because the build is its own test of this fix.

This same change will be needed on the stable-2.204 branch.

### Proposed changelog entries

* No changelog - internal build issue only

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] Issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@mikecirioli  @daniel-beck @jenkinsci/code-reviewers

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [{] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`