### PR TITLE
[JENKINS-55582] Split instance-identity to a plugin

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -422,11 +422,6 @@ THE SOFTWARE.
       <!-- Modules -->
       <dependency>
         <groupId>org.jenkins-ci.modules</groupId>
-        <artifactId>instance-identity</artifactId>
-        <version>2.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.modules</groupId>
         <artifactId>ssh-cli-auth</artifactId>
         <version>1.8</version>
       </dependency>

--- a/core/src/main/resources/jenkins/split-plugin-cycles.txt
+++ b/core/src/main/resources/jenkins/split-plugin-cycles.txt
@@ -32,3 +32,10 @@ junit jaxb
 bouncycastle-api jaxb
 command-launcher jaxb
 jdk-tool jaxb
+
+# JENKINS-55582
+bouncycastle-api instance-identity
+bouncycastle-api command-launcher
+trilead-api instance-identity
+jdk-tool instance-identity
+bouncycastle-api jdk-tool

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -20,7 +20,7 @@ windows-slaves 1.547 1.0
 antisamy-markup-formatter 1.553 1.0
 matrix-project 1.561 1.0
 junit 1.577 1.0
-bouncycastle-api 2.16 2.16.0
+bouncycastle-api 2.18 2.16.0
 # JENKINS-47393
 command-launcher 2.86 1.0
 # JENKINS-22367
@@ -31,3 +31,6 @@ jaxb 2.163 2.3.0 11
 
 #JENKINS-43610 Split Trilead out from Core
 trilead-api 2.184 1.0.4
+
+# JENKINS-55582
+instance-identity 2.281 3.0

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@ THE SOFTWARE.
 
     <matrix-auth.version>2.6.5</matrix-auth.version>
     <matrix-project.version>1.18</matrix-project.version>
+    <instance-identity.version>3.0</instance-identity.version>
     <sorcerer.version>0.11</sorcerer.version>
     <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>
     <java.level>8</java.level>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -138,6 +138,11 @@ THE SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>instance-identity</artifactId>
+      <version>${instance-identity.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>2.2</version>

--- a/test/src/test/java/jenkins/security/ClassFilterImplTest.java
+++ b/test/src/test/java/jenkins/security/ClassFilterImplTest.java
@@ -159,7 +159,6 @@ public class ClassFilterImplTest {
         ClassFilterImpl filter = new ClassFilterImpl();
         filter.check("org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl");
         filter.check("org.jenkinsci.modules.windows_slave_installer.WindowsSlaveInstaller");
-        filter.check("org.jenkinsci.main.modules.instance_identity.PageDecoratorImpl");
     }
 
     @TestExtension("xstreamRequiresWhitelist")

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -108,31 +108,63 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
-      <artifactId>instance-identity</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>ssh-cli-auth</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>instance-identity</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>slave-installer</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>instance-identity</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>windows-slave-installer</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>instance-identity</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>launchd-slave-installer</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>instance-identity</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>upstart-slave-installer</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>instance-identity</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>systemd-slave-installer</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.modules</groupId>
+          <artifactId>instance-identity</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
@@ -397,6 +429,12 @@ THE SOFTWARE.
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>trilead-api</artifactId>
                   <version>1.0.4</version>
+                  <type>hpi</type>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.jenkins-ci.modules</groupId>
+                  <artifactId>instance-identity</artifactId>
+                  <version>${instance-identity.version}</version>
                   <type>hpi</type>
                 </artifactItem>
               </artifactItems>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -109,12 +109,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>ssh-cli-auth</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci.modules</groupId>
-          <artifactId>instance-identity</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/instance-identity-plugin/pull/17. ~Requires #5049 because `sshd` depends on `instance-identity` (for real).~

### Proposed changelog entries

* Converting the `instance-identity` module into a (detached) plugin.

### Proposed upgrade guidelines

Normally the new plugin will be automatically installed. If you use an “as-code” installation mechanism like a text file with a list of plugins, you may need to add `instance-identity` (version `3.0` or later) in order to restore this functionality.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
