### PR TITLE
Show item categories in 'New Item' dialog

### DIFF
--- a/core/src/main/resources/hudson/model/View/newJob.jelly
+++ b/core/src/main/resources/hudson/model/View/newJob.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
               </div>
             </div>
 
-            <div id="items" class="categories flat" role="radiogroup" aria-labelledby="Items" data-valid="false" />
+            <div id="items" class="categories" role="radiogroup" aria-labelledby="Items" data-valid="false" />
 
             <j:if test="${!empty(app.itemMap)}">
               <div class="item-copy">


### PR DESCRIPTION
This was one of the features added to the Jenkins 2.0 "New Item" dialog. Manuel removed it by default because categories weren't defined (https://github.com/jenkinsci/jenkins/pull/2191#issuecomment-203378702), and later everyone seems to have forgotten about this.

Now that we're discussing Jenkins 3.0 is probably a good time to actually make this feature visible 🤣

Most of the commonly installed job types all support item categories (and those that don't haven't bothered with icons either):

> <img width="1155" alt="Screenshot 2020-11-27 at 21 39 17" src="https://user-images.githubusercontent.com/1831569/100483397-1b6c3b80-30f9-11eb-8bc9-a6ad35b19ca5.png">

### Proposed changelog entries

* Group job types by category on "New Item" dialog.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
