### PR TITLE
[JENKINS-60788] Add null check to avoid NPE

### DIFF
--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -157,10 +157,12 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
 
             if (toolInstallerList != null) {
                 ToolInstallerEntry[] entryList = toolInstallerList.list;
-                ToolInstallerEntry sampleEntry = entryList[0];
-                if (sampleEntry != null) {
-                    if (sampleEntry.id != null && sampleEntry.name != null && sampleEntry.url != null) {
-                        return true;
+                if (entryList != null) {
+                    ToolInstallerEntry sampleEntry = entryList[0];
+                    if (sampleEntry != null) {
+                        if (sampleEntry.id != null && sampleEntry.name != null && sampleEntry.url != null) {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
See [JENKINS-60788](https://issues.jenkins-ci.org/browse/JENKINS-60788).

Added a null check on the entryList so that if the schema
is not as expected, there is no NullPointerException caused.

No tests are needed for this simple change.

### Proposed changelog entries

* Prevent NullPointerException when hitting _Check Now_ against a custom update center without tool installer metadata

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
- [x] Appropriate autotests or explanation to why this change has no tests

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

