### PR TITLE
Added small part with tips for IntelliJ settings to the Contrubuting.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,10 +119,10 @@ There is no additional action required from pull request authors at this point.
 
 In case you are using IntelliJ, please adjust the default setting in respect to whitespace fixes on save.
 The setting can be found in Settings -> Editor -> General -> On Save -> Remove trailing spaces on: `Modified lines`
-
 This will help minimize the diff, which makes reviewing PRs easier.
 
-
+We also do not recommend `*` imports in the production code.
+Please disable them in Settings > Editor > Codestyle > Java by setting _Class count to use import with '*'_ and Names count to use import with '*'_ to a high value, e.g. 100. 
 ## Copyright
 
 The Jenkins core is licensed under [MIT license], with a few exceptions in bundled classes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ There is no additional action required from pull request authors at this point.
 In case you are using IntelliJ, please adjust the default setting in respect to whitespace fixes on save.
 The setting can be found in Settings -> Editor -> General -> On Save -> Remove trailing spaces on: `Modified lines`
 
-This will prevent adding noise to the changelog because of unrelated whitespace changes.
+This will help minimize the diff, which makes reviewing PRs easier.
 
 
 ## Copyright

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,14 @@ the repository maintainers will integrate it, prepare changelogs, and
 ensure it gets released in one of upcoming Weekly releases.
 There is no additional action required from pull request authors at this point.
 
+## IntelliJ suggestion
+
+In case you are using IntelliJ, please adjust the default setting in respect to whitespace fixes on save.
+The setting can be found in Settings -> Editor -> General -> On Save -> Remove trailing spaces on: `Modified lines`
+
+This will prevent adding noise to the changelog because of unrelated whitespace changes.
+
+
 ## Copyright
 
 The Jenkins core is licensed under [MIT license], with a few exceptions in bundled classes.


### PR DESCRIPTION
Added small part with tips for IntelliJ settings to the Contrubuting.md how to set IntellIj to not change all trailing whitespaces in each touched file. Since I'm getting asked how to disable this behaviour from time to time, I thought adding it here might make sense.

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
