### PR TITLE
Added localizaton for devsecops=DevSecOps

### DIFF
--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -300,6 +300,7 @@ UpdateCenter.PluginCategory.cluster=Cluster Management and Distributed Build
 UpdateCenter.PluginCategory.database=Database
 UpdateCenter.PluginCategory.deployment=Deployment
 UpdateCenter.PluginCategory.devops=DevOps
+UpdateCenter.PluginCategory.devsecops=DevSecOps
 UpdateCenter.PluginCategory.dotnet=.NET Development
 UpdateCenter.PluginCategory.external=External Site/Tool Integrations
 UpdateCenter.PluginCategory.groovy-related=Groovy-related


### PR DESCRIPTION
See https://github.com/jenkins-infra/update-center2/pull/408

### Proposed changelog entries

* Added localization for devsecops=DevSecOps

### Proposed upgrade guidelines

N/A

### Submitter checklist

N/A

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
