### PR TITLE
[JENKINS-64445] - Fix null safety for plugin categories

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1363,8 +1363,8 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     return StringUtils.containsIgnoreCase(plugin.name, query) ||
                         StringUtils.containsIgnoreCase(plugin.title, query) ||
                         StringUtils.containsIgnoreCase(plugin.excerpt, query) ||
-                        Arrays.asList(plugin.categories).contains(query) ||
-                        Arrays.stream(plugin.categories)
+                        plugin.hasCategory(query) ||
+                        plugin.getCategoriesStream()
                             .map(UpdateCenter::getCategoryDisplayName)
                             .anyMatch(category -> StringUtils.containsIgnoreCase(category, query)) ||
                         plugin.hasWarnings() && query.equalsIgnoreCase("warning:");
@@ -1396,7 +1396,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     jsonObject.put("title", plugin.title);
                     jsonObject.put("displayName", plugin.getDisplayName());
                     jsonObject.put("wiki", plugin.wiki);
-                    jsonObject.put("categories", Arrays.stream(plugin.categories)
+                    jsonObject.put("categories", plugin.getCategoriesStream()
                         .filter(PluginManager::isNonMetaLabel)
                         .map(UpdateCenter::getCategoryDisplayName)
                         .collect(toList())
@@ -2406,11 +2406,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     @Restricted(DoNotUse.class) // Used from table.jelly
     public boolean hasAdoptThisPluginLabel(UpdateSite.Plugin plugin) {
-        final String[] categories = plugin.categories;
-        if (categories == null) {
-            return false;
-        }
-        return Arrays.asList(categories).contains("adopt-this-plugin");
+        return plugin.hasCategory("adopt-this-plugin");
     }
 
     @Restricted(DoNotUse.class) // Used from table.jelly
@@ -2427,11 +2423,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         if (pluginMeta == null) {
             return false;
         }
-        final String[] categories = pluginMeta.categories;
-        if (categories == null) {
-            return false;
-        }
-        return Arrays.asList(categories).contains("adopt-this-plugin");
+        return pluginMeta.hasCategory("adopt-this-plugin");
     }
 
     /**

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -1091,7 +1091,7 @@ public class UpdateSite {
         public final String minimumJavaVersion;
         /**
          * Categories for grouping plugins, taken from labels assigned to wiki page.
-         * Can be {@code null} if the update center does not support plugin categories.
+         * Can be {@code null} if the update center does not return categories.
          */
         @Exported
         @CheckForNull

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -66,6 +66,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Stream;
+
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -626,11 +628,9 @@ public class UpdateSite {
 
                 // compatibility with update sites that have no separate 'deprecated' top-level entry.
                 // Also do this even if there are deprecations to potentially allow limiting the top-level entry to overridden URLs.
-                if (p.categories != null) {
-                    if (Arrays.asList(p.categories).contains("deprecated")) {
-                        if (!this.deprecations.containsKey(p.name)) {
-                            this.deprecations.put(p.name, new Deprecation(p.wiki));
-                        }
+                if (p.hasCategory("deprecated")) {
+                    if (!this.deprecations.containsKey(p.name)) {
+                        this.deprecations.put(p.name, new Deprecation(p.wiki));
                     }
                 }
             }
@@ -1091,9 +1091,10 @@ public class UpdateSite {
         public final String minimumJavaVersion;
         /**
          * Categories for grouping plugins, taken from labels assigned to wiki page.
-         * Can be null.
+         * Can be {@code null} in the update center does not support plugin categories.
          */
         @Exported
+        @CheckForNull
         public final String[] categories;
 
         /**
@@ -1508,6 +1509,26 @@ public class UpdateSite {
             }
 
             return warnings;
+        }
+
+        /**
+         * Checks whether a plugin has a desired category
+         * @since TODO
+         */
+        public boolean hasCategory(String category) {
+            if (categories == null) {
+                return false;
+            }
+            // TODO: cache it in a hashset for performance improvements
+            return Arrays.asList(categories).contains(category);
+        }
+
+        /**
+         * Get categories stream for further search.
+         * @since TODO
+         */
+        public Stream<String> getCategoriesStream() {
+            return categories != null ? Arrays.stream(categories) : Stream.empty();
         }
 
         /**

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -1091,7 +1091,7 @@ public class UpdateSite {
         public final String minimumJavaVersion;
         /**
          * Categories for grouping plugins, taken from labels assigned to wiki page.
-         * Can be {@code null} in the update center does not support plugin categories.
+         * Can be {@code null} if the update center does not support plugin categories.
          */
         @Exported
         @CheckForNull


### PR DESCRIPTION
See [JENKINS-64445](https://issues.jenkins-ci.org/browse/JENKINS-64445). Not all update centers support categories. Hopefully handling of these issues becomes more automatic once SpotBugs is fully cleaned up for Normal level

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Prevent NullPointerException in Plugin Manager when using an update center without support for plugin categories
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
