### PR TITLE
Limit rssChangelog to 20 entries (JENKINS-18992)

### DIFF
--- a/core/src/main/java/jenkins/model/RssFeedItem.java
+++ b/core/src/main/java/jenkins/model/RssFeedItem.java
@@ -1,0 +1,50 @@
+package jenkins.model;
+
+import hudson.model.Run;
+import hudson.scm.ChangeLogSet;
+
+/**
+ * The type Rss feed item for Rss changelog.
+ */
+public class RssFeedItem {
+    private final ChangeLogSet.Entry entry;
+    private final int index;
+
+    /**
+     * Instantiates a new Rss feed item.
+     *
+     * @param e   the e
+     * @param idx the idx
+     */
+    public RssFeedItem(ChangeLogSet.Entry e, int idx) {
+        this.entry = e;
+        this.index = idx;
+    }
+
+    /**
+     * Gets the run.
+     *
+     * @return the run
+     */
+    public Run<?, ?> getRun() {
+        return entry.getParent().getRun();
+    }
+
+    /**
+     * Gets the entry.
+     *
+     * @return the entry
+     */
+    public ChangeLogSet.Entry getEntry() {
+        return entry;
+    }
+
+    /**
+     * Gets the index.
+     *
+     * @return the index
+     */
+    public int getIndex() {
+        return index;
+    }
+}

--- a/core/src/main/java/jenkins/model/RssFeedItem.java
+++ b/core/src/main/java/jenkins/model/RssFeedItem.java
@@ -6,6 +6,7 @@ import hudson.scm.ChangeLogSet;
 /**
  * The type Rss feed item for Rss changelog.
  */
+@Restricted(NoExternalUse.class)
 public class RssFeedItem {
     private final ChangeLogSet.Entry entry;
     private final int index;

--- a/core/src/test/java/jenkins/model/RssFeedItemTest.java
+++ b/core/src/test/java/jenkins/model/RssFeedItemTest.java
@@ -1,0 +1,50 @@
+package jenkins.model;
+
+import hudson.model.Run;
+import hudson.scm.ChangeLogSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class RssFeedItemTest {
+
+    private RssFeedItem itemToTest = null;
+    
+    private ChangeLogSet mockChangelog;
+    private ChangeLogSet.Entry mockEntry;
+    private Run<?, ?> mockRun;
+
+    @BeforeEach
+    void setup() {
+        mockEntry = mock(ChangeLogSet.Entry.class);
+        mockChangelog = mock(ChangeLogSet.class);
+        mockRun = mock(Run.class);
+        when(mockChangelog.getRun()).thenReturn(mockRun);
+        when(mockEntry.getParent()).thenReturn(mockChangelog);
+        itemToTest = new RssFeedItem(mockEntry, 0);
+    }
+    
+    @Test
+    void testGetRun() {
+        assertEquals(mockRun, itemToTest.getRun());
+        verify(mockChangelog, times(1)).getRun();
+        verify(mockEntry, times(1)).getParent();
+        verifyNoMoreInteractions(mockEntry, mockChangelog, mockRun);
+    }
+
+    @Test
+    void testGetEntry() {
+        assertEquals(mockEntry, itemToTest.getEntry());
+    }
+
+    @Test
+    void testGetIndex() {
+        assertEquals(0, itemToTest.getIndex());
+    }
+}


### PR DESCRIPTION
Limit the rssChangelog to 20 entries, as suggested by
See [JENKINS-18992](https://issues.jenkins-ci.org/browse/JENKINS-18992).

I extracted the internal class and slightly improved it, also added a test class which covers the functionality

I do not know how to accept an additional parameter for disabling this limit. If someone has a hint I would add the functionality also with this PR.

### Proposed changelog entries

* Entry 1: Restrit RSS build changelog to 20 entries (JENKINS-18992)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
