### PR TITLE
[JENKINS-63082] SLAVE_LOG_HANDLER should avoid synch logging

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -102,7 +102,10 @@ import java.util.logging.SimpleFormatter;
 import java.util.stream.Stream;
 
 import static hudson.slaves.SlaveComputer.LogHolder.SLAVE_LOG_HANDLER;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.NamingThreadFactory;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.jenkinsci.remoting.util.LoggingChannelListener;
 
 
@@ -1027,7 +1030,7 @@ public class SlaveComputer extends Computer {
         public Void call() {
             SLAVE_LOG_HANDLER = new RingBufferLogHandler(ringBufferSize) {
                 ThreadLocal<Formatter> dummy = ThreadLocal.withInitial(() -> new SimpleFormatter());
-                ExecutorService executor = Channel.currentOrFail().executor;
+                ExecutorService executor = new ScheduledThreadPoolExecutor(1, new NamingThreadFactory(new DaemonThreadFactory(), "SLAVE_LOG_HANDLER")); // inaccessible: Channel.currentOrFail().executor
                 @Override
                 public /* not synchronized */ void publish(LogRecord record) {
                     executor.submit(() -> {


### PR DESCRIPTION
[JENKINS-63082](https://issues.jenkins-ci.org/browse/JENKINS-63082): Amends #4621. As with #4714, I cannot verify the fix in a test or manually since I am unaware of steps to reproduce, but the fix has been confirmed effective by @marcusphi and @jpfeuffer. The alternative is to simply back out #4621 and live with that bug, which would be appropriate for 2.235.x if we are still considering new releases in that line.

### Proposed changelog entries

* Reattempted fix for a deadlock in agent logging.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
