### PR TITLE
[JENKINS-62231] OldDataMonitor avoids Jenkins from loading a plugin

### DIFF
--- a/core/src/main/java/hudson/util/RobustReflectionConverter.java
+++ b/core/src/main/java/hudson/util/RobustReflectionConverter.java
@@ -53,6 +53,8 @@ import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import static java.util.logging.Level.FINE;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import net.jcip.annotations.GuardedBy;
@@ -371,8 +373,9 @@ public class RobustReflectionConverter implements Converter {
             // one.
             try {
                 OldDataMonitor.report((Saveable) result, (ArrayList<Throwable>) context.get("ReadError"));
-            } catch (Throwable ignored) {
-                // it should be already reported
+            } catch (Throwable t) {
+                // it should be already reported, but we report with INFO just in case
+                LOGGER.log(Level.INFO, "There was a problem reporting unmarshalling field errors", t);
             }
             context.put("ReadError", null);
         }

--- a/core/src/main/java/hudson/util/RobustReflectionConverter.java
+++ b/core/src/main/java/hudson/util/RobustReflectionConverter.java
@@ -376,11 +376,13 @@ public class RobustReflectionConverter implements Converter {
             } catch (Throwable t) {
                 // it should be already reported, but we report with INFO just in case
                 StringBuilder message = new StringBuilder("There was a problem reporting unmarshalling field errors");
+                Level level = Level.WARNING;
                 if (t instanceof IllegalStateException && t.getMessage().contains("Expected 1 instance of " + OldDataMonitor.class.getName())) {
                     message.append(". Make sure this code is executed after InitMilestone.EXTENSIONS_AUGMENTED stage, for example in Plugin#postInitialize instead of Plugin#start");
+                    level = Level.INFO; // it was reported when getting the singleton for OldDataMonitor
                 }
                 // it should be already reported, but we report with INFO just in case
-                LOGGER.log(Level.INFO, message.toString(), t);
+                LOGGER.log(level, message.toString(), t);
             }
             context.put("ReadError", null);
         }

--- a/core/src/main/java/hudson/util/RobustReflectionConverter.java
+++ b/core/src/main/java/hudson/util/RobustReflectionConverter.java
@@ -376,11 +376,10 @@ public class RobustReflectionConverter implements Converter {
             } catch (Throwable t) {
                 // it should be already reported, but we report with INFO just in case
                 StringBuilder message = new StringBuilder("There was a problem reporting unmarshalling field errors");
-                String additionalMessage = ". Be sure this code is executed after InitMilestone.EXTENSIONS_AUGMENTED stage, for example in Plugin#postInitialize instead of Plugin#start";
                 if (t instanceof IllegalStateException && t.getMessage().contains("Expected 1 instance of " + OldDataMonitor.class.getName())) {
-                    // it should be already reported, but we report with INFO just in case
-                    message.append(additionalMessage);
+                    message.append(". Make sure this code is executed after InitMilestone.EXTENSIONS_AUGMENTED stage, for example in Plugin#postInitialize instead of Plugin#start");
                 }
+                // it should be already reported, but we report with INFO just in case
                 LOGGER.log(Level.INFO, message.toString(), t);
             }
             context.put("ReadError", null);

--- a/core/src/main/java/hudson/util/RobustReflectionConverter.java
+++ b/core/src/main/java/hudson/util/RobustReflectionConverter.java
@@ -375,7 +375,13 @@ public class RobustReflectionConverter implements Converter {
                 OldDataMonitor.report((Saveable) result, (ArrayList<Throwable>) context.get("ReadError"));
             } catch (Throwable t) {
                 // it should be already reported, but we report with INFO just in case
-                LOGGER.log(Level.INFO, "There was a problem reporting unmarshalling field errors", t);
+                StringBuilder message = new StringBuilder("There was a problem reporting unmarshalling field errors");
+                String additionalMessage = ". Be sure this code is executed after InitMilestone.EXTENSIONS_AUGMENTED stage, for example in Plugin#postInitialize instead of Plugin#start";
+                if (t instanceof IllegalStateException && t.getMessage().contains("Expected 1 instance of " + OldDataMonitor.class.getName())) {
+                    // it should be already reported, but we report with INFO just in case
+                    message.append(additionalMessage);
+                }
+                LOGGER.log(Level.INFO, message.toString(), t);
             }
             context.put("ReadError", null);
         }


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-62231](https://issues.jenkins-ci.org/browse/JENKINS-62231).

This PR is an easy fix, filed to raise a discussion. I don't know at this point if there is a better way.

Tested manually with the ec2-plugin. Downgrading from 1.50.2 to 1.49.1.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Internal Avoid an error when reporting errors because of field unmarshalling to stop loading a plugin.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [N/A] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev @daniel-beck @res0nance 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [N/A] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [N/A] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
