### PR TITLE
JENKINS-61205 System read - global security configuration

### DIFF
--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -182,7 +182,7 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
     
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.ADMINISTER;
+        return Jenkins.SYSTEM_READ;
     }
 
     @Restricted(NoExternalUse.class)

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
@@ -19,7 +19,6 @@ l.layout(permission:app.SYSTEM_READ, title:my.displayName, cssclass:request.getP
         }
         if (!h.hasPermission(app.ADMINISTER)) {
             set("readOnlyMode", "true")
-            input(id: "readOnlyMode", type: "hidden", name: "readOnlyMode", value: "true")
         }
 
         p()

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
@@ -11,11 +11,15 @@ def f=namespace(lib.FormTagLib)
 def l=namespace(lib.LayoutTagLib)
 def st=namespace("jelly:stapler")
 
-l.layout(permission:app.ADMINISTER, title:my.displayName, cssclass:request.getParameter('decorate')) {
+l.layout(permission:app.SYSTEM_READ, title:my.displayName, cssclass:request.getParameter('decorate')) {
     l.main_panel {
         h1 {
             l.icon(class: 'icon-secure icon-xlg')
             text(my.displayName)
+        }
+        if (!h.hasPermission(app.ADMINISTER)) {
+            set("readOnlyMode", "true")
+            input(id: "readOnlyMode", type: "hidden", name: "readOnlyMode", value: "true")
         }
 
         p()
@@ -101,13 +105,17 @@ l.layout(permission:app.ADMINISTER, title:my.displayName, cssclass:request.getPa
                 }
             }
 
-            f.bottomButtonBar {
-                f.submit(value:_("Save"))
-                f.apply()
+            l.isAdmin() {
+                f.bottomButtonBar {
+                    f.submit(value: _("Save"))
+                    f.apply()
+                }
             }
         }
 
-        st.adjunct(includes: "lib.form.confirm")
+        l.isAdmin() {
+            st.adjunct(includes: "lib.form.confirm")
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JEP-224](https://jenkins.io/jep/224) https://github.com/jenkinsci/jenkins/pull/4506 
[JENKINS-61205](https://issues.jenkins-ci.org/browse/JENKINS-61205).

Adds system read permission support to global security configuration

For implementations in plugins, see downstream PRs:

* https://github.com/jenkinsci/matrix-auth-plugin/pull/78
* https://github.com/jenkinsci/role-strategy-plugin/pull/124

### Manual testing notes

When using the core-pr-tester (`docker run --rm -ti -p 8080:8080 -e ID=4524 jenkins/core-pr-tester`), you can use script console to enable the new permission: 

`Jenkins.SYSTEM_READ.enabled = true`


### Screenshots

<details>

<summary>Global security configuration</summary>


![image](https://user-images.githubusercontent.com/21194782/75227192-a48ac680-57a5-11ea-9653-bdfbc6e0ccc4.png)


</details>

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: JENKINS-61201, Allows users with system read permission to view the global security configuration page
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

