### PR TITLE
Deprecating jenkins.model.Configuration

### DIFF
--- a/core/src/main/java/jenkins/model/Configuration.java
+++ b/core/src/main/java/jenkins/model/Configuration.java
@@ -26,7 +26,10 @@ package jenkins.model;
 import jenkins.util.SystemProperties;
 import hudson.model.Hudson;
 
-
+/**
+ * @deprecated use {@link SystemProperties} directly
+ */
+@Deprecated
 public class Configuration {
 
     public static boolean getBooleanConfigParameter(String name, boolean defaultValue) {


### PR DESCRIPTION
As suggested in https://github.com/jenkinsci/jenkins/pull/4707#issuecomment-624620876.

For now I am not switching internal usages because the natural change would be to inline the `jenkins.model.Jenkins.XXX` variant (dropping support for the old `hudson.model.Hudson.XXX` variant), but this would be a bit more involved as https://www.jenkins.io/doc/book/managing/system-properties/ documents at least some of these, but with an inconsistent variant (sometimes old, sometimes new, but not both), so would require a docs patch too.

### Proposed changelog entries

* Deprecating `jenkins.model.Configuration` in the Java API.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
