### PR TITLE
Highlight when plugins have the adopt-this-plugin label

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -126,6 +126,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -2243,6 +2244,33 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         }
         return this;
+    }
+
+    @Restricted(DoNotUse.class) // Used from table.jelly
+    public boolean isMetaLabel(String label) {
+        return "adopt-this-plugin".equals(label);
+    }
+
+    @Restricted(DoNotUse.class) // Used from table.jelly
+    public boolean hasAdoptThisPluginLabel(UpdateSite.Plugin plugin) {
+        final String[] categories = plugin.categories;
+        if (categories == null) {
+            return false;
+        }
+        return Arrays.asList(categories).contains("adopt-this-plugin");
+    }
+
+    @Restricted(DoNotUse.class) // Used from table.jelly
+    public boolean hasAdoptThisPluginLabel(PluginWrapper plugin) {
+        final UpdateSite.Plugin pluginMeta = Jenkins.get().getUpdateCenter().getPlugin(plugin.getShortName());
+        if (pluginMeta == null) {
+            return false;
+        }
+        final String[] categories = pluginMeta.categories;
+        if (categories == null) {
+            return false;
+        }
+        return Arrays.asList(categories).contains("adopt-this-plugin");
     }
 
     /**

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -111,6 +111,11 @@ THE SOFTWARE.
                         </ul>
                       </div>
                     </j:if>
+                    <j:if test="${it.hasAdoptThisPluginLabel(p)}">
+                      <div class="alert alert-warning">
+                        ${%adoptThisPlugin}
+                      </div>
+                    </j:if>
                   </td>
                   <td class="center pane" style="white-space:normal">
                     <a href="plugin/${p.shortName}/thirdPartyLicenses">

--- a/core/src/main/resources/hudson/PluginManager/installed.properties
+++ b/core/src/main/resources/hudson/PluginManager/installed.properties
@@ -26,3 +26,6 @@ detached-uninstall=This plugin may not be safe to uninstall
 detached-possible-dependents=Its functionality was at one point moved out of Jenkins core, and another plugin with a core dependency predating the split may be relying on it implicitly.
 securityWarning=\
   Warning: The currently installed plugin version may not be safe to use. Please review the following security notices:
+adoptThisPlugin=\
+  <strong>This plugin is up for adoption!</strong> We are looking for new maintainers. \
+  Visit our <a href="https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" target="_blank">Adopt a Plugin</a> initiative for more information.

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -76,9 +76,11 @@ THE SOFTWARE.
                       <j:if test="${!p.categories.isEmpty()}">
                         <div class="plugin-manager__categories">
                           <j:forEach var="label" items="${p.categories}">
-                            <span class="plugin-manager__category-label">
-                              ${app.updateCenter.getCategoryDisplayName(label)}
-                            </span>
+                            <j:if test="${!it.isMetaLabel(label)}">
+                              <span class="plugin-manager__category-label">
+                                ${app.updateCenter.getCategoryDisplayName(label)}
+                              </span>
+                            </j:if>
                           </j:forEach>
                         </div>
                       </j:if>
@@ -129,6 +131,11 @@ THE SOFTWARE.
                               <li><a href="${warning.url}" target="_blank">${warning.message}</a></li>
                             </j:forEach>
                           </ul>
+                        </div>
+                      </j:if>
+                      <j:if test="${it.hasAdoptThisPluginLabel(p)}">
+                        <div class="alert alert-warning">
+                          ${%adoptThisPlugin}
                         </div>
                       </j:if>
                     </td>

--- a/core/src/main/resources/hudson/PluginManager/table.properties
+++ b/core/src/main/resources/hudson/PluginManager/table.properties
@@ -46,3 +46,6 @@ depJavaWarning=\
 securityWarning=\
   Warning: This plugin version may not be safe to use. Please review the following security notices:
 ago={0} ago
+adoptThisPlugin=\
+  <strong>This plugin is up for adoption!</strong> We are looking for new maintainers. \
+  Visit our <a href="https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" target="_blank">Adopt a Plugin</a> initiative for more information.


### PR DESCRIPTION
This removes the label from the regular list of categories shown on the UI, and instead adds a warning box. The warning box is shown on all three tabs, including installed plugins.

I don't think this warrants an admin monitor, just make this label more noticeable.

Wording was taken from the plugin site, e.g. https://plugins.jenkins.io/envinject/

### Available

> ![Screenshot](https://user-images.githubusercontent.com/1831569/76703563-d4592a00-66d2-11ea-91e8-6a433846742d.png)

### Installed

> ![Screenshot](https://user-images.githubusercontent.com/1831569/76703788-965d0580-66d4-11ea-8dd8-fa6a6c2067c5.png)


### Proposed changelog entries

* Highlight in the plugin manager when plugins are looking for new maintainers ("Adopt this plugin").

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

