### PR TITLE
Fix various "incompatible" messages for plugin manager

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/table.properties
+++ b/core/src/main/resources/hudson/PluginManager/table.properties
@@ -38,11 +38,11 @@ depCompatWarning=\
  Jobs using that plugin may need to be reconfigured, and/or you may not be able to cleanly revert to the prior version without manually restoring old settings. \
  Consult the plugin release notes for details.
 depCoreWarning=\
- Warning: This plugin has dependencies to other plugins that require Jenkins {0} or newer. \
+ Warning: This plugin has dependencies on other plugins that require Jenkins {0} or newer. \
  Jenkins will refuse to load the dependencies requiring a newer version of Jenkins, \
  and in turn loading this plugin will fail.
 depJavaWarning=\
- Warning: this plugin has dependencies to other plugins that require Java {0} or newer. \
+ Warning: this plugin has dependencies on other plugins that require Java {0} or newer. \
  Jenkins will refuse to load the dependencies requiring a newer version of Jenkins, \
  and in turn loading this plugin will fail.
 securityWarning=\

--- a/core/src/main/resources/hudson/PluginManager/table.properties
+++ b/core/src/main/resources/hudson/PluginManager/table.properties
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 compatWarning=\
- Warning: the new version of this plugin claims to use a different settings format than the installed version. \
+ Warning: The new version of this plugin is marked as incompatible with the installed version. \
+ This is usually the case because its behavior changed, or because it uses a different settings format than the installed version. \
  Jobs using this plugin may need to be reconfigured, and/or you may not be able to cleanly revert to the prior version without manually restoring old settings. \
  Consult the plugin release notes for details.
 parentDepCompatWarning=The following plugins are incompatible:
@@ -32,16 +33,17 @@ javaWarning=\
  Warning: This plugin requires Java {0} or newer. \
  Jenkins will refuse to load this plugin if installed.
 depCompatWarning=\
- Warning: This plugin requires dependent plugins be upgraded and at least one of these dependent plugins claims to use a different settings format than the installed version. \
+ Warning: This plugin requires newer versions of dependencies and at least one of those plugins is not compatible with the installed version. \
+ This is usually the case because its behavior changed, or it uses a different settings format than the installed version. \
  Jobs using that plugin may need to be reconfigured, and/or you may not be able to cleanly revert to the prior version without manually restoring old settings. \
  Consult the plugin release notes for details.
 depCoreWarning=\
- Warning: This plugin requires dependent plugins that require Jenkins {0} or newer. \
- Jenkins will refuse to load the dependent plugins requiring a newer version of Jenkins, \
+ Warning: This plugin has dependencies to other plugins that require Jenkins {0} or newer. \
+ Jenkins will refuse to load the dependencies requiring a newer version of Jenkins, \
  and in turn loading this plugin will fail.
 depJavaWarning=\
- Warning: this plugin requires other plugins which in turn require Java {0} or newer. \
- Jenkins will refuse to load the dependent plugins requiring a newer version of Jenkins, \
+ Warning: this plugin has dependencies to other plugins that require Java {0} or newer. \
+ Jenkins will refuse to load the dependencies requiring a newer version of Jenkins, \
  and in turn loading this plugin will fail.
 securityWarning=\
   Warning: This plugin version may not be safe to use. Please review the following security notices:


### PR DESCRIPTION
This is essentially two changes combined:

* Broaden the meaning of compatibility warnings (`compatibleSince`) to match how it's sometimes used – to warn about an incompatible behavior change.
* Replace the term "dependent" (AFAICT, that which _has_ a dependency, rather than _is_ a dependency) with "dependencies"

Plus made some similar messages more consistent in wording.

### Proposed changelog entries

Too minor

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] JIRA issue is well described
- [n/a] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

