### PR TITLE
JENKINS-64650: Upgrade Commons FileUpload from 1.3.1-jenkins-2 to 1.4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -262,7 +262,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.3.1-jenkins-2</version>
+        <version>1.4</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.txw2</groupId>

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1771,6 +1771,9 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             File t = File.createTempFile("uploaded", ".jpi");
             t.deleteOnExit();
             try {
+                // TODO Remove this workaround after FILEUPLOAD-293 is resolved.
+                t.delete();
+
                 fileItem.write(t);
             } catch (Exception e) {
                 // Exception thrown is too generic so at least limit the scope where it can occur


### PR DESCRIPTION
### Background

Subsumes #5171. See [JENKINS-64650](https://issues.jenkins.io/browse/JENKINS-64650) and [the corresponding mailing list thread](https://groups.google.com/g/jenkinsci-dev/c/G0itLB-tbF4).

### Problem

Jenkins core uses a fork of [Commons FileUpload](https://commons.apache.org/proper/commons-fileupload/) 1.3.1 (which was released upstream on February 7, 2014). Two changes were made to the Jenkins fork:

1. `DiskFileItem` was made no longer `Serializable` in commit 28d997704f as part of [SECURITY-159](https://www.jenkins.io/security/advisory/2014-10-01/#security-159cve-2013-2186-arbitrary-file-system-write) on September 27, 2014. Upstream made the same change over 4 years later in [1.4](https://dist.apache.org/repos/dist/release/commons/fileupload/RELEASE-NOTES.txt) (which was released on December 23, 2018).
2. The fix for [CVE-2016-3092](https://nvd.nist.gov/vuln/detail/CVE-2016-3092) (originally released upstream in [1.3.2](https://dist.apache.org/repos/dist/release/commons/fileupload/RELEASE-NOTES.txt) on May 26, 2016) was backported to the Jenkins fork in commit ea981a029c as part of [SECURITY-490](https://www.jenkins.io/security/advisory/2017-10-11/#jenkins-core-bundled-vulnerable-version-of-the-commons-fileupload-library) on September 28-29, 2017.

As of 2021, the latest upstream release (1.4) contains all the changes present in the fork; therefore, the fork is no longer necessary. Furthermore, it prevents us from receiving upstream fixes.

## Solution

Upgrade to the latest upstream release, [Commons FileUpload](https://commons.apache.org/proper/commons-fileupload/) 1.4.

## Testing done

All testing was done with `mvn jetty:run` or `mvn hpi:run` with remote debugging enabled to verify that all relevant code paths were being exercised.

- [x] Test Jenkins core
  - [x] Run Jenkins core test suite with these changes
  - [x] Build a job with a file parameter from a browser (to exercise `FileParameterValue` and `FilePath#copyFrom(FileItem)`)
  - [x] Build a job with a file parameter from the CLI (to exercise `FileParameterDefinition`)
  - [x] Upload a plugin from a browser (to exercise `PluginManager#doUploadPlugin`)
  - [x] Upload a fingerprint from a browser (to exercise `MultipartFormDataParser`)
  - [x] Ensure that `QueueTest#fileItemPersistence` still works as intended
- [x] Test Stapler
  - [x] Functional test of multi-part form data (tested by uploading a fingerprint)
  - [x] Run Stapler test suite with these changes
- [x] Test Credentials and Plain Credentials plugins
  - [x] Upload a secret file credential from a browser (to exercise `org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl`)
  - [x] Upload a certificate credential from a browser (to exercise `com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl.UploadedKeyStoreSource.Upload.doUpload`)
  - [x] Run `plain-credentials-plugin` test suite with these changes
- [x] Test Docker Pipeline plugin
  - [x] Run `org.jenkinsci.plugins.docker.workflow.WithContainerStepTest#fileCredentials` with these changes
- [x] Test Active Choices plugin
  - [x] Run Active Choices plugin test suite with these changes
- [x] Test File Parameters plugin
  - [x] Run File Parameters plugin test suite with these changes
- [x] Test Maven Release plugin
  - [x] Create a job with a file parameter and click *Perform Maven Release* (to exercise `org.jvnet.hudson.plugins.m2release.M2ReleaseAction.StaplerRequestWrapper`)
- [x] Test Scriptler plugin
  - [x] Click *Upload new Script* from Scriptler (to exercise `org.jenkinsci.plugins.scriptler.ScriptlerManagement#doUploadScript`)
  - [x] Run Scriptler plugin test suite with these changes
- [x] Test Sidebar Link plugin
  - [x] Click *Upload an image file* from *Additional Sidebar Links* (to exercise `hudson.plugins.sidebar_link.SidebarLinkPlugin.doUpload`)

### Proposed changelog entries

*  Jenkins now uses an updated version of the [Commons FileUpload](https://commons.apache.org/proper/commons-fileupload/) library without custom patches.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jeffret-b @jglick @timja