### PR TITLE
Backporting for LTS 2.235.2

### DIFF
--- a/core/src/main/java/hudson/model/ItemGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ItemGroupMixIn.java
@@ -235,6 +235,7 @@ public abstract class ItemGroupMixIn {
         }
         src.getDescriptor().checkApplicableIn(parent);
         acl.getACL().checkCreatePermission(parent, src.getDescriptor());
+        Jenkins.checkGoodName(name);
         ItemListener.checkBeforeCopy(src, parent);
 
         T result = (T)createProject(src.getDescriptor(),name,false);
@@ -264,6 +265,7 @@ public abstract class ItemGroupMixIn {
 
         Jenkins.get().getProjectNamingStrategy().checkName(name);
         Items.verifyItemDoesNotAlreadyExist(parent, name, null);
+        Jenkins.checkGoodName(name);
 
         // place it as config.xml
         File configXml = Items.getConfigFile(getRootDirFor(name)).getFile();
@@ -311,6 +313,7 @@ public abstract class ItemGroupMixIn {
 
         Jenkins.get().getProjectNamingStrategy().checkName(name);
         Items.verifyItemDoesNotAlreadyExist(parent, name, null);
+        Jenkins.checkGoodName(name);
 
         TopLevelItem item = type.newInstance(parent, name);
         item.onCreatedFromScratch();

--- a/core/src/main/java/hudson/model/ItemGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ItemGroupMixIn.java
@@ -235,7 +235,6 @@ public abstract class ItemGroupMixIn {
         }
         src.getDescriptor().checkApplicableIn(parent);
         acl.getACL().checkCreatePermission(parent, src.getDescriptor());
-        Jenkins.checkGoodName(name);
         ItemListener.checkBeforeCopy(src, parent);
 
         T result = (T)createProject(src.getDescriptor(),name,false);
@@ -265,7 +264,6 @@ public abstract class ItemGroupMixIn {
 
         Jenkins.get().getProjectNamingStrategy().checkName(name);
         Items.verifyItemDoesNotAlreadyExist(parent, name, null);
-        Jenkins.checkGoodName(name);
 
         // place it as config.xml
         File configXml = Items.getConfigFile(getRootDirFor(name)).getFile();
@@ -313,7 +311,6 @@ public abstract class ItemGroupMixIn {
 
         Jenkins.get().getProjectNamingStrategy().checkName(name);
         Items.verifyItemDoesNotAlreadyExist(parent, name, null);
-        Jenkins.checkGoodName(name);
 
         TopLevelItem item = type.newInstance(parent, name);
         item.onCreatedFromScratch();

--- a/war/src/main/less/modules/buttons.less
+++ b/war/src/main/less/modules/buttons.less
@@ -120,7 +120,9 @@ a.yui-button:visited {
   border: 2px solid;
   border-radius: 4px;
 
-  transition: all 0.15s ease-in-out;
+  transition: color 0.15s ease-in-out,
+    background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out;
 
   .button-secondary();
 


### PR DESCRIPTION
Backporting has started and the RC is scheduled for 2020-07-01.

Please have look at the changes proposed and rejected so we have a consensus of what goes in by 2020-07-01.

This needs to be merged together with https://github.com/jenkinsci/jenkins/pull/4812 proposed by @oleg-nenashev 

Fixed
-----

JENKINS-62560		Minor     		2.240
	Buttons linger when closing modal
	https://issues.jenkins-ci.org/browse/JENKINS-62560

JENKINS-61956		Minor     		2.237
	ItemGroupMixin#createProject() does not call Jenkins#checkGoodName()
	https://issues.jenkins-ci.org/browse/JENKINS-61956

JENKINS-61823		Critical  		Wed, 1 Jul 2020 06:23:00 +0000
	"--httpKeepAliveTimeout" no longer has any effect after upgrading to 2.222.1
	non-trivial-lts-backporting regression
	https://issues.jenkins-ci.org/browse/JENKINS-61823