### PR TITLE
Add target=_blank to Descriptor.From

### DIFF
--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -113,7 +113,7 @@ ComputerSet.SlaveAlreadyExists=Agent called \u2018{0}\u2019 already exists
 ComputerSet.SpecifySlaveToCopy=Specify which agent to copy
 ComputerSet.DisplayName=Nodes
 
-Descriptor.From=(from <a href="{1}">{0}</a>)
+Descriptor.From=(from <a href="{1}" target="_blank">{0}</a>)
 
 Executor.NotAvailable=N/A
 

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -113,7 +113,7 @@ ComputerSet.SlaveAlreadyExists=Agent called \u2018{0}\u2019 already exists
 ComputerSet.SpecifySlaveToCopy=Specify which agent to copy
 ComputerSet.DisplayName=Nodes
 
-Descriptor.From=(from <a href="{1}" target="_blank">{0}</a>)
+Descriptor.From=(from <a href="{1}" rel="noopener noreferrer" target="_blank">{0}</a>)
 
 Executor.NotAvailable=N/A
 


### PR DESCRIPTION
Minor tweak. When you expand a help box and see

> (from Such-and-such Plugin)

the link will navigate you away from the current config screen. That is risky since you might have modifications and the **Back** button might not restore everything the way you think. Better to always open in a browser tab.

### Proposed changelog entries

* The link in a configuration screen’s inline help to a plugin now opens a new browser tab to avoid losing work in progress.

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
