### PR TITLE
[JENKINS-61841] Limit the number of exceptions stored by CompositeIOException

### DIFF
--- a/core/src/main/java/jenkins/util/io/CompositeIOException.java
+++ b/core/src/main/java/jenkins/util/io/CompositeIOException.java
@@ -43,7 +43,7 @@ public class CompositeIOException extends IOException {
      * {@code CompositeIOException}.
      * <p>
      * The number of exceptions is limited to avoid pathological cases where
-     * where a huge number of exceptions could lead to excessive memory usage.
+     * a huge number of exceptions could lead to excessive memory usage.
      * For example, if the number of exceptions was unlimited, a call to
      * {@code Util.deleteRecursive} could fail with a
      * {@code CompositeIOException} that contains an exception for every
@@ -58,15 +58,13 @@ public class CompositeIOException extends IOException {
      * exceptions are added as suppressed exceptions to the new exception.
      * <p>
      * If the given list of exceptions is longer than {@link #EXCEPTION_LIMIT},
-     * the list will be truncated to that length, and an exception whose message
-     * contains the number of exceptions that were removed will be added as a
-     * suppressed exception to the new exception.
+     * the list will be truncated to that length, and a message indicating the
+     * number of discarded exceptions will be appended to the original message.
      */
     public CompositeIOException(String message, @NonNull List<IOException> exceptions) {
-        super(message);
+        super(message + getDiscardedExceptionsMessage(exceptions));
         if (exceptions.size() > EXCEPTION_LIMIT) {
             this.exceptions = new ArrayList<>(exceptions.subList(0, EXCEPTION_LIMIT));
-            this.exceptions.add(new ExceptionLimitReached(exceptions.size() - EXCEPTION_LIMIT));
         } else {
             this.exceptions = exceptions;
         }
@@ -88,21 +86,11 @@ public class CompositeIOException extends IOException {
         return new UncheckedIOException(this);
     }
 
-    /**
-     * An exception with no stack trace used to inform users that not all
-     * exceptions are being reported.
-     */
-    private static class ExceptionLimitReached extends IOException {
-        private static final long serialVersionUID = 1L;
-
-        public ExceptionLimitReached(int truncated) {
-            super(truncated + " additional exceptions were thrown");
-        }
-
-        @Override
-        public Throwable fillInStackTrace() {
-            // Do not create a strack trace for this exception.
-            return this;
+    private static String getDiscardedExceptionsMessage(List<IOException> exceptions) {
+        if (exceptions.size() > EXCEPTION_LIMIT) {
+            return " (Discarded " + (exceptions.size() - EXCEPTION_LIMIT) + " additional exceptions)";
+        } else {
+            return "";
         }
     }
 }

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -446,7 +446,7 @@ public class PathRemoverTest {
             fail("Deletion should have failed");
         } catch (CompositeIOException e) {
             assertThat(e.getSuppressed(), arrayWithSize(maxExceptions));
-            assertThat(e.getMessage(), endsWith("(Discarded" + (lockedFiles + 1 - maxExceptions) + " additional exceptions)"));
+            assertThat(e.getMessage(), endsWith("(Discarded " + (lockedFiles + 1 - maxExceptions) + " additional exceptions)"));
         }
         assertTrue(dir.exists());
         assertThat(dir.listFiles().length, equalTo(lockedFiles));

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -55,6 +55,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertFalse;
@@ -444,9 +445,8 @@ public class PathRemoverTest {
             PathRemover.newSimpleRemover().forceRemoveRecursive(dir.toPath());
             fail("Deletion should have failed");
         } catch (CompositeIOException e) {
-            assertThat(e.getSuppressed(), arrayWithSize(maxExceptions + 1));
-            assertThat(e.getSuppressed()[maxExceptions].getMessage(),
-                    containsString((lockedFiles + 1 - maxExceptions) + " additional exceptions"));
+            assertThat(e.getSuppressed(), arrayWithSize(maxExceptions));
+            assertThat(e.getMessage(), endsWith("(Discarded" + (lockedFiles + 1 - maxExceptions) + " additional exceptions)"));
         }
         assertTrue(dir.exists());
         assertThat(dir.listFiles().length, equalTo(lockedFiles));

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -51,10 +51,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -416,6 +422,34 @@ public class PathRemoverTest {
 
         assertTrue("Unable to delete directory: " + d1p, Files.notExists(d1p));
         assertFalse(d1.exists());
+    }
+
+    @Test
+    @Issue("JENKINS-55448")
+    public void testForceRemoveRecursive_TruncatesNumberOfExceptions() throws IOException {
+        assumeTrue(Functions.isWindows());
+        final int maxExceptions = CompositeIOException.EXCEPTION_LIMIT;
+        final int lockedFiles = maxExceptions + 5;
+        final int totalFiles = lockedFiles + 5;
+        File dir = tmp.newFolder();
+        File[] files = new File[totalFiles];
+        for (int i = 0; i < totalFiles; i++) {
+            files[i] = new File(dir, "f" + i);
+        }
+        touchWithFileName(files);
+        for (int i = 0; i < lockedFiles; i++) {
+            locker.acquireLock(files[i]);
+        }
+        try {
+            PathRemover.newSimpleRemover().forceRemoveRecursive(dir.toPath());
+            fail("Deletion should have failed");
+        } catch (CompositeIOException e) {
+            assertThat(e.getSuppressed(), arrayWithSize(maxExceptions + 1));
+            assertThat(e.getSuppressed()[maxExceptions].getMessage(),
+                    containsString((lockedFiles + 1 - maxExceptions) + " additional exceptions"));
+        }
+        assertTrue(dir.exists());
+        assertThat(dir.listFiles().length, equalTo(lockedFiles));
     }
 
     private static void mkdirs(File... dirs) {


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-61841](https://issues.jenkins-ci.org/browse/JENKINS-61841).

This PR truncates the list of exceptions passed to `CompositeIOException` to only contain the first 10 exceptions. I expect that the only callers of `new CompositeIOException()` that will be affected by this limit in practice are `PathRemover.forceRemoveDirectoryContents` and `PathRemover.forceRemoveRecursive`, but `LogRotator.perform` could potentially run into this issue as well, so I thought it made sense to perform the truncation in `CompositeIOException` itself. 10 was my rough guess for the point where additional exceptions are probably going to contain mostly redundant information. Right now, this value is not configurable by users, but I am happy to make it configurable as a system property or change the default value if desired.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Robustness: Limit the number of exceptions thrown by some operations such as recursive directory deletion. Previously, in rare cases, exceptions thrown when failing to delete large directories could consume significant amounts of memory.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a JIRA issue should exist and be labeled as `lts-candidate`