### PR TITLE
[JENKINS-29785] CLI: no fatal error when an optional "file parameter" is not set

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -134,9 +134,6 @@ public class BuildCommand extends CLICommand {
 
                 // not passed in use default
                 ParameterValue defaultValue = pd.getDefaultParameterValue();
-                if (defaultValue == null) {
-                    throw new CmdLineException(null, String.format("No default value for the parameter '%s'.",pd.getName()));
-                }
                 values.add(defaultValue);
             }
 


### PR DESCRIPTION
See [JENKINS-29785](https://issues.jenkins-ci.org/browse/JENKINS-29785).

This PR to not block the Jenkins CLI when an optional "file parameter" (*hudson.model.FileParameterDefinition*) is not set. Here with a "file parameter" named "config.zip":
```
$ java -jar jenkins-cli.jar -noCertificateCheck -s https://jenkins.local/ -auth USER:PASS build PUBLIC/JOB -f -v -p URL="https://artifactory.local/my-files.zip"
mai 28, 2020 8:24:53 PM hudson.cli.CLI _main
INFOS: Skipping HTTPS certificate checks altogether. Note that this is not secure at all.

ERROR: No default value for the parameter 'config.zip'.
```

There is certainly a proper way to fix it (by adding a check on the parameter type).

### Proposed changelog entries

* CLI: no fatal error when an optional "file parameter" is not set

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
