### PR TITLE
[JENKINS-63276] Make empty installed plugins text readable

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -68,9 +68,12 @@ THE SOFTWARE.
       <table id="plugins" class="pane bigtable sortable stripped-odd">
         <j:choose>
           <j:when test="${empty(app.pluginManager.plugins) and empty(app.pluginManager.failedPlugins)}">
-            <tr><th>
-              ${%No plugins installed.}
-            </th></tr>
+            <tr>
+              <th>${%Installed plugins}</th>
+            </tr>
+            <tr>
+              <td align="center">${%No plugins installed.}</td>
+            </tr>
           </j:when>
           <j:otherwise>
             <tr>

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -68,9 +68,9 @@ THE SOFTWARE.
       <table id="plugins" class="pane bigtable sortable stripped-odd">
         <j:choose>
           <j:when test="${empty(app.pluginManager.plugins) and empty(app.pluginManager.failedPlugins)}">
-            <tr><td>
+            <tr><th>
               ${%No plugins installed.}
-            </td></tr>
+            </th></tr>
           </j:when>
           <j:otherwise>
             <tr>


### PR DESCRIPTION
See [JENKINS-63276](https://issues.jenkins-ci.org/browse/JENKINS-63276).

Fixes text readability when there are no installed plugins on the `/pluginManager/installed` table. It was due to wrong markup but was triggered by table header changes on 2.249.

<details>
<summary>Screenshot</summary>
Before:
<img width="678" alt="Captura de pantalla 2020-08-03 a las 9 54 37" src="https://user-images.githubusercontent.com/5738588/89159124-5d340d80-d56f-11ea-9cb3-c9583963d59c.png">

After:
<img width="689" alt="Captura de pantalla 2020-08-03 a las 10 03 58" src="https://user-images.githubusercontent.com/5738588/89160787-ec422500-d571-11ea-9908-766423b03dc7.png">


</details>
 

### Proposed changelog entries

* JENKINS-63276, Empty installed plugins table text is readable again (regression in 2.249).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
