### PR TITLE
[JENKINS-64655] Provide default implementation for external storage

### DIFF
--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -63,11 +63,14 @@ import hudson.util.io.ArchiverFactory;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.ArtifactManager;
 import jenkins.security.MasterToSlaveCallable;
+import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.AbstractFileSet;
 import org.apache.tools.ant.types.selectors.SelectorUtils;
 import org.apache.tools.ant.types.selectors.TokenizedPath;
 import org.apache.tools.ant.types.selectors.TokenizedPattern;
+import org.apache.tools.zip.ZipEntry;
+import org.apache.tools.zip.ZipOutputStream;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -334,12 +337,60 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
     }
 
     /**
+     * Create a ZIP archive from the list of folders/files using the includes and excludes to filter them.
+     * 
+     * <p>The default implementation calls other existing methods to list the folders/files, then retrieve them and zip them all.
+     * 
+     * @param includes comma-separated Ant-style globs as per {@link Util#createFileSet(File, String, String)} using {@code /} as a path separator;
+     *                 the empty string means <em>no matches</em> (use {@link SelectorUtils#DEEP_TREE_MATCH} if you want to match everything except some excludes)
+     * @param excludes optional excludes in similar format to {@code includes}
+     * @param useDefaultExcludes as per {@link AbstractFileSet#setDefaultexcludes}
+     * @param noFollowLinks if true then do not follow links.
+     * @param prefix the partial path that will be added before each entry inside the archive.
+     *               If non-empty, a trailing slash will be enforced.
+     * @return the number of files inside the archive (not the folders)
+     * @throws IOException if this is not a directory, or listing was not possible for some other reason
      * @since TODO
      */
-    @Restricted(NoExternalUse.class)
     public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
-                            boolean noFollowLinks, String prefix) throws IOException, UnsupportedOperationException {
-        throw new UnsupportedOperationException("Not implemented.");
+                   boolean noFollowLinks, String prefix) throws IOException {
+        String correctPrefix;
+        if (StringUtils.isBlank(prefix)) {
+            correctPrefix = "";
+        } else {
+            correctPrefix = Util.ensureEndsWith(prefix, "/");
+        }
+        
+        Collection<String> files = list(includes, excludes, useDefaultExcludes, noFollowLinks);
+        try (ZipOutputStream zos = new ZipOutputStream(outputStream)) {
+            zos.setEncoding(System.getProperty("file.encoding")); // TODO JENKINS-20663 make this overridable via query parameter
+
+            for (String relativePath : files) {
+                VirtualFile virtualFile = this.child(relativePath);
+                sendOneZipEntry(zos, virtualFile, relativePath, noFollowLinks, correctPrefix);
+            }
+        }
+        return files.size();
+    }
+
+    private void sendOneZipEntry(ZipOutputStream zos, VirtualFile vf, String relativePath, boolean noFollowLinks, String prefix) throws IOException {
+        // In ZIP archives "All slashes MUST be forward slashes" (http://pkware.com/documents/casestudies/APPNOTE.TXT)
+        // TODO On Linux file names can contain backslashes which should not treated as file separators.
+        //      Unfortunately, only the file separator char of the master is known (File.separatorChar)
+        //      but not the file separator char of the (maybe remote) "dir".
+        String onlyForwardRelativePath = relativePath.replace('\\', '/');
+        String zipEntryName = prefix + onlyForwardRelativePath;
+        ZipEntry e = new ZipEntry(zipEntryName);
+
+        e.setTime(vf.lastModified());
+        zos.putNextEntry(e);
+        try (InputStream in = vf.open(noFollowLinks)) {
+            // hudson.util.IOUtils is already present
+            org.apache.commons.io.IOUtils.copy(in, zos);
+        }
+        finally {
+            zos.closeEntry();
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-64655](https://issues.jenkins-ci.org/browse/JENKINS-64655).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

The previous security release (esp. SECURITY-1452) around Symlink was implementing new methods without default implementation. That broke the zip download for the external storage plugins.

Now the default implementation is a logic that is not optimized (as we do not have specificities from the plugins) but something that is working. The method "zip" is no longer restricted and thus the implementation can be specialized by the different implementations.

✔️ Manually tested with "default storage", "Compress Artifacts" and "Artifact Manager on S3".

ℹ️ I didn't add unit test in addition to the existing one for the FilePathVF and FileVF as it would require to add a new test dependency. This could be proposed as an improvement in a follow-up PR, here the objective was to correct the regression.

### Proposed changelog entries

* Provide a default implementation of the "all files in zip" download link. This is especially important for external storage plugin.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or **explanation to why this change has no tests**
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck @jeffret-b @timja 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
