### PR TITLE
Make the timestamp on the footer more compact

### DIFF
--- a/war/src/main/less/modules/page-footer.less
+++ b/war/src/main/less/modules/page-footer.less
@@ -40,13 +40,14 @@
 }
 
 .page-footer__generated {
+  font-size: @font-size-xs;
   font-weight: bold;
 }
 
 .page-footer .page-footer__generated-timestamp {
+  display: block;
   font-weight: normal;
   margin: 0;
-  padding-left: 0.25rem;
 }
 
 .page-footer__links {


### PR DESCRIPTION
Small improvement to the footer timestamp. The font size is reduced to 12px and the label is shown on top of the timestamp:

<img width="1293" alt="Captura de pantalla 2020-04-13 a las 16 40 15" src="https://user-images.githubusercontent.com/5738588/79129750-0d55ee80-7da6-11ea-93fd-830024876a32.png">

### Proposed changelog entries

N/A I'd say. The footer changes haven't been released on an LTS yet, and this is a really small one.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@Wadeck 
@oleg-nenashev 
@timja
@daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`

