### PR TITLE
[JENKINS-60866][PoC] Content-Security-Policy

### DIFF
--- a/core/src/main/java/jenkins/security/csp/CspRootAction.java
+++ b/core/src/main/java/jenkins/security/csp/CspRootAction.java
@@ -1,0 +1,252 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.security.csp;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
+import hudson.model.RootAction;
+import hudson.model.UnprotectedRootAction;
+import hudson.security.csrf.CrumbExclusion;
+import hudson.util.HttpResponses;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import net.sf.json.JsonConfig;
+import net.sf.json.util.JavaIdentifierTransformer;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Extension
+@Symbol("CSP")
+public class CspRootAction implements RootAction {
+
+    private boolean reporterOnly = true;
+    private boolean withApprovedHashes = true;
+    private String cspRules = "default-src 'self'; child-src 'none' ; style-src 'self' 'unsafe-inline';"; // style-src is just there to simplify a bit the PoC
+    private String desiredPayload = "payload<script>console.warn(123)</script>injected";
+
+    // contain only sha256-xxxxx stuff
+    private Set<String> approvedHashes = new HashSet<>();
+    Set<SubmitReport> reports = new HashSet<>();
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return "csp-poc";
+    }
+
+    public boolean isReporterOnly() {
+        return reporterOnly;
+    }
+
+    @VisibleForTesting void setReporterOnly(boolean reporterOnly) {
+        this.reporterOnly = reporterOnly;
+    }
+
+    public boolean isWithApprovedHashes() {
+        return withApprovedHashes;
+    }
+
+    public String getCspRules() {
+        return cspRules;
+    }
+
+    public String getFullCspRules() {
+        if (withApprovedHashes && !approvedHashes.isEmpty()) {
+            // self = js file loaded from the application
+            String formattedApprovedHashes = approvedHashes.stream()
+                    .map(s -> "'" + s + "'")
+                    .sorted()
+                    .collect(Collectors.joining(" "));
+            return cspRules + "; script-src 'self' " + formattedApprovedHashes;
+        } else {
+            return cspRules;
+        }
+    }
+
+    public String getFullCspRulesWithReportUrl() {
+        return getFullCspRules() + "; report-uri " + getAbsoluteUrlToReport();
+    }
+
+    public String getDesiredPayload() {
+        return this.desiredPayload;
+    }
+
+    @VisibleForTesting void setDesiredPayload(String desiredPayload) {
+        this.desiredPayload = desiredPayload;
+    }
+
+    public String getApprovedHashes() {
+        return String.join("\n", this.approvedHashes);
+    }
+
+    public String getAbsoluteUrlToReport() {
+        return Jenkins.get().getRootUrl() + "csp-poc-report/submitReport/test";
+    }
+
+    @RequirePOST
+    public void doSubmitPayload(StaplerRequest request, StaplerResponse response) throws IOException, ServletException {
+        SubmitPayload submitPayload = (SubmitPayload) request.getSubmittedForm().toBean(SubmitPayload.class);
+        this.desiredPayload = submitPayload.desiredPayload;
+        this.reporterOnly = submitPayload.reporterOnly;
+        this.cspRules = submitPayload.cspRules;
+
+        String rawApprovedHashes = submitPayload.approvedHashes;
+        this.approvedHashes = Arrays.stream(rawApprovedHashes.split("\n"))
+                .map(s -> s.trim().replaceAll("'", ""))
+                .filter(s -> !s.startsWith("#") && !s.isEmpty())
+                .collect(Collectors.toSet());
+
+        response.sendRedirect2("");
+    }
+
+    public static class SubmitPayload {
+        public String desiredPayload;
+        public String cspRules;
+        public boolean reporterOnly;
+        public String approvedHashes;
+    }
+
+    @Extension
+    public static class CspReportRootActionCrumbExclusion extends CrumbExclusion {
+        @Override
+        public boolean process(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+            String pathInfo = request.getPathInfo();
+            if (pathInfo.startsWith("/csp-poc-report")) {
+                chain.doFilter(request, response);
+                return true;
+            }
+            return false;
+        }
+    }
+
+    @Extension
+    @Symbol("CSP-report")
+    public static class CspReportRootAction implements UnprotectedRootAction {
+        @RequirePOST
+        public HttpResponse doSubmitReport(StaplerRequest request) throws IOException {
+            JSONObject o = JSONObject.fromObject(IOUtils.toString(request.getReader()));
+
+            JsonConfig jsonConfig = new JsonConfig();
+            jsonConfig.setRootClass(SubmitReportWrapper.class);
+            jsonConfig.setJavaIdentifierTransformer(JavaIdentifierTransformer.CAMEL_CASE);
+
+            SubmitReportWrapper wrapper = (SubmitReportWrapper) JSONObject.toBean(o, jsonConfig);
+            SubmitReport report = wrapper.cspReport;
+
+            CspRootAction cspRootAction = Jenkins.get().getExtensionList(RootAction.class).get(CspRootAction.class);
+            cspRootAction.reports.add(report);
+
+            return HttpResponses.ok();
+        }
+
+        @Override
+        public String getIconFileName() {
+            return null;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+
+        @Override
+        public String getUrlName() {
+            return "csp-poc-report";
+        }
+    }
+
+    public static class SubmitReportWrapper {
+        public SubmitReport cspReport;
+    }
+
+    public static class SubmitReport {
+        public String blockedUri;
+        public String disposition;
+        public String documentUri;
+        public String effectiveDirective;
+        public String originalPolicy;
+        public String referrer;
+        public String scriptSample;
+        public String statusCode;
+        public String violatedDirective;
+
+        // specific to some types of report
+        public String sourceFile;
+        public Integer lineNumber;
+        public Integer columnNumber;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SubmitReport that = (SubmitReport) o;
+            return Objects.equals(blockedUri, that.blockedUri) &&
+                    Objects.equals(disposition, that.disposition) &&
+                    Objects.equals(documentUri, that.documentUri) &&
+                    Objects.equals(effectiveDirective, that.effectiveDirective) &&
+                    Objects.equals(originalPolicy, that.originalPolicy) &&
+                    Objects.equals(referrer, that.referrer) &&
+                    Objects.equals(scriptSample, that.scriptSample) &&
+                    Objects.equals(statusCode, that.statusCode) &&
+                    Objects.equals(violatedDirective, that.violatedDirective) &&
+                    Objects.equals(sourceFile, that.sourceFile) &&
+                    Objects.equals(lineNumber, that.lineNumber) &&
+                    Objects.equals(columnNumber, that.columnNumber);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(blockedUri, disposition, documentUri, effectiveDirective, originalPolicy, referrer, scriptSample, statusCode, violatedDirective, sourceFile, lineNumber, columnNumber);
+        }
+    }
+
+}

