### PR TITLE
[JENKINS-61823] - Winstone 5.10: Fix --httpKeepAliveTimeout, update Jetty to 9.4.30

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -103,7 +103,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>5.9</version>
+      <version>5.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This pull request updates Winstone to 5.10. Needs careful review, because we jump over 3 Jetty versions.

Notable changes:

* Add `--httpsRedirectHttp` option that activates automatic HTTP request redirects to HTTPs (jenkinsci/winstone#98) @slide
* [JENKINS-61823](https://issues.jenkins-ci.org/browse/JENKINS-61823) - Fix `--httpKeepAliveTimeout` option which had no effect in 5.9 (jenkinsci/winstone#100) @olamy
* Bump jetty.version from 9.4.27.v20200227 to 9.4.30.v20200611 (jenkinsci/winstone#107, jenkinsci/winstone#110) @dependabot
  * [9.4.28.v20200408 changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.28.v20200408)
  * [9.4.29.v20200521 changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.29.v20200521)
  * [9.4.30.v20200611 changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.30.v20200611)

Full changelog and diff: https://github.com/jenkinsci/winstone/releases/tag/winstone-5.10

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE - Winstone 5.10: Add `--httpsRedirectHttp` option that activates automatic HTTP request redirects to HTTPs
* BUG - Winstone 5.10: [JENKINS-61823](https://issues.jenkins-ci.org/browse/JENKINS-61823) - Fix `--httpKeepAliveTimeout` option which had no effect (regression in 2.224)
* RFE - Winstone 5.10: Update Jetty from 9.4.27.v20200227 to 9.4.30.v20200611 
  * 9.4.28.v20200408 changelog - https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.28.v20200408
  * 9.4.29.v20200521 changelog - https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.29.v20200521
  * 9.4.30.v20200611 changelog - https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.30.v20200611


<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A, fingers crossed

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
