### PR TITLE
[JENKINS-62264] User with MANAGE permissions can access node monitoring

### DIFF
--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -220,7 +220,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      */
     @RequirePOST
     public void doUpdateNow( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
         
         for (NodeMonitor nodeMonitor : NodeMonitor.getAll()) {
             Thread t = nodeMonitor.triggerUpdate();

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -343,7 +343,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     public synchronized HttpResponse doConfigSubmit( StaplerRequest req) throws IOException, ServletException, FormException {
         BulkChange bc = new BulkChange(MONITORS_OWNER);
         try {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.MANAGE);
             monitors.rebuild(req,req.getSubmittedForm(),getNodeMonitorDescriptors());
 
             // add in the rest of instances are ignored instances

--- a/core/src/main/resources/hudson/model/ComputerSet/configure.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/configure.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout permission="${app.ADMINISTER}" title="${%Node Monitoring Configuration}">
+  <l:layout permission="${app.MANAGE}" title="${%Node Monitoring Configuration}">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <!-- to make the form field binding work -->

--- a/core/src/main/resources/hudson/model/ComputerSet/configure.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/configure.jelly
@@ -40,12 +40,12 @@ THE SOFTWARE.
                           descriptors="${it.nodeMonitorDescriptors}"
                           instances="${it.nonIgnoredMonitors}" />
 
-        <j:if test="${h.hasPermission(app.MANAGE)}">
+        <l:hasAdministerOrManage>
           <f:bottomButtonBar>
             <f:submit value="${%OK}" />
             <f:apply />
           </f:bottomButtonBar>
-        </j:if>
+        </l:hasAdministerOrManage>
       </f:form>
       <st:adjunct includes="lib.form.confirm" />
     </l:main-panel>

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -94,13 +94,13 @@ THE SOFTWARE.
       </tr>
 
     </table>
-    <j:if test="${app.hasPermission(app.ADMINISTER)}">
+    <l:hasAdministerOrManage>
       <div align="right" style="margin-top:0.5em">
         <form method="post" action="updateNow">
           <s:submit value="${%Refresh status}"/>
         </form>
       </div>
-    </j:if>
+    </l:hasAdministerOrManage>
   </l:main-panel>
 </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
       <l:task href="${rootURL}/manage" icon="icon-gear2 icon-md" permission="${app.MANAGE}" title="${%Manage Jenkins}"/>
       <l:task href="new" icon="icon-new-computer icon-md" permission="${createPermission}" title="${%New Node}"/>
       <l:task href="${rootURL}/configureClouds" icon="icon-health-40to59 icon-md" permission="${app.ADMINISTER}" title="${%Configure Clouds}"/>
-      <l:task href="configure" icon="icon-gear2 icon-md" permission="${app.ADMINISTER}" title="${%Node Monitoring}"/>
+      <l:task href="configure" icon="icon-gear2 icon-md" permission="${app.MANAGE}" title="${%Node Monitoring}"/>
     </l:tasks>
     <t:queue items="${app.queue.items}" />
     <t:executors />

--- a/test/src/test/java/hudson/model/ComputerSetTest.java
+++ b/test/src/test/java/hudson/model/ComputerSetTest.java
@@ -24,15 +24,22 @@
 package hudson.model;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.cli.CLICommandInvoker;
 import hudson.slaves.DumbSlave;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+
+import java.net.HttpURLConnection;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -79,5 +86,46 @@ public class ComputerSetTest {
         assertThat(ComputerSet.getComputerNames(), contains("aNode"));
         j.createSlave("anAnotherNode", "", null);
         assertThat(ComputerSet.getComputerNames(), containsInAnyOrder("aNode", "anAnotherNode"));
+    }
+
+    @Test
+    public void managePermissionCanConfigure() throws Exception {
+        final String USER = "user";
+        final String MANAGER = "manager";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                // Read access
+                .grant(Jenkins.READ).everywhere().to(USER)
+
+                // Read and Manage
+                .grant(Jenkins.READ).everywhere().to(MANAGER)
+                .grant(Jenkins.MANAGE).everywhere().to(MANAGER)
+        );
+
+        JenkinsRule.WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
+
+        // Jenkins.READ can access /computer but not /computer/configure
+        wc.login(USER);
+        HtmlPage page = wc.goTo("computer/");
+        assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+        String responseContent = page.getWebResponse().getContentAsString();
+        // the "Node Monitoring" link in the sidepanel is not visible
+        assertThat(responseContent, not(containsString("Node Monitoring")));
+        page = wc.goTo("computer/configure");
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, page.getWebResponse().getStatusCode());
+
+        // Jenkins.MANAGER can access /computer and /computer/configure
+        wc.login(MANAGER);
+        page = wc.goTo("computer/");
+        assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+        responseContent = page.getWebResponse().getContentAsString();
+        // the "Node Monitoring" link in the sidepanel is visible
+        assertThat(responseContent, containsString("Node Monitoring"));
+        page = wc.goTo("computer/configure");
+        assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+        // and the OK (save) button is visible
+        responseContent = page.getWebResponse().getContentAsString();
+        assertThat(responseContent, containsString("OK"));
     }
 }


### PR DESCRIPTION
See [JENKINS-62264](https://issues.jenkins-ci.org/browse/JENKINS-62264).

### Proposed changelog entries

* JENKINS-62264: Users with MANAGE permission can configure Node Monitoring.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
