### PR TITLE
[JENKINS-64805] Fixes IE11 error on the available tab

### DIFF
--- a/war/src/main/js/plugin-manager-ui.js
+++ b/war/src/main/js/plugin-manager-ui.js
@@ -34,7 +34,7 @@ function applyFilter(searchQuery) {
 
         clearOldResults()
         var rows = pluginManagerAvailable({
-            plugins: plugins.filter(plugin => !selectedPlugins.includes(plugin.name)),
+            plugins: plugins.filter(plugin => selectedPlugins.indexOf(plugin.name) === -1),
             admin
         });
 


### PR DESCRIPTION
See [JENKINS-64805](https://issues.jenkins-ci.org/browse/JENKINS-64805).

https://github.com/jenkinsci/jenkins/pull/5051 introduced an issue on IE11 where the _available_ tab of the plugin manager would not work at all due to the use of `Array.includes` throwing an error. This PR fixes it.

<img width="670" alt="Captura de pantalla 2021-02-04 a las 17 30 43" src="https://user-images.githubusercontent.com/5738588/106924845-cb6caf00-670f-11eb-8cf9-2934151f5ef8.png">

This is a big regression and a LTS-candidate IMO.

### Proposed changelog entries

* Fix issue where the _available_ plugins tab would break on IE11.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 
@MRamonLeon 
@alecharp 
@oleg-nenashev 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
