### PR TITLE
[JENKINS 62750] Transform rss bar items into transparent buttons

### DIFF
--- a/core/src/main/resources/hudson/logging/LogRecorderManager/feeds.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/feeds.jelly
@@ -25,13 +25,27 @@ THE SOFTWARE.
 <!-- list of feed links -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
-  <div align="right">
-    <l:svgIcon class="icon-small" tooltip="Atom feed" href="${imagesURL}/material-icons/svg-sprite-communication-symbol.svg#ic_rss_feed_24px" />
-    <st:nbsp/><st:nbsp/><st:nbsp/><st:nbsp/>
-    <a href="rss">${%All}</a>
-    <st:nbsp/><st:nbsp/><st:nbsp/><st:nbsp/>
-    <a href="rss?level=SEVERE">${%&gt; SEVERE}</a>
-    <st:nbsp/><st:nbsp/><st:nbsp/><st:nbsp/>
-    <a href="rss?level=WARNING">${%&gt; WARNING}</a>
-  </div>
+    <div align="right">
+        <a href="rss" class="yui-button link-button">
+            <span class="leading-icon">
+                <l:svgIcon class="icon-small" tooltip="Atom feed"
+                           href="${imagesURL}/material-icons/svg-sprite-communication-symbol.svg#ic_rss_feed_24px"/>
+            </span>
+            <span>${%All}</span>
+        </a>
+        <a href="rss?level=SEVERE" class="yui-button link-button">
+            <span class="leading-icon">
+                <l:svgIcon class="icon-small" tooltip="Atom feed"
+                           href="${imagesURL}/material-icons/svg-sprite-communication-symbol.svg#ic_rss_feed_24px"/>
+            </span>
+            <span>${%SEVERE}</span>
+        </a>
+        <a href="rss?level=WARNING" class="yui-button link-button">
+            <span class="leading-icon">
+                <l:svgIcon class="icon-small" tooltip="Atom feed"
+                           href="${imagesURL}/material-icons/svg-sprite-communication-symbol.svg#ic_rss_feed_24px"/>
+            </span>
+            <span>${%WARNING}</span>
+        </a>
+    </div>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/rssBar.jelly
+++ b/core/src/main/resources/lib/hudson/rssBar.jelly
@@ -23,23 +23,41 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div id="rss-bar">
-    <a href="${rootURL}/legend" class="rss-bar-legend-link">${%Legend}</a>
-    <span class="rss-bar-item">
-      <a href="rssAll"><l:svgIcon class="icon-small" tooltip="Atom feed" href="${imagesURL}/material-icons/svg-sprite-communication-symbol.svg#ic_rss_feed_24px" /></a>
-      <st:nbsp/>
-      <a href="rssAll" class="rss-bar-item-link">Atom feed ${%for all}</a>
-    </span>
-    <span class="rss-bar-item">
-      <a href="rssFailed" class="rss-bar-item-icon-link"><l:svgIcon class="icon-small" tooltip="Atom feed" href="${imagesURL}/material-icons/svg-sprite-communication-symbol.svg#ic_rss_feed_24px" /></a>
-      <st:nbsp/>
-      <a href="rssFailed" class="rss-bar-item-link">Atom feed ${%for failures}</a>
-    </span>
-    <span class="rss-bar-item">
-      <a href="rssLatest" class="rss-bar-item-icon-link" ><l:svgIcon class="icon-small" tooltip="Atom feed" href="${imagesURL}/material-icons/svg-sprite-communication-symbol.svg#ic_rss_feed_24px" /></a>
-      <st:nbsp/>
-      <a href="rssLatest" class="rss-bar-item-link">Atom feed ${%for just latest builds}</a>
-    </span>
-  </div>
+<j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <div id="rss-bar">
+        <a href="${rootURL}/legend" class="yui-button link-button rss-bar-legend-link">${%Legend}</a>
+
+
+        <span class="rss-bar-item">
+            <a href="rssAll" class="yui-button link-button rss-bar-item-link">
+                <span class="leading-icon">
+                    <l:svgIcon class="icon-small" tooltip="Atom feed"
+                               ariaHidden="true"
+                               href="${imagesURL}/material-icons/svg-sprite-communication-symbol.svg#ic_rss_feed_24px"/>
+                </span>
+                <span>Atom feed ${%for all}</span>
+            </a>
+        </span>
+        <span class="rss-bar-item">
+            <a href="rssFailed" class="yui-button link-button rss-bar-item-link">
+                <span class="leading-icon">
+                    <l:svgIcon class="icon-small" tooltip="Atom feed"
+                               ariaHidden="true"
+                               href="${imagesURL}/material-icons/svg-sprite-communication-symbol.svg#ic_rss_feed_24px"/>
+                </span>
+                <span>Atom feed ${%for failures}</span>
+            </a>
+        </span>
+        <span class="rss-bar-item">
+            <a href="rssLatest" class="yui-button link-button rss-bar-item-link">
+                <span class="leading-icon">
+                    <l:svgIcon class="icon-small" tooltip="Atom feed"
+                               ariaHidden="true"
+                               href="${imagesURL}/material-icons/svg-sprite-communication-symbol.svg#ic_rss_feed_24px"/>
+                </span>
+                <span>Atom feed ${%for just latest builds}</span>
+            </a>
+        </span>
+    </div>
 </j:jelly>

