### PR TITLE
[JENKINS-61823] - Winstone 5.9.1: Fix --httpKeepAliveTimeout option which had no effect (regression in 2.235.1)

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -103,7 +103,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>5.9</version>
+      <version>5.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Backports https://github.com/jenkinsci/winstone/commit/738887b1b12dfc861523ae841416e100b8ff3bbf into Winstone 5.9 so that we do not need to update Jetty in LTS to pick up the fix.

Changelog: https://github.com/jenkinsci/winstone/releases/tag/winstone-5.9.1

### Proposed changelog entries

* Winstone 5.9.1: Fix --httpKeepAliveTimeout option which had no effect (regression in 2.235.1)
  * Winstone 5.9.1 changelog: https://github.com/jenkinsci/winstone/releases/tag/winstone-5.9.1

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
