### PR TITLE
Prevent resource leak in FileFingerprintStorage

### DIFF
--- a/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
+++ b/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
@@ -137,8 +137,7 @@ public class FileFingerprintStorage extends FingerprintStorage {
             file.getParentFile().mkdirs();
             // JENKINS-16301: fast path for the common case.
             AtomicFileWriter afw = new AtomicFileWriter(file);
-            try {
-                PrintWriter w = new PrintWriter(afw);
+            try (PrintWriter w = new PrintWriter(afw)) {
                 w.println("<?xml version='1.1' encoding='UTF-8'?>");
                 w.println("<fingerprint>");
                 w.print("  <timestamp>");


### PR DESCRIPTION
Prevents a possible resource leak by calling the [Printwriter.close()](https://docs.oracle.com/javase/8/docs/api/java/io/PrintWriter.html#close--) method through a try-with-resource block.

### Proposed changelog entries

Skip changelog entry.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

None.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
