### PR TITLE
Fix broken select.js widget with tabular markup

### DIFF
--- a/core/src/main/resources/lib/form/select/select.js
+++ b/core/src/main/resources/lib/form/select/select.js
@@ -6,15 +6,31 @@ function updateListBox(listBox,url,config) {
     var originalOnSuccess = config.onSuccess;
     var l = $(listBox);
 
-    var settingMain = listBox.closest('.setting-main')
-    if (!settingMain) {
-        console.warn("Couldn't find the expected parent element (.setting-main) for element", listBox)
-        return;
+    // Hacky function to retrofit compatibility with tables-to-divs
+    // If the <select> tag parent is a <td> element we can consider it's following a
+    // form entry using tables-to-divs markup.
+    function getStatusElement() {
+        function getStatusForTabularForms() {
+            return findFollowingTR(listBox, "validation-error-area").firstChild.nextSibling;
+        }
+        function getStatusForDivBasedForms() {
+            var settingMain = listBox.closest('.setting-main')
+            if (!settingMain) {
+                console.warn("Couldn't find the expected parent element (.setting-main) for element", listBox)
+                return;
+            }
+
+            return settingMain.nextElementSibling;
+        }
+
+        return listBox.parentNode.tagName === 'TD'
+            ? getStatusForTabularForms()
+            : getStatusForDivBasedForms();
     }
 
-    var status = settingMain.nextElementSibling;
+    var status = getStatusElement();
     if (!status) {
-        console.warn("Couldn't find the expected status element", settingMain)
+        console.warn("Couldn't find the expected status element")
         return;
     }
     if (status.firstChild && status.firstChild.getAttribute('data-select-ajax-error')) {


### PR DESCRIPTION
See [JENKINS-64071](https://issues.jenkins-ci.org/browse/JENKINS-64071) and [JENKINS-64125](https://issues.jenkins-ci.org/browse/JENKINS-64125).

- The JS changes introduced in 2.244 caused several plugins that pre-populated select tags to stop working.
- This was due to failing to locate a `.validation-error-area` node.
- The solution is to introduce a fallback to handle this edge case.

I think this is an LTS-candidate, as it is a regression that should be backported IMO.


### Proposed changelog entries

* Entry 1: JENKINS-64071 Fixed issue where select fields would not be populated with default values.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 
@joseblas 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
