### PR TITLE
Replaced deprecated Configuration with SystemProperties

### DIFF
--- a/core/src/main/java/hudson/lifecycle/ExitLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/ExitLifecycle.java
@@ -26,13 +26,13 @@ package hudson.lifecycle;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 
+import jenkins.util.SystemProperties;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import jenkins.model.Configuration;
 import jenkins.model.Jenkins;
 
 /**
@@ -56,7 +56,7 @@ public class ExitLifecycle extends Lifecycle {
     private Integer exitOnRestart;
 
     public ExitLifecycle() {
-        exitOnRestart = Integer.parseInt(Configuration.getStringConfigParameter(EXIT_CODE_ON_RESTART, DEFAULT_EXIT_CODE));
+        exitOnRestart = Integer.parseInt(SystemProperties.getString(EXIT_CODE_ON_RESTART, DEFAULT_EXIT_CODE));
     }
 
     @Override

--- a/core/src/main/java/hudson/lifecycle/ExitLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/ExitLifecycle.java
@@ -56,7 +56,7 @@ public class ExitLifecycle extends Lifecycle {
     private Integer exitOnRestart;
 
     public ExitLifecycle() {
-        exitOnRestart = Integer.parseInt(SystemProperties.getString(EXIT_CODE_ON_RESTART, DEFAULT_EXIT_CODE));
+        exitOnRestart = Integer.parseInt(SystemProperties.getString(Jenkins.class.getName() + "." + EXIT_CODE_ON_RESTART, DEFAULT_EXIT_CODE));
     }
 
     @Override

--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -31,6 +31,7 @@ import hudson.security.AccessControlled;
 import hudson.slaves.ComputerListener;
 import hudson.slaves.RetentionStrategy;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 import org.kohsuke.stapler.StaplerFallback;
 import org.kohsuke.stapler.StaplerProxy;
 
@@ -39,11 +40,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
-import jenkins.model.Configuration;
-
 public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelItem>, StaplerProxy, StaplerFallback, ViewGroup, AccessControlled, DescriptorByNameOwner {
 
-    public static boolean LOG_STARTUP_PERFORMANCE = Configuration.getBooleanConfigParameter("logStartupPerformance", false);
+    public static boolean LOG_STARTUP_PERFORMANCE = SystemProperties.getBoolean("logStartupPerformance", false);
 
     private static final Logger LOGGER = Logger.getLogger(AbstractCIBase.class.getName());
 

--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -42,7 +42,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelItem>, StaplerProxy, StaplerFallback, ViewGroup, AccessControlled, DescriptorByNameOwner {
 
-    public static boolean LOG_STARTUP_PERFORMANCE = SystemProperties.getBoolean("logStartupPerformance", false);
+    public static boolean LOG_STARTUP_PERFORMANCE = SystemProperties.getBoolean(Jenkins.class.getName() + "." + "logStartupPerformance", false);
 
     private static final Logger LOGGER = Logger.getLogger(AbstractCIBase.class.getName());
 

--- a/core/src/main/java/jenkins/InitReactorRunner.java
+++ b/core/src/main/java/jenkins/InitReactorRunner.java
@@ -7,7 +7,6 @@ import hudson.init.InitReactorListener;
 import hudson.security.ACL;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.NamingThreadFactory;
-import jenkins.model.Configuration;
 import jenkins.model.Jenkins;
 import jenkins.security.ImpersonatingExecutorService;
 import org.jvnet.hudson.reactor.Milestone;
@@ -64,7 +63,7 @@ public class InitReactorRunner {
     private ReactorListener buildReactorListener() throws IOException {
         List<ReactorListener> r = Lists.newArrayList(ServiceLoader.load(InitReactorListener.class, Thread.currentThread().getContextClassLoader()));
         r.add(new ReactorListener() {
-            final Level level = Level.parse( Configuration.getStringConfigParameter("initLogLevel", "FINE") );
+            final Level level = Level.parse( SystemProperties.getString("initLogLevel", "FINE") );
             public void onTaskStarted(Task t) {
                 LOGGER.log(level, "Started {0}", getDisplayName(t));
             }

--- a/core/src/main/java/jenkins/InitReactorRunner.java
+++ b/core/src/main/java/jenkins/InitReactorRunner.java
@@ -63,7 +63,7 @@ public class InitReactorRunner {
     private ReactorListener buildReactorListener() throws IOException {
         List<ReactorListener> r = Lists.newArrayList(ServiceLoader.load(InitReactorListener.class, Thread.currentThread().getContextClassLoader()));
         r.add(new ReactorListener() {
-            final Level level = Level.parse( SystemProperties.getString("initLogLevel", "FINE") );
+            final Level level = Level.parse( SystemProperties.getString(Jenkins.class.getName() + "." + "initLogLevel", "FINE") );
             public void onTaskStarted(Task t) {
                 LOGGER.log(level, "Started {0}", getDisplayName(t));
             }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3494,7 +3494,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     command.run();
                 }
             }, new ReactorListener() {
-                final Level level = Level.parse(Configuration.getStringConfigParameter("termLogLevel", "FINE"));
+                final Level level = Level.parse(SystemProperties.getString("termLogLevel", "FINE"));
 
                 public void onTaskStarted(Task t) {
                     LOGGER.log(level, "Started {0}", InitReactorRunner.getDisplayName(t));
@@ -5234,8 +5234,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     public static String VIEW_RESOURCE_PATH = "/resources/TBD";
 
-    public static boolean PARALLEL_LOAD = Configuration.getBooleanConfigParameter("parallelLoad", true);
-    public static boolean KILL_AFTER_LOAD = Configuration.getBooleanConfigParameter("killAfterLoad", false);
+    public static boolean PARALLEL_LOAD = SystemProperties.getBoolean("parallelLoad", true);
+    public static boolean KILL_AFTER_LOAD = SystemProperties.getBoolean("killAfterLoad", false);
     /**
      * @deprecated No longer used.
      */
