### PR TITLE
[JENKINS-60118] - Ensure that UserLanguages telemetry initializer always runs after extensions are augmented

### DIFF
--- a/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
+++ b/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
@@ -24,6 +24,7 @@
 package jenkins.telemetry.impl;
 
 import hudson.Extension;
+import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.util.PluginServletFilter;
 import jenkins.telemetry.Telemetry;
@@ -94,7 +95,7 @@ public class UserLanguages extends Telemetry {
         return payload;
     }
 
-    @Initializer
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
     public static void setUpFilter() {
         Filter filter = new AcceptLanguageFilter();
         if (!PluginServletFilter.hasFilter(filter)) {


### PR DESCRIPTION
UserLanguages static initializer sets up a PluginServletFilter. In order to do so, we need an initialized Jenkins instance.  It does not manifest in common Jenkins runs, but it pops up in Jenkinsfile Runner when running in the standalone JAR mode: https://github.com/jenkinsci/jenkinsfile-runner/issues/193

The code is now similar to the ResourceDomainFilter:

```java
    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
    public static void init() throws ServletException {
        PluginServletFilter.addFilter(new ResourceDomainFilter());
    }
```

See [JENKINS-60118](https://issues.jenkins-ci.org/browse/JENKINS-60118).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Ensure that UserLanguages telemetry initializer always runs after extensions are augmented
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
