### PR TITLE
remove specified maven-war-plugin.version to use newer version from parent project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,6 @@ THE SOFTWARE.
 
     <changelog.url>https://jenkins.io/changelog</changelog.url>
 
-    <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
-
     <!-- Bundled Remoting version -->
     <remoting.version>4.5</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->


### PR DESCRIPTION
remove specified `maven-war-plugin.version` to use newer version (3.3.1) from parent project:

Actually updating from 3.2.3 to 3.3.1:

* [Release notes of 3.3.0](https://blogs.apache.org/maven/entry/apache-maven-war-plugin-version3)
* [Release notes of 3.3.1](https://blogs.apache.org/maven/entry/apache-maven-war-plugin-version4)

### Proposed changelog entries

* Developer: Updated maven-war-plugin from 3.2.3 to 3.3.1


### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
