### PR TITLE
Bump LDAP from 1.26 to 2.3

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -284,7 +284,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>ldap</artifactId>
-                  <version>1.26</version> <!-- TODO or pick up https://github.com/jenkinsci/ldap-plugin/pull/49 -->
+                  <version>2.3</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
Noticed this `TODO` in `war/pom.xml` that can easily be resolved. jenkinsci/ldap-plugin#49 has been present in upstream LDAP releases since 2.0, and the latest upstream LDAP release (2.3) depends only on Mailer 1.32.1, which we are also bundling as a detached plugin as of ~#5185~ #4938.