### PR TITLE
[JENKINS-61166] Show on 'updates' tab when a warning would be fixed

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -67,6 +67,7 @@ import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import jenkins.model.Jenkins;
 import jenkins.plugins.DetachedPluginsUtil;
 import jenkins.security.UpdateSiteWarningsConfiguration;
+import jenkins.security.UpdateSiteWarningsMonitor;
 import jenkins.util.JSONSignatureValidator;
 import jenkins.util.SystemProperties;
 import jenkins.util.java.JavaUtils;
@@ -1274,6 +1275,32 @@ public class UpdateSite {
         @Restricted(NoExternalUse.class) // table.jelly
         public boolean isNeededDependenciesCompatibleWithInstalledVersion(PluginManager.MetadataCache cache) {
             return getDependenciesIncompatibleWithInstalledVersion(cache).isEmpty();
+        }
+
+        /**
+         * Returns true if and only if this update addressed a currently active security vulnerability.
+         *
+         * @return true if and only if this update addressed a currently active security vulnerability.
+         */
+        @Restricted(NoExternalUse.class) // Jelly
+        public boolean fixesSecurityVulnerabilities() {
+            final PluginWrapper installed = getInstalled();
+            if (installed == null) {
+                return false;
+            }
+            boolean allWarningsStillApply = true;
+            for (Warning warning : ExtensionList.lookupSingleton(UpdateSiteWarningsMonitor.class).getActivePluginWarningsByPlugin().getOrDefault(installed, Collections.emptyList())) {
+                boolean thisWarningApplies = false;
+                for (WarningVersionRange range : warning.versionRanges) {
+                    if (range.includes(new VersionNumber(version))) {
+                        thisWarningApplies = true;
+                    }
+                }
+                if (!thisWarningApplies) {
+                    allWarningsStillApply = false;
+                }
+            }
+            return !allWarningsStillApply;
         }
 
         /**

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -120,7 +120,7 @@ THE SOFTWARE.
                         <div class="alert alert-danger">${%javaWarning(p.minimumJavaVersion)}</div>
                       </j:if>
                       <j:if test="${p.fixesSecurityVulnerabilities()}">
-                        <div class="alert alert-warning">${%Applying this update will address security vulnerabilities currently affecting Jenkins.}</div>
+                        <div class="alert alert-warning">${%Applying this update will address security vulnerabilities in the currently installed version.}</div>
                       </j:if>
                       <j:if test="${!p.isNeededDependenciesCompatibleWithInstalledVersion(cache)}">
                         <div class="alert alert-danger">${%depCompatWarning}

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -119,6 +119,9 @@ THE SOFTWARE.
                       <j:if test="${p.isForNewerJava()}">
                         <div class="alert alert-danger">${%javaWarning(p.minimumJavaVersion)}</div>
                       </j:if>
+                      <j:if test="${p.fixesSecurityVulnerabilities()}">
+                        <div class="alert alert-warning">${%Applying this update will address security vulnerabilities currently affecting Jenkins.}</div>
+                      </j:if>
                       <j:if test="${!p.isNeededDependenciesCompatibleWithInstalledVersion(cache)}">
                         <div class="alert alert-danger">${%depCompatWarning}
                           <br/>${%parentDepCompatWarning}


### PR DESCRIPTION
See [JENKINS-61166](https://issues.jenkins-ci.org/browse/JENKINS-61166).

> ![Screenshot](https://user-images.githubusercontent.com/1831569/75073272-65384d80-54f9-11ea-98fe-e37b5d3b44be.png)

This does not apply to warnings that are currently hidden by configuration, to not introduce confusion: If you've hidden it, you don't want to see it anywhere.

This gets shown even when the admin monitor is entirely disabled. While it would make sense in that case to show more details about which warnings get addressed, I would not optimize for that configuration. I doubt users care _that much_ to see the full list of warnings here.

### Proposed changelog entries

* Indicate when security issues would be addressed by an update in plugin manager.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

