### PR TITLE
[JENKINS-61806] Form validation for TimeZoneProperty.timeZoneName

### DIFF
--- a/core/src/main/java/hudson/model/TimeZoneProperty.java
+++ b/core/src/main/java/hudson/model/TimeZoneProperty.java
@@ -6,6 +6,10 @@ import hudson.util.ListBoxModel.Option;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Util;
+import hudson.util.FormValidation;
+import java.text.DateFormat;
+import java.util.Date;
 import java.util.TimeZone;
 import java.util.logging.Logger;
 import java.util.logging.Level;
@@ -13,6 +17,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.QueryParameter;
 
 
 /**
@@ -85,6 +90,18 @@ public class TimeZoneProperty extends UserProperty {
             }
             return items;
         }
+
+        public FormValidation doCheckTimeZoneName(@QueryParameter String timeZoneName) {
+            Date now = new Date();
+            if (Util.fixEmpty(timeZoneName) == null) {
+                return FormValidation.ok(Messages.TimeZoneProperty_current_time_in_(TimeZone.getDefault().getDisplayName(), DateFormat.getDateTimeInstance().format(now)));
+            } else {
+                DateFormat localTime = DateFormat.getDateTimeInstance();
+                localTime.setTimeZone(TimeZone.getTimeZone(timeZoneName));
+                return FormValidation.ok(Messages.TimeZoneProperty_current_time_on_server_in_in_proposed_di(TimeZone.getDefault().getDisplayName(), DateFormat.getDateTimeInstance().format(now), localTime.format(now)));
+            }
+        }
+
     }
 
     @Nullable

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -403,6 +403,8 @@ User.IllegalFullname="{0}" is prohibited as a full name for security reasons.
 
 TimeZoneProperty.DisplayName=User Defined Time Zone 
 TimeZoneProperty.DisplayDefaultTimeZone=Default
+TimeZoneProperty.current_time_in_=Current time in {0}: {1}
+TimeZoneProperty.current_time_on_server_in_in_proposed_di=Current time on server in {0}: {1}; in proposed display zone: {2}
 
 ManagementLink.Category.CONFIGURATION=System Configuration
 ManagementLink.Category.SECURITY=Security

--- a/core/src/main/resources/hudson/model/TimeZoneProperty/config.properties
+++ b/core/src/main/resources/hudson/model/TimeZoneProperty/config.properties
@@ -18,4 +18,3 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 title=Time Zone
-description=Specify user defined time zone for displaying time rather than system default.

--- a/core/src/main/resources/hudson/model/TimeZoneProperty/help-timeZoneName.html
+++ b/core/src/main/resources/hudson/model/TimeZoneProperty/help-timeZoneName.html
@@ -1,0 +1,3 @@
+<div>
+    Specify user defined time zone for displaying time rather than system default.
+</div>


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/4748#issuecomment-654367061 seemed to have a positive reception.

![tz](https://user-images.githubusercontent.com/154109/87171375-9646ce00-c2a0-11ea-8234-8676ee206e08.png)

### Proposed changelog entries

* When configuring your **User Defined Time Zone**, you will now see hints about the current time on the server’s zone and, if not selecting **Default**, in the selected zone.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
