### PR TITLE
[JENKINS-62332] Show when a plugin version newer than offered exists

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2267,6 +2267,14 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
 
     @Restricted(DoNotUse.class) // Used from table.jelly
+    public boolean hasLatestVersionNewerThanOffered(UpdateSite.Plugin plugin) {
+        if (plugin.latest == null) {
+            return false;
+        }
+        return !plugin.latest.equalsIgnoreCase(plugin.version); // we can assume that any defined 'latest' will be newer than the actual offered version
+    }
+
+    @Restricted(DoNotUse.class) // Used from table.jelly
     public boolean hasAdoptThisPluginLabel(PluginWrapper plugin) {
         final UpdateSite.Plugin pluginMeta = Jenkins.get().getUpdateCenter().getPlugin(plugin.getShortName());
         if (pluginMeta == null) {

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1060,6 +1060,24 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         return new ArrayList<>(pluginMap.values());
     }
 
+    @Restricted(NoExternalUse.class)
+    public List<Plugin> getPluginsWithUnavailableUpdates() {
+        Map<String,Plugin> pluginMap = new LinkedHashMap<>();
+        for (PluginWrapper wrapper : Jenkins.get().getPluginManager().getPlugins()) {
+            for (UpdateSite site : sites) {
+                UpdateSite.Plugin plugin = site.getPlugin(wrapper.getShortName());
+                final Plugin existing = pluginMap.get(plugin.name);
+                if (existing == null) { // TODO better support for overlapping update sites
+                    if (plugin.latest != null && !plugin.latest.equalsIgnoreCase(plugin.version) && !plugin.latest.equalsIgnoreCase(wrapper.getVersion())) {
+                        pluginMap.put(plugin.name, plugin);
+                    }
+                }
+            }
+        }
+        final ArrayList<Plugin> unavailable = new ArrayList<>(pluginMap.values());
+        return unavailable;
+    }
+
     /**
      * Ensure that all UpdateSites are up to date, without requiring a user to
      * browse to the instance.

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -1047,6 +1047,13 @@ public class UpdateSite {
         @Restricted(NoExternalUse.class)
         public final Double popularity;
 
+        /**
+         * The latest existing version of this plugin. May be different from the version being offered by the
+         * update site, which will result in a notice on the UI.
+         */
+        @Restricted(NoExternalUse.class)
+        public String latest;
+
         @DataBoundConstructor
         public Plugin(String sourceId, JSONObject o) {
             super(sourceId, o, UpdateSite.this.url);
@@ -1055,6 +1062,7 @@ public class UpdateSite {
             this.excerpt = get(o,"excerpt");
             this.compatibleSinceVersion = Util.intern(get(o,"compatibleSinceVersion"));
             this.minimumJavaVersion = Util.intern(get(o, "minimumJavaVersion"));
+            this.latest = get(o, "latest");
             this.requiredCore = Util.intern(get(o,"requiredCore"));
             final String releaseTimestamp = get(o, "releaseTimestamp");
             Date date = null;

--- a/core/src/main/resources/hudson/PluginManager/_table.css
+++ b/core/src/main/resources/hudson/PluginManager/_table.css
@@ -76,3 +76,7 @@ time {
 .hidden {
     display: none;
 }
+
+#plugins tr.unavailable {
+  background-color: #f4f4f4;
+}

--- a/core/src/main/resources/hudson/PluginManager/_table.css
+++ b/core/src/main/resources/hudson/PluginManager/_table.css
@@ -80,3 +80,19 @@ time {
 #plugins tr.unavailable {
   background-color: #f4f4f4;
 }
+tr.unavailable span.unavailable-label {
+    display: inline-block;
+    border: 1px solid #666;
+    background-color: #fcc;
+    color: #333;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    padding: 0 0.5rem;
+    margin: 0.25rem 0.5rem;
+    text-decoration: none;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    text-transform: uppercase;
+}

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -165,6 +165,11 @@ THE SOFTWARE.
                           ${%adoptThisPlugin}
                         </div>
                       </j:if>
+                      <j:if test="${it.hasLatestVersionNewerThanOffered(p)}">
+                        <div class="alert alert-info">
+                          ${%newerVersionExists(p.latest)}
+                        </div>
+                      </j:if>
                     </td>
                     <td class="pane"><st:out value="${p.version}" /></td>
                     <td class="pane" data="${p.releaseTimestamp.time}">
@@ -187,6 +192,54 @@ THE SOFTWARE.
                     </j:if>
                   </tr>
                 </j:forEach>
+                <j:if test="${isUpdates}">
+                  <!-- TODO this might be nicer by going through the root list element and populating it in index.jelly -->
+                  <j:forEach var="p" items="${app.updateCenter.pluginsWithUnavailableUpdates}">
+                    <j:if test="${!list.contains(p)}"><!-- only show entries for plugins not already in the real updates list -->
+                      <tr class="unavailable">
+                        <l:isAdmin>
+                          <td><!-- install --></td>
+                        </l:isAdmin>
+                        <td class="pane" data="${h.xmlEscape(p.displayName)}" data-id="${h.xmlEscape(p.name+':'+p.version)}">
+                          <div>
+                            <a href="${p.wiki}" target="_blank"><st:out value="${p.displayName}"/></a>
+                          </div>
+                          <j:if test="${!p.categories.isEmpty()}">
+                            <div class="plugin-manager__categories">
+                              <j:forEach var="label" items="${p.categories}">
+                                <j:if test="${!it.isMetaLabel(label)}">
+                                  <a href="?filter=${app.updateCenter.getCategoryDisplayName(label)}"
+                                     class="plugin-manager__category-label">
+                                    ${app.updateCenter.getCategoryDisplayName(label)}
+                                  </a>
+                                </j:if>
+                              </j:forEach>
+                            </div>
+                          </j:if>
+                          <j:if test="${p.excerpt!=null}">
+                            <div class="excerpt"><j:out value="${p.excerpt}" /></div>
+                          </j:if>
+                          <j:if test="${it.hasLatestVersionNewerThanOffered(p)}">
+                            <div class="alert alert-info">
+                              ${%newerVersionEntry(p.latest)}
+                            </div>
+                          </j:if>
+                        </td>
+                        <td>${p.latest}</td>
+                        <td><!-- timestamp --></td>
+                        <td class="pane">
+                          <j:choose><j:when test="${p.installed.active}">
+                            <st:out value="${p.installed.version}" />
+                          </j:when><j:otherwise>
+                            <span title="${%Inactive}">
+                              (<st:out value="${p.installed.version}" />)
+                            </span>
+                          </j:otherwise></j:choose>
+                        </td>
+                      </tr>
+                    </j:if>
+                  </j:forEach>
+                </j:if>
               </j:when>
               <j:otherwise>
                 <tr>

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -203,6 +203,7 @@ THE SOFTWARE.
                         <td class="pane" data="${h.xmlEscape(p.displayName)}" data-id="${h.xmlEscape(p.name+':'+p.version)}">
                           <div>
                             <a href="${p.wiki}" target="_blank"><st:out value="${p.displayName}"/></a>
+                            <span class="unavailable-label">${%unavailable}</span>
                           </div>
                           <j:if test="${!p.categories.isEmpty()}">
                             <div class="plugin-manager__categories">
@@ -221,7 +222,7 @@ THE SOFTWARE.
                           </j:if>
                           <j:if test="${it.hasLatestVersionNewerThanOffered(p)}">
                             <div class="alert alert-info">
-                              ${%newerVersionEntry(p.latest)}
+                              ${%newerVersionEntry(p.wiki)}
                             </div>
                           </j:if>
                         </td>

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -72,8 +72,9 @@ THE SOFTWARE.
               <th>${%Released}</th>
               <j:if test="${isUpdates}"><th>${%Installed}</th></j:if>
             </tr>
+            <j:set var="unavailableList" value="${app.updateCenter.pluginsWithUnavailableUpdates}"/>
             <j:choose>
-              <j:when test="${!empty(list)}">
+              <j:when test="${!empty(list) or (isUpdates and !empty(unavailableList))}">
                 <j:set var="cache" value="${it.createCache()}"/>
                 <j:if test="${filtered == 'true'}">
                   <tr id="hidden-by-default-instructions">
@@ -194,7 +195,7 @@ THE SOFTWARE.
                 </j:forEach>
                 <j:if test="${isUpdates}">
                   <!-- TODO this might be nicer by going through the root list element and populating it in index.jelly -->
-                  <j:forEach var="p" items="${app.updateCenter.pluginsWithUnavailableUpdates}">
+                  <j:forEach var="p" items="${unavailableList}">
                     <j:if test="${!list.contains(p)}"><!-- only show entries for plugins not already in the real updates list -->
                       <tr class="unavailable">
                         <l:isAdmin>

--- a/core/src/main/resources/hudson/PluginManager/table.properties
+++ b/core/src/main/resources/hudson/PluginManager/table.properties
@@ -51,6 +51,13 @@ ago={0} ago
 adoptThisPlugin=\
   <strong>This plugin is up for adoption!</strong> We are looking for new maintainers. \
   Visit our <a href="https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" target="_blank">Adopt a Plugin</a> initiative for more information.
+newerVersionExists=\
+  A newer version than being offered for installation exists (version {0}). \
+  This is typically the case when plugin requirements, e.g. a recent version of Jenkins, are not satisfied.
+newerVersionEntry=\
+  This version of the plugin exists but it is not being offered as an update. \
+  This is typically the case when plugin requirements, e.g. a recent version of Jenkins, are not satisfied. \
+  See the plugin documentation for information about its requirements.
 
 loading=Plugin list is loading...
 instructions=Use the search field above to search for available plugins.

--- a/core/src/main/resources/hudson/PluginManager/table.properties
+++ b/core/src/main/resources/hudson/PluginManager/table.properties
@@ -57,7 +57,8 @@ newerVersionExists=\
 newerVersionEntry=\
   This version of the plugin exists but it is not being offered as an update. \
   This is typically the case when plugin requirements, e.g. a recent version of Jenkins, are not satisfied. \
-  See the plugin documentation for information about its requirements.
+  See the <a href="{0}" target="_blank">plugin documentation</a> for information about its requirements.
+unavailable=Unavailable
 
 loading=Plugin list is loading...
 instructions=Use the search field above to search for available plugins.


### PR DESCRIPTION
See [JENKINS-62332](https://issues.jenkins-ci.org/browse/JENKINS-62332) and https://github.com/jenkins-infra/update-center2/pull/382

This adds notices to entries on the 'Updates' and 'Available' tabs of the plugin manager when a newer version exists than is being offered for installation.

If the instance has the latest offered plugin release installed, new virtual (uninstallable) entries are created on the 'Updates' tab to inform users that something newer exists. On one hand I like that this shows unavailable content right where it would appear, OTOH it could be weird or confusing, especially if admins don't read. Feedback welcome.

<details>
<summary>Screenshots</summary>

#### Before

<img width="1438" alt="Screenshot 2020-05-25 at 22 39 03" src="https://user-images.githubusercontent.com/1831569/82842093-a5341580-9ed8-11ea-98b8-8f1b11c9522d.png">

#### After

<img width="1440" alt="Screenshot 2020-05-25 at 22 38 40" src="https://user-images.githubusercontent.com/1831569/82842098-a6fdd900-9ed8-11ea-8641-35504bcd933e.png">
</details>

### Testing notes

Replace the update site URL in _Plugin Manager » Advanced_ with `https://updates.jenkins.io/2.204/update-center.json`

### Proposed changelog entries

* Show in plugin manager when newer releases of plugins exist but aren't being offered due to unsatisfied requirements.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
