### PR TITLE
Use native Java functionality rather than Guava's Lists#newArrayList, Maps#newHashMap, and Sets#newHashSet where possible

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -23,7 +23,6 @@
  */
 package hudson;
 
-import com.google.common.collect.Lists;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Plugin.DummyImpl;
 import hudson.PluginWrapper.Dependency;
@@ -343,7 +342,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
             finder.scout(type, hudson);
         }
 
-        List<ExtensionComponent<T>> r = Lists.newArrayList();
+        List<ExtensionComponent<T>> r = new ArrayList<>();
         for (ExtensionFinder finder : finders) {
             try {
                 r.addAll(finder.find(type, hudson));
@@ -354,7 +353,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
             }
         }
 
-        List<ExtensionComponent<T>> filtered = Lists.newArrayList();
+        List<ExtensionComponent<T>> filtered = new ArrayList<>();
         for (ExtensionComponent<T> e : r) {
             if (ExtensionFilter.isAllowed(type,e))
                 filtered.add(e);

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -25,8 +25,6 @@ package hudson;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.inject.AbstractModule;
 import com.google.inject.Binding;
 import com.google.inject.Guice;
@@ -259,7 +257,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
         /**
          * Map from {@link GuiceExtensionAnnotation#annotationType} to {@link GuiceExtensionAnnotation}
          */
-        private Map<Class<? extends Annotation>,GuiceExtensionAnnotation<?>> extensionAnnotations = Maps.newHashMap();
+        private Map<Class<? extends Annotation>,GuiceExtensionAnnotation<?>> extensionAnnotations = new HashMap<>();
 
         public GuiceFinder() {
             refreshExtensionAnnotations();
@@ -307,7 +305,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
         }
 
         private ImmutableList<IndexItem<?, Object>> loadSezpozIndices(ClassLoader classLoader) {
-            List<IndexItem<?,Object>> indices = Lists.newArrayList();
+            List<IndexItem<?,Object>> indices = new ArrayList<>();
             for (GuiceExtensionAnnotation<?> gea : extensionAnnotations.values()) {
                 Iterables.addAll(indices, Index.load(gea.annotationType, Object.class, classLoader));
             }
@@ -330,7 +328,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
         public synchronized ExtensionComponentSet refresh() throws ExtensionRefreshException {
             refreshExtensionAnnotations();
             // figure out newly discovered sezpoz components
-            List<IndexItem<?, Object>> delta = Lists.newArrayList();
+            List<IndexItem<?, Object>> delta = new ArrayList<>();
             for (Class<? extends Annotation> annotationType : extensionAnnotations.keySet()) {
                 delta.addAll(Sezpoz.listDelta(annotationType,sezpozIndex));
             }
@@ -346,7 +344,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
             try {
                 final Injector child = container.createChildInjector(modules);
                 container = child;
-                List<IndexItem<?, Object>> l = Lists.newArrayList(sezpozIndex);
+                List<IndexItem<?, Object>> l = new ArrayList<>(sezpozIndex);
                 l.addAll(deltaExtensions.getLoadedIndex());
                 sezpozIndex = l;
 
@@ -661,7 +659,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
 
             final List<IndexItem<Extension, Object>> delta = listDelta(Extension.class,old);
 
-            List<IndexItem<Extension,Object>> r = Lists.newArrayList(old);
+            List<IndexItem<Extension,Object>> r = new ArrayList<>(old);
             r.addAll(delta);
             indices = ImmutableList.copyOf(r);
 
@@ -675,7 +673,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
 
         static <T extends Annotation> List<IndexItem<T,Object>> listDelta(Class<T> annotationType, List<? extends IndexItem<?,Object>> old) {
             // list up newly discovered components
-            final List<IndexItem<T,Object>> delta = Lists.newArrayList();
+            final List<IndexItem<T,Object>> delta = new ArrayList<>();
             ClassLoader cl = Jenkins.get().getPluginManager().uberClassLoader;
             for (IndexItem<T,Object> ii : Index.load(annotationType, Object.class, cl)) {
                 if (!old.contains(ii)) {

--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -23,7 +23,6 @@
  */
 package hudson;
 
-import com.google.common.collect.Lists;
 import hudson.init.InitMilestone;
 import hudson.model.Hudson;
 import jenkins.ExtensionComponentSet;
@@ -341,7 +340,7 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
 
             Collection<ExtensionComponent<T>> found = load(delta);
             if (!found.isEmpty()) {
-                List<ExtensionComponent<T>> l = Lists.newArrayList(extensions);
+                List<ExtensionComponent<T>> l = new ArrayList<>(extensions);
                 l.addAll(found);
                 extensions = sort(l);
                 fireOnChangeListeners = true;

--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -23,7 +23,6 @@
  */
 package hudson;
 
-import com.google.common.collect.Lists;
 import com.thoughtworks.xstream.XStream;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -45,6 +44,7 @@ import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -215,7 +215,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
     public static List<Pattern> getNoProxyHostPatterns(String noProxyHost) {
         if (noProxyHost==null)  return Collections.emptyList();
 
-        List<Pattern> r = Lists.newArrayList();
+        List<Pattern> r = new ArrayList<>();
         for (String s : noProxyHost.split("[ \t\n,|]+")) {
             if (s.length()==0)  continue;
             r.add(Pattern.compile(s.replace(".", "\\.").replace("*", ".*")));

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -50,8 +50,6 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.google.common.collect.Lists;
-import static com.google.common.collect.Sets.newHashSet;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.util.SystemProperties;
@@ -242,8 +240,8 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
             parametersAction.safeParameters = this.safeParameters;
             return parametersAction;
         }
-        List<ParameterValue> combinedParameters = Lists.newArrayList(overrides);
-        Set<String> names = newHashSet();
+        List<ParameterValue> combinedParameters = new ArrayList<>(overrides);
+        Set<String> names = new HashSet<>();
 
         for(ParameterValue v : overrides) {
             if (v == null) continue;

--- a/core/src/main/java/jenkins/ExtensionComponentSet.java
+++ b/core/src/main/java/jenkins/ExtensionComponentSet.java
@@ -23,13 +23,13 @@
  */
 package jenkins;
 
-import com.google.common.collect.Lists;
 import hudson.ExtensionComponent;
 import hudson.ExtensionFinder;
 import hudson.ExtensionPoint;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -66,7 +66,7 @@ public abstract class ExtensionComponentSet {
         return new ExtensionComponentSet() {
             @Override
             public <T> Collection<ExtensionComponent<T>> find(Class<T> type) {
-                List<ExtensionComponent<T>> a = Lists.newArrayList();
+                List<ExtensionComponent<T>> a = new ArrayList<>();
                 for (ExtensionComponent<T> c : base.find(type)) {
                     if (ExtensionFilter.isAllowed(type,c))
                         a.add(c);
@@ -93,7 +93,7 @@ public abstract class ExtensionComponentSet {
         return new ExtensionComponentSet() {
             @Override
             public <T> Collection<ExtensionComponent<T>> find(Class<T> type) {
-                List<ExtensionComponent<T>> r = Lists.newArrayList();
+                List<ExtensionComponent<T>> r = new ArrayList<>();
                 for (ExtensionComponentSet d : base)
                     r.addAll(d.find(type));
                 return r;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -30,7 +30,6 @@ import antlr.ANTLRException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.thoughtworks.xstream.XStream;
@@ -2733,14 +2732,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 throw new ExtensionRefreshException(ef+" doesn't support refresh");
         }
 
-        List<ExtensionComponentSet> fragments = Lists.newArrayList();
+        List<ExtensionComponentSet> fragments = new ArrayList<>();
         for (ExtensionFinder ef : finders) {
             fragments.add(ef.refresh());
         }
         ExtensionComponentSet delta = ExtensionComponentSet.union(fragments).filtered();
 
         // if we find a new ExtensionFinder, we need it to list up all the extension points as well
-        List<ExtensionComponent<ExtensionFinder>> newFinders = Lists.newArrayList(delta.find(ExtensionFinder.class));
+        List<ExtensionComponent<ExtensionFinder>> newFinders = new ArrayList<>(delta.find(ExtensionFinder.class));
         while (!newFinders.isEmpty()) {
             ExtensionFinder f = newFinders.remove(newFinders.size()-1).getInstance();
 

--- a/core/src/main/java/jenkins/scm/SCMCheckoutStrategyDescriptor.java
+++ b/core/src/main/java/jenkins/scm/SCMCheckoutStrategyDescriptor.java
@@ -1,11 +1,11 @@
 package jenkins.scm;
 
-import com.google.common.collect.Lists;
 import hudson.DescriptorExtensionList;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -34,7 +34,7 @@ public abstract class SCMCheckoutStrategyDescriptor extends Descriptor<SCMChecko
     }
     
     public static List<SCMCheckoutStrategyDescriptor> _for(AbstractProject p) {
-        List<SCMCheckoutStrategyDescriptor> r = Lists.newArrayList();
+        List<SCMCheckoutStrategyDescriptor> r = new ArrayList<>();
         for (SCMCheckoutStrategyDescriptor d : all()) {
             if (d.isApplicable(p))
                 r.add(d);

--- a/core/src/test/java/hudson/EnvVarsTest.java
+++ b/core/src/test/java/hudson/EnvVarsTest.java
@@ -31,9 +31,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.TreeMap;
 
-import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -141,7 +142,7 @@ public class EnvVarsTest {
         OverrideOrderCalculator calc = new OverrideOrderCalculator(env, overrides);
         List<String> order = calc.getOrderedVariableNames();
         assertEquals(Arrays.asList("B", "A", "C"), order.subList(0, 3));
-        assertEquals(Sets.newHashSet("E", "D"), new HashSet<>(order.subList(3, order.size())));
+        assertThat(new HashSet<>(order.subList(3, order.size())), containsInAnyOrder("E", "D"));
     }
 
     @Test


### PR DESCRIPTION
Guava's `Lists#newArrayList`, `Maps#newHashMap`, and `Sets#newHashSet` were quite handy in the days of Java 6, prior to the introduction of the diamond operator in Java 7. Nowadays, they are largely unnecessary since the native Java functionality with the diamond operator suffices. In this PR I am eliminating the usage of any of those Guava methods where they can be trivially replaced with native Java functionality.