### PR TITLE
Backporting for LTS 2.222.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -75,7 +75,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.6</version>
+      <version>1.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
@@ -598,6 +598,11 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
       <optional>true</optional>
     </dependency>
 

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1187,6 +1187,7 @@ public class Functions {
      * degrades gracefully if "it" is not an {@link AccessControlled} object.
      * Otherwise it will perform no check and that problem is hard to notice.
      */
+    @Restricted(NoExternalUse.class)
     public static void checkAnyPermission(Object object, Permission[] permissions) throws IOException, ServletException {
         if (permissions == null || permissions.length == 0) {
             return;

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1182,6 +1182,31 @@ public class Functions {
         ac.checkAnyPermission(permissions);
     }
 
+    /**
+     * This version is so that the 'checkAnyPermission' on {@code layout.jelly}
+     * degrades gracefully if "it" is not an {@link AccessControlled} object.
+     * Otherwise it will perform no check and that problem is hard to notice.
+     */
+    public static void checkAnyPermission(Object object, Permission[] permissions) throws IOException, ServletException {
+        if (permissions == null || permissions.length == 0) {
+            return;
+        }
+
+        if (object instanceof AccessControlled)
+            checkAnyPermission((AccessControlled) object, permissions);
+        else {
+            List<Ancestor> ancs = Stapler.getCurrentRequest().getAncestors();
+            for(Ancestor anc : Iterators.reverse(ancs)) {
+                Object o = anc.getObject();
+                if (o instanceof AccessControlled) {
+                    checkAnyPermission((AccessControlled) o, permissions);
+                    return;
+                }
+            }
+            checkAnyPermission(Jenkins.get(), permissions);
+        }
+    }
+
     private static class Tag implements Comparable<Tag> {
         double ordinal;
         String hierarchy;

--- a/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
+++ b/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
@@ -161,10 +161,15 @@ public class TokenBasedRememberMeServices2 extends TokenBasedRememberMeServices 
 
     @Override
     public Authentication autoLogin(HttpServletRequest request, HttpServletResponse response) {
-        if(Jenkins.get().isDisableRememberMe()){
+        Jenkins j = Jenkins.getInstanceOrNull();
+        if (j == null) {
+            // as this filter could be called during restart, this corrects at least the symptoms
+            return null;
+        }
+        if (j.isDisableRememberMe()) {
             cancelCookie(request, response, null);
             return null;
-        }else {
+        } else {
             try {
                 // we use a patched version of the super.autoLogin
                 String rememberMeValue = findRememberMeCookieValue(request, response);

--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -157,10 +157,12 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
 
             if (toolInstallerList != null) {
                 ToolInstallerEntry[] entryList = toolInstallerList.list;
-                ToolInstallerEntry sampleEntry = entryList[0];
-                if (sampleEntry != null) {
-                    if (sampleEntry.id != null && sampleEntry.name != null && sampleEntry.url != null) {
-                        return true;
+                if (entryList != null) {
+                    ToolInstallerEntry sampleEntry = entryList[0];
+                    if (sampleEntry != null) {
+                        if (sampleEntry.id != null && sampleEntry.name != null && sampleEntry.url != null) {
+                            return true;
+                        }
                     }
                 }
             }

--- a/core/src/main/java/jenkins/model/GlobalBuildDiscarderConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalBuildDiscarderConfiguration.java
@@ -48,6 +48,10 @@ public class GlobalBuildDiscarderConfiguration extends GlobalConfiguration {
         return ExtensionList.lookupSingleton(GlobalBuildDiscarderConfiguration.class);
     }
 
+    public GlobalBuildDiscarderConfiguration() {
+        load();
+    }
+
     private final DescribableList<GlobalBuildDiscarderStrategy, GlobalBuildDiscarderStrategyDescriptor> configuredBuildDiscarders =
             new DescribableList<>(this, Collections.singletonList(new JobGlobalBuildDiscarderStrategy()));
 

--- a/core/src/main/resources/hudson/ProxyConfiguration/config.groovy
+++ b/core/src/main/resources/hudson/ProxyConfiguration/config.groovy
@@ -22,5 +22,5 @@ f.advanced(){
         f.textbox()
     }
     f.validateButton(title:_("Validate Proxy"), 
-                     method:"validateProxy", with:"testUrl,name,port,userName,password,noProxyHost")
+                     method:"validateProxy", with:"testUrl,name,port,userName,secretPassword,noProxyHost")
 }

--- a/test/src/test/java/hudson/security/ACLTest.java
+++ b/test/src/test/java/hudson/security/ACLTest.java
@@ -24,8 +24,10 @@
 
 package hudson.security;
 
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
+import hudson.model.UnprotectedRootAction;
 import hudson.model.User;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,6 +41,9 @@ import org.junit.rules.ExpectedException;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.TestExtension;
+
+import javax.annotation.CheckForNull;
 
 public class ACLTest {
 
@@ -121,6 +126,29 @@ public class ACLTest {
         r.jenkins.getACL().checkAnyPermission();
     }
 
+    @Test
+    @Issue("JENKINS-61465")
+    public void checkAnyPermissionOnNonAccessControlled() throws Exception {
+        expectedException = ExpectedException.none();
+
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ).everywhere().toEveryone());
+
+        JenkinsRule.WebClient wc = r.createWebClient();
+        try {
+            wc.goTo("either");
+            fail();
+        } catch (FailingHttpStatusCodeException ex) {
+            assertEquals(403, ex.getStatusCode());
+        }
+
+        r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER).everywhere().toEveryone());
+
+        wc.goTo("either"); // expected to work
+    }
+
     private static class DoNotBotherMe extends AuthorizationStrategy {
 
         @Override
@@ -138,6 +166,28 @@ public class ACLTest {
             return Collections.emptySet();
         }
 
+    }
+
+    @TestExtension
+    public static class EitherPermission implements UnprotectedRootAction {
+
+        @CheckForNull
+        @Override
+        public String getIconFileName() {
+            return null;
+        }
+
+        @CheckForNull
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+
+        @CheckForNull
+        @Override
+        public String getUrlName() {
+            return "either";
+        }
     }
 
 }

--- a/test/src/test/java/jenkins/model/GlobalBuildDiscarderTest.java
+++ b/test/src/test/java/jenkins/model/GlobalBuildDiscarderTest.java
@@ -5,14 +5,34 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.LogRotator;
+import hudson.util.DescribableList;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 public class GlobalBuildDiscarderTest {
     @Rule
     public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @LocalData
+    @Issue("JENKINS-61688")
+    public void testLoading() throws Exception {
+        Assert.assertEquals(0, GlobalBuildDiscarderConfiguration.get().getConfiguredBuildDiscarders().size());
+    }
+
+    @Test
+    @LocalData
+    @Issue("JENKINS-61688")
+    public void testLoadingWithDiscarders() throws Exception {
+        final DescribableList<GlobalBuildDiscarderStrategy, GlobalBuildDiscarderStrategyDescriptor> configuredBuildDiscarders = GlobalBuildDiscarderConfiguration.get().getConfiguredBuildDiscarders();
+        Assert.assertEquals(2, configuredBuildDiscarders.size());
+        Assert.assertNotNull(configuredBuildDiscarders.get(JobGlobalBuildDiscarderStrategy.class));
+        Assert.assertEquals(5, ((LogRotator)configuredBuildDiscarders.get(SimpleGlobalBuildDiscarderStrategy.class).getDiscarder()).getNumToKeep());
+    }
 
     @Test
     public void testJobBuildDiscarder() throws Exception {

--- a/test/src/test/resources/hudson/security/ACLTest/EitherPermission/index.jelly
+++ b/test/src/test/resources/hudson/security/ACLTest/EitherPermission/index.jelly
@@ -1,0 +1,39 @@
+<!--
+The MIT License
+
+Copyright (c) 2011, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!-- 3rd party license acknowledgements and  -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+<l:layout permissions="${app.MANAGE_AND_SYSTEM_READ}" type="one-column" title="Hello">
+    <l:main-panel>
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-md-24">
+                    <h1>Hello, world!</h1>
+                </div>
+            </div>
+        </div>
+    </l:main-panel>
+</l:layout>
+</j:jelly>

--- a/test/src/test/resources/jenkins/model/GlobalBuildDiscarderTest/testLoading/jenkins.model.GlobalBuildDiscarderConfiguration.xml
+++ b/test/src/test/resources/jenkins/model/GlobalBuildDiscarderTest/testLoading/jenkins.model.GlobalBuildDiscarderConfiguration.xml
@@ -1,0 +1,4 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.model.GlobalBuildDiscarderConfiguration>
+  <configuredBuildDiscarders/>
+</jenkins.model.GlobalBuildDiscarderConfiguration>

--- a/test/src/test/resources/jenkins/model/GlobalBuildDiscarderTest/testLoadingWithDiscarders/jenkins.model.GlobalBuildDiscarderConfiguration.xml
+++ b/test/src/test/resources/jenkins/model/GlobalBuildDiscarderTest/testLoadingWithDiscarders/jenkins.model.GlobalBuildDiscarderConfiguration.xml
@@ -1,0 +1,14 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.model.GlobalBuildDiscarderConfiguration>
+  <configuredBuildDiscarders>
+    <jenkins.model.JobGlobalBuildDiscarderStrategy/>
+    <jenkins.model.SimpleGlobalBuildDiscarderStrategy>
+      <discarder class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>5</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </discarder>
+    </jenkins.model.SimpleGlobalBuildDiscarderStrategy>
+  </configuredBuildDiscarders>
+</jenkins.model.GlobalBuildDiscarderConfiguration>


### PR DESCRIPTION
Backporting has started and the RC is scheduled for 2020-04-08.

This is for the first time we do backporting review in github, partially to see how practical it will be. We are expected to learn and reflect back on the process as we go.

Please have look at the change proposed and rejected so we have a consensus of what goes in by 2020-04-08.

---

- Initially, I propose to backport:

```
JENKINS-61692		Minor     		2.229
	"HTTP Proxy Configuration" -> "Validate Proxy" crashs immediately with NullPointerException
	regression
	https://issues.jenkins-ci.org/browse/JENKINS-61692

JENKINS-61688		Critical  		2.229
	Global build discarders configuration isn't loaded from disk
	https://issues.jenkins-ci.org/browse/JENKINS-61688

JENKINS-61465		Major     		2.226
	Make Functions#checkAnyPermission work on objects that aren't AccessControlled
	https://issues.jenkins-ci.org/browse/JENKINS-61465

JENKINS-60788		Minor     		2.224
	NullPointerException when hitting Check Now against a custom update center
	https://issues.jenkins-ci.org/browse/JENKINS-60788

JENKINS-60454		Major     		2.223
	Jenkins.instance is missing after restart
	https://issues.jenkins-ci.org/browse/JENKINS-60454
```

- What remains to be discussed is the troika of issues introducing and fixing the read only config page. It looks somewhat safe, but given that is a minor improvement that has caused a critical regression, I prefer not to backport JENKINS-61202 and giving it more soak time to 2.222.3.
```
JENKINS-61202		Minor     		2.223
	Read only view of job configuration page
	https://issues.jenkins-ci.org/browse/JENKINS-61202
		Caused https://issues.jenkins-ci.org/browse/JENKINS-61321
		Caused https://issues.jenkins-ci.org/browse/JENKINS-61284

JENKINS-61321		Blocker   		2.224
	Pipeline Job configuration appears read-only for users with project-level permissions after update to Jenkins 2.223
	regression
	https://issues.jenkins-ci.org/browse/JENKINS-61321

JENKINS-61284		Minor     		2.224
	Grey bar below textarea in read only mode looks weird
	https://issues.jenkins-ci.org/browse/JENKINS-61284
```

- [JENKINS-61279: Update version number dependency to 1.7](https://issues.jenkins-ci.org/browse/JENKINS-61279) is being discussed in the issue as something potentially too minor to backport.
	