### PR TITLE
Update detached plugin versions after security release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@ THE SOFTWARE.
     <project.patchManagement.url>https://api.github.com</project.patchManagement.url>
     <patch.tracker.serverId>jenkins-jira</patch.tracker.serverId>
 
-    <matrix-auth.version>2.3</matrix-auth.version>
-    <matrix-project.version>1.14</matrix-project.version>
+    <matrix-auth.version>2.6.2</matrix-auth.version>
+    <matrix-project.version>1.17</matrix-project.version>
     <sorcerer.version>0.11</sorcerer.version>
     <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>
     <java.level>8</java.level>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -141,13 +141,13 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.26.1</version>
+      <version>1.29</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.7</version>
+      <version>1.20</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -142,12 +142,22 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
       <version>1.29</version>
+      <!-- TODO define property for this and share with war/pom.xml-->
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
       <version>1.20</version>
+      <!-- TODO define property for this and share with war/pom.xml-->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- requireUpperBounds via matrix-project and junit -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.73</version>
+      <!-- TODO define property for this and share with war/pom.xml-->
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -370,21 +370,21 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>junit</artifactId>
-                  <version>1.26.1</version>
+                  <version>1.29</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of junit -->
                   <groupId>org.jenkins-ci.plugins.workflow</groupId>
                   <artifactId>workflow-api</artifactId>
-                  <version>2.35</version>
+                  <version>2.40</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of junit -->
                   <groupId>org.jenkins-ci.plugins.workflow</groupId>
                   <artifactId>workflow-step-api</artifactId>
-                  <version>2.20</version>
+                  <version>2.22</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -398,7 +398,7 @@ THE SOFTWARE.
                   <!-- dependency of junit -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>structs</artifactId>
-                  <version>1.18</version>
+                  <version>1.20</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
Update detached plugin versions after security release: matrix-auth and matrix-project

- JUnit and structs also due to requireUpperBoundDeps

See [advisory/2020-07-15](https://www.jenkins.io/security/advisory/2020-07-15/).