### PR TITLE
[JENKINS-61465] Make checkAnyPermission work on non-AccessControlled

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1172,6 +1172,31 @@ public class Functions {
         ac.checkAnyPermission(permissions);
     }
 
+    /**
+     * This version is so that the 'checkAnyPermission' on {@code layout.jelly}
+     * degrades gracefully if "it" is not an {@link AccessControlled} object.
+     * Otherwise it will perform no check and that problem is hard to notice.
+     */
+    public static void checkAnyPermission(Object object, Permission[] permissions) throws IOException, ServletException {
+        if (permissions == null || permissions.length == 0) {
+            return;
+        }
+
+        if (object instanceof AccessControlled)
+            checkAnyPermission((AccessControlled) object, permissions);
+        else {
+            List<Ancestor> ancs = Stapler.getCurrentRequest().getAncestors();
+            for(Ancestor anc : Iterators.reverse(ancs)) {
+                Object o = anc.getObject();
+                if (o instanceof AccessControlled) {
+                    checkAnyPermission((AccessControlled) o, permissions);
+                    return;
+                }
+            }
+            checkAnyPermission(Jenkins.get(), permissions);
+        }
+    }
+
     private static class Tag implements Comparable<Tag> {
         double ordinal;
         String hierarchy;

--- a/test/src/test/java/hudson/security/ACLTest.java
+++ b/test/src/test/java/hudson/security/ACLTest.java
@@ -24,8 +24,10 @@
 
 package hudson.security;
 
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
+import hudson.model.UnprotectedRootAction;
 import hudson.model.User;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,6 +41,9 @@ import org.junit.rules.ExpectedException;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.TestExtension;
+
+import javax.annotation.CheckForNull;
 
 public class ACLTest {
 
@@ -121,6 +126,29 @@ public class ACLTest {
         r.jenkins.getACL().checkAnyPermission();
     }
 
+    @Test
+    @Issue("JENKINS-61465")
+    public void checkAnyPermissionOnNonAccessControlled() throws Exception {
+        expectedException = ExpectedException.none();
+
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ).everywhere().toEveryone());
+
+        JenkinsRule.WebClient wc = r.createWebClient();
+        try {
+            wc.goTo("either");
+            fail();
+        } catch (FailingHttpStatusCodeException ex) {
+            assertEquals(403, ex.getStatusCode());
+        }
+
+        r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER).everywhere().toEveryone());
+
+        wc.goTo("either"); // expected to work
+    }
+
     private static class DoNotBotherMe extends AuthorizationStrategy {
 
         @Override
@@ -138,6 +166,28 @@ public class ACLTest {
             return Collections.emptySet();
         }
 
+    }
+
+    @TestExtension
+    public static class EitherPermission implements UnprotectedRootAction {
+
+        @CheckForNull
+        @Override
+        public String getIconFileName() {
+            return null;
+        }
+
+        @CheckForNull
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+
+        @CheckForNull
+        @Override
+        public String getUrlName() {
+            return "either";
+        }
     }
 
 }

--- a/test/src/test/resources/hudson/security/ACLTest/EitherPermission/index.jelly
+++ b/test/src/test/resources/hudson/security/ACLTest/EitherPermission/index.jelly
@@ -1,0 +1,39 @@
+<!--
+The MIT License
+
+Copyright (c) 2011, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!-- 3rd party license acknowledgements and  -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+<l:layout permissions="${app.MANAGE_AND_SYSTEM_READ}" type="one-column" title="Hello">
+    <l:main-panel>
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-md-24">
+                    <h1>Hello, world!</h1>
+                </div>
+            </div>
+        </div>
+    </l:main-panel>
+</l:layout>
+</j:jelly>


### PR DESCRIPTION
See [JENKINS-61465](https://issues.jenkins-ci.org/browse/JENKINS-61465).

@amuniz identified a problem in https://github.com/jenkinsci/jenkins/pull/4569#issuecomment-598617364: https://github.com/jenkinsci/jenkins/pull/4506 did not add an overload for `#checkAnyPermission` like it exists for `#checkPermission` in https://github.com/jenkinsci/jenkins/blob/a79101ce5440f2cff160dde791e923ce2548cfbe/core/src/main/java/hudson/Functions.java#L838-L843

This means that `<l:layout permissions="…">` would not work for `it` that aren't `AccessControlled`.

### Proposed changelog entries

* Developer: Make `h.checkAnyPermission` and `<l:layout permissions="…">` work on objects that aren't `AccessControlled`.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs


### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

