### PR TITLE
[JENKINS-63828] It is legal to have a CloudProvisioningListener not implementing `canProvision`

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1480,7 +1480,7 @@ public class Util {
         if (isOverridden(base, derived, methodName, types)) {
             return supplier.get();
         } else {
-            throw new AbstractMethodError("You must override at least one of the "
+            throw new AbstractMethodError("The class " + derived.getName() + " must override at least one of the "
                     + base.getSimpleName() + "." + methodName + " methods");
         }
     }

--- a/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
+++ b/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
@@ -42,13 +42,16 @@ public abstract class CloudProvisioningListener implements ExtensionPoint {
      */
     @Deprecated
     public CauseOfBlockage canProvision(Cloud cloud, Label label, int numExecutors) {
-        return Util.ifOverridden(() -> canProvision(cloud, new CloudState(label, 0), numExecutors),
-                CloudProvisioningListener.class,
+        if (Util.isOverridden(CloudProvisioningListener.class,
                 getClass(),
                 "canProvision",
                 Cloud.class,
                 CloudState.class,
-                int.class);
+                int.class)) {
+            return canProvision(cloud, new CloudState(label, 0), numExecutors);
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -598,7 +598,7 @@ public class UtilTest {
         AbstractMethodError error = Assert.assertThrows(AbstractMethodError.class, () -> {
             Util.ifOverridden(() -> true, BaseClass.class, DerivedClassFailure.class, "method");
         });
-        assertEquals("You must override at least one of the BaseClass.method methods", error.getMessage());
+        assertEquals("The class " + DerivedClassFailure.class.getName() + " must override at least one of the BaseClass.method methods", error.getMessage());
     }
 
     public static class BaseClass {

--- a/core/src/test/java/hudson/slaves/CloudProvisioningListenerTest.java
+++ b/core/src/test/java/hudson/slaves/CloudProvisioningListenerTest.java
@@ -1,37 +1,36 @@
 package hudson.slaves;
 
+import hudson.model.Messages;
 import hudson.model.queue.CauseOfBlockage;
-import org.junit.Assert;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.localizer.Localizable;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class CloudProvisioningListenerTest {
-    public static class CloudProvisioningListenerFailing extends CloudProvisioningListener {}
+    public static class CloudProvisioningListenerNoOverride extends CloudProvisioningListener {}
 
-    public static class CloudProvisioningListenerSuccess extends CloudProvisioningListener {
+    public static class CloudProvisioningListenerOverride extends CloudProvisioningListener {
         @Override
         public CauseOfBlockage canProvision(Cloud cloud, Cloud.CloudState state, int numExecutors) {
-            return null;
+            return CauseOfBlockage.fromMessage(Messages._Queue_InProgress());
         }
     }
 
     @Issue("JENKINS-63828")
     @Test
-    public void failing(){
+    public void noOverride(){
         Cloud.CloudState state = new Cloud.CloudState(null, 0);
-        AbstractMethodError error = Assert.assertThrows(AbstractMethodError.class, () -> {
-            new CloudProvisioningListenerFailing().canProvision(null, state, 0);
-        });
-        assertEquals("You must override at least one of the CloudProvisioningListener.canProvision methods", error.getMessage());
+        assertNull(new CloudProvisioningListenerNoOverride().canProvision(null, state, 0));
     }
 
     @Issue("JENKINS-63828")
     @Test
-    public void success() {
+    public void override() {
         Cloud.CloudState state = new Cloud.CloudState(null, 0);
-        assertNull(new CloudProvisioningListenerSuccess().canProvision(null, state, 0));
+        assertNotNull(new CloudProvisioningListenerOverride().canProvision(null, state, 0));
     }
 }


### PR DESCRIPTION
Follow-up of #4922, #4955

I got confused in https://github.com/jenkinsci/jenkins/commit/3992a30efb1abf697cae8e02f9e81dd04b92b135 by `Cloud#canProvision` which was abstract vs. `CloudProvisioningListener#canProvision` which wasn't and was returning `null`.

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-63828](https://issues.jenkins-ci.org/browse/JENKINS-63828).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fix docker build agent provisioning (regression in 2.259-260) (take 2).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
