### PR TITLE
[JENKINS-61937] Downgrade ant dependency to allow hpi:run on JDK 8

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -59,7 +59,8 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.10.7</version>
+        <!-- JENKINS-61937: 1.10.6 and 1.10.7 cause hpi:run failures in plugins on JDK 8 -->
+        <version>1.10.5</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
See [JENKINS-61937](https://issues.jenkins-ci.org/browse/JENKINS-61937).

Strictly speaking this is a breaking change, but seems less relevant to Jenkins than what the original change broke.

We're reverting the following:

* https://downloads.apache.org/ant/RELEASE-NOTES-1.10.6.html
* https://downloads.apache.org/ant/RELEASE-NOTES-1.10.7.html

### Proposed changelog entries

* Developer: Downgrade Ant dependency from 1.10.7 to 1.10.5 to restore the ability use `hpi:run` on JDK 8. (regression in 2.230)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mwinter69 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
