### PR TITLE
Use support-log-formatter from jetty:run

### DIFF
--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -73,6 +73,9 @@ import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.security.Security;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 
 import static java.util.logging.Level.*;
@@ -123,7 +126,24 @@ public class WebAppMain implements ServletContextListener {
     /**
      * Creates the sole instance of {@link jenkins.model.Jenkins} and register it to the {@link ServletContext}.
      */
+    @Override
     public void contextInitialized(ServletContextEvent event) {
+        // Nicer console log formatting when using mvn jetty:run.
+        if (Main.isDevelopmentMode && System.getProperty("java.util.logging.config.file") == null) {
+            try {
+                Formatter formatter = (Formatter) Class.forName("io.jenkins.lib.support_log_formatter.SupportLogFormatter").newInstance();
+                for (Handler h : java.util.logging.Logger.getLogger("").getHandlers()) {
+                    if (h instanceof ConsoleHandler) {
+                        ((ConsoleHandler) h).setFormatter(formatter);
+                    }
+                }
+            } catch (ClassNotFoundException x) {
+                // ignore
+            } catch (Exception x) {
+                LOGGER.log(Level.WARNING, null, x);
+            }
+        }
+
         JenkinsJVMAccess._setJenkinsJVM(true);
         final ServletContext context = event.getServletContext();
         File home=null;

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -431,6 +431,27 @@ THE SOFTWARE.
               <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
+          <execution> <!-- see jetty-maven-plugin config and WebAppMain -->
+            <id>support-log-formatter</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.jenkins.lib</groupId>
+                  <artifactId>support-log-formatter</artifactId>
+                  <version>1.0</version>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <stripVersion>true</stripVersion>
+              <overWriteIfNewer>true</overWriteIfNewer>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin><!-- generate licenses.xml -->
@@ -521,8 +542,8 @@ THE SOFTWARE.
             </systemProperty>
           </systemProperties>
           <webApp>
-            <!-- Allows resources to be reloaded. -->
-            <extraClasspath>${project.basedir}/../core/src/main/resources,${project.basedir}/../core/target/classes</extraClasspath>
+            <!-- Allows resources to be reloaded, and enable nicer console logging. -->
+            <extraClasspath>${project.basedir}/../core/src/main/resources,${project.basedir}/../core/target/classes,${project.build.directory}/support-log-formatter.jar</extraClasspath>
             <contextPath>${contextPath}</contextPath>
             <configurationDiscovered>false</configurationDiscovered>
             <webInfIncludeJarPattern>NONE</webInfIncludeJarPattern><!-- see https://wiki.eclipse.org/Jetty/Howto/Avoid_slow_deployment -->


### PR DESCRIPTION
Should not affect tests, generated artifacts, plugin usage (covered by https://github.com/jenkinsci/maven-hpi-plugin/pull/177), etc.; only `mvn -pl war jetty:run` here. Before:

```
…
[INFO] Started Jetty Server
[INFO] Console reloading is ENABLED. Hit ENTER on the console to restart the context.
Jul 21, 2020 10:57:42 AM jenkins.InitReactorRunner$1 onAttained
INFO: Started initialization
Jul 21, 2020 10:57:42 AM jenkins.InitReactorRunner$1 onAttained
INFO: Listed all plugins
Jul 21, 2020 10:57:43 AM jenkins.InitReactorRunner$1 onAttained
INFO: Prepared all plugins
Jul 21, 2020 10:57:43 AM jenkins.InitReactorRunner$1 onAttained
INFO: Started all plugins
Jul 21, 2020 10:57:43 AM jenkins.InitReactorRunner$1 onAttained
INFO: Augmented all extensions
Jul 21, 2020 10:57:43 AM jenkins.InitReactorRunner$1 onAttained
INFO: System config loaded
Jul 21, 2020 10:57:43 AM jenkins.InitReactorRunner$1 onAttained
INFO: System config adapted
Jul 21, 2020 10:57:43 AM jenkins.InitReactorRunner$1 onAttained
INFO: Loaded all jobs
Jul 21, 2020 10:57:43 AM jenkins.InitReactorRunner$1 onAttained
INFO: Configuration for all jobs updated
Jul 21, 2020 10:57:43 AM hudson.model.AsyncPeriodicWork lambda$doRun$0
INFO: Started Download metadata
Jul 21, 2020 10:57:43 AM hudson.model.AsyncPeriodicWork lambda$doRun$0
INFO: Finished Download metadata. 4 ms
Jul 21, 2020 10:57:44 AM org.springframework.context.support.AbstractApplicationContext prepareRefresh
INFO: Refreshing org.springframework.web.context.support.StaticWebApplicationContext@4dac1a83: display name [Root WebApplicationContext]; startup date [Tue Jul 21 10:57:44 EDT 2020]; root of context hierarchy
Jul 21, 2020 10:57:44 AM org.springframework.context.support.AbstractApplicationContext obtainFreshBeanFactory
INFO: Bean factory for application context [org.springframework.web.context.support.StaticWebApplicationContext@4dac1a83]: org.springframework.beans.factory.support.DefaultListableBeanFactory@7748e1f7
Jul 21, 2020 10:57:44 AM org.springframework.beans.factory.support.DefaultListableBeanFactory preInstantiateSingletons
INFO: Pre-instantiating singletons in org.springframework.beans.factory.support.DefaultListableBeanFactory@7748e1f7: defining beans [authenticationManager]; root of factory hierarchy
Jul 21, 2020 10:57:44 AM org.springframework.context.support.AbstractApplicationContext prepareRefresh
INFO: Refreshing org.springframework.web.context.support.StaticWebApplicationContext@30ccaa83: display name [Root WebApplicationContext]; startup date [Tue Jul 21 10:57:44 EDT 2020]; root of context hierarchy
Jul 21, 2020 10:57:44 AM org.springframework.context.support.AbstractApplicationContext obtainFreshBeanFactory
INFO: Bean factory for application context [org.springframework.web.context.support.StaticWebApplicationContext@30ccaa83]: org.springframework.beans.factory.support.DefaultListableBeanFactory@2f828a79
Jul 21, 2020 10:57:44 AM org.springframework.beans.factory.support.DefaultListableBeanFactory preInstantiateSingletons
INFO: Pre-instantiating singletons in org.springframework.beans.factory.support.DefaultListableBeanFactory@2f828a79: defining beans [filter,legacy]; root of factory hierarchy
Jul 21, 2020 10:57:44 AM jenkins.model.Jenkins setInstallState
INFO: Install state transitioning from: DEVELOPMENT to : DEVELOPMENT
Jul 21, 2020 10:57:44 AM jenkins.InitReactorRunner$1 onAttained
INFO: Completed initialization
Jul 21, 2020 10:57:44 AM hudson.WebAppMain$3 run
INFO: Jenkins is fully up and running
```

After:

```
…
[INFO] Started Jetty Server
[INFO] Console reloading is ENABLED. Hit ENTER on the console to restart the context.
2020-07-21 14:56:26.228+0000 [id=42]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
2020-07-21 14:56:26.281+0000 [id=61]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
2020-07-21 14:56:26.948+0000 [id=45]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
2020-07-21 14:56:26.953+0000 [id=55]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
2020-07-21 14:56:26.959+0000 [id=41]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
2020-07-21 14:56:27.123+0000 [id=41]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
2020-07-21 14:56:27.124+0000 [id=52]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
2020-07-21 14:56:27.124+0000 [id=52]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
2020-07-21 14:56:27.125+0000 [id=49]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
2020-07-21 14:56:27.134+0000 [id=76]	INFO	hudson.model.AsyncPeriodicWork#lambda$doRun$0: Started Download metadata
2020-07-21 14:56:27.140+0000 [id=76]	INFO	hudson.model.AsyncPeriodicWork#lambda$doRun$0: Finished Download metadata. 4 ms
2020-07-21 14:56:27.701+0000 [id=61]	INFO	o.s.c.s.AbstractApplicationContext#prepareRefresh: Refreshing org.springframework.web.context.support.StaticWebApplicationContext@5c818b5c: display name [Root WebApplicationContext]; startup date [Tue Jul 21 10:56:27 EDT 2020]; root of context hierarchy
2020-07-21 14:56:27.701+0000 [id=61]	INFO	o.s.c.s.AbstractApplicationContext#obtainFreshBeanFactory: Bean factory for application context [org.springframework.web.context.support.StaticWebApplicationContext@5c818b5c]: org.springframework.beans.factory.support.DefaultListableBeanFactory@25a2f30a
2020-07-21 14:56:27.708+0000 [id=61]	INFO	o.s.b.f.s.DefaultListableBeanFactory#preInstantiateSingletons: Pre-instantiating singletons in org.springframework.beans.factory.support.DefaultListableBeanFactory@25a2f30a: defining beans [authenticationManager]; root of factory hierarchy
2020-07-21 14:56:27.856+0000 [id=61]	INFO	o.s.c.s.AbstractApplicationContext#prepareRefresh: Refreshing org.springframework.web.context.support.StaticWebApplicationContext@4cdcb1fc: display name [Root WebApplicationContext]; startup date [Tue Jul 21 10:56:27 EDT 2020]; root of context hierarchy
2020-07-21 14:56:27.856+0000 [id=61]	INFO	o.s.c.s.AbstractApplicationContext#obtainFreshBeanFactory: Bean factory for application context [org.springframework.web.context.support.StaticWebApplicationContext@4cdcb1fc]: org.springframework.beans.factory.support.DefaultListableBeanFactory@ce68271
2020-07-21 14:56:27.857+0000 [id=61]	INFO	o.s.b.f.s.DefaultListableBeanFactory#preInstantiateSingletons: Pre-instantiating singletons in org.springframework.beans.factory.support.DefaultListableBeanFactory@ce68271: defining beans [filter,legacy]; root of factory hierarchy
2020-07-21 14:56:27.931+0000 [id=61]	INFO	jenkins.model.Jenkins#setInstallState: Install state transitioning from: DEVELOPMENT to : DEVELOPMENT
2020-07-21 14:56:27.937+0000 [id=55]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
2020-07-21 14:56:28.031+0000 [id=36]	INFO	hudson.WebAppMain$3#run: Jenkins is fully up and running
```

### Proposed changelog entries

None required.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
