### PR TITLE
[JENKINS-64621] Fix zip regression

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -484,13 +484,15 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      *             Any symlinks between a file and root should be ignored.
      *             Symlinks in the parentage outside root will not be checked.
      * @param noFollowLinks true if it should not follow links.
+     * @param prefix The portion of file path that will be added at the beginning of the relative path inside the archive.
+     *               If non-empty, a trailing forward slash will be enforced.
      *
      * @return The number of files/directories archived.
      *          This is only really useful to check for a situation where nothing
      */
     @Restricted(NoExternalUse.class)
-    public int zip(OutputStream out, DirScanner scanner, String verificationRoot, boolean noFollowLinks) throws IOException, InterruptedException {
-        ArchiverFactory archiverFactory = noFollowLinks ? ArchiverFactory.ZIP_WTHOUT_FOLLOWING_SYMLINKS : ArchiverFactory.ZIP;
+    public int zip(OutputStream out, DirScanner scanner, String verificationRoot, boolean noFollowLinks, String prefix) throws IOException, InterruptedException {
+        ArchiverFactory archiverFactory = noFollowLinks ? ArchiverFactory.createZipWithoutSymlink(prefix) : ArchiverFactory.ZIP;
         return archive(archiverFactory, out, scanner, verificationRoot, noFollowLinks);
     }
 

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -251,7 +251,16 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         if(baseFile.isDirectory()) {
             if(zip) {
                 rsp.setContentType("application/zip");
-                baseFile.zip(rsp.getOutputStream(), StringUtils.isBlank(rest) ? "**" : rest, null, true, getNoFollowLinks());
+                String includes, prefix;
+                if (StringUtils.isBlank(rest)) {
+                    includes = "**";
+                    // JENKINS-19947, JENKINS-61473: traditional behavior is to prepend the directory name
+                    prefix = baseFile.getName();
+                } else {
+                    includes = rest;
+                    prefix = "";
+                }
+                baseFile.zip(rsp.getOutputStream(), includes, null, true, getNoFollowLinks(), prefix);
                 return;
             }
             if (plain) {

--- a/core/src/main/java/hudson/util/io/ArchiverFactory.java
+++ b/core/src/main/java/hudson/util/io/ArchiverFactory.java
@@ -61,10 +61,13 @@ public abstract class ArchiverFactory implements Serializable {
 
     /**
      * Zip format, without following symlinks.
+     * @param prefix The portion of file path that will be added at the beginning of the relative path inside the archive.
+     *               If non-empty, a trailing forward slash will be enforced.
      */
     @Restricted(NoExternalUse.class)
-    public static ArchiverFactory ZIP_WTHOUT_FOLLOWING_SYMLINKS = new ZipWithoutSymLinksArchiverFactory();
-
+    public static ArchiverFactory createZipWithoutSymlink(String prefix) {
+        return new ZipWithoutSymLinksArchiverFactory(prefix);
+    }
 
     private static final class TarArchiverFactory extends ArchiverFactory {
         private final TarCompression method;
@@ -89,8 +92,14 @@ public abstract class ArchiverFactory implements Serializable {
     }
 
     private static final class ZipWithoutSymLinksArchiverFactory extends ArchiverFactory {
+        private final String prefix;
+
+        ZipWithoutSymLinksArchiverFactory(String prefix){
+            this.prefix = prefix;
+        }
+
         public Archiver create(OutputStream out) {
-            return new ZipArchiver(out, true);
+            return new ZipArchiver(out, true, prefix);
         }
 
         private static final long serialVersionUID = 1L;

--- a/core/src/main/java/hudson/util/io/ZipArchiver.java
+++ b/core/src/main/java/hudson/util/io/ZipArchiver.java
@@ -24,14 +24,19 @@
 
 package hudson.util.io;
 
+import hudson.Util;
 import hudson.util.FileVisitor;
 import hudson.util.IOUtils;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.Zip64Mode;
 import org.apache.tools.zip.ZipOutputStream;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,12 +53,21 @@ final class ZipArchiver extends Archiver {
     private final byte[] buf = new byte[8192];
     private final ZipOutputStream zip;
     private final OpenOption[] openOptions;
+    private final String prefix;
 
     ZipArchiver(OutputStream out) {
-        this(out, false);
+        this(out, false, "");
     }
 
-    ZipArchiver(OutputStream out, boolean failOnSymLink) {
+    // Restriction added for clarity, it's a package class, you should not use it outside of Jenkins core
+    @Restricted(NoExternalUse.class)
+    ZipArchiver(OutputStream out, boolean failOnSymLink, String prefix) {
+        if (StringUtils.isBlank(prefix)) {
+            this.prefix = "";
+        } else {
+            this.prefix = Util.ensureEndsWith(prefix, "/");
+        }
+        
         zip = new ZipOutputStream(out);
         openOptions = failOnSymLink ? new LinkOption[]{LinkOption.NOFOLLOW_LINKS} : new OpenOption[0];
         zip.setEncoding(System.getProperty("file.encoding"));
@@ -69,7 +83,7 @@ final class ZipArchiver extends Archiver {
         String relativePath = _relativePath.replace('\\', '/');
         
         if(f.isDirectory()) {
-            ZipEntry dirZipEntry = new ZipEntry(relativePath+'/');
+            ZipEntry dirZipEntry = new ZipEntry(this.prefix + relativePath+'/');
             // Setting this bit explicitly is needed by some unzipping applications (see JENKINS-3294).
             dirZipEntry.setExternalAttributes(BITMASK_IS_DIRECTORY);
             if (mode!=-1)   dirZipEntry.setUnixMode(mode);
@@ -77,7 +91,7 @@ final class ZipArchiver extends Archiver {
             zip.putNextEntry(dirZipEntry);
             zip.closeEntry();
         } else {
-            ZipEntry fileZipEntry = new ZipEntry(relativePath);
+            ZipEntry fileZipEntry = new ZipEntry(this.prefix + relativePath);
             if (mode!=-1)   fileZipEntry.setUnixMode(mode);
             fileZipEntry.setTime(f.lastModified());
             zip.putNextEntry(fileZipEntry);

--- a/core/src/main/java/hudson/util/io/ZipArchiver.java
+++ b/core/src/main/java/hudson/util/io/ZipArchiver.java
@@ -65,7 +65,7 @@ final class ZipArchiver extends Archiver {
         if (StringUtils.isBlank(prefix)) {
             this.prefix = "";
         } else {
-            this.prefix = Util.ensureEndsWith(prefix.trim(), "/");
+            this.prefix = Util.ensureEndsWith(prefix, "/");
         }
         
         zip = new ZipOutputStream(out);

--- a/core/src/main/java/hudson/util/io/ZipArchiver.java
+++ b/core/src/main/java/hudson/util/io/ZipArchiver.java
@@ -65,7 +65,7 @@ final class ZipArchiver extends Archiver {
         if (StringUtils.isBlank(prefix)) {
             this.prefix = "";
         } else {
-            this.prefix = Util.ensureEndsWith(prefix, "/");
+            this.prefix = Util.ensureEndsWith(prefix.trim(), "/");
         }
         
         zip = new ZipOutputStream(out);

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -338,7 +338,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
      */
     @Restricted(NoExternalUse.class)
     public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
-                            boolean noFollowLinks) throws IOException, UnsupportedOperationException {
+                            boolean noFollowLinks, String prefix) throws IOException, UnsupportedOperationException {
         throw new UnsupportedOperationException("Not implemented.");
     }
 
@@ -611,10 +611,10 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
             @Override
             public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
-                           boolean noFollowLinks) throws IOException {
+                           boolean noFollowLinks, String prefix) throws IOException {
                 String rootPath = determineRootPath();
                 DirScanner.Glob globScanner = new DirScanner.Glob(includes, excludes, useDefaultExcludes, !noFollowLinks);
-                ArchiverFactory archiverFactory = noFollowLinks ? ArchiverFactory.ZIP_WTHOUT_FOLLOWING_SYMLINKS : ArchiverFactory.ZIP;
+                ArchiverFactory archiverFactory = noFollowLinks ? ArchiverFactory.createZipWithoutSymlink(prefix) : ArchiverFactory.ZIP;
                 try (Archiver archiver = archiverFactory.create(outputStream)) {
                     globScanner.scan(f, FilePath.ignoringSymlinks(archiver, rootPath, noFollowLinks));
                     return archiver.countEntries();
@@ -920,11 +920,11 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
             @Override
             public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
-                                    boolean noFollowLinks) throws IOException {
+                                    boolean noFollowLinks, String prefix) throws IOException {
                 try {
                     String rootPath = root == null ? null : root.getRemote();
                     DirScanner.Glob globScanner = new DirScanner.Glob(includes, excludes, useDefaultExcludes, !noFollowLinks);
-                    return f.zip(outputStream, globScanner, rootPath, noFollowLinks);
+                    return f.zip(outputStream, globScanner, rootPath, noFollowLinks, prefix);
                 } catch (InterruptedException x) {
                     throw new IOException(x);
                 }

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -249,7 +249,7 @@ public class VirtualFileTest {
 
         VirtualFile sourcePath = VirtualFile.forFilePath(new FilePath(source));
         try (FileOutputStream outputStream = new FileOutputStream(zipFile)) {
-            sourcePath.zip( outputStream,"**", null, true, true);
+            sourcePath.zip( outputStream,"**", null, true, true, "");
         }
         FilePath zipPath = new FilePath(zipFile);
         assertTrue(zipPath.exists());
@@ -268,6 +268,36 @@ public class VirtualFileTest {
     }
 
     @Test
+    @Issue({"JENKINS-19947", "JENKINS-61473"})
+    public void zip_NoFollowLinks_FilePathVF_withPrefix() throws Exception {
+        File zipFile = new File(tmp.getRoot(), "output.zip");
+        File root = tmp.getRoot();
+        File source = new File(root, "source");
+        prepareFileStructureForIsDescendant(source);
+
+        VirtualFile sourcePath = VirtualFile.forFilePath(new FilePath(source));
+        String prefix = "test1";
+        try (FileOutputStream outputStream = new FileOutputStream(zipFile)) {
+            sourcePath.zip( outputStream,"**", null, true, true, prefix + "/");
+        }
+        FilePath zipPath = new FilePath(zipFile);
+        assertTrue(zipPath.exists());
+        assertFalse(zipPath.isDirectory());
+        FilePath unzipPath = new FilePath(new File(tmp.getRoot(), "unzip"));
+        zipPath.unzip(unzipPath);
+        assertTrue(unzipPath.exists());
+        assertTrue(unzipPath.isDirectory());
+        assertTrue(unzipPath.child(prefix).isDirectory());
+        assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aa.txt").exists());
+        assertTrue(unzipPath.child(prefix).child("a").child("ab").child("ab.txt").exists());
+        assertFalse(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
+        assertFalse(unzipPath.child(prefix).child("a").child("_b").exists());
+        assertTrue(unzipPath.child(prefix).child("b").child("ba").child("ba.txt").exists());
+        assertFalse(unzipPath.child(prefix).child("b").child("_a").exists());
+        assertFalse(unzipPath.child(prefix).child("b").child("_aatxt").exists());
+    }
+
+    @Test
     @Issue("SECURITY-1452")
     public void zip_NoFollowLinks_FileVF() throws Exception {
         File zipFile = new File(tmp.getRoot(), "output.zip");
@@ -277,7 +307,7 @@ public class VirtualFileTest {
 
         VirtualFile sourcePath = VirtualFile.forFile(source);
         try (FileOutputStream outputStream = new FileOutputStream(zipFile)) {
-            sourcePath.zip( outputStream,"**", null, true, true);
+            sourcePath.zip( outputStream,"**", null, true, true, "");
         }
         FilePath zipPath = new FilePath(zipFile);
         assertTrue(zipPath.exists());
@@ -293,6 +323,36 @@ public class VirtualFileTest {
         assertTrue(unzipPath.child("b").child("ba").child("ba.txt").exists());
         assertFalse(unzipPath.child("b").child("_a").exists());
         assertFalse(unzipPath.child("b").child("_aatxt").exists());
+    }
+
+    @Test
+    @Issue({"JENKINS-19947", "JENKINS-61473"})
+    public void zip_NoFollowLinks_FileVF_withPrefix() throws Exception {
+        File zipFile = new File(tmp.getRoot(), "output.zip");
+        File root = tmp.getRoot();
+        File source = new File(root, "source");
+        prepareFileStructureForIsDescendant(source);
+
+        String prefix = "test1";
+        VirtualFile sourcePath = VirtualFile.forFile(source);
+        try (FileOutputStream outputStream = new FileOutputStream(zipFile)) {
+            sourcePath.zip( outputStream,"**", null, true, true, prefix + "/");
+        }
+        FilePath zipPath = new FilePath(zipFile);
+        assertTrue(zipPath.exists());
+        assertFalse(zipPath.isDirectory());
+        FilePath unzipPath = new FilePath(new File(tmp.getRoot(), "unzip"));
+        zipPath.unzip(unzipPath);
+        assertTrue(unzipPath.exists());
+        assertTrue(unzipPath.isDirectory());
+        assertTrue(unzipPath.child(prefix).isDirectory());
+        assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aa.txt").exists());
+        assertTrue(unzipPath.child(prefix).child("a").child("ab").child("ab.txt").exists());
+        assertFalse(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
+        assertFalse(unzipPath.child(prefix).child("a").child("_b").exists());
+        assertTrue(unzipPath.child(prefix).child("b").child("ba").child("ba.txt").exists());
+        assertFalse(unzipPath.child(prefix).child("b").child("_a").exists());
+        assertFalse(unzipPath.child(prefix).child("b").child("_aatxt").exists());
     }
 
     @Issue("JENKINS-26810")

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -173,7 +173,7 @@ public class DirectoryBrowserSupportTest {
 
         ZipFile readzip = new ZipFile(zipfile);
 
-        InputStream is = readzip.getInputStream(readzip.getEntry("artifact.out"));
+        InputStream is = readzip.getInputStream(readzip.getEntry("archive/artifact.out"));
 
         // ZipException in case of JENKINS-19752
         assertNotEquals("Downloaded zip file must not be empty", is.read(), -1);
@@ -520,8 +520,18 @@ public class DirectoryBrowserSupportTest {
         }
 
         // zip feature
-        { // all the outside folders / files are not included in the zip
+        { // all the outside folders / files are not included in the zip, also the parent folder is included
             Page zipPage = wc.goTo(p.getUrl() + "ws/*zip*/ws.zip", null);
+            assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
+
+            List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
+            assertThat(entryNames, containsInAnyOrder(
+                    p.getName() + "/intermediateFolder/public2.key",
+                    p.getName() + "/public1.key"
+            ));
+        }
+        { // workaround for JENKINS-19947 is still supported, i.e. no parent folder
+            Page zipPage = wc.goTo(p.getUrl() + "ws/**/*zip*/ws.zip", null);
             assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
@@ -532,6 +542,13 @@ public class DirectoryBrowserSupportTest {
         }
         { // all the outside folders / files are not included in the zip
             Page zipPage = wc.goTo(p.getUrl() + "ws/intermediateFolder/*zip*/intermediateFolder.zip", null);
+            assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
+
+            List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
+            assertThat(entryNames, contains("intermediateFolder/public2.key"));
+        }
+        { // workaround for JENKINS-19947 is still supported, i.e. no parent folder, even inside a sub-folder
+            Page zipPage = wc.goTo(p.getUrl() + "ws/intermediateFolder/**/*zip*/intermediateFolder.zip", null);
             assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
@@ -739,8 +756,8 @@ public class DirectoryBrowserSupportTest {
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
             assertThat(entryNames, containsInAnyOrder(
-                     "intermediateFolder/public2.key",
-                    "public1.key"
+                    p.getName() + "/intermediateFolder/public2.key",
+                    p.getName() + "/public1.key"
             ));
         }
         { // all the outside folders / files are not included in the zip
@@ -748,7 +765,7 @@ public class DirectoryBrowserSupportTest {
             assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
-            assertThat(entryNames, contains("public2.key"));
+            assertThat(entryNames, contains("intermediateFolder/public2.key"));
         }
     }
 


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-64621](https://issues.jenkins-ci.org/browse/JENKINS-64621).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->
The zip created from the workspace (or other location related to DirectoryBrowserSupport) contains the parent folder when there is no glob pattern. This behavior was changed during the fix but was not required.

⚠️ At the time of writing this PR, this regression does not seem to have sufficiently important impact to justify an expedite merge/LTS, but please change my mind :)

History of that feature being broken:
- [JENKINS-19947](https://issues.jenkins.io/browse/JENKINS-19947), October 2013
- [JENKINS-61473](https://issues.jenkins.io/browse/JENKINS-61473), March 2020

⚠️ There are other issues related to this security fix that are not addressed by this PR:
- [JENKINS-64632](https://issues.jenkins.io/browse/JENKINS-64632), file descriptor leak
- [JENKINS-64655](https://issues.jenkins.io/browse/JENKINS-64655), regression on external storage plugin

### Proposed changelog entries

* Include root folder in downloaded zip files.  Regression in 2.263.2 (SECURITY-1452)
* Also resolve the previously (before security release) reported issue JENKINS-61473 around the same area.
* (internal) Restricted methods FilePath#zip(OutputStream, DirScanner, String, boolean) and VirtualFile#zip(OutputStream, String, String, boolean, boolean) have a new parameter `String prefix`.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jeffret-b @daniel-beck @timja

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
