### PR TITLE
Revert "[JENKINS-63014] Stop passing extra -url to agents"

### DIFF
--- a/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
@@ -89,6 +89,21 @@ THE SOFTWARE.
 
         <argument>-url</argument>
         <argument>${rootURL}</argument>
+
+        <j:if test="${rootURL!=app.rootUrlFromRequest}">
+          <!--
+            rootURL is based on the URL in the system config, but there has been
+            numerous reports about people moving Jenkins to another place but
+            forgetting to update it. To improve the user experience in this regard,
+            let's also pass the URL that the browser sent us as well, so that the
+            JNLP Main class can try both.
+
+            Note that rootURL is still necessary in various situations, such
+            as reverse HTTP proxy situation, which makes rootUrlFromRequest incorrect.
+          -->
+          <argument>-url</argument>
+          <argument>${app.rootUrlFromRequest}</argument>
+        </j:if>
       </application-desc>
     </jnlp>
   </l:view>


### PR DESCRIPTION
Submitting it for a discussion - jenkinsci/jenkins#4839 removes the feature which was supposed to be unused, but apparently it caused breaking changes in some configurations: https://issues.jenkins-ci.org/browse/JENKINS-63222 . We need to define which path we take to proceed.

Since WebSocket is an experimental feature, it might be the easiest way to just revert the fix.

Would be happy to consider any alternate fixes which do not break Websockets again. Documentation-only fix might be an option as well

