### PR TITLE
Remove BeanBuilder.loadBeans(String)

### DIFF
--- a/core/src/main/java/hudson/util/spring/BeanBuilder.java
+++ b/core/src/main/java/hudson/util/spring/BeanBuilder.java
@@ -297,18 +297,6 @@ public class BeanBuilder extends GroovyObjectSupport {
             }
 		}
 	}
-	/**
-	 * Takes a resource pattern as (@see org.springframework.core.io.support.PathMatchingResourcePatternResolver)
-	 * This allows you load multiple bean resources in this single builder
-	 *
-	 * eg loadBeans("classpath:*Beans.groovy")
-	 *
-	 * @param resourcePattern
-	 * @throws IOException When the path cannot be matched
-	 */
-	public void loadBeans(String resourcePattern) throws IOException {
-		loadBeans(new PathMatchingResourcePatternResolver().getResources(resourcePattern));
-	}
 
 	/**
 	 * Loads a single Resource into the bean builder


### PR DESCRIPTION
Remove the unused method `BeanBuilder.loadBeans(String)`. I've checked that the message is unused via grep and usage-in-plugins. Nothing in core references it either.

Rather than just deprecating it, this method needs to be removed so that no one uses it. The implementation connects with CVE-2014-3578. The method itself has the same flaws, without any protections or examples of how it might be safely used. 

No tests are needed for removing this unused method.

### Proposed changelog entries

* Developer: Remove method BeanBuilder.loadBeans(String).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [n/a] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [n/a] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
