### PR TITLE
[JENKINS-63958] - Revert "Upgrade winstone 5.11 to introduce Jetty LowResourceMonitor"

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -103,7 +103,7 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>5.11</version>
+      <version>5.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Reverts jenkinsci/jenkins#4975 as a temporary measure to resolve https://issues.jenkins-ci.org/browse/JENKINS-63958 . I suggest this PR as a conservative mitigation for the regression so that the tomorrow's weekly release could become a candidate for the LTS baseline selection.

## Better solution

Alternative approach is to update to newer version of Jetty with https://github.com/eclipse/jetty.project/issues/5417 fix is out (PR: https://github.com/eclipse/jetty.project/pull/5419 ). As noticed by @zbynek and confirmed by @richardfearn in JENKINS-63958, it is likely to fix the issue. Updating Jetty one day before the LTS baseline selection is YOLO, but it may be reasonable in this case.

If Jetty release happens tomorrow as anticipated, we could get the Jetty update into it. CC @timja @olblak @MarkEWaite whose approval would be great for such expedited release. We might need to disable the automatic weekly release as well.

### Proposed changelog entries

* Revert Jetty from 9.4.32.v20200930 to 9.4.30.v20200611 to fix the issue with wrong ports appearing in redirect URLs created by Jenkins (regression in 2.261).
* Revert the LowResourceMonitor feature introduced in 2.261

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@olamy @daniel-beck @timja @jenkinsci/core 