### PR TITLE
Ignoring flaky UpdateCenter2Test.install

### DIFF
--- a/test/src/test/java/hudson/model/UpdateCenter2Test.java
+++ b/test/src/test/java/hudson/model/UpdateCenter2Test.java
@@ -29,6 +29,7 @@ import hudson.model.UpdateCenter.DownloadJob.Failure;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeNotNull;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -46,7 +47,7 @@ public class UpdateCenter2Test {
     /**
      * Makes sure a plugin installs fine.
      */
-    // TODO randomly fails: SocketTimeoutException from goTo due to GET http://localhost:…/update-center.json?…
+    @Ignore("TODO randomly fails: SocketTimeoutException from goTo due to GET http://localhost:…/update-center.json?…; or: Downloaded file …/changelog-history.jpi.tmp does not match expected SHA-256, expected '…', actual '…'")
     @Test public void install() throws Exception {
         UpdateSite.neverUpdate = false;
         j.jenkins.pluginManager.doCheckUpdatesServer(); // load the metadata


### PR DESCRIPTION
Probably unrelated to #4915, but coincidentally I [recently saw a flake](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-4848/73/testReport/hudson.model/UpdateCenter2Test/Linux_jdk11___Linux_Publishing___install/) here:

```
   9.759 [id=156]	INFO	h.model.UpdateCenter$DownloadJob#run: Starting the installation of changelog-history on behalf of SYSTEM
   9.770 [id=156]	INFO	h.m.UpdateCenter$UpdateCenterConfiguration#download: Downloading changelog-history
   9.771 [id=156]	SEVERE	h.model.UpdateCenter$DownloadJob#run: Failed to install changelog-history
java.io.IOException: Downloaded file /home/jenkins/workspace/Core_jenkins_PR-4848/test/target/jenkins6396764151275203920/changelog-history.jpi.tmp does not match expected SHA-256, expected 'NSpdMK30cB+40Yo3DajcANulMRrCX46BEsQt6cJ0J48=', actual 'TiTKeEMpaAVS4+aNkBqRYRbixW2Ok1yhRyHS21z/44U='
	at hudson.model.UpdateCenter.throwVerificationFailure(UpdateCenter.java:2019)
	at hudson.model.UpdateCenter.verifyChecksums(UpdateCenter.java:2054)
	at hudson.model.UpdateCenter$InstallationJob.replace(UpdateCenter.java:2233)
	at hudson.model.UpdateCenter$UpdateCenterConfiguration.install(UpdateCenter.java:1343)
	at hudson.model.UpdateCenter$DownloadJob._run(UpdateCenter.java:1872)
	at hudson.model.UpdateCenter$InstallationJob._run(UpdateCenter.java:2147)
	at hudson.model.UpdateCenter$DownloadJob.run(UpdateCenter.java:1843)
	at …
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at hudson.model.UpdateCenter2Test.install(UpdateCenter2Test.java:57)
	at …
```

### Proposed changelog entries

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
