### PR TITLE
[JENKINS-62421] Added aria-labels to username & password input fields

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -83,7 +83,7 @@ THE SOFTWARE.
                 </j:if>
                 <div class="formRow">
                   <input
-                    aria-label="Username"
+                    aria-label="${%Username}"
                     class="${inputClass}"
                     type="text"
                     name="j_username"
@@ -95,7 +95,7 @@ THE SOFTWARE.
                 </div>
                 <div class="formRow">
                   <input
-                    aria-label="Password"
+                    aria-label="${%Password}"
                     class="${inputClass}"
                     type="password"
                     name="j_password"

--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -83,6 +83,7 @@ THE SOFTWARE.
                 </j:if>
                 <div class="formRow">
                   <input
+                    aria-label="Username"
                     class="${inputClass}"
                     type="text"
                     name="j_username"
@@ -94,6 +95,7 @@ THE SOFTWARE.
                 </div>
                 <div class="formRow">
                   <input
+                    aria-label="Password"
                     class="${inputClass}"
                     type="password"
                     name="j_password"


### PR DESCRIPTION
Since we want to keep the clean aspect while improving accessibility, I opted for aria-labels instead of labels for the username and password input fields in the login form.

See [JENKINS-62421](https://issues.jenkins-ci.org/browse/JENKINS-62421).


### Proposed changelog entries

* Added aria-labels for username and password fields in login form to improve accessibility

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [X] Appropriate autotests or explanation to why this change has no tests
- [N/A] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@oleg-nenashev 
@scherler 
@fqueiruga 
@timja 


### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
