### PR TITLE
Remove beta mark from APIs introduced for JEP-202

### DIFF
--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -66,7 +66,6 @@ import org.apache.tools.ant.types.selectors.SelectorUtils;
 import org.apache.tools.ant.types.selectors.TokenizedPath;
 import org.apache.tools.ant.types.selectors.TokenizedPattern;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
@@ -154,7 +153,6 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
      * @throws IOException if reading the link, or even determining whether this file is a link, failed
      * @since 2.118
      */
-    @Restricted(Beta.class)
     public @CheckForNull String readLink() throws IOException {
         return null;
     }
@@ -219,7 +217,6 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
      * @throws IOException if this is not a directory, or listing was not possible for some other reason
      * @since 2.118
      */
-    @Restricted(Beta.class)
     public @NonNull Collection<String> list(@NonNull String includes, @CheckForNull String excludes, boolean useDefaultExcludes) throws IOException {
         Collection<String> r = run(new CollectFiles(this));
         List<TokenizedPattern> includePatterns = patterns(includes);
@@ -297,7 +294,6 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
      * @throws IOException if checking the mode failed
      * @since 2.118
      */
-    @Restricted(Beta.class)
     public int mode() throws IOException {
         return -1;
     }
@@ -379,7 +375,6 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
      * @since 2.118
      * @see #toURI
      */
-    @Restricted(Beta.class)
     public @CheckForNull URL toExternalURL() throws IOException {
         return null;
     }


### PR DESCRIPTION
@oleg-nenashev pointed out in https://github.com/jenkinsci/jep/pull/280 that for the JEP to be considered final we would expect these APIs to become unrestricted. They have long been in use in plugin releases.

### Proposed changelog entries

* Pluggable Artifact Storage: Make the `VirtualFile` API generally available to plugin developers.
  * JEP-202: https://github.com/jenkinsci/jep/tree/master/jep/202

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
