### PR TITLE
List failed plugins on Installed tab

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -161,15 +161,21 @@ THE SOFTWARE.
                 </tr>
               </j:forEach>
               <!-- failed ones -->
-              <j:forEach var="p" items="${it.pluginManager.failedPlugins}">
+              <j:forEach var="p" items="${it.failedPlugins}">
                 <tr class="hoverback">
-                  <td class="pane" />
+                  <td class="center pane enable">
+                    <input type="checkbox" disabled="disabled"/>
+                  </td>
                   <td class="pane">
-                    <h4 class="error">Failed : ${p.name}</h4>
-                    <div style="padding-left: 1em">
-                      <pre>${p.exceptionString}</pre>
+                    <div>
+                        ${p.name}
+                    </div>
+                    <div class="alert alert-danger">
+                      <pre>${p.cause.message}</pre>
                     </div>
                   </td>
+                  <td class="pane" />
+                  <td class="pane" />
                   <td class="pane" />
                 </tr>
               </j:forEach>


### PR DESCRIPTION
Did you ever wonder why plugins suddenly vanish from the plugin manager when they failed to load? No? Well, I have. Turns out the reason is because of a typo. This line of code from 2008 should have said `app.pluginManager` (like [further up](https://github.com/jenkinsci/jenkins/blob/9ceeb55624345b1e97747260cc2fa124fab687f8/core/src/main/resources/hudson/PluginManager/installed.jelly#L10)), not `it.pluginManager`:
https://github.com/jenkinsci/jenkins/blob/9ceeb55624345b1e97747260cc2fa124fab687f8/core/src/main/resources/hudson/PluginManager/installed.jelly#L44

This PR fixes that (`it` is `app.pluginManager`), and uses a _slightly_ improved UI for this.

> ![Screenshot](https://user-images.githubusercontent.com/1831569/76804086-b9261180-67db-11ea-8dd7-9cb7209b570e.png)

IMO the existing UI was a bit too annoying:

<details>
<summary>Screenshot</summary>

> ![Screenshot](https://user-images.githubusercontent.com/1831569/76804208-04402480-67dc-11ea-9ca7-a4ac28d7ea17.png)

</details>

### Proposed changelog entries

* List plugins that failed to load on the Installed tab of the plugin manager.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

