### PR TITLE
[JENKINS-64632] File handle leak correction

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -355,14 +355,15 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         if(LOGGER.isLoggable(Level.FINE))
             LOGGER.fine("Serving "+baseFile+" with lastModified=" + lastModified + ", length=" + length);
 
-        InputStream in;
-        try {
-            in = baseFile.open(getNoFollowLinks());
-        } catch (IOException ioe) {
-            rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
-            return;
-        }
         if (view) {
+            InputStream in;
+            try {
+                in = baseFile.open(getNoFollowLinks());
+            } catch (IOException ioe) {
+                rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
+
             // for binary files, provide the file name for download
             rsp.setHeader("Content-Disposition", "inline; filename=" + baseFile.getName());
 
@@ -383,7 +384,14 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                         }
                     }
                 }
-                rsp.serveFile(req, baseFile.open(), lastModified, -1, length, baseFile.getName());
+                InputStream in;
+                try {
+                    in = baseFile.open(getNoFollowLinks());
+                } catch (IOException ioe) {
+                    rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                    return;
+                }
+                rsp.serveFile(req, in, lastModified, -1, length, baseFile.getName());
             }
         }
     }


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-64632](https://issues.jenkins-ci.org/browse/JENKINS-64632).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

A file handle leak was already corrected fairly recently but due to a wrongly resolved merge conflict, we re-introduce this bug into the latest security release. This PR corrects the behavior.

Reproduction/test steps:
- Compile this PR (or use `docker run --rm -it -p 8081:8080 -e ID=XXXX jenkins/core-pr-tester`
- Go inside the JENKINS_HOME (inside docker)
- Go inside userContent
- Create a simple file there (e.g. `echo test > test.txt`)
- (step "display") In your browser, go to <jenkinsUrl>/userContent, then click on the "test.txt", this will display the content ("test")
- Now from the command line, find the PID of the Jenkins process (e.g. using `ps aux | grep java`)
- Then for unix: `ls -ltra /proc/PID/fd | grep userContent`
- If you repeat multiple time the "display" step, you will see no difference. If you test with the version without this PR (2.275), you will see multiple occurrences of `<jenkinsHome>/work/userContent/test.txt` appearing and not disappearing (handles leaking)

This issue was reported originally against simple-theme-plugin, but the root cause was in Jenkins core.

### Proposed changelog entries

* Fix the file handle leak inside DirectoryBrowserSupport. Regression in 2.263.2 (SECURITY-1452). A file handle leaked everytime someone is downloading a file from the workspace view or the userContent view.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck @jeffret-b @timja

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
