### PR TITLE
[JENKINS-61457] Allow Jenkins.MANAGE to configure UsageStatistics

### DIFF
--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -27,6 +27,7 @@ import hudson.PluginWrapper;
 import hudson.Util;
 import hudson.Extension;
 import hudson.node_monitors.ArchitectureMonitor.DescriptorImpl;
+import hudson.security.Permission;
 import hudson.util.Secret;
 import static java.util.concurrent.TimeUnit.DAYS;
 
@@ -35,6 +36,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.Nonnull;
 import javax.crypto.Cipher;
 import javax.crypto.CipherOutputStream;
 import javax.crypto.KeyGenerator;
@@ -190,6 +192,12 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
         } catch (GeneralSecurityException e) {
             throw new Error(e); // impossible
         }
+    }
+
+    @Nonnull
+    @Override
+    public Permission getRequiredGlobalConfigPagePermission() {
+        return Jenkins.MANAGE;
     }
 
     @Override

--- a/test/src/test/java/jenkins/model/JenkinsManagePermissionTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsManagePermissionTest.java
@@ -22,7 +22,6 @@ import hudson.cli.DisablePluginCommand;
 import hudson.model.Descriptor;
 import hudson.model.MyView;
 import hudson.model.View;
-import hudson.model.labels.LabelAtom;
 import hudson.tasks.Shell;
 
 import static org.hamcrest.Matchers.containsString;
@@ -30,7 +29,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
@@ -177,6 +176,21 @@ public class JenkinsManagePermissionTest {
         HtmlPage updated = j.submit(form);
         assertThat("User with Jenkins.MANAGE permission should be able to update global configuration",
                 updated.getWebResponse(), hasResponseCode(HttpURLConnection.HTTP_OK));
+    }
+
+    @Issue("JENKINS-61457")
+    @Test
+    public void managePermissionCanChangeUsageStatistics() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                                   .grant(Jenkins.MANAGE, Jenkins.READ).everywhere().toEveryone());
+
+        boolean previousValue = j.jenkins.isUsageStatisticsCollected();
+        HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
+        form.getInputByName("_.usageStatisticsCollected").setChecked(!previousValue);
+        j.submit(form);
+
+        assertThat("Can set UsageStadistics", j.jenkins.isUsageStatisticsCollected(), not(previousValue));
     }
 
     private String getShell() {

--- a/test/src/test/java/jenkins/model/JenkinsManagePermissionTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsManagePermissionTest.java
@@ -190,7 +190,7 @@ public class JenkinsManagePermissionTest {
         form.getInputByName("_.usageStatisticsCollected").setChecked(!previousValue);
         j.submit(form);
 
-        assertThat("Can set UsageStadistics", j.jenkins.isUsageStatisticsCollected(), not(previousValue));
+        assertThat("Can set UsageStatistics", j.jenkins.isUsageStatisticsCollected(), not(previousValue));
     }
 
     private String getShell() {


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-61457](https://issues.jenkins-ci.org/browse/JENKINS-61457).

### Proposed changelog entries

* _Usage Statistics_ in _Global Configuration_ is now configurable by users with `Jenkins.MANAGE` permission (as well as the usual `Jenkins.ADMINISTER`)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

