### PR TITLE
Removed redundant String.format

### DIFF
--- a/core/src/main/java/hudson/cli/EnablePluginCommand.java
+++ b/core/src/main/java/hudson/cli/EnablePluginCommand.java
@@ -78,10 +78,10 @@ public class EnablePluginCommand extends CLICommand {
         if (plugin.isEnabled()) {
             return false;
         }
-        stdout.println(String.format("Enabling plugin `%s' (%s)", plugin.getShortName(), plugin.getVersion()));
+        stdout.printf("Enabling plugin `%s' (%s)%n", plugin.getShortName(), plugin.getVersion());
         enableDependencies(manager, plugin);
         plugin.enable();
-        stdout.println(String.format("Plugin `%s' was enabled.", plugin.getShortName()));
+        stdout.printf("Plugin `%s' was enabled.%n", plugin.getShortName());
         return true;
     }
 
@@ -93,7 +93,7 @@ public class EnablePluginCommand extends CLICommand {
             }
             if (!dependency.isEnabled()) {
                 enableDependencies(manager, dependency);
-                stdout.println(String.format("Enabling plugin dependency `%s' (%s) for `%s'", dependency.getShortName(), dependency.getVersion(), plugin.getShortName()));
+                stdout.printf("Enabling plugin dependency `%s' (%s) for `%s'%n", dependency.getShortName(), dependency.getVersion(), plugin.getShortName());
                 dependency.enable();
             }
         }

--- a/core/src/main/java/hudson/cli/ListPluginsCommand.java
+++ b/core/src/main/java/hudson/cli/ListPluginsCommand.java
@@ -94,6 +94,6 @@ public class ListPluginsCommand extends CLICommand {
         }
 
         String formatString = String.format("%%-%ds %%-%ds %%s", colWidthShortName, colWidthDisplayName);
-        stdout.println(String.format(formatString, plugin.getShortName(), plugin.getDisplayName(), version));
+        stdout.printf((formatString) + "%n", plugin.getShortName(), plugin.getDisplayName(), version);
     }
 }

--- a/core/src/main/java/hudson/cli/ListPluginsCommand.java
+++ b/core/src/main/java/hudson/cli/ListPluginsCommand.java
@@ -94,6 +94,6 @@ public class ListPluginsCommand extends CLICommand {
         }
 
         String formatString = String.format("%%-%ds %%-%ds %%s", colWidthShortName, colWidthDisplayName);
-        stdout.printf((formatString) + "%n", plugin.getShortName(), plugin.getDisplayName(), version);
+        stdout.printf(formatString + "%n", plugin.getShortName(), plugin.getDisplayName(), version);
     }
 }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -645,9 +645,9 @@ public class SlaveComputer extends Computer {
         log.println("Remoting version: " + slaveVersion);
         VersionNumber agentVersion = new VersionNumber(slaveVersion);
         if (agentVersion.isOlderThan(RemotingVersionInfo.getMinimumSupportedVersion())) {
-            log.println(String.format("WARNING: Remoting version is older than a minimum required one (%s). " +
-                    "Connection will not be rejected, but the compatibility is NOT guaranteed",
-                    RemotingVersionInfo.getMinimumSupportedVersion()));
+            log.printf("WARNING: Remoting version is older than a minimum required one (%s). " +
+                            "Connection will not be rejected, but the compatibility is NOT guaranteed%n",
+                    RemotingVersionInfo.getMinimumSupportedVersion());
         }
 
         boolean _isUnix = channel.call(new DetectOS());

--- a/core/src/main/java/jenkins/cli/StopBuildsCommand.java
+++ b/core/src/main/java/jenkins/cli/StopBuildsCommand.java
@@ -95,13 +95,13 @@ public class StopBuildsCommand extends CLICommand {
             try {
                 executor.doStop();
                 isAnyBuildStopped = true;
-                stdout.println(String.format("Build '%s' stopped for job '%s'", buildName, jobName));
+                stdout.printf("Build '%s' stopped for job '%s'%n", buildName, jobName);
             } catch (final Exception e) {
-                stdout.print(String.format("Exception occurred while trying to stop build '%s' for job '%s'. ", buildName, jobName));
-                stdout.println(String.format("Exception class: %s, message: %s", e.getClass().getSimpleName(), e.getMessage()));
+                stdout.printf("Exception occurred while trying to stop build '%s' for job '%s'. ", buildName, jobName);
+                stdout.printf("Exception class: %s, message: %s%n", e.getClass().getSimpleName(), e.getMessage());
             }
         } else {
-            stdout.println(String.format("Build '%s' in job '%s' not stopped", buildName, jobName));
+            stdout.printf("Build '%s' in job '%s' not stopped%n", buildName, jobName);
         }
     }
 


### PR DESCRIPTION
This is just a minor performance/readability improvement. I removed redundant `String.format` calls and replaced the `print` with `printf`

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
