### PR TITLE
[JENKINS-61808] Always transmit f:password values as Secret

### DIFF
--- a/core/src/main/java/hudson/model/PasswordParameterDefinition.java
+++ b/core/src/main/java/hudson/model/PasswordParameterDefinition.java
@@ -46,10 +46,16 @@ public class PasswordParameterDefinition extends SimpleParameterDefinition {
 
     private Secret defaultValue;
 
-    @DataBoundConstructor
+    @Deprecated
     public PasswordParameterDefinition(String name, String defaultValue, String description) {
         super(name, description);
         this.defaultValue = Secret.fromString(defaultValue);
+    }
+
+    @DataBoundConstructor
+    public PasswordParameterDefinition(String name, Secret defaultValueAsSecret, String description) {
+        super(name, description);
+        this.defaultValue = defaultValueAsSecret;
     }
 
     @Override

--- a/core/src/main/java/hudson/model/PasswordParameterValue.java
+++ b/core/src/main/java/hudson/model/PasswordParameterValue.java
@@ -44,10 +44,16 @@ public class PasswordParameterValue extends ParameterValue {
         this(name, value, null);
     }
 
-    @DataBoundConstructor
+    @Deprecated
     public PasswordParameterValue(String name, String value, String description) {
         super(name, description);
         this.value = Secret.fromString(value);
+    }
+
+    @DataBoundConstructor
+    public PasswordParameterValue(String name, Secret value, String description) {
+        super(name, description);
+        this.value = value;
     }
 
     @Override

--- a/core/src/main/java/hudson/util/Secret.java
+++ b/core/src/main/java/hudson/util/Secret.java
@@ -301,6 +301,12 @@ public final class Secret implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    @Restricted(NoExternalUse.class)
+    public static final boolean AUTO_ENCRYPT_PASSWORD_CONTROL = SystemProperties.getBoolean(Secret.class.getName() + ".AUTO_ENCRYPT_PASSWORD_CONTROL", true);
+
+    @Restricted(NoExternalUse.class)
+    public static /* non-final */ boolean BLANK_NONSECRET_PASSWORD_FIELDS_WITHOUT_ITEM_CONFIGURE = SystemProperties.getBoolean(Secret.class.getName() + ".BLANK_NONSECRET_PASSWORD_FIELDS_WITHOUT_ITEM_CONFIGURE", true);
+
     static {
         Stapler.CONVERT_UTILS.register(new org.apache.commons.beanutils.Converter() {
             public Secret convert(Class type, Object value) {
@@ -310,9 +316,23 @@ public final class Secret implements Serializable {
                 if (value instanceof Secret) {
                     return (Secret) value;
                 }
-
                 return Secret.fromString(value.toString());
             }
         }, Secret.class);
+        if (AUTO_ENCRYPT_PASSWORD_CONTROL) {
+            Stapler.CONVERT_UTILS.register(new org.apache.commons.beanutils.Converter() {
+                public String convert(Class type, Object value) {
+                    if (value == null) {
+                        return null;
+                    }
+                    Secret decrypted = Secret.decrypt(value.toString());
+                    if (decrypted == null) {
+                        return value.toString();
+                    } else {
+                        return decrypted.getPlainText();
+                    }
+                }
+            }, String.class);
+        }
     }
 }

--- a/core/src/main/resources/hudson/model/PasswordParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/PasswordParameterDefinition/config.jelly
@@ -29,8 +29,8 @@ THE SOFTWARE.
     <f:entry title="${%Name}" help="/help/parameter/name.html">
 		<f:textbox name="parameter.name" value="${instance.name}" />
 	</f:entry>
-	<f:entry title="${%Default Value}" help="/help/parameter/string-default.html">
-		<f:password name="parameter.defaultValue" value="${instance.defaultValueAsSecret}" />
+	<f:entry field="defaultValueAsSecret" title="${%Default Value}" help="/help/parameter/string-default.html">
+		<f:password />
 	</f:entry>
     <f:entry title="${%Description}" help="/help/parameter/description.html">
         <f:textarea name="parameter.description" value="${instance.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription" />

--- a/core/src/main/resources/hudson/model/PasswordParameterValue/value.jelly
+++ b/core/src/main/resources/hudson/model/PasswordParameterValue/value.jelly
@@ -26,8 +26,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-        <j:set var="escapeEntryTitleAndDescription" value="false"/>
-        <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
-		<f:password name="value" value="********" readonly="true" />
+	<j:set var="escapeEntryTitleAndDescription" value="false"/>
+	<j:set var="readOnlyMode" value="true"/>
+	<f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
+		<em>${%hidden}</em>
 	</f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/PasswordParameterValue/value.properties
+++ b/core/src/main/resources/hudson/model/PasswordParameterValue/value.properties
@@ -1,0 +1,1 @@
+hidden=(password value not shown)

--- a/test/src/test/java/lib/form/PasswordTest.java
+++ b/test/src/test/java/lib/form/PasswordTest.java
@@ -24,23 +24,35 @@
 package lib.form;
 
 import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlHiddenInput;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import hudson.FilePath;
+import hudson.Launcher;
 import hudson.cli.CopyJobCommand;
 import hudson.cli.GetJobCommand;
 import hudson.model.*;
+import hudson.tasks.BuildStep;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
+import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
+import jenkins.model.TransientActionFactory;
 import jenkins.security.apitoken.ApiTokenTestHelper;
+import jenkins.tasks.SimpleBuildStep;
 import org.acegisecurity.Authentication;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -54,9 +66,13 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 public class PasswordTest {
 
@@ -223,4 +239,441 @@ public class PasswordTest {
         }
     }
 
+    @Test
+    public void testBackgroundSecretConversion() throws Exception {
+        final JenkinsRule.WebClient wc = j.createWebClient();
+        j.configRoundtrip();
+        // empty default values
+        assertEquals("", PasswordHolderConfiguration.getInstance().secretWithSecretGetterAndSetter.getPlainText());
+        assertEquals("", PasswordHolderConfiguration.getInstance().secretWithStringGetterAndSetter.getPlainText());
+        assertEquals("", PasswordHolderConfiguration.getInstance().stringWithSecretGetterAndSetter);
+        assertEquals("", PasswordHolderConfiguration.getInstance().stringWithStringGetterAndSetter);
+
+        // set some values and expect them to remain after round-trip
+        final Secret secretWithSecretGetterAndSetter = Secret.fromString("secretWithSecretGetterAndSetter");
+        secretWithSecretGetterAndSetter.getEncryptedValue(); // ensure IV is set so the encrypted value is stable
+        PasswordHolderConfiguration.getInstance().secretWithSecretGetterAndSetter = secretWithSecretGetterAndSetter;
+
+        final Secret secretWithStringGetterAndSetter = Secret.fromString("secretWithStringGetterAndSetter");
+        secretWithStringGetterAndSetter.getEncryptedValue(); // ensure IV is set so the encrypted value is stable
+        PasswordHolderConfiguration.getInstance().secretWithStringGetterAndSetter = secretWithStringGetterAndSetter;
+
+        PasswordHolderConfiguration.getInstance().stringWithSecretGetterAndSetter = "stringWithSecretGetterAndSetter";
+        PasswordHolderConfiguration.getInstance().stringWithStringGetterAndSetter = "stringWithStringGetterAndSetter";
+
+
+        final HtmlPage configPage = wc.goTo("configure");
+        for (DomElement element : configPage.getElementsByTagName("input")) {
+            if ("hidden".equals(element.getAttribute("type")) && element.getAttribute("class").contains("complex-password-field")) {
+                final HtmlHiddenInput input = (HtmlHiddenInput) element;
+                // assert that all password fields contain encrypted values after we set plain values
+                assertTrue(input.getValueAttribute().startsWith("{"));
+                assertTrue(input.getValueAttribute().endsWith("}"));
+            }
+        }
+
+        j.configRoundtrip();
+
+        // confirm round-trip did not change effective values
+        assertEquals("secretWithSecretGetterAndSetter", PasswordHolderConfiguration.getInstance().secretWithSecretGetterAndSetter.getPlainText());
+        assertEquals("secretWithStringGetterAndSetter", PasswordHolderConfiguration.getInstance().secretWithStringGetterAndSetter.getPlainText());
+        assertEquals("stringWithSecretGetterAndSetter", PasswordHolderConfiguration.getInstance().stringWithSecretGetterAndSetter);
+        assertEquals("stringWithStringGetterAndSetter", PasswordHolderConfiguration.getInstance().stringWithStringGetterAndSetter);
+
+        assertEquals(secretWithSecretGetterAndSetter.getEncryptedValue(), PasswordHolderConfiguration.getInstance().secretWithSecretGetterAndSetter.getEncryptedValue());
+
+        // The following is because the serialized "Secret" value in the form gets decrypted, losing IV, to be passed as String into the setter, to be converted to Secret, getting new IV in #getEncryptedValue call.
+        assertNotEquals(secretWithStringGetterAndSetter.getEncryptedValue(), PasswordHolderConfiguration.getInstance().secretWithStringGetterAndSetter.getEncryptedValue());
+    }
+
+    @TestExtension
+    public static class PasswordHolderConfiguration extends GlobalConfiguration {
+        private Secret secretWithStringGetterAndSetter; // the badly implemented secret migration
+        private Secret secretWithSecretGetterAndSetter; // the old, good case
+        private String stringWithStringGetterAndSetter; // the trivially wrong case
+        private String stringWithSecretGetterAndSetter;
+
+        public String getSecretWithStringGetterAndSetter() {
+            return secretWithStringGetterAndSetter == null ? null : secretWithStringGetterAndSetter.getPlainText();
+        }
+
+        public void setSecretWithStringGetterAndSetter(String secretWithStringGetterAndSetter) {
+            this.secretWithStringGetterAndSetter = Secret.fromString(secretWithStringGetterAndSetter);
+        }
+
+        public Secret getSecretWithSecretGetterAndSetter() {
+            return secretWithSecretGetterAndSetter;
+        }
+
+        public void setSecretWithSecretGetterAndSetter(Secret secretWithSecretGetterAndSetter) {
+            this.secretWithSecretGetterAndSetter = secretWithSecretGetterAndSetter;
+        }
+
+        public String getStringWithStringGetterAndSetter() {
+            return stringWithStringGetterAndSetter;
+        }
+
+        public void setStringWithStringGetterAndSetter(String stringWithStringGetterAndSetter) {
+            this.stringWithStringGetterAndSetter = stringWithStringGetterAndSetter;
+        }
+
+        public Secret getStringWithSecretGetterAndSetter() {
+            return Secret.fromString(stringWithSecretGetterAndSetter);
+        }
+
+        public void setStringWithSecretGetterAndSetter(Secret stringWithSecretGetterAndSetter) {
+            this.stringWithSecretGetterAndSetter = stringWithSecretGetterAndSetter == null? null : stringWithSecretGetterAndSetter.getPlainText();
+        }
+
+        public static PasswordHolderConfiguration getInstance() {
+            return GlobalConfiguration.all().getInstance(PasswordHolderConfiguration.class);
+        }
+    }
+
+    @Test
+    public void testBuildStep() throws Exception {
+        final FreeStyleProject project = j.createFreeStyleProject();
+        project.getBuildersList().add(new PasswordHolderBuildStep());
+        project.save();
+        assertEquals(1, project.getBuilders().size());
+        j.configRoundtrip(project);
+
+        // empty default values after initial form submission
+        PasswordHolderBuildStep buildStep = (PasswordHolderBuildStep) project.getBuildersList().get(0);
+        assertNotNull(buildStep);
+        assertEquals("", buildStep.secretWithSecretGetterSecretSetter.getPlainText());
+        assertEquals("", buildStep.secretWithSecretGetterStringSetter.getPlainText());
+        assertEquals("", buildStep.secretWithStringGetterSecretSetter.getPlainText());
+        assertEquals("", buildStep.secretWithStringGetterStringSetter.getPlainText());
+        assertEquals("", buildStep.stringWithSecretGetterSecretSetter);
+        assertEquals("", buildStep.stringWithSecretGetterStringSetter);
+        assertEquals("", buildStep.stringWithStringGetterSecretSetter);
+        assertEquals("", buildStep.stringWithStringGetterStringSetter);
+
+        buildStep = (PasswordHolderBuildStep) project.getBuildersList().get(0);
+        assertNotNull(buildStep);
+
+
+        // set some values and expect them to remain after round-trip
+        final Secret secretWithSecretGetterSecretSetter = Secret.fromString("secretWithSecretGetterSecretSetter");
+        secretWithSecretGetterSecretSetter.getEncryptedValue(); // ensure IV is set so the encrypted value is stable
+        buildStep.secretWithSecretGetterSecretSetter = secretWithSecretGetterSecretSetter;
+
+        final Secret secretWithStringGetterStringSetter = Secret.fromString("secretWithStringGetterStringSetter");
+        secretWithStringGetterStringSetter.getEncryptedValue(); // ensure IV is set so the encrypted value is stable
+        buildStep.secretWithStringGetterStringSetter = secretWithStringGetterStringSetter;
+
+        final Secret secretWithStringGetterSecretSetter = Secret.fromString("secretWithStringGetterSecretSetter");
+        secretWithStringGetterSecretSetter.getEncryptedValue(); // ensure IV is set so the encrypted value is stable
+        buildStep.secretWithStringGetterSecretSetter = secretWithStringGetterSecretSetter;
+
+        final Secret secretWithSecretGetterStringSetter = Secret.fromString("secretWithSecretGetterStringSetter");
+        secretWithSecretGetterStringSetter.getEncryptedValue(); // ensure IV is set so the encrypted value is stable
+        buildStep.secretWithSecretGetterStringSetter = secretWithSecretGetterStringSetter;
+
+        buildStep.stringWithSecretGetterSecretSetter = "stringWithSecretGetterSecretSetter";
+        buildStep.stringWithStringGetterStringSetter = "stringWithStringGetterStringSetter";
+        buildStep.stringWithStringGetterSecretSetter = "stringWithStringGetterSecretSetter";
+        buildStep.stringWithSecretGetterStringSetter = "stringWithSecretGetterStringSetter";
+
+        project.save();
+
+        final HtmlPage configPage = j.createWebClient().goTo(project.getUrl() + "/configure");
+        int i = 0;
+        for (DomElement element : configPage.getElementsByTagName("input")) {
+            if ("hidden".equals(element.getAttribute("type")) && element.getAttribute("class").contains("complex-password-field")) {
+                final HtmlHiddenInput input = (HtmlHiddenInput) element;
+                // assert that all password fields contain encrypted values after we set plain values
+                assertTrue(input.getValueAttribute().startsWith("{"));
+                assertTrue(input.getValueAttribute().endsWith("}"));
+                i++;
+            }
+        }
+        assertTrue(i >= 8); // at least 8 password fields expected on that job config form
+
+        j.configRoundtrip(project);
+        buildStep = (PasswordHolderBuildStep) project.getBuildersList().get(0);
+
+        // confirm round-trip did not change effective values
+        assertEquals("secretWithSecretGetterSecretSetter", buildStep.secretWithSecretGetterSecretSetter.getPlainText());
+        assertEquals("secretWithStringGetterStringSetter", buildStep.secretWithStringGetterStringSetter.getPlainText());
+        assertEquals("secretWithStringGetterSecretSetter", buildStep.secretWithStringGetterSecretSetter.getPlainText());
+        assertEquals("secretWithSecretGetterStringSetter", buildStep.secretWithSecretGetterStringSetter.getPlainText());
+
+        assertEquals("stringWithSecretGetterSecretSetter", buildStep.stringWithSecretGetterSecretSetter);
+        assertEquals("stringWithStringGetterStringSetter", buildStep.stringWithStringGetterStringSetter);
+        assertEquals("stringWithStringGetterSecretSetter", buildStep.stringWithStringGetterSecretSetter);
+        assertEquals("stringWithSecretGetterStringSetter", buildStep.stringWithSecretGetterStringSetter);
+
+        // confirm the Secret getter/setter will not change encrypted value (keeps IV)
+        assertEquals(secretWithSecretGetterSecretSetter.getEncryptedValue(), buildStep.secretWithSecretGetterSecretSetter.getEncryptedValue());
+
+        // This depends on implementation; if the Getter returns the plain text (to be re-encrypted by Functions#getPasswordValue), then this won't work, but if they getter returns #getEncrytedValue (as implemented in the build step here), it does
+        // While clever, would recommend fixing mismatched getters/setters here
+        assertEquals(secretWithStringGetterSecretSetter.getEncryptedValue(), buildStep.secretWithStringGetterSecretSetter.getEncryptedValue());
+
+        // This isn't equal because we expect that the code cannot handle an encrypted secret value passed to the setter, so we decrypt it
+        assertNotEquals(secretWithStringGetterStringSetter.getEncryptedValue(), buildStep.secretWithStringGetterStringSetter.getEncryptedValue());
+    }
+
+    public static class PasswordHolderBuildStep extends Builder implements SimpleBuildStep {
+
+        // There are actually more cases than this, but between this and testStringlyTypedSecrets we should be covering everything sufficiently:
+        // Storage permutations:
+        // - Secret
+        // - plain string
+        // - encrypted string
+        // Getter permutations:
+        // - Secret
+        // - plain string
+        // - encrypted string
+        // Setter permutations:
+        // - Secret
+        // - String that can handle encrypted values
+        // - String that cannot handle encrypted values
+        //
+        // These last two aren't really all that different, since we decrypt encrypted Strings now.
+        private Secret secretWithStringGetterStringSetter; // the badly implemented secret migration
+        private Secret secretWithSecretGetterStringSetter;
+        private Secret secretWithStringGetterSecretSetter;
+        private Secret secretWithSecretGetterSecretSetter; // the old, good case
+        private String stringWithStringGetterStringSetter; // the trivially wrong case
+        private String stringWithSecretGetterStringSetter;
+        private String stringWithStringGetterSecretSetter;
+        private String stringWithSecretGetterSecretSetter;
+
+        @DataBoundConstructor
+        public PasswordHolderBuildStep() {
+            // data binding
+        }
+
+        public String getSecretWithStringGetterStringSetter() {
+            return secretWithStringGetterStringSetter == null ? null : secretWithStringGetterStringSetter.getEncryptedValue(); // model half-assed migration from String to Secret
+        }
+
+        @DataBoundSetter
+        public void setSecretWithStringGetterStringSetter(String secretWithStringGetterStringSetter) {
+            this.secretWithStringGetterStringSetter = Secret.fromString(secretWithStringGetterStringSetter);
+        }
+
+        public Secret getSecretWithSecretGetterStringSetter() {
+            return secretWithSecretGetterStringSetter;
+        }
+
+        @DataBoundSetter
+        public void setSecretWithSecretGetterStringSetter(String secretWithSecretGetterStringSetter) {
+            this.secretWithSecretGetterStringSetter = Secret.fromString(secretWithSecretGetterStringSetter);
+        }
+
+        public String getSecretWithStringGetterSecretSetter() {
+            return secretWithStringGetterSecretSetter == null ? null : secretWithStringGetterSecretSetter.getEncryptedValue(); // model half-assed migration from String to Secret
+        }
+
+        @DataBoundSetter
+        public void setSecretWithStringGetterSecretSetter(Secret secretWithStringGetterSecretSetter) {
+            this.secretWithStringGetterSecretSetter = secretWithStringGetterSecretSetter;
+        }
+
+        public Secret getSecretWithSecretGetterSecretSetter() {
+            return secretWithSecretGetterSecretSetter;
+        }
+
+        @DataBoundSetter
+        public void setSecretWithSecretGetterSecretSetter(Secret secretWithSecretGetterSecretSetter) {
+            this.secretWithSecretGetterSecretSetter = secretWithSecretGetterSecretSetter;
+        }
+
+        public String getStringWithStringGetterStringSetter() {
+            return stringWithStringGetterStringSetter;
+        }
+
+        @DataBoundSetter
+        public void setStringWithStringGetterStringSetter(String stringWithStringGetterStringSetter) {
+            this.stringWithStringGetterStringSetter = stringWithStringGetterStringSetter;
+        }
+
+        public Secret getStringWithSecretGetterStringSetter() {
+            return Secret.fromString(stringWithSecretGetterStringSetter);
+        }
+
+        @DataBoundSetter
+        public void setStringWithSecretGetterStringSetter(String stringWithSecretGetterStringSetter) {
+            this.stringWithSecretGetterStringSetter = stringWithSecretGetterStringSetter;
+        }
+
+        public String getStringWithStringGetterSecretSetter() {
+            return stringWithStringGetterSecretSetter;
+        }
+
+        @DataBoundSetter
+        public void setStringWithStringGetterSecretSetter(Secret stringWithStringGetterSecretSetter) {
+            this.stringWithStringGetterSecretSetter = stringWithStringGetterSecretSetter == null? null : stringWithStringGetterSecretSetter.getPlainText();
+        }
+
+        public Secret getStringWithSecretGetterSecretSetter() {
+            return Secret.fromString(stringWithSecretGetterSecretSetter);
+        }
+
+        @DataBoundSetter
+        public void setStringWithSecretGetterSecretSetter(Secret stringWithSecretGetterSecretSetter) {
+            this.stringWithSecretGetterSecretSetter = stringWithSecretGetterSecretSetter == null? null : stringWithSecretGetterSecretSetter.getPlainText();
+        }
+
+        @Override
+        public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+            // do nothing
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return jobType == FreeStyleProject.class;
+            }
+        }
+    }
+
+    @Test
+    public void testStringlyTypedSecrets() throws Exception {
+        final FreeStyleProject project = j.createFreeStyleProject();
+        project.getBuildersList().add(new StringlyTypedSecretsBuilder(""));
+        project.save();
+        assertEquals(1, project.getBuilders().size());
+        j.configRoundtrip(project);
+
+        // empty default values after initial form submission
+        StringlyTypedSecretsBuilder buildStep = (StringlyTypedSecretsBuilder) project.getBuildersList().get(0);
+        assertNotNull(buildStep);
+        assertTrue(buildStep.mySecret.startsWith("{"));
+        assertTrue(buildStep.mySecret.endsWith("}"));
+        assertTrue(Secret.fromString(buildStep.mySecret).getPlainText().isEmpty());
+
+        // set a value and expect it to remain after round-trip
+        final Secret stringlyTypedSecret = Secret.fromString("stringlyTypedSecret");
+        stringlyTypedSecret.getEncryptedValue(); // ensure IV is set so the encrypted value is stable
+        buildStep.mySecret = stringlyTypedSecret.getEncryptedValue();
+
+        project.save();
+
+        final HtmlPage configPage = j.createWebClient().goTo(project.getUrl() + "/configure");
+        for (DomElement element : configPage.getElementsByTagName("input")) {
+            if ("hidden".equals(element.getAttribute("type")) && element.getAttribute("class").contains("complex-password-field")) {
+                final HtmlHiddenInput input = (HtmlHiddenInput) element;
+                // assert that all password fields contain encrypted values after we set plain values
+                assertTrue(input.getValueAttribute().startsWith("{"));
+                assertTrue(input.getValueAttribute().endsWith("}"));
+            }
+        }
+
+        j.configRoundtrip(project);
+        buildStep = (StringlyTypedSecretsBuilder) project.getBuildersList().get(0);
+
+        // confirm round-trip did not change effective values
+        assertEquals("stringlyTypedSecret", Secret.fromString(buildStep.mySecret).getPlainText());
+
+        // Unfortunately the constructor parameter will be decrypted transparently now, so this is sort of a minor regression with this enhancement.
+        // Note that it's not enough to just undo the related changes to core/src/main to try this; as Functions#getPasswordValue will throw a SecurityException during tests only and break the previous assertion.
+        assertNotEquals(stringlyTypedSecret.getEncryptedValue(), buildStep.mySecret);
+    }
+
+    public static class StringlyTypedSecretsBuilder extends Builder implements SimpleBuildStep {
+
+        private String mySecret;
+
+        @DataBoundConstructor
+        public StringlyTypedSecretsBuilder(String mySecret) {
+            this.mySecret = Secret.fromString(mySecret).getEncryptedValue();
+        }
+
+        public String getMySecret() {
+            return mySecret;
+        }
+
+        @Override
+        public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+            // do nothing
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return jobType == FreeStyleProject.class;
+            }
+        }
+    }
+
+    @Test
+    public void testBlankoutOfStringBackedPasswordFieldWithoutItemConfigure() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage htmlPage = wc.goTo(p.getUrl() + "/passwordFields");
+        for (DomElement element : htmlPage.getElementsByTagName("input")) {
+            if ("hidden".equals(element.getAttribute("type")) && element.getAttribute("class").contains("complex-password-field")) {
+                final HtmlHiddenInput input = (HtmlHiddenInput) element;
+                // assert that all password fields contain encrypted values after we set plain values
+                assertTrue(input.getValueAttribute().startsWith("{"));
+                assertTrue(input.getValueAttribute().endsWith("}"));
+            }
+        }
+
+        final MockAuthorizationStrategy a = new MockAuthorizationStrategy();
+        a.grant(Jenkins.READ, Job.READ, Job.EXTENDED_READ).everywhere().toEveryone();
+        j.jenkins.setAuthorizationStrategy(a);
+
+        /* Now go to the page without Item/Configure and expect asterisks */
+        htmlPage = wc.goTo(p.getUrl() + "/passwordFields");
+        for (DomElement element : htmlPage.getElementsByTagName("input")) {
+            if ("hidden".equals(element.getAttribute("type")) && element.getAttribute("class").contains("complex-password-field")) {
+                final HtmlHiddenInput input = (HtmlHiddenInput) element;
+                assertTrue(input.getValueAttribute().equals("********"));
+            }
+        }
+    }
+
+    @TestExtension
+    public static class FactoryImpl extends TransientActionFactory<Job> {
+
+        @Override
+        public Class<Job> type() {
+            return Job.class;
+        }
+
+        @Nonnull
+        @Override
+        public Collection<? extends Action> createFor(@Nonnull Job target) {
+            return Collections.singletonList(new ActionImpl());
+        }
+    }
+
+    public static class ActionImpl implements Action {
+
+        @CheckForNull
+        @Override
+        public String getIconFileName() {
+            return null;
+        }
+
+        @CheckForNull
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+
+        @CheckForNull
+        @Override
+        public String getUrlName() {
+            return "passwordFields";
+        }
+
+        public Secret getSecretPassword() {
+            return Secret.fromString("secretPassword");
+        }
+
+        public String getStringPassword() {
+            return "stringPassword";
+        }
+    }
 }

