### PR TITLE
[JENKINS-61102] Use XMLUnit to fix test

### DIFF
--- a/core/src/test/java/jenkins/util/xstream/XStreamDOMTest.java
+++ b/core/src/test/java/jenkins/util/xstream/XStreamDOMTest.java
@@ -27,8 +27,11 @@ import hudson.util.XStream2;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
 
 import static org.junit.Assert.*;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,7 +65,8 @@ public class XStreamDOMTest {
         Foo foo = createSomeFoo();
         String xml = xs.toXML(foo);
         System.out.println(xml);
-        assertEquals(getTestData1().trim(), xml.trim());
+        assertThat(getTestData1().trim(), isSimilarTo(xml.trim()).ignoreWhitespace()
+                .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
     }
 
     private String getTestData1() throws IOException {
@@ -100,7 +104,8 @@ public class XStreamDOMTest {
 
         String xml = xs.toXML(foo);
         System.out.println(xml);
-        assertEquals(getTestData1().trim(), xml.trim());
+        assertThat(getTestData1().trim(), isSimilarTo(xml.trim()).ignoreWhitespace()
+                .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
     }
 
     @Test


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-61102](https://issues.jenkins-ci.org/browse/JENKINS-61102).
This PR proposes to use XMLUnit to fix the problem. It ignores the order of XML elements to make the tests more robust.
<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Make tests more stable by using XMLUnit to compare XML results.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
   *Use the `Internal:` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs


