### PR TITLE
Make the SystemProperties API available to plugins

### DIFF
--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -74,9 +74,10 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  *
  * <p>While it looks like it on first glance, this cannot be mapped to {@link EnvVars},
  * because {@link EnvVars} is only for build variables, not Jenkins itself variables.
+ *
+ * @since TODO
  */
 @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "Currently Jenkins instance may have one ond only one context")
-@Restricted(NoExternalUse.class)
 public class SystemProperties {
 
     @FunctionalInterface
@@ -90,6 +91,7 @@ public class SystemProperties {
     private static @NonNull Handler handler = NULL_HANDLER;
 
     // declared in WEB-INF/web.xml
+    @Restricted(NoExternalUse.class)
     public static final class Listener implements ServletContextListener, OnMaster {
 
         /**
@@ -122,12 +124,15 @@ public class SystemProperties {
 
     /**
      * Mark a key whose value should be made accessible in agent JVMs.
+     *
+     * @param key Property key to be explicitly allowed
      */
     public static void allowOnAgent(String key) {
         ALLOW_ON_AGENT.add(key);
     }
 
     @Extension
+    @Restricted(NoExternalUse.class)
     public static final class AgentCopier extends ComputerListener {
         @Override
         public void preOnline(Computer c, Channel channel, FilePath root, TaskListener listener) throws IOException, InterruptedException {


### PR DESCRIPTION
As @jglick and @daniel-beck asked, I would like to make the SystemProperties API available to plugin developers

### Proposed changelog entries

* Make the SystemProperties API available to plugins so that their properties could be managed by a standard engine
  * Javadoc: https://javadoc.jenkins.io/jenkins/util/SystemProperties.html
  * Jenkins Features Controlled with System Properties: https://www.jenkins.io/doc/book/managing/system-properties/

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
