### PR TITLE
JENKINS-61285 Fix blank page on configure clouds if no cloud plugin installed

### DIFF
--- a/core/src/main/resources/jenkins/model/GlobalCloudConfiguration/index.groovy
+++ b/core/src/main/resources/jenkins/model/GlobalCloudConfiguration/index.groovy
@@ -40,12 +40,8 @@ l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName) {
             }
             st.adjunct(includes: "lib.form.confirm")
         } else {
-            p {
-                _("There are no cloud implementations for dynamically allocated agents installed.")
-                a(href: rootURL + "/pluginManager/available") {
-                    _("Go to plugin manager.")
-                }
-            }
+            p(_("There are no cloud implementations for dynamically allocated agents installed. "))
+            a(href: rootURL + "/pluginManager/available", _("Go to plugin manager."))
         }
     }
 }


### PR DESCRIPTION

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-61285](https://issues.jenkins-ci.org/browse/JENKINS-61285).

This was broken when it was moved to it's own page and converted to groovy, the syntax that is used doesn't work and just ended up rendering nothing.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Screenshots

<details>

<summary>Before</summary>

![image](https://user-images.githubusercontent.com/21194782/75623734-0d5ab000-5ba5-11ea-95db-05d69bcd3da1.png)

</details>

<details>

<summary>After</summary>

![image](https://user-images.githubusercontent.com/21194782/75623751-2a8f7e80-5ba5-11ea-895e-bbbf54f02503.png)


</details>

### Proposed changelog entries

* Entry 1: JENKINS-61285, Fix blank page on configure clouds page if no cloud plugin installed
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

