### PR TITLE
[JENKINS-64390] make FieldUtils behave as it used to

### DIFF
--- a/core/src/test/java/org/acegisecurity/util/FieldUtilsTest.java
+++ b/core/src/test/java/org/acegisecurity/util/FieldUtilsTest.java
@@ -6,7 +6,8 @@ import org.jvnet.hudson.test.Issue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class FieldUtilsTest {
+@SuppressWarnings("deprecation")
+public class FieldUtilsTest {
 
     @Issue("JENKINS-64390")
     @Test

--- a/core/src/test/java/org/acegisecurity/util/FieldUtilsTest.java
+++ b/core/src/test/java/org/acegisecurity/util/FieldUtilsTest.java
@@ -1,0 +1,59 @@
+package org.acegisecurity.util;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FieldUtilsTest {
+
+    @Issue("JENKINS-64390")
+    @Test
+    public void setProtectedFieldValue_Should_fail_silently_to_set_public_final_fields_in_InnerClass() throws Exception {
+        InnerClassWithPublicFinalField sut = new InnerClassWithPublicFinalField();
+        FieldUtils.setProtectedFieldValue("myField", sut, "test");
+        assertEquals(sut.getMyField(), "original");
+    }
+
+    @Test
+    @Issue("JENKINS-64390")
+    public void setProtectedFieldValue_Should_fail_silently_to_set_public_final_fields_in_OuterClass() throws Exception {
+        OuterClassWithPublicFinalField sut = new OuterClassWithPublicFinalField();
+        FieldUtils.setProtectedFieldValue("myField", sut, "test");
+        assertEquals(sut.getMyField(), "original");
+    }
+
+    @Test
+    public void setProtectedFieldValue_Should_Succeed() throws Exception {
+        InnerClassWithProtectedField sut = new InnerClassWithProtectedField();
+        FieldUtils.setProtectedFieldValue("myProtectedField", sut, "test");
+        assertEquals(sut.getMyNonFinalField(), "test");
+    }
+
+    @Test
+    public void setNonExistingField_Should_Fail() throws Exception {
+        InnerClassWithProtectedField sut = new InnerClassWithProtectedField();
+        assertThrows(Exception.class, () -> FieldUtils.setProtectedFieldValue("bogus", sut, "whatever"));
+    }
+
+    class InnerClassWithPublicFinalField {
+
+        public final String myField = "original";
+
+        public String getMyField() {
+            return myField;
+        }
+        
+    }
+
+    public class InnerClassWithProtectedField {
+
+        protected String myProtectedField = "original";
+
+        public String getMyNonFinalField() {
+            return myProtectedField;
+        }
+    }
+
+}

--- a/core/src/test/java/org/acegisecurity/util/OuterClassWithPublicFinalField.java
+++ b/core/src/test/java/org/acegisecurity/util/OuterClassWithPublicFinalField.java
@@ -1,0 +1,10 @@
+package org.acegisecurity.util;
+
+public class OuterClassWithPublicFinalField {
+
+    public final String myField = "original";
+
+    public String getMyField() {
+        return myField;
+    }
+}


### PR DESCRIPTION
acegi FieldUtils used to silently fail when you tried to set a field that was both `public` and `final`

Whilst it seems silly to do that (the code was obviously a no-op) I observed a breakage in a plugin (test code) that was doing exactly that.  seems like there is a possibility that some production code may exist that also was doing this that would now be broken, so make the code also silently fail for that case.

See [JENKINS-64390](https://issues.jenkins-ci.org/browse/JENKINS-64390).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* `FieldUtils` now silently fails to set `public final` fields again.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jglick

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
