### PR TITLE
Ensure that encoded console annotations are stripped from system logger messages

### DIFF
--- a/core/src/main/java/hudson/util/LogTaskListener.java
+++ b/core/src/main/java/hudson/util/LogTaskListener.java
@@ -24,7 +24,7 @@
 
 package hudson.util;
 
-import hudson.console.ConsoleNote;
+import hudson.console.PlainTextConsoleOutputStream;
 import hudson.model.TaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -47,7 +47,7 @@ public class LogTaskListener extends AbstractTaskListener implements TaskListene
     private final TaskListener delegate;
 
     public LogTaskListener(Logger logger, Level level) {
-        delegate = new StreamTaskListener(new LogOutputStream(logger, level, new Throwable().getStackTrace()[1]));
+        delegate = new StreamTaskListener(new PlainTextConsoleOutputStream(new LogOutputStream(logger, level, new Throwable().getStackTrace()[1])));
     }
 
     @Override
@@ -56,16 +56,11 @@ public class LogTaskListener extends AbstractTaskListener implements TaskListene
     }
 
     @Override
-    @SuppressWarnings("rawtypes")
-    public void annotate(ConsoleNote ann) {
-        // no annotation support
-    }
-
-    @Override
     public void close() {
         delegate.getLogger().close();
     }
 
+    // TODO a bit simpler to use LineTransformationOutputStream
     private static class LogOutputStream extends OutputStream {
 
         private final Logger logger;

--- a/test/src/test/java/hudson/util/LogTaskListenerTest.java
+++ b/test/src/test/java/hudson/util/LogTaskListenerTest.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.util;
+
+import hudson.console.HyperlinkNote;
+import hudson.model.TaskListener;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+public class LogTaskListenerTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule().record("LogTaskListenerTest", Level.ALL).capture(100);
+
+    @Test
+    public void annotations() throws Exception {
+        TaskListener l = new LogTaskListener(Logger.getLogger("LogTaskListenerTest"), Level.FINE);
+        l.getLogger().println("plain line");
+        String url = "http://nowhere.net/";
+        l.annotate(new HyperlinkNote(url, 0));
+        l.getLogger().println("from annotate");
+        l.hyperlink(url, "from hyperlink");
+        l.getLogger().println();
+        l.getLogger().println(HyperlinkNote.encodeTo(url, "there") + " from encoded");
+        assertEquals("[plain line, from annotate, from hyperlink, there from encoded]", logging.getMessages().toString());
+    }
+
+}


### PR DESCRIPTION
A minor annoyance: plugins which printed console annotations in some manners would dump Base64 gobbledygook into `LogTaskListener`, even though it claimed to suppress these.

### Proposed changelog entries

* Ensure that encoded console annotations are stripped from system logger messages.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

