### PR TITLE
Improve presentation of plugin categories

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -989,7 +989,9 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     /**
      * Returns a list of plugins that should be shown in the "available" tab, grouped by category.
      * A plugin with multiple categories will appear multiple times in the list.
+     * @deprecated
      */
+    @Deprecated
     public PluginEntry[] getCategorizedAvailables() {
         TreeSet<PluginEntry> entries = new TreeSet<>();
         for (Plugin p : getAvailables()) {
@@ -1002,7 +1004,8 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         return entries.toArray(new PluginEntry[0]);
     }
 
-    private static String getCategoryDisplayName(String category) {
+    @Restricted(NoExternalUse.class) // Jelly only
+    public static String getCategoryDisplayName(String category) {
         if (category==null)
             return Messages.UpdateCenter_PluginCategory_misc();
         try {
@@ -1011,7 +1014,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         } catch (RuntimeException ex) {
             throw ex;
         } catch (Exception ex) {
-            return Messages.UpdateCenter_PluginCategory_unrecognized(category);
+            return category;
         }
     }
 
@@ -2454,6 +2457,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         }
     }
 
+    @Deprecated
     public static final class PluginEntry implements Comparable<PluginEntry> {
         public Plugin plugin;
         public String category;

--- a/core/src/main/resources/hudson/PluginManager/_table.css
+++ b/core/src/main/resources/hudson/PluginManager/_table.css
@@ -8,10 +8,15 @@
     margin: 1em;
     text-align: right;
 }
-.category-label {
+.plugin-manager__categories {
+    margin-top: 0.5em;
+}
+
+.plugin-manager__category-label {
+    display: inline-block;
     border: 1px solid #ccc;
     background-color: #eee;
     border-radius: 4px;
-    padding: 3px;
-    margin: 5px;
+    padding: 0.25rem;
+    margin: 0 0.25rem 0.25rem 0;
 }

--- a/core/src/main/resources/hudson/PluginManager/_table.css
+++ b/core/src/main/resources/hudson/PluginManager/_table.css
@@ -8,3 +8,10 @@
     margin: 1em;
     text-align: right;
 }
+.category-label {
+    border: 1px solid #ccc;
+    background-color: #eee;
+    border-radius: 4px;
+    padding: 3px;
+    margin: 5px;
+}

--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -7,27 +7,6 @@ function checkPluginsWithoutWarnings() {
         }
     }
 }
