### PR TITLE
[JENKINS-64504] stuck plugin manager buttons

### DIFF
--- a/war/package.json
+++ b/war/package.json
@@ -56,6 +56,7 @@
     "jenkins-js-modules": "^1.5.0",
     "jquery": "3.5.1",
     "lodash": "^4.17.20",
+    "raf": "^3.4.1",
     "window-handle": "^1.0.0"
   },
   "browserslist": [

--- a/war/src/main/js/plugin-manager-ui.js
+++ b/war/src/main/js/plugin-manager-ui.js
@@ -1,7 +1,8 @@
+import debounce from 'lodash/debounce'
+import requestAnimationFrame from 'raf';
+
 import pluginManagerAvailable from './templates/plugin-manager/available.hbs'
 import pluginManager from './api/pluginManager';
-
-import debounce from 'lodash/debounce'
 
 function applyFilter(searchQuery) {
     // debounce reduces number of server side calls while typing
@@ -38,6 +39,11 @@ function applyFilter(searchQuery) {
         });
 
         tbody.insertAdjacentHTML('beforeend', rows);
+
+        // @see JENKINS-64504 - Update the sticky buttons position after each search.
+        requestAnimationFrame(() => {
+            layoutUpdateCallback.call()
+        })
     })
 }
 

--- a/war/yarn.lock
+++ b/war/yarn.lock
@@ -6723,6 +6723,13 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
+raf@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
See [JENKINS-64504](https://issues.jenkins-ci.org/browse/JENKINS-64504).

Fixing another issue introduced on https://github.com/jenkinsci/jenkins/pull/5051. Plugin manager buttons get stuck on the footer when the search results do not cause the page to scroll. This causes many ATH tests to fail. 

**Technical considerations:**

- Uses the window.requestAnimationFrame to throttle callback calls through the raf polyfill

<details>
<summary>Before</summary>

<img width="1680" alt="Captura de pantalla 2020-12-22 a las 11 25 36" src="https://user-images.githubusercontent.com/5738588/102880218-45d8bc80-444b-11eb-92a5-0572f7fdd465.png">

</details>

<details>
<summary>After</summary>

<img width="1680" alt="Captura de pantalla 2020-12-22 a las 11 30 42" src="https://user-images.githubusercontent.com/5738588/102880245-4c673400-444b-11eb-9b3a-4fadd7f6d78f.png">

</details>

### Proposed changelog entries

* JENKINS-64504 Fixed an issue that caused the buttons on the plugin manager to get stuck under certain conditions.


### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 
@oleg-nenashev 
@jtnord 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
