### PR TITLE
[JENKINS-61300] Update search box size on page resize, max width

### DIFF
--- a/core/src/main/resources/lib/layout/pageHeader.jelly
+++ b/core/src/main/resources/lib/layout/pageHeader.jelly
@@ -47,8 +47,6 @@
             <!-- search box -->
             <j:set var="searchURL" value="${h.searchURL}"/>
             <form action="${searchURL}" method="get" style="position:relative;" class="no-json" name="search" role="search">
-                <!-- this div determines the minimum width -->
-                <div id="search-box-minWidth"/>
                 <!-- this div is used to calculate the width of the text box -->
                 <div id="search-box-sizer"/>
                 <div id="searchform">

--- a/war/src/main/less/modules/page-header.less
+++ b/war/src/main/less/modules/page-header.less
@@ -204,11 +204,12 @@ a.page-header__brand-link {
 }
 
 #search-box-completion LI {
-    white-space:nowrap;
-
+    white-space: nowrap;
     padding: 0.25rem 1.25rem;
     font-size: 1rem;
     line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 #search-box-completion LI.yui-ac-highlight {
@@ -220,4 +221,5 @@ a.page-header__brand-link {
     position:absolute;
     visibility: hidden;
     min-width: 15rem;
+    max-width: calc(100vw - 500px);
 }

--- a/war/src/main/less/modules/page-header.less
+++ b/war/src/main/less/modules/page-header.less
@@ -216,13 +216,8 @@ a.page-header__brand-link {
     font-weight: bold;
 }
 
-#search-box-minWidth {
-    position:absolute;
-    visibility: hidden;
-    width:15rem;
-}
-
 #search-box-sizer {
     position:absolute;
     visibility: hidden;
+    min-width: 15rem;
 }

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2397,25 +2397,25 @@ function createSearchBox(searchURL) {
     var comp  = $("search-box-completion");
 
     Behaviour.addLoadEvent(function(){
-        // make sure all three components have the same font settings
-        function copyFontStyle(s,d) {
-            var ds = d.style;
-            ds.fontFamily = getStyle(s,"fontFamily");
-            ds.fontSize = getStyle(s,"fontSize");
-            ds.fontStyle = getStyle(s,"fontStyle");
-            ds.fontWeight = getStyle(s,"fontWeight");
-        }
-
-        copyFontStyle(box,sizer);
+        // copy font style of box to sizer
+        var ds = sizer.style;
+        ds.fontFamily = getStyle(box, "fontFamily");
+        ds.fontSize = getStyle(box, "fontSize");
+        ds.fontStyle = getStyle(box, "fontStyle");
+        ds.fontWeight = getStyle(box, "fontWeight");
     });
 
     // update positions and sizes of the components relevant to search
     function updatePos() {
         sizer.innerHTML = box.value.escapeHTML();
-        var w = sizer.offsetWidth;
+        var cssWidth, offsetWidth = sizer.offsetWidth;
+        if (offsetWidth > 0) {
+            cssWidth = offsetWidth + "px";
+        } else { // sizer hidden on small screen, make sure resizing looks OK
+            cssWidth =  getStyle(sizer, "minWidth");
+        }
         box.style.width =
-        comp.style.width =
-        comp.firstChild.style.minWidth = (w+60)+"px";
+        comp.firstChild.style.minWidth = "calc(60px + " + cssWidth + ")";
 
         var pos = YAHOO.util.Dom.getXY(box);
         pos[1] += YAHOO.util.Dom.get(box).offsetHeight + 2;
@@ -2423,9 +2423,7 @@ function createSearchBox(searchURL) {
     }
 
     updatePos();
-    // on small screens offsetWith is 0, update when screen gets bigger
-    window.addEventListener("resize", updatePos);
-    box.onkeyup = updatePos;
+    box.addEventListener("input", updatePos);
 }
 
 

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2395,7 +2395,6 @@ function createSearchBox(searchURL) {
     var box   = $("search-box");
     var sizer = $("search-box-sizer");
     var comp  = $("search-box-completion");
-    var minW  = $("search-box-minWidth");
 
     Behaviour.addLoadEvent(function(){
         // make sure all three components have the same font settings
@@ -2408,18 +2407,15 @@ function createSearchBox(searchURL) {
         }
 
         copyFontStyle(box,sizer);
-        copyFontStyle(box,minW);
     });
 
     // update positions and sizes of the components relevant to search
     function updatePos() {
-        function max(a,b) { if(a>b) return a; else return b; }
-
         sizer.innerHTML = box.value.escapeHTML();
-        var w = max(sizer.offsetWidth,minW.offsetWidth);
+        var w = sizer.offsetWidth;
         box.style.width =
-        comp.style.width = 
-        comp.firstChild.style.width = (w+60)+"px";
+        comp.style.width =
+        comp.firstChild.style.minWidth = (w+60)+"px";
 
         var pos = YAHOO.util.Dom.getXY(box);
         pos[1] += YAHOO.util.Dom.get(box).offsetHeight + 2;
@@ -2427,6 +2423,8 @@ function createSearchBox(searchURL) {
     }
 
     updatePos();
+    // on small screens offsetWith is 0, update when screen gets bigger
+    window.addEventListener("resize", updatePos);
     box.onkeyup = updatePos;
 }
 


### PR DESCRIPTION
To reproduce:
* open Jenkins in a small browser window (small enough for search to be hidden)
* make the window bigger
* type in  long text

Expected:
1) after resize the search box is reasonably big
2) when typing, autocompletion size follows search box size

Actual:
1) after resize there is a 60px wide search box
![image](https://user-images.githubusercontent.com/1105305/75290559-e3119700-5820-11ea-8740-0e6d1f45addb.png)

2) when typing, on key up the autocomplete size syncs with box, but resizes back when autocomplete results are fetched

This PR fixes 1) by adding a resize listener and 2) by applying minWidth instead of width. Also removes extra div that was used for minWidth computation and uses CSS min-width instead.

### Proposed changelog entries

* Entry 1: Update size of the search box properly when screen is resized.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@fqueiruga 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

