### PR TITLE
Do not block rendering of Manage Jenkins while waiting for UC data

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -1307,9 +1307,12 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
         /* Would be much nicer to go through getInfoFromAllSites but that only works for currently published plugins */
         List<UpdateSite.Deprecation> deprecations = new ArrayList<>();
         for (UpdateSite site : Jenkins.get().getUpdateCenter().getSites()) {
-            for (Map.Entry<String, UpdateSite.Deprecation> entry : site.getData().getDeprecations().entrySet()) {
-                if (entry.getKey().equals(this.shortName)) {
-                    deprecations.add(entry.getValue());
+            final UpdateSite.Data data = site.getData();
+            if (data != null) {
+                for (Map.Entry<String, UpdateSite.Deprecation> entry : data.getDeprecations().entrySet()) {
+                    if (entry.getKey().equals(this.shortName)) {
+                        deprecations.add(entry.getValue());
+                    }
                 }
             }
         }

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -1306,12 +1306,15 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     public List<UpdateSite.Deprecation> getDeprecations() {
         /* Would be much nicer to go through getInfoFromAllSites but that only works for currently published plugins */
         List<UpdateSite.Deprecation> deprecations = new ArrayList<>();
-        for (UpdateSite site : Jenkins.get().getUpdateCenter().getSites()) {
-            final UpdateSite.Data data = site.getData();
-            if (data != null) {
-                for (Map.Entry<String, UpdateSite.Deprecation> entry : data.getDeprecations().entrySet()) {
-                    if (entry.getKey().equals(this.shortName)) {
-                        deprecations.add(entry.getValue());
+        final UpdateCenter updateCenter = Jenkins.get().getUpdateCenter();
+        if (updateCenter.isSiteDataReady()) {
+            for (UpdateSite site : updateCenter.getSites()) {
+                final UpdateSite.Data data = site.getData();
+                if (data != null) {
+                    for (Map.Entry<String, UpdateSite.Deprecation> entry : data.getDeprecations().entrySet()) {
+                        if (entry.getKey().equals(this.shortName)) {
+                            deprecations.add(entry.getValue());
+                        }
                     }
                 }
             }

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -336,6 +336,7 @@ public class UpdateSite {
      *
      * @return  null if no data is available.
      */
+    @CheckForNull
     public Data getData() {
         if (data == null) {
             JSONObject o = getJSONObject();

--- a/core/src/main/java/jenkins/management/PluginsLink.java
+++ b/core/src/main/java/jenkins/management/PluginsLink.java
@@ -26,11 +26,14 @@ package jenkins.management;
 
 import hudson.Extension;
 import hudson.model.ManagementLink;
+import hudson.model.UpdateCenter;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -67,5 +70,15 @@ public class PluginsLink extends ManagementLink {
     @Override
     public Category getCategory() {
         return Category.CONFIGURATION;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public boolean hasUpdates() {
+        final UpdateCenter updateCenter = Jenkins.get().getUpdateCenter();
+        if (!updateCenter.isSiteDataReady()) {
+            // Do not display message during this page load, but possibly later.
+            return false;
+        }
+        return !updateCenter.getUpdates().isEmpty();
     }
 }

--- a/core/src/main/resources/jenkins/management/PluginsLink/info.jelly
+++ b/core/src/main/resources/jenkins/management/PluginsLink/info.jelly
@@ -24,7 +24,7 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-  <j:if test="${!empty app.updateCenter.updates}">
+  <j:if test="${it.hasUpdates()}">
     <i class="fa fa-bell" aria-hidden="true" style="color: red"></i> ${%updates available}
   </j:if>
 </j:jelly>


### PR DESCRIPTION
Similar to #4413

### Manual testing notes

This is easiest to test with plugin updates being available. Instructions below are written for that case. Disable the following administrative monitors:

* Deprecated Plugin Monitor
* Jenkins Update Notification
* Update Site Warnings

All of these end up checking update site data, which is what we don't want.

Then run `Jenkins.get().updateCenter.sites[0].doInvalidateData()` in Script Console.

From that point on, Jenkins will probably have unparsed data on disk (`JENKINS_HOME/updates/default.json`), which will only be parsed, asynchronously, after you visit Manage Jenkins. The notable change here is that Manage Jenkins will not block rendering, and the first (few) reload(s) of the page will not show available updates.

Do not visit the Plugin Manager while doing the above, as that will also cause update center data to load (duh).

### Proposed changelog entries

(Too minor)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jtnord

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
