### PR TITLE
[JENKINS-61429] Fix drag & drop for existing steps in job & folders forms

### DIFF
--- a/war/src/main/js/widgets/config/tabbar.js
+++ b/war/src/main/js/widgets/config/tabbar.js
@@ -7,7 +7,7 @@ import jenkinsLocalStorage from '../../util/jenkinsLocalStorage';
 
 /**
  * Extracting this call from outside of the addPageTabs due to a regression
- * in 2.216/2.217
+ * in 2.216/2.217 (see JENKINS-61429)
  *
  * The proxied call to Behaviour.specify needs to be called from outside of the
  * addPageTabs function. Otherwise, it will not apply to existing draggable

--- a/war/src/main/js/widgets/config/tabbar.js
+++ b/war/src/main/js/widgets/config/tabbar.js
@@ -5,13 +5,25 @@ import tableMetadata from './model/ConfigTableMetaData';
 import behaviorShim from '../../util/behavior-shim';
 import jenkinsLocalStorage from '../../util/jenkinsLocalStorage';
 
+/**
+ * Extracting this call from outside of the addPageTabs due to a regression
+ * in 2.216/2.217
+ *
+ * The proxied call to Behaviour.specify needs to be called from outside of the
+ * addPageTabs function. Otherwise, it will not apply to existing draggable
+ * elements on the form. It would only only apply to new elements.
+ *
+ * Extracting this Behaviour.specify call to the module level causes it to be executed
+ * on script load, and this seems to set up the event listeners properly.
+ */
+behaviorShim.specify(".dd-handle", 'config-drag-start', 1000, function(el) {
+    page.fixDragEvent(el);
+});
+
 export var tabBarShowPreferenceKey = 'config:usetabs';
 
 export var addPageTabs = function(configSelector, onEachConfigTable, options) {
     $(function() {
-        behaviorShim.specify(".dd-handle", 'config-drag-start', 1000, function(el) {
-            page.fixDragEvent(el);
-        });
 
         // We need to wait until after radioBlock.js Behaviour.js rules
         // have been applied, otherwise row-set rows become visible across sections.


### PR DESCRIPTION
See [JENKINS-61429](https://issues.jenkins-ci.org/browse/JENKINS-61429).

This fix seems to do the trick. It seems the webpack introduction in 2.217 caused the proxied callback to Behaviour.specify to not run for repeatable items already on the page at load time.

### Test me

    docker run --rm -ti -p 8080:8080 -e ID=4568 jenkins/core-pr-tester

### Proposed changelog entries

* [JENKINS-61429](https://issues.jenkins-ci.org/browse/JENKINS-61429): Fix bug where drag & drop would fail for for previously saved steps in the job configuration form (regression in 2.217).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