--- a/test/src/test/resources/lib/form/PasswordTest/ActionImpl/index.jelly
+++ b/test/src/test/resources/lib/form/PasswordTest/ActionImpl/index.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+    <l:layout title="Making sure the password field gets an encrypted value">
+        <l:main-panel>
+            <f:form>
+                <f:password value="${it.stringPassword}" />
+                <f:password value="${it.secretPassword}" />
+            </f:form>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/test/src/test/resources/lib/form/PasswordTest/PasswordHolderBuildStep/config.jelly
+++ b/test/src/test/resources/lib/form/PasswordTest/PasswordHolderBuildStep/config.jelly
@@ -1,0 +1,27 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="secretWithStringGetterStringSetter" field="secretWithStringGetterStringSetter">
+        <f:password/>
+    </f:entry>
+    <f:entry title="secretWithSecretGetterStringSetter" field="secretWithSecretGetterStringSetter">
+        <f:password/>
+    </f:entry>
+    <f:entry title="secretWithStringGetterSecretSetter" field="secretWithStringGetterSecretSetter">
+        <f:password/>
+    </f:entry>
+    <f:entry title="secretWithSecretGetterSecretSetter" field="secretWithSecretGetterSecretSetter">
+        <f:password/>
+    </f:entry>
+    <f:entry title="stringWithStringGetterStringSetter" field="stringWithStringGetterStringSetter">
+        <f:password/>
+    </f:entry>
+    <f:entry title="stringWithSecretGetterStringSetter" field="stringWithSecretGetterStringSetter">
+        <f:password/>
+    </f:entry>
+    <f:entry title="stringWithStringGetterSecretSetter" field="stringWithStringGetterSecretSetter">
+        <f:password/>
+    </f:entry>
+    <f:entry title="stringWithSecretGetterSecretSetter" field="stringWithSecretGetterSecretSetter">
+        <f:password/>
+    </f:entry>
+</j:jelly>

