### PR TITLE
Change UpdateSiteWarningsMonitor blurb punctuation

### DIFF
--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.properties
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.properties
@@ -23,7 +23,7 @@
 pluginTitle = {0} {1}
 coreTitle = Jenkins {0} core and libraries
 
-blurb = Warnings have been published for the following currently installed components.
+blurb = Warnings have been published for the following currently installed components:
 more = Additional warnings are hidden due to the current security configuration
 
 

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.properties
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.properties
@@ -24,7 +24,7 @@ pluginTitle = {0} {1}
 coreTitle = Jenkins {0} core and libraries
 
 blurb = Warnings have been published for the following currently installed components:
-more = Additional warnings are hidden due to the current security configuration
+more = Additional warnings are hidden due to the current security configuration.
 
 
 pluginManager.link = Go to plugin manager


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2119212/76450216-c9855900-63a3-11ea-912c-5ac1aecc0f2d.png)

After, the `.` to the left of the "Go to plugin manager" will be a `:`.

### Proposed changelog entries

* Entry 1: Change punctuation for plugin warning

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

