### PR TITLE
[JENKINS-46669] Reword SetupWizard Continue as admin button

### DIFF
--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -65,7 +65,7 @@ installWizard_installIncomplete_banner=Resume Installation
 installWizard_installIncomplete_message=Jenkins was restarted during installation and some plugins did not seem to get installed.
 installWizard_installIncomplete_resumeInstallationButtonLabel=Resume
 installWizard_saveFirstUser=Save and Continue
-installWizard_skipFirstUser=Continue as admin
+installWizard_skipFirstUser=Skip form and continue as admin
 installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
 You have skipped the <strong>setup of an admin user</strong>. <br /><br />\
 To log in, use the username: "admin" and the administrator password you used to access the setup wizard.\

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -65,7 +65,7 @@ installWizard_installIncomplete_banner=Resume Installation
 installWizard_installIncomplete_message=Jenkins was restarted during installation and some plugins did not seem to get installed.
 installWizard_installIncomplete_resumeInstallationButtonLabel=Resume
 installWizard_saveFirstUser=Save and Continue
-installWizard_skipFirstUser=Skip form and continue as admin
+installWizard_skipFirstUser=Skip and continue as admin
 installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
 You have skipped the <strong>setup of an admin user</strong>. <br /><br />\
 To log in, use the username: "admin" and the administrator password you used to access the setup wizard.\


### PR DESCRIPTION
See [JENKINS-46669](https://issues.jenkins-ci.org/browse/JENKINS-46669).

<!-- Comment: 
 * N/A
-->

### Proposed changelog entries

* Entry 1: Reworded "Continue as admin" button of the plugin setup wizard.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@fqueiruga
@timja

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
