### PR TITLE
[JENKINS-62089] Reduces the help icon size to 20px

### DIFF
--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -800,6 +800,24 @@ LABEL.attach-previous {
   /* this marker class is used by JavaScript to locate the area to display help text. */
 }
 
+.help-button {
+  margin-left: 2px;
+  margin-right: 2ch;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+.setting-help .help-button {
+  margin: 0;
+}
+.icon-help,
+.svg-icon.icon-help {
+  height: 1.25rem;
+  width: 1.25rem;
+}
+img.icon-help {
+  vertical-align: text-top;
+}
 
 /* ====================== project view tab bar ===================================== */
 #viewList {


### PR DESCRIPTION
See [JENKINS-62089](https://issues.jenkins-ci.org/browse/JENKINS-62089).

New help icons felt too big, so I reduced their size.

Before:
![Captura de pantalla 2020-04-29 a las 11 14 13](https://user-images.githubusercontent.com/5738588/80579706-c5240680-8a0a-11ea-91ee-25c0c77b70af.png)

After:
![Captura de pantalla 2020-04-29 a las 11 13 21](https://user-images.githubusercontent.com/5738588/80579729-cce3ab00-8a0a-11ea-95f2-e33543b8cc5c.png)





### Proposed changelog entries

N/A 
I don't think it warrants a changelog entry, as they fix a change that's too recent.


### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 
@daniel-beck 
@jsoref 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
