### PR TITLE
Allow anyone to view 'Manage Jenkins'

### DIFF
--- a/core/src/main/java/hudson/AboutJenkins.java
+++ b/core/src/main/java/hudson/AboutJenkins.java
@@ -1,10 +1,12 @@
 package hudson;
 
+import com.google.common.collect.Sets;
 import hudson.model.ManagementLink;
 import hudson.security.Permission;
 import java.net.URL;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -43,8 +45,8 @@ public class AboutJenkins extends ManagementLink {
 
     @NonNull
     @Override
-    public Permission getRequiredPermission() {
-        return Jenkins.READ;
+    public Set<Permission> getRequiredPermissions() {
+        return Sets.newHashSet(Jenkins.MANAGE, Jenkins.SYSTEM_READ);
     }
 
     @NonNull

--- a/core/src/main/java/hudson/model/ManageJenkinsAction.java
+++ b/core/src/main/java/hudson/model/ManageJenkinsAction.java
@@ -35,10 +35,7 @@ import org.jenkinsci.Symbol;
 @Extension(ordinal=100) @Symbol("manageJenkins")
 public class ManageJenkinsAction implements RootAction {
     public String getIconFileName() {
-        if (Jenkins.get().hasAnyPermission(Jenkins.MANAGE, Jenkins.SYSTEM_READ))
-            return "gear2.png";
-        else
-            return null;
+        return "gear2.png";
     }
 
     public String getDisplayName() {

--- a/core/src/main/java/hudson/model/ManageJenkinsAction.java
+++ b/core/src/main/java/hudson/model/ManageJenkinsAction.java
@@ -39,7 +39,11 @@ public class ManageJenkinsAction implements RootAction {
     }
 
     public String getDisplayName() {
-        return Messages.ManageJenkinsAction_DisplayName();
+        if (Jenkins.get().hasAnyPermission(Jenkins.MANAGE, Jenkins.ADMINISTER)) {
+            return Messages.ManageJenkinsAction_DisplayName();
+        } else {
+            return Messages.ManageJenkinsAction_ReadOnlyDisplayName();
+        }
     }
 
     public String getUrlName() {

--- a/core/src/main/java/hudson/model/ManagementLink.java
+++ b/core/src/main/java/hudson/model/ManagementLink.java
@@ -23,11 +23,13 @@
  */
 package hudson.model;
 
+import com.google.common.collect.Sets;
 import hudson.ExtensionPoint;
 import hudson.ExtensionListView;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.security.Permission;
+import java.util.Set;
 import jenkins.model.Jenkins;
 
 import java.util.List;
@@ -126,6 +128,17 @@ public abstract class ManagementLink implements ExtensionPoint, Action {
      */
     public @NonNull Permission getRequiredPermission() {
         return Jenkins.ADMINISTER;
+    }
+
+    /**
+     * Returns the set of possible permissions required for user to see this management link on the "Manage Jenkins" page ({@link ManageJenkinsAction}).
+     * The user only needs one of the permissions to see the link.
+     *
+     * @since TODO
+     * @return the set of permission(s) required for the link to be shown on "Manage Jenkins".
+     */
+    public @NonNull Set<Permission> getRequiredPermissions() {
+        return Sets.newHashSet(getRequiredPermission());
     }
 
     /**

--- a/core/src/main/java/jenkins/management/ConfigureLink.java
+++ b/core/src/main/java/jenkins/management/ConfigureLink.java
@@ -24,9 +24,11 @@
 
 package jenkins.management;
 
+import com.google.common.collect.Sets;
 import hudson.Extension;
 import hudson.model.ManagementLink;
 import hudson.security.Permission;
+import java.util.Set;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
@@ -54,8 +56,8 @@ public class ConfigureLink extends ManagementLink {
 
     @NonNull
     @Override
-    public Permission getRequiredPermission() {
-        return Jenkins.READ;
+    public Set<Permission> getRequiredPermissions() {
+        return Sets.newHashSet(Jenkins.MANAGE, Jenkins.SYSTEM_READ);
     }
 
     @Override

--- a/core/src/main/java/jenkins/management/SystemInfoLink.java
+++ b/core/src/main/java/jenkins/management/SystemInfoLink.java
@@ -24,10 +24,12 @@
 
 package jenkins.management;
 
+import com.google.common.collect.Sets;
 import hudson.Extension;
 import hudson.model.ManagementLink;
 import hudson.security.Permission;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
@@ -53,9 +55,8 @@ public class SystemInfoLink extends ManagementLink {
 
     @NonNull
     @Override
-    public Permission getRequiredPermission() {
-        //This link is displayed to any user with permission to access the management menu
-        return Jenkins.READ;
+    public Set<Permission> getRequiredPermissions() {
+        return Sets.newHashSet(Jenkins.MANAGE, Jenkins.SYSTEM_READ);
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4749,7 +4749,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             if (link.getIconFileName() == null) {
                 continue;
             }
-            if (!Jenkins.get().hasPermission(link.getRequiredPermission())) {
+            if (!Jenkins.get().hasAnyPermission(link.getRequiredPermissions().toArray(new Permission[0]))) {
                 continue;
             }
             byCategory.computeIfAbsent(link.getCategory(), c -> new ArrayList<>()).add(link);

--- a/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
     <j:getStatic var="createPermission" className="hudson.model.Computer" field="CREATE"/>
     <l:tasks>
       <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
-      <l:task href="${rootURL}/manage" icon="icon-gear2 icon-md" permissions="${app.MANAGE_AND_SYSTEM_READ}" title="${%Manage Jenkins}"/>
+      <l:task href="${rootURL}/manage" icon="icon-gear2 icon-md" title="${%Manage Jenkins}"/>
       <l:task href="new" icon="icon-new-computer icon-md" permission="${createPermission}" title="${%New Node}"/>
       <l:task href="${rootURL}/configureClouds" icon="icon-health-40to59 icon-md" permission="${app.SYSTEM_READ}"
               title="${app.hasPermission(app.ADMINISTER) ? '%Configure Clouds' : '%View Clouds'}"/>

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -196,6 +196,7 @@ Label.GroupOf=group of {0}
 Label.InvalidLabel=invalid label
 Label.ProvisionedFrom=Provisioned from {0}
 ManageJenkinsAction.DisplayName=Manage Jenkins
+ManageJenkinsAction.ReadOnlyDisplayName=View Configuration
 MultiStageTimeSeries.EMPTY_STRING=
 Queue.AllNodesOffline=All nodes of label \u2018{0}\u2019 are offline
 Queue.LabelHasNoNodes=There are no nodes with the label \u2018{0}\u2019

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:layout title="${%Manage Jenkins}" permissions="${app.MANAGE_AND_SYSTEM_READ}">
+<l:layout title="${%Manage Jenkins}">
   <l:header>
      <link rel="stylesheet" href="${resURL}/css/font-awesome/css/font-awesome.min.css" />
   </l:header>


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

### Test this

    docker run --rm -ti -p 8080:8080 -e ID=4737 jenkins/core-pr-tester

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

This PR was motivated by https://github.com/jenkinsci/credentials-plugin/pull/150, one of the featured projects of [Hackfest](https://www.jenkins.io/events/online-hackfest/2020-uiux/#tracks-and-project-ideas) (Credentials Management UX)

It allows non administrative permissions to add management links to 'Manage Links' and have users without Overall/Manage, Overall/Administer or Overall/SystemRead view them.

I've changed the existing links that were using the Overall/Read hack to explicitly list the permissions required. Except for Configure Nodes and Agents which only requires read to view anyway so it made sense for it just to be available.

The text has been renamed to 'View Configuration' for users without Manage or Administer


<details>
<summary>Overall/Read</summary>

![image](https://user-images.githubusercontent.com/21194782/82821983-f58d8200-9e9c-11ea-8875-edb1ee74e306.png)


</details>

Requires https://github.com/jenkinsci/credentials-plugin/pull/150
<details>
<summary>Overall/Read and Credentials/View</summary>

![image](https://user-images.githubusercontent.com/21194782/82822036-076f2500-9e9d-11ea-841e-1e5519575e6c.png)

</details>



### Proposed changelog entries

* Entry 1: Add 'Manage Nodes and Clouds' link to 'View Configuration' page
* Entry 2: Developer: Add `ManagementLink.getRequiredPermission()` method that allows configuring more than one permission to allow viewing a `ManagementLink`
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [-] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [-] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
