### PR TITLE
Bump jaxen from 1.1-beta-11 to 1.2.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -416,7 +416,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
-        <version>1.1-beta-11</version>
+        <version>1.2.0-atlassian-2</version>
       </dependency>
 
       <!-- Modules -->

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -416,7 +416,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
-        <version>1.2.0-atlassian-2</version>
+        <version>1.2.0</version>
       </dependency>
 
       <!-- Modules -->

--- a/licenseCompleter.groovy
+++ b/licenseCompleter.groovy
@@ -40,10 +40,6 @@ complete {
     }
 */
 
-    match("jaxen:jaxen") {
-        rewriteLicense([], license("BSD License","http://jaxen.codehaus.org/license.html"))
-    }
-
     match("org.jenkins-ci.dom4j:dom4j") {
         rewriteLicense([],license("BSD License","http://dom4j.sourceforge.net/dom4j-1.6.1/license.html"))
     }


### PR DESCRIPTION
### Background

Subsumes #5224. The Jaxen POM now includes license metadata as of jaxen-xpath/jaxen#27, so a custom license completion is no longer needed.

### Testing done

The Jaxen dependency in Jenkins core is needed for [`jenkins.util.xml.FilteredFunctionContext`](https://github.com/jenkinsci/jenkins/blob/86f6bb31d959097113ad35c439fe2fa285d14ad3/core/src/main/java/jenkins/util/xml/FilteredFunctionContext.java#L27-L30). I verified that this class was exercised by [`hudson.model.ApiTest#xPathDocumentFunction`](https://github.com/jenkinsci/jenkins/blob/8c6327f4c6777d135e374e3d507ba9c20820bfc6/test/src/test/java/hudson/model/ApiTest.java#L87-L102).