### PR TITLE
Deprecate hudson.util.RunList#filter(com.google.common.base.Predicate)

### DIFF
--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -24,7 +24,7 @@
  */
 package hudson.model;
 
-import com.google.common.base.Predicate;
+import java.util.function.Predicate;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;


### PR DESCRIPTION
### Problem

[`com.google.common.base.Predicate`](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/base/Predicate.html) is documented as follows:

>This interface is now a legacy type. Use `java.util.function.Predicate` (or the appropriate primitive specialization such as `IntPredicate`) instead whenever possible.

Therefore it is a liability to have references to this type in the Jenkins public API.

One such reference is `hudson.util.RunList#filter(com.google.common.base.Predicate)`.

### Solution

Introduce a new `hudson.util.RunList#filter(java.util.function.Predicate)` public API to replace `hudson.util.RunList#filter(com.google.common.base.Predicate)`. Deprecate `hudson.util.RunList#filter(com.google.common.base.Predicate)`.

### Usages

Creating `/tmp/additionalMethods` with

```
hudson.util.RunList#filter
```

then using `jenkins-infra/usage-in-plugins` to look for usages in plugins, including those in CloudBees CI, with

```bash
mvn process-classes exec:exec -Dexec.executable=java -Dexec.args='-classpath %classpath org.jenkinsci.deprecatedusage.Main --additionalMethods /tmp/additionalMethods --onlyIncludeSpecified --updateCenter https://jenkins-updates.cloudbees.com/update-center/envelope-core-oc/update-center.json?version=2.263.2.3,https://jenkins-updates.cloudbees.com/update-center/envelope-core-mm/update-center.json?version=2.263.2.3'
```

produced a report. (This pair of UCs is very nearly a superset of the default Jenkins UC.)

The only reference was [`com.smartcodeltd.jenkinsci.plugins.buildmonitor.viewmodel.JobView`](https://github.com/jan-molak/jenkins-build-monitor-plugin/blob/36f8e82492f8d347e4cf1b04a5263ab75fa9fc00/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java#L136) in [Build Monitor View](https://plugins.jenkins.io/build-monitor-plugin/). Once this PR has been released and Build Monitor View adopts a newer Jenkins core, the plan is to update Build Monitor View to the new non-deprecated version. Once that is merged and released, we can then make `hudson.util.RunList#filter(com.google.common.base.Predicate)` private in Jenkins core.