### PR TITLE
[JENKINS-63014] Stop passing extra -url to agents

### DIFF
--- a/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
@@ -89,21 +89,6 @@ THE SOFTWARE.
 
         <argument>-url</argument>
         <argument>${rootURL}</argument>
-
-        <j:if test="${rootURL!=app.rootUrlFromRequest}">
-          <!--
-            rootURL is based on the URL in the system config, but there has been
-            numerous reports about people moving Jenkins to another place but
-            forgetting to update it. To improve the user experience in this regard,
-            let's also pass the URL that the browser sent us as well, so that the
-            JNLP Main class can try both.
-
-            Note that rootURL is still necessary in various situations, such
-            as reverse HTTP proxy situation, which makes rootUrlFromRequest incorrect.
-          -->
-          <argument>-url</argument>
-          <argument>${app.rootUrlFromRequest}</argument>
-        </j:if>
       </application-desc>
     </jnlp>
   </l:view>


### PR DESCRIPTION
See [JENKINS-63014](https://issues.jenkins-ci.org/browse/JENKINS-63014). This logic is incompatible with JEP-222 WebSocket agents (which currently accept only one `-url` argument), but anyway it is long outdated: we have `ReverseProxySetupMonitor` and now `RootUrlNotSetMonitor` and generally we presume that in order for Jenkins to work correctly, the root URL has been configured and has been configured correctly.

### Proposed changelog entries

* Remove the fallback Jenkins URL from the JNLP launch file so that WebSocket agents can be connected over Java Web Start.

Author's version: 

* WebSocket agents launched using the JNLP file would not work if Jenkins were accessed via a root URL distinct from the configured URL. The JNLP launch file no longer attempts to offer a fallback URL, whether for WebSocket or traditional TCP agents.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
