### PR TITLE
[JENKINS-63563] Avoid anonymous class warning for hudson.FilePath$2

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2007,35 +2007,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
             return null;
         }
     }
-    
-    // Used on readFromOffset to avoid a warning about serialization of anonymous classes for FilePath$2.
-    private class RandomAccessFileInputStream extends InputStream {
-        final RandomAccessFile raf;
-        
-        public RandomAccessFileInputStream(@NonNull RandomAccessFile raf) {
-            this.raf = raf;
-        }
-        
-        @Override
-        public int read() throws IOException {
-            return raf.read();
-        }
 
-        @Override
-        public void close() throws IOException {
-            raf.close();
-        }
-
-        @Override
-        public int read(byte[] b, int off, int len) throws IOException {
-            return raf.read(b, off, len);
-        }
-
-        @Override
-        public int read(byte[] b) throws IOException {
-            return raf.read(b);
-        }
-    }
     /**
      * Reads this file from the specific offset.
      * @since 1.586
@@ -2053,7 +2025,27 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                 }
                 throw e;
             }
-            return new RandomAccessFileInputStream(raf);
+            return new InputStream() {
+                @Override
+                public int read() throws IOException {
+                    return raf.read();
+                }
+
+                @Override
+                public void close() throws IOException {
+                    raf.close();
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len) throws IOException {
+                    return raf.read(b, off, len);
+                }
+
+                @Override
+                public int read(byte[] b) throws IOException {
+                    return raf.read(b);
+                }
+            };
         }
 
         final Pipe p = Pipe.createRemoteToLocal();

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -2007,7 +2007,35 @@ public final class FilePath implements SerializableOnlyOverRemoting {
             return null;
         }
     }
+    
+    // Used on readFromOffset to avoid a warning about serialization of anonymous classes for FilePath$2.
+    private class RandomAccessFileInputStream extends InputStream {
+        final RandomAccessFile raf;
+        
+        public RandomAccessFileInputStream(@NonNull RandomAccessFile raf) {
+            this.raf = raf;
+        }
+        
+        @Override
+        public int read() throws IOException {
+            return raf.read();
+        }
 
+        @Override
+        public void close() throws IOException {
+            raf.close();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            return raf.read(b, off, len);
+        }
+
+        @Override
+        public int read(byte[] b) throws IOException {
+            return raf.read(b);
+        }
+    }
     /**
      * Reads this file from the specific offset.
      * @since 1.586
@@ -2025,27 +2053,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                 }
                 throw e;
             }
-            return new InputStream() {
-                @Override
-                public int read() throws IOException {
-                    return raf.read();
-                }
-
-                @Override
-                public void close() throws IOException {
-                    raf.close();
-                }
-
-                @Override
-                public int read(byte[] b, int off, int len) throws IOException {
-                    return raf.read(b, off, len);
-                }
-
-                @Override
-                public int read(byte[] b) throws IOException {
-                    return raf.read(b);
-                }
-            };
+            return new RandomAccessFileInputStream(raf);
         }
 
         final Pipe p = Pipe.createRemoteToLocal();


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-63563](https://issues.jenkins-ci.org/browse/JENKINS-63563).

I can see on  logs:

```
2020-08-27 18:28:43.548+0000 [id=1840]	WARNING	o.j.r.u.AnonymousClassWarnings#warn: Attempt to (de-)serialize anonymous class hudson.FilePath$2 in file:/var/cache/jenkins/war/WEB-INF/lib/jenkins-core-2.235.5-cb-1.jar; see: https://jenkins.io/redirect/serialization-of-anonymous-classes/
```

We have to create an inner static class to take over the adhoc class created on https://github.com/jenkinsci/jenkins/blob/84153f66d2e93df4d9f5c457871e24a8cbf1f016/core/src/main/java/hudson/FilePath.java#L2028

Not tested, well known fix from https://www.jenkins.io/doc/developer/extensibility/serialization-of-anonymous-classes/ The FilePath class implements `SerializableOnlyOverRemoting` so the only allowed serialization is for remoting purposes. So [this topic (usages-in-remoting)](https://www.jenkins.io/doc/developer/extensibility/serialization-of-anonymous-classes/#usages-in-remoting) applies to fix the problem
 
<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Avoid warning on logs about Anonymous Class in hudson.FilePath

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
