### PR TITLE
JENKINS-41805 Cleanup workspace suffixes

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1269,8 +1269,8 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     }
 
     /**
-     * Deletes all suffixed directories that are separated by {@link WorkspaceList.COMBINATOR}, including all its contents recursively.
-     */
+     * Deletes all suffixed directories that are separated by {@link WorkspaceList#COMBINATOR}, including all its contents recursively.
+     */ 
     private class DeleteSuffixesRecursive extends SecureFileCallable<Void> {
         private static final long serialVersionUID = 1L;
 

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1270,7 +1270,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
 
     /**
      * Deletes all suffixed directories that are separated by {@link WorkspaceList#COMBINATOR}, including all its contents recursively.
-     */ 
+     */
     private class DeleteSuffixesRecursive extends SecureFileCallable<Void> {
         private static final long serialVersionUID = 1L;
 

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -48,6 +48,7 @@ import hudson.remoting.RemoteOutputStream;
 import hudson.remoting.VirtualChannel;
 import hudson.remoting.Which;
 import hudson.security.AccessControlled;
+import hudson.slaves.WorkspaceList;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.DirScanner;
 import hudson.util.ExceptionCatchingThreadFactory;
@@ -1256,6 +1257,44 @@ public final class FilePath implements SerializableOnlyOverRemoting {
 
             return mkdirs(f) || f.exists();
         }
+    }
+    
+    /**
+     * Deletes all suffixes recursively.
+     * @throws IOException if it exists but could not be successfully deleted
+     * @since TODO
+     */
+    public void deleteSuffixesRecursive() throws IOException, InterruptedException {
+        act(new DeleteSuffixesRecursive());
+    }
+
+    /**
+     * Deletes all suffixed directories that are separated by {@link WorkspaceList.COMBINATOR}, including all its contents recursively.
+     */
+    private class DeleteSuffixesRecursive extends SecureFileCallable<Void> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Void invoke(File f, VirtualChannel channel) throws IOException {
+            for (File file : listParentFiles(f)) {
+                if (file.getName().startsWith(f.getName() + WorkspaceList.COMBINATOR)) {
+                    Util.deleteRecursive(file.toPath(), path -> deleting(path.toFile()));
+                }
+            }
+            
+            return null;
+        }
+    }
+
+    private static File[] listParentFiles(File f) {
+        File parentFile = f.getParentFile();
+        if (parentFile != null) {
+            File[] files = parentFile.listFiles();
+            if (files != null) {
+                return files;
+            }
+        }
+        return new File[0];
     }
 
     /**

--- a/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
+++ b/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
@@ -89,11 +89,8 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
                 if (check) {
                     listener.getLogger().println("Deleting " + ws + " on " + node.getDisplayName());
                     try {
+                        ws.deleteSuffixesRecursive();
                         ws.deleteRecursive();
-                        FilePath tempDir = WorkspaceList.tempDir(ws);
-                        if (tempDir != null) {
-                            tempDir.deleteRecursive();
-                        }
                     } catch (IOException | InterruptedException x) {
                         Functions.printStackTrace(x, listener.error("Failed to delete " + ws + " on " + node.getDisplayName()));
                     }

--- a/core/src/main/java/hudson/slaves/WorkspaceList.java
+++ b/core/src/main/java/hudson/slaves/WorkspaceList.java
@@ -297,7 +297,7 @@ public final class WorkspaceList {
      * acknowledging that these will be readable by builds of other jobs done on the same node.
      * <p>Each plugin using this directory is responsible for specifying sufficiently unique subdirectory/file names.
      * {@link FilePath#createTempFile} may be used for this purpose if desired.
-     * <p>The resulting directory may not exist; you may call {@link FilePath#mkdirs} on it if you need it to.
+     * <p>The resulting directory may not exist; you may call {@link FilePath#mkdirs()} on it if you need it to.
      * It may be deleted alongside the workspace itself during cleanup actions.
      * @param ws a directory such as a build workspace
      * @return a sibling directory, for example {@code …/something@tmp} for {@code …/something}, or {@code null} if {@link FilePath#getParent} is null
@@ -312,6 +312,7 @@ public final class WorkspaceList {
 
     /**
      * The token that combines the project name and unique number to create unique workspace directory.
+     * @since TODO
      */
-    private static final String COMBINATOR = SystemProperties.getString(WorkspaceList.class.getName(),"@");
+    public static final String COMBINATOR = SystemProperties.getString(WorkspaceList.class.getName(),"@");
 }

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -28,6 +28,7 @@ import hudson.model.TaskListener;
 import hudson.os.PosixAPI;
 import hudson.os.WindowsUtil;
 import hudson.remoting.VirtualChannel;
+import hudson.slaves.WorkspaceList;
 import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
 import org.apache.commons.io.FileUtils;
@@ -808,6 +809,20 @@ public class FilePathTest {
         assertTrue("symlink target should not be deleted", Files.exists(targetDir));
         assertTrue("symlink target contents should not be deleted", Files.exists(targetContents));
         assertFalse("could not delete target", Files.exists(toDelete));
+    }
+
+    @Test
+    @Issue("JENKINS-44909")
+    public void deleteSuffixesRecursive() throws Exception {
+        File deleteSuffixesRecursiveFolder = temp.newFolder("deleteSuffixesRecursive");
+        FilePath filePath = new FilePath(deleteSuffixesRecursiveFolder);
+        FilePath suffix = filePath.withSuffix(WorkspaceList.COMBINATOR + "suffixed");
+        FilePath textTempFile = suffix.createTextTempFile("tmp", null, "dummy", true);
+
+        assertThat(textTempFile.exists(), is(true));
+        
+        filePath.deleteSuffixesRecursive();
+        assertThat(textTempFile.exists(), is(false));
     }
 
     @Test public void deleteRecursiveOnWindows() throws Exception {


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-41805](https://issues.jenkins-ci.org/browse/JENKINS-41805) and [JENKINS-44909](https://issues.jenkins-ci.org/browse/JENKINS-44909)

(JENKINS-44909 description is more specific to this fix but it's closed as a duplicate of JENKINS-41805)

https://github.com/jenkinsci/jenkins/pull/2066 added cleanup of `@tmp` workspace folders, but there's other folders, `@libs` for pipeline libraries and `@script(@tmp)?` not sure where it's from but likely pipeline libraries as well.

`@libs` for every workspace has a copy of all pipeline libraries loaded during a build. These are never cleaned up currently and add up over time. On our instance it's at nearly 10GB.

I don't know if this is the best fix, possibly the plugins should cleanup their directories they create but it seems ideal to me that this is managed centrally

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: JENKINS-41805, Cleanup more workspace related directories, e.g. `@libs` from Pipeline libraries
* Entry 2: JENKINS-41805, Developer: Add API for getting the separator for workspace related directories `WorkspaceList.COMBINATOR`
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
