### PR TITLE
fix build: Update ath docker image to latest

### DIFF
--- a/essentials.yml
+++ b/essentials.yml
@@ -2,6 +2,6 @@
 ath:
   useLocalSnapshots: false
   athRevision: "acceptance-test-harness-1.78" # FTR 1.78 is 51a62122c5cda004db05599487abbb7069cf7b65
-  athImage: "jenkins/ath@sha256:284c2fdfaf1a51e95783126367c0a88c07af83ff9234063d12ba3001959628e8"
+  athImage: "jenkins/ath:acceptance-test-harness-1.80"
   categories:
     - org.jenkinsci.test.acceptance.junit.SmokeTest


### PR DESCRIPTION
this gives us a newer maven and java which fixes the ATH being broken for -ntp