### PR TITLE
[JENKINS-63168] Prevent NPE when calling CommandInterpreter#buildEnvVarsFilterRules

### DIFF
--- a/core/src/main/java/hudson/tasks/CommandInterpreter.java
+++ b/core/src/main/java/hudson/tasks/CommandInterpreter.java
@@ -44,6 +44,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -76,13 +77,13 @@ public abstract class CommandInterpreter extends Builder implements EnvVarsFilte
     }
 
     public @NonNull List<EnvVarsFilterLocalRule> buildEnvVarsFilterRules() {
-        return new ArrayList<>(configuredLocalRules);
+        return configuredLocalRules == null ? Collections.emptyList() : new ArrayList<>(configuredLocalRules);
     }
 
     // used by Jelly view
     @Restricted(NoExternalUse.class)
     public List<EnvVarsFilterLocalRule> getConfiguredLocalRules() {
-        return configuredLocalRules;
+        return configuredLocalRules == null ? Collections.emptyList() : configuredLocalRules;
     }
 
     @Override

--- a/test/src/test/java/hudson/tasks/CommandInterpreterTest.java
+++ b/test/src/test/java/hudson/tasks/CommandInterpreterTest.java
@@ -1,0 +1,72 @@
+package hudson.tasks;
+
+import hudson.FilePath;
+import hudson.model.AbstractProject;
+import hudson.model.FreeStyleProject;
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.recipes.LocalData;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class CommandInterpreterTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Issue("JENKINS-63168")
+    @Test
+    @LocalData
+    public void ensurePluginCommandInterpretersCanBeLoaded() {
+        final Builder builder = j.jenkins.getItemByFullName("a", FreeStyleProject.class).getBuildersList().get(0);
+        Assert.assertTrue(builder instanceof TestCommandInterpreter);
+
+        try {
+            ((TestCommandInterpreter) builder).getConfiguredLocalRules().isEmpty();
+        } catch (NullPointerException ex) {
+            Assert.fail("getConfiguredLocalRules must not return null");
+        }
+        try {
+            ((TestCommandInterpreter)builder).buildEnvVarsFilterRules();
+        } catch (NullPointerException ex) {
+            Assert.fail("buildEnvVarsFilterRules must not throw");
+        }
+    }
+
+    // This doesn't need a UI etc., we just need to be able to load old data with it
+    public static class TestCommandInterpreter extends CommandInterpreter {
+
+        @DataBoundConstructor
+        public TestCommandInterpreter(String command) {
+            super(command);
+        }
+
+        @Override
+        public String[] buildCommandLine(FilePath script) {
+            return new String[0];
+        }
+
+        @Override
+        protected String getContents() {
+            return "";
+        }
+
+        @Override
+        protected String getFileExtension() {
+            return "wat";
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return false;
+            }
+        }
+    }
+}

--- a/test/src/test/resources/hudson/tasks/CommandInterpreterTest/jobs/a/config.xml
+++ b/test/src/test/resources/hudson/tasks/CommandInterpreterTest/jobs/a/config.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.CommandInterpreterTest_-TestCommandInterpreter>
+      <command>env</command>
+    </hudson.tasks.CommandInterpreterTest_-TestCommandInterpreter>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>


### PR DESCRIPTION
See [JENKINS-63168](https://issues.jenkins-ci.org/browse/JENKINS-63168).

### Proposed changelog entries

* Do not throw exceptions when building jobs with certain build steps. (regression in 2.248)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jenkinsci/code-reviewers 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
