### PR TITLE
Replaced deprecated Exception.none with assertThrows

### DIFF
--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -34,7 +34,6 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 
@@ -64,8 +63,6 @@ import static org.junit.Assert.fail;
 public class UtilTest {
 
     @Rule public TemporaryFolder tmp = new TemporaryFolder();
-
-    @Rule public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testReplaceMacro() {
@@ -502,8 +499,8 @@ public class UtilTest {
 
         assertEquals("Non-permission bits should be ignored", PosixFilePermissions.fromString("r-xr-----"), Util.modeToPermissions(0100540));
 
-        expectedException.expectMessage(startsWith("Invalid mode"));
-        Util.modeToPermissions(01777);
+        Exception e = Assert.assertThrows(Exception.class, () -> Util.modeToPermissions(01777));
+        assertThat(e.getMessage(), startsWith("Invalid mode"));
     }
 
     @Test
@@ -522,30 +519,30 @@ public class UtilTest {
 
     @Test
     public void testDifferenceDays() throws Exception {
-        Date may_6_10am = parseDate("2018-05-06 10:00:00"); 
-        Date may_6_11pm55 = parseDate("2018-05-06 23:55:00"); 
-        Date may_7_01am = parseDate("2018-05-07 01:00:00"); 
-        Date may_7_11pm = parseDate("2018-05-07 11:00:00"); 
-        Date may_8_08am = parseDate("2018-05-08 08:00:00"); 
-        Date june_3_08am = parseDate("2018-06-03 08:00:00"); 
-        Date june_9_08am = parseDate("2018-06-09 08:00:00"); 
-        Date june_9_08am_nextYear = parseDate("2019-06-09 08:00:00"); 
-        
+        Date may_6_10am = parseDate("2018-05-06 10:00:00");
+        Date may_6_11pm55 = parseDate("2018-05-06 23:55:00");
+        Date may_7_01am = parseDate("2018-05-07 01:00:00");
+        Date may_7_11pm = parseDate("2018-05-07 11:00:00");
+        Date may_8_08am = parseDate("2018-05-08 08:00:00");
+        Date june_3_08am = parseDate("2018-06-03 08:00:00");
+        Date june_9_08am = parseDate("2018-06-09 08:00:00");
+        Date june_9_08am_nextYear = parseDate("2019-06-09 08:00:00");
+
         assertEquals(0, Util.daysBetween(may_6_10am, may_6_11pm55));
         assertEquals(1, Util.daysBetween(may_6_10am, may_7_01am));
         assertEquals(1, Util.daysBetween(may_6_11pm55, may_7_01am));
         assertEquals(2, Util.daysBetween(may_6_10am, may_8_08am));
         assertEquals(1, Util.daysBetween(may_7_11pm, may_8_08am));
-        
+
         // larger scale
         assertEquals(28, Util.daysBetween(may_6_10am, june_3_08am));
         assertEquals(34, Util.daysBetween(may_6_10am, june_9_08am));
         assertEquals(365 + 34, Util.daysBetween(may_6_10am, june_9_08am_nextYear));
-        
+
         // reverse order
         assertEquals(-1, Util.daysBetween(may_8_08am, may_7_11pm));
     }
-    
+
     private Date parseDate(String dateString) throws ParseException {
         return new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").parse(dateString);
     }

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -27,7 +27,6 @@ package jenkins.util.io;
 import hudson.Functions;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
 import org.jvnet.hudson.test.Issue;
@@ -60,6 +59,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -69,7 +69,6 @@ import static org.mockito.Mockito.mock;
 public class PathRemoverTest {
 
     @Rule public TemporaryFolder tmp = new TemporaryFolder();
-    @Rule public ExpectedException expectedException = ExpectedException.none();
     @Rule public Timeout timeout = new Timeout(10, TimeUnit.SECONDS);
     @Rule public FileLockerRule locker = new FileLockerRule();
 
@@ -232,11 +231,8 @@ public class PathRemoverTest {
         touchWithFileName(f1, d1f1, d2f2);
         locker.acquireLock(d1f1);
         PathRemover remover = PathRemover.newRemoverWithStrategy(retriesAttempted -> retriesAttempted < 1);
-        expectedException.expectMessage(allOf(
-                containsString(dir.getPath()),
-                containsString("Tried 1 time.")
-        ));
-        remover.forceRemoveDirectoryContents(dir.toPath());
+        Exception e = assertThrows(IOException.class, () -> remover.forceRemoveDirectoryContents(dir.toPath()));
+        assertThat(e.getMessage(), allOf(containsString(dir.getPath()), containsString("Tried 1 time.")));
         assertFalse(d2.exists());
         assertFalse(f1.exists());
         assertFalse(d2f2.exists());
@@ -273,8 +269,8 @@ public class PathRemoverTest {
 
         locker.acquireLock(d1f1);
         PathRemover remover = PathRemover.newSimpleRemover();
-        expectedException.expectMessage(containsString(dir.getPath()));
-        remover.forceRemoveRecursive(dir.toPath());
+        Exception e = assertThrows(IOException.class, () -> remover.forceRemoveRecursive(dir.toPath()));
+        assertThat(e.getMessage(), containsString(dir.getPath()));
         assertTrue(dir.exists());
         assertTrue(d1.exists());
         assertTrue(d1f1.exists());

--- a/test/src/test/java/hudson/security/ACLTest.java
+++ b/test/src/test/java/hudson/security/ACLTest.java
@@ -34,12 +34,12 @@ import hudson.model.User;
 import java.util.Collection;
 import java.util.Collections;
 import jenkins.model.Jenkins;
+import org.junit.Assert;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
@@ -53,9 +53,6 @@ public class ACLTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Issue("JENKINS-20474")
     @Test
@@ -94,10 +91,10 @@ public class ACLTest {
 
         final User manager = User.getOrCreateByIdOrFullName("manager");
 
-        expectedException.expectMessage("manager is missing the Overall/Administer permission");
-        expectedException.expect(AccessDeniedException.class);
         try (ACLContext ignored = ACL.as2(manager.impersonate2())) {
-            jenkins.getACL().checkAnyPermission(Jenkins.ADMINISTER);
+            Exception e = Assert.assertThrows(AccessDeniedException.class,
+                    () -> jenkins.getACL().checkAnyPermission(Jenkins.ADMINISTER));
+            Assert.assertEquals("manager is missing the Overall/Administer permission", e.getMessage());
         }
     }
 
@@ -111,10 +108,10 @@ public class ACLTest {
 
         final User manager = User.getOrCreateByIdOrFullName("manager");
 
-        expectedException.expectMessage("manager is missing a permission, one of Overall/Administer, Overall/Read is required");
-        expectedException.expect(AccessDeniedException.class);
         try (ACLContext ignored = ACL.as2(manager.impersonate2())) {
-            jenkins.getACL().checkAnyPermission(Jenkins.ADMINISTER, Jenkins.READ);
+            Exception e = Assert.assertThrows(AccessDeniedException.class,
+                    () -> jenkins.getACL().checkAnyPermission(Jenkins.ADMINISTER, Jenkins.READ));
+            Assert.assertEquals("manager is missing a permission, one of Overall/Administer, Overall/Read is required", e.getMessage());
         }
     }
 
@@ -129,10 +126,10 @@ public class ACLTest {
 
         final User manager = User.getOrCreateByIdOrFullName("manager");
 
-        expectedException.expectMessage("manager is missing the Overall/Administer permission");
-        expectedException.expect(AccessDeniedException.class);
         try (ACLContext ignored = ACL.as2(manager.impersonate2())) {
-            jenkins.getACL().checkAnyPermission(Jenkins.MANAGE, Jenkins.SYSTEM_READ);
+            Exception e = Assert.assertThrows(AccessDeniedException.class,
+                    () -> jenkins.getACL().checkAnyPermission(Jenkins.MANAGE, Jenkins.SYSTEM_READ));
+            Assert.assertEquals("manager is missing the Overall/Administer permission", e.getMessage());
         }
     }
 
@@ -147,30 +144,26 @@ public class ACLTest {
 
         final User manager = User.getOrCreateByIdOrFullName("manager");
 
-        expectedException.expectMessage("manager is missing a permission, one of Job/WipeOut, Run/Artifacts is required");
-        expectedException.expect(AccessDeniedException.class);
         try (ACLContext ignored = ACL.as2(manager.impersonate2())) {
-            jenkins.getACL().checkAnyPermission(Item.WIPEOUT, Build.ARTIFACTS);
+            Exception e = Assert.assertThrows(AccessDeniedException.class,
+                    () -> jenkins.getACL().checkAnyPermission(Item.WIPEOUT, Build.ARTIFACTS));
+            Assert.assertEquals("manager is missing a permission, one of Job/WipeOut, Run/Artifacts is required", e.getMessage());
         }
     }
 
     @Test
     public void hasAnyPermissionThrowsIfNoPermissionProvided() {
-        expectedException.expect(IllegalArgumentException.class);
-        r.jenkins.getACL().hasAnyPermission();
+        Assert.assertThrows(IllegalArgumentException.class, () -> r.jenkins.getACL().hasAnyPermission());
     }
 
     @Test
     public void checkAnyPermissionThrowsIfNoPermissionProvided() {
-        expectedException.expect(IllegalArgumentException.class);
-        r.jenkins.getACL().checkAnyPermission();
+        Assert.assertThrows(IllegalArgumentException.class, () -> r.jenkins.getACL().checkAnyPermission());
     }
 
     @Test
     @Issue("JENKINS-61465")
     public void checkAnyPermissionOnNonAccessControlled() throws Exception {
-        expectedException = ExpectedException.none();
-
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                 .grant(Jenkins.READ).everywhere().toEveryone());
@@ -191,6 +184,7 @@ public class ACLTest {
 
     private static class DoNotBotherMe extends AuthorizationStrategy {
 
+        @NonNull
         @Override
         public ACL getRootACL() {
             return new ACL() {


### PR DESCRIPTION
Replaced deprecated `Exception.none` with `assertThrows`

### Proposed changelog entries

* Internal: N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
