### PR TITLE
[JENKINS-51913] Prevent archiveArtifacts from dumping a stacktrace when empty results are allowed

### DIFF
--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -272,7 +272,9 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
                             listener.getLogger().println(msg);
                         }
                     } catch (Exception e) {
-                        Functions.printStackTrace(e, listener.getLogger());
+                        if (!allowEmptyArchive) {
+                            Functions.printStackTrace(e, listener.getLogger());
+                        }
                     }
                     if (allowEmptyArchive) {
                         listener.getLogger().println(Messages.ArtifactArchiver_NoMatchFound(artifacts));


### PR DESCRIPTION
See [JENKINS-51913](https://issues.jenkins-ci.org/browse/JENKINS-51913).

### Testing
Not sure best approach on this, but my guess would be to add an assertion to this [test](https://github.com/jenkinsci/jenkins/blob/885c05cb437e53b20b12def1314fafee9b994828/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java#L123-L133) that verifies that the string `java.lang.InterruptedException: no matches found within` is not in the output?

### Proposed changelog entries

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
