### PR TITLE
[JENKINS-63654] X-Correlation-ID to monitor Jenkins landscapes called remotly

### DIFF
--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -62,6 +62,11 @@ import javax.annotation.Nonnull;
 @ExportedBean
 public abstract class Cause {
     /**
+     * correlation-id of the cause (generally coming from the X-Correlation-ID HTTP Header field) 
+     */
+	private String correlationId = null; 
+	
+    /**
      * One-line human-readable text of the cause.
      *
      * <p>
@@ -69,6 +74,16 @@ public abstract class Cause {
      */
     @Exported(visibility=3)
     public abstract String getShortDescription();
+
+    @Exported(visibility = 3)
+    public String getCorrelationId() {
+    	return this.correlationId;
+    }
+    
+    public Cause setCorrelationId(final String correlationId) {
+    	this.correlationId = correlationId; 
+    	return this;
+    }
 
     /**
      * Called when the cause is registered.

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -260,6 +260,8 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
         } else {
             cause = new Cause.UserIdCause();
         }
+        
+        cause.setCorrelationId(req!=null?req.getHeader("X-Correlation-ID"):null);
         return new CauseAction(cause);
     }
 

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -261,7 +261,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
             cause = new Cause.UserIdCause();
         }
         
-        cause.setCorrelationId(req!=null?req.getHeader("X-Correlation-ID"):null);
+        cause.setCorrelationId(req != null ? req.getHeader("X-Correlation-ID") : null);
         return new CauseAction(cause);
     }
 


### PR DESCRIPTION
In complex automated build systems cascading events and starting builds
remotely, it can be useful to propagated a X-Correlation-ID to be able
to map related events all together from the begining to the end

As the initial piece of code is there, now, for example, others clients
starting builds remotely can propagate correlation Id which can be
retrieve thru the getCorrelationId() and on their turn, send
it/cascade/propagate it later on.

By using the Run.getCause(Cause.class).getCorrelationId, people will be able to understand from which remote system/request, this build was generated from & will be able to propagate it to others sub calls(others remote jobs, microservices on the backend or whatever), & then to follow from the begining/first caller having created the job to the end. 

For example:
- Parameterized Remote Trigger Plugin to send a X-Correlation-ID in the header to Jenkins & get it stored in the Cause
- SCM Triggers to receive events containing X-Correlation-ID & also store them in the Cause
- Next others plugins invoked (Build Steps) in a Job which need to know from which original sender this job was started & to send this information to others backing services used in Build Steps or others.

See [JENKINS-63654](https://issues.jenkins-ci.org/browse/JENKINS-63654).

### Proposed changelog entries

* correlationId getter & setter added in Cause.java to enable saving X-Correlation-ID stored in the header of the request (Cause.java)
* doBuild & doBuildWithParameters HTTP end points saving the X-Correlation-ID inside the created Cause

(as none of this class were previously tested & due to the very small changes proposed here, no unit test was proposed)

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [X] Appropriate autotests or explanation to why this change has no tests
- [X] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
