### PR TITLE
[JENKINS-49523] Excludes separator clarified

### DIFF
--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-excludes.html
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/help-excludes.html
@@ -1,5 +1,5 @@
 <div>
-  Optionally specify <a href='http://ant.apache.org/manual/Types/fileset.html'>the 'excludes' pattern</a>,
-  such as "foo/bar/**/*". A file that matches this mask will not be archived even if it matches the
+  Optionally specify the 'excludes' pattern, such as "foo/bar/**/*". Use "," to set a list of patterns. 
+  A file that matches this mask will not be archived even if it matches the
   mask specified in 'files to archive' section.
 </div>

--- a/core/src/main/resources/hudson/tasks/Fingerprinter/help-excludes.html
+++ b/core/src/main/resources/hudson/tasks/Fingerprinter/help-excludes.html
@@ -1,5 +1,5 @@
 <div>
-  Optionally specify <a href='http://ant.apache.org/manual/Types/fileset.html'>the 'excludes' pattern</a>,
-  such as "foo/bar/**/*". A file that matches this mask will not be fingerprinted even if it matches the
+  Optionally specify the 'excludes' pattern, such as "foo/bar/**/*". Use "," to set a list of patterns. 
+  A file that matches this mask will not be fingerprinted even if it matches the
   mask specified in 'files to fingerprint' section.
 </div>


### PR DESCRIPTION
See [JENKINS-49523](https://issues.jenkins-ci.org/browse/JENKINS-49523).

Values in Excludes field shoul be separated with comma.
