### PR TITLE
replaced deprecated jenkins.getInstance() calls with .get()

### DIFF
--- a/core/src/main/java/hudson/Plugin.java
+++ b/core/src/main/java/hudson/Plugin.java
@@ -139,9 +139,9 @@ public abstract class Plugin implements Saveable, StaplerProxy {
      *
      * <p>
      * This method is called after {@link #setServletContext(ServletContext)} is invoked.
-     * You can also use {@link jenkins.model.Jenkins#get()} to access the singleton hudson instance,
+     * You can also use {@link jenkins.model.Jenkins#get()} to access the singleton Jenkins instance,
      * although the plugin start up happens relatively early in the initialization
-     * stage and not all the data are loaded in Hudson.
+     * stage and not all the data are loaded in Jenkins.
      *
      * <p>
      * If a plugin wants to run an initialization step after all plugins and extension points

--- a/core/src/main/java/hudson/Plugin.java
+++ b/core/src/main/java/hudson/Plugin.java
@@ -139,7 +139,7 @@ public abstract class Plugin implements Saveable, StaplerProxy {
      *
      * <p>
      * This method is called after {@link #setServletContext(ServletContext)} is invoked.
-     * You can also use {@link jenkins.model.Jenkins#getInstance()} to access the singleton hudson instance,
+     * You can also use {@link jenkins.model.Jenkins#get()} to access the singleton hudson instance,
      * although the plugin start up happens relatively early in the initialization
      * stage and not all the data are loaded in Hudson.
      *

--- a/core/src/main/java/hudson/model/ViewGroup.java
+++ b/core/src/main/java/hudson/model/ViewGroup.java
@@ -137,7 +137,7 @@ public interface ViewGroup extends Saveable, ModelObject, AccessControlled {
      *
      * @return
      *      Never null. Sometimes this is {@link ModifiableItemGroup} (if the container allows arbitrary addition).
-     *      By default, {@link Jenkins#getInstance}.
+     *      By default, {@link Jenkins#get}.
      * @since 1.417
      */
     default ItemGroup<? extends TopLevelItem> getItemGroup() {

--- a/core/src/main/java/hudson/triggers/SlowTriggerAdminMonitor.java
+++ b/core/src/main/java/hudson/triggers/SlowTriggerAdminMonitor.java
@@ -87,7 +87,7 @@ public class SlowTriggerAdminMonitor extends AdministrativeMonitor {
     @RequirePOST
     @NonNull
     public HttpResponse doClear() throws IOException {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         clear();
         return HttpResponses.redirectViaContextPath("/manage");
     }

--- a/core/src/main/java/jenkins/util/ResourceBundleUtil.java
+++ b/core/src/main/java/jenkins/util/ResourceBundleUtil.java
@@ -80,7 +80,7 @@ public class ResourceBundleUtil {
         ResourceBundle bundle = getBundle(baseName, locale, Jenkins.class.getClassLoader());
         if (bundle == null) {
             // Not in Jenkins core. Check the plugins.
-            Jenkins jenkins = Jenkins.getInstance(); // will never return null
+            Jenkins jenkins = Jenkins.get(); // will never return null
             if (jenkins != null) {
                 for (PluginWrapper plugin : jenkins.getPluginManager().getPlugins()) {
                     bundle = getBundle(baseName, locale, plugin.classLoader);

--- a/core/src/main/java/jenkins/util/ResourceBundleUtil.java
+++ b/core/src/main/java/jenkins/util/ResourceBundleUtil.java
@@ -80,7 +80,7 @@ public class ResourceBundleUtil {
         ResourceBundle bundle = getBundle(baseName, locale, Jenkins.class.getClassLoader());
         if (bundle == null) {
             // Not in Jenkins core. Check the plugins.
-            Jenkins jenkins = Jenkins.get(); // will never return null
+            Jenkins jenkins = Jenkins.getInstanceOrNull();
             if (jenkins != null) {
                 for (PluginWrapper plugin : jenkins.getPluginManager().getPlugins()) {
                     bundle = getBundle(baseName, locale, plugin.classLoader);


### PR DESCRIPTION
replaced deprecated `jenkins.getInstance()` calls with `jenkins.get()`

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
