### PR TITLE
Fix: Jelly 'enum' tag 'default' attribute not working

### DIFF
--- a/core/src/main/resources/lib/form/enum.jelly
+++ b/core/src/main/resources/lib/form/enum.jelly
@@ -36,9 +36,14 @@ THE SOFTWARE.
       The name of the enum to set as default value for the first configuration.
     </st:attribute>
   </st:documentation>
-  <select class="setting-input" name="${field}">
-    <j:forEach var="it" items="${descriptor.getPropertyType(instance,field).enumConstants}">
-      <f:option value="${it.name()}" selected="${instance != null ? it==instance[field] : it.name()==default}">
+
+  <j:if test="${attrs.field==null}">
+    <j:set target="${attrs}" property="field" value="${entry.field}" />
+  </j:if>
+
+  <select class="setting-input" name="${attrs.field}">
+    <j:forEach var="it" items="${descriptor.getPropertyType(instance,attrs.field).getEnumConstants()}">
+      <f:option value="${it.name()}" selected="${instance[attrs.field]!=null ? it==instance[attrs.field] : it.name()==attrs.default}">
         <d:invokeBody />
       </f:option>
     </j:forEach>

--- a/test/src/test/java/lib/form/EnumTest.java
+++ b/test/src/test/java/lib/form/EnumTest.java
@@ -1,0 +1,81 @@
+package lib.form;
+
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlSelect;
+import hudson.Extension;
+import hudson.model.BallColor;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.InvisibleAction;
+import hudson.model.RootAction;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.StaplerRequest;
+
+import static org.junit.Assert.assertEquals;
+
+public class EnumTest {
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
+
+    @Test
+    public void testSelectionNoDefault() throws Exception {
+        HtmlForm form = getForm("noDefault");
+        HtmlSelect select;
+
+        select = form.getSelectByName("enum1");
+        assertEquals(BallColor.values().length, select.getOptionSize());
+        assertEquals(BallColor.YELLOW.name(), select.getDefaultValue());
+
+        select = form.getSelectByName("enum2");
+        assertEquals(BallColor.values().length, select.getOptionSize());
+        assertEquals(BallColor.values()[0].name(), select.getDefaultValue());
+    }
+
+    @Test
+    public void testSelectionWithDefault() throws Exception {
+        HtmlForm form = getForm("withDefault");
+        HtmlSelect select;
+
+        select = form.getSelectByName("enum1");
+        assertEquals(BallColor.YELLOW.name(), select.getDefaultValue());
+
+        select = form.getSelectByName("enum2");
+        assertEquals(BallColor.BLUE.name(), select.getDefaultValue());
+    }
+
+    private HtmlForm getForm(String viewName) throws Exception {
+        rule.jenkins.setCrumbIssuer(null);
+        HtmlPage page = rule.createWebClient().goTo("test/" + viewName);
+        return page.getFormByName("config");
+    }
+
+    @TestExtension
+    public static class Form extends InvisibleAction implements RootAction, Describable<EnumTest.Form> {
+
+        public BallColor enum1 = BallColor.YELLOW;
+        public BallColor enum2 = null;
+
+        public void doSubmitForm(StaplerRequest req) throws Exception {
+            JSONObject json = req.getSubmittedForm();
+            System.out.println(json);
+        }
+
+        public Form.DescriptorImpl getDescriptor() {
+            return Jenkins.get().getDescriptorByType(Form.DescriptorImpl.class);
+        }
+
+        @Override
+        public String getUrlName() {
+            return "test";
+        }
+
+        @Extension
+        public static final class DescriptorImpl extends Descriptor<EnumTest.Form> {}
+    }
+}

--- a/test/src/test/resources/lib/form/EnumTest/Form/noDefault.jelly
+++ b/test/src/test/resources/lib/form/EnumTest/Form/noDefault.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+  <l:layout title="Testing enum without default attribute">
+    <l:main-panel>
+      <f:form method="post" name="config" action="submitForm">
+        <j:set var="instance" value="${it}"/>
+        <j:set var="descriptor" value="${it.descriptor}"/>
+        <f:entry field="enum1">
+          <f:enum/>
+        </f:entry>
+        <f:entry field="enum2">
+          <f:enum/>
+        </f:entry>
+        <f:entry>
+          <f:submit value="submit"/>
+        </f:entry>
+      </f:form>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/test/src/test/resources/lib/form/EnumTest/Form/withDefault.jelly
+++ b/test/src/test/resources/lib/form/EnumTest/Form/withDefault.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+  <l:layout title="Testing enum without default attribute">
+    <l:main-panel>
+      <f:form method="post" name="config" action="submitForm">
+        <j:set var="instance" value="${it}"/>
+        <j:set var="descriptor" value="${it.descriptor}"/>
+        <f:entry field="enum1">
+          <f:enum default="BLUE"/>
+        </f:entry>
+        <f:entry field="enum2">
+          <f:enum default="BLUE"/>
+        </f:entry>
+        <f:entry>
+          <f:submit value="submit"/>
+        </f:entry>
+      </f:form>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>


### PR DESCRIPTION
See [JENKINS-61385](https://issues.jenkins-ci.org/browse/JENKINS-61385).



### Proposed changelog entries

* Fix support of the `default` attribute in the Jelly 'enum' form control

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Created complete autotests for the enum field


### Desired reviewers

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

