### PR TITLE
[JENKINS-53720] is fixed already with spotbugs version update

### DIFF
--- a/src/findbugs/findbugs-excludes.xml
+++ b/src/findbugs/findbugs-excludes.xml
@@ -8,9 +8,6 @@
       <Bug pattern="MS_SHOULD_BE_FINAL"/>
       <!-- TODO: It's a real issue, but the code is flooded by it right now-->
       <Bug pattern="DM_DEFAULT_ENCODING"/>
-      <!-- TODO: Remove once we migrate to SpotBugs with full Java support (JENKINS-53720)-->
-      <!-- This check works unreliably on JDK 11 which tries doing some code generation for annotated fields-->
-      <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
     </Or>
   </Match>
   <Match>


### PR DESCRIPTION
The java 11 and spotbugs related bug was already fixed with a recent spotbugs update. It was actually fixed with https://github.com/spotbugs/spotbugs/pull/1248
See [JENKINS-53720](https://issues.jenkins-ci.org/browse/JENKINS-53720).

### Proposed changelog entries

* Internal: Removed rule from spotbugs exclude file, because issue was fixed within SpotBugs

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
