### PR TITLE
[JENKINS-63795] allow MANAGE to restart and safe-restart jenkins.

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4260,7 +4260,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @CLIMethod(name="restart")
     public void doRestart(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, RestartNotSupportedException {
-        checkPermission(ADMINISTER);
+        checkPermission(MANAGE);
         if (req != null && req.getMethod().equals("GET")) {
             req.getView(this,"_restart.jelly").forward(req,rsp);
             return;
@@ -4284,7 +4284,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @CLIMethod(name="safe-restart")
     public HttpResponse doSafeRestart(StaplerRequest req) throws IOException, ServletException, RestartNotSupportedException {
-        checkPermission(ADMINISTER);
+        checkPermission(MANAGE);
         if (req != null && req.getMethod().equals("GET"))
             return HttpResponses.forwardToView(this,"_safeRestart.jelly");
 

--- a/test/src/test/java/jenkins/model/JenkinsManagePermissionTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsManagePermissionTest.java
@@ -1,5 +1,6 @@
 package jenkins.model;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
@@ -19,20 +20,32 @@ import org.jvnet.hudson.test.recipes.WithPlugin;
 import hudson.PluginWrapper;
 import hudson.cli.CLICommandInvoker;
 import hudson.cli.DisablePluginCommand;
+import hudson.lifecycle.RestartNotSupportedException;
 import hudson.model.Descriptor;
 import hudson.model.MyView;
+import hudson.model.User;
 import hudson.model.View;
+import hudson.security.HudsonPrivateSecurityRealm;
+import hudson.security.ProjectMatrixAuthorizationStrategy;
 import hudson.tasks.Shell;
 
+import jenkins.security.ApiTokenProperty;
+
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
+import static hudson.cli.CLICommandInvoker.Matcher.hasNoErrorOutput;
+import static hudson.cli.CLICommandInvoker.Matcher.hasNoStandardOutput;
+import static hudson.cli.CLICommandInvoker.Matcher.succeeded;
 
 /**
  * As Jenkins.MANAGE can be enabled on startup with jenkins.security.ManagePermission property, we need a test class
@@ -226,4 +239,51 @@ public class JenkinsManagePermissionTest {
 
     // End of HudsonTest
     //-------
+
+    @Issue("JENKINS-63795")
+    @Test
+    public void managePermissionShouldBeAllowedToRestart() throws IOException {
+
+        //GIVEN a Jenkins with 3 users : ADMINISTER, MANAGE and READ
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false, false, null);
+        User adminUser = realm.createAccount("Administer", "G0d");
+        User manageUser = realm.createAccount("Manager", "TheB00S");
+        User readUser = realm.createAccount("Reader", "BookW00rm");
+        j.jenkins.setSecurityRealm(realm);
+
+        ProjectMatrixAuthorizationStrategy authorizationStrategy = new ProjectMatrixAuthorizationStrategy();
+        authorizationStrategy.add(Jenkins.ADMINISTER, adminUser.getId());
+
+        authorizationStrategy.add(Jenkins.MANAGE, manageUser.getId());
+        authorizationStrategy.add(Jenkins.READ, manageUser.getId());
+
+        authorizationStrategy.add(Jenkins.READ, readUser.getId());
+        j.jenkins.setAuthorizationStrategy(authorizationStrategy);
+
+        //WHEN Asking for restart or safe-restart
+        //THEN MANAGE and ADMINISTER are allowed but not READ
+        CLICommandInvoker.Result result = new CLICommandInvoker(j, "restart").asUser(readUser.getId()).invoke();
+        assertThat(result, allOf(failedWith(6),hasNoStandardOutput()));
+
+        result = new CLICommandInvoker(j, "safe-restart").asUser(readUser.getId()).invoke();
+        assertThat(result, allOf(failedWith(6),hasNoStandardOutput()));
+
+        // We should assert that cli result is 0
+        // but as restart is not allowed in JenkinsRule, we assert that it has tried to restart.
+        result = new CLICommandInvoker(j, "restart").asUser(manageUser.getId()).invoke();
+        assertThat(result, failedWith(1));
+        assertThat(result.stderr(),containsString("RestartNotSupportedException"));
+
+        result = new CLICommandInvoker(j, "safe-restart").asUser(manageUser.getId()).invoke();
+        assertThat(result, failedWith(1));
+        assertThat(result.stderr(),containsString("RestartNotSupportedException"));
+
+        result = new CLICommandInvoker(j, "restart").asUser(adminUser.getId()).invoke();
+        assertThat(result, failedWith(1));
+        assertThat(result.stderr(),containsString("RestartNotSupportedException"));
+
+        result = new CLICommandInvoker(j, "safe-restart").asUser(adminUser.getId()).invoke();
+        assertThat(result, failedWith(1));
+        assertThat(result.stderr(),containsString("RestartNotSupportedException"));
+    }
 }


### PR DESCRIPTION
See [JENKINS-63795](https://issues.jenkins-ci.org/browse/JENKINS-63795).

Allow user with Jenkins.MANAGE permission to restart and safe restart Jenkins.

### Proposed changelog entries

* [JENKINS-63795](https://issues.jenkins-ci.org/browse/JENKINS-63795): Allow users with the `Jenkins.MANAGE` permission to restart and safe restart Jenkins.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
