### PR TITLE
Fix invalid translations in ApiTokenProperty

### DIFF
--- a/core/src/main/resources/jenkins/security/ApiTokenProperty/config.jelly
+++ b/core/src/main/resources/jenkins/security/ApiTokenProperty/config.jelly
@@ -87,8 +87,8 @@ THE SOFTWARE.
                                             <j:when test="${useCounter > 0}">
                                                 <j:if test="${token.lastUseDate == null}">
                                                     <!--Should normally never happen without manual XML modification-->
-                                                    <span class="token-use-counter" title="${$TokenNeverUsedTooltip}">
-                                                        ${%TokenNeverUsedValue}
+                                                    <span class="token-use-counter" title="${%TokenNeverUsedTooltip}">
+                                                        ${%TokenNeverUsed}
                                                     </span>
                                                 </j:if>
                                                 <j:if test="${token.lastUseDate != null}">


### PR DESCRIPTION
An invalid text is displayed for incomplete user-token usage statistics:
![image](https://user-images.githubusercontent.com/3115961/89749956-e36ac980-db04-11ea-83e4-17109d24d3b5.png)

It isn't displayed normally as described in `config.xml`: https://github.com/jenkinsci/jenkins/blob/jenkins-2.251/core/src/main/resources/jenkins/security/ApiTokenProperty/config.jelly#L89
I had to modify `apiTokenStats.xml` directly and have Jenkins reload configurations.

No tests for this change as only text changes.

### Proposed changelog entries

N/A (too minor)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described -> No JIRA issue as a minor fix.
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs -> N/A

### Desired reviewers

@mention

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
