### PR TITLE
Remove traces from jquery-detached from core

### DIFF
--- a/test/src/test/java/jenkins/model/AssetManagerTest.java
+++ b/test/src/test/java/jenkins/model/AssetManagerTest.java
@@ -49,7 +49,6 @@ public class AssetManagerTest {
 
     @Test
     public void handlebarsLoad() throws Exception {
-        // webclient does not work because it tries to parse the jquery2.js and there is a missing comma
         URL url = new URL(j.getURL() + "assets/handlebars/jsmodules/handlebars3.js");
         HttpURLConnection httpCon = (HttpURLConnection) url.openConnection();
         assertEquals(HttpURLConnection.HTTP_OK, httpCon.getResponseCode());

--- a/test/src/test/java/jenkins/model/AssetManagerTest.java
+++ b/test/src/test/java/jenkins/model/AssetManagerTest.java
@@ -48,10 +48,9 @@ public class AssetManagerTest {
     }
 
     @Test
-    @Issue("JENKINS-9598")
-    public void jqueryLoad() throws Exception {
+    public void handlebarsLoad() throws Exception {
         // webclient does not work because it tries to parse the jquery2.js and there is a missing comma
-        URL url = new URL(j.getURL() + "assets/jquery-detached/jsmodules/jquery2.js");
+        URL url = new URL(j.getURL() + "assets/handlebars/jsmodules/handlebars3.js");
         HttpURLConnection httpCon = (HttpURLConnection) url.openConnection();
         assertEquals(HttpURLConnection.HTTP_OK, httpCon.getResponseCode());
     }

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -140,24 +140,6 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
-      <artifactId>jquery-detached</artifactId>
-      <version>1.2.1</version>
-      <classifier>core-assets</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.ui</groupId>
-      <artifactId>bootstrap</artifactId>
-      <version>1.3.2</version>
-      <classifier>core-assets</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci.ui</groupId>
-          <artifactId>jquery-detached</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>handlebars</artifactId>
       <version>1.1.1</version>
       <classifier>core-assets</classifier>


### PR DESCRIPTION
Follow up cleanup to https://github.com/jenkinsci/jenkins/pull/4929

This PR removes some dependencies that cause a _WEB-INF/lib/jquery-detached-1.2.1-core-assets.jar_ to be included on the a compiled Jenkins _war_. 

No issues when manually testing so far.

### Proposed changelog entries

* Remove unused jquery dependencies.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 
@oleg-nenashev 
@Wadeck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
