### PR TITLE
[JENKINS-41729] update to new localizer plugin version

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -227,7 +227,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jvnet.localizer</groupId>
         <artifactId>localizer</artifactId>
-        <version>1.26</version>
+        <version>1.28</version>
       </dependency>
       <dependency>
         <groupId>antlr</groupId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -68,7 +68,6 @@
     <dependency>
       <groupId>org.jvnet.localizer</groupId>
       <artifactId>localizer</artifactId>
-      <version>1.26</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -154,7 +153,7 @@
       </plugin>
       <plugin>
         <groupId>org.jvnet.localizer</groupId>
-        <artifactId>maven-localizer-plugin</artifactId>
+        <artifactId>localizer-maven-plugin</artifactId>
         <!-- version specified in grandparent pom -->
         <executions>
           <execution>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -668,7 +668,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <groupId>org.jvnet.localizer</groupId>
-        <artifactId>maven-localizer-plugin</artifactId>
+        <artifactId>localizer-maven-plugin</artifactId>
         <!-- version specified in grandparent pom -->
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.61-20201201.120825-2</version>
+    <version>1.61</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.58</version>
+    <version>1.61-20201201.120825-2</version>
     <relativePath />
   </parent>
 
@@ -345,7 +345,7 @@ THE SOFTWARE.
         </plugin>
         <plugin>
           <groupId>org.jvnet.localizer</groupId>
-          <artifactId>maven-localizer-plugin</artifactId>
+          <artifactId>localizer-maven-plugin</artifactId>
           <configuration>
             <outputEncoding>UTF-8</outputEncoding>
           </configuration>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/pom/pull/150

which is in turn downstream of
>  updates the localizer plugin to 1.28 (adds threadsagety support for parallel builds, and messages from XML) kohsuke/localizer@localizer-parent-1.26...localizer-parent-1.28

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->

*NOTE*: this also pick up a change in localizer to allow definition of messages in XML files as well as properties, bit *I* have not tested that and there is discussion in the Jira if we actually would want that.  I leave that to others to decide if we want to mention it in the release notes.  The main change required here was that localizer was not thread safe and thus threaded maven builds (`-T`) could (in theory but not observed) produce corrupted output at worst and a best produced an annoying warning at build time

[JENKINS-41729](https://issues.jenkins.io/browse/JENKINS-41729)


<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Developer: update localizer plugin to allow threaded builds and localization from XML as well as properties

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
