### PR TITLE
Revert symbol-annotation bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,5 @@ updates:
       - dependency-name: "javax.servlet:javax.servlet-api"
       # log4j 1.2.17 is the final 1.x release
       - dependency-name: "log4j:log4j"
+      # using a newer version clashes in RequireUpperBoundDeps with plugins using a valid script-security dependency
+      - dependency-name: "org.jenkins-ci:symbol-annotation"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -518,7 +518,7 @@ THE SOFTWARE.
     <dependency> <!-- Not included into BOM, plugins should use one from structs-plugin -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
-      <version>1.21</version>
+      <version>1.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Reverts #5265. Noticed in https://github.com/jenkinsci/file-parameters-plugin/pull/27 that this caused a build failure

```
[WARNING] Rule 5: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.jenkins-ci:symbol-annotation:1.20 paths to dependency are:
+-io.jenkins.plugins:file-parameters:98.728b4f423129
  +-org.jenkins-ci.plugins:structs:1.20
    +-org.jenkins-ci:symbol-annotation:1.20
and
+-io.jenkins.plugins:file-parameters:98.728b4f423129
  +-org.jenkins-ci.main:jenkins-core:2.281-rc30899.58174df06127
    +-org.jenkins-ci:symbol-annotation:1.20 (managed) <-- org.jenkins-ci:symbol-annotation:1.21
]
```

This is the most straightforward way to fix the immediate regression. There are probably other workarounds, though _not_ using `optional`—we do want it bundled in the WAR! Really the root of the evil is that we have this JAR which is both a core library dep _and_ bundled in a plugin. I do not recall why things were set up this way exactly; probably to avoid needing to use new core deps in plugins, at a time when that seemed really scary.

## Proposed changelog entries

* Developer: Downgrade the bundled symbol-annotation library version to prevent build failures in plugins