### PR TITLE
[JENKINS-28022] Make descriptions copy-able without zero-width spaces

### DIFF
--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -799,6 +799,7 @@ table.parameters > tbody:hover {
   margin-top: 5px;
   white-space: normal;
   opacity: 0.6;
+  word-break: break-word;
 }
 
 #buildHistory .build-row-cell {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1869,7 +1869,7 @@ function updateBuildHistory(ajaxUrl,nBuild) {
         // Undo everything from the previous poll.
         resetCellOverflows();
 
-        // Mark the text as multiline, if it is so
+        // Mark the text as multiline, if it has more than one line
         if (desc) {
             markMultiline();
         }

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1856,8 +1856,6 @@ function updateBuildHistory(ajaxUrl,nBuild) {
                 blockUnwrap(blockWraps[i]);
             }
 
-            removeZeroWidthSpaces(displayName);
-            removeZeroWidthSpaces(desc);
             buildName.classList.remove('block');
             buildName.removeAttribute('style');
             buildDetails.classList.remove('block');
@@ -1871,10 +1869,8 @@ function updateBuildHistory(ajaxUrl,nBuild) {
         // Undo everything from the previous poll.
         resetCellOverflows();
 
-        // Insert zero-width spaces so as to allow text to wrap, allowing us to get the true clientWidth.
-        insertZeroWidthSpacesInElementText(displayName, 2);
+        // Mark the text as multiline, if it is so
         if (desc) {
-            insertZeroWidthSpacesInElementText(desc, 30);
             markMultiline();
         }
 
@@ -1886,13 +1882,6 @@ function updateBuildHistory(ajaxUrl,nBuild) {
         var controlsOverflowParams;
         if (buildControls) {
             controlsOverflowParams = getElementOverflowParams(buildControls);
-        }
-
-        if (nameOverflowParams.isOverflowed) {
-            // If the name is overflowed, lets remove the zero-width spaces we added above and
-            // re-add zero-width spaces with a bigger max word sizes.
-            removeZeroWidthSpaces(displayName);
-            insertZeroWidthSpacesInElementText(displayName, 20);
         }
 
         function fitToControlsHeight(element) {
@@ -2057,16 +2046,6 @@ function updateBuildHistory(ajaxUrl,nBuild) {
         var bh = $('buildHistory');
         var dataTable = getDataTable(bh);
         var rows = dataTable.rows;
-
-        // Insert zero-width spaces in text that may cause overflow distortions.
-        var displayNames = $(bh).getElementsBySelector('.display-name');
-        for (var i = 0; i < displayNames.length; i++) {
-            insertZeroWidthSpacesInElementText(displayNames[i], 2);
-        }
-        var descriptions = $(bh).getElementsBySelector('.desc');
-        for (var i = 0; i < descriptions.length; i++) {
-            insertZeroWidthSpacesInElementText(descriptions[i], 30);
-        }
 
         for (var i = 0; i < rows.length; i++) {
             var row = rows[i];
@@ -2329,85 +2308,6 @@ function getElementOverflowParams(element) {
         return  overflowParams;
     } finally {
         element.classList.remove('force-nowrap');
-    }
-}
-
-var zeroWidthSpace = String.fromCharCode(8203);
-var ELEMENT_NODE = 1;
-var TEXT_NODE = 3;
-function insertZeroWidthSpacesInText(textNode, maxWordSize) {
-    if (textNode.textContent.length < maxWordSize) {
-        return;
-    }
-
-    // capture the original text
-    textNode.preZWSText = textNode.textContent;
-
-    var words = textNode.textContent.split(/\s+/);
-    var newTextContent = '';
-
-    var splitRegex = new RegExp('.{1,' + maxWordSize + '}', 'g');
-    for (var i = 0; i < words.length; i++) {
-        var word = words[i];
-        var wordTokens = word.match(splitRegex);
-        if (wordTokens) {
-            for (var ii = 0; ii < wordTokens.length; ii++) {
-                if (newTextContent.length === 0) {
-                    newTextContent += wordTokens[ii];
-                } else {
-                    newTextContent += zeroWidthSpace + wordTokens[ii];
-                }
-            }
-        } else {
-            newTextContent += word;
-        }
-        newTextContent += ' ';
-    }
-
-    textNode.textContent = newTextContent;
-}
-function insertZeroWidthSpacesInElementText(element, maxWordSize) {
-    if (element.classList.contains('zws-inserted')) {
-        // already done.
-        return;
-    }
-    if (!element.hasChildNodes()) {
-        return;
-    }
-
-    var children = element.childNodes;
-    for (var i = 0; i < children.length; i++) {
-        var child = children[i];
-        if (child.nodeType === TEXT_NODE) {
-            insertZeroWidthSpacesInText(child, maxWordSize);
-        } else if (child.nodeType === ELEMENT_NODE) {
-            insertZeroWidthSpacesInElementText(child, maxWordSize);
-        }
-    }
-
-    element.classList.add('zws-inserted');
-}
-function removeZeroWidthSpaces(element) {
-    if (element) {
-        if (!element.classList.contains('zws-inserted')) {
-            // Doesn't have ZWSed text.
-            return;
-        }
-        if (!element.hasChildNodes()) {
-            return;
-        }
-
-        var children = element.childNodes;
-        for (var i = 0; i < children.length; i++) {
-            var child = children[i];
-            if (child.nodeType === TEXT_NODE && child.preZWSText) {
-                child.textContent = child.preZWSText;
-            } else if (child.nodeType === ELEMENT_NODE) {
-                removeZeroWidthSpaces(child);
-            }
-        }
-
-        element.classList.remove('zws-inserted');
     }
 }
 


### PR DESCRIPTION
as they cause obscure issues almost everywhere where they are used.
At the same time simplify the code substantially.
    
*Update*: thx to @hakubo for providing the target solution using `word-break: break-word;`.

## Proposed changelog entries

* [JENKINS-28022] - Make descriptions in the Build History widget copy-able without zero-width spaces