### PR TITLE
Revert "Clean up VirtualFile after adding base implementation (#5212)"

### DIFF
--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -661,6 +661,18 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
             }
 
             @Override
+            public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
+                           boolean noFollowLinks, String prefix) throws IOException {
+                String rootPath = determineRootPath();
+                DirScanner.Glob globScanner = new DirScanner.Glob(includes, excludes, useDefaultExcludes, !noFollowLinks);
+                ArchiverFactory archiverFactory = noFollowLinks ? ArchiverFactory.createZipWithoutSymlink(prefix) : ArchiverFactory.ZIP;
+                try (Archiver archiver = archiverFactory.create(outputStream)) {
+                    globScanner.scan(f, FilePath.ignoringSymlinks(archiver, rootPath, noFollowLinks));
+                    return archiver.countEntries();
+                }
+            }
+
+            @Override
             public boolean hasSymlink(boolean noFollowLinks) throws IOException {
                 String rootPath = determineRootPath();
                 return FilePath.isSymlink(f, rootPath, noFollowLinks);
@@ -952,6 +964,18 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
                 try {
                     String rootPath = root == null ? null : root.getRemote();
                     return f.act(new Scanner(includes, excludes, useDefaultExcludes, rootPath, noFollowLinks));
+                } catch (InterruptedException x) {
+                    throw new IOException(x);
+                }
+            }
+
+            @Override
+            public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
+                                    boolean noFollowLinks, String prefix) throws IOException {
+                try {
+                    String rootPath = root == null ? null : root.getRemote();
+                    DirScanner.Glob globScanner = new DirScanner.Glob(includes, excludes, useDefaultExcludes, !noFollowLinks);
+                    return f.zip(outputStream, globScanner, rootPath, noFollowLinks, prefix);
                 } catch (InterruptedException x) {
                     throw new IOException(x);
                 }


### PR DESCRIPTION
This reverts commit 792efa7c241dd86af855b7c83aefcdafa0696847.

The previous #5212 removed code that allowed attackers to elevate their permissions as described in https://www.jenkins.io/security/advisory/2021-02-19/ but at the same time introduced a performance regression.

As the security vulnerability is now properly fixed in 2.280 through the Spring Security update, we can restore this code to speed things up again.

### Proposed changelog entries

* Improve performance when downloading workspace zip files

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
