### PR TITLE
Add `CloudState` to be passed to `Cloud#provision` and `Cloud#canProvision` methods.

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -79,6 +79,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -1458,6 +1459,29 @@ public class Util {
         // the lookup will either return null or the base method when no override has been found (depending on whether
         // the base is an interface)
         return derivedMethod != null && derivedMethod != baseMethod;
+    }
+
+    /**
+     * Calls the given supplier if the method defined on the base type with the given arguments is overridden in the
+     * given derived type.
+     *
+     * @param supplier   The supplier to call if the method is indeed overridden.
+     * @param base       The base type.
+     * @param derived    The derived type.
+     * @param methodName The name of the method.
+     * @param types      The types of the arguments for the method.
+     * @return {@code true} when {@code derived} provides the specified method other than as inherited from {@code base}.
+     * @throws IllegalArgumentException When {@code derived} does not derive from {@code base}, or when {@code base}
+     *                                  does not contain the specified method.
+     * @throws AbstractMethodError If the derived class doesn't override the given method.
+     */
+    public static <T> T ifOverridden(Supplier<T> supplier, @NonNull Class<?> base, @NonNull Class<?> derived, @NonNull String methodName, @NonNull Class<?>... types) {
+        if (isOverridden(base, derived, methodName, types)) {
+            return supplier.get();
+        } else {
+            throw new AbstractMethodError("you must override at least one of the "
+                    + base.getSimpleName() + "." + methodName + " methods");
+        }
     }
 
     private static Method getMethod(@NonNull Class<?> clazz, @Nullable Class<?> base, @NonNull String methodName, @NonNull Class<?>... types) {

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1474,6 +1474,7 @@ public class Util {
      * @throws IllegalArgumentException When {@code derived} does not derive from {@code base}, or when {@code base}
      *                                  does not contain the specified method.
      * @throws AbstractMethodError If the derived class doesn't override the given method.
+     * @since TODO
      */
     public static <T> T ifOverridden(Supplier<T> supplier, @NonNull Class<?> base, @NonNull Class<?> derived, @NonNull String methodName, @NonNull Class<?>... types) {
         if (isOverridden(base, derived, methodName, types)) {

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1480,7 +1480,7 @@ public class Util {
         if (isOverridden(base, derived, methodName, types)) {
             return supplier.get();
         } else {
-            throw new AbstractMethodError("you must override at least one of the "
+            throw new AbstractMethodError("You must override at least one of the "
                     + base.getSimpleName() + "." + methodName + " methods");
         }
     }

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -259,7 +259,7 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
 
     /**
      * Parameter object for {@link hudson.slaves.Cloud}.
-     * @since XXX
+     * @since TODO
      */
     public static final class CloudState {
         /**

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.ExtensionPoint;
 import hudson.Extension;
 import hudson.DescriptorExtensionList;
+import hudson.Util;
 import hudson.model.Actionable;
 import hudson.model.Computer;
 import hudson.model.Slave;
@@ -41,7 +42,6 @@ import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
 import hudson.util.DescriptorList;
-import org.apache.commons.lang.NotImplementedException;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -161,14 +161,13 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
      * @deprecated Use {@link #provision(CloudState, int)} instead.
      */
     @Deprecated
-    public Collection<PlannedNode> provision(Label label, int excessWorkload){
-        try {
-            // Check if the new method is implemented
-            getClass().getDeclaredMethod("provision", CloudState.class, int.class);
+    public Collection<PlannedNode> provision(Label label, int excessWorkload) {
+        String methodName = "provision";
+        if (Util.isOverridden(Cloud.class, getClass(), methodName, CloudState.class, int.class)) {
             return provision(new CloudState(label, 0), excessWorkload);
-        } catch (NoSuchMethodException e) {
-            throw new NotImplementedException("Subclasses of " + Cloud.class.getName()
-                            + " must implement provision(Cloud.CloudState)");
+        } else {
+            throw new AbstractMethodError("you must override at least one of the "
+                    + Cloud.class.getSimpleName() + "." + methodName + " methods");
         }
     }
 
@@ -209,13 +208,12 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
      */
     @Deprecated
     public boolean canProvision(Label label) {
-        try {
-            // Check if the new method is implemented
-            getClass().getDeclaredMethod("canProvision", CloudState.class);
+        String methodName = "canProvision";
+        if (Util.isOverridden(Cloud.class, getClass(), methodName, CloudState.class)) {
             return canProvision(new CloudState(label, 0));
-        } catch (NoSuchMethodException e) {
-            throw new NotImplementedException("Subclasses of " + Cloud.class.getName()
-                    + " must implement canProvision(Cloud.CloudState)");
+        } else {
+            throw new AbstractMethodError("you must override at least one of the "
+                    + Cloud.class.getSimpleName() + "." + methodName + " methods");
         }
     }
 

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -290,7 +290,7 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
          * The additional planned capacity for this {@link #getLabel()} and provisioned by previous strategies during
          * the current updating of the {@link NodeProvisioner}.
          */
-        public synchronized int getAdditionalPlannedCapacity() {
+        public int getAdditionalPlannedCapacity() {
             return additionalPlannedCapacity;
         }
     }

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -162,13 +162,12 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
      */
     @Deprecated
     public Collection<PlannedNode> provision(Label label, int excessWorkload) {
-        String methodName = "provision";
-        if (Util.isOverridden(Cloud.class, getClass(), methodName, CloudState.class, int.class)) {
-            return provision(new CloudState(label, 0), excessWorkload);
-        } else {
-            throw new AbstractMethodError("you must override at least one of the "
-                    + Cloud.class.getSimpleName() + "." + methodName + " methods");
-        }
+        return Util.ifOverridden(() -> provision(new CloudState(label, 0), excessWorkload),
+                Cloud.class,
+                getClass(),
+                "provision",
+                CloudState.class,
+                int.class);
     }
 
     /**
@@ -208,13 +207,11 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
      */
     @Deprecated
     public boolean canProvision(Label label) {
-        String methodName = "canProvision";
-        if (Util.isOverridden(Cloud.class, getClass(), methodName, CloudState.class)) {
-            return canProvision(new CloudState(label, 0));
-        } else {
-            throw new AbstractMethodError("you must override at least one of the "
-                    + Cloud.class.getSimpleName() + "." + methodName + " methods");
-        }
+        return Util.ifOverridden(() -> canProvision(new CloudState(label, 0)),
+                Cloud.class,
+                getClass(),
+                "canProvision",
+                CloudState.class);
     }
 
     /**

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -167,7 +167,8 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
             getClass().getDeclaredMethod("provision", CloudState.class, int.class);
             return provision(new CloudState(label, 0), excessWorkload);
         } catch (NoSuchMethodException e) {
-            throw new NotImplementedException();
+            throw new NotImplementedException("Subclasses of " + Cloud.class.getName()
+                            + " must implement provision(Cloud.CloudState)");
         }
     }
 
@@ -213,7 +214,8 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
             getClass().getDeclaredMethod("canProvision", CloudState.class);
             return canProvision(new CloudState(label, 0));
         } catch (NoSuchMethodException e) {
-            throw new NotImplementedException();
+            throw new NotImplementedException("Subclasses of " + Cloud.class.getName()
+                    + " must implement canProvision(Cloud.CloudState)");
         }
     }
 

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -23,6 +23,7 @@
  */
 package hudson.slaves;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.ExtensionPoint;
 import hudson.Extension;
 import hudson.DescriptorExtensionList;
@@ -40,6 +41,7 @@ import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
 import hudson.util.DescriptorList;
+import org.apache.commons.lang.NotImplementedException;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -156,13 +158,71 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
      *      just needs to return {@link PlannedNode}s that each contain an object that implements {@link Future}.
      *      When the {@link Future} has completed its work, {@link Future#get} will be called to obtain the
      *      provisioned {@link Node} object.
+     * @deprecated Use {@link #provision(CloudState, int)} instead.
      */
-    public abstract Collection<PlannedNode> provision(Label label, int excessWorkload);
+    @Deprecated
+    public Collection<PlannedNode> provision(Label label, int excessWorkload){
+        try {
+            // Check if the new method is implemented
+            getClass().getDeclaredMethod("provision", CloudState.class, int.class);
+            return provision(new CloudState(label, 0), excessWorkload);
+        } catch (NoSuchMethodException e) {
+            throw new NotImplementedException();
+        }
+    }
+
+    /**
+     * Provisions new {@link Node}s from this cloud.
+     *
+     * <p>
+     * {@link NodeProvisioner} performs a trend analysis on the load,
+     * and when it determines that it <b>really</b> needs to bring up
+     * additional nodes, this method is invoked.
+     *
+     * <p>
+     * The implementation of this method asynchronously starts
+     * node provisioning.
+     *
+     * @param state the current state.
+     * @param excessWorkload
+     *      Number of total executors needed to meet the current demand.
+     *      Always ≥ 1. For example, if this is 3, the implementation
+     *      should launch 3 agents with 1 executor each, or 1 agent with
+     *      3 executors, etc.
+     * @return
+     *      {@link PlannedNode}s that represent asynchronous {@link Node}
+     *      provisioning operations. Can be empty but must not be null.
+     *      {@link NodeProvisioner} will be responsible for adding the resulting {@link Node}s
+     *      into Hudson via {@link jenkins.model.Jenkins#addNode(Node)}, so a {@link Cloud} implementation
+     *      just needs to return {@link PlannedNode}s that each contain an object that implements {@link Future}.
+     *      When the {@link Future} has completed its work, {@link Future#get} will be called to obtain the
+     *      provisioned {@link Node} object.
+     */
+    public Collection<PlannedNode> provision(CloudState state, int excessWorkload) {
+        return provision(state.getLabel(), excessWorkload);
+    }
+
+    /**
+     * Returns true if this cloud is capable of provisioning new nodes for the given label.
+     * @deprecated Use {@link #canProvision(CloudState)} instead.
+     */
+    @Deprecated
+    public boolean canProvision(Label label) {
+        try {
+            // Check if the new method is implemented
+            getClass().getDeclaredMethod("canProvision", CloudState.class);
+            return canProvision(new CloudState(label, 0));
+        } catch (NoSuchMethodException e) {
+            throw new NotImplementedException();
+        }
+    }
 
     /**
      * Returns true if this cloud is capable of provisioning new nodes for the given label.
      */
-    public abstract boolean canProvision(Label label);
+    public boolean canProvision(CloudState state) {
+        return canProvision(state.getLabel());
+    }
 
     public Descriptor<Cloud> getDescriptor() {
         return Jenkins.get().getDescriptorOrDie(getClass());
@@ -194,4 +254,42 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
     public static final Permission PROVISION = new Permission(
             Computer.PERMISSIONS, "Provision", Messages._Cloud_ProvisionPermission_Description(), Jenkins.ADMINISTER, PERMISSION_SCOPE
     );
+
+    /**
+     * Parameter object for {@link hudson.slaves.Cloud}.
+     * @since XXX
+     */
+    public static final class CloudState {
+        /**
+         * The label under consideration.
+         */
+        @CheckForNull
+        private final Label label;
+        /**
+         * The additional planned capacity for this {@link #label} and provisioned by previous strategies during the
+         * current updating of the {@link NodeProvisioner}.
+         */
+        private final int additionalPlannedCapacity;
+
+        public CloudState(@CheckForNull Label label, int additionalPlannedCapacity) {
+            this.label = label;
+            this.additionalPlannedCapacity = additionalPlannedCapacity;
+        }
+
+        /**
+         * The label under consideration.
+         */
+        @CheckForNull
+        public Label getLabel() {
+            return label;
+        }
+
+        /**
+         * The additional planned capacity for this {@link #getLabel()} and provisioned by previous strategies during
+         * the current updating of the {@link NodeProvisioner}.
+         */
+        public synchronized int getAdditionalPlannedCapacity() {
+            return additionalPlannedCapacity;
+        }
+    }
 }

--- a/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
+++ b/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
@@ -46,7 +46,8 @@ public abstract class CloudProvisioningListener implements ExtensionPoint {
             getClass().getDeclaredMethod("canProvision", Cloud.class, Cloud.CloudState.class, int.class);
             return canProvision(cloud, new Cloud.CloudState(label, 0), numExecutors);
         } catch (NoSuchMethodException e) {
-            throw new NotImplementedException("canProvision(Cloud, Label");
+            throw new NotImplementedException("Subclasses of " + CloudProvisioningListener.class.getName()
+                    + " must implement canProvision(Cloud, Cloud.CloudState, int)");
         }
     }
 

--- a/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
+++ b/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
@@ -42,13 +42,11 @@ public abstract class CloudProvisioningListener implements ExtensionPoint {
      */
     @Deprecated
     public CauseOfBlockage canProvision(Cloud cloud, Label label, int numExecutors) {
-        String methodName = "canProvision";
-        if (Util.isOverridden(CloudProvisioningListener.class, getClass(), methodName, CloudState.class)) {
-            return canProvision(cloud, new CloudState(label, 0), numExecutors);
-        } else {
-            throw new AbstractMethodError("you must override at least one of the "
-                    + CloudProvisioningListener.class.getSimpleName() + "." + methodName + " methods");
-        }
+        return Util.ifOverridden(() -> canProvision(cloud, new CloudState(label, 0), numExecutors),
+                CloudProvisioningListener.class,
+                getClass(),
+                "canProvision",
+                CloudState.class);
     }
 
     /**

--- a/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
+++ b/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.concurrent.Future;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.commons.lang.NotImplementedException;
 
 /**
  * Allows extensions to be notified of events in any {@link Cloud} and to prevent
@@ -35,9 +36,34 @@ public abstract class CloudProvisioningListener implements ExtensionPoint {
      *
      * @return {@code null} if provisioning can proceed, or a
      * {@link CauseOfBlockage} reason why it cannot be provisioned.
+     *
+     * @deprecated Use {@link #canProvision(Cloud, Cloud.CloudState, int)} instead.
      */
+    @Deprecated
     public CauseOfBlockage canProvision(Cloud cloud, Label label, int numExecutors) {
-        return null;
+        try {
+            // Check if the new method is implemented
+            getClass().getDeclaredMethod("canProvision", Cloud.class, Cloud.CloudState.class, int.class);
+            return canProvision(cloud, new Cloud.CloudState(label, 0), numExecutors);
+        } catch (NoSuchMethodException e) {
+            throw new NotImplementedException("canProvision(Cloud, Label");
+        }
+    }
+
+    /**
+     * Allows extensions to prevent a cloud from provisioning.
+     *
+     * Return null to allow provisioning, or non-null to prevent it.
+     *
+     * @param cloud The cloud being provisioned from.
+     * @param state The current cloud state.
+     * @param numExecutors The number of executors needed.
+     *
+     * @return {@code null} if provisioning can proceed, or a
+     * {@link CauseOfBlockage} reason why it cannot be provisioned.
+     */
+    public CauseOfBlockage canProvision(Cloud cloud, Cloud.CloudState state, int numExecutors) {
+        return canProvision(cloud, state.getLabel(), numExecutors);
     }
 
     /**

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -705,9 +705,10 @@ public class NodeProvisioner {
                         if (excessWorkload < 0) {
                             break;  // enough agents allocated
                         }
+                        Cloud.CloudState cloudState = new Cloud.CloudState(state.getLabel(), state.getAdditionalPlannedCapacity());
 
                         // Make sure this cloud actually can provision for this label.
-                        if (c.canProvision(state.getLabel())) {
+                        if (c.canProvision(cloudState)) {
                             // provisioning a new node should be conservative --- for example if excessWorkload is 1.4,
                             // we don't want to allocate two nodes but just one.
                             // OTOH, because of the exponential decay, even when we need one agent,
@@ -719,14 +720,13 @@ public class NodeProvisioner {
                             int workloadToProvision = (int) Math.round(Math.floor(excessWorkload + m));
 
                             for (CloudProvisioningListener cl : CloudProvisioningListener.all()) {
-                                if (cl.canProvision(c, state.getLabel(), workloadToProvision) != null) {
+                                if (cl.canProvision(c, cloudState, workloadToProvision) != null) {
                                     // consider displaying reasons in a future cloud ux
                                     continue CLOUD;
                                 }
                             }
 
-                            Collection<PlannedNode> additionalCapacities =
-                                    c.provision(state.getLabel(), workloadToProvision);
+                            Collection<PlannedNode> additionalCapacities = c.provision(cloudState, workloadToProvision);
 
                             fireOnStarted(c, state.getLabel(), additionalCapacities);
 

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -30,6 +30,7 @@ import hudson.util.StreamTaskListener;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -585,5 +586,35 @@ public class UtilTest {
         // intermediate symlinks are NOT resolved
         assertNull(Util.resolveSymlinkToFile(new File(_a, "aa")));
         assertNull(Util.resolveSymlinkToFile(new File(_a, "aa/aa.txt")));
+    }
+
+    @Test
+    public void ifOverriddenSuccess() {
+        assertTrue(Util.ifOverridden(() -> true, BaseClass.class, DerivedClassSuccess.class, "method"));
+    }
+
+    @Test
+    public void ifOverriddenFailure() {
+        AbstractMethodError error = Assert.assertThrows(AbstractMethodError.class, () -> {
+            Util.ifOverridden(() -> true, BaseClass.class, DerivedClassFailure.class, "method");
+        });
+        assertEquals("You must override at least one of the BaseClass.method methods", error.getMessage());
+    }
+
+    public static class BaseClass {
+        protected String method() {
+            return "base";
+        }
+    }
+
+    public static class DerivedClassFailure extends BaseClass {
+
+    }
+
+    public static class DerivedClassSuccess extends BaseClass {
+        @Override
+        protected String method() {
+            return DerivedClassSuccess.class.getName();
+        }
     }
 }


### PR DESCRIPTION
This gives more insight to the Cloud implementation to ongoing
provisioning operations and helps implement better control on the number
of nodes provisioned when provisioning limits are defined.

* Downstream PR https://github.com/jenkinsci/kubernetes-plugin/pull/835

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Cloud implementations are given more context about ongoing planned nodes.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