--- a/core/src/main/resources/jenkins/security/csp/CspRootAction/index.jelly
+++ b/core/src/main/resources/jenkins/security/csp/CspRootAction/index.jelly
@@ -1,0 +1,65 @@
+<!--
+The MIT License
+
+Copyright (c) 2020, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <l:layout title="CSP configuration">
+        <st:include page="sidepanel.jelly" it="${app}"/>
+        <l:main-panel>
+            <h1>
+                CSP Playground
+            </h1>
+            <div>
+                <a href="${rootURL}/csp-poc/testPayload">Test payload page</a>
+                <br />
+                <br />
+            </div>
+            <div>
+                <h3>Configuration:</h3>
+                <div>
+                    <form action="submitPayload" method="post" enctype="">
+                        <table>
+                            <f:entry field="reporterOnly" title="Reporter Only">
+                                <f:checkbox checked="${it.isReporterOnly()}" />
+                            </f:entry>
+                            <f:entry title="Desired Payload" field="desiredPayload">
+                                <f:textarea value="${it.getDesiredPayload()}" />
+                            </f:entry>
+                            <f:entry title="CSP Rules" field="cspRules">
+                                <f:textarea value="${it.getCspRules()}" />
+                            </f:entry>
+                            <f:entry field="withApprovedHashes" title="Includes approved hashes">
+                                <f:checkbox checked="${it.isWithApprovedHashes()}" />
+                            </f:entry>
+                            <f:entry title="Approved hashes" field="approvedHashes">
+                                <f:textarea value="${it.getApprovedHashes()}" />
+                            </f:entry>
+                        </table>
+                        <f:submit/>
+                    </form>
+                </div>
+            </div>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>
+

