### PR TITLE
These at-since were improperly added

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1386,7 +1386,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *
      * @return {@code true} if usage statistics should be collected.
      *                Defaults to {@code true} when {@link #noUsageStatistics} is not set.
-     * @since 2.226
      */
     public boolean isUsageStatisticsCollected() {
         return noUsageStatistics==null || !noUsageStatistics;
@@ -1395,7 +1394,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Sets the noUsageStatistics flag
      *
-     * @since 2.226
      */
     public void setNoUsageStatistics(Boolean noUsageStatistics) throws IOException {
         this.noUsageStatistics = noUsageStatistics;


### PR DESCRIPTION
Our tooling assumes that nobody would backfill `@since TODO` for old code, since it's already known what the first release was.

So https://github.com/jenkinsci/jenkins/pull/4549 improperly added `@since TODO` to methods that have existed for a decade, and nobody noticed in https://github.com/jenkinsci/jenkins/pull/4587.

Origin branch (not on dev machine right now), please delete on merge.