### PR TITLE
[JENKINS-64746] public API hudson.model.UpdateCenter.HudsonUpgradeJob constructor signature change

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -2111,6 +2111,15 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
             this(plugin,site,auth,false);
         }
 
+        /**
+         * @deprecated use {@code InstallationJob(Plugin, UpdateSite, Authentication, boolean)}
+         * @see #InstallationJob(Plugin, UpdateSite, Authentication, boolean)
+         */
+        @Deprecated
+        public InstallationJob(Plugin plugin, UpdateSite site, org.acegisecurity.Authentication auth, boolean dynamicLoad) {
+            this(plugin, site, auth.toSpring(), dynamicLoad);
+        }
+
         public InstallationJob(Plugin plugin, UpdateSite site, Authentication auth, boolean dynamicLoad) {
             super(site, auth);
             this.plugin = plugin;
@@ -2326,6 +2335,16 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
 
         private final PluginManager pm = Jenkins.get().getPluginManager();
 
+        /**
+         * @deprecated use {@code PluginDowngradeJob(Plugin, UpdateSite, Authentication)}
+         * @see #PluginDowngradeJob(Plugin, UpdateSite, Authentication)
+         */
+        @Deprecated
+        public PluginDowngradeJob(Plugin plugin, UpdateSite site, org.acegisecurity.Authentication auth) {
+            this(plugin, site, auth.toSpring());
+        }
+
+
         public PluginDowngradeJob(Plugin plugin, UpdateSite site, Authentication auth) {
             super(site, auth);
             this.plugin = plugin;
@@ -2411,6 +2430,10 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      */
     public final class HudsonUpgradeJob extends DownloadJob {
 
+        /**
+          * @deprecated use {@code HudsonUpgradeJob(UpdateSite site, Authentication auth)}
+          * @see #HudsonUpgradeJob(UpdateSite, Authentication)
+         */
         @Deprecated
         public HudsonUpgradeJob(UpdateSite site, org.acegisecurity.Authentication auth) {
             super(site, auth.toSpring());
@@ -2450,6 +2473,16 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     }
 
     public final class HudsonDowngradeJob extends DownloadJob {
+
+        /**
+         * @deprecated use {@code HudsonDowngradeJob(UpdateSite site, Authentication auth)}
+         * @see #HudsonDowngradeJob(UpdateSite, Authentication)
+         */
+        @Deprecated
+        public HudsonDowngradeJob(UpdateSite site, org.acegisecurity.Authentication auth) {
+            super(site, auth.toSpring());
+        }
+
         public HudsonDowngradeJob(UpdateSite site, Authentication auth) {
             super(site, auth);
         }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -2112,8 +2112,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         }
 
         /**
-         * @deprecated use {@code InstallationJob(Plugin, UpdateSite, Authentication, boolean)}
-         * @see #InstallationJob(Plugin, UpdateSite, Authentication, boolean)
+         * @deprecated use {@link InstallationJob(Plugin, UpdateSite, Authentication, boolean)}
          */
         @Deprecated
         public InstallationJob(Plugin plugin, UpdateSite site, org.acegisecurity.Authentication auth, boolean dynamicLoad) {
@@ -2336,8 +2335,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         private final PluginManager pm = Jenkins.get().getPluginManager();
 
         /**
-         * @deprecated use {@code PluginDowngradeJob(Plugin, UpdateSite, Authentication)}
-         * @see #PluginDowngradeJob(Plugin, UpdateSite, Authentication)
+         * @deprecated use {@link PluginDowngradeJob(Plugin, UpdateSite, Authentication)}
          */
         @Deprecated
         public PluginDowngradeJob(Plugin plugin, UpdateSite site, org.acegisecurity.Authentication auth) {
@@ -2431,8 +2429,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     public final class HudsonUpgradeJob extends DownloadJob {
 
         /**
-          * @deprecated use {@code HudsonUpgradeJob(UpdateSite site, Authentication auth)}
-          * @see #HudsonUpgradeJob(UpdateSite, Authentication)
+          * @deprecated use {@link HudsonUpgradeJob(UpdateSite site, Authentication auth)}
          */
         @Deprecated
         public HudsonUpgradeJob(UpdateSite site, org.acegisecurity.Authentication auth) {
@@ -2475,8 +2472,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     public final class HudsonDowngradeJob extends DownloadJob {
 
         /**
-         * @deprecated use {@code HudsonDowngradeJob(UpdateSite site, Authentication auth)}
-         * @see #HudsonDowngradeJob(UpdateSite, Authentication)
+         * @deprecated use {@link HudsonDowngradeJob(UpdateSite site, Authentication auth)}
          */
         @Deprecated
         public HudsonDowngradeJob(UpdateSite site, org.acegisecurity.Authentication auth) {

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -2410,6 +2410,12 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      * Represents the state of the upgrade activity of Jenkins core.
      */
     public final class HudsonUpgradeJob extends DownloadJob {
+
+        @Deprecated
+        public HudsonUpgradeJob(UpdateSite site, org.acegisecurity.Authentication auth) {
+            super(site, auth.toSpring());
+        }
+
         public HudsonUpgradeJob(UpdateSite site, Authentication auth) {
             super(site, auth);
         }

--- a/test/src/test/java/jenkins/install/InstallUtilTest.java
+++ b/test/src/test/java/jenkins/install/InstallUtilTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import hudson.security.ACL;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -180,7 +181,7 @@ public class InstallUtilTest {
 					json.put("dependencies", new JSONArray());
 					Plugin p = new Plugin(getId(), json);
 
-					InstallationJob job = new InstallationJob(p, null, null, false);
+					InstallationJob job = new InstallationJob(p, null, ACL.SYSTEM2, false);
 						job.status = status;
 						job.setCorrelationId(UUID.randomUUID()); // this indicates the plugin was 'directly selected'
 		                updates.add(job);

--- a/test/src/test/java/jenkins/install/InstallUtilTest.java
+++ b/test/src/test/java/jenkins/install/InstallUtilTest.java
@@ -53,6 +53,7 @@ import hudson.model.UpdateSite;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.springframework.security.core.Authentication;
 
 /**
  * Test

--- a/test/src/test/java/jenkins/install/InstallUtilTest.java
+++ b/test/src/test/java/jenkins/install/InstallUtilTest.java
@@ -181,7 +181,7 @@ public class InstallUtilTest {
 					json.put("dependencies", new JSONArray());
 					Plugin p = new Plugin(getId(), json);
 
-					InstallationJob job = new InstallationJob(p, null, ACL.SYSTEM2, false);
+					InstallationJob job = new InstallationJob(p, null, (Authentication) null, false);
 						job.status = status;
 						job.setCorrelationId(UUID.randomUUID()); // this indicates the plugin was 'directly selected'
 		                updates.add(job);


### PR DESCRIPTION
See [JENKINS-64746](https://issues.jenkins-ci.org/browse/JENKINS-64746).

The breaking change was introduced by https://github.com/jenkinsci/jenkins/pull/4848


### Proposed changelog entries

* Restore, as deprecated, the old constructor based on acegisecurity Authentication parameter in order to keep backward compatibility.


### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
