### PR TITLE
Use DirectoryBrowserSupport to serve FileParameterValue

### DIFF
--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -226,46 +226,11 @@ public class FileParameterValue extends ParameterValue {
      *
      * @param request
      * @param response
-     * @throws ServletException
-     * @throws IOException
      */
-    public void doDynamic(StaplerRequest request, StaplerResponse response) throws ServletException, IOException {
-        if (("/" + originalFileName).equals(request.getRestOfPath())) {
-            AbstractBuild build = (AbstractBuild)request.findAncestor(AbstractBuild.class).getObject();
-            File fileParameter = getLocationUnderBuild(build);
-
-            if (!ALLOW_FOLDER_TRAVERSAL_OUTSIDE_WORKSPACE) {
-                File fileParameterFolder = getFileParameterFolderUnderBuild(build);
-
-                //TODO can be replaced by Util#isDescendant in 2.80+
-                Path child = fileParameter.getAbsoluteFile().toPath().normalize();
-                Path parent = fileParameterFolder.getAbsoluteFile().toPath().normalize();
-                if (!child.startsWith(parent)) {
-                    throw new IllegalStateException("The fileParameter tried to escape the expected folder: " + location);
-                }
-            }
-
-            if (fileParameter.isFile()) {
-                try (InputStream data = Files.newInputStream(fileParameter.toPath())) {
-                    long lastModified = fileParameter.lastModified();
-                    long contentLength = fileParameter.length();
-                    if (request.hasParameter("view")) {
-                        response.serveFile(request, data, lastModified, contentLength, "plain.txt");
-                    } else {
-                        String csp = SystemProperties.getString(DirectoryBrowserSupport.class.getName() + ".CSP", DirectoryBrowserSupport.DEFAULT_CSP_VALUE);
-                        if (!csp.trim().equals("")) {
-                            // allow users to prevent sending this header by setting empty system property
-                            for (String header : new String[]{"Content-Security-Policy", "X-WebKit-CSP", "X-Content-Security-Policy"}) {
-                                response.setHeader(header, csp);
-                            }
-                        }
-                        response.serveFile(request, data, lastModified, contentLength, originalFileName);
-                    }
-                } catch (InvalidPathException e) {
-                    throw new IOException(e);
-                }
-            }
-        }
+    public DirectoryBrowserSupport doDynamic(StaplerRequest request, StaplerResponse response) {
+        AbstractBuild build = (AbstractBuild)request.findAncestor(AbstractBuild.class).getObject();
+        File fileParameter = getFileParameterFolderUnderBuild(build);
+        return new DirectoryBrowserSupport(build, new FilePath(fileParameter), Messages.FileParameterValue_IndexTitle(), "folder.png", false);
     }
 
     /**

--- a/core/src/main/resources/hudson/model/FileParameterValue/value.jelly
+++ b/core/src/main/resources/hudson/model/FileParameterValue/value.jelly
@@ -26,16 +26,23 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-        <j:set var="escapeEntryTitleAndDescription" value="false"/>
-        <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
-        <j:if test="${it.originalFileName != null}">
-            <j:invokeStatic var="encodedName" className="hudson.Util" method="rawEncode">
-                <j:arg value="${it.name}" />
-            </j:invokeStatic>
-            <j:set var="path" value="parameter/${encodedName}/${it.originalFileName}"/>
-            <a href="${path}">${it.originalFileName}</a>
-            <st:nbsp/>
-            <a href="${path}?view">${%view}</a>
-        </j:if>
+    <j:set var="escapeEntryTitleAndDescription" value="false"/>
+    <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
+        <j:choose>
+            <j:when test="${it.originalFileName != null and it.originalFileName != ''}">
+                <j:invokeStatic var="encodedName" className="hudson.Util" method="rawEncode">
+                    <j:arg value="${it.name}" />
+                </j:invokeStatic>
+                <j:set var="path" value="parameter/${encodedName}/${encodedName}"/>
+                <a href="${path}">${%open}</a>
+                <st:nbsp/>
+                <a href="${path}/*view*">${%view}</a>
+            </j:when>
+            <j:otherwise>
+                <em>
+                    ${%nofile}
+                </em>
+            </j:otherwise>
+        </j:choose>
     </f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/FileParameterValue/value.properties
+++ b/core/src/main/resources/hudson/model/FileParameterValue/value.properties
@@ -1,0 +1,1 @@
+nofile=(No file was uploaded)

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -412,3 +412,5 @@ ManagementLink.Category.TROUBLESHOOTING=Troubleshooting
 ManagementLink.Category.TOOLS=Tools and Actions
 ManagementLink.Category.MISC=Other
 ManagementLink.Category.UNCATEGORIZED=Uncategorized
+
+FileParameterValue.IndexTitle=File Parameters


### PR DESCRIPTION
This will allow the use of Resource Root URLs for those files.

Additionally, minor UI improvements:
- Explicitly indicate when no file was uploaded
- Do not show original file name on the UI, nobody cares

----

This is a followup to [SECURITY-1793](https://jenkins.io/security/advisory/2020-03-25/#SECURITY-1793): While this is much nicer, it's the bigger change compared to [just adding a few headers](https://github.com/jenkinsci/jenkins/commit/c2d22b241eba718c62996e2ceeb5f2e0e9787f81#diff-e8306d2fa3739c665711d9e64ae885aa), and as such less suitable for a security fix.

It's a bit weird internally, because every file parameter (whose name is the file name) creates a DBS to the same directory containing all uploaded file parameters, and then the link includes the file name as additional arguments. So it's always `…/parameters/foo.ext/foo.ext`. If you have 2+ file parameters you can even mismatch parameter and file names, since all serve files from the same directory: `…/parameters/bar.ext/foo.ext`. I don't think this is a problem, just a quirk.

Another quirk is that `DirectoryBrowserSupport` allows browsing the directory. Want to see all file parameters for a job? Go to `../parameters/foo.ext/**`. Again, not really deliberate, just a quirk of using `DirectoryBrowserSupport`, and not a problem IMO.

Additionally, it seems the code attempted to prevent showing an argument value when there's no file uploaded, but it looks like that didn't work: At least for me, `originalFileName` is always the empty string in that case, rather than `null`. So fix up that check.

### Screenshots

> ![Screenshot](https://user-images.githubusercontent.com/1831569/78009415-48393a80-7341-11ea-8b8b-fc97819207ba.png)
> ![Screenshot](https://user-images.githubusercontent.com/1831569/78009423-4a9b9480-7341-11ea-8968-310380f923e6.png)

Here's the new hidden feature, directory browser:

> ![Screenshot](https://user-images.githubusercontent.com/1831569/78011039-5e47fa80-7343-11ea-8482-876539afaeeb.png)

### Proposed changelog entries

* Add support for serving file parameter values from the resource root URL, if set.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

