### PR TITLE
LTS backport SECURITY-1452 regression fixes

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -483,13 +483,15 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      *             Any symlinks between a file and root should be ignored.
      *             Symlinks in the parentage outside root will not be checked.
      * @param noFollowLinks true if it should not follow links.
+     * @param prefix The portion of file path that will be added at the beginning of the relative path inside the archive.
+     *               If non-empty, a trailing forward slash will be enforced.
      *
      * @return The number of files/directories archived.
      *          This is only really useful to check for a situation where nothing
      */
     @Restricted(NoExternalUse.class)
-    public int zip(OutputStream out, DirScanner scanner, String verificationRoot, boolean noFollowLinks) throws IOException, InterruptedException {
-        ArchiverFactory archiverFactory = noFollowLinks ? ArchiverFactory.ZIP_WTHOUT_FOLLOWING_SYMLINKS : ArchiverFactory.ZIP;
+    public int zip(OutputStream out, DirScanner scanner, String verificationRoot, boolean noFollowLinks, String prefix) throws IOException, InterruptedException {
+        ArchiverFactory archiverFactory = noFollowLinks ? ArchiverFactory.createZipWithoutSymlink(prefix) : ArchiverFactory.ZIP;
         return archive(archiverFactory, out, scanner, verificationRoot, noFollowLinks);
     }
 

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -355,14 +355,15 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         if(LOGGER.isLoggable(Level.FINE))
             LOGGER.fine("Serving "+baseFile+" with lastModified=" + lastModified + ", length=" + length);
 
-        InputStream in;
-        try {
-            in = baseFile.open(getNoFollowLinks());
-        } catch (IOException ioe) {
-            rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
-            return;
-        }
         if (view) {
+            InputStream in;
+            try {
+                in = baseFile.open(getNoFollowLinks());
+            } catch (IOException ioe) {
+                rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
+
             // for binary files, provide the file name for download
             rsp.setHeader("Content-Disposition", "inline; filename=" + baseFile.getName());
 
@@ -383,7 +384,14 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                         }
                     }
                 }
