### PR TITLE
Make the archived artifacts summary on build pages theme-aware

### DIFF
--- a/war/src/main/less/base/yui-compatibility.less
+++ b/war/src/main/less/base/yui-compatibility.less
@@ -95,6 +95,14 @@
   color: inherit;
 }
 
+.ygtvfocus {
+  background-color: var(--panel-header-bg-color, #c0e0e0);
+}
+
+.ygtvfocus .ygtvlabel, .ygtvfocus .ygtvlabel:link, .ygtvfocus .ygtvlabel:visited, .ygtvfocus .ygtvlabel:hover {
+  background-color: var(--panel-header-bg-color, #c0e0e0) !important;
+}
+
 DIV.yahooTree td {
   vertical-align: middle;
 }

--- a/war/src/main/less/base/yui-compatibility.less
+++ b/war/src/main/less/base/yui-compatibility.less
@@ -96,7 +96,7 @@
 }
 
 .ygtvfocus {
-  background-color: var(--panel-header-bg-color, #c0e0e0);
+  background-color: var(--panel-header-bg-color, #c0e0e0) !important;
 }
 
 .ygtvfocus .ygtvlabel, .ygtvfocus .ygtvlabel:link, .ygtvfocus .ygtvlabel:visited, .ygtvfocus .ygtvlabel:hover {

--- a/war/src/main/less/base/yui-compatibility.less
+++ b/war/src/main/less/base/yui-compatibility.less
@@ -91,6 +91,8 @@
   }
 }
 
+/* Overrides for treeview-skin.css */
+
 .ygtvlabel, .ygtvlabel:link, .ygtvlabel:visited, .ygtvlabel:hover {
   color: inherit;
 }

--- a/war/src/main/webapp/scripts/yui/treeview/assets/skins/sam/treeview-skin.css
+++ b/war/src/main/webapp/scripts/yui/treeview/assets/skins/sam/treeview-skin.css
@@ -126,7 +126,6 @@ a.ygtvspacer {
 .ygtvlabel, .ygtvlabel:link, .ygtvlabel:visited, .ygtvlabel:hover { 
     margin-left:2px;
     text-decoration: none;
-    background-color: var(--background, white);
     cursor:pointer;
 }
 
@@ -137,11 +136,7 @@ a.ygtvspacer {
 .ygtvspacer { height: 22px; width: 18px; }
 
 .ygtvfocus {
-	background-color: var(--panel-header-bg-color, #c0e0e0);
 	border: none;
-}
-.ygtvfocus .ygtvlabel, .ygtvfocus .ygtvlabel:link, .ygtvfocus .ygtvlabel:visited, .ygtvfocus .ygtvlabel:hover {
-	background-color: var(--panel-header-bg-color, #c0e0e0);
 }
 
 .ygtvfocus  a  {

--- a/war/src/main/webapp/scripts/yui/treeview/assets/skins/sam/treeview-skin.css
+++ b/war/src/main/webapp/scripts/yui/treeview/assets/skins/sam/treeview-skin.css
@@ -126,6 +126,7 @@ a.ygtvspacer {
 .ygtvlabel, .ygtvlabel:link, .ygtvlabel:visited, .ygtvlabel:hover { 
     margin-left:2px;
     text-decoration: none;
+    background-color: white; /* workaround for IE font smoothing bug */
     cursor:pointer;
 }
 
@@ -136,7 +137,12 @@ a.ygtvspacer {
 .ygtvspacer { height: 22px; width: 18px; }
 
 .ygtvfocus {
+	background-color: #c0e0e0;
 	border: none;
+}
+
+.ygtvfocus .ygtvlabel, .ygtvfocus .ygtvlabel:link, .ygtvfocus .ygtvlabel:visited, .ygtvfocus .ygtvlabel:hover {
+	background-color: #c0e0e0;
 }
 
 .ygtvfocus  a  {

--- a/war/src/main/webapp/scripts/yui/treeview/assets/skins/sam/treeview-skin.css
+++ b/war/src/main/webapp/scripts/yui/treeview/assets/skins/sam/treeview-skin.css
@@ -126,8 +126,8 @@ a.ygtvspacer {
 .ygtvlabel, .ygtvlabel:link, .ygtvlabel:visited, .ygtvlabel:hover { 
     margin-left:2px;
     text-decoration: none;
-    background-color: white; /* workaround for IE font smoothing bug */
-	cursor:pointer;
+    background-color: var(--background, white);
+    cursor:pointer;
 }
 
 .ygtvcontent {
@@ -137,11 +137,11 @@ a.ygtvspacer {
 .ygtvspacer { height: 22px; width: 18px; }
 
 .ygtvfocus {
-	background-color: #c0e0e0;
+	background-color: var(--panel-header-bg-color, #c0e0e0);
 	border: none;
 }
 .ygtvfocus .ygtvlabel, .ygtvfocus .ygtvlabel:link, .ygtvfocus .ygtvlabel:visited, .ygtvfocus .ygtvlabel:hover {
-	background-color: #c0e0e0;
+	background-color: var(--panel-header-bg-color, #c0e0e0);
 }
 
 .ygtvfocus  a  {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5424257/92902784-25649380-f454-11ea-8da4-9b78d39fd088.png)

After:
![image](https://user-images.githubusercontent.com/5424257/92902755-1a116800-f454-11ea-9c20-f2655374572d.png)

Light theme is unchanged.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
