### PR TITLE
[JENKINS-64465] Fix race condition on HudsonFilter#reset

### DIFF
--- a/core/src/main/java/hudson/security/HudsonFilter.java
+++ b/core/src/main/java/hudson/security/HudsonFilter.java
@@ -130,7 +130,7 @@ public class HudsonFilter implements Filter {
     /**
      * Reset the proxies and filter for a change in {@link SecurityRealm}.
      */
-    public void reset(SecurityRealm securityRealm) throws ServletException {
+    public synchronized void reset(SecurityRealm securityRealm) throws ServletException {
         if (securityRealm != null) {
             SecurityRealm.SecurityComponents sc = securityRealm.getSecurityComponents();
             AUTHENTICATION_MANAGER.setDelegate(sc.manager2);


### PR DESCRIPTION
If `Jenkins#setSecurityRealm` is called concurrently from multiple threads there is a potential race condition on the authentication filters registration.

`Jenkins#setSecurityRealm` calls `filter.reset()`, `HudsonFilter#reset` is not synchronized however it is replacing the old filter with the new filter (if there was one) which is not a thread safe operation.

The effect of this race condition is the wrong auth filter being registered.

See [JENKINS-64465](https://issues.jenkins-ci.org/browse/JENKINS-64465).

### Proposed changelog entries

* JENKINS-64465: Fix race condition on authentication filters registration

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jenkinsci/code-reviewers 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
