### PR TITLE
Fixed testparamter in ZipArchiverTest

### DIFF
--- a/core/src/test/java/hudson/util/io/ZipArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/ZipArchiverTest.java
@@ -99,7 +99,7 @@ public class ZipArchiverTest {
         File hugeFile = new File(tmpDir, "huge64bitFileTest.txt");
         try {
             RandomAccessFile largeFile = new RandomAccessFile(hugeFile, "rw");
-            largeFile.setLength(4 * 1024 * 1024 * 1024 + 2);
+            largeFile.setLength(4L * 1024 * 1024 * 1024 + 2);
         } catch (IOException e) {
             /* We probably don't have enough free disk space
              * That's ok, we'll skip this test...
@@ -135,7 +135,6 @@ public class ZipArchiverTest {
         String zipEntryName = null;
 
         try (ZipFile zipFileVerify = new ZipFile(zipFile)) {
-
             zipEntryName = ((ZipEntry) zipFileVerify.entries().nextElement()).getName();
         } catch (Exception e) {
             fail("failure enumerating zip entries", e);


### PR DESCRIPTION
I stumbled upon a minor issue I thought, but this might be a real bug in the implementation. The existing txt file was just 2 bytes big, instead of 4gb +2. As soon as I corrected this, the test fails.

The PR introducing this functionality was: https://github.com/jenkinsci/jenkins/pull/3536

### Proposed changelog entries

* TBD

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jsoref 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
