### PR TITLE
[JENKINS-36720] Spotbugs fix possible NPE

### DIFF
--- a/core/src/main/java/jenkins/telemetry/impl/SecuritySystemProperties.java
+++ b/core/src/main/java/jenkins/telemetry/impl/SecuritySystemProperties.java
@@ -99,11 +99,7 @@ public class SecuritySystemProperties extends Telemetry {
 
         Map<String, Object> info = new TreeMap<>();
         VersionNumber jenkinsVersion = Jenkins.getVersion();
-        if (jenkinsVersion != null) {
-            info.put("core", jenkinsVersion.toString());
-        } else {
-            info.put("core", "UNKNOWN");
-        }
+        info.put("core", jenkinsVersion != null ? jenkinsVersion.toString() : "UNKNOWN");
         info.put("clientDate", clientDateString());
         info.put("properties", security);
 

--- a/core/src/main/java/jenkins/telemetry/impl/SecuritySystemProperties.java
+++ b/core/src/main/java/jenkins/telemetry/impl/SecuritySystemProperties.java
@@ -24,6 +24,7 @@
 package jenkins.telemetry.impl;
 
 import hudson.Extension;
+import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import jenkins.telemetry.Telemetry;
 import jenkins.util.SystemProperties;
@@ -97,7 +98,12 @@ public class SecuritySystemProperties extends Telemetry {
         putStringInfo(security, "hudson.security.HudsonPrivateSecurityRealm.ID_REGEX");
 
         Map<String, Object> info = new TreeMap<>();
-        info.put("core", Jenkins.getVersion().toString());
+        VersionNumber jenkinsVersion = Jenkins.getVersion();
+        if (jenkinsVersion != null) {
+            info.put("core", jenkinsVersion.toString());
+        } else {
+            info.put("core", "UNKNOWN");
+        }
         info.put("clientDate", clientDateString());
         info.put("properties", security);
 

--- a/core/src/main/java/jenkins/telemetry/impl/java11/MissingClassTelemetry.java
+++ b/core/src/main/java/jenkins/telemetry/impl/java11/MissingClassTelemetry.java
@@ -162,11 +162,7 @@ public class MissingClassTelemetry extends Telemetry {
 
         JSONObject info = new JSONObject();
         VersionNumber jenkinsVersion = Jenkins.getVersion();
-        if (jenkinsVersion != null) {
-            info.put("core", jenkinsVersion.toString());
-        } else {
-            info.put("core", "UNKNOWN");
-        }
+        info.put("core", jenkinsVersion != null ? jenkinsVersion.toString() : "UNKNOWN");
         info.put("clientDate", clientDateString());
         info.put("classMissingEvents", events);
 

--- a/core/src/main/java/jenkins/telemetry/impl/java11/MissingClassTelemetry.java
+++ b/core/src/main/java/jenkins/telemetry/impl/java11/MissingClassTelemetry.java
@@ -26,6 +26,7 @@ package jenkins.telemetry.impl.java11;
 
 import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
+import hudson.util.VersionNumber;
 import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import jenkins.model.Jenkins;
 import jenkins.telemetry.Telemetry;
@@ -160,7 +161,12 @@ public class MissingClassTelemetry extends Telemetry {
         }
 
         JSONObject info = new JSONObject();
-        info.put("core", Jenkins.getVersion() != null ? Jenkins.getVersion().toString() : "UNKNOWN");
+        VersionNumber jenkinsVersion = Jenkins.getVersion();
+        if (jenkinsVersion != null) {
+            info.put("core", jenkinsVersion.toString());
+        } else {
+            info.put("core", "UNKNOWN");
+        }
         info.put("clientDate", clientDateString());
         info.put("classMissingEvents", events);
 


### PR DESCRIPTION
Fix NP - NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE in 2 files

See [JENKINS-36720](https://issues.jenkins-ci.org/browse/JENKINS-36720).

Spotbugs fixes

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

