### PR TITLE
Always set a crumb issuer

### DIFF
--- a/core/src/main/java/hudson/security/csrf/GlobalCrumbIssuerConfiguration.java
+++ b/core/src/main/java/hudson/security/csrf/GlobalCrumbIssuerConfiguration.java
@@ -56,7 +56,6 @@ public class GlobalCrumbIssuerConfiguration extends GlobalConfiguration {
         if (json.has("crumbIssuer")) {
             j.setCrumbIssuer(req.bindJSON(CrumbIssuer.class, json.getJSONObject("crumbIssuer")));
         } else {
-            // set the default crumb issuer
             j.setCrumbIssuer(createDefaultCrumbIssuer());
         }
 
@@ -73,10 +72,9 @@ public class GlobalCrumbIssuerConfiguration extends GlobalConfiguration {
         if (DISABLE_CSRF_PROTECTION) {
             return null;
         }
-        return new DefaultCrumbIssuer(SystemProperties.getBoolean(Jenkins.class.getName() + ".crumbIssuerProxyCompatibility",false));
+        return new DefaultCrumbIssuer(SystemProperties.getBoolean(Jenkins.class.getName() + ".crumbIssuerProxyCompatibility", false));
     }
 
     @Restricted(NoExternalUse.class)
     public static /* non-final */ boolean DISABLE_CSRF_PROTECTION = SystemProperties.getBoolean(GlobalCrumbIssuerConfiguration.class.getName() + ".DISABLE_CSRF_PROTECTION");
 }
-

