### PR TITLE
[JENKINS-61467] Do not show disabled, implied permissions in errors

### DIFF
--- a/core/src/main/java/hudson/security/ACL.java
+++ b/core/src/main/java/hudson/security/ACL.java
@@ -29,6 +29,7 @@ import hudson.model.ViewDescriptor;
 import hudson.model.ViewGroup;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
@@ -102,7 +103,7 @@ public abstract class ACL {
 
         Authentication authentication = Jenkins.getAuthentication();
         if (failed) { // we know that none of the permissions are granted
-            Set<Permission> enabledPermissions = new HashSet<>();
+            Set<Permission> enabledPermissions = new LinkedHashSet<>();
             for (Permission p : permissions) {
                 while (!p.enabled && p.impliedBy != null) {
                     p = p.impliedBy;

--- a/core/src/main/java/hudson/security/ACL.java
+++ b/core/src/main/java/hudson/security/ACL.java
@@ -28,6 +28,8 @@ import hudson.model.View;
 import hudson.model.ViewDescriptor;
 import hudson.model.ViewGroup;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -99,13 +101,20 @@ public abstract class ACL {
         boolean failed = !hasAnyPermission(permissions);
 
         Authentication authentication = Jenkins.getAuthentication();
-        if (failed) {
-            String permissionsDisplayName = Arrays.stream(permissions)
+        if (failed) { // we know that none of the permissions are granted
+            Set<Permission> enabledPermissions = new HashSet<>();
+            for (Permission p : permissions) {
+                while (!p.enabled && p.impliedBy != null) {
+                    p = p.impliedBy;
+                }
+                enabledPermissions.add(p);
+            }
+            String permissionsDisplayName = enabledPermissions.stream()
                     .map(p -> p.group.title + "/" + p.name)
                     .collect(Collectors.joining(", "));
 
             String errorMessage;
-            if (permissions.length == 1) {
+            if (enabledPermissions.size() == 1) {
                 errorMessage = Messages.AccessDeniedException2_MissingPermission(authentication.getName(), permissionsDisplayName);
             } else {
                 errorMessage = Messages.AccessDeniedException_MissingPermissions(authentication.getName(), permissionsDisplayName);

--- a/test/src/test/java/hudson/security/ACLTest.java
+++ b/test/src/test/java/hudson/security/ACLTest.java
@@ -24,6 +24,7 @@
 
 package hudson.security;
 
+import hudson.model.Build;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.User;
@@ -106,6 +107,42 @@ public class ACLTest {
         expectedException.expect(AccessDeniedException.class);
         try (ACLContext ignored = ACL.as(manager.impersonate())) {
             jenkins.getACL().checkAnyPermission(Jenkins.ADMINISTER, Jenkins.READ);
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-61467")
+    public void checkAnyPermissionDoesNotShowDisabledPermissionsInError() throws Exception {
+        Jenkins jenkins = r.jenkins;
+        jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ).everywhere().to("manager")
+        );
+
+        final User manager = User.getOrCreateByIdOrFullName("manager");
+
+        expectedException.expectMessage("manager is missing the Overall/Administer permission");
+        expectedException.expect(AccessDeniedException.class);
+        try (ACLContext ignored = ACL.as(manager.impersonate())) {
+            jenkins.getACL().checkAnyPermission(Jenkins.MANAGE, Jenkins.SYSTEM_READ);
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-61467")
+    public void checkAnyPermissionShouldShowDisabledPermissionsIfNotImplied() throws Exception {
+        Jenkins jenkins = r.jenkins;
+        jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ).everywhere().to("manager")
+        );
+
+        final User manager = User.getOrCreateByIdOrFullName("manager");
+
+        expectedException.expectMessage("manager is missing a permission, one of Job/WipeOut, Run/Artifacts is required");
+        expectedException.expect(AccessDeniedException.class);
+        try (ACLContext ignored = ACL.as(manager.impersonate())) {
+            jenkins.getACL().checkAnyPermission(Item.WIPEOUT, Build.ARTIFACTS);
         }
     }
 

--- a/test/src/test/java/jenkins/security/StackTraceSuppressionTest.java
+++ b/test/src/test/java/jenkins/security/StackTraceSuppressionTest.java
@@ -74,7 +74,7 @@ public class StackTraceSuppressionTest {
         HtmlPage page = wc.goTo("manage");
 
         String content = page.getWebResponse().getContentAsString();
-        assertThat(content, containsString(alice.getId() + " is missing a permission"));
+        assertThat(content, containsString(alice.getId() + " is missing the Overall/Administer permission"));
         assertThat(content, not(containsString("Caused by")));
     }
 


### PR DESCRIPTION
See [JENKINS-61467](https://issues.jenkins-ci.org/browse/JENKINS-61467).

### Proposed changelog entries

* Do not show disabled permissions in permission errors when checking for any of several permissions.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

