### PR TITLE
Fixed eslint warnings of type no-mixed-spaces-and-tabs

### DIFF
--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -502,18 +502,18 @@ var createPluginSetupWizard = function(appendTarget) {
 			var events = $._data($c[0], "events");
 			if (!events || !events.scroll) {
 				$c.on('scroll', function() {
-				    if (!$c.data('wasAutoScrolled')) {
-				    	var top = $c[0].scrollHeight - $c.height();
-				        if ($c.scrollTop() === top) {
-				        	// resume auto-scroll
-				        	$c.data('userScrolled', false);
-				        } else {
-				        	// user scrolled up
-					    	$c.data('userScrolled', true);
-				        }
-				    } else {
-				    	$c.data('wasAutoScrolled', false);
-				    }
+					if (!$c.data('wasAutoScrolled')) {
+						var top = $c[0].scrollHeight - $c.height();
+						if ($c.scrollTop() === top) {
+							// resume auto-scroll
+							$c.data('userScrolled', false);
+						} else {
+							// user scrolled up
+							$c.data('userScrolled', true);
+						}
+					} else {
+						$c.data('wasAutoScrolled', false);
+					}
 				});
 			}
 		};

--- a/war/src/main/js/util/page.js
+++ b/war/src/main/js/util/page.js
@@ -60,15 +60,15 @@ function fixDragEvent(handle) {
     var $chunk = $handle.closest('.repeated-chunk');
     $handle.add('#ygddfdiv')
 	.mousedown(function(){
-	    isReady = true;
+		isReady = true;
 	})
 	.mousemove(function(){
-	    if(isReady && !$chunk.hasClass('dragging')){
+		if(isReady && !$chunk.hasClass('dragging')){
 		$chunk.addClass('dragging');
-	    }
+		}
 	}).mouseup(function(){
-	    isReady = false;
-	    $chunk.removeClass('dragging');
+		isReady = false;
+		$chunk.removeClass('dragging');
 	});
 }
 

--- a/war/src/test/js/pluginSetupWizard.spec.js
+++ b/war/src/test/js/pluginSetupWizard.spec.js
@@ -66,21 +66,21 @@ var ajaxMocks = function(responseMappings) {
         '/jenkins/updateCenter/installStatus': new LastResponse([{
             status: 'ok',
             data: { // first, return nothing by default, no ongoing install
-            	state: 'NEW',
-            	jobs: []
-        	}
+                state: 'NEW',
+                jobs: []
+            }
         },
         {
             status: 'ok',
             data: {
-            	state: 'INSTALLING_PLUGINS',
-            	jobs: [
-	              {
-	                  name: 'subversion',
-	                  type: 'InstallJob',
-	                  installStatus: 'Success'
-	              }
-	            ]
+                state: 'INSTALLING_PLUGINS',
+                jobs: [
+                  {
+                      name: 'subversion',
+                      type: 'InstallJob',
+                      installStatus: 'Success'
+                  }
+                ]
             }
         }]),
         '/jenkins/pluginManager/plugins': {


### PR DESCRIPTION
Fixed some eslint warnings, to reduce warnings during build.
All errrors were type: `no-mixed-spaces-and-tabs`
I saw that some files just use spaces and some use whitespaces. Do we have a rule for that?
Personally I like whitespaces more, but I would stick to the majority.

### Proposed changelog entries

* Internal: N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
