### PR TITLE
JENKINS-25259: added sortable+initialSortDir to tables at oldDataMonitor/manage.jelly + Error column name

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/OldDataMonitor/manage.jelly
+++ b/core/src/main/resources/hudson/diagnosis/OldDataMonitor/manage.jelly
@@ -30,8 +30,13 @@ THE SOFTWARE.
     <h1>${%Manage Old Data}</h1>
     <p>${%blurb.1}</p>
     <p>${%blurb.2}</p>
-    <table class="pane bigtable width-auto">
-      <tr><th>${%Type}</th><th>${%Name}</th><th>${%Version}</th><th></th></tr>
+    <table class="sortable pane bigtable width-auto">
+      <tr>
+         <th initialSortDir="down">${%Type}</th>
+         <th>${%Name}</th>
+         <th>${%Version}</th>
+         <th>${%Error}</th>
+      </tr>
       <j:forEach var="item" items="${it.data.entrySet()}">
         <j:set var="obj" value="${item.key}"/>
         <j:choose>
@@ -85,8 +90,12 @@ THE SOFTWARE.
       <br/>
       <h2>${%Unreadable Data}</h2>
       <p>${%blurb.6}</p>
-      <table class="pane bigtable width-auto">
-        <tr><th>${%Type}</th><th>${%Name}</th><th>${%Error}</th></tr>
+      <table class="sortable pane bigtable width-auto">
+        <tr>
+            <th initialSortDir="down">${%Type}</th>
+            <th>${%Name}</th>
+            <th>${%Error}</th>
+        </tr>
         <j:forEach var="item" items="${it.data.entrySet()}">
           <j:if test="${item.value.extra!=null and item.value==''}">
             <j:set var="obj" value="${item.key}"/>


### PR DESCRIPTION
See [JENKINS-25259](https://issues.jenkins-ci.org/browse/JENKINS-25259).

### Proposed changelog entries

* Entry 1: JENKINS-25259, Added sorting to old data management tables

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
