### PR TITLE
Fix up Protector class

### DIFF
--- a/core/src/main/java/hudson/util/Scrambler.java
+++ b/core/src/main/java/hudson/util/Scrambler.java
@@ -34,7 +34,6 @@ import java.util.logging.Logger;
  * Use {@link Secret} instead.
  *
  * @author Kohsuke Kawaguchi
- * @see Protector
  */
 public class Scrambler {
     private static final Logger LOGGER = Logger.getLogger(Scrambler.class.getName());


### PR DESCRIPTION
While it would _generally_ be a pretty severe problem to use DES, the way this class is written and used makes it fairly harmless. Still, get rid of it.

The benefit of a session specific key here makes it very easy to just change the algorithm etc. without having to be able to decrypt old data.

An argument could be made that we should just use `Secret` here, and perhaps `f:password` as the form field; OTOH I like the idea with a session-specific encryption and probably want to use it elsewhere. So for now, restrict the class. According to `usage-in-plugins`, it's not used in any plugin anyway.

### Testing notes

This is only used for the form UI and form submission of the "Password" user property fields when using the Jenkins security realm (editing users, creating users).

### Proposed changelog entries

(Internal only)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
