### PR TITLE
Updated the bundled XStream library from 1.4.13 to 1.4.14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "com.thoughtworks.xstream:xstream"

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -334,7 +334,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.13</version>
+        <version>1.4.14</version>
       </dependency>
       <dependency>
         <groupId>net.sf.kxml</groupId>


### PR DESCRIPTION
Amends #4944 with the [recently released 1.4.14](https://x-stream.github.io/changes.html). The upstream is a security fix which due to JEP-200 should not make any difference to Jenkins, but we may as well bump the version and settle the minds of people running scanners.

Full diff: https://github.com/x-stream/xstream/compare/XSTREAM_1_4_13...XSTREAM_1_4_14

### Proposed changelog entries

* Updated the bundled XStream library from 1.4.13 to 1.4.14.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
