### PR TITLE
[JENKINS-62477] Remove subversion from suggested

### DIFF
--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -68,7 +68,7 @@
             { "name": "gitlab-plugin" },
             { "name": "p4" },
             { "name": "repo" },
-            { "name": "subversion", "suggested": true },
+            { "name": "subversion" },
             { "name": "tfs" }
         ]
     },


### PR DESCRIPTION
subversion plugin is not actively maintained, however it is in the list
of suggested plugins during first install. Having a unmaintained plugin
in the suggested list of plugins does not look correct.

See [JENKINS-62477](https://issues.jenkins-ci.org/browse/JENKINS-62477).

### Proposed changelog entries

* JENKINS-62477: remove subversion from suggested plugins in the setup wizard

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
