### PR TITLE
Commenting out part of FunctionsTest.printThrowable which fails in JDK 11.0.9+

### DIFF
--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -510,6 +510,7 @@ public class FunctionsTest {
                 s.println("Some custom exception");
             }
         }, "Some custom exception\n", "Some custom exception\n");
+        /* TODO exact format changed in 11.0.9 (JDK-8226809 / JDK-8252444)
         // Circular references:
         Stack stack1 = new Stack("p.Exc1", "p.C.method1:17");
         Stack stack2 = new Stack("p.Exc2", "p.C.method2:27");
@@ -526,6 +527,7 @@ public class FunctionsTest {
             "\tat p.C.method2(C.java:27)\n" +
             "Caused: p.Exc1\n" +
             "\tat p.C.method1(C.java:17)\n");
+        */
     }
     private static void assertPrintThrowable(Throwable t, String traditional, String custom) {
         StringWriter sw = new StringWriter();


### PR DESCRIPTION
Just began failing recently. Someone must have updated the version of Java 11 in our ACI images. Passes in JDK 8 or 11.0.8 but fails in 11.0.9 due to https://github.com/openjdk/jdk/commit/d96ed63fd080f52236e67ebcca80694c4f4449c9

```
org.junit.ComparisonFailure: 
expected:<....method2(C.java:27)
[Caused by: [CIRCULAR REFERENCE: ]p.Exc1]
> but was:<....method2(C.java:27)
[	[CIRCULAR REFERENCE:]p.Exc1]
>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at hudson.FunctionsTest.assertPrintThrowable(FunctionsTest.java:533)
	at hudson.FunctionsTest.printThrowable(FunctionsTest.java:518)
```

### Proposed changelog entries

* N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
