### PR TITLE
[JENKINS-61105] Add support for cross-compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -665,6 +665,12 @@ THE SOFTWARE.
         <!-- TODO: https://issues.jenkins-ci.org/browse/JENKINS-53788 (JDK11 issue on CI) -->
         <doclint>none</doclint>
         <maven.javadoc.skip>true</maven.javadoc.skip>
+        <!-- release is needed for reliable cross compilation. It is supported
+        starting JDK 9, but as the only earlier version we support is 8, it would
+        be either compiled by javac from 8 or one from a newer compiler that
+        correctly handle the release flag. This will replace both source and target
+        once we drop support for JDK 8 that only recognize source and target. -->
+        <maven.compiler.release>${java.level}</maven.compiler.release>
       </properties>
       <activation>
         <jdk>11</jdk>


### PR DESCRIPTION
Use the `javac` `--release` flag over `-source` and `-target` on JDK 9+ to make sure the compiler reflect JDK API differences.

See [JENKINS-61105](https://issues.jenkins-ci.org/browse/JENKINS-61105).

The issue at hand was, code compiled with javac 11 actually targeted Java API from 11 choosing method overloads that did not existed in JDK 8 and broke backward compatibility:

```
java.lang.NoSuchMethodError: java.nio.CharBuffer.rewind()Ljava/nio/CharBuffer;
        at hudson.Util.rawEncode(Util.java:886)
```

While JDK 8 have only the overload with signature: `java/nio/CharBuffer.rewind:()Ljava/nio/Buffer;`

I have verified using the affected `Util` class making both `old` and `fix` builds against both Jdk 8 and 11. The invoked signatures ware extracted as `javap -c Util.class | grep -Po 'Method.*'` and they confirm the correct signature is generated when the option is added.

![screenshot](https://user-images.githubusercontent.com/206841/77053610-e25ac380-69ce-11ea-929f-210eb11decf4.png)


### Proposed changelog entries

* Entry 1: Permit core building using newer JDK than version 8

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev, @jglick, @MarkEWaite, PTAL

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

