### PR TITLE
Removed redundant supressions

### DIFF
--- a/core/src/test/java/hudson/model/AbstractItemTest.java
+++ b/core/src/test/java/hudson/model/AbstractItemTest.java
@@ -13,7 +13,6 @@ import org.jvnet.hudson.test.Issue;
 /**
  * @author kingfai
  */
-@SuppressWarnings("unchecked")
 public class AbstractItemTest {
 
     private static class StubAbstractItem extends AbstractItem {

--- a/core/src/test/java/hudson/model/ActionableTest.java
+++ b/core/src/test/java/hudson/model/ActionableTest.java
@@ -74,7 +74,6 @@ public class ActionableTest {
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Issue("JENKINS-39555")
     @Test
     public void testExtensionOverrides() {

--- a/core/src/test/java/hudson/model/StubJob.java
+++ b/core/src/test/java/hudson/model/StubJob.java
@@ -31,7 +31,7 @@ import java.util.SortedMap;
  * @deprecated Does not behave very consistently. Either write a real functional test with {@code JenkinsRule}, or use PowerMock/Mockito.
  */
 @Deprecated
-@SuppressWarnings({ "rawtypes", "unchecked" })
+@SuppressWarnings({ "rawtypes" })
 class StubJob extends Job {
 
     public final static String DEFAULT_STUB_JOB_NAME = "StubJob";

--- a/core/src/test/java/hudson/model/listeners/SCMListenerTest.java
+++ b/core/src/test/java/hudson/model/listeners/SCMListenerTest.java
@@ -40,7 +40,7 @@ import org.mockito.Mockito;
 public class SCMListenerTest {
 
     @Issue("JENKINS-23522")
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({"rawtypes"})
     @Test public void onChangeLogParsed() throws Exception {
         SCM scm = Mockito.mock(SCM.class);
         BuildListener bl = Mockito.mock(BuildListener.class);


### PR DESCRIPTION
Removed redundant supressions

### Proposed changelog entries

* Internal: N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
