### PR TITLE
Remove unused org.kohsuke.stapler:stapler-adjunct-zeroclipboard

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -361,11 +361,6 @@ THE SOFTWARE.
       </dependency>
       <dependency>
         <groupId>org.kohsuke.stapler</groupId>
-        <artifactId>stapler-adjunct-zeroclipboard</artifactId>
-        <version>1.3.5-1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kohsuke.stapler</groupId>
         <artifactId>stapler-adjunct-timeline</artifactId>
         <version>1.5</version>
       </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -155,10 +155,6 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
-      <artifactId>stapler-adjunct-zeroclipboard</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler-adjunct-timeline</artifactId>
     </dependency>
     <dependency>

--- a/core/src/main/resources/lib/layout/copyButton.jelly
+++ b/core/src/main/resources/lib/layout/copyButton.jelly
@@ -39,11 +39,6 @@ THE SOFTWARE.
       This is required as in some browsers, button doesn't properly provide feedback to user actions
       due to the nature of the hack needed to make copy work.
     </st:attribute>
-    <st:attribute name="container">
-      Specify the CSS selector (like ".foo") that points to the ancestor block element that has "positive:relative".
-      According to ZeroClipboard documentation, having such container would improve the accuracy of invisible flash
-      overlay.
-    </st:attribute>
     <st:attribute name="style">
       Additional CSS styles to apply.
     </st:attribute>
@@ -53,7 +48,7 @@ THE SOFTWARE.
   </st:documentation>
 
   <span class="copy-button ${attrs.clazz}" title="${attrs.tooltip}" text="${attrs.text}"
-    message="${attrs.message}" container="${attrs.container}" style="${attrs.style}">
+    message="${attrs.message}" style="${attrs.style}">
     <input type="button"/>
   </span>
   <st:adjunct includes="lib.layout.copyButton.copyButton"/>


### PR DESCRIPTION
Cleans up a dep made obsolete in #3780. `zeroclipboard` is a flash implementation of the Copy-to-Clipboard control

### Proposed changelog entries

* Removing the deprecated `zeroclipboard` UI component and the unused dependency on ZeroClipboard

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
