### PR TITLE
[JENKINS-61197] Skip $WORKSPACE_TMP for root directories

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1321,7 +1321,8 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     }
 
     /**
-     * Short for {@code getParent().child(rel)}. Useful for getting other files in the same directory. 
+     * Short for {@code getParent().child(rel)}. Useful for getting other files in the same directory.
+     * @return null if {@link #getParent} would have
      */
     @CheckForNull
     public FilePath sibling(String rel) {

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1323,8 +1323,10 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     /**
      * Short for {@code getParent().child(rel)}. Useful for getting other files in the same directory. 
      */
+    @CheckForNull
     public FilePath sibling(String rel) {
-        return getParent().child(rel);
+        FilePath parent = getParent();
+        return parent != null ? parent.child(rel) : null;
     }
 
     /**
@@ -1347,6 +1349,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * Gets the parent file.
      * @return parent FilePath or null if there is no parent
      */
+    @CheckForNull
     public FilePath getParent() {
         int i = remote.length() - 2;
         for (; i >= 0; i--) {

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -865,7 +865,10 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         FilePath ws = getWorkspace();
         if (ws != null) { // if this is done very early on in the build, workspace may not be decided yet. see HUDSON-3997
             env.put("WORKSPACE", ws.getRemote());
-            env.put("WORKSPACE_TMP", WorkspaceList.tempDir(ws).getRemote()); // JENKINS-60634
+            FilePath tempDir = WorkspaceList.tempDir(ws);
+            if (tempDir != null) {
+                env.put("WORKSPACE_TMP", tempDir.getRemote()); // JENKINS-60634
+            }
         }
 
         project.getScm().buildEnvVars(this,env);

--- a/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
+++ b/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
@@ -90,7 +90,10 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
                     listener.getLogger().println("Deleting " + ws + " on " + node.getDisplayName());
                     try {
                         ws.deleteRecursive();
-                        WorkspaceList.tempDir(ws).deleteRecursive();
+                        FilePath tempDir = WorkspaceList.tempDir(ws);
+                        if (tempDir != null) {
+                            tempDir.deleteRecursive();
+                        }
                     } catch (IOException | InterruptedException x) {
                         Functions.printStackTrace(x, listener.error("Failed to delete " + ws + " on " + node.getDisplayName()));
                     }

--- a/core/src/main/java/hudson/slaves/WorkspaceList.java
+++ b/core/src/main/java/hudson/slaves/WorkspaceList.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
@@ -302,6 +303,7 @@ public final class WorkspaceList {
      * @return a sibling directory, for example {@code …/something@tmp} for {@code …/something}
      * @since 1.652
      */
+    @CheckForNull
     public static FilePath tempDir(FilePath ws) {
         return ws.sibling(ws.getName() + COMBINATOR + "tmp");
     }

--- a/core/src/main/java/hudson/slaves/WorkspaceList.java
+++ b/core/src/main/java/hudson/slaves/WorkspaceList.java
@@ -300,7 +300,7 @@ public final class WorkspaceList {
      * <p>The resulting directory may not exist; you may call {@link FilePath#mkdirs} on it if you need it to.
      * It may be deleted alongside the workspace itself during cleanup actions.
      * @param ws a directory such as a build workspace
-     * @return a sibling directory, for example {@code …/something@tmp} for {@code …/something}
+     * @return a sibling directory, for example {@code …/something@tmp} for {@code …/something}, or {@code null} if {@link FilePath#getParent} is null
      * @since 1.652
      */
     @CheckForNull

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
@@ -14,7 +14,8 @@ NODE_LABELS.blurb=Whitespace-separated list of labels that the node is assigned.
 WORKSPACE.blurb=The absolute path of the directory assigned to the build as a workspace.
 WORKSPACE_TMP.blurb=\
   A temporary directory near the workspace that will not be browsable and will not interfere with SCM checkouts. \
-  May not initially exist, so be sure to create the directory as needed (e.g., <code>mkdir -p</code> on Linux).
+  May not initially exist, so be sure to create the directory as needed (e.g., <code>mkdir -p</code> on Linux). \
+  Not defined when the regular workspace is a drive root.
 JENKINS_HOME.blurb=The absolute path of the directory assigned on the master node for Jenkins to store data.
 JENKINS_URL.blurb=Full URL of Jenkins, like <tt>http://server:port/jenkins/</tt> (note: only available if <i>Jenkins URL</i> set in system configuration)
 BUILD_URL.blurb=Full URL of this build, like <tt>http://server:port/jenkins/job/foo/15/</tt> (<i>Jenkins URL</i> must be set)


### PR DESCRIPTION
Amends #4414. Unlike #4526 but like https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/129, this is a conservative fix.

See [JENKINS-61197](https://issues.jenkins-ci.org/browse/JENKINS-61197).

### Proposed changelog entries

* Avoid a `NullPointerException` when starting a non-Pipeline build with a custom root directory set to a filesystem root (e.g., `C:\`).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

