### PR TITLE
UpdateCenter2Test.installInvalidChecksum timed out

### DIFF
--- a/test/src/test/java/hudson/model/UpdateCenter2Test.java
+++ b/test/src/test/java/hudson/model/UpdateCenter2Test.java
@@ -64,6 +64,7 @@ public class UpdateCenter2Test {
         assertEquals(Messages.UpdateCenter_n_a(), j.jenkins.getUpdateCenter().getLastUpdatedString());
     }
 
+    @Ignore("TODO times out when UC is down with SocketTimeoutException")
     @Issue("SECURITY-234")
     @Test public void installInvalidChecksum() throws Exception {
         UpdateSite.neverUpdate = false;


### PR DESCRIPTION
Seems to pass now, but a few days ago this test was timing out on unrelated PRs, for example in https://github.com/jenkinsci/jenkins/pull/5048/checks?check_run_id=1397643103. Suppressing until it can be rewritten to run against a mock UC. Follows up #4916.

### Proposed changelog entries

* N/A, internal

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
