### PR TITLE
Make plugin manager table headers alignment consistent

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -137,7 +137,7 @@ THE SOFTWARE.
                     </div>
                   </j:if>
                 </td>
-                <td class="center pane" style="white-space:normal">
+                <td class="pane" style="white-space:normal">
                   <a href="plugin/${p.shortName}/thirdPartyLicenses">
                     ${p.version}
                   </a>
@@ -158,7 +158,7 @@ THE SOFTWARE.
                           <j:set var="uninstallPossible" value="false"/>
                       </j:otherwise>
                   </j:choose>
-                  <td class="center pane uninstall" data="${uninstallPossible}">
+                  <td class="pane uninstall" data="${uninstallPossible}">
                     <j:choose>
                       <j:when test="${p.isDeleted()}">
                         <p>${%Uninstallation pending}</p>


### PR DESCRIPTION
This PR makes the alignment of the _Version_ and _Uninstall_ cells on the installed plugin tables consistent with the other tables.

Before:
<img width="1130" alt="Captura de pantalla 2020-07-21 a las 16 13 34" src="https://user-images.githubusercontent.com/5738588/88065935-7c916a80-cb6d-11ea-81eb-09a7c5dec9f7.png">

After:
<img width="1130" alt="Captura de pantalla 2020-07-21 a las 16 13 17" src="https://user-images.githubusercontent.com/5738588/88065946-7f8c5b00-cb6d-11ea-9efb-85ffdc1e955e.png">

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 
@oleg-nenashev 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
