### PR TITLE
Bump Ant from 1.8 to 1.11

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -266,7 +266,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>ant</artifactId>
-                  <version>1.8</version>
+                  <version>1.11</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
The only dependency of Ant is Structs 1.17, and we already bundle Structs 1.20.