### PR TITLE
[JENKINS-62723] Fix behaviour of Util.isOverridden()

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1440,6 +1440,8 @@ public class Util {
      * @param methodName The name of the method.
      * @param types      The types of the arguments for the method.
      * @return {@code true} when {@code derived} provides the specified method other than as inherited from {@code base}.
+     * @throws IllegalArgumentException When {@code derived} does not derive from {@code base}, or when {@code base}
+     *                                  does not contain the specified method.
      */
     public static boolean isOverridden(@NonNull Class<?> base, @NonNull Class<?> derived, @NonNull String methodName, @NonNull Class<?>... types) {
         // If derived is not a subclass or implementor of base, it can't override any method

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1432,36 +1432,63 @@ public class Util {
     }
 
     /**
-     * Checks if the method defined on the base type with the given arguments
-     * is overridden in the given derived type.
+     * Checks whether the method defined on the base type with the given arguments is overridden in the given derived
+     * type.
+     *
+     * @param base       The base type.
+     * @param derived    The derived type.
+     * @param methodName The name of the method.
+     * @param types      The types of the arguments for the method.
+     * @return {@code true} when {@code derived} provides the specified method other than as inherited from {@code base}.
      */
-    public static boolean isOverridden(@NonNull Class base, @NonNull Class derived, @NonNull String methodName, @NonNull Class... types) {
-        return !getMethod(base, methodName, types).equals(getMethod(derived, methodName, types));
+    public static boolean isOverridden(@NonNull Class<?> base, @NonNull Class<?> derived, @NonNull String methodName, @NonNull Class<?>... types) {
+        // If derived is not a subclass or implementor of base, it can't override any method
+        if (!base.isAssignableFrom(derived)) {
+            throw new IllegalArgumentException("The specified derived class (" + derived.getCanonicalName() + ") does not derive from the specified base class (" + base.getCanonicalName() + ").");
+        }
+        final Method baseMethod = Util.getMethod(base, null, methodName, types);
+        if (baseMethod == null) {
+            throw new IllegalArgumentException("The specified method is not declared by the specified base class (" + base.getCanonicalName() + "), or it is private, static or final.");
+        }
+        final Method derivedMethod = Util.getMethod(derived, base, methodName, types);
+        // the lookup will either return null or the base method when no override has been found (depending on whether
+        // the base is an interface)
+        return derivedMethod != null && derivedMethod != baseMethod;
     }
 
-    private static Method getMethod(@NonNull Class clazz, @NonNull String methodName, @NonNull Class... types) {
-        Method res = null;
+    private static Method getMethod(@NonNull Class<?> clazz, @Nullable Class<?> base, @NonNull String methodName, @NonNull Class<?>... types) {
         try {
-            res = clazz.getDeclaredMethod(methodName, types);
-            // private, static or final methods can not be overridden
-            if (res != null && (Modifier.isPrivate(res.getModifiers()) || Modifier.isFinal(res.getModifiers()) 
-                    || Modifier.isStatic(res.getModifiers()))) {
-                res = null;
+            final Method res = clazz.getDeclaredMethod(methodName, types);
+            final int mod = res.getModifiers();
+            // private and static methods are never ok, and end the search
+            if (Modifier.isPrivate(mod) || Modifier.isStatic(mod)) {
+                return null;
             }
+            // when looking for the base/declaring method, final is not ok
+            if (base == null && Modifier.isFinal(mod)) {
+                return null;
+            }
+            // when looking for the overriding method, abstract is not ok
+            if (base != null && Modifier.isAbstract(mod)) {
+                return null;
+            }
+            return res;
         } catch (NoSuchMethodException e) {
             // Method not found in clazz, let's search in superclasses
-            Class superclass = clazz.getSuperclass();
+            Class<?> superclass = clazz.getSuperclass();
+            // TODO: When base is an interface, it's _possible_ that the class may implement a subinterface of base
+            //       which provides a default implementation. Such a case is not currently detected as an override.
             if (superclass != null) {
-                res = getMethod(superclass, methodName, types);
+                // if the superclass doesn't derive from base anymore, stop looking
+                if (base != null && !base.isAssignableFrom(superclass)) {
+                    return null;
+                }
+                return getMethod(superclass, base, methodName, types);
             }
+            return null;
         } catch (SecurityException e) {
             throw new AssertionError(e);
         }
-        if (res == null) {
-            throw new IllegalArgumentException(
-                    String.format("Method %s not found in %s (or it is private, final or static)", methodName, clazz.getName()));
-        }
-        return res;
     }
 
     /**

--- a/core/src/test/java/hudson/util/IsOverriddenTest.java
+++ b/core/src/test/java/hudson/util/IsOverriddenTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import hudson.Util;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -89,14 +90,14 @@ public class IsOverriddenTest {
     @Issue("JENKINS-62723")
     @Test
     public void finalOverrides() {
-        errors.checkThat("X1 overrides X.m1", Util.isOverridden(X.class, X1.class, "m1"), is(true));
-        errors.checkThat("X1 does not override X.m2", Util.isOverridden(X.class, X1.class, "m2"), is(false));
-        errors.checkThat("X2 overrides X.m1", Util.isOverridden(X.class, X2.class, "m1"), is(true));
-        errors.checkThat("X2 does not override X.m2", Util.isOverridden(X.class, X2.class, "m2"), is(false));
-        errors.checkThat("X3 overrides X.m1", Util.isOverridden(X.class, X3.class, "m1"), is(true));
-        errors.checkThat("X3 overrides X.m2", Util.isOverridden(X.class, X3.class, "m2"), is(true));
-        errors.checkThat("X4 overrides X.m1", Util.isOverridden(X.class, X4.class, "m1"), is(true));
-        errors.checkThat("X4 overrides X.m2", Util.isOverridden(X.class, X4.class, "m2"), is(true));
+        errors.checkSucceeds(() -> {assertThat("X1 overrides X.m1", Util.isOverridden(X.class, X1.class, "m1"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X1 does not override X.m2", Util.isOverridden(X.class, X1.class, "m2"), is(false)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X2 overrides X.m1", Util.isOverridden(X.class, X2.class, "m1"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X2 does not override X.m2", Util.isOverridden(X.class, X2.class, "m2"), is(false)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X3 overrides X.m1", Util.isOverridden(X.class, X3.class, "m1"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X3 overrides X.m2", Util.isOverridden(X.class, X3.class, "m2"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X4 overrides X.m1", Util.isOverridden(X.class, X4.class, "m1"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X4 overrides X.m2", Util.isOverridden(X.class, X4.class, "m2"), is(true)); return null;});
     }
     public static interface X {
         void m1();

--- a/core/src/test/java/hudson/util/IsOverriddenTest.java
+++ b/core/src/test/java/hudson/util/IsOverriddenTest.java
@@ -139,9 +139,8 @@ public class IsOverriddenTest {
         errors.checkSucceeds(() -> {assertThat("I1 does not override I1.bar", Util.isOverridden(I1.class, I1.class, "bar"), is(false)); return null;});
         errors.checkSucceeds(() -> {assertThat("I2 overrides I1.bar", Util.isOverridden(I1.class, I2.class, "bar"), is(true)); return null;});
         errors.checkSucceeds(() -> {assertThat("C1 does not override I1.bar", Util.isOverridden(I1.class, C1.class, "bar"), is(false)); return null;});
-        // TODO: Not currently handled by isOverridden()
-        //errors.checkSucceeds(() -> {assertThat("C2 overrides I1.bar (via I2)", Util.isOverridden(I1.class, C2.class, "bar"), is(true)); return null;});
-        //errors.checkSucceeds(() -> {assertThat("C3 overrides I1.bar (via I2)", Util.isOverridden(I1.class, C3.class, "bar"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("C2 overrides I1.bar (via I2)", Util.isOverridden(I1.class, C2.class, "bar"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("C3 overrides I1.bar (via I2)", Util.isOverridden(I1.class, C3.class, "bar"), is(true)); return null;});
         errors.checkSucceeds(() -> {assertThat("C4 overrides I1.bar", Util.isOverridden(I1.class, C4.class, "bar"), is(true)); return null;});
     }
     private interface I1 {

--- a/core/src/test/java/hudson/util/IsOverriddenTest.java
+++ b/core/src/test/java/hudson/util/IsOverriddenTest.java
@@ -28,11 +28,19 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import hudson.Util;
+import static org.hamcrest.Matchers.is;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.rules.ErrorCollector;
+import org.jvnet.hudson.test.Issue;
 
 /**
  * Test for {@link Util#isOverridden} method.
  */
 public class IsOverriddenTest {
+
+    @Rule
+    public ErrorCollector errors = new ErrorCollector();
 
     /**
      * Test that a method is found by isOverridden even when it is inherited from an intermediate class.
@@ -76,6 +84,40 @@ public class IsOverriddenTest {
         public Integer getX() { return 0; }
     }
     public class Derived extends Intermediate {}
+
+    @Ignore("TODO fails as predicted")
+    @Issue("JENKINS-62723")
+    @Test
+    public void finalOverrides() {
+        errors.checkThat("X1 overrides X.m1", Util.isOverridden(X.class, X1.class, "m1"), is(true));
+        errors.checkThat("X1 does not override X.m2", Util.isOverridden(X.class, X1.class, "m2"), is(false));
+        errors.checkThat("X2 overrides X.m1", Util.isOverridden(X.class, X2.class, "m1"), is(true));
+        errors.checkThat("X2 does not override X.m2", Util.isOverridden(X.class, X2.class, "m2"), is(false));
+        errors.checkThat("X3 overrides X.m1", Util.isOverridden(X.class, X3.class, "m1"), is(true));
+        errors.checkThat("X3 overrides X.m2", Util.isOverridden(X.class, X3.class, "m2"), is(true));
+        errors.checkThat("X4 overrides X.m1", Util.isOverridden(X.class, X4.class, "m1"), is(true));
+        errors.checkThat("X4 overrides X.m2", Util.isOverridden(X.class, X4.class, "m2"), is(true));
+    }
+    public static interface X {
+        void m1();
+        default void m2() {}
+    }
+    public static class X1 implements X {
+        public void m1() {}
+    }
+    public static class X2 implements X {
+        public final void m1() {}
+    }
+    public static class X3 implements X {
+        public void m1() {}
+        @Override
+        public void m2() {}
+    }
+    public static class X4 implements X {
+        public void m1() {}
+        @Override
+        public final void m2() {}
+    }
 
 }
 


### PR DESCRIPTION
See [JENKINS-62723](https://issues.jenkins-ci.org/browse/JENKINS-62723).

Based on https://github.com/jenkinsci/jenkins/pull/4832 (which provides a unit test reproducing the issue)

### Proposed changelog entries

* JENKINS-62723: Fix `IllegalArgumentException: Method not found` error caused by misbehaviour in `Util.isOverridden()` (regression in 2.241)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [X] Appropriate autotests or explanation to why this change has no tests
- [X] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jglick

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
