### PR TITLE
Omit stacktraces on ClassNotFoundException in PluginStrategy classloading

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -38,7 +38,7 @@ import jenkins.plugins.DetachedPluginsUtil;
 import jenkins.util.AntClassLoader;
 import jenkins.util.AntWithFindResourceClassLoader;
 import jenkins.util.SystemProperties;
-import jenkins.util.java.ClassNotFoundNoStacktraceException;
+import jenkins.util.java.ClassNotFoundNoStackTraceException;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -93,7 +93,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
     };
 
     private PluginManager pluginManager;
-    private boolean omitStacktracesOnClassNotFoundException;
+    private boolean fillInStackTracesOnClassNotFoundException;
 
     /**
      * All the plugins eventually delegate this classloader to load core, servlet APIs, and SE runtime.
@@ -107,12 +107,12 @@ public class ClassicPluginStrategy implements PluginStrategy {
     /**
      * Sets whether the classloader should include stacktraces on {@link ClassNotFoundException}s.
      *
-     * @param skipStacktraces {@link false} to skip stacktraces.
-     *        The classloader injects stacktraces by default.
+     * @param fillInStackTraces {@link true} to fill in stacktraces.
+     *        The classloader does not inject stacktraces by default.
      * @since TODO
      */
-    public ClassicPluginStrategy withOmitStacktracesOnClassNotFoundException(boolean skipStacktraces) {
-        this.omitStacktracesOnClassNotFoundException = skipStacktraces;
+    public ClassicPluginStrategy withFillInStackTracesOnClassNotFoundException(boolean fillInStackTraces) {
+        this.fillInStackTracesOnClassNotFoundException = fillInStackTraces;
         return this;
     }
 
@@ -310,13 +310,13 @@ public class ClassicPluginStrategy implements PluginStrategy {
                 classLoader.setParentFirst( false );
                 classLoader.setParent( parent );
                 classLoader.addPathFiles( paths );
-                classLoader.withOmitStacktracesOnClassNotFound(omitStacktracesOnClassNotFoundException);
+                classLoader.withFillInStackTracesOnClassNotFound(fillInStackTracesOnClassNotFoundException);
                 return classLoader;
             }
         }
 
         AntClassLoader2 classLoader = new AntClassLoader2(parent);
-        classLoader.withOmitStacktracesOnClassNotFound(omitStacktracesOnClassNotFoundException);
+        classLoader.withFillInStackTracesOnClassNotFound(fillInStackTracesOnClassNotFoundException);
         classLoader.addPathFiles(paths);
         return classLoader;
     }
@@ -665,8 +665,8 @@ public class ClassicPluginStrategy implements PluginStrategy {
                 }
             }
 
-            throw omitStacktracesOnClassNotFoundException ?
-                    new ClassNotFoundNoStacktraceException(name) : new ClassNotFoundException(name);
+            throw fillInStackTracesOnClassNotFoundException ?
+                    new ClassNotFoundException(name) : new ClassNotFoundNoStackTraceException(name);
         }
 
         @Override

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -107,7 +107,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
     /**
      * Sets whether the classloader should include stacktraces on {@link ClassNotFoundException}s.
      *
-     * @param fillInStackTraces {@link true} to fill in stacktraces.
+     * @param fillInStackTraces {@code true} to fill in stacktraces.
      *        The classloader does not inject stacktraces by default.
      * @since TODO
      */

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -56,6 +56,9 @@ import org.apache.tools.zip.ZipOutputStream;
 import org.jenkinsci.bytecode.Transformer;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -111,6 +114,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
      *        The classloader does not inject stacktraces by default.
      * @since TODO
      */
+    @Restricted(Beta.class)
     public ClassicPluginStrategy withFillInStackTracesOnClassNotFoundException(boolean fillInStackTraces) {
         this.fillInStackTracesOnClassNotFoundException = fillInStackTraces;
         return this;

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1216,10 +1216,10 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 		// Default and fallback strategy
         // The default Plugin Manager implementation does not propagate/log stacktraces for ClassNotFoundExceptions,
         // hence stacktraces are omitted by default for better performance.
-        boolean omitClassNotFoundExceptionStacktraces =SystemProperties.getBoolean(
-                ClassicPluginStrategy.class.getName() + ".omitClassNotFoundStacktraces", true);
+        boolean fillInClassNotFoundExceptionStackTraces =SystemProperties.getBoolean(
+                ClassicPluginStrategy.class.getName() + ".fillInClassNotFoundExceptionStackTraces", false);
 		return new ClassicPluginStrategy(this)
-                .withOmitStacktracesOnClassNotFoundException(omitClassNotFoundExceptionStacktraces);
+                .withFillInStackTracesOnClassNotFoundException(fillInClassNotFoundExceptionStackTraces);
     }
 
     public PluginStrategy getPluginStrategy() {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1213,8 +1213,13 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 			LOGGER.info("Falling back to ClassicPluginStrategy");
 		}
 
