### PR TITLE
Remove unused Objenesis dependency

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -203,11 +203,6 @@ THE SOFTWARE.
       <version>4.0.3</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.objenesis</groupId>
-      <artifactId>objenesis</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
This dependency was added in commit fed7f2e35c to resolve a `RequireUpperBoundDeps` issue. It is no longer needed.