### PR TITLE
Fix available tab sort order and support popularity outside 0..1 range

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -136,6 +136,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -2240,7 +2241,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     @Restricted(DoNotUse.class)
     public String unscientific(double d) {
-        return String.format("%.4f", d);
+        return String.format(Locale.US, "%15.4f", d);
     }
 
     @Override

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -63,7 +63,7 @@ THE SOFTWARE.
           <table id="plugins" class="sortable pane bigtable stripped-odd">
             <tr>
               <l:isAdmin>
-                <th initialSortDir="${isUpdates?null:'down'}"
+                <th initialSortDir="${isUpdates?null:'up'}"
                     tooltip="${%Check to install the plugin}"
                     width="32">${%Install}</th>
               </l:isAdmin>


### PR DESCRIPTION
There are two problems with sorting plugins on the Available tab by sort order (https://github.com/jenkinsci/jenkins/pull/4588):

* It's the wrong direction 🤦 (I forgot about https://github.com/jenkinsci/jenkins/pull/1737 etc. and somehow slipped through in my testing)
* It doesn't support values outside the 0...1 range.

The latter wasn't a big problem when popularity was normalized to be within that range. And I did that deliberately due to a weird behavior with sortable tables in Jenkins: It alternates between interpreting values as a string and as a number. Try this with the "versions" column: Sometimes 8.x or 9.x is the top value, sometimes double digit major versions. The cycle seems to be something like numeric asc / numeric desc / string asc / string desc.

When all values are in the 0...1 range, never use scientific notation, and have a fixed number of digits, all is well.

Unfortunately it turned out that there's something off between Jenkins and the update center generator that results in signature check failures when there are numbers with fractions in the JSON file.

The way the JSON signature works is that update-center2 first writes the entire rest of the content in a "canonical" format, then computes its checksum, and then inserts the signatures block with computed checksums and signatures. Jenkins downloads the file, deserializes it, removes the `signatures` block, and then it serializes what's left in a "canonical" format. If the specified checksum computed by update-center2 matches the one Jenkins determines, it proceeds with the signature check.

This means that update-center2 and Jenkins (core) are coupled tightly to this "canonical" format -- earlier today, the number of fractional digits between update-center2 and (some) Jenkins instances differed; which made signature checks in Jenkins fail. This is being addressed in https://github.com/jenkins-infra/update-center2/pull/369

As a workaround, update-center2 could just publish the popularity as an integer, which can be consumed by Jenkins and doesn't cause problems (both components strip trailing `0` fractional digits, as well as a `.` separator if it's the last char).

Unfortunately, in this case, the problem of sort order comes back. 999 installs (or 9999, or 99999) is not the largest value!

So this PR formats the number to have a large fixed number of digits, and left pads with spaces. That way, 9 is no longer larger than 10 half the time.

### Testing note

While 2.233 is the latest release, I'm reverting the addition of popularity to the metadata. A recent update-center.json file _with_ the popularity data is https://gist.github.com/daniel-beck/5f8f70725c6f22fd47686359535eed52 and can be used for testing.

### Proposed changelog entries

* Fix sort order in Available tab of the plugin manager

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
