### PR TITLE
Show plugin release date in plugin manager

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -27,6 +27,8 @@ package hudson;
 
 import hudson.model.Slave;
 import hudson.security.*;
+
+import java.text.SimpleDateFormat;
 import java.util.function.Predicate;
 import jenkins.util.SystemProperties;
 import hudson.cli.CLICommand;
@@ -219,8 +221,34 @@ public class Functions {
         return Util.XS_DATETIME_FORMATTER.format(cal.getTime());
     }
 
+    @Restricted(NoExternalUse.class)
+    public static String iso8601DateTime(Date date) {
+        return Util.XS_DATETIME_FORMATTER.format(date);
+    }
+
+    /**
+     * Returns a localized string for the specified date, not including time.
+     * @param date
+     * @return
+     */
+    @Restricted(NoExternalUse.class)
+    public static String localDate(Date date) {
+        return SimpleDateFormat.getDateInstance(SimpleDateFormat.SHORT).format(date);
+    }
+
     public static String rfc822Date(Calendar cal) {
         return Util.RFC822_DATETIME_FORMATTER.format(cal.getTime());
+    }
+
+    /**
+     * Returns a human-readable string describing the time difference between now and the specified date.
+     *
+     * @param date
+     * @return
+     */
+    @Restricted(NoExternalUse.class)
+    public static String getTimeSpanString(Date date) {
+        return Util.getTimeSpanString(Math.abs(date.getTime() - new Date().getTime()));
     }
 
     /**

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -1022,6 +1022,7 @@ public class UpdateSite {
 
         /**
          * Date when this plugin was released.
+         * @since TODO
          */
         @Exported
         public final Date releaseTimestamp;

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -43,8 +43,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -1018,6 +1020,12 @@ public class UpdateSite {
          */
         private Set<Plugin> incompatibleParentPlugins;
 
+        /**
+         * Date when this plugin was released.
+         */
+        @Exported
+        public final Date releaseTimestamp;
+
         @DataBoundConstructor
         public Plugin(String sourceId, JSONObject o) {
             super(sourceId, o, UpdateSite.this.url);
@@ -1027,6 +1035,16 @@ public class UpdateSite {
             this.compatibleSinceVersion = Util.intern(get(o,"compatibleSinceVersion"));
             this.minimumJavaVersion = Util.intern(get(o, "minimumJavaVersion"));
             this.requiredCore = Util.intern(get(o,"requiredCore"));
+            final String releaseTimestamp = get(o, "releaseTimestamp");
+            Date date = null;
+            if (releaseTimestamp != null) {
+                try {
+                    date = Date.from(Instant.parse(releaseTimestamp));
+                } catch (Exception ex) {
+                    LOGGER.log(Level.FINE, "Failed to parse releaseTimestamp for " + title + " from " + sourceId, ex);
+                }
+            }
+            this.releaseTimestamp = date;
             this.categories = o.has("labels") ? internInPlace((String[])o.getJSONArray("labels").toArray(EMPTY_STRING_ARRAY)) : null;
             JSONArray ja = o.getJSONArray("dependencies");
             int depCount = (int)(ja.stream().filter(IS_DEP_PREDICATE.and(IS_NOT_OPTIONAL)).count());

--- a/core/src/main/resources/hudson/PluginManager/_table.css
+++ b/core/src/main/resources/hudson/PluginManager/_table.css
@@ -4,6 +4,10 @@
     width: 15em;
 }
 
+time {
+    white-space: nowrap;
+}
+
 #filter-container {
     margin: 1em;
     text-align: right;

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -67,7 +67,7 @@ THE SOFTWARE.
               <th initialSortDir="${isUpdates?'down':null}"
                   onclick="showhideCategories(this,0)">${%Name}</th>
               <th onclick="showhideCategories(this,0)">${%Version}</th>
-              <th>${%Released}</th>
+              <th onclick="showhideCategories(this,0)">${%Released}</th>
               <j:if test="${isUpdates}"><th>${%Installed}</th></j:if>
             </tr>
             <j:choose>
@@ -147,7 +147,7 @@ THE SOFTWARE.
                       </j:if>
                     </td>
                     <td class="pane"><st:out value="${p.version}" /></td>
-                    <td class="pane">
+                    <td class="pane" data="${p.releaseTimestamp.time}">
                       <j:if test="${p.releaseTimestamp != null}">
                         <i:formatDate value="${p.releaseTimestamp}" type="date" dateStyle="short" />
                       </j:if>

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
      page: page name to be passed to local:tabBar
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%Update Center}" permission="${app.ADMINISTER}">
     <l:header>
       <script type="text/javascript">
@@ -67,6 +67,7 @@ THE SOFTWARE.
               <th initialSortDir="${isUpdates?'down':null}"
                   onclick="showhideCategories(this,0)">${%Name}</th>
               <th onclick="showhideCategories(this,0)">${%Version}</th>
+              <th>${%Released}</th>
               <j:if test="${isUpdates}"><th>${%Installed}</th></j:if>
             </tr>
             <j:choose>
@@ -146,6 +147,11 @@ THE SOFTWARE.
                       </j:if>
                     </td>
                     <td class="pane"><st:out value="${p.version}" /></td>
+                    <td class="pane">
+                      <j:if test="${p.releaseTimestamp != null}">
+                        <i:formatDate value="${p.releaseTimestamp}" type="date" dateStyle="short" />
+                      </j:if>
+                    </td>
                     <j:if test="${isUpdates}">
                       <td class="pane">
                         <j:choose><j:when test="${p.installed.active}">

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -149,7 +149,9 @@ THE SOFTWARE.
                     <td class="pane"><st:out value="${p.version}" /></td>
                     <td class="pane" data="${p.releaseTimestamp.time}">
                       <j:if test="${p.releaseTimestamp != null}">
-                        <i:formatDate value="${p.releaseTimestamp}" type="date" dateStyle="short" />
+                        <time datetime="${h.iso8601DateTime(p.releaseTimestamp)}" tooltip="${h.localDate(p.releaseTimestamp)}">
+                          ${%ago(h.getTimeSpanString(p.releaseTimestamp))}
+                        </time>
                       </j:if>
                     </td>
                     <j:if test="${isUpdates}">

--- a/core/src/main/resources/hudson/PluginManager/table.properties
+++ b/core/src/main/resources/hudson/PluginManager/table.properties
@@ -45,4 +45,4 @@ depJavaWarning=\
  and in turn loading this plugin will fail.
 securityWarning=\
   Warning: This plugin version may not be safe to use. Please review the following security notices:
-
+ago={0} ago


### PR DESCRIPTION
This was one of the feedbacks at the contributor summit at FOSDEM: It would be helpful to see at a glance when a plugin was released, to help understand how actively it is maintained.

Up to date screenshots in https://github.com/jenkinsci/jenkins/pull/4535#issuecomment-593385560

### Proposed changelog entries

* Show plugin release date in plugin manager

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

