### PR TITLE
[JENKINS-60866] Un-inline JavaScript from ReverseProxySetupMonitor

### DIFF
--- a/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
@@ -24,10 +24,13 @@
 package hudson.diagnosis;
 
 import hudson.Extension;
+import hudson.RestrictedSince;
 import hudson.Util;
 import hudson.model.AdministrativeMonitor;
 import jenkins.security.stapler.StaplerDispatchable;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
@@ -37,7 +40,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
@@ -62,15 +65,31 @@ public class ReverseProxySetupMonitor extends AdministrativeMonitor {
         return true;
     }
 
-    public HttpResponse doTest() {
-        String referer = Stapler.getCurrentRequest().getReferer();
+    @Restricted(DoNotUse.class) // WebOnly
+    @RestrictedSince("TODO since")
+    public HttpResponse doTest(StaplerRequest request, @QueryParameter boolean testWithContext) {
+        String referer = request.getReferer();
         Jenkins j = Jenkins.get();
+        String redirect;
         // May need to send an absolute URL, since handling of HttpRedirect with a relative URL does not currently honor X-Forwarded-Proto/Port at all.
-        String redirect = j.getRootUrl() + "administrativeMonitor/" + id + "/testForReverseProxySetup/" + (referer != null ? Util.rawEncode(referer) : "NO-REFERER") + "/";
+        if (testWithContext) {
+            // Some of the possible values: "/jenkins" or ""
+            String contextPath = request.getServletContext().getContextPath();
+            if (contextPath.startsWith("/")) {
+                // getRootUrl's contract is to end with /, we need to ensure the contextPath is not starting with one
+                // and as only the empty string does not contain a leading slash, we have to also add one at the end
+                contextPath = contextPath.substring(1) + "/";
+            }
+            redirect = j.getRootUrl() + contextPath + "administrativeMonitor/" + id + "/testForReverseProxySetup/" + (referer != null ? Util.rawEncode(referer) : "NO-REFERER") + "/";
+        } else {
+            redirect = j.getRootUrl() + "administrativeMonitor/" + id + "/testForReverseProxySetup/" + (referer != null ? Util.rawEncode(referer) : "NO-REFERER") + "/";
+        }
         LOGGER.log(Level.FINE, "coming from {0} and redirecting to {1}", new Object[] {referer, redirect});
         return new HttpRedirect(redirect);
     }
 
+    @Restricted(DoNotUse.class) // WebOnly
+    @RestrictedSince("TODO since")
     @StaplerDispatchable
     public void getTestForReverseProxySetup(String rest) {
         Jenkins j = Jenkins.get();
@@ -87,6 +106,8 @@ public class ReverseProxySetupMonitor extends AdministrativeMonitor {
     /**
      * Depending on whether the user said "yes" or "no", send him to the right place.
      */
+    @Restricted(DoNotUse.class) // WebOnly
+    @RestrictedSince("TODO since")
     @RequirePOST
     public HttpResponse doAct(@QueryParameter String no) throws IOException {
         if(no!=null) { // dismiss

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -21,28 +21,16 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <script>
-    var checkAjax=new Ajax.Request('${rootURL}/${it.url}/test', {
-        onComplete : function(transport) {
-          if (transport.status != 200) {
-          
-            
-            // redirect failed. Unfortunately, according to the spec http://www.w3.org/TR/XMLHttpRequest/
-            // in case of error, we can either get 0 or a failure code
-            $$('redirect-error').style.display = "block";
-          }
-        }
-      }
-    );
-  </script>
-  <div id="redirect-error" class="alert alert-danger" style="display:none">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <div id="redirect-error" class="alert alert-danger" style="display:none" 
+       data-url="${rootURL}/${it.url}/test" data-context="${rootURL}">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%More Info}"/>
       <f:submit name="no" value="${%Dismiss}"/>
     </form>
-    ${%blurb}
+    <div>${%blurb}</div>
+    <div class="context-message" style="display:none"> ${%missingContextMessage(rootURL)}</div>
   </div>
+  <st:adjunct includes="hudson.diagnosis.ReverseProxySetupMonitor.resources"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -23,14 +23,14 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-  <div id="redirect-error" class="alert alert-danger" style="display:none" 
+  <div id="redirect-error" class="alert alert-danger reverse-proxy__hidden"
        data-url="${rootURL}/${it.url}/test" data-context="${rootURL}">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%More Info}"/>
       <f:submit name="no" value="${%Dismiss}"/>
     </form>
     <div>${%blurb}</div>
-    <div class="context-message" style="display:none"> ${%missingContextMessage(rootURL)}</div>
+    <div class="context-message reverse-proxy__hidden">${%missingContextMessage(rootURL)}</div>
   </div>
   <st:adjunct includes="hudson.diagnosis.ReverseProxySetupMonitor.resources"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
       <f:submit name="no" value="${%Dismiss}"/>
     </form>
     <div>${%blurb}</div>
-    <div class="context-message reverse-proxy__hidden">${%missingContextMessage(rootURL)}</div>
+    <div class="js-context-message reverse-proxy__hidden">${%missingContextMessage(rootURL)}</div>
   </div>
   <st:adjunct includes="hudson.diagnosis.ReverseProxySetupMonitor.resources"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.properties
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.properties
@@ -1,1 +1,2 @@
 blurb=It appears that your reverse proxy set up is broken.
+missingContextMessage=Your configured root URL does not contain the contextPath ("{0}").

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message_fr.properties
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message_fr.properties
@@ -23,3 +23,4 @@
 Dismiss=Annuler
 More\ Info=Plus d\u2019informations
 blurb=La configuration de votre proxy inverse est incorrecte.
+missingContextMessage=L\u2019URL de votre instance ne semble pas comporter le chemin de contexte ("{0}").

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.css
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.css
@@ -1,0 +1,3 @@
+.reverse-proxy__hidden { 
+	display: none;
+}

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
@@ -16,17 +16,19 @@
 								if (response.status === 200) {
 									// this means the root URL was configured but without the contextPath, 
 									// so different message to display
-									redirectForm.style.display = "block";
-									redirectForm.querySelectorAll('.context-message').forEach(node => node.style.display = "block");
+									redirectForm.classList.remove('reverse-proxy__hidden');
+									redirectForm.querySelectorAll('.context-message').forEach(node => 
+										node.classList.remove('reverse-proxy__hidden')
+									);
 								} else {
-									redirectForm.style.display = "block";
+									redirectForm.classList.remove('reverse-proxy__hidden');
 								}
 							}
 						});
 					} else {
 						// redirect failed. Unfortunately, according to the spec http://www.w3.org/TR/XMLHttpRequest/
 						// in case of error, we can either get 0 or a failure code
-						redirectForm.style.display = "block";
+						redirectForm.classList.remove('reverse-proxy__hidden');
 					}
 				}
 			}

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
@@ -19,9 +19,9 @@
 	var displayWarningMessage = function(withContextMessage) {
 		redirectForm.classList.remove('reverse-proxy__hidden');
 		if (withContextMessage === true) {
-			redirectForm.querySelectorAll('.js-context-message').forEach(node =>
-				node.classList.remove('reverse-proxy__hidden')
-			);
+			redirectForm.querySelectorAll('.js-context-message').forEach(function (node) {
+				return node.classList.remove('reverse-proxy__hidden');
+			});
 		}
 	};
 

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
@@ -1,37 +1,49 @@
-(() => {
+(function () {
 	var redirectForm = document.getElementById('redirect-error');
 	if (!redirectForm) {
 		console.warn('This script expects to have an element with id="redirect-error" to be working.');
-	} else {
-		var urlToTest = redirectForm.getAttribute('data-url');
-		new Ajax.Request(urlToTest, {
-			onComplete : function(response) {
-				if (response.status !== 200) {
-					var context = redirectForm.getAttribute('data-context');
-					// to cover the case where the JenkinsRootUrl is configured without the context
-					if (context) {
-						new Ajax.Request(urlToTest, {
-							parameters: { testWithContext:true },
-							onComplete: function (response) {
-								if (response.status === 200) {
-									// this means the root URL was configured but without the contextPath, 
-									// so different message to display
-									redirectForm.classList.remove('reverse-proxy__hidden');
-									redirectForm.querySelectorAll('.context-message').forEach(node => 
-										node.classList.remove('reverse-proxy__hidden')
-									);
-								} else {
-									redirectForm.classList.remove('reverse-proxy__hidden');
-								}
-							}
-						});
-					} else {
-						// redirect failed. Unfortunately, according to the spec http://www.w3.org/TR/XMLHttpRequest/
-						// in case of error, we can either get 0 or a failure code
-						redirectForm.classList.remove('reverse-proxy__hidden');
-					}
-				}
-			}
-		});
+		return;
 	}
+
+	var urlToTest = redirectForm.getAttribute('data-url');
+	var callUrlToTest = function(testWithContext, callback) {
+		var options = {
+			onComplete: callback
+		};
+		if (testWithContext === true) {
+			options.parameters = { testWithContext: true };
+		}
+		new Ajax.Request(urlToTest, options);
+	};
+	
+	var displayWarningMessage = function(withContextMessage) {
+		redirectForm.classList.remove('reverse-proxy__hidden');
+		if (withContextMessage === true) {
+			redirectForm.querySelectorAll('.context-message').forEach(node =>
+				node.classList.remove('reverse-proxy__hidden')
+			);
+		}
+	};
+
+	callUrlToTest( false, function(response) {
+		if (response.status !== 200) {
+			var context = redirectForm.getAttribute('data-context');
+			// to cover the case where the JenkinsRootUrl is configured without the context
+			if (context) {
+				callUrlToTest(true, function(response2) {
+					if (response2.status === 200) {
+						// this means the root URL was configured but without the contextPath, 
+						// so different message to display
+						displayWarningMessage(true);
+					} else {
+						displayWarningMessage(false);
+					}
+				});
+			} else {
+				// redirect failed. Unfortunately, according to the spec http://www.w3.org/TR/XMLHttpRequest/
+				// in case of error, we can either get 0 or a failure code
+				displayWarningMessage(false);
+			}
+		}
+	});
 })();

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
@@ -1,0 +1,35 @@
+(() => {
+	var redirectForm = document.getElementById('redirect-error');
+	if (!redirectForm) {
+		console.warn('This script expects to have an element with id="redirect-error" to be working.');
+	} else {
+		var urlToTest = redirectForm.getAttribute('data-url');
+		new Ajax.Request(urlToTest, {
+			onComplete : function(response) {
+				if (response.status !== 200) {
+					var context = redirectForm.getAttribute('data-context');
+					// to cover the case where the JenkinsRootUrl is configured without the context
+					if (context) {
+						new Ajax.Request(urlToTest, {
+							parameters: { testWithContext:true },
+							onComplete: function (response) {
+								if (response.status === 200) {
+									// this means the root URL was configured but without the contextPath, 
+									// so different message to display
+									redirectForm.style.display = "block";
+									redirectForm.querySelectorAll('.context-message').forEach(node => node.style.display = "block");
+								} else {
+									redirectForm.style.display = "block";
+								}
+							}
+						});
+					} else {
+						// redirect failed. Unfortunately, according to the spec http://www.w3.org/TR/XMLHttpRequest/
+						// in case of error, we can either get 0 or a failure code
+						redirectForm.style.display = "block";
+					}
+				}
+			}
+		});
+	}
+})();

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
@@ -19,7 +19,7 @@
 	var displayWarningMessage = function(withContextMessage) {
 		redirectForm.classList.remove('reverse-proxy__hidden');
 		if (withContextMessage === true) {
-			redirectForm.querySelectorAll('.context-message').forEach(node =>
+			redirectForm.querySelectorAll('.js-context-message').forEach(node =>
 				node.classList.remove('reverse-proxy__hidden')
 			);
 		}


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-60866](https://issues.jenkins-ci.org/browse/JENKINS-60866).

As I was playing with the rootURL and the reverse proxy monitor, I fall into a situation where my root URL does not contain the contextPath (manually set) and thus it told me that the configuration is not good. So I added a logic for adding a warning message when such situation occurs.

The existing test was not really testing stuff, so I added several ones.

At the same time, I did some cleanup. If some of the changes do not satisfy you, we can keep only the un-inlining of JavaScript.
I quickly look for potential usage of the doTest method, and found nothing. So this breaking change should not have any impact. _(it's especially a bad idea to call programmatically a web method, but anyway)_

<details>

<summary>Screenshot of the additional warning message</summary>

![Screenshot-2020-04-05_12-54-02](https://user-images.githubusercontent.com/2662497/78473702-fdedfa00-7742-11ea-8643-b213f4347cde.png)

</details>

💡 If you have a typo fix, or unquestionable change, please suggest+commit directly ;)

### Proposed changelog entries

* (internal) Remove inline resources from ReverseProxySetupMonitor view
* Add a specific warning when the Jenkins Root URL does not contain the contextPath.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

