### PR TITLE
Make sortable table footers less prominent

### DIFF
--- a/war/src/main/less/modules/panes-and-bigtable.less
+++ b/war/src/main/less/modules/panes-and-bigtable.less
@@ -107,7 +107,7 @@ table.bigtable {
 .bigtable tfoot th,
 .bigtable .sortbottom th {
   color: var(--text-color);
-  background-color: var(--white);
+  background-color: var(--background);
 }
 
 .bigtable td {

--- a/war/src/main/less/modules/panes-and-bigtable.less
+++ b/war/src/main/less/modules/panes-and-bigtable.less
@@ -104,6 +104,11 @@ table.bigtable {
     text-align: right;
   }
 }
+.bigtable tfoot th,
+.bigtable .sortbottom th {
+  color: var(--text-color);
+  background-color: var(--white);
+}
 
 .bigtable td {
   border-top: var(--bigtable-border-width) solid var(--bigtable-row-border-color);


### PR DESCRIPTION
Currently when table has a footing using the `.sortbottom` class the footing is too strong. This PR restyles this footing to make it so that only the table font is changed & emphasized.

Before:
<img width="1134" alt="Captura de pantalla 2020-07-20 a las 9 38 42" src="https://user-images.githubusercontent.com/5738588/87912253-54224700-ca6d-11ea-87e8-24820a3090bd.png">

After:
<img width="1135" alt="Captura de pantalla 2020-07-20 a las 9 38 56" src="https://user-images.githubusercontent.com/5738588/87912260-57b5ce00-ca6d-11ea-8170-6016254d8707.png">

### Proposed changelog entries

* Entry 1: Restyles sortable footer in tables to grab less attention.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 
@uhafner 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
