### PR TITLE
Remove unused geb-implicit-assertions dependency

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -181,11 +181,6 @@ THE SOFTWARE.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.geb</groupId>
-      <artifactId>geb-implicit-assertions</artifactId>
-      <version>0.7.2</version>
-    </dependency>
-    <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
       <version>3.27.0-GA</version>


### PR DESCRIPTION
This dependency was originally added in commit c329f03 in 2013 to work around some sort of strange Groovy compiler issue, but the use of Groovy in this codebase was removed in #3184.