### PR TITLE
Bump antlr-maven-plugin from 2.1 to 2.2

### DIFF
--- a/core/src/main/grammar/labelExpr.g
+++ b/core/src/main/grammar/labelExpr.g
@@ -83,6 +83,10 @@ options { generateAmbigWarnings=false; }
   ;
 
 class LabelExpressionLexer extends Lexer;
+options {
+  // There must be an options section to satisfy
+  // org.codehaus.mojo.antlr.metadata.MetadataExtracter#intrepret, even if it is empty.
+}
 
 AND:    "&&";
 OR:     "||";

--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>antlr-maven-plugin</artifactId>
-          <version>2.1</version>
+          <version>2.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Subsumes #5219. Adds an explicit `options` section to satisfy `org.codehaus.mojo.antlr.metadata.MetadataExtracter#intrepret` (sic).