### PR TITLE
Backporting for LTS 2.222.4

### DIFF
--- a/core/src/main/java/hudson/init/InitMilestone.java
+++ b/core/src/main/java/hudson/init/InitMilestone.java
@@ -106,14 +106,15 @@ public enum InitMilestone implements Milestone {
     JOB_LOADED("Loaded all jobs"),
 
     /**
-     * By this milestone, any job configuration is adapted or updated just in case any plugin needs to update former/old configurations or init scripts
-     * @since TODO
+     * By this milestone, any job configuration is adapted or updated just in case any plugin needs to update former/old configurations.
+     * It does not include {@link hudson.init.impl.GroovyInitScript}s which get executed later
+     * @since 2.220
      */
     JOB_CONFIG_ADAPTED("Configuration for all jobs updated"),
 
     /**
-     * The very last milestone
-     *
+     * The very last milestone.
+     * All executions should be completed by it, including {@link hudson.init.impl.GroovyInitScript}s.
      * This is used in {@link Initializer#before()} since annotations cannot have null as the default value.
      */
     COMPLETED("Completed initialization");

--- a/core/src/main/java/hudson/init/impl/GroovyInitScript.java
+++ b/core/src/main/java/hudson/init/impl/GroovyInitScript.java
@@ -32,11 +32,12 @@ import static hudson.init.InitMilestone.*;
 
 /**
  * Run the initialization script, if it exists.
+ * It runs strictly after the initialization of other tasks during the last initialization milestone.
  * 
  * @author Kohsuke Kawaguchi
  */
 public class GroovyInitScript {
-    @Initializer(after=JOB_LOADED)
+    @Initializer(after=JOB_CONFIG_ADAPTED)
     public static void init(Jenkins j) {
         new GroovyHookScript("init", j.servletContext, j.getRootDir(), j.getPluginManager().uberClassLoader).run();
     }

--- a/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
+++ b/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
@@ -65,7 +65,7 @@ class DOSToUnixPathHelper {
 
                     tokenizedPathBuilder.append(_dir.replace('\\', '/'));
 
-                    if (checkPrefix(_dir + File.pathSeparator + exe, helper))
+                    if (checkPrefix(_dir + File.separator + exe, helper))
                         return;
                 }
                 tokenizedPathBuilder.append('.');

--- a/core/src/main/java/jenkins/agents/WebSocketAgents.java
+++ b/core/src/main/java/jenkins/agents/WebSocketAgents.java
@@ -30,17 +30,16 @@ import hudson.ExtensionList;
 import hudson.model.Computer;
 import hudson.model.InvisibleAction;
 import hudson.model.UnprotectedRootAction;
-import hudson.remoting.AbstractByteArrayCommandTransport;
+import hudson.remoting.AbstractByteBufferCommandTransport;
 import hudson.remoting.Capability;
-import hudson.remoting.Channel;
 import hudson.remoting.ChannelBuilder;
+import hudson.remoting.ChunkHeader;
 import hudson.remoting.Engine;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -106,7 +105,7 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         private final JnlpConnectionState state;
         private final String agent;
         private final Capability remoteCapability;
-        private AbstractByteArrayCommandTransport.ByteArrayReceiver receiver;
+        private Transport transport;
 
         Session(JnlpConnectionState state, String agent, Capability remoteCapability) {
             this.state = state;
@@ -119,7 +118,8 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
             Computer.threadPoolForRemoting.submit(() -> {
                 LOGGER.fine(() -> "setting up channel for " + agent);
                 state.fireBeforeChannel(new ChannelBuilder(agent, Computer.threadPoolForRemoting));
-                state.fireAfterChannel(state.getChannelBuilder().build(new Transport()));
+                transport = new Transport();
+                state.fireAfterChannel(state.getChannelBuilder().build(transport));
                 LOGGER.fine(() -> "set up channel for " + agent);
                 return null;
             });
@@ -128,10 +128,10 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         @Override
         protected void binary(byte[] payload, int offset, int len) {
             LOGGER.finest(() -> "reading block of length " + len + " from " + agent);
-            if (offset == 0 && len == payload.length) {
-                receiver.handle(payload);
-            } else {
-                receiver.handle(Arrays.copyOfRange(payload, offset, offset + len));
+            try {
+                transport.receive(ByteBuffer.wrap(payload, offset, len));
+            } catch (IOException | InterruptedException e) {
+                error(e);
             }
         }
 
@@ -139,7 +139,7 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         protected void closed(int statusCode, String reason) {
             LOGGER.finest(() -> "closed " + statusCode + " " + reason);
             IOException x = new ClosedChannelException();
-            receiver.terminate(x);
+            transport.terminate(x);
             state.fireChannelClosed(x);
             state.fireAfterDisconnect();
         }
@@ -149,22 +149,13 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
             LOGGER.log(Level.WARNING, null, cause);
         }
 
-        class Transport extends AbstractByteArrayCommandTransport {
+        class Transport extends AbstractByteBufferCommandTransport {
 
             @Override
-            public void setup(AbstractByteArrayCommandTransport.ByteArrayReceiver bar) {
-                receiver = bar;
-            }
-
-            @Override
-            public void writeBlock(Channel chnl, byte[] bytes) throws IOException {
-                LOGGER.finest(() -> "writing block of length " + bytes.length + " to " + agent);
-                try {
-                    sendBinary(ByteBuffer.wrap(bytes)).get();
-                } catch (Exception x) {
-                    x.printStackTrace();
-                    throw new IOException(x);
-                }
+            protected void write(ByteBuffer header, ByteBuffer data) throws IOException {
+                LOGGER.finest(() -> "sending message of length " + ChunkHeader.length(ChunkHeader.peek(header)));
+                sendBinary(header, false);
+                sendBinary(data, true);
             }
 
             @Override
@@ -183,7 +174,6 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
                 LOGGER.finest(() -> "closeRead");
                 close();
             }
-
         }
 
     }

--- a/core/src/main/java/jenkins/security/ResourceDomainConfiguration.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainConfiguration.java
@@ -34,6 +34,7 @@ import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.model.identity.InstanceIdentityProvider;
 import jenkins.util.UrlHelper;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
@@ -49,6 +50,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPublicKey;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -168,8 +170,11 @@ public final class ResourceDomainConfiguration extends GlobalConfiguration {
                 }
                 // response is error
                 String responseMessage = httpURLConnection.getResponseMessage();
-                if (responseCode == 404 && responseMessage.equals(ERROR_RESPONSE)) {
-                    return FormValidation.ok(Messages.ResourceDomainConfiguration_ResourceResponse());
+                if (responseCode == 404) {
+                    String responseBody = String.join("", IOUtils.readLines(httpURLConnection.getErrorStream(), StandardCharsets.UTF_8));
+                    if (responseMessage.contains(ERROR_RESPONSE) || responseBody.contains(ERROR_RESPONSE)) {
+                        return FormValidation.ok(Messages.ResourceDomainConfiguration_ResourceResponse());
+                    }
                 }
                 return FormValidation.error(Messages.ResourceDomainConfiguration_FailedIdentityCheck(responseCode, responseMessage));
             }

--- a/core/src/main/java/jenkins/websocket/WebSocketSession.java
+++ b/core/src/main/java/jenkins/websocket/WebSocketSession.java
@@ -60,6 +60,7 @@ public abstract class WebSocketSession {
     private static final Logger LOGGER = Logger.getLogger(WebSocketSession.class.getName());
 
     private Object session;
+    // https://www.eclipse.org/jetty/javadoc/9.4.24.v20191120/org/eclipse/jetty/websocket/common/WebSocketRemoteEndpoint.html
     private Object remoteEndpoint;
     private ScheduledFuture<?> pings;
 
@@ -125,6 +126,15 @@ public abstract class WebSocketSession {
     protected final Future<Void> sendBinary(ByteBuffer data) {
         try {
             return (Future<Void>) remoteEndpoint.getClass().getMethod("sendBytesByFuture", ByteBuffer.class).invoke(remoteEndpoint, data);
+        } catch (Exception x) {
+            throw new RuntimeException(x);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected final void sendBinary(ByteBuffer partialByte, boolean isLast) {
+        try {
+            remoteEndpoint.getClass().getMethod("sendPartialBytes", ByteBuffer.class, boolean.class).invoke(remoteEndpoint, partialByte, isLast);
         } catch (Exception x) {
             throw new RuntimeException(x);
         }

--- a/core/src/main/java/jenkins/websocket/WebSocketSession.java
+++ b/core/src/main/java/jenkins/websocket/WebSocketSession.java
@@ -60,7 +60,6 @@ public abstract class WebSocketSession {
     private static final Logger LOGGER = Logger.getLogger(WebSocketSession.class.getName());
 
     private Object session;
-    // https://www.eclipse.org/jetty/javadoc/9.4.24.v20191120/org/eclipse/jetty/websocket/common/WebSocketRemoteEndpoint.html
     private Object remoteEndpoint;
     private ScheduledFuture<?> pings;
 
@@ -126,15 +125,6 @@ public abstract class WebSocketSession {
     protected final Future<Void> sendBinary(ByteBuffer data) {
         try {
             return (Future<Void>) remoteEndpoint.getClass().getMethod("sendBytesByFuture", ByteBuffer.class).invoke(remoteEndpoint, data);
-        } catch (Exception x) {
-            throw new RuntimeException(x);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    protected final void sendBinary(ByteBuffer partialByte, boolean isLast) {
-        try {
-            remoteEndpoint.getClass().getMethod("sendPartialBytes", ByteBuffer.class, boolean.class).invoke(remoteEndpoint, partialByte, isLast);
         } catch (Exception x) {
             throw new RuntimeException(x);
         }

--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -30,6 +30,15 @@ THE SOFTWARE.
 
   <l:layout norefresh="true" type="one-column" permission="${it.EXTENDED_READ}" title="${%Config(it.displayName)}">
 
+    <j:choose>
+      <j:when test="${app.hasPermission(it.CONFIGURE)}">
+        <j:set var="readOnlyMode" value="false" />
+      </j:when>
+      <j:otherwise>
+        <j:set var="readOnlyMode" value="true" />
+      </j:otherwise>
+    </j:choose>
+
     <l:js src="jsbundles/config-scrollspy.js" />
     <l:css src="jsbundles/config-scrollspy.css" />
 

--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
   <l:layout norefresh="true" type="one-column" permission="${it.EXTENDED_READ}" title="${%Config(it.displayName)}">
 
     <j:choose>
-      <j:when test="${app.hasPermission(it.CONFIGURE)}">
+      <j:when test="${it.hasPermission(it.CONFIGURE)}">
         <j:set var="readOnlyMode" value="false" />
       </j:when>
       <j:otherwise>

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -60,20 +60,22 @@ THE SOFTWARE.
       If any other value is specified then requests will use GET.
     </st:attribute>
   </st:documentation>
+  <f:prepareDatabinding/>
+  <j:set var="resolvedValue" value="${attrs.value ?: instance[attrs.field]}" />
+
   <j:choose>
     <j:when test="${readOnlyMode}">
       <j:choose>
-        <j:when test="${value}"><span class="jenkins-readonly">****</span></j:when>
+        <j:when test="${!empty(resolvedValue)}"><span class="jenkins-readonly">****</span></j:when>
         <j:otherwise>
           <span class="jenkins-not-applicable">N/A</span>
         </j:otherwise>
       </j:choose>
     </j:when>
     <j:otherwise>
-      <f:prepareDatabinding/>
       <j:choose>
         <j:when test="${h.useHidingPasswordFields()}">
-          <j:set var="value" value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"/>
+        <j:set var="value" value="${h.getPasswordValue(resolvedValue)}"/>
           <j:choose>
             <j:when test="${ value != null }">
               <st:adjunct includes="lib.form.password.password"/>
@@ -134,7 +136,7 @@ THE SOFTWARE.
           <m:input xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
                    class="setting-input ${attrs.checkUrl!=null?'validated ':''}${attrs.clazz}"
                    name="${attrs.name ?: '_.'+attrs.field}"
-                   value="${h.getPasswordValue(attrs.value ?: instance[attrs.field])}"
+                   value="${h.getPasswordValue(resolvedValue)}"
                    type="password"
                    checkMethod="post"
                    ATTRIBUTES="${attrs}" EXCEPT="field clazz value"/>

--- a/core/src/main/resources/lib/form/textarea.jelly
+++ b/core/src/main/resources/lib/form/textarea.jelly
@@ -98,12 +98,12 @@ THE SOFTWARE.
         <j:if test="${value != null &amp;&amp; !empty(value.toString()) &amp;&amp; (value.toString().codePointAt(0) == 10 || value.toString().codePointAt(0) == 13)}"><j:whitespace>&#10;</j:whitespace></j:if>
         <st:out value="${value}" />
       </textarea>
+    <j:if test="${customizedFields != null and attrs.field != null and value != default}">
+      <j:mute>${customizedFields.add(name)}</j:mute>
+    </j:if>
+    <!-- resize handle -->
+    <div class="textarea-handle"/>
   </f:possibleReadOnlyField>
-  <j:if test="${customizedFields != null and attrs.field != null and value != default}">
-    <j:mute>${customizedFields.add(name)}</j:mute>
-  </j:if>
-  <!-- resize handle -->
-  <div class="textarea-handle"/>
   <j:if test="${attrs.previewEndpoint!=null}">
     <div class="textarea-preview-container">
       <j:if test="${attrs.previewEndpoint == '/markupFormatter/previewDescription'}">

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>4.2</remoting.version>
+    <remoting.version>4.2.1</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>4.3-20200323.083513-2</remoting.version><!-- https://github.com/jenkinsci/remoting/pull/373 -->
+    <remoting.version>4.2.1</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>4.2.1</remoting.version>
+    <remoting.version>4.2</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>4.2</remoting.version>
+    <remoting.version>4.3-20200323.083513-2</remoting.version><!-- https://github.com/jenkinsci/remoting/pull/373 -->
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/test/src/test/java/hudson/util/FormValidationTest.java
+++ b/test/src/test/java/hudson/util/FormValidationTest.java
@@ -1,0 +1,33 @@
+package hudson.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FormValidationTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Issue("JENKINS-61711")
+    @Test
+    public void testValidateExecutableWithFix() {
+        // Global Tool Configuration is able to find git executable in system environment at PATH.
+        FormValidation actual = FormValidation.validateExecutable("git");
+        assertThat(actual, is(FormValidation.ok()));
+    }
+
+    @Issue("JENKINS-61711")
+    @Test
+    public void testValidateExecutableWithoutFix() {
+        // Without JENKINS-61711 fix, Git installations under Global Tool Configuration is not able to find git
+        // executable at system PATH despite git exec existing at the path.
+        FormValidation actual = FormValidation.validateExecutable("git");
+        String failMessage = "There's no such executable git in PATH:";
+        assertThat(actual, not(is(FormValidation.error(failMessage))));
+    }
+}

--- a/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
+++ b/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
@@ -35,6 +35,7 @@ import hudson.slaves.SlaveComputer;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
 import java.io.File;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -99,9 +100,10 @@ public class WebSocketAgentsTest {
             ).stdout(System.out).start());
             r.waitOnline(s);
             assertEquals("response", s.getChannel().call(new DummyTask()));
+            assertNotNull(s.getChannel().call(new FatTask()));
             FreeStyleProject p = r.createFreeStyleProject();
             p.setAssignedNode(s);
-            p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo hello") : new Shell("echo hello"));
+            p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo hello") : new Shell("dd if=/dev/random count=1024 bs=200"));
             r.buildAndAssertSuccess(p);
             s.toComputer().getLogText().writeLogTo(0, System.out);
         } finally {
@@ -119,6 +121,20 @@ public class WebSocketAgentsTest {
         @Override
         public String call() {
             return "response";
+        }
+    }
+
+    private static class FatTask extends SlaveToMasterCallable<String, RuntimeException> {
+        private byte[] payload;
+
+        private FatTask() {
+            payload = new byte[1024 * 1024];
+            new Random().nextBytes(payload);
+        }
+
+        @Override
+        public String call() {
+            return new String(payload);
         }
     }
 

--- a/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
+++ b/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
@@ -103,7 +103,7 @@ public class WebSocketAgentsTest {
             assertNotNull(s.getChannel().call(new FatTask()));
             FreeStyleProject p = r.createFreeStyleProject();
             p.setAssignedNode(s);
-            p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo hello") : new Shell("dd if=/dev/random count=1024 bs=200"));
+            p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo hello") : new Shell("echo hello"));
             r.buildAndAssertSuccess(p);
             s.toComputer().getLogText().writeLogTo(0, System.out);
         } finally {

--- a/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
+++ b/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
@@ -35,7 +35,6 @@ import hudson.slaves.SlaveComputer;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
 import java.io.File;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -100,10 +99,9 @@ public class WebSocketAgentsTest {
             ).stdout(System.out).start());
             r.waitOnline(s);
             assertEquals("response", s.getChannel().call(new DummyTask()));
-            assertNotNull(s.getChannel().call(new FatTask()));
             FreeStyleProject p = r.createFreeStyleProject();
             p.setAssignedNode(s);
-            p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo hello") : new Shell("dd if=/dev/random count=1024 bs=200"));
+            p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo hello") : new Shell("echo hello"));
             r.buildAndAssertSuccess(p);
             s.toComputer().getLogText().writeLogTo(0, System.out);
         } finally {
@@ -121,20 +119,6 @@ public class WebSocketAgentsTest {
         @Override
         public String call() {
             return "response";
-        }
-    }
-
-    private static class FatTask extends SlaveToMasterCallable<String, RuntimeException> {
-        private byte[] payload;
-
-        private FatTask() {
-            payload = new byte[1024 * 1024];
-            new Random().nextBytes(payload);
-        }
-
-        @Override
-        public String call() {
-            return new String(payload);
         }
     }
 

--- a/war/src/main/js/config-scrollspy.less
+++ b/war/src/main/js/config-scrollspy.less
@@ -24,6 +24,10 @@
   .section-header-row.config_general .section-header {
     display: none;
   }
+
+  td.setting-main {
+    line-height: 29px
+  }
 }
 
 .jenkins-config-widgets {

--- a/war/src/main/less/pluginSetupWizard.less
+++ b/war/src/main/less/pluginSetupWizard.less
@@ -96,6 +96,10 @@
     }
     }
 
+    .error {
+        margin-bottom: 1em;
+    }
+
     .modal-body {
         background: linear-gradient(175deg, #f8f8f8 0%, rgba(255, 255, 255, 1) 22%, rgba(255, 255, 255, 0) 100%);
         overflow-y: auto;


### PR DESCRIPTION
Backporting has started and the RC is scheduled for 2020-05-06.

Please have look at the changes proposed and rejected so we have a consensus of what goes in by 2020-05-06.

At large, I propose to get the Read-Only config page changes backported, but to leave the banner rework out.

```
Fixed
-----

JENKINS-62133		Minor     		2.235
	Configure screen: Resource Root URL validation error - 404 instance-identity
	regression
	https://issues.jenkins-ci.org/browse/JENKINS-62133

JENKINS-61812		Minor     		2.234
	Read-only f:password field always shows "N/A"
	https://issues.jenkins-ci.org/browse/JENKINS-61812

JENKINS-61711		Minor     		2.232
	Git plugin global config incorrectly reports git not in PATH
	https://issues.jenkins-ci.org/browse/JENKINS-61711

JENKINS-61694		Major     		2.230
	Groovy Hooks may run before or after JOB_CONFIG_ADAPTED
	https://issues.jenkins-ci.org/browse/JENKINS-61694

JENKINS-61660		Minor     		2.232
	Lack of spacing between setup wizard form errors
	regression
	https://issues.jenkins-ci.org/browse/JENKINS-61660

JENKINS-61409		Critical  		2.229
	Websocket connections crash if message size is greater than 64Kb
	non-trivial-lts-backporting
	https://issues.jenkins-ci.org/browse/JENKINS-61409

JENKINS-61321		Blocker   		2.224
	Pipeline Job configuration appears read-only for users with project-level permissions after update to Jenkins 2.223
	regression
	https://issues.jenkins-ci.org/browse/JENKINS-61321

JENKINS-61284		Minor     		2.224
	Grey bar below textarea in read only mode looks weird
	https://issues.jenkins-ci.org/browse/JENKINS-61284

JENKINS-61202		Minor     		2.223
	Read only view of job configuration page
	https://issues.jenkins-ci.org/browse/JENKINS-61202
		Caused https://issues.jenkins-ci.org/browse/JENKINS-61321
		Caused https://issues.jenkins-ci.org/browse/JENKINS-61284

Rejected
--------

JENKINS-62065		Minor     		2.235
	The bread crumb navigation on the top of the job is not responding after clicking Apply
	regression
	https://issues.jenkins-ci.org/browse/JENKINS-62065

JENKINS-61478		Minor     		2.230
	"Apply" (and similar) banners look really bad with larger header bar
	regression
	https://issues.jenkins-ci.org/browse/JENKINS-61478
		Caused https://issues.jenkins-ci.org/browse/JENKINS-62065

JENKINS-61479		Minor     		2.230
	java.lang.ClassCastException: java.lang.Long cannot be cast to java.util.Date
	https://issues.jenkins-ci.org/browse/JENKINS-61479

JENKINS-61841		Minor     		2.235
	PathRemover methods can throw enormous CompositeIOExceptions
	https://issues.jenkins-ci.org/browse/JENKINS-61841
```