### PR TITLE
Add form validation warning when signup is enabled

### DIFF
--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -30,6 +30,7 @@ import hudson.ExtensionList;
 import hudson.Util;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.Descriptor;
+import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import hudson.model.ManagementLink;
 import hudson.model.ModelObject;
@@ -61,6 +62,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.ForwardToView;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -916,6 +918,13 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
     public static final class DescriptorImpl extends Descriptor<SecurityRealm> {
         public String getDisplayName() {
             return Messages.HudsonPrivateSecurityRealm_DisplayName();
+        }
+
+        public FormValidation doCheckAllowsSignup(@QueryParameter boolean value) {
+            if (value) {
+                return FormValidation.warning(Messages.HudsonPrivateSecurityRealm_SignupWarning());
+            }
+            return FormValidation.ok();
         }
     }
 

--- a/core/src/main/resources/hudson/security/Messages.properties
+++ b/core/src/main/resources/hudson/security/Messages.properties
@@ -26,6 +26,7 @@ HudsonPrivateSecurityRealm.WouldYouLikeToSignUp=This {0} {1} is new to Jenkins. 
 LegacyAuthorizationStrategy.DisplayName=Legacy mode
 
 HudsonPrivateSecurityRealm.DisplayName=Jenkins\u2019 own user database
+HudsonPrivateSecurityRealm.SignupWarning=With signup enabled, anyone on your network can become an authenticated user. It is recommended in this case to minimize the permissions granted to any authenticated user.
 HudsonPrivateSecurityRealm.Details.DisplayName=Password
 HudsonPrivateSecurityRealm.Details.PasswordError=\
   The confirmed password is not the same as the one entered. \


### PR DESCRIPTION
> <img width="1094" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/80285945-b5fe3980-8728-11ea-8082-ed51e21a2fd0.png">

### Proposed changelog entries

(too minor)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
