### PR TITLE
Add Javadoc for the categories

### DIFF
--- a/core/src/main/java/hudson/model/ManagementLink.java
+++ b/core/src/main/java/hudson/model/ManagementLink.java
@@ -171,12 +171,36 @@ public abstract class ManagementLink implements ExtensionPoint, Action {
      * @since TODO
      */
     public enum Category {
+        /**
+         * Configuration pages that don't fit into a more specific section.
+         */
         CONFIGURATION(Messages._ManagementLink_Category_CONFIGURATION()),
+        /**
+         * Security related options. Useful for plugins providing security related {@code ManagementLink}s (e.g. security realms).
+         * Use {@link Category#STATUS} instead if the feature is informational.
+         */
         SECURITY(Messages._ManagementLink_Category_SECURITY()),
+        /**
+         * Status information about the Jenkins instance, such as log messages, load statistics, or general information.
+         */
         STATUS(Messages._ManagementLink_Category_STATUS()),
+        /**
+         * Troubleshooting utilities. This overlaps some with status information, but the difference is that status
+         * always applies, while troubleshooting only matters when things go wrong.
+         */
         TROUBLESHOOTING(Messages._ManagementLink_Category_TROUBLESHOOTING()),
+        /**
+         * Tools are specifically tools for administrators, such as the Jenkins CLI and Script Console, as well as specific stand-alone administrative features ({@link jenkins.management.ShutdownLink}, {@link jenkins.management.ReloadLink}).
+         * This has nothing to do with build tools or tool installers.
+         */
         TOOLS(Messages._ManagementLink_Category_TOOLS()),
+        /**
+         * Anything that doesn't fit into any of the other categories. Expected to be necessary only very rarely.
+         */
         MISC(Messages._ManagementLink_Category_MISC()),
+        /**
+         * The default category for uncategorized items. Do not explicitly specify this category for your {@code ManagementLink}.
+         */
         UNCATEGORIZED(Messages._ManagementLink_Category_UNCATEGORIZED());
 
         private Localizable label;


### PR DESCRIPTION
Followup to https://github.com/jenkinsci/jenkins/pull/4546: I expected a lot of feedback on what the categories should be, so did hold back on defining them in more detail. I ended up getting absolutely no feedback on the category definitions before the change got integrated, so this is the followup PR with definitions.

We might still be able to redefine categories here, so if you really don't like what we have, let me know (and why!).

### Proposed changelog entries

* Add Javadoc for management link category definitions 

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

