### PR TITLE
Upgrade to 4.5 version of Remoting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ THE SOFTWARE.
     <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>4.3</remoting.version>
+    <remoting.version>4.5</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 


### PR DESCRIPTION
Upgrade the Remoting (agent) jar from 4.3 to 4.5.

The only significant change here is that we now perform the release on the Jenkins release system and sign with the CDF certificate. This does not change any behavior.

The other changes in the 4.4 and 4.5 releases involve minor maintenance changes to improve ongoing maintainability. There is one minor logging improvement, which might help in some error situations.

See the Remoting changelogs: .

### Proposed changelog entries

* Upgrade to Remoting 4.5. This switches agent.jar and remoting.jar to a code-signing certificate owned by the CDF. Changelogs: [4.4](https://github.com/jenkinsci/remoting/releases/tag/remoting-4.4) and [4.5](https://github.com/jenkinsci/remoting/releases/tag/remoting-4.5)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [N/A] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [N/A] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->


### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [N/A] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
