### PR TITLE
[JENKINS-61398] Don't lose SCM configuration when saving job

### DIFF
--- a/core/src/main/java/hudson/DescriptorExtensionList.java
+++ b/core/src/main/java/hudson/DescriptorExtensionList.java
@@ -140,9 +140,8 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
     public T newInstanceFromRadioList(JSONObject config) throws FormException {
         if(config.isNullObject())
             return null;    // none was selected
-        String descriptorId = config.getString("value");
-        Descriptor<T> d = findByName(descriptorId);
-        return d != null ? d.newInstance(Stapler.getCurrentRequest(),config) : null;
+        int idx = config.getInt("value");
+        return get(idx).newInstance(Stapler.getCurrentRequest(),config);
     }
 
     public T newInstanceFromRadioList(JSONObject parent, String name) throws FormException {

--- a/core/src/main/java/hudson/util/DescriptorList.java
+++ b/core/src/main/java/hudson/util/DescriptorList.java
@@ -158,9 +158,8 @@ public final class DescriptorList<T extends Describable<T>> extends AbstractList
     public T newInstanceFromRadioList(JSONObject config) throws FormException {
         if(config.isNullObject())
             return null;    // none was selected
-        String descriptorId = config.getString("value");
-        Descriptor<T> d = findByName(descriptorId);
-        return d != null ? d.newInstance(Stapler.getCurrentRequest(),config) : null;
+        int idx = config.getInt("value");
+        return get(idx).newInstance(Stapler.getCurrentRequest(),config);
     }
 
     /**

--- a/core/src/main/resources/lib/form/descriptorRadioList.jelly
+++ b/core/src/main/resources/lib/form/descriptorRadioList.jelly
@@ -48,8 +48,8 @@ THE SOFTWARE.
   <j:set var="targetType" value="${attrs.targetType?:it.class}"/>
   <f:section title="${attrs.title}">
     <d:invokeBody />
-	  <j:forEach var="d" items="${descriptors}">
-      <f:radioBlock name="${varName}" help="${d.helpFile}" value="${d.id}"
+	  <j:forEach var="d" items="${descriptors}" varStatus="loop">
+      <f:radioBlock name="${varName}" help="${d.helpFile}" value="${loop.index}"
         title="${d.displayName}" checked="${instance.descriptor==d}">
         <j:set var="descriptor" value="${d}" />
 	      <j:set var="instance" value="${instance.descriptor==d?instance:null}" />

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -6,23 +6,20 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import jenkins.model.Jenkins;
+import hudson.model.Descriptor;
+import hudson.model.Describable;
+import hudson.util.DescriptorList;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
+
 import java.util.List;
-import java.util.Map;
+import java.util.Collection;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
-
-import hudson.model.Describable;
-import hudson.model.Descriptor;
-import hudson.util.DescriptorList;
-import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -175,27 +172,6 @@ public class ExtensionListTest {
         // create a new list and it forgets everything.
         LIST = new DescriptorList<Fish>();
         assertEquals(0,LIST.size());
-    }
-
-    @Test
-    public void newInstanceFromRadioList() throws Exception {
-        // test for DescriptorList
-        Map<String, String> CONFIGMAP = new HashMap<>();
-        CONFIGMAP.put("value", Tai.class.getName());
-        JSONObject CONFIG = JSONObject.fromObject(CONFIGMAP);
-
-        DescriptorList<Fish> LIST = new DescriptorList<Fish>(Fish.class);
-        Fish FISH = LIST.newInstanceFromRadioList(CONFIG);
-        assertTrue(FISH instanceof Tai);
-
-        // test for DescriptorExtensionList
-        Map<String, String> configMap = new HashMap<>();
-        configMap.put("value", Saba.class.getName());
-        JSONObject config = JSONObject.fromObject(configMap);
-
-        DescriptorExtensionList<Fish, Descriptor<Fish>> list = j.jenkins.<Fish, Descriptor<Fish>>getDescriptorList(Fish.class);
-        Fish fish = list.newInstanceFromRadioList(config);
-        assertTrue(fish instanceof Saba);
     }
 
     public static class Car implements ExtensionPoint {


### PR DESCRIPTION
## Don't lose SCM configuration when saving job

Fix [JENKINS-61398](https://issues.jenkins-ci.org/browse/JENKINS-61398) by reverting "[JENKINS-51495](https://issues.jenkins-ci.org/browse/JENKINS-51495) descriptorRadioList does not honor DescriptorVisibilityFilter (#3969)"

This reverts commit 6c2142ccb728798e0ad3f92226b7ea5ac20ce900.

Change has no tests for now so that we have the option of delivering the fix quickly as a new weekly release.

### Proposed changelog entries

* Don't lose SCM configuration when saving job

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change).
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@oleg-nenashev, @jenkinsci/code-reviewers

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
