### PR TITLE
Add optional layout property to suppress loading of Bootstrap 3 grid

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -58,6 +58,10 @@ THE SOFTWARE.
     <st:attribute name="type" use="optional">
       Available values: two-column (by default), one-column (full-width size) or full-screen (since 2.53).
     </st:attribute>
+    <st:attribute name="nogrid" use="optional">
+      Do not include Bootstrap 3 grid. When a plugin wants to use a more recent version of Bootstrap then
+      the bundled grid will cause conflicts.
+    </st:attribute>
   </st:documentation>
 <l:view contentType="text/html;charset=UTF-8">
 <st:setHeader name="Expires" value="0" />
@@ -107,7 +111,9 @@ THE SOFTWARE.
 
     <link rel="stylesheet" href="${resURL}/jsbundles/base-styles-v2.css" type="text/css" />
     <link rel="stylesheet" href="${resURL}/css/color.css" type="text/css" />
-    <link rel="stylesheet" href="${resURL}/css/responsive-grid.css" type="text/css" />
+    <j:if test="${attrs.nogrid==null or attrs.nogrid.equals(false)}">
+      <link rel="stylesheet" href="${resURL}/css/responsive-grid.css" type="text/css" />
+    </j:if>
     <j:if test="${attrs.css!=null}">
       <link rel="stylesheet" href="${resURL}${attrs.css}" type="text/css" />
     </j:if>


### PR DESCRIPTION
Jenkins bundles the grid of Bootstrap 3 (that has been patched to use 24 columns). It is not compatible with new JS frameworks (see https://issues.jenkins-ci.org/browse/JENKINS-61326) that are based on BS4 and a 12 column grid (see https://github.com/jenkinsci/bootstrap4-api-plugin).

This pull request provides a workaround by adding a new optional property to the `layout.jelly` file until a fix for https://issues.jenkins-ci.org/browse/JENKINS-61326 is available. Using this toggle a plugin can suppress loading of the BS3 grid when using the layout tag. 

### Proposed changelog entries

Developer: Add `nogrid` option to `layout.jelly` tag to allow suppressing the bootstrap 3 grid. See [bootstrap4-api-plugin](https://github.com/jenkinsci/bootstrap4-api-plugin) for details.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@fqueiruga 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
