### PR TITLE
[JENKINS-62065]  Breadcrumbs clickable after notification bar disappears

### DIFF
--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1666,7 +1666,7 @@ table.progress-bar.red td.progress-bar-done {
   animation: fadeout 350ms ease-in 1 normal forwards;
 }
 
-@-webkit-keyframes fadein{
+@keyframes fadein{
   from{
     opacity: 0;
   }
@@ -1675,7 +1675,7 @@ table.progress-bar.red td.progress-bar-done {
   }
 }
 
-@-webkit-keyframes fadeout{
+@keyframes fadeout{
   from{
     opacity: 1;
   }

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1672,6 +1672,7 @@ table.progress-bar.red td.progress-bar-done {
   }
   to{
     opacity: 1;
+    visibility: visible;
   }
 }
 
@@ -1681,6 +1682,7 @@ table.progress-bar.red td.progress-bar-done {
   }
   to{
     opacity: 0;
+    visibility: hidden;
   }
 }
 


### PR DESCRIPTION
See [JENKINS-62065](https://issues.jenkins-ci.org/browse/JENKINS-62065).

Setting visibility to hidden along with the opacity transition makes the underlying breadcrumb clickable again, despite the notification-bar div.

Also, using the generic keyframe, rather than webkit.

### Proposed changelog entries

* Fixed bug that was causing breadcrums to not be clickable after notification alerts were displayed 

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [N/A] Appropriate autotests or explanation to why this change has no tests
- [N/A] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@daniel-beck 
@fqueiruga 
@timja 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
