### PR TITLE
[JENKINS-61694] - Update Groovy Init hooks to run after all job configurations are adapted

### DIFF
--- a/core/src/main/java/hudson/init/InitMilestone.java
+++ b/core/src/main/java/hudson/init/InitMilestone.java
@@ -106,14 +106,15 @@ public enum InitMilestone implements Milestone {
     JOB_LOADED("Loaded all jobs"),
 
     /**
-     * By this milestone, any job configuration is adapted or updated just in case any plugin needs to update former/old configurations or init scripts
+     * By this milestone, any job configuration is adapted or updated just in case any plugin needs to update former/old configurations.
+     * It does not include {@link hudson.init.impl.GroovyInitScript}s which get executed later
      * @since 2.220
      */
     JOB_CONFIG_ADAPTED("Configuration for all jobs updated"),
 
     /**
-     * The very last milestone
-     *
+     * The very last milestone.
+     * All executions should be completed by it, including {@link hudson.init.impl.GroovyInitScript}s.
      * This is used in {@link Initializer#before()} since annotations cannot have null as the default value.
      */
     COMPLETED("Completed initialization");

--- a/core/src/main/java/hudson/init/impl/GroovyInitScript.java
+++ b/core/src/main/java/hudson/init/impl/GroovyInitScript.java
@@ -32,11 +32,12 @@ import static hudson.init.InitMilestone.*;
 
 /**
  * Run the initialization script, if it exists.
+ * It runs strictly after the initialization of other tasks during the last initialization milestone.
  * 
  * @author Kohsuke Kawaguchi
  */
 public class GroovyInitScript {
-    @Initializer(after=JOB_LOADED)
+    @Initializer(after=JOB_CONFIG_ADAPTED)
     public static void init(Jenkins j) {
         new GroovyHookScript("init", j.servletContext, j.getRootDir(), j.getPluginManager().uberClassLoader).run();
     }


### PR DESCRIPTION
After introduction a new milestones in the core, Groovy run after jobs are loaded. It may happen before JOB_CONFIG_ADAPTED... or actually after it. It depends on how the graph is executed. This pull request restores https://github.com/jenkinsci/jenkins/commit/ab12f71a48901ab3b78521382057a03e166fe668 from @fcojfernandez to make it more deterministic and to make Groovy Hooks to be executed after all other stuff. 

Alternative is to add `before`, feedback from other maintainers will be appreciated.

P.S: Originally this patch was supposed to be a part of https://github.com/jenkinsci/configuration-as-code-plugin/pull/1262, but my analysis there was wrong

This PR restores the status quo when Init groovy hooks run after all other initialization milestones. More milestones can be added later if needed.

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-61694](https://issues.jenkins-ci.org/browse/JENKINS-61694).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Update Groovy Init hooks to run after all job configurations are adapted
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

