### PR TITLE
Bump Javadoc from 1.1 to 1.6

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -272,7 +272,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>javadoc</artifactId>
-                  <version>1.1</version>
+                  <version>1.6</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
The Javadoc plugin has no explicit dependencies on other plugins.