### PR TITLE
Add inline security warnings to installed plugins list

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -36,6 +36,7 @@ import hudson.util.VersionNumber;
 import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
+import jenkins.security.UpdateSiteWarningsMonitor;
 import jenkins.util.java.JavaUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.LogFactory;
@@ -1263,6 +1264,10 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
         return HttpResponses.redirectViaContextPath("/pluginManager/installed");   // send back to plugin manager
     }
 
+    @Restricted(DoNotUse.class) // Jelly
+    public List<UpdateSite.Warning> getActiveWarnings() {
+        return ExtensionList.lookupSingleton(UpdateSiteWarningsMonitor.class).getActivePluginWarningsByPlugin().getOrDefault(this, Collections.emptyList());
+    }
 
     private static final Logger LOGGER = Logger.getLogger(PluginWrapper.class.getName());
 

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -102,6 +102,15 @@ THE SOFTWARE.
                         </j:otherwise>
                       </j:choose>
                     </div>
+                    <j:if test="${!p.getActiveWarnings().isEmpty()}">
+                      <div class="alert alert-danger">${%securityWarning}
+                        <ul>
+                          <j:forEach var="warning" items="${p.getActiveWarnings()}">
+                            <li><a href="${warning.url}" target="_blank">${warning.message}</a></li>
+                          </j:forEach>
+                        </ul>
+                      </div>
+                    </j:if>
                   </td>
                   <td class="center pane" style="white-space:normal">
                     <a href="plugin/${p.shortName}/thirdPartyLicenses">

--- a/core/src/main/resources/hudson/PluginManager/installed.properties
+++ b/core/src/main/resources/hudson/PluginManager/installed.properties
@@ -24,3 +24,5 @@ requires.restart=This Jenkins instance requires a restart. Changing the state of
 detached-disable=This plugin may not be safe to disable
 detached-uninstall=This plugin may not be safe to uninstall
 detached-possible-dependents=Its functionality was at one point moved out of Jenkins core, and another plugin with a core dependency predating the split may be relying on it implicitly.
+securityWarning=\
+  Warning: The currently installed plugin version may not be safe to use. Please review the following security notices:


### PR DESCRIPTION
Nothing special, pretty much what the title says.

UI is mostly taken from the "Available" and "Updates" tabs, with a slight rewording because in this case, it's about installed plugins.

### Screenshot

> ![Screenshot](https://user-images.githubusercontent.com/1831569/76150210-27febe80-60a8-11ea-829d-d1138752d5bc.png)

### Proposed changelog entries

* Show in plugin manager table when there are security issues in a currently installed plugin.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

