### PR TITLE
Document the weekly release line in README and the Maintainer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,16 @@ Use Jenkins to automate your development workflow so you can focus on work that 
 Execute repetitive tasks, save time, and optimize your development process with Jenkins.
 
 # Downloads
-Non-source downloads such as WAR files and several Linux packages can be found on our [Mirrors].
+
+The Jenkins project provides official distributions as WAR files, Docker images, native packages and installers for platforms including several Linux distributions and Windows.
+See the [Downloads](https://www.jenkins.io/download) page for references.
+
+For all distributions Jenkins offers two release lines:
+
+* [Weekly](https://www.jenkins.io/download/weekly/) -
+  Frequent releases which include all new features, improvements, and bug fixes.
+* [Long-Term Support (LTS)](https://www.jenkins.io/download/lts/) -
+  Older release line which gets periodically updated via bug fix backports.
 
 # Source
 Our latest and greatest source of Jenkins can be found on [GitHub]. Fork us!

--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -246,6 +246,14 @@ When do we squash commits?
 * We squash commits when core maintainers decide to do so (`squash-merge-me` label), usually when the conditions above are not met.
 * There is no strong requirement to squash merge pull requests at the moment, so there might be deviations from the merge policy in practice.
 
+== Weekly release process
+
+link:https://www.jenkins.io/download/weekly/[Jenkins Weekly releases] are managed by the Jenkins Release Team which has access to the dedicated release environment within the Jenkins Infrastructure.
+References:
+
+* link:https://www.jenkins.io/download/weekly/[Jenkins Weekly Releases Documentation]
+* link:https://github.com/jenkins-infra/release[Jenkins Release Environment and the release process]
+
 == LTS Process
 
 Jenkins also offers the link:https://jenkins.io/download/lts/[LTS Release Line].

--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -253,6 +253,8 @@ References:
 
 * link:https://www.jenkins.io/download/weekly/[Jenkins Weekly Releases Documentation]
 * link:https://github.com/jenkins-infra/release[Jenkins Release Environment and the release process]
+* link:https://github.com/jenkinsci/packaging[Native Jenkins packages and installers for platforms]
+* link:https://github.com/jenkinsci/docker[Docker packaging for Jenkins]
 
 == LTS Process
 


### PR DESCRIPTION
Depends on https://github.com/jenkins-infra/jenkins.io/pull/3512 

It extends the documentation a bit and references the weekly release documentation and the release environment. It also extends the Downloads page in README so that it provides more information without duplicating content
