### PR TITLE
Add a report of commits and releases to update-since-todo.sh

### DIFF
--- a/update-since-todo.sh
+++ b/update-since-todo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is a developer tool, to be used by maintainers
 # to update '@since TODO' entries with actual Jenkins release versions.
@@ -8,6 +8,9 @@ set -o nounset
 set -o pipefail
 
 me="$( basename "$0" )"
+
+# Needs bash 4+
+declare -A commitsAndTags
 
 IFS=$'\n'
 for todo in $( git grep --line-number '@since TODO' | grep -v "$me" )
@@ -25,6 +28,7 @@ do
 
     if [[ -n $firstTag ]]; then
         echo -e "\tfirst tag was $firstTag"
+        commitsAndTags[$lineSha]="$firstTag"
         echo -e "\tUpdating file in place"
         sedExpr="${line}s/@since TODO/@since ${firstTag//jenkins-/}/"
         sed -i.bak "$sedExpr" "$file"
@@ -33,3 +37,25 @@ do
         echo -e "\tNot updating file, no tag found. Normal if the associated PR/commit is not merged and released yet; otherwise make sure to fetch tags from jenkinsci/jenkins"
     fi
 done
+
+if [[ "${#commitsAndTags[@]}" -gt 0 ]] ; then
+  echo ''
+  echo "List of commits introducing new API and the first release they went in:"
+  declare -A releases
+  for commit in "${!commitsAndTags[@]}" ; do
+    release="${commitsAndTags[$commit]}"
+    releases[$release]=1
+  done
+
+  mapfile -t sortedReleases < <( sort <<<"${!releases[*]}" )
+
+  for release in "${sortedReleases[@]}" ; do
+      echo "* https://github.com/jenkinsci/jenkins/releases/tag/${release}"
+      for commit in "${!commitsAndTags[@]}" ; do
+        firstRelease="${commitsAndTags[$commit]}"
+        if [[ "$release" = "$firstRelease" ]] ; then
+          echo "  - https://github.com/jenkinsci/jenkins/commit/$commit"
+        fi
+      done
+  done
+fi


### PR DESCRIPTION
This makes the replacements by the tool more easily reviewable. Modeled after the PR message in #5276 but not bothering to determine PRs (can rather easily be done manually).

Sample output corresponding to #5276: 

```
List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.253
  - https://github.com/jenkinsci/jenkins/commit/9b0d18aba319ba6a7c548a06a92435775553948d
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.257
  - https://github.com/jenkinsci/jenkins/commit/5b1dd72d9b7f295c23f19dd21a8827de519be6d8
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.258
  - https://github.com/jenkinsci/jenkins/commit/702bd3921c553e70cdb11aff53370be8c7eeceb1
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.259
  - https://github.com/jenkinsci/jenkins/commit/ded319294049f773455d752526e7984dee00b026
  - https://github.com/jenkinsci/jenkins/commit/3992a30efb1abf697cae8e02f9e81dd04b92b135
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.260
  - https://github.com/jenkinsci/jenkins/commit/eb0876cdb981a83c9f4c6f07d1eede585614612a
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.265
  - https://github.com/jenkinsci/jenkins/commit/b40f70e3d868b5bd41bada18aa23955822521e33
  - https://github.com/jenkinsci/jenkins/commit/9c256ad8305db82e7186b7687e3300a8115a2d10
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.266
  - https://github.com/jenkinsci/jenkins/commit/a9ca5ef3d4c97937636bf3c585f4232514279b14
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.267
  - https://github.com/jenkinsci/jenkins/commit/bd59971eac813f4bc8471d6c2646334a0b704105
  - https://github.com/jenkinsci/jenkins/commit/15cfddf2a77b9fce3cc48cd0fec055b593eb6493
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.272
  - https://github.com/jenkinsci/jenkins/commit/9f50735a8b0f73e9ef73bdabfb1dcefaad55f4f2
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.275
  - https://github.com/jenkinsci/jenkins/commit/71d2ecf1a4e5303e80815eaa3935c4f2fa3d9104
  - https://github.com/jenkinsci/jenkins/commit/b1ca2849660798fd0f7fe8fda8e372cfb2ded621
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.279
  - https://github.com/jenkinsci/jenkins/commit/44e11f66bc59150e48835410ac7462b61371f9a3
```

Or, rendered as Markdown in a pull request:

List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.253
  - https://github.com/jenkinsci/jenkins/commit/9b0d18aba319ba6a7c548a06a92435775553948d
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.257
  - https://github.com/jenkinsci/jenkins/commit/5b1dd72d9b7f295c23f19dd21a8827de519be6d8
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.258
  - https://github.com/jenkinsci/jenkins/commit/702bd3921c553e70cdb11aff53370be8c7eeceb1
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.259
  - https://github.com/jenkinsci/jenkins/commit/ded319294049f773455d752526e7984dee00b026
  - https://github.com/jenkinsci/jenkins/commit/3992a30efb1abf697cae8e02f9e81dd04b92b135
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.260
  - https://github.com/jenkinsci/jenkins/commit/eb0876cdb981a83c9f4c6f07d1eede585614612a
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.265
  - https://github.com/jenkinsci/jenkins/commit/b40f70e3d868b5bd41bada18aa23955822521e33
  - https://github.com/jenkinsci/jenkins/commit/9c256ad8305db82e7186b7687e3300a8115a2d10
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.266
  - https://github.com/jenkinsci/jenkins/commit/a9ca5ef3d4c97937636bf3c585f4232514279b14
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.267
  - https://github.com/jenkinsci/jenkins/commit/bd59971eac813f4bc8471d6c2646334a0b704105
  - https://github.com/jenkinsci/jenkins/commit/15cfddf2a77b9fce3cc48cd0fec055b593eb6493
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.272
  - https://github.com/jenkinsci/jenkins/commit/9f50735a8b0f73e9ef73bdabfb1dcefaad55f4f2
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.275
  - https://github.com/jenkinsci/jenkins/commit/71d2ecf1a4e5303e80815eaa3935c4f2fa3d9104
  - https://github.com/jenkinsci/jenkins/commit/b1ca2849660798fd0f7fe8fda8e372cfb2ded621
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.279
  - https://github.com/jenkinsci/jenkins/commit/44e11f66bc59150e48835410ac7462b61371f9a3


### Proposed changelog entries

n/a

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
