### PR TITLE
Update .NET version checks to be more correct when Windows services when installing master and agent on platforms with modern .NET versions

### DIFF
--- a/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
@@ -119,7 +119,7 @@ public class WindowsInstallerLink extends ManagementLink {
             sendError("Installation is already complete",req,rsp);
             return;
         }
-        if(!DotNet.isInstalled(2,0)) {
+        if(!DotNet.isInstalled(4,0) && !DotNet.isInstalled(2,0)) {
             sendError(".NET Framework 2.0 or later is required for this feature",req,rsp);
             return;
         }

--- a/core/src/main/java/hudson/util/jna/DotNet.java
+++ b/core/src/main/java/hudson/util/jna/DotNet.java
@@ -30,8 +30,6 @@ import org.jinterop.winreg.JIPolicyHandle;
 import org.jinterop.winreg.JIWinRegFactory;
 
 import java.net.UnknownHostException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * .NET related code.
@@ -39,74 +37,233 @@ import java.util.regex.Pattern;
  * @author Kohsuke Kawaguchi
  */
 public class DotNet {
+    private static final String PATH10 = "SOFTWARE\\Microsoft\\.NETFramework\\Policy\\v1.0\\3705";
+    private static final String PATH11 = "SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v1.1.4322";
+    private static final String PATH20 = "SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v2.0.50727";
+    private static final String PATH30 = "SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v3.0\\Setup";
+    private static final String PATH35 = "SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v3.5";
+    private static final String PATH4  = "SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full";
+
+    private static final String VALUE_INSTALL = "Install";
+    private static final String VALUE_INSTALL_SUCCESS = "InstallSuccess";
+    private static final String VALUE_RELEASE = "Release";
+
     /**
-     * Returns true if the .NET framework of the given version (or greater) is installed.
+     * Returns true if the .NET framework of a compatible version is installed.
      */
     public static boolean isInstalled(int major, int minor) {
         try {
-            // see http://support.microsoft.com/?scid=kb;en-us;315291 for the basic algorithm
-            // observation in my registry shows that the actual key name can be things like "v2.0 SP1"
-            // or "v2.0.50727", so the regexp is written to accommodate this.
-            RegistryKey key = RegistryKey.LOCAL_MACHINE.openReadonly("SOFTWARE\\Microsoft\\.NETFramework");
-            try {
-                for( String keyName : key.getSubKeys() ) {
-                    if (matches(keyName, major, minor))
-                        return true;
-                }
+            if (major == 4 && minor >= 5) {
+                return isV45PlusInstalled(minor);
+            } else if (major == 4 && minor == 0) {
+                return isV40Installed();
+            } else if (major == 3 && minor == 5) {
+                return isV35Installed();
+            } else if (major == 3 && minor == 0) {
+                return isV35Installed() || isV30Installed();
+            } else if (major == 2 && minor == 0) {
+                return isV35Installed() || isV30Installed() || isV20Installed();
+            } else if (major == 1 && minor == 1) {
+                return isV11Installed();
+            } else if (major == 1 && minor == 0) {
+                return isV11Installed() || isV10Installed();
+            } else {
                 return false;
-            } finally {
-                key.dispose();
             }
         } catch (JnaException e) {
-            if(e.getErrorCode()==2) // thrown when openReadonly fails because the key doesn't exist.
+            if (e.getErrorCode() == 2) {
+                // thrown when openReadonly fails because the key doesn't exist.
                 return false;
+            }
             throw e;
         }
     }
 
+    private static boolean isV45PlusInstalled(int minor) {
+        try (RegistryKey key = RegistryKey.LOCAL_MACHINE.openReadonly(PATH4)) {
+            return key.getIntValue(VALUE_RELEASE) >= GetV45PlusMinRelease(minor);
+        }
+    }
+
+    private static boolean isV40Installed() {
+        try (RegistryKey key = RegistryKey.LOCAL_MACHINE.openReadonly(PATH4)) {
+            return key.getIntValue(VALUE_INSTALL) == 1;
+        }
+    }
+
+    private static boolean isV35Installed() {
+        try (RegistryKey key = RegistryKey.LOCAL_MACHINE.openReadonly(PATH35)) {
+            return key.getIntValue(VALUE_INSTALL) == 1;
+        }
+    }
+
+    private static boolean isV30Installed() {
+        try (RegistryKey key = RegistryKey.LOCAL_MACHINE.openReadonly(PATH30)) {
+            return key.getIntValue(VALUE_INSTALL_SUCCESS) == 1;
+        }
+    }
+
+    private static boolean isV20Installed() {
+        try (RegistryKey key = RegistryKey.LOCAL_MACHINE.openReadonly(PATH20)) {
+            return key.getIntValue(VALUE_INSTALL) == 1;
+        }
+    }
+
+    private static boolean isV11Installed() {
+        try (RegistryKey key = RegistryKey.LOCAL_MACHINE.openReadonly(PATH11)) {
+            return key.getIntValue(VALUE_INSTALL) == 1;
+        }
+    }
+
+    private static boolean isV10Installed() {
+        try (RegistryKey key = RegistryKey.LOCAL_MACHINE.openReadonly(PATH10)) {
+            return key.getStringValue(VALUE_INSTALL) == "1";
+        }
+    }
+
     /**
-     * Returns true if the .NET framework of the given version (or grater) is installed
-     * on a remote machine. 
+     * Returns true if the .NET framework of a compatible version is installed on a remote machine. 
      */
     public static boolean isInstalled(int major, int minor, String targetMachine, IJIAuthInfo session) throws JIException, UnknownHostException {
-        IJIWinReg registry = JIWinRegFactory.getSingleTon().getWinreg(session,targetMachine,true);
-        JIPolicyHandle hklm=null;
-        JIPolicyHandle key=null;
-
+        IJIWinReg registry = JIWinRegFactory.getSingleTon().getWinreg(session, targetMachine, true);
+        JIPolicyHandle hklm = null;
         try {
             hklm = registry.winreg_OpenHKLM();
-            key = registry.winreg_OpenKey(hklm,"SOFTWARE\\Microsoft\\.NETFramework", IJIWinReg.KEY_READ );
-
-            for( int i=0; ; i++ ) {
-                String keyName = registry.winreg_EnumKey(key,i)[0];
-                if(matches(keyName,major,minor))
-                    return true;
+            if (major == 4 && minor >= 5) {
+                return isV45PlusInstalled(minor, registry, hklm);
+            } else if (major == 4 && minor == 0) {
+                return isV40Installed(registry, hklm);
+            } else if (major == 3 && minor == 5) {
+                return isV35Installed(registry, hklm);
+            } else if (major == 3 && minor == 0) {
+                return isV35Installed(registry, hklm) || isV30Installed(registry, hklm);
+            } else if (major == 2 && minor == 0) {
+                return isV35Installed(registry, hklm) || isV30Installed(registry, hklm) || isV20Installed(registry, hklm);
+            } else if (major == 1 && minor == 1) {
+                return isV11Installed(registry, hklm);
+            } else if (major == 1 && minor == 0) {
+                return isV11Installed(registry, hklm) || isV10Installed(registry, hklm);
+            } else {
+                return false;
             }
         } catch (JIException e) {
-            if(e.getErrorCode()==2)
-                return false;       // not found
+            if (e.getErrorCode() == 2) {
+                // not found
+                return false;
+            }
             throw e;
         } finally {
-            if(hklm!=null)
+            if (hklm != null) {
                 registry.winreg_CloseKey(hklm);
-            if(key!=null)
-                registry.winreg_CloseKey(key);
+            }
             registry.closeConnection();
         }
     }
 
-    private static boolean matches(String keyName, int major, int minor) {
-        Matcher m = VERSION_PATTERN.matcher(keyName);
-        if(m.matches()) {
-            int mj = Integer.parseInt(m.group(1));
-            if(mj>=major) {
-                int mn = Integer.parseInt(m.group(2));
-                if(mn>=minor)
-                    return true;
+    private static boolean isV45PlusInstalled(int minor, IJIWinReg registry, JIPolicyHandle hklm) throws JIException {
+        JIPolicyHandle key = null;
+        try {
+            key = registry.winreg_OpenKey(hklm, PATH4, IJIWinReg.KEY_READ);
+            return GetIntValue(registry, key, VALUE_RELEASE) >= GetV45PlusMinRelease(minor);
+        } finally {
+            if (key != null) {
+                registry.winreg_CloseKey(key);
             }
         }
-        return false;
     }
 
-    private static final Pattern VERSION_PATTERN = Pattern.compile("v(\\d+)\\.(\\d+).*");
+    private static boolean isV40Installed(IJIWinReg registry, JIPolicyHandle hklm) throws JIException {
+        JIPolicyHandle key = null;
+        try {
+            key = registry.winreg_OpenKey(hklm, PATH4, IJIWinReg.KEY_READ);
+            return GetIntValue(registry, key, VALUE_INSTALL) == 1;
+        } finally {
+            if (key != null) {
+                registry.winreg_CloseKey(key);
+            }
+        }
+    }
+
+    private static boolean isV35Installed(IJIWinReg registry, JIPolicyHandle hklm) throws JIException {
+        JIPolicyHandle key = null;
+        try {
+            key = registry.winreg_OpenKey(hklm, PATH35, IJIWinReg.KEY_READ);
+            return GetIntValue(registry, key, VALUE_INSTALL) == 1;
+        } finally {
+            if (key != null) {
+                registry.winreg_CloseKey(key);
+            }
+        }
+    }
+
+    private static boolean isV30Installed(IJIWinReg registry, JIPolicyHandle hklm) throws JIException {
+        JIPolicyHandle key = null;
+        try {
+            key = registry.winreg_OpenKey(hklm, PATH30, IJIWinReg.KEY_READ);
+            return GetIntValue(registry, key, VALUE_INSTALL_SUCCESS) == 1;
+        } finally {
+            if (key != null) {
+                registry.winreg_CloseKey(key);
+            }
+        }
+    }
+
+    private static boolean isV20Installed(IJIWinReg registry, JIPolicyHandle hklm) throws JIException {
+        JIPolicyHandle key = null;
+        try {
+            key = registry.winreg_OpenKey(hklm, PATH20, IJIWinReg.KEY_READ);
+            return GetIntValue(registry, key, VALUE_INSTALL) == 1;
+        } finally {
+            if (key != null) {
+                registry.winreg_CloseKey(key);
+            }
+        }
+    }
+
+    private static boolean isV11Installed(IJIWinReg registry, JIPolicyHandle hklm) throws JIException {
+        JIPolicyHandle key = null;
+        try {
+            key = registry.winreg_OpenKey(hklm, PATH11, IJIWinReg.KEY_READ);
+            return GetIntValue(registry, key, VALUE_INSTALL) == 1;
+        } finally {
+            if (key != null) {
+                registry.winreg_CloseKey(key);
+            }
+        }
+    }
+
+    private static boolean isV10Installed(IJIWinReg registry, JIPolicyHandle hklm) throws JIException {
+        JIPolicyHandle key = null;
+        try {
+            key = registry.winreg_OpenKey(hklm, PATH10, IJIWinReg.KEY_READ);
+            return GetStringValue(registry, key, VALUE_INSTALL) == "1";
+        } finally {
+            if (key != null) {
+                registry.winreg_CloseKey(key);
+            }
+        }
+    }
+
+    private static int GetIntValue(IJIWinReg registry, JIPolicyHandle key, String name) throws JIException {
+        return RegistryKey.convertBufferToInt((byte[])registry.winreg_QueryValue(key, name, Integer.BYTES)[1]);
+    }
+
+    private static String GetStringValue(IJIWinReg registry, JIPolicyHandle key, String name) throws JIException {
+        return RegistryKey.convertBufferToString((byte[])registry.winreg_QueryValue(key, name, Character.BYTES * 2)[1]);
+    }
+
+    private static int GetV45PlusMinRelease(int minor) {
+        switch (minor) {
+            case 5:
+                return 378389;
+            case 6:
+                return 393295;
+            case 7:
+                return 460798;
+            case 8:
+                return 528040;
+            default:
+                return Integer.MAX_VALUE;
+        }
+    }
 }

--- a/core/src/main/java/hudson/util/jna/RegistryKey.java
+++ b/core/src/main/java/hudson/util/jna/RegistryKey.java
@@ -27,7 +27,7 @@ import java.util.TreeSet;
  *
  * @author Kohsuke Kawaguchi
  */
-public class RegistryKey {
+public class RegistryKey implements AutoCloseable {
     /**
      * 32bit Windows key value.
      */
@@ -64,7 +64,7 @@ public class RegistryKey {
      * @throws java.io.UnsupportedEncodingException on error
      * @return String
      */
-    private static String convertBufferToString(byte[] buf) {
+    static String convertBufferToString(byte[] buf) {
         return new String(buf, 0, buf.length - 2, StandardCharsets.UTF_16LE);
     }
 
@@ -74,7 +74,7 @@ public class RegistryKey {
      * @param buf buffer
      * @return int
      */
-    private static int convertBufferToInt(byte[] buf) {
+    static int convertBufferToInt(byte[] buf) {
         return ((buf[0] & 0xff) + ((buf[1] & 0xff) << 8) + ((buf[2] & 0xff) << 16) + ((buf[3] & 0xff) << 24));
     }
 
@@ -285,6 +285,10 @@ public class RegistryKey {
         if(handle!=0)
             Advapi32.INSTANCE.RegCloseKey(handle);
         handle = 0;
+    }
+
+    public void close() {
+        dispose();
     }
 
     //


### PR DESCRIPTION
 * We do not require JIRA issues for minor improvements.

No functional changes will be involved if this class is only used internally.

- .NET 1.0 and .NET 1.1 are compatible.
- .NET 2.0, .NET 3.0 and .NET 3.5 are compatible.
- .NET 4.0 and later versions are compatible.

For more information on version checks, see [How to: Determine which .NET Framework versions are installed](https://docs.microsoft.com/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed).

This change has no tests because CI runs on Linux.

### Proposed changelog entries

* Update supported .NET version checks to be more correct when Windows services when installing master and agent on platforms with modern .NET versions

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

/cc @oleg-nenashev 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

