### PR TITLE
Remove unnecessary Guava exclusion

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -174,10 +174,6 @@ THE SOFTWARE.
       <artifactId>reflections</artifactId>
       <version>0.9.12</version>
       <exclusions>
-        <exclusion> <!-- TODO requests 15; apparently works well enough with the 11 we bundle -->
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
         <exclusion> <!-- pick up from Stapler -->
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>


### PR DESCRIPTION
Reflections removed its Guava dependency in ronmamo/reflections#272, so this exclusion is no longer necessary.