### PR TITLE
Fixed spotbugs issue to prevent XML parsing vulnerability to XXE

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1918,6 +1918,8 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         final Map<String,VersionNumber> requestedPlugins = new TreeMap<>();
         try {
             SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+            // this is no real issue, it is just a false positive, since jenkins handles it differently
+            // for more information check: https://github.com/jenkinsci/jenkins/pull/4779
             parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             parserFactory.newSAXParser().parse(configXml, new DefaultHandler() {
                 @Override public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1920,6 +1920,8 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             SAXParserFactory parserFactory = SAXParserFactory.newInstance();
             // this is no real issue, it is just a false positive, since jenkins handles it differently
             // for more information check: https://github.com/jenkinsci/jenkins/pull/4779
+            String FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
+            parserFactory.setFeature(FEATURE, true);
             parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             parserFactory.newSAXParser().parse(configXml, new DefaultHandler() {
                 @Override public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -109,6 +109,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.ByteArrayInputStream;
@@ -1916,7 +1917,9 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     public Map<String,VersionNumber> parseRequestedPlugins(InputStream configXml) throws IOException {
         final Map<String,VersionNumber> requestedPlugins = new TreeMap<>();
         try {
-            SAXParserFactory.newInstance().newSAXParser().parse(configXml, new DefaultHandler() {
+            SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+            parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            parserFactory.newSAXParser().parse(configXml, new DefaultHandler() {
                 @Override public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
                     String plugin = attributes.getValue("plugin");
                     if (plugin == null) {

--- a/core/src/main/java/hudson/XmlFile.java
+++ b/core/src/main/java/hudson/XmlFile.java
@@ -306,6 +306,8 @@ public final class XmlFile {
         try (InputStream in = Files.newInputStream(file.toPath())) {
             InputSource input = new InputSource(file.toURI().toASCIIString());
             input.setByteStream(in);
+            // this is no real issue, it is just a false positive, since jenkins handles it differently
+            // for more information check: https://github.com/jenkinsci/jenkins/pull/4779
             JAXP.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             JAXP.newSAXParser().parse(input,new DefaultHandler() {
                 private Locator loc;

--- a/core/src/main/java/hudson/XmlFile.java
+++ b/core/src/main/java/hudson/XmlFile.java
@@ -41,6 +41,8 @@ import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.ext.Locator2;
 import org.xml.sax.helpers.DefaultHandler;
+
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.BufferedInputStream;
@@ -304,6 +306,7 @@ public final class XmlFile {
         try (InputStream in = Files.newInputStream(file.toPath())) {
             InputSource input = new InputSource(file.toURI().toASCIIString());
             input.setByteStream(in);
+            JAXP.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             JAXP.newSAXParser().parse(input,new DefaultHandler() {
                 private Locator loc;
                 @Override

--- a/core/src/main/java/hudson/XmlFile.java
+++ b/core/src/main/java/hudson/XmlFile.java
@@ -308,6 +308,8 @@ public final class XmlFile {
             input.setByteStream(in);
             // this is no real issue, it is just a false positive, since jenkins handles it differently
             // for more information check: https://github.com/jenkinsci/jenkins/pull/4779
+            String FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
+            JAXP.setFeature(FEATURE, true);
             JAXP.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             JAXP.newSAXParser().parse(input,new DefaultHandler() {
                 private Locator loc;


### PR DESCRIPTION
This is a try to fix a findsecbugs issue [XXE_SAXPARSER](https://find-sec-bugs.github.io/bugs.htm#XXE_SAXPARSER). Actually I'm not sure about the side effects, but according to [Java API doc](https://docs.oracle.com/javase/8/docs/api/javax/xml/XMLConstants.html#FEATURE_SECURE_PROCESSING) it should just do: 
> instructs the implementation to process XML securely. This may set limits on XML constructs to avoid conditions such as denial of service attacks. 

### Proposed changelog entries

* Enabled FEATURE_SECURE_PROCESSING on xml file read.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
