### PR TITLE
Mark some more administrative monitors as security-related

### DIFF
--- a/core/src/main/java/jenkins/security/QueueItemAuthenticatorMonitor.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticatorMonitor.java
@@ -66,6 +66,11 @@ public class QueueItemAuthenticatorMonitor extends AdministrativeMonitor {
         return !isQueueItemAuthenticatorPresent() || !isQueueItemAuthenticatorConfigured() || isAnyBuildLaunchedAsSystemWithAuthenticatorPresent();
     }
 
+    @Override
+    public boolean isSecurity() {
+        return true;
+    }
+
     @RequirePOST
     public HttpResponse doAct(@QueryParameter String redirect, @QueryParameter String dismiss, @QueryParameter String reset) throws IOException {
         if (redirect != null) {

--- a/core/src/main/java/jenkins/security/RekeySecretAdminMonitor.java
+++ b/core/src/main/java/jenkins/security/RekeySecretAdminMonitor.java
@@ -86,6 +86,11 @@ public class RekeySecretAdminMonitor extends AsynchronousAdministrativeMonitor {
         return scanOnBoot.isOn();
     }
 
+    @Override
+    public boolean isSecurity() {
+        return true;
+    }
+
     @RequirePOST
     public HttpResponse doScan(StaplerRequest req) throws IOException, GeneralSecurityException {
         if(req.hasParameter("background")) {

--- a/core/src/main/java/jenkins/security/s2m/AdminCallableMonitor.java
+++ b/core/src/main/java/jenkins/security/s2m/AdminCallableMonitor.java
@@ -34,6 +34,11 @@ public class AdminCallableMonitor extends AdministrativeMonitor {
     }
 
     @Override
+    public boolean isSecurity() {
+        return true;
+    }
+
+    @Override
     public boolean isActivated() {
         return !rule.rejected.describe().isEmpty();
     }


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/5078 made it apparent that some monitors that are security-related weren't categorized as such.

### Proposed changelog entries

(too minor)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
