### PR TITLE
Add memory usage monitor to the system information page

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/systemInfo.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/systemInfo.jelly
@@ -59,6 +59,53 @@ THE SOFTWARE.
             </j:otherwise>
           </j:choose>
         </table>
+        <h1>${%Memory Usage}</h1>
+        <j:set var="type" value="${request.getParameter('type')}" />
+        <j:choose>
+            <j:when test="${type == 'sec10'}" />
+            <j:when test="${type == 'min'}" />
+            <j:when test="${type == 'hour'}" />
+            <j:otherwise>
+                <j:set var="type" value="min" />
+            </j:otherwise>
+        </j:choose>
+
+        <div>
+            ${%Timespan}:
+            <j:choose>
+                <j:when test="${type != 'sec10'}">
+                    <a href="?type=sec10">${%Short}</a>
+                </j:when>
+                <j:otherwise>
+                    ${%Short}
+                </j:otherwise>
+            </j:choose>
+            <st:nbsp />
+            <j:choose>
+                <j:when test="${type != 'min'}">
+                    <a href="?type=min">${%Medium}</a>
+                </j:when>
+                <j:otherwise>
+                    ${%Medium}
+                </j:otherwise>
+            </j:choose>
+            <st:nbsp />
+            <j:choose>
+                <j:when test="${type != 'hour'}">
+                    <a href="?type=hour">${%Long}</a>
+                </j:when>
+                <j:otherwise>
+                    ${%Long}
+                </j:otherwise>
+            </j:choose>
+        </div>
+        <script type="text/javascript">
+            var w = document.getElementById('main-panel').offsetWidth - 30;
+            document.write('<img src="${rootURL}/extensionList/hudson.diagnosis.MemoryUsageMonitor/0/heap/graph?type=${type}&amp;width=' + w + '&amp;height=500" alt="[${%Memory usage graph}]" />');
+        </script>
+        <noscript>
+            <img src="${rootURL}/extensionList/hudson.diagnosis.MemoryUsageMonitor/0/heap/graph?type=${type}&amp;width=500&amp;height=300" alt="[${%Memory usage graph}]" />
+        </noscript>
         <h1>${%Thread Dumps}</h1>
         <p>${%threadDump_blurb('threadDump')}</p>
     </l:main-panel>


### PR DESCRIPTION
In case you've wondered what https://jenkins.io/security/advisory/2020-01-29/#SECURITY-1650 was about…

I was unable to find any references to this class, despite it being pretty nice. So let's add the reference. There's probably a better way to do this, but 🤷‍♂ 

> ![Screenshot](https://user-images.githubusercontent.com/1831569/74546984-aeadf900-4f4b-11ea-93c3-eec8742e1f10.png)

Mostly copy&pasted from loadStatistics graph UI.

### Proposed changelog entries

* Add memory usage monitor to system information page

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

