### PR TITLE
JENKINS-64373 Add additional help locator fallback

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -753,7 +753,8 @@ function labelAttachPreviousOnClick() {
 
 function helpButtonOnClick() {
     var tr = findFollowingTR(this, "help-area", "help-sibling") ||
-             findFollowingTR(this, "help-area", "setting-help");
+             findFollowingTR(this, "help-area", "setting-help") ||
+            findFollowingTR(this, "help-area");
     var div = $(tr).down();
     if (!div.hasClassName("help"))
         div = div.next().down();

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -754,7 +754,7 @@ function labelAttachPreviousOnClick() {
 function helpButtonOnClick() {
     var tr = findFollowingTR(this, "help-area", "help-sibling") ||
              findFollowingTR(this, "help-area", "setting-help") ||
-            findFollowingTR(this, "help-area");
+             findFollowingTR(this, "help-area");
     var div = $(tr).down();
     if (!div.hasClassName("help"))
         div = div.next().down();


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-64373](https://issues.jenkins-ci.org/browse/JENKINS-64373).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

Fixes:
![image](https://user-images.githubusercontent.com/21194782/101276543-97bfe800-37a5-11eb-9ac7-e8eacd430d78.png)

When clicking the first help icon in a trait from github-branch-source

![image](https://user-images.githubusercontent.com/21194782/101276551-ad351200-37a5-11eb-9107-daac65e6e38c.png)

After this change it correctly expands:

![image](https://user-images.githubusercontent.com/21194782/101276556-bfaf4b80-37a5-11eb-9f9c-2ec020d56e0b.png)

The next tr doesn't have either of the additional locator's that are required for the current code to work:

![image](https://user-images.githubusercontent.com/21194782/101276586-de154700-37a5-11eb-9522-e1e357ff159e.png)

Going back to before tables to divs it was only the one class required.

Not sure if @jsoref or @fqueiruga can remember why it was changed but having this as the last fallback doesn't seem to cause any issues, and fixes at least this bug.

Another alternative would be tracking down what is creating that help icon and adding the class

### Proposed changelog entries

* Entry 1: JENKINS-64373, Help text now expands in behaviours for GitHub organization folders
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
