### PR TITLE
[JENKINS-36720] Spotbugs issues

### DIFF
--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -254,7 +254,10 @@ public class WebAppMain implements ServletContextListener {
             // check that and report an error
             try {
                 File f = File.createTempFile("test", "test");
-                f.delete();
+                boolean result = f.delete();
+                if (!result) {
+                    LOGGER.log(WARNING, "Temp file test.test could not be deleted.");
+                }
             } catch (IOException e) {
                 throw new NoTempDir(e);
             }

--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -256,7 +256,7 @@ public class WebAppMain implements ServletContextListener {
                 File f = File.createTempFile("test", "test");
                 boolean result = f.delete();
                 if (!result) {
-                    LOGGER.log(WARNING, "Temp file test.test could not be deleted.");
+                    LOGGER.log(FINE, "Temp file test.test could not be deleted.");
                 }
             } catch (IOException e) {
                 throw new NoTempDir(e);

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -392,9 +392,9 @@ public class UpdateSite {
         r.sort(new Comparator<Plugin>() {
             @Override
             public int compare(Plugin plugin, Plugin t1) {
-                final int pop = plugin.popularity.compareTo(t1.popularity);
+                final int pop = t1.popularity.compareTo(plugin.popularity);
                 if (pop != 0) {
-                    return -pop; // highest popularity first
+                    return pop; // highest popularity first
                 }
                 return plugin.getDisplayName().compareTo(plugin.getDisplayName());
             }


### PR DESCRIPTION
Fixed Spotbugs issues:
* [RV_NEGATING_RESULT_OF_COMPARETO](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#rv-negating-the-result-of-compareto-compare-rv-negating-result-of-compareto)
* [RV_RETURN_VALUE_IGNORED_BAD_PRACTICE](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#rv-method-ignores-exceptional-return-value-rv-return-value-ignored-bad-practice)

See [JENKINS-36720](https://issues.jenkins-ci.org/browse/JENKINS-36720).

### Proposed changelog entries

* Internal: N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
