### PR TITLE
Add the Core Infrastructure Initiative Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # About
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/jenkins/jenkins.svg)](https://hub.docker.com/r/jenkins/jenkins/)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3538/badge)](https://bestpractices.coreinfrastructure.org/projects/3538)
 
 In a nutshell, Jenkins is the leading open-source automation server. 
 Built with Java, it provides over 1700 [plugins](https://plugins.jenkins.io/) to support automating virtually anything, 


### PR DESCRIPTION
Follow-up to https://groups.google.com/forum/#!msg/jenkinsci-dev/n1qH1K5_td0/a3SoeMGzBQAJ. We have reached the 133% mark in the CII certification, and now we get a fancy green badge. I suggest adding t to the repository, because the certification checklist can act as a source of additional information for Jenkins users.
