### PR TITLE
Fix comment about when this is set

### DIFF
--- a/core/src/main/java/hudson/Main.java
+++ b/core/src/main/java/hudson/Main.java
@@ -220,7 +220,8 @@ public class Main {
     public static boolean isUnitTest = false;
 
     /**
-     * Set to true if we are running inside {@code mvn hpi:run} or {@code mvn jetty:run}.
+     * Set to true if we are running inside {@code mvn jetty:run}.
+     * This is also set if running inside {@code mvn hpi:run} since plugins parent POM 2.30.
      */
     public static boolean isDevelopmentMode = SystemProperties.getBoolean(Main.class.getName()+".development");
 


### PR DESCRIPTION
This claim was established in core in https://github.com/jenkinsci/jenkins/commit/21ad12ffc040067f4ad17f262ab323b844ebc4a8 but it seems this hasn't been true for the first seven years.

I've been unable to find any trace of it in the plugins POM or maven-hpi-plugin… until 2.30 introduced it in https://github.com/jenkinsci/plugin-pom/commit/a7571e5b65b0299ed4645f1511c59df90ca2bbfa

Testing with plugins on an older 2.x plugins POM (run-condition as of 1.2) and a fairly late 1.x parent pom (ssh plugin on 1.609.x) confirm the system property was never set before that change.