@@ -5257,7 +5257,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Switch to enable people to use a shorter workspace name.
      */
-    private static final String WORKSPACE_DIRNAME = Configuration.getStringConfigParameter("workspaceDirName", "workspace");
+    private static final String WORKSPACE_DIRNAME = SystemProperties.getString("workspaceDirName", "workspace");
 
     /**
      * Default value of job's builds dir.

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3494,7 +3494,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     command.run();
                 }
             }, new ReactorListener() {
-                final Level level = Level.parse(SystemProperties.getString("termLogLevel", "FINE"));
+                final Level level = Level.parse(SystemProperties.getString(Jenkins.class.getName() + "." +"termLogLevel", "FINE"));
 
                 public void onTaskStarted(Task t) {
                     LOGGER.log(level, "Started {0}", InitReactorRunner.getDisplayName(t));
@@ -5234,8 +5234,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     public static String VIEW_RESOURCE_PATH = "/resources/TBD";
 
-    public static boolean PARALLEL_LOAD = SystemProperties.getBoolean("parallelLoad", true);
-    public static boolean KILL_AFTER_LOAD = SystemProperties.getBoolean("killAfterLoad", false);
+    public static boolean PARALLEL_LOAD = SystemProperties.getBoolean(Jenkins.class.getName() + "." + "parallelLoad", true);
+    public static boolean KILL_AFTER_LOAD = SystemProperties.getBoolean(Jenkins.class.getName() + "." + "killAfterLoad", false);
     /**
      * @deprecated No longer used.
      */
@@ -5257,7 +5257,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Switch to enable people to use a shorter workspace name.
      */
-    private static final String WORKSPACE_DIRNAME = SystemProperties.getString("workspaceDirName", "workspace");
+    private static final String WORKSPACE_DIRNAME = SystemProperties.getString(Jenkins.class.getName() + "." + "workspaceDirName", "workspace");
 
     /**
      * Default value of job's builds dir.


### PR DESCRIPTION
Replaced deprecated usages of `Configuration` with `SystemProperties`

If this is approved, I already prepared another PR for updating the documentation: https://github.com/jenkins-infra/jenkins.io/pull/3830

### Proposed changelog entries

* Minor: Dropped support for deprecated system properties: `hudson.model.Hudson.logStartupPerformance`, `hudson.model.Hudson.initLogLevel`, `hudson.model.Hudson.parallelLoad`, `hudson.model.Hudson.killAfterLoad` and `hudson.model.Hudson.workspaceDirName` - please use `jenkins.model.Jenkins.`-prefixed SystemProperties

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
