### PR TITLE
Fix empty updates list

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -156,7 +156,7 @@ THE SOFTWARE.
               </j:when>
               <j:otherwise>
                 <tr>
-                  <td colspan="4" align="center">
+                  <td colspan="5" align="center">
                     <div style="padding:1em">
                       ${%No updates}
                     </div>


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/4535 added a column. So 2.225 looks all wrong:

> ![regular](https://user-images.githubusercontent.com/1831569/76692432-e7c6af80-6656-11ea-936d-7e718e2ed887.png)

> ![hover](https://user-images.githubusercontent.com/1831569/76692426-c239a600-6656-11ea-938c-d95a327044dd.png)

This change fixes this.

![Screenshot 2020-03-15 at 00 55 11](https://user-images.githubusercontent.com/1831569/76692478-a551a280-6657-11ea-89ff-d67cc77b949e.png)
![Screenshot 2020-03-15 at 00 55 15](https://user-images.githubusercontent.com/1831569/76692479-a71b6600-6657-11ea-9c63-95476d7f85f0.png)



### Proposed changelog entries

(too minor)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
