### PR TITLE
Remove unneeded and falsy String.trim polyfill

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2775,20 +2775,6 @@ var toggleCheckboxes = function(toggle) {
     }
 };
 
-// this used to be in prototype.js but it must have been removed somewhere between 1.4.0 to 1.5.1
-String.prototype.trim = function() {
-    var temp = this;
-    var obj = /^(\s*)([\W\w]*)(\b\s*$)/;
-    if (obj.test(temp))
-        temp = temp.replace(obj, '$2');
-    obj = /  /g;
-    while (temp.match(obj))
-        temp = temp.replace(obj, " ");
-    return temp;
-}
-
-
-
 var hoverNotification = (function() {
     var msgBox;
     var body;


### PR DESCRIPTION
1. [it is not required anymore since ages](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Browser_compatibility)
2. If "this" is of type type "object", an instance of the same type is returned. [This is completely wrong, because it should be "string"](https://tc39.es/ecma262/#sec-string.prototype.trim), which causes things like [sorting in BootstrapVue tables to break](https://github.com/jenkinsci/dependency-track-plugin/blob/cc5f1bb8900f201384f05b633471dbd7ca48c69a/src/main/webapp/js/result-action.js#L6).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
