### PR TITLE
org.apache.ant:ant 1.10.8 → 1.10.9

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -61,7 +61,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.10.8</version>
+        <version>1.10.9</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
https://ant.apache.org/security.html https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11979 though we do not use this task from Jenkins code, so this is just to get security scanners to stop panicking.

### Proposed changelog entries

* Updated bundled version of Apache Ant from 1.10.8 to 1.10.9.

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