--- a/test/src/test/resources/lib/form/PasswordTest/PasswordHolderConfiguration/config.jelly
+++ b/test/src/test/resources/lib/form/PasswordTest/PasswordHolderConfiguration/config.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:section title="${%Password holder}">
+        <f:entry title="secretWithStringGetterAndSetter" field="secretWithStringGetterAndSetter">
+            <f:password/>
+        </f:entry>
+        <f:entry title="secretWithSecretGetterAndSetter" field="secretWithSecretGetterAndSetter">
+            <f:password/>
+        </f:entry>
+        <f:entry title="stringWithStringGetterAndSetter" field="stringWithStringGetterAndSetter">
+            <f:password/>
+        </f:entry>
+        <f:entry title="stringWithSecretGetterAndSetter" field="stringWithSecretGetterAndSetter">
+            <f:password/>
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/test/src/test/resources/lib/form/PasswordTest/StringlyTypedSecretsBuilder/config.jelly
+++ b/test/src/test/resources/lib/form/PasswordTest/StringlyTypedSecretsBuilder/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="mySecret" field="mySecret">
+        <f:password/>
+    </f:entry>
+</j:jelly>


### PR DESCRIPTION
See [JENKINS-61808](https://issues.jenkins-ci.org/browse/JENKINS-61808).

The `<f:password/>` form control has a magic behavior, provided by `Functions#getPasswordValue` and a converter in `Secret.java`:
If it's backed by a `Secret`, it will use the encrypted form of the password (or token, key, etc.) as `value`, rather than the plain text.
Additionally, if it's backed by a `Secret`, an `Item` is in the URL hierarchy, and the user lacks _Item/Configure_, it will only receive `******` to be rendered, instead of a real value.
The latter is less important since Jenkins 2.223, which introduced read-only forms for users with Item/ExtendedRead, and a representation of `f:password` that doesn't even attempt to render a real value.

Unfortunately, many plugin maintainers get this wrong and use `String`-based for values only shown using `<f:password/>`. This affects both plugins who get storage right (using `Secret`), and those that get that part wrong, too.

So what does this do?
* When rendering an `<f:password/>`, even if it's not backed by a `Secret`, we will convert the value to be shown to a `Secret` and render its encrypted form in most cases.
  Additionally, we also allow non-`Secret` backed `<f:password/>` to be `******` out when the user lacks a relevant Item/Configure permission.
* When processing form submissions, a new `Converter` will convert any value that's an encrypted `Secret` to its decrypted `String` representation.

In addition to the above, we also add a new warning to the log whenever a `<f:password/>` is backed by a string, and attempt to identify which view it's coming from (which is surprisingly annoying to do). This PR does _not_ mean that plugins having `String` APIs wouldn't be a bug. This warning will appear when running `jetty:run` and `hpi:run`, but not in production use. It can also serve as a useful reminder that the underlying field should be a `Secret`.

Since the APIs for password parameters were using the `String` type, they have been adapted in this PR.

### Escape hatches

This PR introduce more magic, so we have two different escape hatches in case things go sideways:

* `hudson.util.Secret.AUTO_ENCRYPT_PASSWORD_CONTROL` is `true` by default and controls whether the basic new behavior is active. This must be set on startup, as we don't even want the converter to register if something goes wrong.
* `hudson.util.Secret.BLANK_NONSECRET_PASSWORD_FIELDS_WITHOUT_ITEM_CONFIGURE` is `true` by default and controls whether the `*****` masking that existed for `Secret` backed `f:password` fields is extended to those without a `Secret`.


### Limitations

This introduces a _slight_ regression with `String`-based "setter" APIs around a `Secret` field: A round-trip will now result in changes to the persisted value, as Jenkins transparently decrypts any submitted value. IOW, it now behaves as though the user always entered the same value manually.

In development mode, Jenkins will log warnings when it encounters secrets not backed by a `Secret`, including fields showing a fixed `String` value that's not protection-worthy. This should rarely occur legitimately. It would occur on "Build With Parameters" with password parameters, which use a fixed `<DEFAULT>` placeholder, if we didn't specifically support that in `getPasswordValue`, and it happened in the "Parameters" action of builds when _not_ showing a password value, so I replaced the (inappropriate) use of `f:password` there.

If the _storage_ of credentials is wrong, rather than just the Java API exposing values to form fields, then users can still obtain the plain-text stored credential using `GET config.xml`. But plain-text storage of credentials is a problem independent of the UI and remote API to begin with and would need to be addressed anyway.

This PR _removes_ a protection that would make (some) unit tests fail:
https://github.com/jenkinsci/jenkins/blob/449c5aced523a6e66fe3d6a804e5dbfd5c5c67c6/core/src/main/java/hudson/Functions.java#L2027-L2029
We can probably restore that if desired, and set a flag to ignore that for these specific tests, but TBH I'm not sure how much this helps anyway.


### Proposed changelog entries

* Security hardening: Always round-trip password form control values in an encrypted form, even if not backed by an encrypted `Secret` field. In case of problems, this can be disabled by setting the system property `hudson.util.Secret.AUTO_ENCRYPT_PASSWORD_CONTROL` to `false` on startup.
* Security hardening: Always use a placeholder value for password form control values in item related configuration forms when the user is missing Item/Configure permission, even if not backed by an encrypted `Secret` field. In case of problems, this can be disabled by setting the system property `hudson.util.Secret.BLANK_NONSECRET_PASSWORD_FIELDS_WITHOUT_ITEM_CONFIGURE` to `false`.

Or we can limit the details we expose to users here and just go with

* Security hardening related to password form fields.

If there are real problems, we can provide the system properties in regression reports.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

