### PR TITLE
Support null Secrets when converting form submissions

### DIFF
--- a/core/src/main/java/hudson/util/Secret.java
+++ b/core/src/main/java/hudson/util/Secret.java
@@ -303,6 +303,9 @@ public final class Secret implements Serializable {
     static {
         Stapler.CONVERT_UTILS.register(new org.apache.commons.beanutils.Converter() {
             public Secret convert(Class type, Object value) {
+                if (value == null) {
+                    return null;
+                }
                 if (value instanceof Secret) {
                     return (Secret) value;
                 }


### PR DESCRIPTION
Inspired by [JENKINS-61692](https://issues.jenkins-ci.org/browse/JENKINS-61692).

The actual fix for the issue is at https://github.com/jenkinsci/jenkins/pull/4607 but I wondered why there's even an NPE.

Looks like the converter used by Stapler to provide `@QueryParameter`s to web methods does not support `null` `Secrets`. This _seems_ like an unintentional failure mode (but not sure).

### Proposed changelog entries

* Robustness: Don't throw `NullPointerException`s when trying to convert `null` to `Secret`.

(No idea how better to explain this for a user audience.)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

