### PR TITLE
[JENKINS-63910] Correct help behavior for dropdownList

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -372,7 +372,7 @@ function findFollowingTR(node, className, nodeClass) {
         // Supports plugins with custom variants of <f:entry> that call
         // findFollowingTR(element, 'validation-error-area') and haven't migrated
         // to use querySelector
-        if (className === 'validation-error-area' || className === 'help-area') {
+        if (arguments.length <= 2 && (className === 'validation-error-area' || className === 'help-area')) {
             var queryChildren = tr.getElementsByClassName(className);
             if (queryChildren.length > 0 && (isTR(queryChildren[0]) || Element.hasClassName(queryChildren[0], className) ))
                 return queryChildren[0];


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-63910](https://issues.jenkins-ci.org/browse/JENKINS-63910).

⚠️ No ticket as issues.jenkins.io seems currently broken. IMO this bug is not blocking per se, annoying yes but not enough critical to be a candidate for backport.

----

**Issue**: When you click on the help icon (since #4818) related to a dropdownList, the behavior is currently broken. It will display the help text in an incorrect location due to the legacy behavior support added to cover the table2div migration.

If the dropdownList is "closed" (no dropdownListBody displayed), the help will not appear. If the body is displayed, the help of the dropdownList entry will be displayed inside the first entry helpArea instead of the one from dropdownList. _(The behavior is the same for both situations due to the body being closed)_

**Solution**: add condition (arg.length <= 2) for legacy detection.

⚠️ Not tested with other component, just with the dropdownList.

<details>

<summary>:fire: Screenshots :fire:</summary>

### Before
#### Click on help from dropdownList entry directly
![dropdown_help_bug](https://user-images.githubusercontent.com/2662497/95681614-33d3d580-0be1-11eb-9c0e-73ce67b8a193.png)

#### Click on help inside dropdownList, on the first entry
![dropdown_help_bug_2](https://user-images.githubusercontent.com/2662497/95681615-359d9900-0be1-11eb-891e-0da96ee3f41e.png)

----

### After
#### Click on help from dropdownList entry directly (body open)
![dropdown_help_correction](https://user-images.githubusercontent.com/2662497/95681620-3c2c1080-0be1-11eb-98a5-2c7fc8f9a61a.png)

#### Click on help from dropdownList entry directly (body closed)
![dropdown_help_correction_2](https://user-images.githubusercontent.com/2662497/95681623-3d5d3d80-0be1-11eb-93ee-947c0b2a9720.png)

----

</details>

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* (internal, minor) Correction of the help button not working for dropdownList

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck @timja 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
