### PR TITLE
Updating display-url-api dep to match mailer

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -320,7 +320,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>display-url-api</artifactId>
-                  <version>2.0</version>
+                  <version>2.3.1</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
#4938 updated the bundled `mailer`, but this has a dep on a newer version of `display-url-api` than what we currently bundle.

### Proposed changelog entries

* Updating bundled version of the Display URL API plugin from 2.0 to 2.3.1.

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
