### PR TITLE
[JENKINS-41727] Invalidate update center caches after up/downgrade

### DIFF
--- a/core/src/main/java/jenkins/install/InstallState.java
+++ b/core/src/main/java/jenkins/install/InstallState.java
@@ -208,6 +208,9 @@ public class InstallState implements ExtensionPoint {
             super("DOWNGRADE", true);
         }
         public void initializeState() {
+            // Invalidate update site cache after a Jenkins downgrade
+            Jenkins.get().getUpdateCenter().doInvalidateData();
+
             InstallUtil.saveLastExecVersion();
         }
     }

--- a/core/src/main/java/jenkins/install/UpgradeWizard.java
+++ b/core/src/main/java/jenkins/install/UpgradeWizard.java
@@ -58,6 +58,9 @@ public class UpgradeWizard extends InstallState {
     @Override
     public void initializeState() {
         applyForcedChanges();
+
+        // Invalidate update site cache after a Jenkins update
+        Jenkins.get().getUpdateCenter().doInvalidateData();
         
         // Initializing this state is directly related to 
         // running the detached plugin checks, these should be consolidated somehow


### PR DESCRIPTION
See [JENKINS-41727](https://issues.jenkins-ci.org/browse/JENKINS-41727).

Untested. I'm still looking into whether we can get test coverage for this with `@LocalData` and faking `jenkins.install.InstallUtil.lastExecVersion`. If anyone knows of better approaches, please let me know!

Some notes:

- [ ] Test upgrade from an earlier version
- [ ] Test upgrade from an (artificial) earlier version
- [ ] Test downgrade from an (artificial) newer version
- [ ] Ensure thread is running as SYSTEM to pass permission check

### Proposed changelog entries

* Invalidate update center caches after upgrading or downgrading Jenkins

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
