### PR TITLE
Do not show an empty tooltip on svg icons

### DIFF
--- a/core/src/main/resources/lib/layout/svgIcon.jelly
+++ b/core/src/main/resources/lib/layout/svgIcon.jelly
@@ -34,7 +34,7 @@
          aria-hidden="${attrs.ariaHidden}"
          style="${attrs.style}"
          onclick="${attrs.onclick}"
-         tooltip="${h.xmlEscape(attrs.tooltip ?: '')}">
+         tooltip="${attrs.tooltip != null ? h.xmlEscape(attrs.tooltip) : null}">
 
         <j:choose>
             <j:when test="${attrs.href != null}">


### PR DESCRIPTION
Strictly speaking a regression introduced by @Wadeck with the fix for https://www.jenkins.io/security/advisory/2020-08-12/#SECURITY-1955, but probably too minor to backport etc.

### Before

> <img width="150" alt="Screenshot 2020-12-18 at 20 47 40" src="https://user-images.githubusercontent.com/1831569/102656753-a8446b00-4174-11eb-82e1-6e2cb0938c02.png">

### After

> <img width="128" alt="Screenshot 2020-12-18 at 20 48 00" src="https://user-images.githubusercontent.com/1831569/102656750-a67aa780-4174-11eb-87d1-4c2cde1263b3.png">


### Proposed changelog entries

(too minor)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
