### PR TITLE
Hyperlinks in label-related CauseOfBlockage.print

### DIFF
--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -54,6 +54,13 @@ public class ModelHyperlinkNote extends HyperlinkNote {
         return encodeTo("/computer/" + nodePath, node.getDisplayName());
     }
 
+    /**
+     * @since TODO
+     */
+    public static String encodeTo(Label label) {
+        return encodeTo("/" + label.getUrl(), label.getName());
+    }
+
     public static String encodeTo(String url, String text) {
         return HyperlinkNote.encodeTo(url, text, ModelHyperlinkNote::new);
     }

--- a/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
+++ b/core/src/main/java/hudson/model/queue/CauseOfBlockage.java
@@ -151,6 +151,16 @@ public abstract class CauseOfBlockage {
                 return Messages.Queue_AllNodesOffline(label.getName());
             }
         }
+
+        @Override
+        public void print(TaskListener listener) {
+            if (label.isEmpty()) {
+                listener.getLogger().println(Messages.Queue_LabelHasNoNodes(ModelHyperlinkNote.encodeTo(label)));
+            } else {
+                listener.getLogger().println(Messages.Queue_AllNodesOffline(ModelHyperlinkNote.encodeTo(label)));
+            }
+        }
+
     }
 
     /**
@@ -187,5 +197,11 @@ public abstract class CauseOfBlockage {
         public String getShortDescription() {
             return Messages.Queue_WaitingForNextAvailableExecutorOn(label.getName());
         }
+
+        @Override
+        public void print(TaskListener listener) {
+            listener.getLogger().println(Messages.Queue_WaitingForNextAvailableExecutorOn(ModelHyperlinkNote.encodeTo(label)));
+        }
+
     }
 }


### PR DESCRIPTION
Together with https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/134 you can see what it looks like before

![before](https://user-images.githubusercontent.com/154109/78059189-732e8900-7357-11ea-865d-eeae49d41609.png)

vs. after

![after](https://user-images.githubusercontent.com/154109/78059201-788bd380-7357-11ea-9a99-34046bf8fde8.png)

with links to the label index page

![label-index](https://user-images.githubusercontent.com/154109/78059223-7f1a4b00-7357-11ea-86fe-f78257a6a8bd.png)

or via context menu to statistics page

![label-stats](https://user-images.githubusercontent.com/154109/78059246-86415900-7357-11ea-8fc8-d58405d0cddf.png)

Other variants:

![no-nodes](https://user-images.githubusercontent.com/154109/78059264-8ccfd080-7357-11ea-809d-a0bb0ba8a608.png)
![next-avail](https://user-images.githubusercontent.com/154109/78059270-8fcac100-7357-11ea-92a5-455a4aef383a.png)

### Proposed changelog entries

* Allow hyperlinks to be used when displaying causes of blockage related to labels rather than individual nodes.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

