### PR TITLE
Cherry pick JDK 11.0.9 / 8.0.272+ compatible FunctionsTest#printThrowable() to stable-2.249

### DIFF
--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -40,6 +40,8 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import static org.junit.Assert.assertEquals;
@@ -515,17 +517,40 @@ public class FunctionsTest {
         Stack stack2 = new Stack("p.Exc2", "p.C.method2:27");
         stack1.cause(stack2);
         stack2.cause(stack1);
-        assertPrintThrowable(stack1,
-            "p.Exc1\n" +
-            "\tat p.C.method1(C.java:17)\n" +
-            "Caused by: p.Exc2\n" +
-            "\tat p.C.method2(C.java:27)\n" +
-            "\t[CIRCULAR REFERENCE:p.Exc1]\n",
-            "<cycle to p.Exc1>\n" +
-            "Caused: p.Exc2\n" +
-            "\tat p.C.method2(C.java:27)\n" +
-            "Caused: p.Exc1\n" +
-            "\tat p.C.method1(C.java:17)\n");
+        //Format changed in 11.0.9 / 8.0.272 (JDK-8226809 / JDK-8252444 / JDK-8252489)
+        if ((getVersion().getDigitAt(0) == 11 && getVersion().isNewerThanOrEqualTo(new VersionNumber("11.0.9"))) ||
+                (getVersion().getDigitAt(0) == 8 && getVersion().isNewerThanOrEqualTo(new VersionNumber("8.0.272")))) {
+            assertPrintThrowable(stack1,
+                    "p.Exc1\n" +
+                            "\tat p.C.method1(C.java:17)\n" +
+                            "Caused by: p.Exc2\n" +
+                            "\tat p.C.method2(C.java:27)\n" +
+                            "Caused by: [CIRCULAR REFERENCE: p.Exc1]\n",
+                    "<cycle to p.Exc1>\n" +
+                            "Caused: p.Exc2\n" +
+                            "\tat p.C.method2(C.java:27)\n" +
+                            "Caused: p.Exc1\n" +
+                            "\tat p.C.method1(C.java:17)\n");
+        } else {
+            assertPrintThrowable(stack1,
+                    "p.Exc1\n" +
+                            "\tat p.C.method1(C.java:17)\n" +
+                            "Caused by: p.Exc2\n" +
+                            "\tat p.C.method2(C.java:27)\n" +
+                            "\t[CIRCULAR REFERENCE:p.Exc1]\n",
+                    "<cycle to p.Exc1>\n" +
+                            "Caused: p.Exc2\n" +
+                            "\tat p.C.method2(C.java:27)\n" +
+                            "Caused: p.Exc1\n" +
+                            "\tat p.C.method1(C.java:17)\n");
+        }
+    }
+    private static VersionNumber getVersion() {
+        String version = System.getProperty("java.version");
+        if(version.startsWith("1.")) {
+            version = version.substring(2).replace("_", ".");
+        }
+        return new VersionNumber(version);
     }
     private static void assertPrintThrowable(Throwable t, String traditional, String custom) {
         StringWriter sw = new StringWriter();


### PR DESCRIPTION
## Cherry pick JDK 11.0.9 / 8.0.272+ printThrowable() to stable-2.249

* JDK 11.0.9 / 8.0.272+ FunctionsTest#printThrowable()

* Ensure proper older java 11 backwards compatibility

(cherry picked from commit e83e6a11dce552d8ea17b272d0fdb418792c215f)


### Proposed changelog entries

* No changelog entry - no user visible change

### Proposed upgrade guidelines

* No upgrade guidelines - no user visible change

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/code-reviewers need an accelerated review so that the 2.249.3 LTS build can run.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).