### PR TITLE
[JENKINS-51495 ] - Restore "Update descriptorRadioList form elements to honor DescriptorVisibilityFilter extension points"

### DIFF
--- a/core/src/main/java/hudson/DescriptorExtensionList.java
+++ b/core/src/main/java/hudson/DescriptorExtensionList.java
@@ -140,8 +140,9 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
     public T newInstanceFromRadioList(JSONObject config) throws FormException {
         if(config.isNullObject())
             return null;    // none was selected
-        int idx = config.getInt("value");
-        return get(idx).newInstance(Stapler.getCurrentRequest(),config);
+        String descriptorId = config.getString("value");
+        Descriptor<T> d = findByName(descriptorId);
+        return d != null ? d.newInstance(Stapler.getCurrentRequest(),config) : null;
     }
 
     public T newInstanceFromRadioList(JSONObject parent, String name) throws FormException {

--- a/core/src/main/java/hudson/util/DescriptorList.java
+++ b/core/src/main/java/hudson/util/DescriptorList.java
@@ -158,8 +158,9 @@ public final class DescriptorList<T extends Describable<T>> extends AbstractList
     public T newInstanceFromRadioList(JSONObject config) throws FormException {
         if(config.isNullObject())
             return null;    // none was selected
-        int idx = config.getInt("value");
-        return get(idx).newInstance(Stapler.getCurrentRequest(),config);
+        String descriptorId = config.getString("value");
+        Descriptor<T> d = findByName(descriptorId);
+        return d != null ? d.newInstance(Stapler.getCurrentRequest(),config) : null;
     }
 
     /**

--- a/core/src/main/resources/lib/form/descriptorRadioList.jelly
+++ b/core/src/main/resources/lib/form/descriptorRadioList.jelly
@@ -48,8 +48,8 @@ THE SOFTWARE.
   <j:set var="targetType" value="${attrs.targetType?:it.class}"/>
   <f:section title="${attrs.title}">
     <d:invokeBody />
-	  <j:forEach var="d" items="${descriptors}" varStatus="loop">
-      <f:radioBlock name="${varName}" help="${d.helpFile}" value="${loop.index}"
+	  <j:forEach var="d" items="${descriptors}">
+      <f:radioBlock name="${varName}" help="${d.helpFile}" value="${d.id}"
         title="${d.displayName}" checked="${instance.descriptor==d}">
         <j:set var="descriptor" value="${d}" />
 	      <j:set var="instance" value="${instance.descriptor==d?instance:null}" />

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -6,20 +6,23 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import jenkins.model.Jenkins;
-import hudson.model.Descriptor;
-import hudson.model.Describable;
-import hudson.util.DescriptorList;
 import java.util.ArrayList;
-
-import java.util.List;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
+
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.util.DescriptorList;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -172,6 +175,27 @@ public class ExtensionListTest {
         // create a new list and it forgets everything.
         LIST = new DescriptorList<Fish>();
         assertEquals(0,LIST.size());
+    }
+
+    @Test
+    public void newInstanceFromRadioList() throws Exception {
+        // test for DescriptorList
+        Map<String, String> CONFIGMAP = new HashMap<>();
+        CONFIGMAP.put("value", Tai.class.getName());
+        JSONObject CONFIG = JSONObject.fromObject(CONFIGMAP);
+
+        DescriptorList<Fish> LIST = new DescriptorList<Fish>(Fish.class);
+        Fish FISH = LIST.newInstanceFromRadioList(CONFIG);
+        assertTrue(FISH instanceof Tai);
+
+        // test for DescriptorExtensionList
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("value", Saba.class.getName());
+        JSONObject config = JSONObject.fromObject(configMap);
+
+        DescriptorExtensionList<Fish, Descriptor<Fish>> list = j.jenkins.<Fish, Descriptor<Fish>>getDescriptorList(Fish.class);
+        Fish fish = list.newInstanceFromRadioList(config);
+        assertTrue(fish instanceof Saba);
     }
 
     public static class Car implements ExtensionPoint {


### PR DESCRIPTION
Reverts jenkinsci/jenkins#4559 and restores the original code from @matsushou in #3969. I restore it to indicate that I consider the filtering change as important, we just need to find a better way which would not cause hidden compatibility issues. E.g. we would need to pick up a fix from @timja in #4560 

**Suggested Next steps**: 

- Option 1: AFAICT the best way would be to make `f:radioBlock` and the modified methods to be compatible with both name-based and ID-based selection. And to add additional test coverage
- Option 2: Introduce new methods for filtered item creation and, if necessary, new controls. It is the most safe approach, but the adoption will be much slower


