### PR TITLE
[JENKINS-62446] adding CasC compatibility to Global tool > Global Maven

### DIFF
--- a/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java
+++ b/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java
@@ -11,7 +11,7 @@ import org.jenkinsci.Symbol;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 //as close as it gets to the global Maven Project configuration
-@Extension(ordinal = 50) @Symbol("maven")
+@Extension(ordinal = 50) @Symbol("mavenGlobalConfig")
 public class GlobalMavenConfig extends GlobalConfiguration  implements PersistentDescriptor {
     private SettingsProvider settingsProvider;
     private GlobalSettingsProvider globalSettingsProvider;


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-62446](https://issues.jenkins-ci.org/browse/JENKINS-62446).

Global maven configuration was not exported because the symbol `@Symbol("maven")` was used twice.
- https://github.com/jenkinsci/jenkins/blob/0ce4268d219f249615ced798ed23b1cb3ecce93c/core/src/main/java/hudson/tasks/Maven.java#L427
- https://github.com/jenkinsci/jenkins/blob/0ce4268d219f249615ced798ed23b1cb3ecce93c/core/src/main/java/jenkins/mvn/GlobalMavenConfig.java#L14

I keep the `@Symbol("maven")` for the currently CasC exportable part to not break existing configuration, and renamed the one that was not working.

Manual tests done locally:
- export (see screenshot)
- import with a new configuration values on `tool.mavenGlobalConfig`

Test coverage in https://github.com/jenkinsci/configuration-as-code-plugin/pull/1525

Example:
```
tool:
  mavenGlobalConfig:
    globalSettingsProvider:
      filePath:
        path: "/tmp3/settings.xml"
    settingsProvider:
      filePath:
        path: "/tmp2/settings.xml"
```

Does anyone know if there is a JCasC compatibility test class in this project ?

FYI screenshots of UI and JCasC export:
![config UI](https://user-images.githubusercontent.com/3634942/96272956-116dfd80-0fcf-11eb-8956-ea144b296bdd.png)
![export casc global tool](https://user-images.githubusercontent.com/3634942/96272970-159a1b00-0fcf-11eb-9aca-6bea394a1680.png)

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: JCasC compatibility for Global tool (/configureTools) > Maven Configuration
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
