### PR TITLE
Create a perform method with Run class

### DIFF
--- a/core/src/main/java/hudson/tasks/CommandInterpreter.java
+++ b/core/src/main/java/hudson/tasks/CommandInterpreter.java
@@ -78,6 +78,10 @@ public abstract class CommandInterpreter extends Builder {
         return false;
     }
 
+    //To support plugins for pipeline. 
+    public boolean perform(Run<?,?> build, Launcher launcher, TaskListener listener) throws InterruptedException {
+        //Code
+    }
     public boolean perform(AbstractBuild<?,?> build, Launcher launcher, TaskListener listener) throws InterruptedException {
         FilePath ws = build.getWorkspace();
         if (ws == null) {


### PR DESCRIPTION
### Issue:

Creating this PR as I am not able to create issue on Github (there is no Jira ticket)

I am currently writing (updating) a custom plugin to make it compatible for Pipeline view using following documentation:

https://www.jenkins.io/doc/developer/plugin-development/pipeline-integration/

I want this plugin to support both Freestyle and Pipeline Jobs. I have updated Perform function with following signature:

`public void perform(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws InterruptedException, IOException { }`

In my previous plugin, I have a code where Shell commands to execute are being passed to hudson.tasks.Shell constructor and using that object `public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException` is called. Given this method asks for AbstractBuild class and new plugin perform method has Run class, I am not able to use above method. I could not find any perform method which accepts Run class. 

### Proposed changelog entries:

* I have added a comment in class, If we create a perform method supporting Run class in core/src/main/java/hudson/tasks/CommandInterpreter.java, this can be helpful for future plugin development. 

### Help:

If, there is a way I can achieve the result I want to without this change, please help. Any help is appreciated. Thank you in advance!