### PR TITLE
Test refactoring, mainly to use hamcrest matcher instead of deprecated junit assertThat

### DIFF
--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -54,7 +54,13 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.*;
@@ -293,7 +299,7 @@ public class FilePathTest {
     }
 
     @Issue("JENKINS-6494")
-    @Test public void getParent() throws Exception {
+    @Test public void getParent() {
         FilePath fp = new FilePath((VirtualChannel)null, "/abc/def");
         assertEquals("/abc", (fp = fp.getParent()).getRemote());
         assertEquals("/", (fp = fp.getParent()).getRemote());
@@ -491,7 +497,7 @@ public class FilePathTest {
     }
 
     @Issue("JENKINS-13649")
-    @Test public void multiSegmentRelativePaths() throws Exception {
+    @Test public void multiSegmentRelativePaths() {
         VirtualChannel d = Mockito.mock(VirtualChannel.class);
         FilePath winPath = new FilePath(d, "c:\\app\\jenkins\\workspace");
         FilePath nixPath = new FilePath(d, "/opt/jenkins/workspace");

--- a/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
+++ b/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
@@ -23,8 +23,12 @@
  */
 package hudson.util;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -22,9 +22,9 @@ import java.util.Set;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
@@ -86,7 +86,7 @@ public class AtomicFileWriterTest {
     }
 
     @Test
-    public void createFile() throws Exception {
+    public void createFile() {
         // Verify the file we created exists
         assertTrue(Files.exists(afw.getTemporaryPath()));
     }
@@ -163,7 +163,7 @@ public class AtomicFileWriterTest {
 
     @Issue("JENKINS-48407")
     @Test
-    public void checkPermissionsRespectUmask() throws IOException, InterruptedException {
+    public void checkPermissionsRespectUmask() throws IOException {
 
         final File newFile = tmp.newFile();
         boolean posixSupported = isPosixSupported(newFile);

--- a/core/src/test/java/hudson/util/FileChannelWriterTest.java
+++ b/core/src/test/java/hudson/util/FileChannelWriterTest.java
@@ -13,7 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.StandardOpenOption;
 
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class FileChannelWriterTest {

--- a/core/src/test/java/jenkins/security/ClassFilterImplSanityTest.java
+++ b/core/src/test/java/jenkins/security/ClassFilterImplSanityTest.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import jenkins.util.MemoryReductionUtil;
 import org.apache.commons.io.IOUtils;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Test;
 import org.jvnet.hudson.test.For;
 

--- a/core/src/test/java/jenkins/security/DefaultConfidentialStoreTest.java
+++ b/core/src/test/java/jenkins/security/DefaultConfidentialStoreTest.java
@@ -7,7 +7,11 @@ import java.nio.charset.Charset;
 
 import org.apache.commons.io.FileUtils;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;

--- a/core/src/test/java/jenkins/security/apitoken/ApiTokenStatsTest.java
+++ b/core/src/test/java/jenkins/security/apitoken/ApiTokenStatsTest.java
@@ -52,10 +52,10 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ApiTokenPropertyConfiguration.class)
@@ -108,6 +108,7 @@ public class ApiTokenStatsTest {
             lastUsage = stats.getLastUseDate();
             assertNotNull(lastUsage);
             // to avoid flaky test in case the test is run at midnight, normally it's 0 
+            
             assertThat(stats.getNumDaysUse(), lessThanOrEqualTo(1L));
         }
         
@@ -164,7 +165,7 @@ public class ApiTokenStatsTest {
     }
     
     @Test
-    public void testResilientIfFileDoesNotExist() throws Exception {
+    public void testResilientIfFileDoesNotExist() {
         ApiTokenStats tokenStats = createFromFile(tmp.getRoot());
         assertNotNull(tokenStats);
     }
@@ -193,7 +194,7 @@ public class ApiTokenStatsTest {
             String content = FileUtils.readFileToString(statsFile.getFile(), Charset.defaultCharset());
             // now there are multiple times the same id in the file with different stats
             String newContentWithDuplicatedId = content.replace(ID_1, ID_2).replace(ID_3, ID_2);
-            FileUtils.write(statsFile.getFile(), newContentWithDuplicatedId);
+            FileUtils.write(statsFile.getFile(), newContentWithDuplicatedId, Charset.defaultCharset());
         }
         
         {


### PR DESCRIPTION
Test refactoring, mainly to use hamcrest matcher instead of deprecated junit assertThat to solve some deprecated warnings inside the IDE

### Proposed changelog entries

* N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
