### PR TITLE
Remove unused mock-javamail dependency

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -138,17 +138,6 @@ THE SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jvnet.mock-javamail</groupId>
-      <artifactId>mock-javamail</artifactId>
-      <version>1.7</version>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.mail</groupId>
-          <artifactId>mail</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>2.2</version>


### PR DESCRIPTION
The last reference to the `org.jvnet.mock_javamail` package was in `MavenMailerTest`, which was deleted in commit 5612b235ef in 2014.