### PR TITLE
[JENKINS-61711] Fix validateExecutable to allow Git plugin global config correctly report git executable in PATH

### DIFF
--- a/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
+++ b/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
@@ -65,7 +65,7 @@ class DOSToUnixPathHelper {
 
                     tokenizedPathBuilder.append(_dir.replace('\\', '/'));
 
-                    if (checkPrefix(_dir + File.pathSeparator + exe, helper))
+                    if (checkPrefix(_dir + File.separator + exe, helper))
                         return;
                 }
                 tokenizedPathBuilder.append('.');

--- a/test/src/test/java/hudson/util/FormValidationTest.java
+++ b/test/src/test/java/hudson/util/FormValidationTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FormValidationTest {

--- a/test/src/test/java/hudson/util/FormValidationTest.java
+++ b/test/src/test/java/hudson/util/FormValidationTest.java
@@ -28,6 +28,6 @@ public class FormValidationTest {
         // executable at system PATH despite git exec existing at the path.
         FormValidation actual = FormValidation.validateExecutable("git");
         String failMessage = "There's no such executable git in PATH:";
-        assertThat(actual.equals(FormValidation.error(failMessage)), is(false));
+        assertThat(actual, not(is(FormValidation.error(failMessage))));
     }
 }

--- a/test/src/test/java/hudson/util/FormValidationTest.java
+++ b/test/src/test/java/hudson/util/FormValidationTest.java
@@ -1,0 +1,33 @@
+package hudson.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FormValidationTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Issue("JENKINS-61711")
+    @Test
+    public void testValidateExecutableWithFix() {
+        // Global Tool Configuration is able to find git executable in system environment at PATH.
+        FormValidation actual = FormValidation.validateExecutable("git");
+        assertThat(actual, is(FormValidation.ok()));
+    }
+
+    @Issue("JENKINS-61711")
+    @Test
+    public void testValidateExecutableWithoutFix() {
+        // Without JENKINS-61711 fix, Git installations under Global Tool Configuration is not able to find git
+        // executable at system PATH despite git exec existing at the path.
+        FormValidation actual = FormValidation.validateExecutable("git");
+        String failMessage = "There's no such executable git in PATH:";
+        assertThat(actual.equals(FormValidation.error(failMessage)), is(false));
+    }
+}


### PR DESCRIPTION
## [JENKINS-61711](https://issues.jenkins-ci.org/browse/JENKINS-61711)

bugfix: A fix in `DOSToUnixPathHelper` to allow the user to define git implementations which are then used as tools.

Proposed changelog entries:

* Fix input field hints for tools that search the PATH for their executable (like the git plugin) (regression in 2.205 and 2.222.1)

Issue introduced in 4cd3e338c0e89ee8192d29b5da66e7f3a23d5134 as part of a refactoring effort.

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@MarkEWaite 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate` (backport not needed, issue is cosmetic)