-		// default and fallback
-		return new ClassicPluginStrategy(this);
+		// Default and fallback strategy
+        // The default Plugin Manager implementation does not propagate/log stacktraces for ClassNotFoundExceptions,
+        // hence stacktraces are omitted by default for better performance.
+        boolean omitClassNotFoundExceptionStacktraces =SystemProperties.getBoolean(
+                ClassicPluginStrategy.class.getName() + ".omitClassNotFoundStacktraces", true);
+		return new ClassicPluginStrategy(this)
+                .withOmitStacktracesOnClassNotFoundException(omitClassNotFoundExceptionStacktraces);
     }
 
     public PluginStrategy getPluginStrategy() {

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -31,6 +31,7 @@ import org.apache.tools.ant.util.JavaEnvUtils;
 import org.apache.tools.ant.util.LoaderUtils;
 import org.apache.tools.ant.util.ReflectUtil;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -582,6 +583,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
      *        The classloader does not add stacktraces by default.
      * @since TODO
      */
+    @Restricted(Beta.class)
     public AntClassLoader withFillInStackTracesOnClassNotFound(boolean fillInStackTraces) {
         this.fillInStackTracesOnClassNotFoundException = fillInStackTraces;
         return this;

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -578,7 +578,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
     /**
      * Sets whether the classloader should include stacktraces on {@link ClassNotFoundException}s.
      *
-     * @param fillInStackTraces {@link true} to fill in stacktraces.
+     * @param fillInStackTraces {@code true} to fill in stacktraces.
      *        The classloader does not add stacktraces by default.
      * @since TODO
      */

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -18,7 +18,7 @@
 package jenkins.util;
 
 import jenkins.telemetry.impl.java11.MissingClassTelemetry;
-import jenkins.util.java.ClassNotFoundNoStacktraceException;
+import jenkins.util.java.ClassNotFoundNoStackTraceException;
 import org.apache.tools.ant.BuildEvent;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -246,7 +246,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
      * Whether or not to include stacktraces in {@link ClassNotFoundException}.
      * @since TODO
      */
-    private boolean omitStacktracesOnClassNotFoundException;
+    private boolean fillInStackTracesOnClassNotFoundException;
 
     /**
      * Create an Ant ClassLoader for a given project, with
@@ -578,12 +578,12 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
     /**
      * Sets whether the classloader should include stacktraces on {@link ClassNotFoundException}s.
      *
-     * @param skipStacktraces {@link true} to skip stacktraces.
-     *        The classloader adds stacktraces by default.
+     * @param fillInStackTraces {@link true} to fill in stacktraces.
+     *        The classloader does not add stacktraces by default.
      * @since TODO
      */
-    public AntClassLoader withOmitStacktracesOnClassNotFound(boolean skipStacktraces) {
-        this.omitStacktracesOnClassNotFoundException = skipStacktraces;
+    public AntClassLoader withFillInStackTracesOnClassNotFound(boolean fillInStackTraces) {
+        this.fillInStackTracesOnClassNotFoundException = fillInStackTraces;
         return this;
     }
 
@@ -1404,8 +1404,8 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
             }
         }
 
-        throw omitStacktracesOnClassNotFoundException
-                ? new ClassNotFoundNoStacktraceException(name) : new ClassNotFoundException(name);
+        throw fillInStackTracesOnClassNotFoundException
+                ? new ClassNotFoundException(name) : new ClassNotFoundNoStackTraceException(name);
     }
 
     /**

--- a/core/src/main/java/jenkins/util/java/ClassNotFoundNoStackTraceException.java
+++ b/core/src/main/java/jenkins/util/java/ClassNotFoundNoStackTraceException.java
@@ -32,8 +32,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * e.g. like in {@link hudson.ClassicPluginStrategy}.
  */
 @Restricted(NoExternalUse.class)
-public class ClassNotFoundNoStacktraceException extends ClassNotFoundException {
-    public ClassNotFoundNoStacktraceException(String className) {
+public class ClassNotFoundNoStackTraceException extends ClassNotFoundException {
+    public ClassNotFoundNoStackTraceException(String className) {
         super(className);
     }
 

--- a/core/src/main/java/jenkins/util/java/ClassNotFoundNoStacktraceException.java
+++ b/core/src/main/java/jenkins/util/java/ClassNotFoundNoStacktraceException.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.util.java;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * {@link ClassNotFoundException} which does not store the stacktrace on initialization.
+ * It improves classloading performance when the stacktrace is ignored,
+ * e.g. like in {@link hudson.ClassicPluginStrategy}.
+ */
+@Restricted(NoExternalUse.class)
+public class ClassNotFoundNoStacktraceException extends ClassNotFoundException {
+    public ClassNotFoundNoStacktraceException(String className) {
+        super(className);
+    }
+
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}


### PR DESCRIPTION
The default Plugin Manager implementation suppresses in `ClassNotFoundException`s thrown by `ClassicPluginStrategy` and `AntClassloader`. Such exceptions are a part of the normal Jenkins classloading behavior, there are thousands of them on normal Jenkins startup with plugins. Each exception construction is a CPU/memory-heavy operation due to stacktrace initialized in the constructor. For example, in Jenkinsfile Runner vanilla build allocates around 200Mb of stacktraces on startup (see https://github.com/jenkinsci/jenkinsfile-runner/pull/358/ for references). Such behavior decreases startup performance, especially on instances with low memory limits. And the data is not really needed 🤷‍♂️ .

This pull request...

* Adds API in `AntClassLoader` and `ClassicPluginStrategy` which allows disabling stacktrace generation in plugin manager implementations
* Disables stacktraces in `PluginManager` by default 
* Adds a System Property which allows to enable stacktrace generation (YAGNI?)

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* RFE: Reduce memory consumption when loading classes from plugins
* Developer: Allow omitting `ClassNotFoundException`s in `AntClassLoader` and `ClassicPluginStrategy` 

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

CC @dwnusbaum @jglick wit whom we discussed this optimization a while ago

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