--- a/core/src/main/resources/jenkins/security/csp/CspRootAction/testPayload.jelly
+++ b/core/src/main/resources/jenkins/security/csp/CspRootAction/testPayload.jelly
@@ -1,0 +1,69 @@
+<!--
+The MIT License
+
+Copyright (c) 2020, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <l:layout title="CSP payload injection">
+        <l:header>
+            <j:if test="${it.isReporterOnly()}">
+                <!-- 
+                the Report-Only must be delivered through header, 
+                while the regular CSP can be delivered either by meta or header
+                -->
+                <st:header name="Content-Security-Policy-Report-Only" value="${it.getFullCspRulesWithReportUrl()}" />
+            </j:if>
+            <j:if test="${!it.isReporterOnly()}">
+                <st:header name="Content-Security-Policy-Report-Only" value="${it.getFullCspRulesWithReportUrl()}" />
+                <meta http-equiv="Content-Security-Policy" content="${it.getFullCspRules()}" />
+            </j:if>
+        </l:header>
+        <st:include page="sidepanel.jelly" it="${app}"/>
+        <l:main-panel>
+            <h1>
+                CSP Playground, page with payload injection
+            </h1>
+            <div>
+                <a href="${rootURL}/csp-poc/">CSP configuration page</a>
+                <br />
+                <br />
+            </div>
+            <h3>Payload injection:</h3>
+            <div>
+                <div>
+                    Before injection<br />
+                    <pre style="border: 1px solid grey; padding: 5px;">
+                        <j:out value="${it.getDesiredPayload()}" />
+                    </pre>
+                    After injection<br />
+                </div>
+            </div>
+            <br />
+            <br />
+            <div>
+                <h5>CSP rules used in this page</h5>
+                <pre>${it.getFullCspRules()}</pre>
+            </div>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>
+

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -75,6 +75,12 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>jenkins-test-harness-htmlunit</artifactId>
+      <version>3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness-tools</artifactId>
       <version>2.0</version>
       <scope>test</scope>

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -256,7 +256,8 @@ public class ProjectTest {
         HtmlForm form = j.createWebClient().goTo(p.getUrl() + "/configure").getFormByName("config");
         ((HtmlElement)form.getByXPath("//div[@class='advancedLink']//button").get(0)).click();
         // required due to the new default behavior of click
-        form.getInputByName("hasCustomScmCheckoutRetryCount").click(new Event(), true);
+//        form.getInputByName("hasCustomScmCheckoutRetryCount").click(new Event(), true);
+        form.getInputByName("hasCustomScmCheckoutRetryCount").click(new Event(), false, false, false, true);
         form.getInputByName("scmCheckoutRetryCount").setValueAttribute("7");
         j.submit(form);
         assertEquals("Scm retry count was set.", 7, p.getScmCheckoutRetryCount());

--- a/test/src/test/java/jenkins/security/csp/CspRootActionTest.java
+++ b/test/src/test/java/jenkins/security/csp/CspRootActionTest.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.security.csp;
+
+import com.gargoylesoftware.htmlunit.BrowserVersionFeatures;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.model.RootAction;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+// only partial support in 2.40 (https://github.com/HtmlUnit/htmlunit/commit/56bd6c3a151896d3a84c5c02870dd4fe286d2b71)
+// partial = frame only :'(
+public class CspRootActionTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void isWebClientCspCapable() throws Exception {
+        CspRootAction cspRootAction = j.jenkins.getExtensionList(RootAction.class).get(CspRootAction.class);
+        cspRootAction.setDesiredPayload("payload<script>alert(123)</script>injected");
+        cspRootAction.setReporterOnly(false);
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        Assume.assumeFalse(wc.getBrowserVersion().hasFeature(BrowserVersionFeatures.CONTENT_SECURITY_POLICY_IGNORED));
+
+        AtomicBoolean alertReceived = new AtomicBoolean(false);
+        wc.setAlertHandler((page, s) -> 
+                alertReceived.set(true)
+        );
+
+        HtmlPage page = wc.goTo("csp-poc/testPayload");
+        assertFalse("XSS not prevented by CSP", alertReceived.get());
+    }
+
+    @Test
+    public void canWebClientReportCsp() throws Exception {
+        CspRootAction cspRootAction = j.jenkins.getExtensionList(RootAction.class).get(CspRootAction.class);
+        cspRootAction.setDesiredPayload("payload<script>alert(123)</script>injected");
+        cspRootAction.setReporterOnly(true);
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        Assume.assumeFalse(wc.getBrowserVersion().hasFeature(BrowserVersionFeatures.CONTENT_SECURITY_POLICY_IGNORED));
+
+        AtomicBoolean alertReceived = new AtomicBoolean(false);
+        wc.setAlertHandler((page, s) -> alertReceived.set(true));
+
+        int beforeSize = cspRootAction.reports.size();
+        
+        HtmlPage page = wc.goTo("csp-poc/testPayload");
+        assertTrue("XSS should not be prevented due to report-only", alertReceived.get());
+        assertThat("CSP report not sent by the WebClient", cspRootAction.reports.size(), greaterThan(beforeSize));
+    }
+}


### PR DESCRIPTION
**Not intented to be merged at any time.**


