### PR TITLE
Downgrade recently-upgraded detached plugins

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -284,7 +284,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>ldap</artifactId>
-                  <version>2.3</version>
+                  <version>2.0</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -266,7 +266,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>ant</artifactId>
-                  <version>1.11</version>
+                  <version>1.8</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -272,7 +272,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>javadoc</artifactId>
-                  <version>1.6</version>
+                  <version>1.1</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
See [#5244 (comment)](https://github.com/jenkinsci/jenkins/pull/5244#issuecomment-786142004). In #5244, #5255, and #5256 I upgraded three detached plugins to the latest versions under the naïve assumption that this was merely updating already bundled dependencies to newer versions without any impact to end users. What I did not realize was that if the installed version of a detached plugin is older than the bundled version, then users must upgrade the installed version. This affects end users negatively in a way that I had not anticipated by forcing them to upgrade Jenkins core and plugins in lockstep; my apologies for that. To resolve this I am reverting #5255 and #5256 in this change and bumping LDAP down from 2.3 to 2.0 as suggested in the comments to #5244. I will also spend some time reading through the logic in `PluginManager` that deals with detached plugins before proposing future changes to detached plugin versions.

*Proposed changelog entry:* Lower the minimum required version of the LDAP plugin from 2.3 to 2.0.