### PR TITLE
Remove Guava reference in PeepholePermalink public API

### DIFF
--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -1,6 +1,6 @@
 package jenkins.model;
 
-import com.google.common.base.Predicate;
+import java.util.function.Predicate;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Job;
@@ -73,6 +73,11 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
      * This is the "G(B)" as described in the class javadoc.
      */
     public abstract boolean apply(Run<?,?> run);
+
+    @Override
+    public boolean test(Run<?, ?> run) {
+        return apply(run);
+    }
 
     /** @deprecated No longer used. */
     @Deprecated


### PR DESCRIPTION
### Problem

[`com.google.common.base.Predicate`](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/base/Predicate.html) is documented as follows:

>This interface is now a legacy type. Use `java.util.function.Predicate` (or the appropriate primitive specialization such as `IntPredicate`) instead whenever possible.

Therefore it is a liability to have references to this type in the Jenkins public API.

One such reference is `jenkins.model.PeepholePermalink`, which implements `com.google.common.base.Predicate`.

### Solution

As of this PR, `jenkins.model.PeepholePermalink` now implements `java.util.function.Predicate` instead. Note that I did _not_ rename the existing abstract `apply` method in order to preserve compatibility for plugins using this API. Rather I defined the new `PeepholePermalink#test` method in terms of the existing abstract `apply` method. This simplifies the compatibility problem to just ensuring that no existing consumers of `PeepholePermalink` are relying on the fact that it implements `com.google.common.base.Predicate`.

### Usages

Creating `/tmp/additionalClasses` with

```
jenkins/model/PeepholePermalink
```

then using `jenkins-infra/usage-in-plugins` to look for usages in plugins, including those in CloudBees CI, with

```bash
mvn process-classes exec:exec -Dexec.executable=java -Dexec.args='-classpath %classpath org.jenkinsci.deprecatedusage.Main --additionalClasses /tmp/additionalClasses --onlyIncludeSpecified --updateCenter https://jenkins-updates.cloudbees.com/update-center/envelope-core-oc/update-center.json?version=2.263.2.3,https://jenkins-updates.cloudbees.com/update-center/envelope-core-mm/update-center.json?version=2.263.2.3'
```

produced a report. (This pair of UCs is very nearly a superset of the default Jenkins UC.) Usages were as follows:

- [`io.jenkins.plugins.build_symlink.RunListenerImpl`](https://github.com/jenkinsci/build-symlink-plugin/blob/174b41aff90ec703a29c70059f46eae55b46257b/src/main/java/io/jenkins/plugins/build_symlink/RunListenerImpl.java)
- [`org.jvnet.hudson.plugins.m2release.LastReleasePermalink`](https://github.com/jenkinsci/m2release-plugin/blob/266ce67a53623593346c79fdd1c8dd3db51a4bb5/src/main/java/org/jvnet/hudson/plugins/m2release/LastReleasePermalink.java)
- [`com.itemis.jenkins.plugins.unleash.permalinks.LastSuccessfulReleasePermalink`](https://github.com/jenkinsci/unleash-plugin/blob/da89e75726bae6b355610c9ed0a9a5a8d35cd435/src/main/java/com/itemis/jenkins/plugins/unleash/permalinks/LastSuccessfulReleasePermalink.java)
- [`cloudbees-long-running-build`](https://docs.cloudbees.com/docs/release-notes/latest/plugins/cloudbees-long-running-build-plugin/)

These usages are fine as long as they are not relying on the fact that `PeepholePermalink` implements `com.google.common.base.Predicate`. I verified that was indeed the case by ensuring there were no references to `com.google.common.base.Predicate` anywhere in Build Symlink, Maven Release, and Unleash Mavens: both source (with `git grep`) and bytecode (with `javap -c`). So these plugins rely only on the fact that `apply(hudson.model.Run)` is part of the interface, which we are not changing in this PR. So this PR is safe.

To be extra paranoid, I compiled a plugin class that extended `PeepholePermalink` both before and after this change and compared the bytecode with `javap -c`. As expected, there were no changes in calling conventions. Both before and after the change to this core API, plugin classes that implemented it had bytecode for `apply(hudson.model.Run)` and no references to `com.google.common.base.Predicate`.