### Objective of this PR
Letting you test the **CSP protection**, activated for a single page in Jenkins.
More information about the CSP: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP.
See [JENKINS-60866](https://issues.jenkins-ci.org/browse/JENKINS-60866) for the long term initiative.

### Testing notes
`docker run --rm -ti -p 8080:8080 -e ID=4891 jenkins/core-pr-tester`

#### Step 1 (no CSP protection)
1.1) **[action]** Browse to http://localhost:8080/csp-poc/
1.2) You will see a configuration page. If you want, you can change the payload to contain `alert(123)` instead of `console.warn(123)`.
1.3) With the "Reporter Only" checked, the CSP engine of your browser will report the different problems to a specific URL (inside Jenkins for this test).
1.4) You do not have to change any other settings at this step.
1.5) **[action]** Click on the "Test payload page" link at the top. It will send you to the page with the "Desired Payload" being injected.
1.6) Inside your DevTool (F12 in common browsers), you will see lots of `[Report Only] Refused to execute inline script because [...], a hash ('sha256-XXXXXXX'), [...]`
1.7) Those are instructions about what to do to enable the execution of those scripts in case you want to allow them when CSP is enabled _(without the report-only mode)_

#### Step 2 (activate CSP protection)
2.1) **[action]** Browse back to http://localhost:8080/csp-poc/ _(you can also click on the link "CSP configuration page" at the top)_
2.2) **[action]** Uncheck the "Reporter Only"
2.3) We will first try without any other modifications. This will break some parts of the pages, that's for the demo.
2.4) **[action]** Click on the "Test payload page" link at the top.
2.5) This time some elements on the page will be broken. For example, the warning "bell" with the red number will be at the bottom of the page _(if you have some warnings)_, also, the search field at the top of the page will not work due to the inline JavaScript being rejected.
2.6) In this mode, we are not allowing the scripts that are inline. Those coming from a separate files are included and executed as before.
2.7) If it's not clear, your payload is **not executed** thanks to the CSP protection.

#### Step 3 (CSP protection with _allowlist_)
3.1) **[action]** Browse back to http://localhost:8080/csp-poc/
3.2) Now, we will collect all the hashes of the scripts you want to execute and configure the allowlist to include them.
3.3) You have the choice to either collect the hashes yourself inside your DevTool or use the one I provide in the following block. Be warned that the hashes will change if those scripts are updated in the meantime.

<details>

<summary>Status on 2020-08-02</summary>

<pre>
# script tag and its attributes are removed and all spaces are considered
#<script>createSearchBox("/jenkins/search/");</script>
sha256-WLS1Ykotk6IVIEvoDjup+JfKGLqRDinJCwsdNdV4Wv8=
#<script defer="defer">refreshPart('buildQueue',"/jenkins/ajaxBuildQueue");</script>
sha256-rqOcnQM8ThVVEPMbG67oIVCM090YNL0PShOzRbQFORI=
#<script defer="defer">refreshPart('executors',"/jenkins/ajaxExecutors");</script>
sha256-Luz/jaK8S0vMWv+Bkl9f5cc2UbNC4Nt4TDbiW2SyoU0=
#multiline script related to "visible-am-container"
sha256-GHBfjJwmMrE3qvIU03YoguKuoKtRHkuu9e9L6i3ju8E=
</pre>

</details>

3.4) **[action]** Once you have collected the hashes, you can copy-paste them into the "Approved hashes" text area. It accepts one hash per line, without considering the line starting with `#` _(comments)_.
3.5) **[action]** Click on the "Test payload page" link at the top.
3.6) At this point you will see a reduced number of warning in the DevTool. In my case I only got one, due to an "unsafe-eval" in addition to the payload I inserted.
3.7) If you test the search field at the top it will work because we allowed the `createSearchBox` script.

----

### Summary
The objective of this PoC is to show you why I am working on the un-inlining of JavaScript and CSS in Jenkins. Once it's done, we will be able to make a step forward a global CSP protection.
What you have allowed during step 3.4 will not be necessary if they are coming from a file. The test page used in this PoC does not contain lots of features and thus, does not require lots of un-inline / allowed entries, but it's just to show you the CSP in action.

#### Hashes
The hashes we used in this PoC are another possibility to allow the scripts using their content. It will increase drastically the size of the CSP header and is not really easy to maintain. In addition, it does not work with dynamic content. 

#### Nonces
The nonce is a technique that let the template engine knows a random value that is injected in the script during the page generation and provided to the browser within the CSP instructions. The overcost is smaller than the hashes but the main issue is that it will not protect you against XSS inside the script, e.g. in case of Java variables being injected during the page generation.

#### Un-inline resources
By moving the content of the scripts / CSS to separate files, we are moving from the injection of variables in general and thus, reduce the number of potential XSS dangerous area by forcing "good practices" of value communication between Java and JavaScript. It's "a bit" more expensive in terms of energy / time as the other could be done from template engine directly.

----

cc @daniel-beck