### PR TITLE
Improve performance when loading tied jobs

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -778,7 +778,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     @Exported
     public Set<LabelAtom> getAssignedLabels() {
         Node node = getNode();
-        return (node != null) ? node.getAssignedLabels() : Collections.EMPTY_SET;
+        return (node != null) ? node.getAssignedLabels() : Collections.emptySet();
     }
 
     /**
@@ -786,7 +786,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     public List<AbstractProject> getTiedJobs() {
         Node node = getNode();
-        return (node != null) ? node.getSelfLabel().getTiedJobs() : Collections.EMPTY_LIST;
+        return (node != null) ? node.getSelfLabel().getTiedJobs() : Collections.emptyList();
     }
 
     public RunList getBuilds() {

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -66,6 +66,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
@@ -388,12 +390,10 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
      */
     @Exported
     public List<AbstractProject> getTiedJobs() {
-        List<AbstractProject> r = new ArrayList<>();
-        for (AbstractProject<?,?> p : Jenkins.get().allItems(AbstractProject.class, i -> i instanceof TopLevelItem && this.equals(i.getAssignedLabel()))) {
-            r.add(p);
-        }
-        r.sort(Items.BY_FULL_NAME);
-        return r;
+        return StreamSupport.stream(Jenkins.get().allItems(AbstractProject.class,
+                i -> i instanceof TopLevelItem && this.equals(i.getAssignedLabel())).spliterator(),
+                true)
+                .sorted(Items.BY_FULL_NAME).collect(Collectors.toList());
     }
 
     /**

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -389,9 +389,8 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     @Exported
     public List<AbstractProject> getTiedJobs() {
         List<AbstractProject> r = new ArrayList<>();
-        for (AbstractProject<?,?> p : Jenkins.get().allItems(AbstractProject.class)) {
-            if(p instanceof TopLevelItem && this.equals(p.getAssignedLabel()))
-                r.add(p);
+        for (AbstractProject<?,?> p : Jenkins.get().allItems(AbstractProject.class, i -> i instanceof TopLevelItem && this.equals(i.getAssignedLabel()))) {
+            r.add(p);
         }
         r.sort(Items.BY_FULL_NAME);
         return r;

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -131,14 +131,15 @@ public class ComputerTest {
 
     @Test
     public void tiedJobs() throws Exception {
-        Label label1 = new LabelAtom("label1");
-        Computer c = j.createOnlineSlave(label1).toComputer();
+        DumbSlave s = j.createOnlineSlave();
+        Label l = s.getSelfLabel();
+        Computer c = s.toComputer();
         FreeStyleProject p = j.createFreeStyleProject();
-        p.setAssignedLabel(label1);
+        p.setAssignedLabel(l);
         FreeStyleProject p2 = j.createFreeStyleProject();
         MockFolder f = j.createFolder("test");
         FreeStyleProject p3 = f.createProject(FreeStyleProject.class, "project");
-        p3.setAssignedLabel(label1);
+        p3.setAssignedLabel(l);
         assertThat(c.getTiedJobs(), containsInAnyOrder(p, p3));
     }
 

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -24,6 +24,7 @@
 package hudson.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
@@ -36,6 +37,7 @@ import java.io.File;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 
+import hudson.model.labels.LabelAtom;
 import jenkins.model.Jenkins;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
@@ -46,6 +48,7 @@ import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.SmokeTest;
 import org.jvnet.hudson.test.recipes.LocalData;
 
@@ -124,6 +127,19 @@ public class ComputerTest {
         assertEquals(1, c.getActions(A.class).size());
         c.addAction(new A());
         assertEquals(2, c.getActions(A.class).size());
+    }
+
+    @Test
+    public void tiedJobs() throws Exception {
+        Label label1 = new LabelAtom("label1");
+        Computer c = j.createOnlineSlave(label1).toComputer();
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.setAssignedLabel(label1);
+        FreeStyleProject p2 = j.createFreeStyleProject();
+        MockFolder f = j.createFolder("test");
+        FreeStyleProject p3 = f.createProject(FreeStyleProject.class, "project");
+        p3.setAssignedLabel(label1);
+        assertThat(c.getTiedJobs(), containsInAnyOrder(p, p3));
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

Use pre-auth filtering (#4469) for tied jobs. This will be useful if users have Pipeline jobs, this will stop doing permissions checks for all those pipeline jobs.

This is called every time a user clicks a node from the UI

For child filtering this needs ItemGroup's such as Folders plugin to implement the predicate form of `getItems` for a speedup.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Improve performance when loading tied jobs
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

