### PR TITLE
[JENKINS-62949] - Escape special characters from href attrib

### DIFF
--- a/core/src/main/java/hudson/console/HyperlinkNote.java
+++ b/core/src/main/java/hudson/console/HyperlinkNote.java
@@ -25,6 +25,7 @@ package hudson.console;
 
 import hudson.Extension;
 import hudson.MarkupText;
+import hudson.Util;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -69,7 +70,7 @@ public class HyperlinkNote extends ConsoleNote {
                 url = Jenkins.get().getRootUrl()+url.substring(1);
             }
         }
-        text.addMarkup(charPos, charPos + length, "<a href='" + url + "'"+extraAttributes()+">", "</a>");
+        text.addMarkup(charPos, charPos + length, "<a href='" + Util.escape(url) + "'"+extraAttributes()+">", "</a>");
         return null;
     }
 

--- a/test/src/test/java/hudson/console/HyperlinkNoteTest.java
+++ b/test/src/test/java/hudson/console/HyperlinkNoteTest.java
@@ -88,7 +88,7 @@ public class HyperlinkNoteTest {
         FreeStyleBuild b = r.buildAndAssertSuccess(upstream);
         r.waitUntilNoActivity();
         HtmlPage rsp = r.createWebClient().goTo(b.getUrl()+"console");
-        assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
+        assertThat(rsp.querySelector(".console-output").asText(), containsString("Triggering a new build of"));
     }
 
     

--- a/test/src/test/java/hudson/console/HyperlinkNoteTest.java
+++ b/test/src/test/java/hudson/console/HyperlinkNoteTest.java
@@ -90,6 +90,7 @@ public class HyperlinkNoteTest {
         r.waitUntilNoActivity();
         HtmlPage rsp = r.createWebClient().goTo(b.getUrl()+"console");
         assertThat(rsp.querySelector(".console-output").asText(), containsString("Triggering a new build of"));
+		assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
     }
 
     

--- a/test/src/test/java/hudson/console/HyperlinkNoteTest.java
+++ b/test/src/test/java/hudson/console/HyperlinkNoteTest.java
@@ -90,7 +90,7 @@ public class HyperlinkNoteTest {
         r.waitUntilNoActivity();
         HtmlPage rsp = r.createWebClient().goTo(b.getUrl()+"console");
         assertThat(rsp.querySelector(".console-output").asText(), containsString("Triggering a new build of"));
-		assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
+        assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
     }
 
     

--- a/test/src/test/java/hudson/console/HyperlinkNoteTest.java
+++ b/test/src/test/java/hudson/console/HyperlinkNoteTest.java
@@ -28,6 +28,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.tasks.BuildTrigger;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -38,11 +39,13 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import com.gargoylesoftware.htmlunit.ElementNotFoundException;
+import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThat;
 
 public class HyperlinkNoteTest {
 
@@ -77,18 +80,27 @@ public class HyperlinkNoteTest {
                 containsString(new ModelHyperlinkNote("", 0).extraAttributes()),
                 containsString(">" + noteTextSanitized + "</a>")));
     }
-
-	@Test
+    
+    @Test
     public void textWithSingleQuote() throws Exception {
-    	FreeStyleProject upstream = r.createFreeStyleProject("upstream");
-    	r.createFreeStyleProject("d0wnstr3'am");
-    	upstream.getPublishersList().add(new BuildTrigger("d0wnstr3'am", Result.SUCCESS));
-    	FreeStyleBuild b = r.buildAndAssertSuccess(upstream);
+        FreeStyleProject upstream = r.createFreeStyleProject("upstream");
+        r.createFreeStyleProject("d0wnstr3'am");
+        upstream.getPublishersList().add(new BuildTrigger("d0wnstr3'am", Result.SUCCESS));
+        FreeStyleBuild b = r.buildAndAssertSuccess(upstream);
         r.waitUntilNoActivity();
         HtmlPage rsp = r.createWebClient().goTo(b.getUrl()+"console");
         //This would fail if job name has `'`
-        assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
+        try {
+            assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
+        } catch(ElementNotFoundException enfe) {
+            String str = "";
+            for(HtmlAnchor ha: rsp.getAnchors()) {
+                str += "getNameAttribute: " + ha.getNameAttribute() + " getTextContent: " + ha.getTextContent();
+            }
+            throw new Exception(str);
+        }
     }
