### PR TITLE
Backporting for LTS 2.235.4

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1432,36 +1432,78 @@ public class Util {
     }
 
     /**
-     * Checks if the method defined on the base type with the given arguments
-     * is overridden in the given derived type.
+     * Checks whether the method defined on the base type with the given arguments is overridden in the given derived
+     * type.
+     *
+     * @param base       The base type.
+     * @param derived    The derived type.
+     * @param methodName The name of the method.
+     * @param types      The types of the arguments for the method.
+     * @return {@code true} when {@code derived} provides the specified method other than as inherited from {@code base}.
+     * @throws IllegalArgumentException When {@code derived} does not derive from {@code base}, or when {@code base}
+     *                                  does not contain the specified method.
      */
-    public static boolean isOverridden(@NonNull Class base, @NonNull Class derived, @NonNull String methodName, @NonNull Class... types) {
-        return !getMethod(base, methodName, types).equals(getMethod(derived, methodName, types));
+    public static boolean isOverridden(@NonNull Class<?> base, @NonNull Class<?> derived, @NonNull String methodName, @NonNull Class<?>... types) {
+        // If derived is not a subclass or implementor of base, it can't override any method
+        // Technically this should also be triggered when base == derived, because it can't override its own method, but
+        // the unit tests explicitly test for that as working.
+        if (!base.isAssignableFrom(derived)) {
+            throw new IllegalArgumentException("The specified derived class (" + derived.getCanonicalName() + ") does not derive from the specified base class (" + base.getCanonicalName() + ").");
+        }
+        final Method baseMethod = Util.getMethod(base, null, methodName, types);
+        if (baseMethod == null) {
+            throw new IllegalArgumentException("The specified method is not declared by the specified base class (" + base.getCanonicalName() + "), or it is private, static or final.");
+        }
+        final Method derivedMethod = Util.getMethod(derived, base, methodName, types);
+        // the lookup will either return null or the base method when no override has been found (depending on whether
+        // the base is an interface)
+        return derivedMethod != null && derivedMethod != baseMethod;
     }
 
-    private static Method getMethod(@NonNull Class clazz, @NonNull String methodName, @NonNull Class... types) {
-        Method res = null;
+    private static Method getMethod(@NonNull Class<?> clazz, @Nullable Class<?> base, @NonNull String methodName, @NonNull Class<?>... types) {
         try {
-            res = clazz.getDeclaredMethod(methodName, types);
-            // private, static or final methods can not be overridden
-            if (res != null && (Modifier.isPrivate(res.getModifiers()) || Modifier.isFinal(res.getModifiers()) 
-                    || Modifier.isStatic(res.getModifiers()))) {
-                res = null;
+            final Method res = clazz.getDeclaredMethod(methodName, types);
+            final int mod = res.getModifiers();
+            // private and static methods are never ok, and end the search
+            if (Modifier.isPrivate(mod) || Modifier.isStatic(mod)) {
+                return null;
             }
+            // when looking for the base/declaring method, final is not ok
+            if (base == null && Modifier.isFinal(mod)) {
+                return null;
+            }
+            // when looking for the overriding method, abstract is not ok
+            if (base != null && Modifier.isAbstract(mod)) {
+                return null;
+            }
+            return res;
         } catch (NoSuchMethodException e) {
-            // Method not found in clazz, let's search in superclasses
-            Class superclass = clazz.getSuperclass();
-            if (superclass != null) {
-                res = getMethod(superclass, methodName, types);
+            // If the base is an interface, the implementation may come from a default implementation on a derived
+            // interface. So look at interfaces too.
+            if (base != null && Modifier.isInterface(base.getModifiers())) {
+                for (Class<?> iface : clazz.getInterfaces()) {
+                    if (base.equals(iface) || !base.isAssignableFrom(iface)) {
+                        continue;
+                    }
+                    final Method defaultImpl = Util.getMethod(iface, base, methodName, types);
+                    if (defaultImpl != null) {
+                        return defaultImpl;
+                    }
+                }
             }
+            // Method not found in clazz, let's search in superclasses
+            Class<?> superclass = clazz.getSuperclass();
+            if (superclass != null) {
+                // if the superclass doesn't derive from base anymore (or IS base), stop looking
+                if (base != null && (base.equals(superclass) || !base.isAssignableFrom(superclass))) {
+                    return null;
+                }
+                return getMethod(superclass, base, methodName, types);
+            }
+            return null;
         } catch (SecurityException e) {
             throw new AssertionError(e);
         }
-        if (res == null) {
-            throw new IllegalArgumentException(
-                    String.format("Method %s not found in %s (or it is private, final or static)", methodName, clazz.getName()));
-        }
-        return res;
     }
 
     /**

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -41,6 +41,7 @@ import hudson.model.PersistentDescriptor;
 import hudson.model.Run;
 import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
+import hudson.util.DaemonThreadFactory;
 import hudson.util.FlushProofOutputStream;
 import hudson.util.FormValidation;
 import hudson.util.NamingThreadFactory;
@@ -219,7 +220,7 @@ public class SCMTrigger extends Trigger<Item> {
     public static class DescriptorImpl extends TriggerDescriptor implements PersistentDescriptor {
 
         private static ThreadFactory threadFactory() {
-            return new NamingThreadFactory(Executors.defaultThreadFactory(), "SCMTrigger");
+            return new NamingThreadFactory(new DaemonThreadFactory(), "SCMTrigger");
         }
 
         /**

--- a/core/src/test/java/hudson/util/IsOverriddenTest.java
+++ b/core/src/test/java/hudson/util/IsOverriddenTest.java
@@ -27,11 +27,20 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 import hudson.Util;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Rule;
+import org.junit.rules.ErrorCollector;
+import org.jvnet.hudson.test.Issue;
 
 /**
  * Test for {@link Util#isOverridden} method.
  */
 public class IsOverriddenTest {
+
+    @Rule
+    public ErrorCollector errors = new ErrorCollector();
 
     /**
      * Test that a method is found by isOverridden even when it is inherited from an intermediate class.
@@ -47,11 +56,17 @@ public class IsOverriddenTest {
 
     /**
      * Negative test.
-     * Trying to check for a method which does not exist in the hierarchy,
+     * Trying to check for a method which does not exist in the hierarchy.
      */
     @Test(expected = IllegalArgumentException.class)
     public void isOverriddenNegativeTest() {
         Util.isOverridden(Base.class, Derived.class, "method2");
+    }
+
+    /** Specifying a base class that is not a base class should result in an error. */
+    @Test(expected = IllegalArgumentException.class)
+    public void badHierarchyIsReported() {
+        Util.isOverridden(Derived.class, Base.class, "method");
     }
 
     /**
@@ -75,6 +90,77 @@ public class IsOverriddenTest {
         public Integer getX() { return 0; }
     }
     public class Derived extends Intermediate {}
+
+    @Issue("JENKINS-62723")
+    @Test
+    public void finalOverrides() {
+        errors.checkSucceeds(() -> {assertThat("X1 overrides X.m1", Util.isOverridden(X.class, X1.class, "m1"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X1 does not override X.m2", Util.isOverridden(X.class, X1.class, "m2"), is(false)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X2 overrides X.m1", Util.isOverridden(X.class, X2.class, "m1"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X2 does not override X.m2", Util.isOverridden(X.class, X2.class, "m2"), is(false)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X3 overrides X.m1", Util.isOverridden(X.class, X3.class, "m1"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X3 overrides X.m2", Util.isOverridden(X.class, X3.class, "m2"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X4 overrides X.m1", Util.isOverridden(X.class, X4.class, "m1"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("X4 overrides X.m2", Util.isOverridden(X.class, X4.class, "m2"), is(true)); return null;});
+    }
+    public static interface X {
+        void m1();
+        default void m2() {}
+    }
+    public static class X1 implements X {
+        public void m1() {}
+    }
+    public static class X2 implements X {
+        public final void m1() {}
+    }
+    public static class X3 implements X {
+        public void m1() {}
+        @Override
+        public void m2() {}
+    }
+    public static class X4 implements X {
+        public void m1() {}
+        @Override
+        public final void m2() {}
+    }
+
+    @Issue("JENKINS-62723")
+    @Test
+    public void baseInterface() {
+        // Normal case: classes implementing interface methods
+        errors.checkSucceeds(() -> {assertThat("I1 does not override I1.foo", Util.isOverridden(I1.class, I1.class, "foo"), is(false)); return null;});
+        errors.checkSucceeds(() -> {assertThat("I2 does not override I1.foo", Util.isOverridden(I1.class, I2.class, "foo"), is(false)); return null;});
+        errors.checkSucceeds(() -> {assertThat("C1 does not override I1.foo", Util.isOverridden(I1.class, C1.class, "foo"), is(false)); return null;});
+        errors.checkSucceeds(() -> {assertThat("C2 does not override I1.foo", Util.isOverridden(I1.class, C2.class, "foo"), is(false)); return null;});
+        errors.checkSucceeds(() -> {assertThat("C3 overrides I1.foo", Util.isOverridden(I1.class, C3.class, "foo"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("C4 overrides I1.foo", Util.isOverridden(I1.class, C4.class, "foo"), is(true)); return null;});
+        // Special case: interfaces providing default implementation of base interface
+        errors.checkSucceeds(() -> {assertThat("I1 does not override I1.bar", Util.isOverridden(I1.class, I1.class, "bar"), is(false)); return null;});
+        errors.checkSucceeds(() -> {assertThat("I2 overrides I1.bar", Util.isOverridden(I1.class, I2.class, "bar"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("C1 does not override I1.bar", Util.isOverridden(I1.class, C1.class, "bar"), is(false)); return null;});
+        errors.checkSucceeds(() -> {assertThat("C2 overrides I1.bar (via I2)", Util.isOverridden(I1.class, C2.class, "bar"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("C3 overrides I1.bar (via I2)", Util.isOverridden(I1.class, C3.class, "bar"), is(true)); return null;});
+        errors.checkSucceeds(() -> {assertThat("C4 overrides I1.bar", Util.isOverridden(I1.class, C4.class, "bar"), is(true)); return null;});
+    }
+    private interface I1 {
+        String foo();
+        String bar();
+    }
+    private interface I2 extends I1 {
+        default String bar() { return "default"; }
+    }
+    private static abstract class C1 implements I1 {
+    }
+    private static abstract class C2 extends C1 implements I2 {
+        @Override public abstract String foo();
+    }
+    private static abstract class C3 extends C2 {
+        @Override public String foo() { return "foo"; }
+    }
+    private static class C4 extends C3 implements I1 {
+        @Override public String bar() { return "bar"; }
+    }
+
 
 }
 


### PR DESCRIPTION
Please have look at the changes proposed so we have a consensus of what goes in. I suggest to backport all three candidates.

Fixed
-----

JENKINS-62723		Blocker   		2.248
	Build fails with "java.lang.IllegalArgumentException: Method perform not found in hudson.plugins.analysis.core.HealthAwareRecorder"
	https://issues.jenkins-ci.org/browse/JENKINS-62723

JENKINS-62695		Major     		2.243
	SCMTrigger thread blocks graceful shutdown
	https://issues.jenkins-ci.org/browse/JENKINS-62695

Removed after PR discussion
-----------------------------

JENKINS-63014		Major     		2.248
	Agent connection error using nginx proxy with WebSocket
	https://issues.jenkins-ci.org/browse/JENKINS-63014
		Caused https://issues.jenkins-ci.org/browse/JENKINS-63222
