### PR TITLE
Reduce log level on notice about optional extensions

### DIFF
--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -444,12 +444,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                         }
                     }
                     void error(Key<T> key, Throwable x) {
-                        if (verbose) {
-                            LOGGER.log(Level.WARNING, "Failed to instantiate " + key + "; skipping this component", x);
-                        } else {
-                            LOGGER.log(Level.INFO, "Failed to instantiate optional component {0}; skipping", key.getTypeLiteral());
-                            LOGGER.log(Level.FINE, key.toString(), x);
-                        }
+                        LOGGER.log(verbose ? Level.WARNING : Level.FINE, "Failed to instantiate " + key + "; skipping this component", x);
                     }
                 };
             }


### PR DESCRIPTION
Noticed an inconsistency in https://github.com/jenkinsci/kubernetes-credentials-plugin/pull/20. Extends #2305 to better match ec616605d8604a618599b31f55bf4793ceaaa713 which uses `FINE` for optional extensions. If an extension is optional and it is not loaded, that is usually because the required plugin is missing, which is not interesting—do not clutter the log with it.

### Proposed changelog entries

* By default suppress log message about a missing optional extension.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

