### PR TITLE
Fix typo in automate publish release artifacts

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -182,7 +182,7 @@ jobs:
           # we need opensuse to the file 
           OUTPUT_FILE_NAME=jenkins-${PROJECT_VERSION}-1.2-opensuse.noarch.rpm
           IS_LTS=${{ needs.determine-version.outputs.is-lts }}
-          echo "::set-output name=file-name::$FILE_NAME"
+          echo "::set-output name=file-name::$OUTPUT_FILE_NAME"
 
           REPO=opensuse
           if [ ${IS_LTS} = 'true' ]


### PR DESCRIPTION
I addressed some minor review comments and didn't re-test after which caused the opensuse RPM to fail: https://github.com/jenkinsci/jenkins/pull/5088