### PR TITLE
[JENKINS-61455] "About Jenkins" accessible with Jenkins.MANAGE

### DIFF
--- a/core/src/main/java/hudson/AboutJenkins.java
+++ b/core/src/main/java/hudson/AboutJenkins.java
@@ -44,6 +44,6 @@ public class AboutJenkins extends ManagementLink {
     @Nonnull
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.SYSTEM_READ;
+        return Jenkins.READ;
     }
 }

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -440,7 +440,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     }
 
     public Api getApi() {
-        Jenkins.get().checkPermission(Jenkins.SYSTEM_READ);
+        Jenkins.get().checkAnyPermission(Jenkins.SYSTEM_READ, Jenkins.MANAGE);
         return new Api(this);
     }
 

--- a/core/src/main/resources/hudson/AboutJenkins/index.jelly
+++ b/core/src/main/resources/hudson/AboutJenkins/index.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
 
-  <l:layout permission="${app.SYSTEM_READ}" type="one-column" title="${%about(app.VERSION)}">
+  <l:layout permissions="${app.MANAGE_AND_SYSTEM_READ}" type="one-column" title="${%about(app.VERSION)}">
     <l:main-panel>
     <div class="container-fluid">
       <div class="row">

--- a/core/src/main/resources/hudson/PluginWrapper/thirdPartyLicenses.jelly
+++ b/core/src/main/resources/hudson/PluginWrapper/thirdPartyLicenses.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <!-- 3rd party license acknowledgements and  -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-  <l:layout title="${%about(it.longName)}" permission="${app.SYSTEM_READ}">
+  <l:layout title="${%about(it.longName)}" permissions="${app.MANAGE_AND_SYSTEM_READ}">
     <l:main-panel>
       <h1>${%about(it.longName+' '+it.version)}</h1>
 

--- a/test/src/test/java/hudson/AboutJenkinsTest.java
+++ b/test/src/test/java/hudson/AboutJenkinsTest.java
@@ -56,10 +56,22 @@ public class AboutJenkinsTest {
         
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                // full access
                 .grant(Jenkins.ADMINISTER).everywhere().to(ADMIN)
+
+                // Read access
                 .grant(Jenkins.READ).everywhere().to(USER)
+
+                // Read and Manage
+                .grant(Jenkins.READ).everywhere().to(MANAGER)
                 .grant(Jenkins.MANAGE).everywhere().to(MANAGER)
+
+                // Read and System read
+                .grant(Jenkins.READ).everywhere().to(READONLY)
                 .grant(Jenkins.SYSTEM_READ).everywhere().to(READONLY)
+
+                // Read, Manage and System read
+                .grant(Jenkins.READ).everywhere().to(MANAGER_READONLY)
                 .grant(Jenkins.MANAGE).everywhere().to(MANAGER_READONLY)
                 .grant(Jenkins.SYSTEM_READ).everywhere().to(MANAGER_READONLY)
         );


### PR DESCRIPTION
See [JENKINS-61455](https://issues.jenkins-ci.org/browse/JENKINS-61455).



### Proposed changelog entries

* _About Jenkins_ management link is now accessible to users with
`Jenkins.MANAGE` or `Jenkins.SYSTEM_READ` (as well as the usual
`Jenkins.ADMINISTRATOR`)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

Anyone.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

