### PR TITLE
Maintainer guide - Add a Release Process section

### DIFF
--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -405,7 +405,9 @@ When do we squash commits?
 * We squash commits when core maintainers decide to do so (`squash-merge-me` label), usually when the conditions above are not met.
 * There is no strong requirement to squash merge pull requests at the moment, so there might be deviations from the merge policy in practice.
 
-== Weekly release process
+== Release process
+
+=== Weekly release process
 
 link:https://www.jenkins.io/download/weekly/[Jenkins Weekly releases] are managed by the Jenkins Release Team which has access to the dedicated release environment within the Jenkins Infrastructure.
 References:
@@ -415,7 +417,7 @@ References:
 * link:https://github.com/jenkinsci/packaging[Native Jenkins packages and installers for platforms]
 * link:https://github.com/jenkinsci/docker[Docker packaging for Jenkins]
 
-== LTS Process
+=== LTS Process
 
 Jenkins also offers the link:https://jenkins.io/download/lts/[LTS Release Line].
 It is maintained by the Jenkins Release Team which coordinates link:https://jenkins.io/download/lts/#backporting-process[backporting] and release candidate testing.


### PR DESCRIPTION
This change adds a new section so that we can add a redirect for https://wiki.jenkins.io/display/JENKINS/Release+Process which contains obsolete content

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@MarkEWaite @olblak 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
