### PR TITLE
Add compact rows variant to the .bigtable class

### DIFF
--- a/core/src/main/resources/lib/hudson/projectView.jelly
+++ b/core/src/main/resources/lib/hudson/projectView.jelly
@@ -67,7 +67,7 @@ THE SOFTWARE.
         <d:invokeBody/>
       </div>
       <!-- project list -->
-      <table id="projectstatus" class="sortable pane bigtable stripped-odd">
+      <table id="projectstatus" class="sortable pane bigtable stripped-odd ${iconSize == '16x16' ? 'bigtable--compact' : ''}">
         <tr class="header">
           <j:forEach var="col" items="${columnExtensions}">
             <st:include page="columnHeader.jelly" it="${col}" />

--- a/war/src/main/less/modules/panes-and-bigtable.less
+++ b/war/src/main/less/modules/panes-and-bigtable.less
@@ -141,3 +141,11 @@ table.bigtable.sortable a.sortheader,
 table.bigtable.sortable span.sortarrow {
   color: var(--bigtable-header-text-color);
 }
+
+/* ========================= Bigtable variants ========================= */
+
+.bigtable--compact th,
+.bigtable--compact td {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}


### PR DESCRIPTION
This PR adds a `.bigtable--compact` CSS variant for the bigtables to allow for compact rows with less vertical padding. 

Sample use: `<table class="bigtable bigtable--compact">`.

It's applied on the projects view table when the icon size is S (see discussion on https://github.com/jenkinsci/jenkins/pull/4835#issuecomment-660111478).

- The compact option is enabled by adding the .bigtable--compact class
- It's applied to the projects table when the iconSize is small

Before:
<img width="1082" alt="Captura de pantalla 2020-07-20 a las 9 32 27" src="https://user-images.githubusercontent.com/5738588/87912643-0a862c00-ca6e-11ea-87aa-90285c770bf8.png">

After:
<img width="1086" alt="Captura de pantalla 2020-07-20 a las 9 35 54" src="https://user-images.githubusercontent.com/5738588/87912653-0e19b300-ca6e-11ea-9cce-8ef2c17144ee.png">

### Proposed changelog entries

* Add a compact rows variant to tables.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 
@uhafner 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