--- a/core/src/main/java/hudson/security/csrf/GlobalCrumbIssuerConfiguration.java
+++ b/core/src/main/java/hudson/security/csrf/GlobalCrumbIssuerConfiguration.java
@@ -27,8 +27,11 @@ import hudson.Extension;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
@@ -49,14 +52,31 @@ public class GlobalCrumbIssuerConfiguration extends GlobalConfiguration {
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
         // for compatibility reasons, the actual value is stored in Jenkins
         Jenkins j = Jenkins.get();
-        if (json.has("csrf")) {
-            JSONObject csrf = json.getJSONObject("csrf");
-            j.setCrumbIssuer(CrumbIssuer.all().newInstanceFromRadioList(csrf, "issuer"));
+
+        if (json.has("crumbIssuer")) {
+            j.setCrumbIssuer(req.bindJSON(CrumbIssuer.class, json.getJSONObject("crumbIssuer")));
         } else {
-            j.setCrumbIssuer(null);
+            // set the default crumb issuer
+            j.setCrumbIssuer(createDefaultCrumbIssuer());
         }
 
         return true;
     }
+
+    @Restricted(NoExternalUse.class) // Jelly
+    public CrumbIssuer getCrumbIssuer() {
+        return Jenkins.get().getCrumbIssuer();
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static CrumbIssuer createDefaultCrumbIssuer() {
+        if (DISABLE_CSRF_PROTECTION) {
+            return null;
+        }
+        return new DefaultCrumbIssuer(SystemProperties.getBoolean(Jenkins.class.getName() + ".crumbIssuerProxyCompatibility",false));
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static /* non-final */ boolean DISABLE_CSRF_PROTECTION = SystemProperties.getBoolean(GlobalCrumbIssuerConfiguration.class.getName() + ".DISABLE_CSRF_PROTECTION");
 }
 

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import hudson.security.csrf.GlobalCrumbIssuerConfiguration;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.security.seed.UserSeedProperty;
 import jenkins.util.SystemProperties;
@@ -133,7 +134,7 @@ public class SetupWizard extends PageDecorator {
                     jenkins.setSlaveAgentPort(SystemProperties.getInteger(Jenkins.class.getName()+".slaveAgentPort",-1));
 
                     // require a crumb issuer
-                    jenkins.setCrumbIssuer(new DefaultCrumbIssuer(SystemProperties.getBoolean(Jenkins.class.getName() + ".crumbIssuerProxyCompatibility",false)));
+                    jenkins.setCrumbIssuer(GlobalCrumbIssuerConfiguration.createDefaultCrumbIssuer());
     
                     // set master -> slave security:
                     jenkins.getInjector().getInstance(AdminWhitelistRule.class)

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -37,6 +37,8 @@ import com.thoughtworks.xstream.XStream;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.*;
 import hudson.Launcher.LocalLauncher;
+import hudson.security.csrf.DefaultCrumbIssuer;
+import hudson.security.csrf.GlobalCrumbIssuerConfiguration;
 import jenkins.AgentProtocol;
 import jenkins.diagnostics.URICheckEncodingMonitor;
 import jenkins.security.stapler.DoActionFilter;
@@ -656,7 +658,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * {@link hudson.security.csrf.CrumbIssuer}
      */
-    private volatile CrumbIssuer crumbIssuer;
+    private volatile CrumbIssuer crumbIssuer = GlobalCrumbIssuerConfiguration.createDefaultCrumbIssuer();
 
     /**
      * All labels known to Jenkins. This allows us to reuse the same label instances
@@ -3298,9 +3300,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     }
                 }
 
-
-                // Initialize the filter with the crumb issuer
-                setCrumbIssuer(crumbIssuer);
+                // Allow the disabling system property to interfere here
+                setCrumbIssuer(getCrumbIssuer());
 
                 // auto register root actions
                 for (Action a : getExtensionList(RootAction.class))
@@ -3836,7 +3837,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @CheckForNull
     public CrumbIssuer getCrumbIssuer() {
-        return crumbIssuer;
+        return GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION ? null : crumbIssuer;
     }
 
     public void setCrumbIssuer(CrumbIssuer issuer) {

--- a/core/src/main/resources/hudson/security/csrf/GlobalCrumbIssuerConfiguration/config.groovy
+++ b/core/src/main/resources/hudson/security/csrf/GlobalCrumbIssuerConfiguration/config.groovy
@@ -7,12 +7,13 @@ def all = CrumbIssuer.all()
 
 if (!all.isEmpty()) {
     f.section(title: _("CSRF Protection")) {
-        f.optionalBlock(field:"csrf", title:_("Prevent Cross Site Request Forgery exploits"), checked: app.useCrumbs ) {
-            f.entry(title:_("Crumbs")) {
-                table(style:"width:100%") {
-                    f.descriptorRadioList(title:_("Crumb Algorithm"), varName:"issuer", instance:app.crumbIssuer, descriptors:all)
-                }
+        if (hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION) {
+            f.entry {
+                p(raw(_('disabled')))
+                p(_('unsupported'))
             }
+        } else {
+            f.dropdownDescriptorSelector(title: _("Crumb Issuer"), descriptors: all, field: 'crumbIssuer')
         }
     }
 }

--- a/core/src/main/resources/hudson/security/csrf/GlobalCrumbIssuerConfiguration/config.properties
+++ b/core/src/main/resources/hudson/security/csrf/GlobalCrumbIssuerConfiguration/config.properties
@@ -1,0 +1,2 @@
+disabled=This configuration is unavailable because the System property <code>hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION</code> is set to <code>true</code>.
+unsupported=That option should be considered unsupported and its use should be limited to working around compatibility problems until they are resolved.


### PR DESCRIPTION
Twitter driven development: https://twitter.com/danielbeck/status/1214346538618621964

Make sure that the crumb issuer is always set.

### New UI

#### The default

> ![Screenshot](https://user-images.githubusercontent.com/1831569/74840413-3d918b80-5327-11ea-9227-a46e56daab99.png)

#### A custom crumb issuer

> ![Screenshot](https://user-images.githubusercontent.com/1831569/74840441-484c2080-5327-11ea-8465-e9c91771c2ea.png)

#### With escape hatch set

> ![Screenshot](https://user-images.githubusercontent.com/1831569/74840452-50a45b80-5327-11ea-9c20-955c4a96e9ec.png)

#### A note on not removing the UI

Configuration UI for some options in Jenkins are not shown when there's only one option. I decided against this approach here for two reasons:

* Even with the default crumb issuer, there's still the proxy compatibility setting.
* The configuration disappearing altogether might worry experienced and security-conscious Jenkins administrators.

### On proxy compatibility

I decided to use the same approach to proxy compatibility as is currently used in the setup wizard, i.e. require a system property to enable greater compatibility out of the box.

In some cases (CSRF protection disabled, load balancer or otherwise unusually configured reverse proxy in front of Jenkins), this may result in a problem requiring a minor system property dance, bypassing the proxy for a moment to reconfigure, or patching `config.xml` to restore UI functionality in Jenkins.

I think these cases are rare enough so this shouldn't be a huge problem; an argument can be made to slightly lower protection for greater compatibility: Since https://jenkins.io/security/advisory/2019-07-17/#SECURITY-626, we make the the session ID part of the crumb, so requiring an IP address match on top of that isn't _that_ important.

### Escape hatch

While there's an escape hatch in `hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION`, I wouldn't advertise it much.

How it works:

* If the system property is set on Jenkins startup, Jenkins will set or unset the crumb issuer according to the value set.
* While Jenkins is running, the config UI can be locked/unlocked by setting the field of the same name as the system property to `true`/`false`. This will not immediately change the configured crumb issuer; a global security config form submission is needed for that.

### Proposed changelog entries

* Remove the ability to have CSRF protection disabled. Instances upgrading from older versions of Jenkins will have CSRF protection enabled and the default issuer set if they currently have it disabled.

### Proposed upgrade guidelines

Jenkins will automatically enable CSRF protection with the default crumb issuer if it was disabled before. The ability to not have CSRF protection enabled has been deprecated and removed from the UI. Set the system property `hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION` to `true` on startup to disable CSRF protection as well as the configuration UI for it.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

