### PR TITLE
UsageStatisticsTest failure: java.vendor vs. java.vm.vendor

### DIFF
--- a/test/src/test/java/hudson/model/UsageStatisticsTest.java
+++ b/test/src/test/java/hudson/model/UsageStatisticsTest.java
@@ -166,7 +166,7 @@ public class UsageStatisticsTest {
 
         Class clazz = this.getClass();
         String fileContent = Resources.toString(clazz.getResource(clazz.getSimpleName() + "/" + fileName), StandardCharsets.UTF_8);
-        fileContent = fileContent.replace("JVMVENDOR", System.getProperty("java.vendor"));
+        fileContent = fileContent.replace("JVMVENDOR", System.getProperty("java.vm.vendor"));
         fileContent = fileContent.replace("JVMNAME", System.getProperty("java.vm.name"));
         fileContent = fileContent.replace("JVMVERSION", System.getProperty("java.version"));
         assertEquals(fileContent, object.toString());


### PR DESCRIPTION
[Master](https://ci.jenkins.io/job/Core/job/jenkins/job/master/2109/testReport/hudson.model/UsageStatisticsTest/Linux_jdk11___Linux_Publishing___roundtrip/) and PRs started failing with

```
org.junit.ComparisonFailure: expected:<...:true,"jvm-vendor":"[N/A]","jvm-name":"OpenJD...> but was:<...:true,"jvm-vendor":"[Oracle Corporation]","jvm-name":"OpenJD...>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at hudson.model.UsageStatisticsTest.compareWithFile(UsageStatisticsTest.java:172)
	at hudson.model.UsageStatisticsTest.roundtrip(UsageStatisticsTest.java:126)
```

Seems there was a mismatch between https://github.com/jenkinsci/jenkins/blob/816c7659eabe0603af44056eb2e09e469a4a7c0d/core/src/main/java/hudson/model/UsageStatistics.java#L140-L142 and https://github.com/jenkinsci/jenkins/blob/816c7659eabe0603af44056eb2e09e469a4a7c0d/test/src/test/java/hudson/model/UsageStatisticsTest.java#L169-L171 though I cannot reproduce locally on Ubuntu:

```
openjdk version "11.0.8" 2020-07-14
OpenJDK Runtime Environment (build 11.0.8+10-post-Ubuntu-0ubuntu120.04)
OpenJDK 64-Bit Server VM (build 11.0.8+10-post-Ubuntu-0ubuntu120.04, mixed mode, sharing)
```

for which both system properties have the value `Private Build`. I am guessing we just switched JDK on build machines or something?

### Proposed changelog entries

None needed.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