-function showhideCategories(hdr,on) {
-  var table = hdr.parentNode.parentNode.parentNode,
-      newDisplay = on ? '' : 'none',
-      nameList = new Array(), id;
-  for (var i = 1; i < table.rows.length; i++) {
-    if (on || table.rows[i].cells.length == 1)
-      table.rows[i].style.display = newDisplay;
-     else {
-      // Hide duplicate rows for a plugin:version when not viewing by-category
-      id = table.rows[i].cells[1].getAttribute('data-id');
-      if (nameList[id] == 1) table.rows[i].style.display = 'none';
-      nameList[id] = 1;
-    }
-  }
-}
-function showhideCategory(col) {
-  var row = col.parentNode.nextSibling;
-  var newDisplay = row && row.style.display == 'none' ? '' : 'none';
-  for (; row && row.cells.length > 1; row = row.nextSibling)
-    row.style.display = newDisplay;
-}
 
 Behaviour.specify("#filter-box", '_table', 0, function(e) {
       function applyFilter() {

--- a/core/src/main/resources/hudson/PluginManager/available.jelly
+++ b/core/src/main/resources/hudson/PluginManager/available.jelly
@@ -27,5 +27,5 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <local:table page="available" list="${app.updateCenter.categorizedAvailables}" xmlns:local="/hudson/PluginManager" />
+  <local:table page="available" list="${app.updateCenter.availables}" xmlns:local="/hudson/PluginManager" />
 </j:jelly>

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -72,9 +72,15 @@ THE SOFTWARE.
                       <div>
                         <a href="${p.wiki}" target="_blank"><st:out value="${p.displayName}"/></a>
                       </div>
-                      <j:forEach var="label" items="${p.categories}">
-                        <span class="category-label">${app.updateCenter.getCategoryDisplayName(label)}</span>
-                      </j:forEach>
+                      <j:if test="${!p.categories.isEmpty()}">
+                        <div class="plugin-manager__categories">
+                          <j:forEach var="label" items="${p.categories}">
+                            <span class="plugin-manager__category-label">
+                              ${app.updateCenter.getCategoryDisplayName(label)}
+                            </span>
+                          </j:forEach>
+                        </div>
+                      </j:if>
                       <j:if test="${p.excerpt!=null}">
                         <div class="excerpt"><j:out value="${p.excerpt}" /></div>
                       </j:if>

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -32,20 +32,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="${%Update Center}" permission="${app.ADMINISTER}">
-    <l:header>
-      <script type="text/javascript">
-      <![CDATA[
-        function flip(item) {
-          var nodes = document.getElementsByName(item.name);
-          for (var i = 0; i < nodes.length; ++i) {
-            if(nodes[i].nodeName == "INPUT") {
-              nodes[i].checked = item.checked;
-            }
-          }
-        }
-        ]]>
-      </script>
-    </l:header>
     <st:include page="sidepanel.jelly"/>
     <l:main-panel>
       <st:adjunct includes="hudson.PluginManager._table"/>
@@ -62,42 +48,33 @@ THE SOFTWARE.
           <table id="plugins" class="sortable pane bigtable stripped-odd">
             <tr>
               <th initialSortDir="${isUpdates?null:'down'}"
-                  tooltip="${%Check to install the plugin}${isUpdates?'':'&lt;br/&gt;'+'%Click this heading to sort by category'}"
-                  width="32" onclick="showhideCategories(this,1)">${%Install}</th>
-              <th initialSortDir="${isUpdates?'down':null}"
-                  onclick="showhideCategories(this,0)">${%Name}</th>
-              <th onclick="showhideCategories(this,0)">${%Version}</th>
+                  tooltip="${%Check to install the plugin}"
+                  width="32">${%Install}</th>
+              <th initialSortDir="${isUpdates?'down':null}">${%Name}</th>
+              <th>${%Version}</th>
               <j:if test="${isUpdates}"><th>${%Installed}</th></j:if>
             </tr>
             <j:choose>
               <j:when test="${!empty(list)}">
-                <j:set var="lastCat" value="" />
                 <j:set var="cache" value="${it.createCache()}"/>
                 <j:forEach var="p" items="${list}">
-                  <j:if test="${!isUpdates}">
-                    <j:set var="thisCat" value="${p.category}" />
-                    <j:set var="p" value="${p.plugin}" />
-                    <j:if test="${thisCat != lastCat}">
-                      <tr class="plugin-category" name="${thisCat}">
-                        <td class="pane" colspan="4" onclick="showhideCategory(this)">${thisCat}</td>
-                      </tr>
-                    </j:if>
-                    <j:set var="lastCat" value="${thisCat}" />
-                  </j:if>
                   <j:set var="installJob" value="${isUpdates ? app.updateCenter.getJob(p) : null}" />
                   <j:set var="installedOk"
                          value="${installJob.status.success and installJob.plugin.version==p.version}" />
                   <tr class="${installJob!=null ? 'already-upgraded' : ''} plugin" name="${p.displayName}">
-                    <td class="pane" align="center" data="${thisCat}_">
+                    <td class="pane" align="center">
                       <input type="checkbox" name="plugin.${p.name}.${p.sourceId}"
                              checked="${installedOk ? 'checked' : null}"
-                             disabled="${installedOk ? 'disabled' : null}" onClick="flip(this);"
+                             disabled="${installedOk ? 'disabled' : null}"
                              data-compat-warning="${!p.isCompatible(cache)}" />
                     </td>
                     <td class="pane" data="${h.xmlEscape(p.displayName)}" data-id="${h.xmlEscape(p.name+':'+p.version)}">
                       <div>
                         <a href="${p.wiki}" target="_blank"><st:out value="${p.displayName}"/></a>
                       </div>
+                      <j:forEach var="label" items="${p.categories}">
+                        <span class="category-label">${app.updateCenter.getCategoryDisplayName(label)}</span>
+                      </j:forEach>
                       <j:if test="${p.excerpt!=null}">
                         <div class="excerpt"><j:out value="${p.excerpt}" /></div>
                       </j:if>


### PR DESCRIPTION
- Show labels/categories in each plugin entry (supporting filtering)
- Don't have multiple table sections for categories

---

The grouping into different table sections may have made sense when there were only 100 plugins total, but using the "Available" tab is basically limited to searching/filtering only now. So nobody really saw the categories anymore. While it is due for a larger overhaul, let's start with fixing how categories are shown.

It probably makes sense to add localizations for recently defined whitelisted labels in update-center2 to make it a rare occurrence to see an unlocalized label, but I think it's fine as is.

I'm open to alternative presentation/styling of the categories in the table entries, just propose alternatives.

## Screenshots

### Available list, filtered by label

> ![Screenshot](https://user-images.githubusercontent.com/1831569/75621074-55bba300-5b90-11ea-9ad7-efabe5e2ef40.png)

### Updates list

> ![Screenshot](https://user-images.githubusercontent.com/1831569/75621078-6409bf00-5b90-11ea-8402-18d5c52a0021.png)


### Proposed changelog entries

* RFE: Show plugin categories as labels in the plugin manager instead of grouping them into different table sections

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

