### PR TITLE
[JENKINS-62056] Fix ExtensionComponent#compareTo

### DIFF
--- a/core/src/main/java/hudson/ExtensionComponent.java
+++ b/core/src/main/java/hudson/ExtensionComponent.java
@@ -91,14 +91,40 @@ public class ExtensionComponent<T> implements Comparable<ExtensionComponent<T>> 
         if (Double.compare(a, b) > 0) return -1;
         if (Double.compare(a, b) < 0) return 1;
 
-        // make the order bit more deterministic among extensions of the same ordinal
-        if (this.instance instanceof Descriptor && that.instance instanceof Descriptor) {
+        boolean thisIsDescriptor = false;
+        String thisLabel = this.instance.getClass().getName();
+        if (this.instance instanceof Descriptor) {
             try {
-                return Util.fixNull(((Descriptor)this.instance).getDisplayName()).compareTo(Util.fixNull(((Descriptor)that.instance).getDisplayName()));
+                thisLabel = Util.fixNull(((Descriptor) this.instance).getDisplayName());
+                thisIsDescriptor = true;
             } catch (RuntimeException | LinkageError x) {
-                LOG.log(Level.WARNING, null, x);
+                LOG.log(Level.WARNING, "Failure during Descriptor#getDisplayName for " + this.instance.getClass().getName(), x);
             }
         }
-        return this.instance.getClass().getName().compareTo(that.instance.getClass().getName());
+
+        boolean thatIsDescriptor = false;
+        String thatLabel = that.instance.getClass().getName();
+        if (that.instance instanceof Descriptor) {
+            try {
+                thatLabel = Util.fixNull(((Descriptor) that.instance).getDisplayName());
+                thatIsDescriptor = true;
+            } catch (RuntimeException | LinkageError x) {
+                LOG.log(Level.WARNING, "Failure during Descriptor#getDisplayName for " + that.instance.getClass().getName(), x);
+            }
+        }
+
+        if (thisIsDescriptor) {
+            if (thatIsDescriptor) {
+                return thisLabel.compareTo(thatLabel);
+            } else {
+                return 1;
+            }
+        } else {
+            if (thatIsDescriptor) {
+                return -1;
+            }
+        }
+
+        return thisLabel.compareTo(thatLabel);
     }
 }

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -217,4 +217,9 @@ public class ExtensionListTest {
         assertEquals(0, list.size());
     }
 
+    @Issue("JENKINS-62056")
+    @Test
+    public void checkSort() {
+        ExtensionList.lookup(Object.class).get(0); // exceptions are a problem
+    }
 }


### PR DESCRIPTION
See [JENKINS-62056](https://issues.jenkins-ci.org/browse/JENKINS-62056)

Originally introduced in fe452bfbc5a4332c81a7cdf2cbd52c3af37ee36d and amended in 093f21f634c8fa52cc7dbaef16c26665a9530782, this only worked if all, or no, instances were `instanceof Descriptor`, otherwise https://github.com/jenkinsci/jenkins/blob/58771040b49a848f005d5a76b957d04203659524/core/src/main/java/hudson/ExtensionList.java#L399-L403 threw exceptions.

This probably didn't get attention because everybody calls `ExtensionList.lookup(…)` for specific extension types that are consistently always or never `instanceof Descriptor`.

### Proposed changelog entries

* Developer: Make it possible to look up extension implementations from more than one specific extension point at a time.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
