### PR TITLE
Create nested context menu (by category) for Manage Jenkins view

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2213,4 +2213,11 @@ public class Functions {
             return true;
         }
     }
+
+    @Restricted(NoExternalUse.class) // for manage.jelly
+    public static ModelObjectWithContextMenu.MenuItem createMenuItemWithSubMenu(String displayName) {
+        final ModelObjectWithContextMenu.MenuItem menuItem = new ModelObjectWithContextMenu.MenuItem().withDisplayName(displayName);
+        menuItem.subMenu = new ModelObjectWithContextMenu.ContextMenu();
+        return menuItem;
+    }
 }

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -47,6 +47,8 @@ THE SOFTWARE.
     </div>
 
     <j:forEach var="category" items="${it.categorizedManagementLinks.entrySet()}">
+      <j:set var="currentCategoryItem" value="${h.createMenuItemWithSubMenu(category.key.label)}"/>
+      ${taskTags!=null and attrs.contextMenu!='false' ? taskTags.add(currentCategoryItem) : null}
       <h2>${category.key.label}</h2>
       <div class="manage-page__row">
       <j:forEach var="m" items="${category.value}">
@@ -55,7 +57,7 @@ THE SOFTWARE.
           <div class="manage-option manage-page__column">
           <j:set var="iconUrl" value="${icon.startsWith('/') ? resURL+icon : imagesURL + '/48x48/' + icon}" />
           <j:set var="alt" value="${icon.replaceAll('\\d*\\.[^.]+$', '')}"/>
-          ${taskTags!=null and attrs.contextMenu!='false' ? taskTags.add(m.urlName, iconUrl, m.displayName, m.requiresPOST, m.requiresConfirmation) : null}
+          ${taskTags!=null and attrs.contextMenu!='false' ? currentCategoryItem.subMenu.add(m.urlName, iconUrl, m.displayName, m.requiresPOST, m.requiresConfirmation) : null}
           <j:choose>
             <j:when test="${m.requiresConfirmation}">
               <l:confirmationLink href="${m.urlName}" post="${m.requiresPOST}" message="${%are.you.sure(m.displayName)}">


### PR DESCRIPTION
Followup to https://github.com/jenkinsci/jenkins/pull/4546#issuecomment-598461338.

Unsure whether I like this, but it would be consistent with the Manage Jenkins UI. Thoughts?

> ![Screenshot](https://user-images.githubusercontent.com/1831569/76693366-eb146800-6663-11ea-80a2-83d17332bf21.png)

There's also a slightly different variant possible, but the limited options to style menu items makes it appear pretty weird without a more extensive styling update of context menu items.

<details><summary>See here</summary>

> ![Screenshot](https://user-images.githubusercontent.com/1831569/76693372-08493680-6664-11ea-9d4d-1c3c46d460f4.png)

</details>

### Proposed changelog entries

* Create nested context menu for Manage Jenkins

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

