### PR TITLE
An agent log record with numeric params could be unformattable on the master

### DIFF
--- a/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
+++ b/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import java.util.logging.SimpleFormatter;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
@@ -93,8 +94,10 @@ public class LogRecorderManagerTest {
         assertFalse(ch.call(new Log(Level.FINER, "ns3", "not displayed")));
         assertTrue(ch.call(new Log(Level.INFO, "ns4", "msg #4")));
         assertFalse(ch.call(new Log(Level.FINE, "ns4", "not displayed")));
+        assertTrue(ch.call(new Log(Level.INFO, "other", "msg #5 {0,number,0.0} {1,number,0.0} ''OK?''", new Object[] {1.0, 2.0})));
         List<LogRecord> recs = c.getLogRecords();
-        assertEquals(show(recs), 4, recs.size());
+        assertEquals(show(recs), 5, recs.size());
+        assertEquals("msg #5 1.0 2.0 'OK?'", new SimpleFormatter().formatMessage(recs.get(0)));
         recs = r1.getSlaveLogRecords().get(c);
         assertNotNull(recs);
         assertEquals(show(recs), 2, recs.size());
@@ -113,14 +116,23 @@ public class LogRecorderManagerTest {
         private final Level level;
         private final String logger;
         private final String message;
+        private final Object[] params;
         Log(Level level, String logger, String message) {
+            this(level, logger, message, null);
+        }
+        Log(Level level, String logger, String message, Object[] params) {
             this.level = level;
             this.logger = logger;
             this.message = message;
+            this.params = params;
         }
         @Override public Boolean call() throws Error {
             Logger log = Logger.getLogger(logger);
-            log.log(level, message);
+            if (params != null) {
+                log.log(level, message, params);
+            } else {
+                log.log(level, message);
+            }
             return log.isLoggable(level);
         }
     }


### PR DESCRIPTION
Noticed in a support bundle an agent log (`nodes/slave/…/jenkins.log`) with

```
…	WARNING	h.r.RemoteInvocationHandler$Unexporter#reportStats: The 15 minute average rate is {0,number,0.0}±{1,number,0.0}/sec. At the 95% confidence level this is above 100.0/sec. If this message is repeated often in the logs then very seriously consider setting system property ''hudson.remoting.RemoteInvocationHandler.Unexporter.retainOrigin'' to ''false'' to trade debug diagnostics for reduced memory pressure.
```

This is from https://github.com/jenkinsci/remoting/blob/a09a8dd40e3269f578a503cee26b859e522ea6e2/src/main/java/hudson/remoting/RemoteInvocationHandler.java#L734-L745 but note the missing actual numbers (and `''` where `'` was meant). The reason is because of https://github.com/openjdk/jdk/blob/6bab0f539fba8fb441697846347597b4a0ade428/src/java.logging/share/classes/java/util/logging/LogRecord.java#L561-L565 plus https://github.com/openjdk/jdk/blob/6bab0f539fba8fb441697846347597b4a0ade428/src/java.logging/share/classes/java/util/logging/Formatter.java#L146-L148.

We _could_ format every log record with parameters, which would be useful for code in the agent JVM doing something like

```java
LOGGER.log(Level.INFO, "ran at {0} producing {1}", new Object[] {new Date(), someMutableObject});
```

but I went for the more conservative fix here.

### Proposed changelog entries

* Ensure that log messages are not missing numeric parameters when log entries are created on an agent. In particular, fix logs collected by the Support Core plugin

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

