### PR TITLE
JENKINS-61208 System read - admin monitor pattern

### DIFF
--- a/core/src/main/java/hudson/model/AdministrativeMonitor.java
+++ b/core/src/main/java/hudson/model/AdministrativeMonitor.java
@@ -27,6 +27,7 @@ import hudson.ExtensionPoint;
 import hudson.ExtensionList;
 import hudson.Extension;
 import hudson.ExtensionPoint.LegacyInstancesAreScopedToHudson;
+import hudson.security.Permission;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
 
@@ -149,8 +150,17 @@ public abstract class AdministrativeMonitor extends AbstractModelObject implemen
      */
     @RequirePOST
     public void doDisable(StaplerRequest req, StaplerResponse rsp) throws IOException {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         disable(true);
         rsp.sendRedirect2(req.getContextPath()+"/manage");
+    }
+
+    /**
+     * Required permission to view this admin monitor
+     *
+     */
+    public Permission getRequiredPermission() {
+        return Jenkins.ADMINISTER;
     }
 
     /**
@@ -158,7 +168,7 @@ public abstract class AdministrativeMonitor extends AbstractModelObject implemen
      */
     @Restricted(NoExternalUse.class)
     public Object getTarget() {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(getRequiredPermission());
         return this;
     }
 

--- a/core/src/main/java/jenkins/diagnostics/RootUrlNotSetMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/RootUrlNotSetMonitor.java
@@ -25,6 +25,8 @@ package jenkins.diagnostics;
 
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.util.UrlHelper;
 import org.jenkinsci.Symbol;
@@ -60,5 +62,10 @@ public class RootUrlNotSetMonitor extends AdministrativeMonitor {
     public boolean isUrlNull(){
         JenkinsLocationConfiguration loc = JenkinsLocationConfiguration.get();
         return loc.getUrl() == null;
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.SYSTEM_READ;
     }
 }

--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
@@ -95,7 +95,7 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
      * @throws ServletException
      */
     public boolean shouldDisplay() throws IOException, ServletException {
-        if (!Functions.hasPermission(Jenkins.ADMINISTER)) {
+        if (!Functions.hasPermission(Jenkins.SYSTEM_READ)) {
             return false;
         }
 

--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
@@ -24,7 +24,6 @@
 package jenkins.management;
 
 import hudson.Extension;
-import hudson.Functions;
 import hudson.diagnosis.ReverseProxySetupMonitor;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.PageDecorator;
@@ -38,8 +37,6 @@ import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.servlet.ServletException;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -91,11 +88,9 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
     /**
      * Whether the administrative monitors notifier should be shown.
      * @return true iff the administrative monitors notifier should be shown.
-     * @throws IOException
-     * @throws ServletException
      */
-    public boolean shouldDisplay() throws IOException, ServletException {
-        if (!Functions.hasPermission(Jenkins.SYSTEM_READ)) {
+    public boolean shouldDisplay() {
+        if (!Jenkins.get().hasPermission(Jenkins.SYSTEM_READ)) {
             return false;
         }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2202,12 +2202,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 2.64
      */
     public List<AdministrativeMonitor> getActiveAdministrativeMonitors() {
-        if (!Jenkins.get().hasPermission(ADMINISTER)) {
+        if (!Jenkins.get().hasPermission(SYSTEM_READ)) {
             return Collections.emptyList();
         }
         return administrativeMonitors.stream().filter(m -> {
             try {
-                return m.isEnabled() && m.isActivated();
+                return m.isEnabled() && m.isActivated() && Jenkins.get().hasPermission(m.getRequiredPermission());
             } catch (Throwable x) {
                 LOGGER.log(Level.WARNING, null, x);
                 return false;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2198,7 +2198,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     /**
-     * Returns the enabled and activated administrative monitors.
+     * Returns the enabled and activated administrative monitors accessible to the current user.
+     *
      * @since 2.64
      */
     public List<AdministrativeMonitor> getActiveAdministrativeMonitors() {
@@ -2207,7 +2208,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
         return administrativeMonitors.stream().filter(m -> {
             try {
-                return m.isEnabled() && m.isActivated() && Jenkins.get().hasPermission(m.getRequiredPermission());
+                return Jenkins.get().hasPermission(m.getRequiredPermission()) && m.isEnabled() && m.isActivated();
             } catch (Throwable x) {
                 LOGGER.log(Level.WARNING, null, x);
                 return false;

--- a/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
@@ -22,11 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
   <div class="alert alert-warning">
-    <form method="post" action="${rootURL}/${it.url}/disable">
-      <f:submit value="${%Dismiss}"/>
-    </form>
+    <l:isAdmin>
+      <form method="post" action="${rootURL}/${it.url}/disable">
+        <f:submit value="${%Dismiss}"/>
+      </form>
+    </l:isAdmin>
     <j:set var="actionAnchor">
       <a href="${rootURL}/configure">${%actionUrlContent}</a>
     </j:set>
@@ -40,6 +42,8 @@ THE SOFTWARE.
       </j:otherwise>
     </j:choose>
     <p />
-    <j:out value="${%actionToTake(actionAnchor)}"/>
+    <l:isAdmin>
+      <j:out value="${%actionToTake(actionAnchor)}"/>
+    </l:isAdmin>
   </div>
 </j:jelly>


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-61208](https://issues.jenkins-ci.org/browse/JENKINS-61208).

Adds initial system read support for admin monitors, I'll do a follow-up(s) for the rest, wanted to validate approach for the first one.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Screenshots

<details>
<summary>Root url monitor</summary>


![image](https://user-images.githubusercontent.com/21194782/75611332-8e686780-5b11-11ea-9383-062f63af6332.png)


</details>

### Manual testing notes

When using the core-pr-tester (`docker run --rm -ti -p 8080:8080 -e ID=4533 jenkins/core-pr-tester`), you can use script console to enable the new permission: 

`Jenkins.SYSTEM_READ.enabled = true`

Or install the `extended-read-permission` plugin

### Proposed changelog entries

* Entry 1: JENKINS-61208, Adds system read support to admin monitors
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