--- a/war/src/main/less/abstracts/colors.less
+++ b/war/src/main/less/abstracts/colors.less
@@ -103,6 +103,8 @@
   --btn-secondary-bg: var(--btn-text-color);
   --btn-secondary-border: #9ba7af;
   --btn-text-color: var(--white);
+  --btn-link-bg--hover: #f8f8f8;
+  --btn-link-bg--active: #eaeff2;
 
   // Help area
   --help-area-bg-color: var(--very-light-grey);

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1844,10 +1844,6 @@ body.no-sticker #bottom-sticker {
     border: 0;
 }
 
-#rss-bar .rss-bar-item {
-    padding-left: 1em;
-}
-
 /* -------------------------------------- */
 
 

--- a/war/src/main/less/modules/buttons.less
+++ b/war/src/main/less/modules/buttons.less
@@ -59,21 +59,21 @@
 }
 
 .button-link {
-  color: var(--primary);
+  color: var(--primary-hover);
   background-color: transparent;
   border-color: transparent;
 
   &:hover,
   &:focus {
-    color: var(--primary-hover);
-    background-color: #f8f8f8;
-    border-color: #f8f8f8;
+    color: var(--primary);
+    background-color: var(--btn-link-bg--hover);
+    border-color: var(--btn-link-bg--hover);
   }
 
   &:active {
     color: var(--primary-active);
-    background-color: #eaeff2;
-    border-color: #eaeff2;
+    background-color: var(--btn-link-bg--active);
+    border-color: var(--btn-link-bg--active);
   }
 }
 


### PR DESCRIPTION
See [JENKINS-62750](https://issues.jenkins-ci.org/browse/JENKINS-62750).

This PR reworks the RSS bar to make the links transparent buttons. It also makes the items more accessible by combining the icons and text into a single link.
As a side effect, this PR also adds theming support for transparent buttons, thus opening core support for https://github.com/jenkinsci/dark-theme-plugin/issues/105.

<details>
<summary>Screenshots</summary>

Home screen
<img width="799" alt="Captura de pantalla 2020-06-22 a las 10 20 28" src="https://user-images.githubusercontent.com/5738588/85293961-5ad59280-b49e-11ea-9eb7-023de83a4edd.png">

Log recorders
<img width="521" alt="Captura de pantalla 2020-06-22 a las 20 04 50" src="https://user-images.githubusercontent.com/5738588/85320949-2bd21780-b4c4-11ea-8dd3-bb963560e91b.png">

</details>


### Proposed changelog entries

* Entry 1: JENKINS 62750, Restyling and improved accessibility for the RSS feed bar.
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
