### PR TITLE
Fixed some deprecated warnings of mockito methods and minor cleanup

### DIFF
--- a/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
+++ b/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
@@ -36,6 +36,7 @@ import hudson.security.ACL;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,9 +69,16 @@ public class ViewOptionHandlerTest {
     @Mock private CompositeView outer;
     @Mock private Jenkins jenkins;
 
+    private AutoCloseable mocks;
+
+    @After
+    public void tearDown() throws Exception {
+        mocks.close();
+    }
+
     @Before public void setUp() {
 
-        MockitoAnnotations.openMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
 
         handler = new ViewOptionHandler(null, null, setter);
 
@@ -91,7 +99,7 @@ public class ViewOptionHandlerTest {
         when(jenkins.getDisplayName()).thenReturn("Jenkins");
         when(jenkins.getACL()).thenReturn(new ACL() {
             @Override
-            public boolean hasPermission2(@Nonnull Authentication a, @Nonnull Permission p) {
+            public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission p) {
                 return true;
             }
         });

--- a/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
+++ b/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
@@ -51,7 +51,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 @PrepareForTest(Jenkins.class)
 @RunWith(PowerMockRunner.class)

--- a/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
+++ b/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import hudson.model.ViewGroup;
 import hudson.model.View;
@@ -51,6 +51,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 
+import javax.annotation.Nonnull;
+
 @PrepareForTest(Jenkins.class)
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
@@ -68,7 +70,7 @@ public class ViewOptionHandlerTest {
 
     @Before public void setUp() {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         handler = new ViewOptionHandler(null, null, setter);
 
@@ -89,7 +91,7 @@ public class ViewOptionHandlerTest {
         when(jenkins.getDisplayName()).thenReturn("Jenkins");
         when(jenkins.getACL()).thenReturn(new ACL() {
             @Override
-            public boolean hasPermission2(Authentication a, Permission p) {
+            public boolean hasPermission2(@Nonnull Authentication a, @Nonnull Permission p) {
                 return true;
             }
         });
@@ -130,7 +132,7 @@ public class ViewOptionHandlerTest {
                 parseFailedWith(IllegalArgumentException.class, "missing_view")
         );
 
-        verifyZeroInteractions(setter);
+        verifyNoInteractions(setter);
     }
 
     @Test public void reportNonexistentNestedView() throws Exception {
@@ -140,7 +142,7 @@ public class ViewOptionHandlerTest {
                 parseFailedWith(IllegalArgumentException.class, "outer/missing_view")
         );
 
-        verifyZeroInteractions(setter);
+        verifyNoInteractions(setter);
     }
 
     @Test public void reportNonexistentInnerView() throws Exception {
@@ -150,7 +152,7 @@ public class ViewOptionHandlerTest {
                 parseFailedWith(IllegalArgumentException.class, "outer/nested/missing_view")
         );
 
-        verifyZeroInteractions(setter);
+        verifyNoInteractions(setter);
     }
 
     @Test public void reportTraversingViewThatIsNotAViewGroup() throws Exception {
@@ -160,30 +162,30 @@ public class ViewOptionHandlerTest {
                 parseFailedWith(IllegalStateException.class, "outer/nested/inner/missing")
         );
 
-        verifyZeroInteractions(setter);
+        verifyNoInteractions(setter);
     }
 
-    @Test public void reportEmptyViewNameRequestAsNull() throws Exception {
+    @Test public void reportEmptyViewNameRequestAsNull() {
         assertNull(handler.getView(""));
-        verifyZeroInteractions(setter);
+        verifyNoInteractions(setter);
     }
 
-    @Test public void reportViewSpaceNameRequestAsIAE() throws Exception {
+    @Test public void reportViewSpaceNameRequestAsIAE() {
         try {
             assertNull(handler.getView(" "));
             fail("No exception thrown. Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             assertEquals("No view named   inside view Jenkins", e.getMessage());
-            verifyZeroInteractions(setter);
+            verifyNoInteractions(setter);
         }
     }
 
-    @Test public void reportNullViewAsNPE() throws Exception {
+    @Test public void reportNullViewAsNPE() {
         try {
             handler.getView(null);
             fail("No exception thrown. Expected NullPointerException");
         } catch (NullPointerException e) {
-            verifyZeroInteractions(setter);
+            verifyNoInteractions(setter);
         }
     }
 
@@ -198,9 +200,9 @@ public class ViewOptionHandlerTest {
 
         verify(outer).checkPermission(View.READ);
 
-        verifyZeroInteractions(nested);
-        verifyZeroInteractions(inner);
-        verifyZeroInteractions(setter);
+        verifyNoInteractions(nested);
+        verifyNoInteractions(inner);
+        verifyNoInteractions(setter);
     }
 
     @Test public void refuseToReadNestedView() throws Exception {
@@ -214,8 +216,8 @@ public class ViewOptionHandlerTest {
 
         verify(nested).checkPermission(View.READ);
 
-        verifyZeroInteractions(inner);
-        verifyZeroInteractions(setter);
+        verifyNoInteractions(inner);
+        verifyNoInteractions(setter);
     }
 
     @Test public void refuseToReadInnerView() throws Exception {
@@ -229,7 +231,7 @@ public class ViewOptionHandlerTest {
 
         verify(inner).checkPermission(View.READ);
 
-        verifyZeroInteractions(setter);
+        verifyNoInteractions(setter);
     }
 
     private void denyAccessOn(View view) {
@@ -256,7 +258,7 @@ public class ViewOptionHandlerTest {
 
     private void parse(final String... params) throws CmdLineException {
         handler.parseArguments(new Parameters() {
-            public String getParameter(int idx) throws CmdLineException {
+            public String getParameter(int idx) {
                 return params[idx];
             }
             public int size() {

--- a/core/src/test/java/hudson/slaves/ChannelPingerTest.java
+++ b/core/src/test/java/hudson/slaves/ChannelPingerTest.java
@@ -31,7 +31,7 @@ public class ChannelPingerTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         mockStatic(ChannelPinger.class);
     }
 

--- a/core/src/test/java/hudson/slaves/ChannelPingerTest.java
+++ b/core/src/test/java/hudson/slaves/ChannelPingerTest.java
@@ -29,9 +29,16 @@ public class ChannelPingerTest {
 
     private Map<String, String> savedSystemProperties = new HashMap<>();
 
+    private AutoCloseable mocks;
+
+    @After
+    public void tearDown() throws Exception {
+        mocks.close();
+    }
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.openMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
         mockStatic(ChannelPinger.class);
     }
 

--- a/core/src/test/java/jenkins/model/CoreEnvironmentContributorTest.java
+++ b/core/src/test/java/jenkins/model/CoreEnvironmentContributorTest.java
@@ -38,7 +38,7 @@ public class CoreEnvironmentContributorTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         instance = new CoreEnvironmentContributor();
     }
 

--- a/core/src/test/java/jenkins/model/CoreEnvironmentContributorTest.java
+++ b/core/src/test/java/jenkins/model/CoreEnvironmentContributorTest.java
@@ -11,6 +11,7 @@ import hudson.model.TaskListener;
 import java.io.File;
 import java.io.IOException;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +27,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public class CoreEnvironmentContributorTest {
     CoreEnvironmentContributor instance;
-    
+
+    private AutoCloseable mocks;
+
     @Mock
     Job job;
     
@@ -36,9 +39,14 @@ public class CoreEnvironmentContributorTest {
     @Mock
     Jenkins jenkins;
 
+    @After
+    public void tearDown() throws Exception {
+        mocks.close();
+    }
+
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.openMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
         instance = new CoreEnvironmentContributor();
     }
 

--- a/test/src/test/java/hudson/model/ComputerConfigDotXmlTest.java
+++ b/test/src/test/java/hudson/model/ComputerConfigDotXmlTest.java
@@ -74,7 +74,7 @@ public class ComputerConfigDotXmlTest {
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         computer = spy(rule.createSlave().toComputer());
         rule.jenkins.setSecurityRealm(rule.createDummySecurityRealm());
         oldSecurityContext = ACL.impersonate2(User.get("user").impersonate2());
@@ -146,7 +146,7 @@ public class ComputerConfigDotXmlTest {
 
     @Test
     @Issue("SECURITY-343")
-    public void emptyNodeMonitorDataWithoutConnect() throws Exception {
+    public void emptyNodeMonitorDataWithoutConnect() {
         rule.jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy());
 
         assertTrue(computer.getMonitorData().isEmpty());
@@ -154,7 +154,7 @@ public class ComputerConfigDotXmlTest {
 
     @Test
     @Issue("SECURITY-343")
-    public void populatedNodeMonitorDataWithConnect() throws Exception {
+    public void populatedNodeMonitorDataWithConnect() {
         GlobalMatrixAuthorizationStrategy auth = new GlobalMatrixAuthorizationStrategy();
         rule.jenkins.setAuthorizationStrategy(auth);
         auth.add(Computer.CONNECT, "user");
@@ -171,7 +171,7 @@ public class ComputerConfigDotXmlTest {
         when(rsp.getOutputStream()).thenReturn(new ServletOutputStream() {
 
             @Override
-            public void write(int b) throws IOException {
+            public void write(int b) {
                 baos.write(b);
             }
 

--- a/test/src/test/java/hudson/model/ComputerConfigDotXmlTest.java
+++ b/test/src/test/java/hudson/model/ComputerConfigDotXmlTest.java
@@ -70,19 +70,20 @@ public class ComputerConfigDotXmlTest {
 
     private Computer computer;
     private SecurityContext oldSecurityContext;
+    private AutoCloseable mocks;
 
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.openMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
         computer = spy(rule.createSlave().toComputer());
         rule.jenkins.setSecurityRealm(rule.createDummySecurityRealm());
         oldSecurityContext = ACL.impersonate2(User.get("user").impersonate2());
     }
 
     @After
-    public void tearDown() {
-
+    public void tearDown() throws Exception {
+        mocks.close();
         SecurityContextHolder.setContext(oldSecurityContext);
     }
 

--- a/test/src/test/java/hudson/util/XStream2Security383Test.java
+++ b/test/src/test/java/hudson/util/XStream2Security383Test.java
@@ -46,7 +46,7 @@ public class XStream2Security383Test {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/test/src/test/java/hudson/util/XStream2Security383Test.java
+++ b/test/src/test/java/hudson/util/XStream2Security383Test.java
@@ -3,6 +3,7 @@ package hudson.util;
 import hudson.model.Items;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,9 +45,16 @@ public class XStream2Security383Test {
     @Mock
     private StaplerResponse rsp;
 
+    private AutoCloseable mocks;
+
+    @After
+    public void tearDown() throws Exception {
+        mocks.close();
+    }
+
     @Before
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
     }
 
     @Test


### PR DESCRIPTION
Fixed some deprecated warnings of mockito methods and minor cleanup.
* Replaced `verifyZeroInteractions` with `verifyNoInteractions` as suggested [here](https://javadoc.io/static/org.mockito/mockito-core/3.7.0/org/mockito/Mockito.html#verifyZeroInteractions-java.lang.Object...-)
* Replaced `initMocks` with `openMocks` as suggested [here](https://www.javadoc.io/doc/org.mockito/mockito-core/3.7.0/org/mockito/MockitoAnnotations.html)

and some minor stuff, added missing `NonNull` and removed superflous `throws Exception`

### Proposed changelog entries

* Internal: N/A 

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
