### PR TITLE
JENKINS-64403 Declare the page variable "divBasedFormLayout" globally, not only inside forms

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -302,7 +302,7 @@ public class Functions {
          */
         context.setVariable("resURL",rootURL+getResourcePath());
         context.setVariable("imagesURL",rootURL+getResourcePath()+"/images");
-
+        context.setVariable("divBasedFormLayout", true);
         context.setVariable("userAgent", currentRequest.getHeader("User-Agent"));
         IconSet.initPageVariables(context);
     }

--- a/core/src/main/resources/lib/form/form.jelly
+++ b/core/src/main/resources/lib/form/form.jelly
@@ -53,7 +53,6 @@ THE SOFTWARE.
       Default: false
     </st:attribute>
   </st:documentation>
-  <j:set var="divBasedFormLayout" value="true" />
   <form action="${action}" method="${method}" enctype="${attrs.enctype}" name="${name}" target="${attrs.target}" autocomplete="${attrs.autocomplete==true?'on':'off'}">
     <div width="100%" class="${attrs.tableClass}">
       <d:invokeBody/>


### PR DESCRIPTION
No jira created for this.
Related to [JENKINS-62437](https://issues.jenkins-ci.org/browse/JENKINS-62437).

In some cases the variable `divBasedFormLayout` is not set, because it is only set inside `f:forms`, but not inside standard HTML `form` (which are a lot in jenkins-core and plugins), or `l:ajax`, as some examples.

The goal of this variable is to help developers to make the plugins compatible with the div layout for forms, and despite `form` and `l:ajax` are compatible with the divs layout for forms, the variable is not working on those cases.

In this PR the variable is configured as a global, so it is always set.

### Proposed changelog entries

* Entry 1: The page variable `divBasedFormLayout` is globally available, not only within `<f:form>`

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@fqueiruga @timja @daniel-beck @jsoref @oleg-nenashev 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