+
     private static String annotate(String text) throws IOException {
         StringWriter writer = new StringWriter();
         try (ConsoleAnnotationOutputStream out = new ConsoleAnnotationOutputStream(writer, null, null, StandardCharsets.UTF_8)) {

--- a/test/src/test/java/hudson/console/HyperlinkNoteTest.java
+++ b/test/src/test/java/hudson/console/HyperlinkNoteTest.java
@@ -83,21 +83,22 @@ public class HyperlinkNoteTest {
     
     @Test
     public void textWithSingleQuote() throws Exception {
-        FreeStyleProject upstream = r.createFreeStyleProject("upstream");
-        r.createFreeStyleProject("d0wnstr3'am");
-        upstream.getPublishersList().add(new BuildTrigger("d0wnstr3'am", Result.SUCCESS));
-        FreeStyleBuild b = r.buildAndAssertSuccess(upstream);
+    	FreeStyleProject upstream = r.createFreeStyleProject("upstream");
+    	r.createFreeStyleProject("d0wnstr3'am");
+    	upstream.getPublishersList().add(new BuildTrigger("d0wnstr3'am", Result.SUCCESS));
+    	FreeStyleBuild b = r.buildAndAssertSuccess(upstream);
         r.waitUntilNoActivity();
         HtmlPage rsp = r.createWebClient().goTo(b.getUrl()+"console");
         //This would fail if job name has `'`
         try {
-            assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
-        } catch(ElementNotFoundException enfe) {
-            String str = "";
-            for(HtmlAnchor ha: rsp.getAnchors()) {
-                str += "getNameAttribute: " + ha.getNameAttribute() + " getTextContent: " + ha.getTextContent();
-            }
-            throw new Exception(str);
+        	assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
+        } catch(Exception enfe) {
+        	String str = "str->\n";
+        	for(HtmlAnchor ha: rsp.getAnchors()) {
+        		str += rsp.toString()+"\n\n";
+        		str += "getNameAttribute: " + ha.getNameAttribute() + " getTextContent: " + ha.getTextContent() + "\n";
+        	}
+        	throw new Exception(str);
         }
     }
 

--- a/test/src/test/java/hudson/console/HyperlinkNoteTest.java
+++ b/test/src/test/java/hudson/console/HyperlinkNoteTest.java
@@ -89,13 +89,14 @@ public class HyperlinkNoteTest {
     	FreeStyleBuild b = r.buildAndAssertSuccess(upstream);
         r.waitUntilNoActivity();
         HtmlPage rsp = r.createWebClient().goTo(b.getUrl()+"console");
+        System.out.println("Before:\n"+rsp.getWebResponse().getContentAsString()+"\n\n");
         //This would fail if job name has `'`
         try {
         	assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
         } catch(Exception enfe) {
         	String str = "str->\n";
+			str += rsp.getWebResponse().getContentAsString()+"\n\n";
         	for(HtmlAnchor ha: rsp.getAnchors()) {
-        		str += rsp.toString()+"\n\n";
         		str += "getNameAttribute: " + ha.getNameAttribute() + " getTextContent: " + ha.getTextContent() + "\n";
         	}
         	throw new Exception(str);

--- a/test/src/test/java/hudson/console/HyperlinkNoteTest.java
+++ b/test/src/test/java/hudson/console/HyperlinkNoteTest.java
@@ -39,8 +39,6 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import com.gargoylesoftware.htmlunit.ElementNotFoundException;
-import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import static org.hamcrest.Matchers.allOf;

--- a/test/src/test/java/hudson/console/HyperlinkNoteTest.java
+++ b/test/src/test/java/hudson/console/HyperlinkNoteTest.java
@@ -45,7 +45,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class HyperlinkNoteTest {
 
@@ -81,28 +81,19 @@ public class HyperlinkNoteTest {
                 containsString(">" + noteTextSanitized + "</a>")));
     }
     
+    
     @Test
     public void textWithSingleQuote() throws Exception {
-    	FreeStyleProject upstream = r.createFreeStyleProject("upstream");
-    	r.createFreeStyleProject("d0wnstr3'am");
-    	upstream.getPublishersList().add(new BuildTrigger("d0wnstr3'am", Result.SUCCESS));
-    	FreeStyleBuild b = r.buildAndAssertSuccess(upstream);
+        FreeStyleProject upstream = r.createFreeStyleProject("upstream");
+        r.createFreeStyleProject("d0wnstr3'am");
+        upstream.getPublishersList().add(new BuildTrigger("d0wnstr3'am", Result.SUCCESS));
+        FreeStyleBuild b = r.buildAndAssertSuccess(upstream);
         r.waitUntilNoActivity();
         HtmlPage rsp = r.createWebClient().goTo(b.getUrl()+"console");
-        System.out.println("Before:\n"+rsp.getWebResponse().getContentAsString()+"\n\n");
-        //This would fail if job name has `'`
-        try {
-        	assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
-        } catch(Exception enfe) {
-        	String str = "str->\n";
-			str += rsp.getWebResponse().getContentAsString()+"\n\n";
-        	for(HtmlAnchor ha: rsp.getAnchors()) {
-        		str += "getNameAttribute: " + ha.getNameAttribute() + " getTextContent: " + ha.getTextContent() + "\n";
-        	}
-        	throw new Exception(str);
-        }
+        assertThat(String.valueOf(rsp.getAnchorByText("d0wnstr3'am").click().getWebResponse().getStatusCode()), containsString("200"));
     }
 
+    
     private static String annotate(String text) throws IOException {
         StringWriter writer = new StringWriter();
         try (ConsoleAnnotationOutputStream out = new ConsoleAnnotationOutputStream(writer, null, null, StandardCharsets.UTF_8)) {

--- a/test/src/test/java/hudson/console/HyperlinkNoteTest.java
+++ b/test/src/test/java/hudson/console/HyperlinkNoteTest.java
@@ -85,6 +85,7 @@ public class HyperlinkNoteTest {
         FreeStyleProject upstream = r.createFreeStyleProject("upstream");
         r.createFreeStyleProject("d0wnstr3'am");
         upstream.getPublishersList().add(new BuildTrigger("d0wnstr3'am", Result.SUCCESS));
+        r.jenkins.rebuildDependencyGraph();
         FreeStyleBuild b = r.buildAndAssertSuccess(upstream);
         r.waitUntilNoActivity();
         HtmlPage rsp = r.createWebClient().goTo(b.getUrl()+"console");


### PR DESCRIPTION
See [JENKINS-62949](https://issues.jenkins-ci.org/browse/JENKINS-62949).

Currently the Jenkins allows single quotes(') in job names.
So if an upstream job triggers downstream jobs(having single quotes), (multijob, trigger another job or paramterized builds), console log rendering HyperLinkNote of jobs has correct text but href value redirects to incomplete job URL.