### PR TITLE
[JENKINS-61688] Load build discarder configuration after restart

### DIFF
--- a/core/src/main/java/jenkins/model/GlobalBuildDiscarderConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalBuildDiscarderConfiguration.java
@@ -48,6 +48,10 @@ public class GlobalBuildDiscarderConfiguration extends GlobalConfiguration {
         return ExtensionList.lookupSingleton(GlobalBuildDiscarderConfiguration.class);
     }
 
+    public GlobalBuildDiscarderConfiguration() {
+        load();
+    }
+
     private final DescribableList<GlobalBuildDiscarderStrategy, GlobalBuildDiscarderStrategyDescriptor> configuredBuildDiscarders =
             new DescribableList<>(this, Collections.singletonList(new JobGlobalBuildDiscarderStrategy()));
 

--- a/test/src/test/java/jenkins/model/GlobalBuildDiscarderTest.java
+++ b/test/src/test/java/jenkins/model/GlobalBuildDiscarderTest.java
@@ -5,14 +5,34 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.LogRotator;
+import hudson.util.DescribableList;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 public class GlobalBuildDiscarderTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @LocalData
+    @Issue("JENKINS-61688")
+    public void testLoading() throws Exception {
+        Assert.assertEquals(0, GlobalBuildDiscarderConfiguration.get().getConfiguredBuildDiscarders().size());
+    }
+
+    @Test
+    @LocalData
+    @Issue("JENKINS-61688")
+    public void testLoadingWithDiscarders() throws Exception {
+        final DescribableList<GlobalBuildDiscarderStrategy, GlobalBuildDiscarderStrategyDescriptor> configuredBuildDiscarders = GlobalBuildDiscarderConfiguration.get().getConfiguredBuildDiscarders();
+        Assert.assertEquals(2, configuredBuildDiscarders.size());
+        Assert.assertNotNull(configuredBuildDiscarders.get(JobGlobalBuildDiscarderStrategy.class));
+        Assert.assertEquals(5, ((LogRotator)configuredBuildDiscarders.get(SimpleGlobalBuildDiscarderStrategy.class).getDiscarder()).getNumToKeep());
+    }
 
     @Test
     public void testJobBuildDiscarder() throws Exception {

--- a/test/src/test/resources/jenkins/model/GlobalBuildDiscarderTest/testLoading/jenkins.model.GlobalBuildDiscarderConfiguration.xml
+++ b/test/src/test/resources/jenkins/model/GlobalBuildDiscarderTest/testLoading/jenkins.model.GlobalBuildDiscarderConfiguration.xml
@@ -1,0 +1,4 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.model.GlobalBuildDiscarderConfiguration>
+  <configuredBuildDiscarders/>
+</jenkins.model.GlobalBuildDiscarderConfiguration>

--- a/test/src/test/resources/jenkins/model/GlobalBuildDiscarderTest/testLoadingWithDiscarders/jenkins.model.GlobalBuildDiscarderConfiguration.xml
+++ b/test/src/test/resources/jenkins/model/GlobalBuildDiscarderTest/testLoadingWithDiscarders/jenkins.model.GlobalBuildDiscarderConfiguration.xml
@@ -1,0 +1,14 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.model.GlobalBuildDiscarderConfiguration>
+  <configuredBuildDiscarders>
+    <jenkins.model.JobGlobalBuildDiscarderStrategy/>
+    <jenkins.model.SimpleGlobalBuildDiscarderStrategy>
+      <discarder class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>5</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </discarder>
+    </jenkins.model.SimpleGlobalBuildDiscarderStrategy>
+  </configuredBuildDiscarders>
+</jenkins.model.GlobalBuildDiscarderConfiguration>


### PR DESCRIPTION
See [JENKINS-61688](https://issues.jenkins-ci.org/browse/JENKINS-61688).

I wish I was joking.

WDYT? 2.222.2?

### Proposed changelog entries

* Actually load a previously saved global build discarder configuration after restart.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

