### PR TITLE
[JENKINS-61692] Fix proxy form validation

### DIFF
--- a/core/src/main/resources/hudson/ProxyConfiguration/config.groovy
+++ b/core/src/main/resources/hudson/ProxyConfiguration/config.groovy
@@ -22,5 +22,5 @@ f.advanced(){
         f.textbox()
     }
     f.validateButton(title:_("Validate Proxy"), 
-                     method:"validateProxy", with:"testUrl,name,port,userName,password,noProxyHost")
+                     method:"validateProxy", with:"testUrl,name,port,userName,secretPassword,noProxyHost")
 }


### PR DESCRIPTION
See [JENKINS-61692](https://issues.jenkins-ci.org/browse/JENKINS-61692).

Manually tested in debugger; the password is sent to the form validation method.

### Proposed changelog entries

* Fix proxy form validation when a password is set. (regression in 2.205)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

