### PR TITLE
[JENKINS-62698] - Restyle hyperlinks to make them look more modern and readable

### DIFF
--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
@@ -95,8 +95,10 @@
     color: #204A87;
     color: var(--link-color);
     text-decoration: underline;
+    text-decoration: var(--link-text-decoration);
     padding: 0;
-    font-weight: normal;
+    font-weight: 600;
+    font-weight: var(--link-font-weight);
 }
 #visible-am-container #visible-am-list a:visited {
     color: #5c3566;
@@ -107,7 +109,7 @@
 #visible-am-container #visible-am-list a:active {
     color: #5c3566;
     color: var(--link-color);
-    text-decoration-color: #5c3566;
     background-color: transparent;
     text-decoration: underline;
+    text-decoration: var(--link-text-decoration--hover);
 }

--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
@@ -95,7 +95,6 @@
     color: #204A87;
     color: var(--link-color);
     text-decoration: underline;
-    text-decoration: var(--link-text-decoration);
     padding: 0;
     font-weight: 600;
     font-weight: var(--link-font-weight);

--- a/war/src/main/less/abstracts/colors.less
+++ b/war/src/main/less/abstracts/colors.less
@@ -116,11 +116,23 @@
   --table-stripped-bg-color--hover: #e8e8e8;
 
   // Link
-  --link-color: #204a87;
-  --link-visited-color: #5c3566;
-  --link-dark-color: var(--black);
+  --link-color: var(--primary-hover);
+  --link-visited-color: var(--link-color);
+  --link-color--hover: var(--link-color);
+  --link-color--active: var(--text-color);
+  --link-text-decoration: none;
+  --link-text-decoration--hover: underline;
+  --link-text-decoration--active: underline;
+  --link-font-weight: 600;
+  // Dark link
+  --link-dark-color: var(--text-color);
+  --link-dark-visited-color: var(--link-dark-color);
   --link-dark-color--hover: var(--primary);
   --link-dark-color--active: var(--primary-active);
+  --link-dark-text-decoration: none;
+  --link-dark-text-decoration--hover: underline;
+  --link-dark-text-decoration--active: underline;
+  --link-dark-font-weight: 600;
 
   // Pane
   --pane-header-color: #eee;

--- a/war/src/main/less/abstracts/mixins.less
+++ b/war/src/main/less/abstracts/mixins.less
@@ -1,0 +1,47 @@
+.link() {
+  text-decoration: var(--link-text-decoration);
+  font-weight: var(--link-font-weight);
+
+  &:link {
+    color: var(--link-color);
+  }
+
+  &:visited {
+    color: var(--link-visited-color);
+  }
+
+  &:hover,
+  &:focus {
+    color: var(--link-color--hover);
+    text-decoration: var(--link-text-decoration--hover);
+  }
+
+  &:active {
+    color: var(--link-color--active);
+    text-decoration: var(--link-text-decoration--active);
+  }
+}
+
+.link-dark() {
+  text-decoration: var(--link-dark-text-decoration);
+  font-weight: var(--link-dark-font-weight);
+
+  &:link {
+    color: var(--link-dark-color);
+  }
+
+  &:visited {
+    color: var(--link-dark-visited-color);
+  }
+
+  &:hover,
+  &:focus {
+    color: var(--link-dark-color--hover);
+    text-decoration: var(--link-dark-text-decoration--hover);
+  }
+
+  &:active {
+    color: var(--link-dark-color--active);
+    text-decoration: var(--link-dark-text-decoration--active);
+  }
+}

--- a/war/src/main/less/base-styles-v2.less
+++ b/war/src/main/less/base-styles-v2.less
@@ -17,6 +17,8 @@ html {
   -moz-osx-font-smoothing: grayscale;
 }
 
+@import './abstracts/mixins.less';
+
 @import './base/typography.less';
 @import './base/layout-commons.less';
 @import './base/style.less';

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -129,6 +129,10 @@ a {
   .link();
 }
 
