### PR TITLE
Listen on loopback interface by default in debug mode

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -40,6 +40,7 @@ THE SOFTWARE.
   <properties>
     <JENKINS_HOME>${basedir}/work</JENKINS_HOME>
     <contextPath>/jenkins</contextPath><!-- context path during test -->
+    <host>localhost</host><!-- HTTP listener host/interface -->
     <port>8080</port><!-- HTTP listener port -->
     <node.version>12.14.1</node.version>
     <yarn.version>1.21.1</yarn.version>
@@ -466,7 +467,8 @@ THE SOFTWARE.
           -->
           <reload>manual</reload>
           <httpConnector>
-              <port>${port}</port>
+            <host>${host}</host>
+            <port>${port}</port>
           </httpConnector>
           <loginServices>
             <loginService implementation="org.eclipse.jetty.security.HashLoginService">


### PR DESCRIPTION
Local development setups usually don't need to listen on all interfaces, so restrict to `localhost` by default when running `mvn jetty:run`.

Apparently `host` is the Jetty terminology for the listen address, so use that for the property.
I didn't want to think about IPv4/IPv6, so use `localhost` instead of e.g. `127.0.0.1`. `JenkinsRule` uses `localhost` as well.

Restore previous behavior by setting `-Dhost=0.0.0.0` on the command line.

Corresponding PR in Maven HPI Plugin at https://github.com/jenkinsci/maven-hpi-plugin/pull/169.

### Proposed changelog entries

Too minor? Unsure.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

