### PR TITLE
Maintainer guide: Reference the IRC channel

### DIFF
--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -26,7 +26,8 @@ Remoting updates in the core are subject to the process though.
 
 === Communication channels
 
-* link:https://groups.google.com/d/forum/jenkinsci-dev[Jenkins Developer Mailing List]
+* Mailing list: link:https://groups.google.com/d/forum/jenkinsci-dev[Jenkins Developer Mailing List]
+* Chat: `#jenkins-release` on Freenode IRC
 
 === Roles
 

--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -27,7 +27,8 @@ Remoting updates in the core are subject to the process though.
 === Communication channels
 
 * Mailing list: link:https://groups.google.com/d/forum/jenkinsci-dev[Jenkins Developer Mailing List]
-* Chat: `#jenkins-release` on Freenode IRC
+* Chat for runtime Jenkins release coordination: `#jenkins-release` on Freenode IRC
+** All async communications should go to the developer mailing list
 
 === Roles
 


### PR DESCRIPTION
We reached an agreement to temporarily use IRC for Jenkins core release coordination needs.
So, updating the docs