### PR TITLE
Slave.numExecutors should default to 1

### DIFF
--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -126,7 +126,7 @@ public abstract class Slave extends Node implements Serializable {
     /**
      * Number of executors of this node.
      */
-    private int numExecutors = 2;
+    private int numExecutors = 1;
 
     /**
      * Job allocation strategy.


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/commit/4acae8cfc7f56738e663b5744e098a96cf8bbda8 has long had the default be 1 in GUI configuration, but for some reason the code default was 2. After #2293, code which created e.g. `DumbSlave` programmatically needed to call `setNumExecutors` explicitly for the common case that you want 1 slot, as in e.g. https://github.com/jenkinsci/mercurial-plugin/pull/135.

### Proposed changelog entries

* The default number of executors for an agent created programmatically (or as-code) is now 1 rather than 2.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