+p a {
+  text-decoration: underline;
+}
+
 a.lowkey:link {
   text-decoration: none;
   color: inherit;
@@ -299,6 +303,7 @@ pre.console {
   padding: 7px 10px;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
+  font-weight: normal;
 }
 .tabBar .tab a:hover {
   background: var(--tab-bar-bg-color--hover);
@@ -740,6 +745,10 @@ LABEL.attach-previous {
   word-break: break-word;
 }
 
+.help a {
+  text-decoration: underline;
+}
+
 .help .from-plugin {
     text-align: right;
     color: #666;
@@ -1150,9 +1159,13 @@ TABLE.fileList TD.fileSize {
 table.sortable a.sortheader {
   text-decoration: none;
   display: block;
+  color: var(--pane-text-color);
+  font-weight: bold;
 }
 table.sortable span.sortarrow {
   text-decoration: none;
+  color: var(--pane-text-color);
+  font-weight: bold;
 }
 
 
@@ -1792,6 +1805,7 @@ body.no-sticker #bottom-sticker {
     margin: 0;
     text-decoration: none !important;
     color: var(--text-color);
+    font-weight: normal;
     outline: 0;
 }
 

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1380,6 +1380,10 @@ TEXTAREA.rich-editor {
     color: #888a85;
 }
 
+#plugins .excerpt a {
+  text-decoration: underline;
+}
+
 /*
  * TODO(andipabst): Not used after https://github.com/jenkinsci/jenkins/pull/4299,
  *                  remove once there are no more dependencies
@@ -1654,6 +1658,16 @@ select.select-ajax-pending {
     border-radius: 4px;
 }
 
+.alert a {
+  text-decoration: underline;
+
+  &:hover,
+  &:focus,
+  &:active {
+    text-decoration: underline;
+  }
+}
+
 .alert-info {
   color: var(--alert-info-color-call-out);
   background-color: var(--alert-info-bg-color-call-out);
@@ -1758,7 +1772,7 @@ body.no-sticker #bottom-sticker {
 }
 
 .manage-messages .alert a:hover {
-    text-decoration: none;
+    text-decoration: underline;
 }
 
 .manage-messages .alert form {

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -125,14 +125,8 @@ dt {
     color: #ccc;
 } */
 
-a:link {
-  text-decoration: underline;
-  color: var(--link-color);
-}
-
-a:visited {
-  text-decoration: underline;
-  color: var(--link-visited-color);
+a {
+  .link();
 }
 
 a.lowkey:link {

--- a/war/src/main/less/base/yui-compatibility.less
+++ b/war/src/main/less/base/yui-compatibility.less
@@ -76,6 +76,7 @@
 
   .yuimenuitemlabel {
     color: var(--menu-text-color);
+    font-weight: normal;
 
     &:visited {
       color: var(--menu-text-color);

--- a/war/src/main/less/modules/page-footer.less
+++ b/war/src/main/less/modules/page-footer.less
@@ -55,4 +55,5 @@
 
 .page-footer a {
   .link-dark();
+  font-weight: 600;
 }

--- a/war/src/main/less/modules/page-footer.less
+++ b/war/src/main/less/modules/page-footer.less
@@ -54,21 +54,5 @@
 }
 
 .page-footer a {
-  &:link,
-  &:visited {
-    font-weight: 600;
-    text-decoration: none;
-    color: var(--link-dark-color);
-  }
-
-  &:focus,
-  &:hover {
-    color: var(--link-dark-color--hover);
-    text-decoration: underline;
-  }
-
-  &:active {
-    color: var(--link-dark-color--active);
-    text-decoration: underline;
-  }
+  .link-dark();
 }

--- a/war/src/main/less/modules/side-panel-tasks.less
+++ b/war/src/main/less/modules/side-panel-tasks.less
@@ -43,13 +43,16 @@
 .task-link:visited {
   color: var(--link-dark-color);
   text-decoration: none;
+  font-weight: 500;
 
   &:hover,
   &:focus {
+    text-decoration: none;
     background-color: var(--task-link-bg-color--hover);
   }
 
   &:active {
+    text-decoration: none;
     background-color: var(--task-link-bg-color--active);
   }
 

--- a/war/src/main/less/modules/side-panel-widgets.less
+++ b/war/src/main/less/modules/side-panel-widgets.less
@@ -70,6 +70,10 @@
   text-decoration: underline;
 }
 
+#side-panel .pane-header a {
+  font-weight: bold;
+}
+
 #side-panel .pane-content a {
   font-weight: 600;
 }

--- a/war/src/main/less/modules/side-panel-widgets.less
+++ b/war/src/main/less/modules/side-panel-widgets.less
@@ -66,21 +66,8 @@
 #side-panel .pane-header a,
 #side-panel .pane-footer a,
 #side-panel .pane-content a {
-  &:link,
-  &:visited {
-    color: var(--link-dark-color);
-  }
-
-  &:focus,
-  &:hover {
-    color: var(--link-dark-color--hover);
-    text-decoration: underline;
-  }
-
-  &:active {
-    color: var(--link-dark-color--active);
-    text-decoration: underline;
-  }
+  .link-dark();
+  text-decoration: underline;
 }
 
 #side-panel .pane-content a {


### PR DESCRIPTION
See [JENKINS-62698](https://issues.jenkins-ci.org/browse/JENKINS-62698).

This PR restyles the hyperlinks as proposed to the UX SIG. The full design brief is located on the JIRA ticket.

#### Description

- Hyperlinks no longer the underline by default except on the help texts, alerts, paragraph and plugin descriptions.
- To ensure accessibility, the hyperlinks are now thicker.
- Visited links no longer have a different colour (this can be changed by using the simple-theme plugin).

#### Tech details

- Created LESS mixins for normal and dark hyperlinks. Dark hyperlinks were de facto used in the footer and sidebar.
- They are fully themeable using CSS variables.


<details>
<summary><b>Screenshots</b></summary>

<img width="2558" alt="Captura de pantalla 2020-06-16 a las 15 40 34" src="https://user-images.githubusercontent.com/5738588/84912836-22a70c00-b0ba-11ea-835b-0a70945b3d4e.png">

<img width="2558" alt="Captura de pantalla 2020-06-16 a las 15 41 29" src="https://user-images.githubusercontent.com/5738588/84912855-26d32980-b0ba-11ea-85e8-74b64f529a89.png">

<img width="2558" alt="Captura de pantalla 2020-06-16 a las 15 42 28" src="https://user-images.githubusercontent.com/5738588/84912859-276bc000-b0ba-11ea-8f05-cefda107429c.png">

<img width="2558" alt="Captura de pantalla 2020-06-16 a las 15 43 16" src="https://user-images.githubusercontent.com/5738588/84912863-28045680-b0ba-11ea-8e68-4cd19eb59372.png">

</details>




### Proposed changelog entries

* Entry 1: JENKINS-62698, Restyle hyperlinks to make them look more modern and readable.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 
@uhafner 
@daniel-beck 
@oleg-nenashev 
@jsoref 


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
