### PR TITLE
Add .factorypath to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,11 @@ work
 .idea
 out
 
-# eclipse project file
+# Eclipse and VSCode project files
 .settings
 .classpath
 .project
+.factorypath
 build
 
 # VSCode workspace file


### PR DESCRIPTION
.factorypath is generated when developing Jenkins using Visual Studio Code. Eclipse can also generate these files in some circumstances. So filtering them away could help contributors