### PR TITLE
Minor pom cleanup and switched assertions to junit5

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -46,6 +46,11 @@ THE SOFTWARE.
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>4.0.1</version>
+      </dependency>
+      <dependency>
         <groupId>net.jcip</groupId>
         <artifactId>jcip-annotations</artifactId>
         <version>1.0</version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,7 +31,6 @@ THE SOFTWARE.
     <version>${revision}${changelist}</version>
   </parent>
 
-  <groupId>org.jenkins-ci.main</groupId>
   <artifactId>jenkins-bom</artifactId>
   <packaging>pom</packaging>
 
@@ -46,11 +45,6 @@ THE SOFTWARE.
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-annotations</artifactId>
-        <version>3.1.11</version>
-      </dependency>
       <dependency>
         <groupId>net.jcip</groupId>
         <artifactId>jcip-annotations</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -66,11 +66,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jvnet.localizer</groupId>
       <artifactId>localizer</artifactId>
       <version>1.26</version>

--- a/cli/src/test/java/hudson/cli/HexDumpTest.java
+++ b/cli/src/test/java/hudson/cli/HexDumpTest.java
@@ -1,41 +1,41 @@
 package hudson.cli;
 
-
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class HexDumpTest {
 
   @Test
   public void testToHex1() {
-    Assert.assertEquals("'fooBar'",
+    assertEquals("'fooBar'",
             HexDump.toHex(new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}));
-    Assert.assertEquals("0xc3",
+    assertEquals("0xc3",
             HexDump.toHex(new byte[] {(byte)'Ã'}));
-    Assert.assertEquals("0xac '100'",
+    assertEquals("0xac '100'",
             HexDump.toHex(new byte[] {(byte)'€', '1', '0', '0'}));
-    Assert.assertEquals("'1' 0xf7 '2'",
+    assertEquals("'1' 0xf7 '2'",
             HexDump.toHex(new byte[] {'1', (byte)'÷', '2'}));
-    Assert.assertEquals("'foo' 0x0a\n'Bar'",
+    assertEquals("'foo' 0x0a\n'Bar'",
             HexDump.toHex(new byte[] {'f', 'o', 'o', '\n', 'B', 'a', 'r'}));
   }
 
   @Test
   public void testToHex2() {
-    Assert.assertEquals("'ooBa'",
+    assertEquals("'ooBa'",
             HexDump.toHex(new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}, 1, 4));
-    Assert.assertEquals("0xc3",
+    assertEquals("0xc3",
             HexDump.toHex(new byte[] {(byte)'Ã'}, 0, 1));
-    Assert.assertEquals("0xac '10'",
+    assertEquals("0xac '10'",
             HexDump.toHex(new byte[] {(byte)'€', '1', '0', '0'}, 0, 3));
-    Assert.assertEquals("0xf7 '2'",
+    assertEquals("0xf7 '2'",
             HexDump.toHex(new byte[] {'1', (byte)'÷', '2'}, 1, 2));
-    Assert.assertEquals("'Bar'",
+    assertEquals("'Bar'",
             HexDump.toHex(new byte[] {'f', 'o', 'o', '\n', 'B', 'a', 'r'}, 4, 3));
-    Assert.assertEquals("",
+    assertEquals("",
             HexDump.toHex(new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}, 0, 0));
   }
 }


### PR DESCRIPTION
Minor pom cleanup and switched assertions to junit5 because class was already switched to junit5


### Proposed changelog entries

* N/A: just internal

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
