### PR TITLE
Deprecating UnbufferedBase64InputStream

### DIFF
--- a/core/src/main/java/hudson/util/UnbufferedBase64InputStream.java
+++ b/core/src/main/java/hudson/util/UnbufferedBase64InputStream.java
@@ -15,7 +15,9 @@ import java.util.Base64;
  *
  * @author Kohsuke Kawaguchi
  * @since 1.349
+ * @deprecated Use {@link java.util.Base64.Decoder#wrap}.
  */
+@Deprecated
 public class UnbufferedBase64InputStream extends FilterInputStream {
     private byte[] encoded = new byte[4];
     private byte[] decoded;


### PR DESCRIPTION
Complementing #5038. Seems that #4636 orphaned this class, and that is good too because [JENKINS-61452](https://issues.jenkins-ci.org/browse/JENKINS-61452) may have been caused by #2958 or #4169.

### Proposed changelog entries

* Deprecate `UnbufferedBase64InputStream`.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
