### PR TITLE
Replace deprecated NullOutputStream

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -515,7 +515,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
 
         final long dirTime = archive.lastModified();
         // this ZipOutputStream is reused and not created for each directory
-        try (ZipOutputStream wrappedZOut = new ZipOutputStream(new NullOutputStream()) {
+        try (ZipOutputStream wrappedZOut = new ZipOutputStream(NullOutputStream.NULL_OUTPUT_STREAM) {
             @Override
             public void putNextEntry(ZipEntry ze) throws IOException {
                 ze.setTime(dirTime+1999);   // roundup

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -345,7 +345,7 @@ public final class TcpSlaveAgentListener extends Thread {
                 }
 
                 InputStream i = s.getInputStream();
-                IOUtils.copy(i, new NullOutputStream());
+                IOUtils.copy(i, NullOutputStream.NULL_OUTPUT_STREAM);
                 s.shutdownInput();
             } finally {
                 s.close();

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1408,7 +1408,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                     }
                 } else {
                     try (InputStream is = connection.getInputStream()) {
-                        IOUtils.copy(is, new NullOutputStream());
+                        IOUtils.copy(is, NullOutputStream.NULL_OUTPUT_STREAM);
                     }
                 }
             } catch (SSLHandshakeException e) {

--- a/core/src/main/java/jenkins/util/JSONSignatureValidator.java
+++ b/core/src/main/java/jenkins/util/JSONSignatureValidator.java
@@ -156,7 +156,7 @@ public class JSONSignatureValidator {
      */
     private FormValidation checkSpecificSignature(JSONObject json, JSONObject signatureJson, MessageDigest digest, String digestEntry, Signature signature, String signatureEntry, String digestName) throws IOException {
         // this is for computing a digest to check sanity
-        DigestOutputStream dos = new DigestOutputStream(new NullOutputStream(), digest);
+        DigestOutputStream dos = new DigestOutputStream(NullOutputStream.NULL_OUTPUT_STREAM, digest);
         SignatureOutputStream sos = new SignatureOutputStream(signature);
 
         String providedDigest = signatureJson.optString(digestEntry, null);

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -242,8 +242,8 @@ public class FilePathTest {
     @Test public void archiveBug() throws Exception {
             FilePath d = new FilePath(channels.french, temp.getRoot().getPath());
             d.child("test").touch(0);
-            d.zip(new NullOutputStream());
-            d.zip(new NullOutputStream(),"**/*");
+            d.zip(NullOutputStream.NULL_OUTPUT_STREAM);
+            d.zip(NullOutputStream.NULL_OUTPUT_STREAM,"**/*");
     }
 
     @Test public void normalization() throws Exception {

--- a/core/src/test/java/hudson/slaves/ComputerLauncherTest.java
+++ b/core/src/test/java/hudson/slaves/ComputerLauncherTest.java
@@ -52,7 +52,7 @@ public class ComputerLauncherTest {
     }
 
     @Test public void jdk5() {
-        assertThrows(IOException.class, () -> ComputerLauncher.checkJavaVersion(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM, "-", new BufferedReader(new StringReader("java version \"1.5.0_22\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_22-b03)\nJava HotSpot(TM) Server VM (build 1.5.0_22-b03, mixed mode)\n"))));
+        assertThrows(IOException.class, () -> ComputerLauncher.checkJavaVersion(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM), "-", new BufferedReader(new StringReader("java version \"1.5.0_22\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_22-b03)\nJava HotSpot(TM) Server VM (build 1.5.0_22-b03, mixed mode)\n"))));
     }
 
     @Test public void j2sdk4() {

--- a/core/src/test/java/hudson/slaves/ComputerLauncherTest.java
+++ b/core/src/test/java/hudson/slaves/ComputerLauncherTest.java
@@ -52,11 +52,11 @@ public class ComputerLauncherTest {
     }
 
     @Test public void jdk5() {
-        assertThrows(IOException.class, () -> ComputerLauncher.checkJavaVersion(new PrintStream(new NullOutputStream()), "-", new BufferedReader(new StringReader("java version \"1.5.0_22\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_22-b03)\nJava HotSpot(TM) Server VM (build 1.5.0_22-b03, mixed mode)\n"))));
+        assertThrows(IOException.class, () -> ComputerLauncher.checkJavaVersion(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM, "-", new BufferedReader(new StringReader("java version \"1.5.0_22\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_22-b03)\nJava HotSpot(TM) Server VM (build 1.5.0_22-b03, mixed mode)\n"))));
     }
 
     @Test public void j2sdk4() {
-        assertThrows(IOException.class, () -> ComputerLauncher.checkJavaVersion(new PrintStream(new NullOutputStream()), "-", new BufferedReader(new StringReader("java version \"1.4.2_19\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.4.2_19-b04)\nJava HotSpot(TM) Client VM (build 1.4.2_19-b04, mixed mode)\n"))));
+        assertThrows(IOException.class, () -> ComputerLauncher.checkJavaVersion(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM), "-", new BufferedReader(new StringReader("java version \"1.4.2_19\"\nJava(TM) 2 Runtime Environment, Standard Edition (build 1.4.2_19-b04)\nJava HotSpot(TM) Client VM (build 1.4.2_19-b04, mixed mode)\n"))));
     }
 
     @Test public void jdk8() throws IOException {

--- a/core/src/test/java/jenkins/RemotingJarSignatureTest.java
+++ b/core/src/test/java/jenkins/RemotingJarSignatureTest.java
@@ -42,7 +42,7 @@ public class RemotingJarSignatureTest {
             if (name.startsWith("META-INF/") && name.endsWith(".DSA")) continue;
 
             // make sure bits are signed
-            IOUtils.copy(myJar.getInputStream(entry), new NullOutputStream());
+            IOUtils.copy(myJar.getInputStream(entry), NullOutputStream.NULL_OUTPUT_STREAM);
             if (entry.getCodeSigners()==null) {
                 fail("No signature for " + name);
             }


### PR DESCRIPTION
Replaced `new NullOutputStream()` with `NULL_OUTPUT_STREAM` because constructor gets private in apache.commons.io in 3.0
See [Apache commons](https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/output/NullOutputStream.html#NullOutputStream--)


### Proposed changelog entries

* Internal: N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