-                rsp.serveFile(req, baseFile.open(), lastModified, -1, length, baseFile.getName());
+                InputStream in;
+                try {
+                    in = baseFile.open(getNoFollowLinks());
+                } catch (IOException ioe) {
+                    rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                    return;
+                }
+                rsp.serveFile(req, in, lastModified, -1, length, baseFile.getName());
             }
         }
     }

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -251,7 +251,16 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         if(baseFile.isDirectory()) {
             if(zip) {
                 rsp.setContentType("application/zip");
-                baseFile.zip(rsp.getOutputStream(), StringUtils.isBlank(rest) ? "**" : rest, null, true, getNoFollowLinks());
+                String includes, prefix;
+                if (StringUtils.isBlank(rest)) {
+                    includes = "**";
+                    // JENKINS-19947, JENKINS-61473: traditional behavior is to prepend the directory name
+                    prefix = baseFile.getName();
+                } else {
+                    includes = rest;
+                    prefix = "";
+                }
+                baseFile.zip(rsp.getOutputStream(), includes, null, true, getNoFollowLinks(), prefix);
                 return;
             }
             if (plain) {

--- a/core/src/main/java/hudson/util/io/ArchiverFactory.java
+++ b/core/src/main/java/hudson/util/io/ArchiverFactory.java
@@ -61,10 +61,13 @@ public abstract class ArchiverFactory implements Serializable {
 
     /**
      * Zip format, without following symlinks.
+     * @param prefix The portion of file path that will be added at the beginning of the relative path inside the archive.
+     *               If non-empty, a trailing forward slash will be enforced.
      */
     @Restricted(NoExternalUse.class)
-    public static ArchiverFactory ZIP_WTHOUT_FOLLOWING_SYMLINKS = new ZipWithoutSymLinksArchiverFactory();
-
+    public static ArchiverFactory createZipWithoutSymlink(String prefix) {
+        return new ZipWithoutSymLinksArchiverFactory(prefix);
+    }
 
     private static final class TarArchiverFactory extends ArchiverFactory {
         private final TarCompression method;
@@ -89,8 +92,14 @@ public abstract class ArchiverFactory implements Serializable {
     }
 
     private static final class ZipWithoutSymLinksArchiverFactory extends ArchiverFactory {
+        private final String prefix;
+
+        ZipWithoutSymLinksArchiverFactory(String prefix){
+            this.prefix = prefix;
+        }
+
         public Archiver create(OutputStream out) {
-            return new ZipArchiver(out, true);
+            return new ZipArchiver(out, true, prefix);
         }
 
         private static final long serialVersionUID = 1L;

--- a/core/src/main/java/hudson/util/io/ZipArchiver.java
+++ b/core/src/main/java/hudson/util/io/ZipArchiver.java
@@ -24,14 +24,19 @@
 
 package hudson.util.io;
 
+import hudson.Util;
 import hudson.util.FileVisitor;
 import hudson.util.IOUtils;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.Zip64Mode;
 import org.apache.tools.zip.ZipOutputStream;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,12 +53,21 @@ final class ZipArchiver extends Archiver {
     private final byte[] buf = new byte[8192];
     private final ZipOutputStream zip;
     private final OpenOption[] openOptions;
+    private final String prefix;
 
     ZipArchiver(OutputStream out) {
-        this(out, false);
+        this(out, false, "");
     }
 
-    ZipArchiver(OutputStream out, boolean failOnSymLink) {
+    // Restriction added for clarity, it's a package class, you should not use it outside of Jenkins core
+    @Restricted(NoExternalUse.class)
+    ZipArchiver(OutputStream out, boolean failOnSymLink, String prefix) {
+        if (StringUtils.isBlank(prefix)) {
+            this.prefix = "";
+        } else {
+            this.prefix = Util.ensureEndsWith(prefix, "/");
+        }
+        
         zip = new ZipOutputStream(out);
         openOptions = failOnSymLink ? new LinkOption[]{LinkOption.NOFOLLOW_LINKS} : new OpenOption[0];
         zip.setEncoding(System.getProperty("file.encoding"));
@@ -69,7 +83,7 @@ final class ZipArchiver extends Archiver {
         String relativePath = _relativePath.replace('\\', '/');
         
         if(f.isDirectory()) {
-            ZipEntry dirZipEntry = new ZipEntry(relativePath+'/');
+            ZipEntry dirZipEntry = new ZipEntry(this.prefix + relativePath+'/');
             // Setting this bit explicitly is needed by some unzipping applications (see JENKINS-3294).
             dirZipEntry.setExternalAttributes(BITMASK_IS_DIRECTORY);
             if (mode!=-1)   dirZipEntry.setUnixMode(mode);
@@ -77,7 +91,7 @@ final class ZipArchiver extends Archiver {
             zip.putNextEntry(dirZipEntry);
             zip.closeEntry();
         } else {
-            ZipEntry fileZipEntry = new ZipEntry(relativePath);
+            ZipEntry fileZipEntry = new ZipEntry(this.prefix + relativePath);
             if (mode!=-1)   fileZipEntry.setUnixMode(mode);
             fileZipEntry.setTime(f.lastModified());
             zip.putNextEntry(fileZipEntry);

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -338,7 +338,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
      */
     @Restricted(NoExternalUse.class)
     public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
-                            boolean noFollowLinks) throws IOException, UnsupportedOperationException {
+                            boolean noFollowLinks, String prefix) throws IOException, UnsupportedOperationException {
         throw new UnsupportedOperationException("Not implemented.");
     }
 
@@ -611,10 +611,10 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
             @Override
             public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
-                           boolean noFollowLinks) throws IOException {
+                           boolean noFollowLinks, String prefix) throws IOException {
                 String rootPath = determineRootPath();
                 DirScanner.Glob globScanner = new DirScanner.Glob(includes, excludes, useDefaultExcludes, !noFollowLinks);
-                ArchiverFactory archiverFactory = noFollowLinks ? ArchiverFactory.ZIP_WTHOUT_FOLLOWING_SYMLINKS : ArchiverFactory.ZIP;
+                ArchiverFactory archiverFactory = noFollowLinks ? ArchiverFactory.createZipWithoutSymlink(prefix) : ArchiverFactory.ZIP;
                 try (Archiver archiver = archiverFactory.create(outputStream)) {
                     globScanner.scan(f, FilePath.ignoringSymlinks(archiver, rootPath, noFollowLinks));
                     return archiver.countEntries();
@@ -920,11 +920,11 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
             @Override
             public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
-                                    boolean noFollowLinks) throws IOException {
+                                    boolean noFollowLinks, String prefix) throws IOException {
                 try {
                     String rootPath = root == null ? null : root.getRemote();
                     DirScanner.Glob globScanner = new DirScanner.Glob(includes, excludes, useDefaultExcludes, !noFollowLinks);
-                    return f.zip(outputStream, globScanner, rootPath, noFollowLinks);
+                    return f.zip(outputStream, globScanner, rootPath, noFollowLinks, prefix);
                 } catch (InterruptedException x) {
                     throw new IOException(x);
                 }

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -63,11 +63,14 @@ import hudson.util.io.ArchiverFactory;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.ArtifactManager;
 import jenkins.security.MasterToSlaveCallable;
+import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.AbstractFileSet;
 import org.apache.tools.ant.types.selectors.SelectorUtils;
 import org.apache.tools.ant.types.selectors.TokenizedPath;
 import org.apache.tools.ant.types.selectors.TokenizedPattern;
+import org.apache.tools.zip.ZipEntry;
+import org.apache.tools.zip.ZipOutputStream;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -334,12 +337,60 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
     }
 
     /**
+     * Create a ZIP archive from the list of folders/files using the includes and excludes to filter them.
+     * 
+     * <p>The default implementation calls other existing methods to list the folders/files, then retrieve them and zip them all.
+     * 
+     * @param includes comma-separated Ant-style globs as per {@link Util#createFileSet(File, String, String)} using {@code /} as a path separator;
+     *                 the empty string means <em>no matches</em> (use {@link SelectorUtils#DEEP_TREE_MATCH} if you want to match everything except some excludes)
+     * @param excludes optional excludes in similar format to {@code includes}
+     * @param useDefaultExcludes as per {@link AbstractFileSet#setDefaultexcludes}
+     * @param noFollowLinks if true then do not follow links.
+     * @param prefix the partial path that will be added before each entry inside the archive.
+     *               If non-empty, a trailing slash will be enforced.
+     * @return the number of files inside the archive (not the folders)
+     * @throws IOException if this is not a directory, or listing was not possible for some other reason
      * @since TODO
      */
-    @Restricted(NoExternalUse.class)
     public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
-                            boolean noFollowLinks, String prefix) throws IOException, UnsupportedOperationException {
-        throw new UnsupportedOperationException("Not implemented.");
+                   boolean noFollowLinks, String prefix) throws IOException {
+        String correctPrefix;
+        if (StringUtils.isBlank(prefix)) {
+            correctPrefix = "";
+        } else {
+            correctPrefix = Util.ensureEndsWith(prefix, "/");
+        }
+        
+        Collection<String> files = list(includes, excludes, useDefaultExcludes, noFollowLinks);
+        try (ZipOutputStream zos = new ZipOutputStream(outputStream)) {
+            zos.setEncoding(System.getProperty("file.encoding")); // TODO JENKINS-20663 make this overridable via query parameter
+
+            for (String relativePath : files) {
+                VirtualFile virtualFile = this.child(relativePath);
+                sendOneZipEntry(zos, virtualFile, relativePath, noFollowLinks, correctPrefix);
+            }
+        }
+        return files.size();
+    }
+
+    private void sendOneZipEntry(ZipOutputStream zos, VirtualFile vf, String relativePath, boolean noFollowLinks, String prefix) throws IOException {
+        // In ZIP archives "All slashes MUST be forward slashes" (http://pkware.com/documents/casestudies/APPNOTE.TXT)
+        // TODO On Linux file names can contain backslashes which should not treated as file separators.
+        //      Unfortunately, only the file separator char of the master is known (File.separatorChar)
+        //      but not the file separator char of the (maybe remote) "dir".
+        String onlyForwardRelativePath = relativePath.replace('\\', '/');
+        String zipEntryName = prefix + onlyForwardRelativePath;
+        ZipEntry e = new ZipEntry(zipEntryName);
+
+        e.setTime(vf.lastModified());
+        zos.putNextEntry(e);
+        try (InputStream in = vf.open(noFollowLinks)) {
+            // hudson.util.IOUtils is already present
+            org.apache.commons.io.IOUtils.copy(in, zos);
+        }
+        finally {
+            zos.closeEntry();
+        }
     }
 
     /**

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -248,7 +248,7 @@ public class VirtualFileTest {
 
         VirtualFile sourcePath = VirtualFile.forFilePath(new FilePath(source));
         try (FileOutputStream outputStream = new FileOutputStream(zipFile)) {
-            sourcePath.zip( outputStream,"**", null, true, true);
+            sourcePath.zip( outputStream,"**", null, true, true, "");
         }
         FilePath zipPath = new FilePath(zipFile);
         assertTrue(zipPath.exists());
@@ -267,6 +267,36 @@ public class VirtualFileTest {
     }
 
     @Test
+    @Issue({"JENKINS-19947", "JENKINS-61473"})
+    public void zip_NoFollowLinks_FilePathVF_withPrefix() throws Exception {
+        File zipFile = new File(tmp.getRoot(), "output.zip");
+        File root = tmp.getRoot();
+        File source = new File(root, "source");
+        prepareFileStructureForIsDescendant(source);
+
+        VirtualFile sourcePath = VirtualFile.forFilePath(new FilePath(source));
+        String prefix = "test1";
+        try (FileOutputStream outputStream = new FileOutputStream(zipFile)) {
+            sourcePath.zip( outputStream,"**", null, true, true, prefix + "/");
+        }
+        FilePath zipPath = new FilePath(zipFile);
+        assertTrue(zipPath.exists());
+        assertFalse(zipPath.isDirectory());
+        FilePath unzipPath = new FilePath(new File(tmp.getRoot(), "unzip"));
+        zipPath.unzip(unzipPath);
+        assertTrue(unzipPath.exists());
+        assertTrue(unzipPath.isDirectory());
+        assertTrue(unzipPath.child(prefix).isDirectory());
+        assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aa.txt").exists());
+        assertTrue(unzipPath.child(prefix).child("a").child("ab").child("ab.txt").exists());
+        assertFalse(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
+        assertFalse(unzipPath.child(prefix).child("a").child("_b").exists());
+        assertTrue(unzipPath.child(prefix).child("b").child("ba").child("ba.txt").exists());
+        assertFalse(unzipPath.child(prefix).child("b").child("_a").exists());
+        assertFalse(unzipPath.child(prefix).child("b").child("_aatxt").exists());
+    }
+
+    @Test
     @Issue("SECURITY-1452")
     public void zip_NoFollowLinks_FileVF() throws Exception {
         File zipFile = new File(tmp.getRoot(), "output.zip");
@@ -276,7 +306,7 @@ public class VirtualFileTest {
 
         VirtualFile sourcePath = VirtualFile.forFile(source);
         try (FileOutputStream outputStream = new FileOutputStream(zipFile)) {
-            sourcePath.zip( outputStream,"**", null, true, true);
+            sourcePath.zip( outputStream,"**", null, true, true, "");
         }
         FilePath zipPath = new FilePath(zipFile);
         assertTrue(zipPath.exists());
@@ -292,6 +322,36 @@ public class VirtualFileTest {
         assertTrue(unzipPath.child("b").child("ba").child("ba.txt").exists());
         assertFalse(unzipPath.child("b").child("_a").exists());
         assertFalse(unzipPath.child("b").child("_aatxt").exists());
+    }
+
+    @Test
+    @Issue({"JENKINS-19947", "JENKINS-61473"})
+    public void zip_NoFollowLinks_FileVF_withPrefix() throws Exception {
+        File zipFile = new File(tmp.getRoot(), "output.zip");
+        File root = tmp.getRoot();
+        File source = new File(root, "source");
+        prepareFileStructureForIsDescendant(source);
+
+        String prefix = "test1";
+        VirtualFile sourcePath = VirtualFile.forFile(source);
+        try (FileOutputStream outputStream = new FileOutputStream(zipFile)) {
+            sourcePath.zip( outputStream,"**", null, true, true, prefix + "/");
+        }
+        FilePath zipPath = new FilePath(zipFile);
+        assertTrue(zipPath.exists());
+        assertFalse(zipPath.isDirectory());
+        FilePath unzipPath = new FilePath(new File(tmp.getRoot(), "unzip"));
+        zipPath.unzip(unzipPath);
+        assertTrue(unzipPath.exists());
+        assertTrue(unzipPath.isDirectory());
+        assertTrue(unzipPath.child(prefix).isDirectory());
+        assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aa.txt").exists());
+        assertTrue(unzipPath.child(prefix).child("a").child("ab").child("ab.txt").exists());
+        assertFalse(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
+        assertFalse(unzipPath.child(prefix).child("a").child("_b").exists());
+        assertTrue(unzipPath.child(prefix).child("b").child("ba").child("ba.txt").exists());
+        assertFalse(unzipPath.child(prefix).child("b").child("_a").exists());
+        assertFalse(unzipPath.child(prefix).child("b").child("_aatxt").exists());
     }
 
     @Issue("JENKINS-26810")

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -34,6 +34,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -1060,6 +1061,7 @@ public class VirtualFileTest {
     }
 
     @Test
+    @Ignore("TODO doesn't pass on ci.jenkins.io due to root user being used in container tests")
     public void testCanRead_False_FileVF() throws Exception {
         File ws = tmp.newFolder("ws");
         String childString = "child";
@@ -1247,6 +1249,7 @@ public class VirtualFileTest {
     }
 
     @Test
+    @Ignore("TODO doesn't pass on ci.jenkins.io due to root user being used in container tests")
     public void testCanRead_False_FilePathVF() throws Exception {
         // This test checks the method's behavior in the abstract base class,
         // which generally does nothing.

--- a/essentials.yml
+++ b/essentials.yml
@@ -2,6 +2,7 @@
 ath:
   useLocalSnapshots: false
   athRevision: "acceptance-test-harness-1.78" # FTR 1.78 is 51a62122c5cda004db05599487abbb7069cf7b65
-  athImage: "jenkins/ath@sha256:284c2fdfaf1a51e95783126367c0a88c07af83ff9234063d12ba3001959628e8"
+  athImage: "jenkins/ath:acceptance-test-harness-1.80"
   tests:
     - '*'
+

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -173,7 +173,7 @@ public class DirectoryBrowserSupportTest {
 
         ZipFile readzip = new ZipFile(zipfile);
 
-        InputStream is = readzip.getInputStream(readzip.getEntry("artifact.out"));
+        InputStream is = readzip.getInputStream(readzip.getEntry("archive/artifact.out"));
 
         // ZipException in case of JENKINS-19752
         assertNotEquals("Downloaded zip file must not be empty", is.read(), -1);
@@ -520,8 +520,18 @@ public class DirectoryBrowserSupportTest {
         }
 
         // zip feature
-        { // all the outside folders / files are not included in the zip
+        { // all the outside folders / files are not included in the zip, also the parent folder is included
             Page zipPage = wc.goTo(p.getUrl() + "ws/*zip*/ws.zip", null);
+            assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
+
+            List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
+            assertThat(entryNames, containsInAnyOrder(
+                    p.getName() + "/intermediateFolder/public2.key",
+                    p.getName() + "/public1.key"
+            ));
+        }
+        { // workaround for JENKINS-19947 is still supported, i.e. no parent folder
+            Page zipPage = wc.goTo(p.getUrl() + "ws/**/*zip*/ws.zip", null);
             assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
@@ -532,6 +542,13 @@ public class DirectoryBrowserSupportTest {
         }
         { // all the outside folders / files are not included in the zip
             Page zipPage = wc.goTo(p.getUrl() + "ws/intermediateFolder/*zip*/intermediateFolder.zip", null);
+            assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
+
+            List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
+            assertThat(entryNames, contains("intermediateFolder/public2.key"));
+        }
+        { // workaround for JENKINS-19947 is still supported, i.e. no parent folder, even inside a sub-folder
+            Page zipPage = wc.goTo(p.getUrl() + "ws/intermediateFolder/**/*zip*/intermediateFolder.zip", null);
             assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
@@ -739,8 +756,8 @@ public class DirectoryBrowserSupportTest {
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
             assertThat(entryNames, containsInAnyOrder(
-                     "intermediateFolder/public2.key",
-                    "public1.key"
+                    p.getName() + "/intermediateFolder/public2.key",
+                    p.getName() + "/public1.key"
             ));
         }
         { // all the outside folders / files are not included in the zip
@@ -748,7 +765,7 @@ public class DirectoryBrowserSupportTest {
             assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
-            assertThat(entryNames, contains("public2.key"));
+            assertThat(entryNames, contains("intermediateFolder/public2.key"));
         }
     }
 


### PR DESCRIPTION
## Backport SECURITY-1452 regression fixes to LTS

See [JENKINS-64621](https://issues.jenkins-ci.org/browse/JENKINS-64621) (zip file path name),  [JENKINS-64632](https://issues.jenkins-ci.org/browse/JENKINS-64632) (file handle leak), and [JENKINS-64655](https://issues.jenkins-ci.org/browse/JENKINS-64655) (external storage default implementation)

### Proposed changelog entries

* Entry 1: Provide a default implementation of the "all files in zip" download link. This is especially important for external storage plugin (regression in 2.263.2).
* Entry 2: Fix the file handle leak inside DirectoryBrowserSupport. Regression in 2.263.2.
* Entry 3: Include root folder in downloaded zip files.  Regression in 2.263.2.  Resolve an additional related zip archive root folder issue.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@timja @wadeck @daniel-beck

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
