### PR TITLE
JENKINS-64049 Replace whitespaces in BUILD_TAG

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2458,7 +2458,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         EnvVars env = getParent().getCharacteristicEnvVars();
         env.put("BUILD_NUMBER",String.valueOf(number));
         env.put("BUILD_ID",getId());
-        env.put("BUILD_TAG","jenkins-"+getParent().getFullName().replace('/', '-')+"-"+number);
+        env.put("BUILD_TAG","jenkins-"+getParent().getFullName().replaceAll("[\\s/]", "-")+"-"+number);
         return env;
     }
 

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.EnvVars;
 import hudson.console.AnnotatedLargeText;
 import jenkins.model.Jenkins;
 import org.apache.commons.jelly.XMLOutput;
@@ -265,6 +266,22 @@ public class RunTest {
 
         assertTrue(r1.compareTo(r2) != 0);
         assertTrue(treeSet.size() == 2);
+    }
+
+    @Issue("JENKINS-64049")
+    @Test
+    public void getCharacteristicEnvVarsReturnsBuildTagWithoutSpaces() throws IOException{
+        final Jenkins group = Mockito.mock(Jenkins.class);
+        Mockito.when(group.getFullName()).thenReturn("group");
+        final Job job = Mockito.mock(Job.class);
+        Mockito.when(job.getParent()).thenReturn(group);
+        Mockito.when(job.getCharacteristicEnvVars()).thenReturn(new EnvVars());
+        Mockito.when(job.getFullName()).thenReturn("space separated name");
+        
+        Run run = new Run(job) {};
+        EnvVars env = run.getCharacteristicEnvVars();
+
+        assertFalse("BUILD_TAG should not contain spaces", env.get("BUILD_TAG").contains(" "));
     }
 
     @Test


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-64049](https://issues.jenkins-ci.org/browse/JENKINS-64049).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

Replaces whitespaces in `BUILD_TAG` with dashes to improve tag portability.
This change should make it easier to use the generated `BUILD_TAG` in other systems where whitespaces are not allowed.

### Proposed changelog entries

* JENKINS-64049: Replace whitespaces with dashes in generated `BUILD_TAG`.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers



<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
