### PR TITLE
Do not print random binary data during WebSocketAgentsTest

### DIFF
--- a/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
+++ b/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
@@ -103,7 +103,7 @@ public class WebSocketAgentsTest {
             assertNotNull(s.getChannel().call(new FatTask()));
             FreeStyleProject p = r.createFreeStyleProject();
             p.setAssignedNode(s);
-            p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo hello") : new Shell("dd if=/dev/random count=1024 bs=200"));
+            p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo hello") : new Shell("echo hello"));
             r.buildAndAssertSuccess(p);
             s.toComputer().getLogText().writeLogTo(0, System.out);
         } finally {


### PR DESCRIPTION
After #4596, there were [test failures in `master`](https://ci.jenkins.io/job/Core/job/jenkins/job/master/1866/testReport/junit/TEST-jenkins.agents.WebSocketAgentsTest/xml/_failed_to_read_/) (and unrelated PRs!)

```
Failed to read test report file /home/jenkins/workspace/Core_jenkins_master/test/target/surefire-reports/TEST-jenkins.agents.WebSocketAgentsTest.xml
org.dom4j.DocumentException: Invalid byte 2 of 2-byte UTF-8 sequence.
	at org.dom4j.io.SAXReader.read(SAXReader.java:464)
	at org.dom4j.io.SAXReader.read(SAXReader.java:325)
	at hudson.tasks.junit.SuiteResult.parse(SuiteResult.java:178)
	at hudson.tasks.junit.TestResult.parse(TestResult.java:348)
	at hudson.tasks.junit.TestResult.parsePossiblyEmpty(TestResult.java:281)
	at hudson.tasks.junit.TestResult.parse(TestResult.java:206)
	at hudson.tasks.junit.TestResult.parse(TestResult.java:178)
	at hudson.tasks.junit.TestResult.<init>(TestResult.java:143)
	at hudson.tasks.junit.JUnitParser$ParseResultCallable.invoke(JUnitParser.java:146)
	at hudson.tasks.junit.JUnitParser$ParseResultCallable.invoke(JUnitParser.java:118)
	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3069)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:369)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:117)
	at java.lang.Thread.run(Thread.java:748)
Caused by: com.sun.org.apache.xerces.internal.impl.io.MalformedByteSequenceException: Invalid byte 2 of 2-byte UTF-8 sequence.
	at com.sun.org.apache.xerces.internal.impl.io.UTF8Reader.invalidByte(UTF8Reader.java:701)
	at com.sun.org.apache.xerces.internal.impl.io.UTF8Reader.read(UTF8Reader.java:372)
	at com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.load(XMLEntityScanner.java:1895)
	at com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.scanData(XMLEntityScanner.java:1375)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanCDATASection(XMLDocumentFragmentScannerImpl.java:1654)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:3014)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:602)
	at com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:112)
	at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:505)
	at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:842)
	at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:771)
	at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
	at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1213)
	at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:643)
	at org.dom4j.io.SAXReader.read(SAXReader.java:445)
	... 19 more
```

which seems to be due to binary content being printed from the test. At root this may be a bug in the `junit` plugin, though I am not sure exactly how this happens, because `TEST-jenkins.agents.WebSocketAgentsTest.xml` itself does not contain output.

```bash
mvn -pl test -Dmaven.test.redirectTestOutputToFile -Dtest=WebSocketAgentsTest test
```

dumps this all in `test/target/surefire-reports/jenkins.agents.WebSocketAgentsTest-output.txt`, not XML.

At any rate, I played with replacing the command with for example

```bash
yes | head -99999
```

which is ASCII only and produces a comparable volume of output, but decided to keep it simple since as in https://github.com/jenkinsci/jenkins/pull/4596#discussion_r395813918 this shell command never reproduced the bug to begin with: as confirmed by

```diff
diff --git core/src/main/java/hudson/slaves/SlaveComputer.java core/src/main/java/hudson/slaves/SlaveComputer.java
index 4c59ec8aae..b76c0018df 100644
--- core/src/main/java/hudson/slaves/SlaveComputer.java
+++ core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -41,6 +41,7 @@ import hudson.model.User;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelBuilder;
 import hudson.remoting.ChannelClosedException;
+import hudson.remoting.Command;
 import hudson.remoting.CommandTransport;
 import hudson.remoting.Launcher;
 import hudson.remoting.VirtualChannel;
@@ -632,6 +633,23 @@ public class SlaveComputer extends Computer {
                 }
             }
         });
+        channel.addListener(new Channel.Listener() {
+            long max;
+            @Override
+            public void onWrite(Channel channel, Command cmd, long blockSize) {
+                x(blockSize);
+            }
+            @Override
+            public void onRead(Channel channel, Command cmd, long blockSize) {
+                x(blockSize);
+            }
+            void x(long x) {
+                if (x > max) {
+                    max = x;
+                    System.err.println("max is now " + x);
+                }
+            }
+        });
         if(listener!=null)
             channel.addListener(listener);
 
```

the largest packet is

```
   5.048 [id=89]	FINEST	o.j.r.u.LoggingChannelListener#onWrite: remote wrote 51238: Response:RPCRequest:hudson.remoting.RemoteClassLoader$IClassLoader.fetch3[java.lang.String](2)(java.util.HashMap)
max is now 51238
```

until the `FatTask` is run; the `Shell` output produces packets just a bit over 8K.